### PR TITLE
[TECH] Injecter les dépendances dans les use-cases pour préparer la migration ESM (épisode 357)

### DIFF
--- a/api/lib/domain/usecases/create-organization-invitation-by-admin.js
+++ b/api/lib/domain/usecases/create-organization-invitation-by-admin.js
@@ -1,4 +1,3 @@
-const organizationInvitationService = require('../services/organization-invitation-service.js');
 const { OrganizationArchivedError } = require('../errors.js');
 
 module.exports = async function createOrganizationInvitationByAdmin({
@@ -8,6 +7,7 @@ module.exports = async function createOrganizationInvitationByAdmin({
   role,
   organizationRepository,
   organizationInvitationRepository,
+  organizationInvitationService,
 }) {
   const organization = await organizationRepository.get(organizationId);
 

--- a/api/lib/domain/usecases/create-organization-invitations.js
+++ b/api/lib/domain/usecases/create-organization-invitations.js
@@ -1,6 +1,5 @@
 const bluebird = require('bluebird');
 
-const organizationInvitationService = require('../../domain/services/organization-invitation-service.js');
 const { OrganizationArchivedError } = require('../errors.js');
 
 module.exports = async function createOrganizationInvitations({
@@ -9,6 +8,7 @@ module.exports = async function createOrganizationInvitations({
   locale,
   organizationRepository,
   organizationInvitationRepository,
+  organizationInvitationService,
 }) {
   const organization = await organizationRepository.get(organizationId);
 

--- a/api/lib/domain/usecases/create-organization.js
+++ b/api/lib/domain/usecases/create-organization.js
@@ -1,9 +1,8 @@
-const organizationCreationValidator = require('../validators/organization-creation-validator.js');
-
 module.exports = async function createOrganization({
   organization,
   dataProtectionOfficerRepository,
   organizationForAdminRepository,
+  organizationCreationValidator,
 }) {
   organizationCreationValidator.validate(organization);
   const createdOrganization = await organizationForAdminRepository.save(organization);

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -2,7 +2,6 @@ const { isEmpty, uniqBy } = require('lodash');
 const bluebird = require('bluebird');
 const Organization = require('../models/Organization.js');
 const OrganizationTag = require('../models/OrganizationTag.js');
-const organizationValidator = require('../validators/organization-with-tags-and-target-profiles-script.js');
 const DomainTransaction = require('../../infrastructure/DomainTransaction.js');
 
 const {
@@ -14,7 +13,6 @@ const {
 } = require('../errors.js');
 
 const SEPARATOR = '_';
-const organizationInvitationService = require('../../domain/services/organization-invitation-service.js');
 
 module.exports = async function createOrganizationsWithTagsAndTargetProfiles({
   organizations,
@@ -25,6 +23,8 @@ module.exports = async function createOrganizationsWithTagsAndTargetProfiles({
   organizationTagRepository,
   organizationInvitationRepository,
   dataProtectionOfficerRepository,
+  organizationValidator,
+  organizationInvitationService,
 }) {
   if (isEmpty(organizations)) {
     throw new ObjectValidationError('Les organisations ne sont pas renseignées.');

--- a/api/lib/domain/usecases/get-campaign-assessment-participation.js
+++ b/api/lib/domain/usecases/get-campaign-assessment-participation.js
@@ -1,5 +1,4 @@
 const { UserNotAuthorizedToAccessEntityError } = require('../errors.js');
-const stageCollectionRepository = require('../../infrastructure/repositories/user-campaign-results/stage-collection-repository');
 
 module.exports = async function getCampaignAssessmentParticipation({
   userId,
@@ -8,6 +7,7 @@ module.exports = async function getCampaignAssessmentParticipation({
   campaignRepository,
   campaignAssessmentParticipationRepository,
   badgeAcquisitionRepository,
+  stageCollectionRepository,
 }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');

--- a/api/lib/domain/usecases/get-target-profile-content-as-json.js
+++ b/api/lib/domain/usecases/get-target-profile-content-as-json.js
@@ -1,12 +1,12 @@
 const { ForbiddenAccess } = require('../../domain/errors.js');
 const dayjs = require('dayjs');
-const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
 
 module.exports = async function getTargetProfileContentAsJson({
   userId,
   targetProfileId,
   adminMemberRepository,
   targetProfileForAdminRepository,
+  learningContentConversionService,
 }) {
   const adminMember = await adminMemberRepository.get({ userId });
   if (!_hasAuthorizationToDownloadContent(adminMember))

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -173,6 +173,7 @@ const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/p
 const disabledPoleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js');
 const organizationInvitationService = require('../services/organization-invitation-service.js');
 const organizationCreationValidator = require('../validators/organization-creation-validator.js');
+const organizationValidator = require('../validators/organization-with-tags-and-target-profiles-script.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -357,6 +358,7 @@ const dependencies = {
   verifyCertificateCodeService,
   organizationInvitationService,
   organizationCreationValidator,
+  organizationValidator,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -172,6 +172,7 @@ const participantResultsSharedRepository = require('../../infrastructure/reposit
 const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
 const disabledPoleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js');
 const organizationInvitationService = require('../services/organization-invitation-service.js');
+const organizationCreationValidator = require('../validators/organization-creation-validator.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -355,6 +356,7 @@ const dependencies = {
   userSavedTutorialRepository,
   verifyCertificateCodeService,
   organizationInvitationService,
+  organizationCreationValidator,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -176,6 +176,7 @@ const organizationCreationValidator = require('../validators/organization-creati
 const organizationValidator = require('../validators/organization-with-tags-and-target-profiles-script.js');
 const userValidator = require('../validators/user-validator.js');
 const passwordValidator = require('../validators/password-validator.js');
+const stageCollectionRepository = require('../../infrastructure/repositories/user-campaign-results/stage-collection-repository');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -363,6 +364,7 @@ const dependencies = {
   organizationValidator,
   userValidator,
   passwordValidator,
+  stageCollectionRepository,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -177,6 +177,7 @@ const organizationValidator = require('../validators/organization-with-tags-and-
 const userValidator = require('../validators/user-validator.js');
 const passwordValidator = require('../validators/password-validator.js');
 const stageCollectionRepository = require('../../infrastructure/repositories/user-campaign-results/stage-collection-repository');
+const campaignValidator = require('../validators/campaign-validator.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -365,6 +366,7 @@ const dependencies = {
   userValidator,
   passwordValidator,
   stageCollectionRepository,
+  campaignValidator,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -178,6 +178,7 @@ const userValidator = require('../validators/user-validator.js');
 const passwordValidator = require('../validators/password-validator.js');
 const stageCollectionRepository = require('../../infrastructure/repositories/user-campaign-results/stage-collection-repository');
 const campaignValidator = require('../validators/campaign-validator.js');
+const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -367,6 +368,7 @@ const dependencies = {
   passwordValidator,
   stageCollectionRepository,
   campaignValidator,
+  learningContentConversionService,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -174,6 +174,8 @@ const disabledPoleEmploiNotifier = require('../../infrastructure/externals/pole-
 const organizationInvitationService = require('../services/organization-invitation-service.js');
 const organizationCreationValidator = require('../validators/organization-creation-validator.js');
 const organizationValidator = require('../validators/organization-with-tags-and-target-profiles-script.js');
+const userValidator = require('../validators/user-validator.js');
+const passwordValidator = require('../validators/password-validator.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -359,6 +361,8 @@ const dependencies = {
   organizationInvitationService,
   organizationCreationValidator,
   organizationValidator,
+  userValidator,
+  passwordValidator,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -171,6 +171,7 @@ const verifyCertificateCodeService = require('../../domain/services/verify-certi
 const participantResultsSharedRepository = require('../../infrastructure/repositories/participant-results-shared-repository.js');
 const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
 const disabledPoleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js');
+const organizationInvitationService = require('../services/organization-invitation-service.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -353,6 +354,7 @@ const dependencies = {
   userService,
   userSavedTutorialRepository,
   verifyCertificateCodeService,
+  organizationInvitationService,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/resend-organization-invitation.js
+++ b/api/lib/domain/usecases/resend-organization-invitation.js
@@ -1,11 +1,10 @@
-const organizationInvitationService = require('../../domain/services/organization-invitation-service.js');
-
 module.exports = async function resendOrganizationInvitation({
   organizationId,
   email,
   locale,
   organizationRepository,
   organizationInvitationRepository,
+  organizationInvitationService,
 }) {
   return organizationInvitationService.createOrUpdateOrganizationInvitation({
     organizationRepository,

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -5,7 +5,6 @@ const {
   ManyOrganizationsFoundError,
   OrganizationArchivedError,
 } = require('../errors.js');
-const organizationInvitationService = require('../../domain/services/organization-invitation-service.js');
 
 module.exports = async function sendScoInvitation({
   uai,
@@ -14,6 +13,7 @@ module.exports = async function sendScoInvitation({
   locale,
   organizationRepository,
   organizationInvitationRepository,
+  organizationInvitationService,
 }) {
   const organizationWithGivenUAI = await _getOrganizationWithGivenUAI({ uai, organizationRepository });
   _ensureOrganizationHasAnEmail({ email: organizationWithGivenUAI.email, uai });

--- a/api/lib/domain/usecases/update-campaign-details-management.js
+++ b/api/lib/domain/usecases/update-campaign-details-management.js
@@ -1,4 +1,3 @@
-const campaignValidator = require('../validators/campaign-validator.js');
 const { EntityValidationError } = require('../errors.js');
 
 module.exports = async function updateCampaignDetailsManagement({
@@ -11,6 +10,7 @@ module.exports = async function updateCampaignDetailsManagement({
   customResultPageButtonUrl,
   multipleSendings,
   campaignManagementRepository,
+  campaignValidator,
 }) {
   const campaign = await campaignManagementRepository.get(campaignId);
   campaign.name = name;

--- a/api/tests/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/integration/domain/usecases/create-organization_test.js
@@ -2,6 +2,7 @@ const { expect, databaseBuilder, knex } = require('../../../test-helper');
 
 const organizationForAdminRepository = require('../../../../lib/infrastructure/repositories/organization-for-admin-repository');
 const dataProtectionOfficerRepository = require('../../../../lib/infrastructure/repositories/data-protection-officer-repository');
+const organizationCreationValidator = require('../../../../lib/domain/validators/organization-creation-validator.js');
 const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
 
 const createOrganization = require('../../../../lib/domain/usecases/create-organization');
@@ -29,6 +30,7 @@ describe('Integration | UseCases | create-organization', function () {
       organization,
       dataProtectionOfficerRepository,
       organizationForAdminRepository,
+      organizationCreationValidator,
     });
 
     // then

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -8,6 +8,8 @@ const organizationTagRepository = require('../../../../lib/infrastructure/reposi
 const targetProfileShareRepository = require('../../../../lib/infrastructure/repositories/target-profile-share-repository');
 const dataProtectionOfficerRepository = require('../../../../lib/infrastructure/repositories/data-protection-officer-repository');
 const tagRepository = require('../../../../lib/infrastructure/repositories/tag-repository');
+const organizationValidator = require('../../../../lib/domain/validators/organization-with-tags-and-target-profiles-script.js');
+const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service.js');
 const {
   OrganizationTagNotFound,
   ManyOrganizationsFoundError,
@@ -82,6 +84,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationTagRepository,
           organizationInvitationRepository,
           dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
         });
 
         // then
@@ -107,6 +111,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationTagRepository,
           organizationInvitationRepository,
           dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
         });
 
         // then
@@ -184,6 +190,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationTagRepository,
           organizationInvitationRepository,
           dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
         });
 
         // then
@@ -223,6 +231,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationTagRepository,
           organizationInvitationRepository,
           dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
         });
 
         // then
@@ -326,6 +336,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationTagRepository,
           organizationInvitationRepository,
           dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
         });
 
         // then
@@ -397,6 +409,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           organizationTagRepository,
           organizationInvitationRepository,
           dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
         });
 
         // then
@@ -472,6 +486,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         organizationTagRepository,
         organizationInvitationRepository,
         dataProtectionOfficerRepository,
+        organizationValidator,
+        organizationInvitationService,
       });
 
       // then
@@ -548,6 +564,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         organizationTagRepository,
         organizationInvitationRepository,
         dataProtectionOfficerRepository,
+        organizationValidator,
+        organizationInvitationService,
       });
 
       // then
@@ -644,6 +662,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         organizationTagRepository,
         organizationInvitationRepository,
         dataProtectionOfficerRepository,
+        organizationValidator,
+        organizationInvitationService,
       });
 
       // then
@@ -720,6 +740,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         organizationTagRepository,
         organizationInvitationRepository,
         dataProtectionOfficerRepository,
+        organizationValidator,
+        organizationInvitationService,
       });
 
       // then
@@ -804,6 +826,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         organizationTagRepository,
         organizationInvitationRepository,
         dataProtectionOfficerRepository,
+        organizationValidator,
+        organizationInvitationService,
       });
 
       // then

--- a/api/tests/integration/domain/usecases/update-campaign-details-management_test.js
+++ b/api/tests/integration/domain/usecases/update-campaign-details-management_test.js
@@ -1,6 +1,7 @@
 const { expect, databaseBuilder, mockLearningContent, knex, catchErr } = require('../../../test-helper');
 
 const campaignManagementRepository = require('../../../../lib/infrastructure/repositories/campaign-management-repository');
+const campaignValidator = require('../../../../lib/domain/validators/campaign-validator.js');
 const updateCampaignDetailsManagement = require('../../../../lib/domain/usecases/update-campaign-details-management');
 const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
@@ -46,7 +47,12 @@ describe('Integration | UseCases | update-campaign-details-management', function
     };
     const expectedCampaign = { ...campaign, ...campaignAttributes };
 
-    await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });
+    await updateCampaignDetailsManagement({
+      campaignId,
+      ...campaignAttributes,
+      campaignManagementRepository,
+      campaignValidator,
+    });
 
     const actualCampaign = await knex.select('*').from('campaigns').first();
     expect(actualCampaign).to.deep.equal(expectedCampaign);
@@ -80,6 +86,7 @@ describe('Integration | UseCases | update-campaign-details-management', function
       campaignId,
       ...campaignAttributes,
       campaignManagementRepository,
+      campaignValidator,
     });
 
     //then
@@ -118,7 +125,12 @@ describe('Integration | UseCases | update-campaign-details-management', function
       multipleSendings: false,
     };
 
-    await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });
+    await updateCampaignDetailsManagement({
+      campaignId,
+      ...campaignAttributes,
+      campaignManagementRepository,
+      campaignValidator,
+    });
 
     //then
     const { name: actualName } = await knex.select('name').from('campaigns').where({ id: campaignId }).first();
@@ -140,7 +152,12 @@ describe('Integration | UseCases | update-campaign-details-management', function
     const expectedCampaign = { ...campaign, ...campaignAttributes };
 
     //when
-    await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });
+    await updateCampaignDetailsManagement({
+      campaignId,
+      ...campaignAttributes,
+      campaignManagementRepository,
+      campaignValidator,
+    });
 
     //then
     const { multipleSendings: actualMultipleSendings } = await knex

--- a/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
@@ -1,10 +1,11 @@
 const { expect, sinon } = require('../../../test-helper');
 const acceptPixCertifTermsOfService = require('../../../../lib/domain/usecases/accept-pix-certif-terms-of-service');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | UseCase | accept-pix-certif-terms-of-service', function () {
+  let userRepository;
+
   beforeEach(function () {
-    sinon.stub(userRepository, 'updatePixCertifTermsOfServiceAcceptedToTrue');
+    userRepository = { updatePixCertifTermsOfServiceAcceptedToTrue: sinon.stub() };
   });
 
   it('should accept terms of service of pix-certif', async function () {

--- a/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
@@ -1,10 +1,10 @@
 const { expect, sinon } = require('../../../test-helper');
 const acceptPixOrgaTermsOfService = require('../../../../lib/domain/usecases/accept-pix-orga-terms-of-service');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | UseCase | accept-pix-orga-terms-of-service', function () {
+  let userRepository;
   beforeEach(function () {
-    sinon.stub(userRepository, 'updatePixOrgaTermsOfServiceAcceptedToTrue');
+    userRepository = { updatePixOrgaTermsOfServiceAcceptedToTrue: sinon.stub() };
   });
 
   it('should accept terms of service of pix-orga', async function () {

--- a/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
@@ -1,10 +1,11 @@
 const { expect, sinon } = require('../../../test-helper');
 const acceptPixLastTermsOfService = require('../../../../lib/domain/usecases/accept-pix-last-terms-of-service');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | UseCase | accept-pix-last-terms-of-service', function () {
+  let userRepository;
+
   beforeEach(function () {
-    sinon.stub(userRepository, 'acceptPixLastTermsOfService');
+    userRepository = { acceptPixLastTermsOfService: sinon.stub() };
   });
 
   it('should accept terms of service of pix', async function () {

--- a/api/tests/unit/domain/usecases/change-user-lang_test.js
+++ b/api/tests/unit/domain/usecases/change-user-lang_test.js
@@ -1,11 +1,13 @@
 const { expect, sinon } = require('../../../test-helper');
 const changeUserLang = require('../../../../lib/domain/usecases/change-user-lang');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | UseCase | change-user-lang', function () {
+  let userRepository;
   beforeEach(function () {
-    sinon.stub(userRepository, 'update').resolves();
-    sinon.stub(userRepository, 'getFullById');
+    userRepository = {
+      update: sinon.stub(),
+      getFullById: sinon.stub(),
+    };
   });
 
   it('should modify user attributes to change lang', async function () {
@@ -13,6 +15,7 @@ describe('Unit | UseCase | change-user-lang', function () {
     const userId = Symbol('userId');
     const updatedUser = Symbol('updateduser');
     const lang = 'jp';
+    userRepository.update.resolves();
     userRepository.getFullById.resolves(updatedUser);
 
     // when

--- a/api/tests/unit/domain/usecases/create-or-update-user-orga-settings_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-user-orga-settings_test.js
@@ -1,16 +1,16 @@
 const createOrUpdateUserOrgaSettings = require('../../../../lib/domain/usecases/create-or-update-user-orga-settings');
 const { expect, catchErr, sinon } = require('../../../test-helper');
 const { UserNotMemberOfOrganizationError } = require('../../../../lib/domain/errors');
-const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
 const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 
 describe('Unit | UseCase | create-or-update-user-orga-settings', function () {
   const userId = 1;
   const organizationId = 3;
+  let userOrgaSettingsRepository;
 
   beforeEach(function () {
     membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
-    sinon.stub(userOrgaSettingsRepository, 'createOrUpdate');
+    userOrgaSettingsRepository = { createOrUpdate: sinon.stub() };
   });
 
   it('should create or update the user orga settings if user is a member of the organization', async function () {
@@ -18,7 +18,12 @@ describe('Unit | UseCase | create-or-update-user-orga-settings', function () {
     membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([{}]);
 
     // when
-    await createOrUpdateUserOrgaSettings({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
+    await createOrUpdateUserOrgaSettings({
+      userId,
+      organizationId,
+      userOrgaSettingsRepository,
+      membershipRepository,
+    });
 
     // then
     expect(userOrgaSettingsRepository.createOrUpdate).to.have.been.calledWithExactly({ userId, organizationId });

--- a/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
@@ -1,6 +1,5 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 
-const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
 const Membership = require('../../../../lib/domain/models/Membership');
 
 const createOrganizationInvitationByAdmin = require('../../../../lib/domain/usecases/create-organization-invitation-by-admin');
@@ -17,7 +16,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
 
       const organizationInvitationRepository = sinon.stub();
       const organizationRepository = { get: sinon.stub().resolves(organization) };
-      sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
+      const organizationInvitationService = { createOrUpdateOrganizationInvitation: sinon.stub() };
 
       // when
       await createOrganizationInvitationByAdmin({
@@ -27,6 +26,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
         role,
         organizationRepository,
         organizationInvitationRepository,
+        organizationInvitationService,
       });
 
       // then
@@ -52,7 +52,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
       const organizationRepository = {
         get: sinon.stub().resolves(archivedOrganization),
       };
-      sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
+      const organizationInvitationService = { createOrUpdateOrganizationInvitation: sinon.stub() };
 
       // when
       const error = await catchErr(createOrganizationInvitationByAdmin)({
@@ -62,6 +62,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
         role,
         organizationRepository,
         organizationInvitationRepository,
+        organizationInvitationService,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/create-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitations_test.js
@@ -1,19 +1,22 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 
-const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
-
 const createOrganizationInvitations = require('../../../../lib/domain/usecases/create-organization-invitations');
 const { OrganizationArchivedError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-organization-invitations', function () {
-  let organizationInvitationRepository, organizationRepository;
+  let organizationInvitationRepository, organizationRepository, organizationInvitationService;
 
   beforeEach(function () {
     const organization = domainBuilder.buildOrganization();
     organizationRepository = {
-      get: sinon.stub().resolves(organization),
+      get: sinon.stub(),
     };
-    sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
+    organizationRepository.get.resolves(organization);
+
+    organizationInvitationService = {
+      createOrUpdateOrganizationInvitation: sinon.stub(),
+    };
+    organizationInvitationService.createOrUpdateOrganizationInvitation.resolves();
   });
 
   describe('#createOrganizationInvitations', function () {
@@ -30,6 +33,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
         locale,
         organizationRepository,
         organizationInvitationRepository,
+        organizationInvitationService,
       });
 
       // then
@@ -54,6 +58,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
         emails,
         organizationRepository,
         organizationInvitationRepository,
+        organizationInvitationService,
       });
 
       // then
@@ -72,6 +77,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
         emails,
         organizationRepository,
         organizationInvitationRepository,
+        organizationInvitationService,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -1,12 +1,12 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
-const { createOrganization } = require('../../../../lib/domain/usecases/index.js');
+const createOrganization = require('../../../../lib/domain/usecases/create-organization.js');
 const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
-const organizationCreationValidator = require('../../../../lib/domain/validators/organization-creation-validator');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-organization', function () {
+  let organizationCreationValidator;
   beforeEach(function () {
-    sinon.stub(organizationCreationValidator, 'validate');
+    organizationCreationValidator = { validate: sinon.stub() };
   });
 
   it('validates organization properties and saves it', async function () {
@@ -30,6 +30,7 @@ describe('Unit | UseCase | create-organization', function () {
       dataProtectionOfficerRepository,
       organization,
       organizationForAdminRepository,
+      organizationCreationValidator,
     });
 
     // then
@@ -56,7 +57,11 @@ describe('Unit | UseCase | create-organization', function () {
         organizationCreationValidator.validate.throws(new EntityValidationError({}));
 
         // when
-        const error = await catchErr(createOrganization)({ organization, organizationRepository });
+        const error = await catchErr(createOrganization)({
+          organization,
+          organizationRepository,
+          organizationCreationValidator,
+        });
 
         // then
         expect(error).to.be.an.instanceOf(EntityValidationError);

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -4,9 +4,6 @@ const Organization = require('../../../../lib/domain/models/Organization');
 const OrganizationTag = require('../../../../lib/domain/models/OrganizationTag');
 const domainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const createOrganizationsWithTagsAndTargetProfiles = require('../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles');
-const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
-
-const organizationValidator = require('../../../../lib/domain/validators/organization-with-tags-and-target-profiles-script');
 
 const {
   ManyOrganizationsFoundError,
@@ -21,6 +18,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
   let organizationInvitationRepositoryStub;
   let targetProfileShareRepository;
   let dataProtectionOfficerRepository;
+  let organizationInvitationService;
+  let organizationValidator;
 
   const allTags = [
     { id: 1, name: 'TAG1' },
@@ -48,13 +47,18 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     dataProtectionOfficerRepository = {
       batchAddDataProtectionOfficerToOrganization: sinon.stub(),
     };
+    organizationInvitationService = {
+      createProOrganizationInvitation: sinon.stub(),
+    };
+    organizationValidator = {
+      validate: sinon.stub(),
+    };
 
     domainTransaction.execute = (lambda) => {
       return lambda(Symbol());
     };
 
-    sinon.stub(organizationInvitationService, 'createProOrganizationInvitation').resolves();
-    sinon.stub(organizationValidator, 'validate');
+    organizationInvitationService.createProOrganizationInvitation.resolves();
   });
 
   it('should throw an ObjectValidationError if organizations are undefined', async function () {
@@ -106,6 +110,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       targetProfileShareRepository,
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -150,6 +156,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       tagRepository: tagRepositoryStub,
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -204,6 +212,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       targetProfileShareRepository,
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -258,6 +268,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       targetProfileShareRepository,
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -303,6 +315,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       targetProfileShareRepository,
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -355,6 +369,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       targetProfileShareRepository,
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -406,6 +422,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
       organizationInvitationRepository: organizationInvitationRepositoryStub,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -458,6 +476,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       organizationTagRepository: organizationTagRepositoryStub,
       dataProtectionOfficerRepository,
       organizationInvitationRepository: organizationInvitationRepositoryStub,
+      organizationValidator,
+      organizationInvitationService,
     });
 
     // then
@@ -481,6 +501,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         organizations,
         organizationRepository: organizationRepositoryStub,
+        organizationValidator,
+        organizationInvitationService,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -2,9 +2,6 @@ const { catchErr, expect, sinon } = require('../../../test-helper');
 
 const { AlreadyRegisteredEmailError, EntityValidationError } = require('../../../../lib/domain/errors');
 
-const passwordValidator = require('../../../../lib/domain/validators/password-validator');
-const userValidator = require('../../../../lib/domain/validators/user-validator');
-
 const User = require('../../../../lib/domain/models/User');
 
 const createUser = require('../../../../lib/domain/usecases/create-user');
@@ -26,6 +23,8 @@ describe('Unit | UseCase | create-user', function () {
   let encryptionService;
   let mailService;
   let userService;
+  let passwordValidator;
+  let userValidator;
 
   beforeEach(function () {
     authenticationMethodRepository = {};
@@ -48,9 +47,12 @@ describe('Unit | UseCase | create-user', function () {
     userService = {
       createUserWithPassword: sinon.stub(),
     };
-
-    sinon.stub(userValidator, 'validate');
-    sinon.stub(passwordValidator, 'validate');
+    passwordValidator = {
+      validate: sinon.stub(),
+    };
+    userValidator = {
+      validate: sinon.stub(),
+    };
 
     userRepository.checkIfEmailIsAvailable.resolves();
     userToCreateRepository.create.resolves(savedUser);
@@ -83,6 +85,8 @@ describe('Unit | UseCase | create-user', function () {
         encryptionService,
         mailService,
         userService,
+        userValidator,
+        passwordValidator,
       });
 
       // then
@@ -103,6 +107,8 @@ describe('Unit | UseCase | create-user', function () {
         encryptionService,
         mailService,
         userService,
+        userValidator,
+        passwordValidator,
       });
 
       //then
@@ -123,6 +129,8 @@ describe('Unit | UseCase | create-user', function () {
         encryptionService,
         mailService,
         userService,
+        userValidator,
+        passwordValidator,
       });
 
       // then
@@ -157,6 +165,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -196,6 +206,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -237,6 +249,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -266,6 +280,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -294,6 +310,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -319,6 +337,8 @@ describe('Unit | UseCase | create-user', function () {
         encryptionService,
         mailService,
         userService,
+        userValidator,
+        passwordValidator,
       });
 
       // then
@@ -342,6 +362,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -385,6 +407,9 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -418,6 +443,8 @@ describe('Unit | UseCase | create-user', function () {
           encryptionService,
           mailService,
           userService,
+          userValidator,
+          passwordValidator,
         });
 
         // then
@@ -448,6 +475,8 @@ describe('Unit | UseCase | create-user', function () {
             encryptionService,
             mailService,
             userService,
+            userValidator,
+            passwordValidator,
           });
 
           // then
@@ -480,6 +509,8 @@ describe('Unit | UseCase | create-user', function () {
             encryptionService,
             mailService,
             userService,
+            userValidator,
+            passwordValidator,
           });
 
           // then
@@ -506,6 +537,8 @@ describe('Unit | UseCase | create-user', function () {
         encryptionService,
         mailService,
         userService,
+        userValidator,
+        passwordValidator,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/disable-certification-center-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-certification-center-membership_test.js
@@ -1,12 +1,17 @@
 const { expect, sinon } = require('../../../test-helper');
-const { disableCertificationCenterMembership } = require('../../../../lib/domain/usecases/index.js');
-const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
+const disableCertificationCenterMembership = require('../../../../lib/domain/usecases/disable-certification-center-membership.js');
 
 describe('Unit | UseCase | disable-certification-center-membership', function () {
+  let certificationCenterMembershipRepository;
+  beforeEach(function () {
+    certificationCenterMembershipRepository = {
+      disableById: sinon.stub(),
+    };
+  });
+
   it('should disable certification center membership', async function () {
     // given
     const certificationCenterMembershipId = 100;
-    sinon.stub(certificationCenterMembershipRepository, 'disableById');
 
     // when
     await disableCertificationCenterMembership({

--- a/api/tests/unit/domain/usecases/disable-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-membership_test.js
@@ -1,11 +1,11 @@
 const { catchErr, expect, sinon } = require('../../../test-helper');
-const { disableMembership } = require('../../../../lib/domain/usecases/index.js');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+const disableMembership = require('../../../../lib/domain/usecases/disable-membership.js');
 const { MembershipUpdateError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | disable-membership', function () {
+  let membershipRepository;
   beforeEach(function () {
-    sinon.stub(membershipRepository, 'updateById');
+    membershipRepository = { updateById: sinon.stub() };
   });
 
   it('should disable membership', async function () {

--- a/api/tests/unit/domain/usecases/find-association-between-user-and-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/find-association-between-user-and-organization-learner_test.js
@@ -1,13 +1,11 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
-const usecases = require('../../../../lib/domain/usecases/index.js');
+const findAssociationBetweenUserAndOrganizationLearner = require('../../../../lib/domain/usecases/find-association-between-user-and-organization-learner.js');
 const OrganizationLearner = require('../../../../lib/domain/models/OrganizationLearner');
 const {
   CampaignCodeError,
   UserNotAuthorizedToAccessEntityError,
   OrganizationLearnerDisabledError,
 } = require('../../../../lib/domain/errors');
-const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
-const organizationLearnerRepository = require('../../../../lib/infrastructure/repositories/organization-learner-repository');
 
 describe('Unit | UseCase | find-association-between-user-and-organization-learner', function () {
   let organizationLearnerReceivedStub;
@@ -16,16 +14,19 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
   let organization;
   let userId;
   let campaign;
+  let campaignRepository;
+  let organizationLearnerRepository;
 
   beforeEach(function () {
     userId = domainBuilder.buildUser().id;
     organization = domainBuilder.buildOrganization();
     campaign = domainBuilder.buildCampaign({ organization });
     organizationLearner = domainBuilder.buildOrganizationLearner({ organization, userId });
-    getCampaignStub = sinon.stub(campaignRepository, 'getByCode').throws('unexpected call');
-    organizationLearnerReceivedStub = sinon
-      .stub(organizationLearnerRepository, 'findOneByUserIdAndOrganizationId')
-      .throws('unexpected call');
+    campaignRepository = { getByCode: sinon.stub() };
+    getCampaignStub = campaignRepository.getByCode.throws('unexpected call');
+    organizationLearnerRepository = { findOneByUserIdAndOrganizationId: sinon.stub() };
+    organizationLearnerReceivedStub =
+      organizationLearnerRepository.findOneByUserIdAndOrganizationId.throws('unexpected call');
   });
 
   describe('There is an organizationLearner linked to the given userId', function () {
@@ -35,10 +36,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
       organizationLearnerReceivedStub.resolves({});
 
       // when
-      await usecases.findAssociationBetweenUserAndOrganizationLearner({
+      await findAssociationBetweenUserAndOrganizationLearner({
         authenticatedUserId: userId,
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -53,10 +56,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
         .resolves(organizationLearner);
 
       // when
-      const result = await usecases.findAssociationBetweenUserAndOrganizationLearner({
+      const result = await findAssociationBetweenUserAndOrganizationLearner({
         authenticatedUserId: userId,
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -72,10 +77,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
       organizationLearnerReceivedStub.withArgs({ userId, organizationId: organization.id }).resolves(null);
 
       // when
-      const result = await usecases.findAssociationBetweenUserAndOrganizationLearner({
+      const result = await findAssociationBetweenUserAndOrganizationLearner({
         authenticatedUserId: userId,
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -91,10 +98,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
       organizationLearnerReceivedStub.withArgs({ userId, organizationId: otherCampaign.organizationId }).resolves(null);
 
       // when
-      const result = await usecases.findAssociationBetweenUserAndOrganizationLearner({
+      const result = await findAssociationBetweenUserAndOrganizationLearner({
         authenticatedUserId: userId,
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -116,10 +125,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
         .resolves(disabledOrganizationLearner);
 
       // when
-      const result = await catchErr(usecases.findAssociationBetweenUserAndOrganizationLearner)({
+      const result = await catchErr(findAssociationBetweenUserAndOrganizationLearner)({
         authenticatedUserId: userId,
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -134,10 +145,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
       organizationLearnerReceivedStub.withArgs({ userId, organizationId: organization.id }).resolves(null);
 
       // when
-      const result = await catchErr(usecases.findAssociationBetweenUserAndOrganizationLearner)({
+      const result = await catchErr(findAssociationBetweenUserAndOrganizationLearner)({
         authenticatedUserId: '999',
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -151,10 +164,12 @@ describe('Unit | UseCase | find-association-between-user-and-organization-learne
       getCampaignStub.withArgs(campaign.code).resolves(null);
 
       // when
-      const result = await catchErr(usecases.findAssociationBetweenUserAndOrganizationLearner)({
+      const result = await catchErr(findAssociationBetweenUserAndOrganizationLearner)({
         authenticatedUserId: userId,
         requestedUserId: userId,
         campaignCode: campaign.code,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -1,9 +1,5 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const getAssessment = require('../../../../lib/domain/usecases/get-assessment');
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
-const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
-const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
-const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
 
@@ -13,6 +9,11 @@ describe('Unit | UseCase | get-assessment', function () {
   let campaignParticipation;
   let competence;
   let course;
+  let assessmentRepository;
+  let campaignRepository;
+  let competenceRepository;
+  let courseRepository;
+
   const certificationCourseId = 1;
 
   const expectedCampaignTitle = 'Campagne Il';
@@ -36,11 +37,13 @@ describe('Unit | UseCase | get-assessment', function () {
       certificationCourseId,
     });
 
-    sinon.stub(assessmentRepository, 'getWithAnswers');
-    sinon.stub(campaignRepository, 'getCampaignTitleByCampaignParticipationId');
-    sinon.stub(campaignRepository, 'getCampaignCodeByCampaignParticipationId');
-    sinon.stub(competenceRepository, 'getCompetenceName');
-    sinon.stub(courseRepository, 'getCourseName');
+    assessmentRepository = { getWithAnswers: sinon.stub() };
+    campaignRepository = {
+      getCampaignTitleByCampaignParticipationId: sinon.stub(),
+      getCampaignCodeByCampaignParticipationId: sinon.stub(),
+    };
+    competenceRepository = { getCompetenceName: sinon.stub() };
+    courseRepository = { getCourseName: sinon.stub() };
   });
 
   it('should resolve the Assessment domain object matching the given assessment ID', async function () {
@@ -48,7 +51,13 @@ describe('Unit | UseCase | get-assessment', function () {
     assessmentRepository.getWithAnswers.resolves(assessment);
 
     // when
-    const result = await getAssessment({ assessmentRepository, assessmentId: assessment.id });
+    const result = await getAssessment({
+      assessmentId: assessment.id,
+      assessmentRepository,
+      campaignRepository,
+      competenceRepository,
+      courseRepository,
+    });
 
     // then
     expect(result).to.be.an.instanceOf(Assessment);
@@ -67,7 +76,9 @@ describe('Unit | UseCase | get-assessment', function () {
       assessmentId: assessment.id,
       locale,
       assessmentRepository,
+      campaignRepository,
       competenceRepository,
+      courseRepository,
     });
 
     // then
@@ -85,6 +96,8 @@ describe('Unit | UseCase | get-assessment', function () {
     const result = await getAssessment({
       assessmentId: assessment.id,
       assessmentRepository,
+      campaignRepository,
+      competenceRepository,
       courseRepository,
     });
 
@@ -104,6 +117,8 @@ describe('Unit | UseCase | get-assessment', function () {
     const result = await getAssessment({
       assessmentId: assessment.id,
       assessmentRepository,
+      campaignRepository,
+      competenceRepository,
       courseRepository,
     });
 
@@ -129,6 +144,8 @@ describe('Unit | UseCase | get-assessment', function () {
       assessmentId: assessment.id,
       assessmentRepository,
       campaignRepository,
+      competenceRepository,
+      courseRepository,
     });
 
     // then
@@ -148,7 +165,9 @@ describe('Unit | UseCase | get-assessment', function () {
     const result = await getAssessment({
       assessmentId: assessment.id,
       assessmentRepository,
+      campaignRepository,
       competenceRepository,
+      courseRepository,
     });
 
     // then
@@ -169,6 +188,8 @@ describe('Unit | UseCase | get-assessment', function () {
       assessmentId: assessment.id,
       assessmentRepository,
       campaignRepository,
+      competenceRepository,
+      courseRepository,
     });
 
     // then

--- a/api/tests/unit/domain/usecases/get-campaign-assessment-participation_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-assessment-participation_test.js
@@ -2,15 +2,17 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 const getCampaignAssessmentParticipation = require('../../../../lib/domain/usecases/get-campaign-assessment-participation');
 const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const CampaignAssessmentParticipation = require('../../../../lib/domain/read-models/CampaignAssessmentParticipation');
-const stageCollectionRepository = require('../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository');
 
 describe('Unit | UseCase | get-campaign-assessment-participation', function () {
-  let campaignRepository, campaignAssessmentParticipationRepository, badgeAcquisitionRepository;
+  let campaignRepository;
+  let campaignAssessmentParticipationRepository;
+  let badgeAcquisitionRepository;
+  let stageCollectionRepository;
   let userId, campaignId, campaignParticipationId;
 
   beforeEach(function () {
-    const findStageCollectionStub = sinon.stub(stageCollectionRepository, 'findStageCollection');
-    findStageCollectionStub.resolves(
+    stageCollectionRepository = { findStageCollection: sinon.stub() };
+    stageCollectionRepository.findStageCollection.resolves(
       domainBuilder.buildStageCollectionForUserCampaignResults({
         campaignId: 1,
         stages: [],
@@ -55,6 +57,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation', function () {
         campaignRepository,
         campaignAssessmentParticipationRepository,
         badgeAcquisitionRepository,
+        stageCollectionRepository,
       });
 
       // then
@@ -80,6 +83,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation', function () {
         campaignRepository,
         campaignAssessmentParticipationRepository,
         badgeAcquisitionRepository,
+        stageCollectionRepository,
       });
 
       // then
@@ -105,6 +109,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation', function () {
         campaignRepository,
         campaignAssessmentParticipationRepository,
         badgeAcquisitionRepository,
+        stageCollectionRepository,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/get-challenge-for-pix-auto-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-challenge-for-pix-auto-answer_test.js
@@ -1,10 +1,10 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const getChallengeForPixAutoAnswer = require('../../../../lib/domain/usecases/get-challenge-for-pix-auto-answer');
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
-const challengeForPixAutoAnswerRepository = require('../../../../lib/infrastructure/repositories/challenge-for-pix-auto-answer-repository');
 
 describe('Unit | UseCase | get-challenge-answer-for-pix-button', function () {
   let assessment;
+  let assessmentRepository;
+  let challengeForPixAutoAnswerRepository;
   const challengeId = 1;
   const challenge = {
     id: challengeId,
@@ -19,8 +19,8 @@ describe('Unit | UseCase | get-challenge-answer-for-pix-button', function () {
       lastChallengeId,
     });
 
-    sinon.stub(assessmentRepository, 'get');
-    sinon.stub(challengeForPixAutoAnswerRepository, 'get');
+    assessmentRepository = { get: sinon.stub() };
+    challengeForPixAutoAnswerRepository = { get: sinon.stub() };
   });
 
   it('should return the solution of the last challenge from the given assessment', async function () {

--- a/api/tests/unit/domain/usecases/get-last-challenge-id-from-assessment-id_test.js
+++ b/api/tests/unit/domain/usecases/get-last-challenge-id-from-assessment-id_test.js
@@ -1,11 +1,11 @@
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 
 const getLastChallengeIdFromAssessmentId = require('../../../../lib/domain/usecases/get-last-challenge-id-from-assessment-id');
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-last-challenge-id-from-assessment-id', function () {
   let assessment;
+  let assessmentRepository;
   const assessmentLastChallengeId = 'last-challenge-id';
 
   beforeEach(async function () {
@@ -13,7 +13,7 @@ describe('Unit | UseCase | get-last-challenge-id-from-assessment-id', function (
       lastChallengeId: assessmentLastChallengeId,
     });
 
-    sinon.stub(assessmentRepository, 'get');
+    assessmentRepository = { get: sinon.stub() };
   });
 
   it('should resolve the Assessment domain object matching the given assessment ID', async function () {

--- a/api/tests/unit/domain/usecases/get-session-certification-candidates_test.js
+++ b/api/tests/unit/domain/usecases/get-session-certification-candidates_test.js
@@ -1,17 +1,15 @@
 const { expect, sinon } = require('../../../test-helper');
-const certificationCandidateRepository = require('../../../../lib/infrastructure/repositories/certification-candidate-repository');
 const getSessionCertificationCandidates = require('../../../../lib/domain/usecases/get-session-certification-candidates');
 
 describe('Unit | Domain | Use Cases | get-session-certification-candidates', function () {
   const sessionId = 'sessionId';
   const certificationCandidates = 'candidates';
+  let certificationCandidateRepository;
 
   beforeEach(function () {
     // given
-    sinon
-      .stub(certificationCandidateRepository, 'findBySessionId')
-      .withArgs(sessionId)
-      .resolves(certificationCandidates);
+    certificationCandidateRepository = { findBySessionId: sinon.stub() };
+    certificationCandidateRepository.findBySessionId.withArgs(sessionId).resolves(certificationCandidates);
   });
 
   it('should return the certification candidates', async function () {

--- a/api/tests/unit/domain/usecases/get-session-certification-reports_test.js
+++ b/api/tests/unit/domain/usecases/get-session-certification-reports_test.js
@@ -1,5 +1,4 @@
 const { expect, sinon } = require('../../../test-helper');
-const certificationReportRepository = require('../../../../lib/infrastructure/repositories/certification-report-repository');
 const getSessionCertificationReports = require('../../../../lib/domain/usecases/get-session-certification-reports');
 
 describe('Unit | Domain | Use Cases | get-session-certification-reports', function () {
@@ -7,7 +6,8 @@ describe('Unit | Domain | Use Cases | get-session-certification-reports', funct
     // given
     const sessionId = 'sessionId';
     const certificationReports = Symbol('some certification candidates');
-    sinon.stub(certificationReportRepository, 'findBySessionId').withArgs(sessionId).resolves(certificationReports);
+    const certificationReportRepository = { findBySessionId: sinon.stub() };
+    certificationReportRepository.findBySessionId.withArgs(sessionId).resolves(certificationReports);
 
     // when
     const actualCandidates = await getSessionCertificationReports({ sessionId, certificationReportRepository });

--- a/api/tests/unit/domain/usecases/get-target-profile-content-as-json_test.js
+++ b/api/tests/unit/domain/usecases/get-target-profile-content-as-json_test.js
@@ -1,11 +1,15 @@
 const { expect, sinon, catchErr, domainBuilder, MockDate } = require('../../../test-helper');
 const { ForbiddenAccess } = require('../../../../lib/domain/errors');
-const learningContentConversionService = require('../../../../lib/domain/services/learning-content/learning-content-conversion-service');
 const getTargetProfileContentAsJson = require('../../../../lib/domain/usecases/get-target-profile-content-as-json');
 
 describe('Unit | UseCase | get-target-profile-content-as-json', function () {
   let targetProfileForAdminRepository;
   let adminMemberRepository;
+  let learningContentConversionService;
+
+  beforeEach(function () {
+    learningContentConversionService = { findActiveSkillsForCappedTubes: sinon.stub() };
+  });
 
   afterEach(function () {
     MockDate.reset();
@@ -15,7 +19,6 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
     beforeEach(function () {
       targetProfileForAdminRepository = { get: sinon.stub() };
       targetProfileForAdminRepository.get.rejects(new Error('I should not be called'));
-      sinon.stub(learningContentConversionService, 'findActiveSkillsForCappedTubes');
       learningContentConversionService.findActiveSkillsForCappedTubes.rejects(new Error('I should not be called'));
     });
 
@@ -30,6 +33,7 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
         targetProfileId: 123,
         adminMemberRepository,
         targetProfileForAdminRepository,
+        learningContentConversionService,
       });
 
       // then
@@ -75,7 +79,6 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
         domainBuilder.buildSkill({ id: 'skill2Tube2', tubeId: 'recTube2' }),
       ];
       const skillsForTube3 = [];
-      sinon.stub(learningContentConversionService, 'findActiveSkillsForCappedTubes');
       learningContentConversionService.findActiveSkillsForCappedTubes
         .withArgs([
           {
@@ -106,6 +109,7 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
           targetProfileId: 123,
           adminMemberRepository,
           targetProfileForAdminRepository,
+          learningContentConversionService,
         });
 
         // then
@@ -128,6 +132,7 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
           targetProfileId: 123,
           adminMemberRepository,
           targetProfileForAdminRepository,
+          learningContentConversionService,
         });
 
         // then
@@ -150,6 +155,7 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
           targetProfileId: 123,
           adminMemberRepository,
           targetProfileForAdminRepository,
+          learningContentConversionService,
         });
 
         // then

--- a/api/tests/unit/domain/usecases/handle-training-recommendation_test.js
+++ b/api/tests/unit/domain/usecases/handle-training-recommendation_test.js
@@ -1,19 +1,19 @@
 const handleTrainingRecommendation = require('../../../../lib/domain/usecases/handle-training-recommendation');
-const trainingRepository = require('../../../../lib/infrastructure/repositories/training-repository');
-const userRecommendedTrainingRepository = require('../../../../lib/infrastructure/repositories/user-recommended-training-repository');
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const config = require('../../../../lib/config.js');
 
 describe('Unit | UseCase | handle-training-recommendation', function () {
+  let trainingRepository;
+  let userRecommendedTrainingRepository;
   let findWithTriggersByCampaignParticipationIdAndLocaleStub;
   let saveStub;
 
   beforeEach(function () {
-    findWithTriggersByCampaignParticipationIdAndLocaleStub = sinon.stub(
-      trainingRepository,
-      'findWithTriggersByCampaignParticipationIdAndLocale'
-    );
-    saveStub = sinon.stub(userRecommendedTrainingRepository, 'save').resolves();
+    trainingRepository = { findWithTriggersByCampaignParticipationIdAndLocale: sinon.stub() };
+    userRecommendedTrainingRepository = { save: sinon.stub() };
+    findWithTriggersByCampaignParticipationIdAndLocaleStub =
+      trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale;
+    saveStub = userRecommendedTrainingRepository.save.resolves();
   });
 
   describe('when assessment is for campaign', function () {

--- a/api/tests/unit/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-sco-organization-learner-automatically_test.js
@@ -1,8 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
-const usecases = require('../../../../lib/domain/usecases/index.js');
+const reconcileScoOrganizationLearnerAutomatically = require('../../../../lib/domain/usecases/reconcile-sco-organization-learner-automatically.js');
 const OrganizationLearner = require('../../../../lib/domain/models/OrganizationLearner');
-const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
-const organizationLearnerRepository = require('../../../../lib/infrastructure/repositories/organization-learner-repository');
 const { CampaignCodeError, UserCouldNotBeReconciledError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', function () {
@@ -12,6 +10,8 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
   let getCampaignStub;
   let organizationLearner;
   let userId;
+  let campaignRepository;
+  let organizationLearnerRepository;
   const organizationId = 1;
   const organizationLearnerId = 1;
   const nationalStudentId = '123456789AZ';
@@ -25,16 +25,18 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
       nationalStudentId,
     });
 
-    getCampaignStub = sinon
-      .stub(campaignRepository, 'getByCode')
+    campaignRepository = { getByCode: sinon.stub() };
+    getCampaignStub = campaignRepository.getByCode
       .withArgs(campaignCode)
       .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
 
-    reconcileUserByNationalStudentIdAndOrganizationIdStub = sinon.stub(
-      organizationLearnerRepository,
-      'reconcileUserByNationalStudentIdAndOrganizationId'
-    );
-    findByUserIdStub = sinon.stub(organizationLearnerRepository, 'findByUserId');
+    organizationLearnerRepository = {
+      reconcileUserByNationalStudentIdAndOrganizationId: sinon.stub(),
+      findByUserId: sinon.stub(),
+    };
+    reconcileUserByNationalStudentIdAndOrganizationIdStub =
+      organizationLearnerRepository.reconcileUserByNationalStudentIdAndOrganizationId;
+    findByUserIdStub = organizationLearnerRepository.findByUserId;
   });
 
   context('When there is no campaign with the given code', function () {
@@ -43,9 +45,11 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
       getCampaignStub.withArgs(campaignCode).resolves(null);
 
       // when
-      const result = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+      const result = await catchErr(reconcileScoOrganizationLearnerAutomatically)({
         userId,
         campaignCode,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -59,9 +63,11 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
       findByUserIdStub.resolves([]);
 
       // when
-      const result = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+      const result = await catchErr(reconcileScoOrganizationLearnerAutomatically)({
         userId,
         campaignCode,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -77,9 +83,11 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
       reconcileUserByNationalStudentIdAndOrganizationIdStub.throws(new UserCouldNotBeReconciledError());
 
       // when
-      const result = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+      const result = await catchErr(reconcileScoOrganizationLearnerAutomatically)({
         userId,
         campaignCode,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -95,9 +103,11 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
       reconcileUserByNationalStudentIdAndOrganizationIdStub.throws(new UserCouldNotBeReconciledError());
 
       // when
-      const result = await catchErr(usecases.reconcileScoOrganizationLearnerAutomatically)({
+      const result = await catchErr(reconcileScoOrganizationLearnerAutomatically)({
         userId,
         campaignCode,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then
@@ -131,9 +141,11 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-automatically', fu
         .resolves(organizationLearner);
 
       // when
-      const result = await usecases.reconcileScoOrganizationLearnerAutomatically({
+      const result = await reconcileScoOrganizationLearnerAutomatically({
         userId,
         campaignCode,
+        campaignRepository,
+        organizationLearnerRepository,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/remember-user-has-seen-assessment-instructions_test.js
+++ b/api/tests/unit/domain/usecases/remember-user-has-seen-assessment-instructions_test.js
@@ -1,10 +1,10 @@
 const { expect, sinon } = require('../../../test-helper');
 const rememberUserHasSeenAssessmentInstructions = require('../../../../lib/domain/usecases/remember-user-has-seen-assessment-instructions');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | UseCase | remember-user-has-seen-assessment-instructions', function () {
+  let userRepository;
   beforeEach(function () {
-    sinon.stub(userRepository, 'updateHasSeenAssessmentInstructionsToTrue');
+    userRepository = { updateHasSeenAssessmentInstructionsToTrue: sinon.stub() };
   });
 
   it('should update has seen assessment instructions', async function () {

--- a/api/tests/unit/domain/usecases/resend-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/resend-organization-invitation_test.js
@@ -1,6 +1,5 @@
 const { expect, sinon } = require('../../../test-helper');
 
-const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
 const resendOrganizationInvitation = require('../../../../lib/domain/usecases/resend-organization-invitation');
 
 describe('Unit | UseCase | resend-organization-invitation', function () {
@@ -13,7 +12,7 @@ describe('Unit | UseCase | resend-organization-invitation', function () {
 
       const organizationRepository = Symbol('organization repository');
       const organizationInvitationRepository = Symbol('organization invitation repository');
-      sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
+      const organizationInvitationService = { createOrUpdateOrganizationInvitation: sinon.stub() };
 
       // when
       await resendOrganizationInvitation({
@@ -22,6 +21,7 @@ describe('Unit | UseCase | resend-organization-invitation', function () {
         locale,
         organizationRepository,
         organizationInvitationRepository,
+        organizationInvitationService,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/send-sco-invitation_test.js
+++ b/api/tests/unit/domain/usecases/send-sco-invitation_test.js
@@ -1,19 +1,21 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
-const usecases = require('../../../../lib/domain/usecases/index.js');
+const sendScoInvitation = require('../../../../lib/domain/usecases/send-sco-invitation.js');
 const {
   OrganizationNotFoundError,
   OrganizationWithoutEmailError,
   ManyOrganizationsFoundError,
   OrganizationArchivedError,
 } = require('../../../../lib/domain/errors');
-const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
 
 describe('Unit | UseCase | send-sco-invitation', function () {
-  let organizationRepository, organizationInvitationRepository;
+  let organizationRepository, organizationInvitationRepository, organizationInvitationService;
 
   beforeEach(function () {
     organizationRepository = {
       findScoOrganizationsByUai: sinon.stub(),
+    };
+    organizationInvitationService = {
+      createScoOrganizationInvitation: sinon.stub(),
     };
   });
 
@@ -30,16 +32,16 @@ describe('Unit | UseCase | send-sco-invitation', function () {
       email: 'sco.orga@example.net',
     });
 
-    sinon.stub(organizationInvitationService, 'createScoOrganizationInvitation').resolves();
     organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([organization]);
 
-    await usecases.sendScoInvitation({
+    await sendScoInvitation({
       firstName,
       lastName,
       locale,
       uai,
       organizationRepository,
       organizationInvitationRepository,
+      organizationInvitationService,
     });
 
     expect(organizationInvitationService.createScoOrganizationInvitation).to.have.been.calledOnceWithExactly({
@@ -62,7 +64,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
 
         organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([]);
 
-        const requestErr = await catchErr(usecases.sendScoInvitation)({
+        const requestErr = await catchErr(sendScoInvitation)({
           uai,
           organizationRepository,
         });
@@ -80,7 +82,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
 
         organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([organization]);
 
-        const requestErr = await catchErr(usecases.sendScoInvitation)({
+        const requestErr = await catchErr(sendScoInvitation)({
           uai,
           organizationRepository,
         });
@@ -102,7 +104,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
         organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([organization1, organization2]);
 
         // when
-        const requestErr = await catchErr(usecases.sendScoInvitation)({
+        const requestErr = await catchErr(sendScoInvitation)({
           uai,
           organizationRepository,
         });
@@ -128,7 +130,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
         organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([archivedOrganization]);
 
         // when
-        const requestErr = await catchErr(usecases.sendScoInvitation)({
+        const requestErr = await catchErr(sendScoInvitation)({
           uai,
           organizationRepository,
         });

--- a/api/tests/unit/domain/usecases/update-campaign-details-management_test.js
+++ b/api/tests/unit/domain/usecases/update-campaign-details-management_test.js
@@ -1,12 +1,12 @@
 const { expect, catchErr, domainBuilder } = require('../../../test-helper');
 const updateCampaignDetailsManagement = require('../../../../lib/domain/usecases/update-campaign-details-management');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
-const campaignValidator = require('../../../../lib/domain/validators/campaign-validator');
 const sinon = require('sinon');
 
 describe('Unit | UseCase | update-campaign-details-management', function () {
   let campaignManagementRepository;
   let campaign;
+  let campaignValidator;
 
   beforeEach(function () {
     campaign = domainBuilder.buildCampaign();
@@ -16,7 +16,7 @@ describe('Unit | UseCase | update-campaign-details-management', function () {
       get: sinon.stub().resolves(campaign),
     };
 
-    sinon.stub(campaignValidator, 'validate');
+    campaignValidator = { validate: sinon.stub() };
   });
 
   it('should update the campaign', async function () {
@@ -31,7 +31,12 @@ describe('Unit | UseCase | update-campaign-details-management', function () {
       multipleSendings: false,
     };
 
-    await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });
+    await updateCampaignDetailsManagement({
+      campaignId,
+      ...campaignAttributes,
+      campaignManagementRepository,
+      campaignValidator,
+    });
 
     expect(campaignManagementRepository.update).to.have.been.calledOnceWith({ campaignId, campaignAttributes });
   });
@@ -44,6 +49,7 @@ describe('Unit | UseCase | update-campaign-details-management', function () {
       const error = await catchErr(updateCampaignDetailsManagement)({
         campaignId,
         campaignManagementRepository,
+        campaignValidator,
       });
 
       expect(error).to.be.an.instanceOf(EntityValidationError);

--- a/api/tests/unit/domain/usecases/update-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-user-password_test.js
@@ -6,8 +6,6 @@ const {
   UserNotAuthorizedToUpdatePasswordError,
 } = require('../../../../lib/domain/errors');
 
-const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
-
 const updateUserPassword = require('../../../../lib/domain/usecases/update-user-password');
 
 describe('Unit | UseCase | update-user-password', function () {
@@ -38,8 +36,6 @@ describe('Unit | UseCase | update-user-password', function () {
     userRepository = {
       get: sinon.stub(),
     };
-
-    sinon.stub(validationErrorSerializer, 'serialize');
 
     encryptionService.hashPassword.resolves();
     resetPasswordService.hasUserAPasswordResetDemandInProgress.withArgs(user.email, temporaryKey).resolves();


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire.

## :rainbow: Remarques
Certains fichiers n'étaient pas injectés avec notre injecteur de dépendances (`usecases/index.js`), bien faire attention pendant la review qu'ils ont bien été ajouté ! Si un problème fonctionnel appairait suite à cette PR, c'est que notre code n'est pas correctement testé.

## :100: Pour tester
CI OK
