### PR TITLE
[FEATURE] Expliquer l'obtention du palier 1er acquis lors du survol du bouton d'ajout de palier premier acquis (PIX-6517)

### DIFF
--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -69,16 +69,24 @@
         Nouveau palier
       </PixButton>
       {{#if @stageCollection.hasStages}}
-        <PixButton
-          class="stages-new-stage"
-          @backgroundColor="transparent-light"
-          @isBorderVisible={{true}}
-          @triggerAction={{this.addFirstSkillStage}}
-          @isDisabled={{this.isAddFirstSkillStageDisabled}}
-          @iconBefore="plus"
-        >
-          Nouveau palier "1er acquis"
-        </PixButton>
+        <PixTooltip @id="tooltip-stage"
+         @isWide="true">
+          <:triggerElement>
+            <PixButton
+              class="stages-new-stage"
+              @backgroundColor="transparent-light"
+              @isBorderVisible={{true}}
+              @triggerAction={{this.addFirstSkillStage}}
+              @isDisabled={{this.isAddFirstSkillStageDisabled}}
+              @iconBefore="plus"
+            >
+              Nouveau palier "1er acquis"
+            </PixButton>
+          </:triggerElement>
+          <:tooltip>
+            Le palier 1er acquis est obtenu dès un acquis réussi par le participant. Il se verra alors attribuer une étoile à la fin de son parcours.
+          </:tooltip>
+        </PixTooltip>
       {{/if}}
     </div>
     {{#if this.hasNewStage}}

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -69,8 +69,7 @@
         Nouveau palier
       </PixButton>
       {{#if @stageCollection.hasStages}}
-        <PixTooltip @id="tooltip-stage"
-         @isWide="true">
+        <PixTooltip @id="tooltip-stage" @isWide="true">
           <:triggerElement>
             <PixButton
               class="stages-new-stage"
@@ -84,7 +83,8 @@
             </PixButton>
           </:triggerElement>
           <:tooltip>
-            Le palier 1er acquis est obtenu dès un acquis réussi par le participant. Il se verra alors attribuer une étoile à la fin de son parcours.
+            Le palier 1er acquis est obtenu dès un acquis réussi par le participant. Il se verra alors attribuer une
+            étoile à la fin de son parcours.
           </:tooltip>
         </PixTooltip>
       {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
C'est un nouveau type de palier. On pense que c'est bien d'en expliquer le fonctionnement !

## :robot: Proposition
Ajouter une PixTooltip sur le hover du bouton d'ajouter de 1er acquis.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur la page d'ajout de paliers et vérifier que le tootlip apparaît.
