### PR TITLE
[BUGFIX] Corriger la width des form-field info sur la page de création de campagne (PIX-7846)

### DIFF
--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -53,7 +53,7 @@
       position: absolute;
       margin: 0 0 0 $pix-spacing-s;
       left: 100%;
-      width: calc(100vw - 100% - #{$app-sidebar-width} - 32px);
+      width: calc(100vw - 580px - #{$app-sidebar-width} - 32px);
     }
 
     &-icon {


### PR DESCRIPTION
## :unicorn: Problème
Le calcule de la width n'était plus bon et causait un scroll horizontal sur la page de création de campagne

## :robot: Proposition
Corriger le calcul de width
## :rainbow: Remarques
Non
## :100: Pour tester
- Se connecter à PixOrga
- Aller sur la page de création de campagne
- Vérifier si le scroll horizontal est toujours présent
- La review est terminée 🎉 