### PR TITLE
[FEATURE] Upgrade pix-ui version to 32.0.0 (PIX-7843)

### DIFF
--- a/orga/app/components/campaign/cards/participants-count.hbs
+++ b/orga/app/components/campaign/cards/participants-count.hbs
@@ -1,7 +1,7 @@
 <PixIndicatorCard
   @title={{t "cards.participants-count.title"}}
   @icon="users"
-  @color="#3D68FF"
+  @color="blue"
   @info={{t "cards.participants-count.information"}}
   @loadingMessage={{t "cards.participants-count.loader"}}
   @isLoading={{@isLoading}}

--- a/orga/app/components/campaign/cards/result-average.hbs
+++ b/orga/app/components/campaign/cards/result-average.hbs
@@ -1,7 +1,7 @@
 <PixIndicatorCard
   @title={{t "cards.participants-average-results.title"}}
   @icon="crown"
-  @color="#2044DC"
+  @color="blue"
   @info={{t "cards.participants-average-results.information"}}
   @isLoading={{@isLoading}}
   class="indicator-card"

--- a/orga/app/components/campaign/cards/shared-count.hbs
+++ b/orga/app/components/campaign/cards/shared-count.hbs
@@ -1,7 +1,7 @@
 <PixIndicatorCard
   @title={{if @isTypeAssessment (t "cards.submitted-count.title") (t "cards.submitted-count.title-profiles")}}
   @icon="inbox-in"
-  @color="#14865D"
+  @color="green"
   @info={{t "cards.submitted-count.information"}}
   @loadingMessage={{t "cards.submitted-count.loader"}}
   @isLoading={{@isLoading}}

--- a/orga/app/components/campaign/cards/stage-average.hbs
+++ b/orga/app/components/campaign/cards/stage-average.hbs
@@ -1,7 +1,7 @@
 <PixIndicatorCard
   @title={{t "cards.participants-average-stages.title"}}
   @icon="crown"
-  @color="#2044DC"
+  @color="blue"
   @info={{t "cards.participants-average-stages.information"}}
   @isLoading={{@isLoading}}
   class="indicator-card"

--- a/orga/app/components/organization-learner/activity.hbs
+++ b/orga/app/components/organization-learner/activity.hbs
@@ -4,7 +4,7 @@
       <h2 class="screen-reader-only">{{t "pages.organization-learner.activity.assessment-summary"}}</h2>
       <PixIndicatorCard
         @title={{t "pages.organization-learner.activity.cards.title.assessment"}}
-        @color="#8A49FF"
+        @color="purple"
         @icon="tachometer"
         @iconPrefix="fapix"
       >
@@ -22,7 +22,7 @@
       <h2 class="screen-reader-only">{{t "pages.organization-learner.activity.profile-collection-summary"}}</h2>
       <PixIndicatorCard
         @title={{t "pages.organization-learner.activity.cards.title.profiles-collection"}}
-        @color="#3D68FF"
+        @color="blue"
         @icon="person-export"
         @iconPrefix="fapix"
       >

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^31.1.0",
+        "@1024pix/pix-ui": "^32.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -239,14 +239,13 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
-      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-32.0.0.tgz",
+      "integrity": "sha512-0XuRmP3Tw56m5TinwHMTec+NVo38zRE+j786lOWPicjPUrnxheh866tXP66wsmoMkhxvp75+5U7GbV0RW7rXLw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@formatjs/intl": "^2.5.1",
-        "color": "^4.2.3",
         "ember-auto-import": "^2.5.0",
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
@@ -12760,19 +12759,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12790,16 +12776,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -33283,21 +33259,6 @@
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
-    },
     "node_modules/sinon": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
@@ -36963,13 +36924,12 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
-      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-32.0.0.tgz",
+      "integrity": "sha512-0XuRmP3Tw56m5TinwHMTec+NVo38zRE+j786lOWPicjPUrnxheh866tXP66wsmoMkhxvp75+5U7GbV0RW7rXLw==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
-        "color": "^4.2.3",
         "ember-auto-import": "^2.5.0",
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
@@ -47053,16 +47013,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -47077,16 +47027,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -63317,23 +63257,6 @@
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
-        }
-      }
     },
     "sinon": {
       "version": "15.0.1",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^31.1.0",
+    "@1024pix/pix-ui": "^32.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",


### PR DESCRIPTION
## :unicorn: Problème
Les couleurs des PixIndicatorCard ne correspondent pas aux couleurs des maquettes

## :robot: Proposition
Montée de version de pix-ui

## :rainbow: Remarques


## :100: Pour tester
Se connecter sur pix-orga et vérifier les couleurs des PixIndicatorCard sur les pages suivantes :
- sur la page d'un utilisateur
- sur la page des campagnes qui ont des participants
