### PR TITLE
[TECH] Annule les mises à jour d'ember-cookies

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -44,7 +44,7 @@
         "ember-cli-sass": "^11.0.1",
         "ember-cli-sri": "^2.1.1",
         "ember-composable-helpers": "^4.5.0",
-        "ember-cookies": "^1.0.0",
+        "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
         "ember-dayjs": "^0.10.3",
         "ember-export-application-global": "^2.0.1",
@@ -16893,15 +16893,16 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
-      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.7.1"
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       },
       "engines": {
-        "node": ">= 16.*"
+        "node": "8.* || 10.* || >= 12.*"
       }
     },
     "node_modules/ember-data": {
@@ -20536,19 +20537,6 @@
       },
       "peerDependencies": {
         "ember-fetch": "^8.0.1"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
       }
     },
     "node_modules/ember-source": {
@@ -48875,12 +48863,13 @@
       }
     },
     "ember-cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
-      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "requires": {
-        "@embroider/addon-shim": "^1.7.1"
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       }
     },
     "ember-data": {
@@ -51820,18 +51809,6 @@
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cookies": "^0.5.0",
         "silent-error": "^1.0.0"
-      },
-      "dependencies": {
-        "ember-cookies": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-          "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.1.0",
-            "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-          }
-        }
       }
     },
     "ember-source": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -71,7 +71,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-composable-helpers": "^4.5.0",
-    "ember-cookies": "^1.0.0",
+    "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
     "ember-dayjs": "^0.10.3",
     "ember-export-application-global": "^2.0.1",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -52,7 +52,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-test-loader": "^3.0.0",
         "ember-collapsible-panel": "^5.0.0",
-        "ember-cookies": "^1.0.0",
+        "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
         "ember-dayjs": "^0.10.3",
         "ember-decorators": "^6.1.1",
@@ -22011,15 +22011,16 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
-      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.7.1"
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       },
       "engines": {
-        "node": ">= 16.*"
+        "node": "8.* || 10.* || >= 12.*"
       }
     },
     "node_modules/ember-data": {
@@ -25413,19 +25414,6 @@
       },
       "peerDependencies": {
         "ember-fetch": "^8.0.1"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
       }
     },
     "node_modules/ember-source": {
@@ -58286,12 +58274,13 @@
       }
     },
     "ember-cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
-      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "requires": {
-        "@embroider/addon-shim": "^1.7.1"
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       }
     },
     "ember-data": {
@@ -60893,18 +60882,6 @@
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cookies": "^0.5.0",
         "silent-error": "^1.0.0"
-      },
-      "dependencies": {
-        "ember-cookies": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-          "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.1.0",
-            "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-          }
-        }
       }
     },
     "ember-source": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -80,7 +80,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-test-loader": "^3.0.0",
     "ember-collapsible-panel": "^5.0.0",
-    "ember-cookies": "^1.0.0",
+    "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
     "ember-dayjs": "^0.10.3",
     "ember-decorators": "^6.1.1",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -51,7 +51,7 @@
         "ember-cli-showdown": "^6.0.1",
         "ember-cli-sri": "^2.1.1",
         "ember-click-outside": "^5.0.1",
-        "ember-cookies": "^1.0.0",
+        "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
         "ember-dayjs": "^0.10.4",
         "ember-fetch": "^8.1.2",
@@ -19096,15 +19096,16 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
-      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.7.1"
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       },
       "engines": {
-        "node": ">= 16.*"
+        "node": "8.* || 10.* || >= 12.*"
       }
     },
     "node_modules/ember-data": {
@@ -21726,19 +21727,6 @@
       },
       "engines": {
         "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
       }
     },
     "node_modules/ember-source": {
@@ -52086,12 +52074,13 @@
       }
     },
     "ember-cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
-      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
       "dev": true,
       "requires": {
-        "@embroider/addon-shim": "^1.7.1"
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       }
     },
     "ember-data": {
@@ -54154,16 +54143,6 @@
           "requires": {
             "broccoli-plugin": "^1.1.0",
             "mkdirp": "^0.5.1"
-          }
-        },
-        "ember-cookies": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-          "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.1.0",
-            "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
           }
         }
       }

--- a/orga/package.json
+++ b/orga/package.json
@@ -76,7 +76,7 @@
     "ember-cli-showdown": "^6.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-click-outside": "^5.0.1",
-    "ember-cookies": "^1.0.0",
+    "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
     "ember-dayjs": "^0.10.4",
     "ember-fetch": "^8.1.2",


### PR DESCRIPTION
## :unicorn: Problème
La mise à jour d'ember-cookies provoque des erreurs dans certains cas, encore pas complétement déterminé, mais probablement du a ember-simple-auth qui en dépend (mais dans la version précédente).

## :robot: Proposition
On revert les mise à jour.

## :100: Pour tester
1. Installer les dépendances
2. Faire tourner les tests
