### PR TITLE
[BUGFIX] Retirer le scroll automatique lors de l'utilisation d'un filtre sur Pix Orga (PIX-7850)

### DIFF
--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -7,8 +7,10 @@ export default class Router extends EmberRouter {
 
   constructor() {
     super(...arguments);
-    this.on('routeDidChange', () => {
-      window.scrollTo(0, 0);
+    this.on('routeDidChange', (transition) => {
+      if (transition.from && transition.to.name !== transition.from.name) {
+        window.scrollTo(0, 0);
+      }
     });
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Depuis le déport du scroll d'une div pour aller sur le scroll du navigateur . lors de l'utilisation des filtres la route didRouteChange est toujours executé avec un scrollTo(0,0); trigger

## :robot: Proposition
Conditionner le trigger de ce scrollTo

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller sur une camapgne avec une liste de participant. cliquer sur Effacer les filtres après avoir scroll un peu. , verifier que le scrollTo n'est pas appelé

sco.admin@example.net