### PR TITLE
[TECH] Migrer les tests vers ember-cli-htmlbars

### DIFF
--- a/admin/tests/integration/components/actions-on-users-role-in-organization_test.js
+++ b/admin/tests/integration/components/actions-on-users-role-in-organization_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/administration/organizations-import_test.js
+++ b/admin/tests/integration/components/administration/organizations-import_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { triggerEvent } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Badges::Badge', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/badges/campaign-criterion_test.js
+++ b/admin/tests/integration/components/badges/campaign-criterion_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/badges/capped-tubes-criterion_test.js
+++ b/admin/tests/integration/components/badges/capped-tubes-criterion_test.js
@@ -2,7 +2,7 @@ import { click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Badges::CappedTubes', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/campaigns/details_test.js
+++ b/admin/tests/integration/components/campaigns/details_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Campaigns | details', function (hooks) {

--- a/admin/tests/integration/components/campaigns/participation-row_test.js
+++ b/admin/tests/integration/components/campaigns/participation-row_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { clickByName, render, fillByLabel } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/campaigns/participations-section_test.js
+++ b/admin/tests/integration/components/campaigns/participations-section_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/campaigns/update_test.js
+++ b/admin/tests/integration/components/campaigns/update_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | Campaigns | Update', function (hooks) {

--- a/admin/tests/integration/components/certification-centers/creation-form_test.js
+++ b/admin/tests/integration/components/certification-centers/creation-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { A as EmberArray } from '@ember/array';
 
 module('Integration | Component | certification-centers/creation-form', function (hooks) {

--- a/admin/tests/integration/components/certification-centers/invitations-action_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations-action_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 

--- a/admin/tests/integration/components/certification-centers/invitations_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 

--- a/admin/tests/integration/components/certification-centers/memberships-section_test.js
+++ b/admin/tests/integration/components/certification-centers/memberships-section_test.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import { render } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 

--- a/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';

--- a/admin/tests/integration/components/certifications/certified-profile_test.js
+++ b/admin/tests/integration/components/certifications/certified-profile_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certifications/certified-profile', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { resolve } from 'rsvp';
 import { click } from '@ember/test-helpers';
 

--- a/admin/tests/integration/components/certifications/details-competence_test.js
+++ b/admin/tests/integration/components/certifications/details-competence_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { resolve } from 'rsvp';
 
 module('Integration | Component | certifications/details-competence', function (hooks) {

--- a/admin/tests/integration/components/certifications/info-competences_test.js
+++ b/admin/tests/integration/components/certifications/info-competences_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certifications/competence-list', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/certifications/info-field_test.js
+++ b/admin/tests/integration/components/certifications/info-field_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, within } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certifications/info-field', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/certifications/info-published_test.js
+++ b/admin/tests/integration/components/certifications/info-published_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certifications/info-published', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/certifications/info-tag_test.js
+++ b/admin/tests/integration/components/certifications/info-tag_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certifications/info-tag', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { certificationIssueReportSubcategories } from 'pix-admin/models/certification-issue-report';
 import Service from '@ember/service';

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 

--- a/admin/tests/integration/components/certifications/list_test.js
+++ b/admin/tests/integration/components/certifications/list_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certifications/list', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/certifications/status-select_test.js
+++ b/admin/tests/integration/components/certifications/status-select_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import { click } from '@ember/test-helpers';
 

--- a/admin/tests/integration/components/common/tubes-selection/tube_test.js
+++ b/admin/tests/integration/components/common/tubes-selection/tube_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | Common:TubesSelection::Tube', function (hooks) {

--- a/admin/tests/integration/components/common/tubes-selection_test.js
+++ b/admin/tests/integration/components/common/tubes-selection_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
 

--- a/admin/tests/integration/components/confirm-popup_test.js
+++ b/admin/tests/integration/components/confirm-popup_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | confirm-popup', function (hooks) {

--- a/admin/tests/integration/components/login-form_test.js
+++ b/admin/tests/integration/components/login-form_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render as renderScreen, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { reject } from 'rsvp';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | menu-bar', function (hooks) {

--- a/admin/tests/integration/components/organizations/all-tags_test.js
+++ b/admin/tests/integration/components/organizations/all-tags_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/admin/tests/integration/components/organizations/campaigns-section-test.js
+++ b/admin/tests/integration/components/organizations/campaigns-section-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | organizations/campaigns-section', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/organizations/creation-form_test.js
+++ b/admin/tests/integration/components/organizations/creation-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | organizations/creation-form', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/organizations/information-section-edit_test.js
+++ b/admin/tests/integration/components/organizations/information-section-edit_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/organizations/invitations-action_test.js
+++ b/admin/tests/integration/components/organizations/invitations-action_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { clickByText } from '@1024pix/ember-testing-library';
 

--- a/admin/tests/integration/components/organizations/invitations_test.js
+++ b/admin/tests/integration/components/organizations/invitations_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import dayjs from 'dayjs';
 import sinon from 'sinon';
 import Service from '@ember/service';

--- a/admin/tests/integration/components/organizations/places-lot-creation-form_test.js
+++ b/admin/tests/integration/components/organizations/places-lot-creation-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 

--- a/admin/tests/integration/components/organizations/places/capacity_test.js
+++ b/admin/tests/integration/components/organizations/places/capacity_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Organizations | Places | Capacity', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/organizations/places/delete-modal_test.js
+++ b/admin/tests/integration/components/organizations/places/delete-modal_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render, clickByText } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/organizations/places/list_test.js
+++ b/admin/tests/integration/components/organizations/places/list_test.js
@@ -3,7 +3,7 @@ import { click } from '@ember/test-helpers';
 import sinon from 'sinon';
 import { render } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Organizations | Places | List', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/organizations/places_test.js
+++ b/admin/tests/integration/components/organizations/places_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render, clickByText } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Organizations | Places', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/integration/components/organizations/target-profiles-section_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/organizations/team-section_test.js
+++ b/admin/tests/integration/components/organizations/team-section_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/certification-centers | list-items', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/organizations | list-items', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/sessions | list-items', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/target-profiles | list-items', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/target-profiles/target-profile | details', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insights_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/target-profiles/target-profile | Insights', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/trainings | list-items', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/routes/authenticated/users/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/users/list-items_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/authenticated/users | list-items', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/stages/stage_test.js
+++ b/admin/tests/integration/components/stages/stage_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Stages::Stage', function (hooks) {

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { find } from '@ember/test-helpers';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | TargetProfiles::Badges', function (hooks) {

--- a/admin/tests/integration/components/target-profiles/category_test.js
+++ b/admin/tests/integration/components/target-profiles/category_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | TargetProfiles::Category', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { triggerEvent } from '@ember/test-helpers';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | TargetProfiles::CreateTargetProfileForm', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/target-profiles/organizations_test.js
+++ b/admin/tests/integration/components/target-profiles/organizations_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | TargetProfiles::Organizations', function (hooks) {

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | TargetProfiles::Stages', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/team-actions-section_test.js
+++ b/admin/tests/integration/components/team-actions-section_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | organization-team-actions-section', function (hooks) {

--- a/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { triggerEvent } from '@ember/test-helpers';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { typeCategories, localeCategories } from 'pix-admin/models/training';
 
 module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', function (hooks) {

--- a/admin/tests/integration/components/trainings/create-training-triggers_test.js
+++ b/admin/tests/integration/components/trainings/create-training-triggers_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render, clickByText } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Trainings::CreateTrainingTriggers', function (hooks) {

--- a/admin/tests/integration/components/trainings/training-details-card_test.js
+++ b/admin/tests/integration/components/trainings/training-details-card_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Trainings::TrainingDetailsCard', function (hooks) {
   setupRenderingTest(hooks);

--- a/admin/tests/integration/components/users/campaign-participations_test.js
+++ b/admin/tests/integration/components/users/campaign-participations_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/users/certification-center-memberships_test.js
+++ b/admin/tests/integration/components/users/certification-center-memberships_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/admin/tests/integration/components/users/user-organization-memberships_test.js
+++ b/admin/tests/integration/components/users/user-organization-memberships_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/admin/tests/integration/components/users/user-profile_test.js
+++ b/admin/tests/integration/components/users/user-profile_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | users | user-profile', function (hooks) {

--- a/certif/tests/integration/components/auth/login-or-register_test.js
+++ b/certif/tests/integration/components/auth/login-or-register_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/certif/tests/integration/components/auth/register-form_test.js
+++ b/certif/tests/integration/components/auth/register-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
 import { triggerEvent } from '@ember/test-helpers';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'common.form-errors.firstname.mandatory';

--- a/certif/tests/integration/components/auth/toggable-login-form_test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form_test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { resolve } from 'rsvp';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { triggerEvent } from '@ember/test-helpers';
 import Service from '@ember/service';

--- a/certif/tests/integration/components/certif-checkbox_test.js
+++ b/certif/tests/integration/components/certif-checkbox_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certif-checkbox', function (hooks) {

--- a/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
+++ b/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render, click } from '@ember/test-helpers';
 import Object from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 

--- a/certif/tests/integration/components/communication-banner_test.js
+++ b/certif/tests/integration/components/communication-banner_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'pix-certif/config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 

--- a/certif/tests/integration/components/formbuilder-link-step_test.js
+++ b/certif/tests/integration/components/formbuilder-link-step_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import config from 'pix-certif/config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { click, fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { reject, resolve } from 'rsvp';
 import sinon from 'sinon';

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -4,7 +4,7 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | login-session-supervisor-form', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/certif/tests/integration/components/session-delete-confirm-modal_test.js
+++ b/certif/tests/integration/components/session-delete-confirm-modal_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | session-delete-confirm-modal', function (hooks) {

--- a/certif/tests/integration/components/session-finalization-step-container_test.js
+++ b/certif/tests/integration/components/session-finalization-step-container_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | session-finalization-step-container', function (hooks) {

--- a/certif/tests/integration/components/session-finalization/complementary-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/complementary-information-step_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 

--- a/certif/tests/integration/components/session-finalization/examiner-global-comment-step_test.js
+++ b/certif/tests/integration/components/session-finalization/examiner-global-comment-step_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { render, click, fillIn } from '@ember/test-helpers';
 import Object from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | SessionFinalization::ExaminerGlobalCommentStep', function (hooks) {

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import { render as renderScreen } from '@1024pix/ember-testing-library';

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { waitForDialogClose } from '../../helpers/wait-for';
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -4,7 +4,7 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { waitForDialogClose } from '../../../helpers/wait-for';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | SessionSupervising::CandidateInList', function (hooks) {

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillIn, click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | SessionSupervising::CandidateList', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/certif/tests/integration/components/session-supervising/header_test.js
+++ b/certif/tests/integration/components/session-supervising/header_test.js
@@ -5,7 +5,7 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { waitForDialogClose } from '../../../helpers/wait-for';
 
 module('Integration | Component | SessionSupervising::Header', function (hooks) {

--- a/certif/tests/integration/components/user-logged-menu_test.js
+++ b/certif/tests/integration/components/user-logged-menu_test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { run } from '@ember/runloop';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/Sitemap/content_test.js
+++ b/mon-pix/tests/integration/components/Sitemap/content_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | Sitemap::Content', function (hooks) {

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { contains } from '../../../helpers/contains';

--- a/mon-pix/tests/integration/components/account-recovery/student-information-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/student-information-form-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
 import { render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { contains } from '../../../helpers/contains';
 import sinon from 'sinon';

--- a/mon-pix/tests/integration/components/assessment-banner_test.js
+++ b/mon-pix/tests/integration/components/assessment-banner_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | assessment-banner', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | authentication | login-or-register-oidc', function (hooks) {

--- a/mon-pix/tests/integration/components/badge-card_test.js
+++ b/mon-pix/tests/integration/components/badge-card_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Badge Card', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { contains } from '../../../../helpers/contains';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card | Archived', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { contains } from '../../../../helpers/contains';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card | Ended', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card | Ongoing ', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import { contains } from '../../../../helpers/contains';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card | ToShare', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Grid', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign-start-block_test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block_test.js
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | campaign-start-block', function (hooks) {

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | Campaign | skill-review', function (hooks) {

--- a/mon-pix/tests/integration/components/certification-banner_test.js
+++ b/mon-pix/tests/integration/components/certification-banner_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Certification Banner', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';

--- a/mon-pix/tests/integration/components/certification-not-certifiable_test.js
+++ b/mon-pix/tests/integration/components/certification-not-certifiable_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certification-not-certifiable', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { fillIn } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { render } from '@1024pix/ember-testing-library';
 import { clickByLabel } from '../../helpers/click-by-label';

--- a/mon-pix/tests/integration/components/certifications-list-item_test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { click, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/certifications-list_test.js
+++ b/mon-pix/tests/integration/components/certifications-list_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | certifications list', function (hooks) {

--- a/mon-pix/tests/integration/components/challenge-actions_test.js
+++ b/mon-pix/tests/integration/components/challenge-actions_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | challenge actions', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { render } from '@1024pix/ember-testing-library';
 

--- a/mon-pix/tests/integration/components/challenge-illustration_test.js
+++ b/mon-pix/tests/integration/components/challenge-illustration_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { triggerEvent } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 

--- a/mon-pix/tests/integration/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/integration/components/challenge-item-qroc_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Challenge item QROC', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import { click, find, findAll } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | ChallengeStatement', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/challenge/item_test.js
+++ b/mon-pix/tests/integration/components/challenge/item_test.js
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Challenge | Item', function (hooks) {

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { click, render, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Tooltip', function (hooks) {

--- a/mon-pix/tests/integration/components/checkpoint-continue_test.js
+++ b/mon-pix/tests/integration/components/checkpoint-continue_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | checkpoint-continue', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/choice-chip_test.js
+++ b/mon-pix/tests/integration/components/choice-chip_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pix-choice-chip', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/circle-chart_test.js
+++ b/mon-pix/tests/integration/components/circle-chart_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | circle-chart', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/communication-banner_test.js
+++ b/mon-pix/tests/integration/components/communication-banner_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'mon-pix/config/environment';
 
 module('Integration | Component | communication-banner', function (hooks) {

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | comparison-window', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/competence-card-default_test.js
+++ b/mon-pix/tests/integration/components/competence-card-default_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | competence-card-default', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | competence-card-mobile', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Congratulations Certification Banner', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Dashboard | Content', function (hooks) {

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
 import ENV from 'mon-pix/config/environment';

--- a/mon-pix/tests/integration/components/feedback-certification-section_test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | feedback-certification-section', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click, fillIn } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 const PICK_SELECT_OPTION_WITH_NESTED_LEVEL = 'question';
 const PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL = 'embed';

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Footer', function (hooks) {

--- a/mon-pix/tests/integration/components/form-textfield-date_test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { fillIn, find, render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | form textfield date', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/form-textfield_test.js
+++ b/mon-pix/tests/integration/components/form-textfield_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | form textfield', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | hexagon-score', function (hooks) {

--- a/mon-pix/tests/integration/components/inaccessible-campaign_test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign_test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | inaccessible-campaign', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/learning-more-panel_test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import { A } from '@ember/array';
 import EmberObject from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | learning-more-panel', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/levelup-notif_test.js
+++ b/mon-pix/tests/integration/components/levelup-notif_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | levelup-notif', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/navbar-burger-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu_test.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | navbar-burger-menu', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header_test.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 module('Integration | Component | navbar-desktop-header', function (hooks) {

--- a/mon-pix/tests/integration/components/navbar-desktop-nav-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-nav-menu_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
 

--- a/mon-pix/tests/integration/components/navbar-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-header_test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { render } from '@1024pix/ember-testing-library';
 

--- a/mon-pix/tests/integration/components/navbar-mobile-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header_test.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 module('Integration | Component | navbar-mobile-header', function (hooks) {

--- a/mon-pix/tests/integration/components/no-certification-panel_test.js
+++ b/mon-pix/tests/integration/components/no-certification-panel_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | no certification panel', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form_test.js
@@ -4,7 +4,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { fillIn } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
 import { clickByLabel } from '../../helpers/click-by-label';

--- a/mon-pix/tests/integration/components/pix-logo_test.js
+++ b/mon-pix/tests/integration/components/pix-logo_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | pix logo', function (hooks) {

--- a/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pix-toggle-deprecated', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/profile-content_test.js
+++ b/mon-pix/tests/integration/components/profile-content_test.js
@@ -4,7 +4,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { setBreakpoint } from 'ember-responsive/test-support';
 

--- a/mon-pix/tests/integration/components/qcm-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcm-proposals_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | QCM proposals', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 const assessment = {};
 let challenge = null;

--- a/mon-pix/tests/integration/components/qcu-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | QCU proposals', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 const assessment = {};
 let challenge = null;

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | QROC solution panel', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 const ANSWER = '.correction-qrocm__answer';
 const INPUT = 'input.correction-qrocm__answer--input';

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 const ANSWER = '.correction-qrocm__answer';
 const INPUT = 'input.correction-qrocm__answer--input';

--- a/mon-pix/tests/integration/components/qrocm-proposal_test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 

--- a/mon-pix/tests/integration/components/reset-password-form_test.js
+++ b/mon-pix/tests/integration/components/reset-password-form_test.js
@@ -3,7 +3,7 @@ import { resolve, reject } from 'rsvp';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, fillIn, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';

--- a/mon-pix/tests/integration/components/result-item-campaign_test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | result-item', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -5,7 +5,7 @@ import { fillInByLabel } from '../../../../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
 import { contains } from '../../../../../helpers/contains';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | routes/campaigns/invited/associate-sup-student-form', function (hooks) {

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import { render, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/campaigns/invited/fill-in-participant-external-id', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
@@ -4,7 +4,7 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 import { contains } from '../../../../../helpers/contains';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/campaigns/profiles_collection/send-profile', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/routes/campaigns/sco-form_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/sco-form_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/routes/login-form_test.js
+++ b/mon-pix/tests/integration/components/routes/login-form_test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { click, fillIn, render, find } from '@ember/test-helpers';
 import { fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { clickByLabel } from '../../../helpers/click-by-label';

--- a/mon-pix/tests/integration/components/routes/login-or-register_test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../../helpers/click-by-label';
 
 module('Integration | Routes | routes/login-or-register', function (hooks) {

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -3,7 +3,7 @@ import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 
 import Service from '@ember/service';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { A } from '@ember/array';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | scorecard-details', function (hooks) {

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { fillIn } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 
 import Service from '@ember/service';

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -8,7 +8,7 @@ import { render, clickByName } from '@1024pix/ember-testing-library';
 import ArrayProxy from '@ember/array/proxy';
 import { resolve, reject } from 'rsvp';
 import EmberObject from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/timeout-gauge_test.js
+++ b/mon-pix/tests/integration/components/timeout-gauge_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | TimeoutGauge', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Training | Card', function (hooks) {

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Tutorial Panel', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/tutorials/cards_test.js
+++ b/mon-pix/tests/integration/components/tutorials/cards_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Tutorials | Cards', function (hooks) {

--- a/mon-pix/tests/integration/components/tutorials/header_test.js
+++ b/mon-pix/tests/integration/components/tutorials/header_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { contains } from '../../../helpers/contains';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';

--- a/mon-pix/tests/integration/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { fillIn, triggerEvent, click } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -5,7 +5,7 @@ import { render } from '@1024pix/ember-testing-library';
 import { fillInByLabel } from '../../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../../helpers/click-by-label';
 import { contains } from '../../../helpers/contains';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | user-account | email-with-validation-form', function (hooks) {

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | user-certifications-detail-competences-list', function (hooks) {

--- a/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | user certifications detail result', function (hooks) {

--- a/mon-pix/tests/integration/components/user-certifications-panel_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-panel_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | user certifications panel', function (hooks) {

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click, triggerKeyEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | user logged menu', function (hooks) {

--- a/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | User-Tutorials | Filters | ItemCheckbox', function (hooks) {

--- a/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | User-Tutorials | Filters | Sidebar', function (hooks) {

--- a/mon-pix/tests/unit/helpers/contains_test.js
+++ b/mon-pix/tests/unit/helpers/contains_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import { contains } from '../../helpers/contains';
 

--- a/orga/tests/integration/components/auth/join-request-form_test.js
+++ b/orga/tests/integration/components/auth/join-request-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent } from '@ember/test-helpers';
 import { fillByLabel } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Auth::JoinRequestForm', function (hooks) {
   setupRenderingTest(hooks);

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -1,5 +1,5 @@
 import { reject, resolve } from 'rsvp';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';

--- a/orga/tests/integration/components/auth/login-or-register_test.js
+++ b/orga/tests/integration/components/auth/login-or-register_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -4,7 +4,7 @@ import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.first-name.error';

--- a/orga/tests/integration/components/banner/communication_test.js
+++ b/orga/tests/integration/components/banner/communication_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'pix-orga/config/environment';
 
 module('Integration | Component | Banner::Communication', function (hooks) {

--- a/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
+++ b/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/campaign/activity/participants-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list_test.js
@@ -4,7 +4,7 @@ import { click } from '@ember/test-helpers';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
 import { fillByLabel, clickByText, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Activity::ParticipantsList', function (hooks) {

--- a/orga/tests/integration/components/campaign/analysis/competences_test.js
+++ b/orga/tests/integration/components/campaign/analysis/competences_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Analysis::Competences', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Analysis::Recommendations', function (hooks) {

--- a/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
+++ b/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/badges_test.js
+++ b/orga/tests/integration/components/campaign/badges_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Badges', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/cards/participants-count_test.js
+++ b/orga/tests/integration/components/campaign/cards/participants-count_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/campaign/cards/result_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/result_average_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/campaign/cards/shared-count_test.js
+++ b/orga/tests/integration/components/campaign/cards/shared-count_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 import { render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';

--- a/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByDay', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/charts/participants-by-mastery-percentage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-mastery-percentage_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByMasteryPercentage', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByStage', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/charts/participants-by-status_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-status_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByStatus', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/charts/result-distribution_test.js
+++ b/orga/tests/integration/components/campaign/charts/result-distribution_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ResultDistribution', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/copy-paste-button_test.js
+++ b/orga/tests/integration/components/campaign/copy-paste-button_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { setupRenderingTest } from 'ember-qunit';

--- a/orga/tests/integration/components/campaign/empty-state_test.js
+++ b/orga/tests/integration/components/campaign/empty-state_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl, t } from 'ember-intl/test-support';
 

--- a/orga/tests/integration/components/campaign/filter/filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/filters_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 import { t } from 'ember-intl/test-support';

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library';

--- a/orga/tests/integration/components/campaign/header/archived-banner_test.js
+++ b/orga/tests/integration/components/campaign/header/archived-banner_test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/orga/tests/integration/components/campaign/header/tabs_test.js
+++ b/orga/tests/integration/components/campaign/header/tabs_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 class CurrentUserStub extends Service {

--- a/orga/tests/integration/components/campaign/header/title_test.js
+++ b/orga/tests/integration/components/campaign/header/title_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Header::Title', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/list_test.js
+++ b/orga/tests/integration/components/campaign/list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 import Service from '@ember/service';

--- a/orga/tests/integration/components/campaign/no-campaign-panel_test.js
+++ b/orga/tests/integration/components/campaign/no-campaign-panel_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl, t } from 'ember-intl/test-support';
 

--- a/orga/tests/integration/components/campaign/results/assessment-cards_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-cards_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 
 module('Integration | Component | Campaign::Results::AssessmentCards', function (hooks) {

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -4,7 +4,7 @@ import { clickByName, render, fillByLabel } from '@1024pix/ember-testing-library
 import { click } from '@ember/test-helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Results::AssessmentList', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/campaign/results/profile-list_test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list_test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | Campaign::Results::ProfileList', function (hooks) {

--- a/orga/tests/integration/components/campaign/settings/view_test.js
+++ b/orga/tests/integration/components/campaign/settings/view_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 

--- a/orga/tests/integration/components/campaign/update-form_test.js
+++ b/orga/tests/integration/components/campaign/update-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | Campaign::UpdateForm', function (hooks) {

--- a/orga/tests/integration/components/dropdown/icon-trigger_test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
 

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import { clickByName } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Object from '@ember/object';
 import Service from '@ember/service';
 

--- a/orga/tests/integration/components/organization-learner/activity/participation-list_test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | OrganizationLearner::Activity::ParticipationList', function (hooks) {

--- a/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
@@ -4,7 +4,7 @@ import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | OrganizationLearner | Activity::ParticipationRow', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/organization-learner/activity_test.js
+++ b/orga/tests/integration/components/organization-learner/activity_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render, within } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | OrganizationLearner::Activity', function (hooks) {

--- a/orga/tests/integration/components/organization-participant/header_test.js
+++ b/orga/tests/integration/components/organization-participant/header_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | OrganizationParticipant::header', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { click } from '@ember/test-helpers';
 import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import sinon from 'sinon';
 

--- a/orga/tests/integration/components/organization-participant/no-participant-panel_test.js
+++ b/orga/tests/integration/components/organization-participant/no-participant-panel_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | OrganizationParticipant::NoParticipantPanel', function (hooks) {

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { t } from 'ember-intl/test-support';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Participant::Assessment::Header', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/participant/assessment/results_test.js
+++ b/orga/tests/integration/components/participant/assessment/results_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { setupIntl, t } from 'ember-intl/test-support';
 

--- a/orga/tests/integration/components/participant/assessment/tabs_test.js
+++ b/orga/tests/integration/components/participant/assessment/tabs_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Participant::Assessment::Tabs', function (hooks) {

--- a/orga/tests/integration/components/participant/profile/header_test.js
+++ b/orga/tests/integration/components/participant/profile/header_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Participant::Profile::Header', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/participant/profile/table_test.js
+++ b/orga/tests/integration/components/participant/profile/table_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Participant::Profile::Table', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -3,7 +3,7 @@ import { render } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | ScoOrganizationParticipant::HeaderActions', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -4,7 +4,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | ScoOrganizationParticipant::List', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/sco-organization-participant/manage-authentication-method-modal_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/manage-authentication-method-modal_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import { resolve } from 'rsvp';
 import { clickByName } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
 import { triggerCopySuccess } from 'ember-cli-clipboard/test-support';

--- a/orga/tests/integration/components/sup-organization-participant/edit-student-number-modal_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/edit-student-number-modal_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | ScoOrganizationParticipant::EditStudentNumberModal', function (hooks) {

--- a/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | SupOrganizationParticipant::HeaderActions', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -4,7 +4,7 @@ import { click } from '@ember/test-helpers';
 import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import { render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | SupOrganizationParticipant::List', function (hooks) {

--- a/orga/tests/integration/components/tables/pagination-control_test.js
+++ b/orga/tests/integration/components/tables/pagination-control_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import Service from '@ember/service';
 import { render, clickByName } from '@1024pix/ember-testing-library';

--- a/orga/tests/integration/components/team/invitations-list-item_test.js
+++ b/orga/tests/integration/components/team/invitations-list-item_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 class CurrentUserStub extends Service {
   organization = { id: 1 };

--- a/orga/tests/integration/components/team/invitations-list_test.js
+++ b/orga/tests/integration/components/team/invitations-list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';

--- a/orga/tests/integration/components/team/invite-form_test.js
+++ b/orga/tests/integration/components/team/invite-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import { fillByLabel } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByText, render, clickByName } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';

--- a/orga/tests/integration/components/team/members-list_test.js
+++ b/orga/tests/integration/components/team/members-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/tube/list_test.js
+++ b/orga/tests/integration/components/tube/list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import { A } from '@ember/array';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/orga/tests/integration/components/ui/breadcrumb_test.js
+++ b/orga/tests/integration/components/ui/breadcrumb_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | Ui | Breadcrumb', function (hooks) {

--- a/orga/tests/integration/components/ui/certificability-tooltip_test.js
+++ b/orga/tests/integration/components/ui/certificability-tooltip_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::CertificabilityTooltip', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/chevron_test.js
+++ b/orga/tests/integration/components/ui/chevron_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::Chevron', function (hooks) {
   setupRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/date_test.js
+++ b/orga/tests/integration/components/ui/date_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Ui | Date', function (hooks) {

--- a/orga/tests/integration/components/ui/divisions-filter_test.js
+++ b/orga/tests/integration/components/ui/divisions-filter_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import sinon from 'sinon';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::DivisionsFilter', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/empty-state_test.js
+++ b/orga/tests/integration/components/ui/empty-state_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Ui::EmptyState', function (hooks) {

--- a/orga/tests/integration/components/ui/groups-filter_test.js
+++ b/orga/tests/integration/components/ui/groups-filter_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
 module('Integration | Component | Ui::GroupsFilter', function (hooks) {

--- a/orga/tests/integration/components/ui/information-wrapper_test.js
+++ b/orga/tests/integration/components/ui/information-wrapper_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui | Information Wrapper', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/information_test.js
+++ b/orga/tests/integration/components/ui/information_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui | Information', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/is-certifiable_test.js
+++ b/orga/tests/integration/components/ui/is-certifiable_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui | IsCertifiable', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/last-participation-date-tooltip_test.js
+++ b/orga/tests/integration/components/ui/last-participation-date-tooltip_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::LastParticipationDateTooltip', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/participation-status_test.js
+++ b/orga/tests/integration/components/ui/participation-status_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui | ParticipationStatus', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/pix-loader_test.js
+++ b/orga/tests/integration/components/ui/pix-loader_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::PixLoader', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/previous-page-button_test.js
+++ b/orga/tests/integration/components/ui/previous-page-button_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import Service from '@ember/service';
 import { clickByName } from '@1024pix/ember-testing-library';

--- a/orga/tests/integration/components/ui/progress-bar_test.js
+++ b/orga/tests/integration/components/ui/progress-bar_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::ProgressBar', function (hooks) {
   setupRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/search-input_test.js
+++ b/orga/tests/integration/components/ui/search-input_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { fillByLabel } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Ui::SearchInput', function (hooks) {


### PR DESCRIPTION
## :unicorn: Problème
htmlbars-inline-precompile est déprécié: https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile

## :robot: Proposition
Utiliser ember-cli-htmlbars: https://github.com/ember-cli/ember-cli-htmlbars#tagged-template-usage--migrating-from-htmlbars-inline-precompile

## :100: Pour tester
Green tests
