### PR TITLE
[TECH] Assurer la cohérence de données lors de la MAJ d'un déclencheur de contenu formatif (PIX-7852).

### DIFF
--- a/api/lib/domain/usecases/create-or-update-training-trigger.js
+++ b/api/lib/domain/usecases/create-or-update-training-trigger.js
@@ -3,9 +3,16 @@ module.exports = async function createOrUpdateTrainingTrigger({
   tubes,
   type,
   threshold,
+  domainTransaction,
   trainingRepository,
   trainingTriggerRepository,
 }) {
-  await trainingRepository.get({ trainingId });
-  return trainingTriggerRepository.createOrUpdate({ trainingId, triggerTubesForCreation: tubes, type, threshold });
+  await trainingRepository.get({ trainingId, domainTransaction });
+  return trainingTriggerRepository.createOrUpdate({
+    trainingId,
+    triggerTubesForCreation: tubes,
+    type,
+    threshold,
+    domainTransaction,
+  });
 };

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -2,6 +2,7 @@ const { sinon, expect, hFake } = require('../../../test-helper');
 const trainingController = require('../../../../lib/application/trainings/training-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
 describe('Unit | Controller | training-controller', function () {
   describe('#findPaginatedTrainingSummaries', function () {
@@ -270,6 +271,11 @@ describe('Unit | Controller | training-controller', function () {
         tubes: Symbol('tubes'),
       };
 
+      const domainTransaction = Symbol();
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback(domainTransaction);
+      });
+
       const createdTrigger = Symbol('createdTrigger');
       const serializedTrigger = Symbol('serializedTrigger');
       sinon.stub(usecases, 'createOrUpdateTrainingTrigger').resolves(createdTrigger);
@@ -296,6 +302,7 @@ describe('Unit | Controller | training-controller', function () {
         threshold: deserializedTrigger.threshold,
         type: deserializedTrigger.type,
         tubes: deserializedTrigger.tubes,
+        domainTransaction,
       });
       expect(result).to.be.equal(serializedTrigger);
     });

--- a/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
@@ -17,11 +17,16 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
   context('when training does not exist', function () {
     it('should throw an error when training does not exist', async function () {
       // given
+      const domainTransaction = Symbol('domainTransaction');
       const trainingId = Symbol('trainingId');
-      trainingRepository.get.withArgs({ trainingId }).throws(new Error('Not Found'));
+      trainingRepository.get.withArgs({ trainingId, domainTransaction }).throws(new Error('Not Found'));
 
       // when
-      const error = await catchErr(createOrUpdateTrainingTrigger)({ trainingId, trainingRepository });
+      const error = await catchErr(createOrUpdateTrainingTrigger)({
+        trainingId,
+        domainTransaction,
+        trainingRepository,
+      });
 
       // then
       expect(error).to.be.instanceOf(Error);
@@ -32,6 +37,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
   context('when training exists', function () {
     it('should call create or update trigger repository method', async function () {
       // given
+      const domainTransaction = Symbol('domainTransaction');
       const trainingId = Symbol('trainingId');
       const tubes = Symbol('tubes');
       const type = Symbol('type');
@@ -46,6 +52,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
         tubes,
         type,
         threshold,
+        domainTransaction,
         trainingRepository,
         trainingTriggerRepository,
       });
@@ -56,6 +63,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
         triggerTubesForCreation: tubes,
         type,
         threshold,
+        domainTransaction,
       });
       expect(result).to.equal(expectedTrainingTrigger);
     });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, si une erreur se produit lors de la mise à jour d'un contenu formatif, nous pouvons nous retrouver dans un état incohérent comme par exemple avoir supprimé les anciens `training-trigger-tubes` mais sans avoir ajouté les nouveaux. 

## :robot: Proposition
Assurer la cohérence des données à l'aide du domain transaction dans le cadre de notre route.
Et assurer la cohérence pour la méthode elle même lorsqu'elle est appelée sans domainTransaction.

## :rainbow: Remarques


## :100: Pour tester
- CI OK 
- Se rendre sur Pix Admin > Contenus Formatifs > Détail d'un CF > Créer un déclencheur et vérifier la bonne création