### PR TITLE
[FEATURE] Changer la couleur des icônes "?" dans la section avec le graphique “statuts” des participations (PIX-7664)

### DIFF
--- a/orga/app/styles/components/campaign/charts/participants-by-status.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-status.scss
@@ -24,7 +24,7 @@
 
   &__legend-tooltip {
     margin-left: 8px;
-    color: $pix-neutral-30;
+    color: $pix-neutral-60;
   }
 
   &__legend-view {


### PR DESCRIPTION
## :unicorn: Problème
Ce n'était pas raccord avec les maquettes.

## :robot: Proposition
Changer les couleur pour un neutral-80

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter
- se rendre sur une page d'orga avec des participations
- observer les icônes "?" du graphique
- Ta review est terminée 🎉 