### PR TITLE
[BUGFIX] Supprimer la mauvaise vérification d'un doublon de candidat lors d'un import en masse de sessions sur Pix Certif (PIX-7838).

### DIFF
--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -71,15 +71,6 @@ module.exports = {
         codes: [CERTIFICATION_SESSIONS_ERRORS.EMPTY_SESSION.code],
         isBlocking: false,
       });
-    } else {
-      if (_hasDuplicateCertificationCandidates(session.certificationCandidates)) {
-        _addToErrorList({
-          errorList: sessionErrors,
-          line,
-          codes: [CERTIFICATION_SESSIONS_ERRORS.DUPLICATE_CANDIDATE_IN_SESSION.code],
-          isBlocking: false,
-        });
-      }
     }
 
     return sessionErrors;
@@ -193,12 +184,4 @@ async function _isSessionStarted({ certificationCourseRepository, sessionId }) {
     sessionId,
   });
   return foundCertificationCourses.length > 0;
-}
-
-function _hasDuplicateCertificationCandidates(certificationCandidates) {
-  const uniqCertificationCandidates = new Set(
-    certificationCandidates.map(({ lastName, firstName, birthdate }) => `${lastName}${firstName}${birthdate}`)
-  );
-
-  return uniqCertificationCandidates.size < certificationCandidates.length;
 }

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -325,35 +325,6 @@ describe('Unit | Service | sessions import validation Service', function () {
       });
     });
 
-    context('when session has certification candidates', function () {
-      context('when at least one candidate is duplicated', function () {
-        it('should return a sessionErrors array that contains a duplicate candidate error', async function () {
-          // given
-          const validCandidateData = _buildValidCandidateData(1);
-          const validCandidateDataDuplicate = _buildValidCandidateData(1);
-          const session = _buildValidSessionWithoutId();
-          session.certificationCandidates = [validCandidateData, validCandidateDataDuplicate];
-
-          // when
-          const sessionErrors = await sessionsImportValidationService.validateSession({
-            session,
-            line: 1,
-            sessionRepository,
-            certificationCourseRepository,
-          });
-
-          // then
-          expect(sessionErrors).to.deep.equal([
-            {
-              line: 1,
-              code: 'DUPLICATE_CANDIDATE_IN_SESSION',
-              isBlocking: false,
-            },
-          ]);
-        });
-      });
-    });
-
     context('when session has one invalid field', function () {
       it('should return a sessionErrors array that contains a session invalid field error', async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, lorsque l'on souhaite importer en masse des sessions avec un csv contenant plusieurs candidats dont un doublon, le message (non-bloquant) indiquant qu'il existe déjà apparaît plusieurs fois (un sur une mauvaise ligne, un sur la bonne ligne)

<img width="1537" alt="Capture d’écran 2023-04-24 à 17 39 52" src="https://user-images.githubusercontent.com/58915422/234046937-9354d21e-7461-40fa-a3ae-a08ef74e812c.png">

screen basé sur le csv donné dans la partie "Pour tester"

## :robot: Proposition
En investiguant, on trouve en réalité 2 checks pour vérifier un potentiel doublon de candidats. L'un jetait l'erreur avec la mauvaise ligne, l'autre la bonne 

## :rainbow: Remarques
Le check supprimé provient du début de l'implémentation de la fonctionnalité. 
Puis [une PR permettant de jeter l'erreur en non bloquant](https://github.com/1024pix/pix/pull/5934) a mis en place un nouveau check. Ce dernier jette l'erreur avec la bonne ligne. On va donc garder celui-ci

([getUniqueCandidates](https://github.com/1024pix/pix/blob/7fefde77bcd85cf4b7832a9b75d6d6e6eb1bf066/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js#L88-L88))

## :100: Pour tester

- Se connecter sur Pix Certif avec certifsup@example.net
- Importer le fichier suivant 

```
Numéro de session préexistante;* Nom du site;* Nom de la salle;* Date de début (format: JJ/MM/AAAA);* Heure de début (heure locale format: HH:MM);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: JJ/MM/AAAA);* Sexe (M ou F);Code INSEE de la commune de naissance;Code postal de la commune de naissance;Nom de la commune de naissance;* Pays de naissance;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant externe;Temps majoré ? (exemple format: 33%);* Tarification part Pix (Gratuite, Prépayée ou Payante);Code de prépaiement (si Tarification part Pix Prépayée);CléA Numérique ('oui' ou laisser vide);Pix+ Édu 2nd degré ('oui' ou laisser vide);Pix+ Édu 1er degré ('oui' ou laisser vide);Pix+ Droit ('oui' ou laisser vide)
;Site Test;Salle Test;21/04/3023;12:00;Surveillant Test;;Testeur;Dylan;01/01/2000;M;75101;;;FRANCE;;;;;Gratuite;;;;;
;Site Test;Salle Test;21/04/3023;12:00;Surveillant Test;;Testeur;Maeva;14/01/2000;F;75101;;;FRANCE;;;;;Gratuite;;;;;
;Site Test;Salle Test;21/04/3023;12:00;Surveillant Test;;Testeur;Maeva;14/01/2000;F;;75001;Paris;FRANCE;;;;;Gratuite;;;;;
;Site Test;Salle Test;21/04/3023;14:00;Surveillant Test;;Testeur;Aurélie;16/01/2000;F;;75001;Paris;FRANCE;;;;;Gratuite;;;;;
;Site Test;Salle Test;21/04/3023;14:00;Surveillant Test;;Testeur;Michelle;17/01/2000;F;75101;;;FRANCE;;;;;Gratuite;;;;;
```

- L'erreur non bloquante pour l'élève en doublon Maeva doit être retourné une seule fois, sur la "bonne" ligne (une des deux)
- Importer quand même
- S'assurer qu'elle a été ajouté dans la session
