### PR TITLE
[FEATURE] Ajouter le language switcher sur la page de connexion de Pix App (PIX-7214)

### DIFF
--- a/mon-pix/app/components/language-switcher.hbs
+++ b/mon-pix/app/components/language-switcher.hbs
@@ -1,0 +1,10 @@
+<PixSelect
+  @id="language-switcher"
+  @label={{@label}}
+  aria-label={{t "pages.inscription.choose-language-aria-label"}}
+  @icon="earth-europe"
+  @value={{this.selectedLanguage}}
+  @options={{this.availableLanguages}}
+  @onChange={{this.onChange}}
+  @hideDefaultOption="true"
+/>

--- a/mon-pix/app/components/language-switcher.js
+++ b/mon-pix/app/components/language-switcher.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class LanguageSwitcher extends Component {
+  @tracked selectedLanguage = this.args.selectedLanguage;
+
+  availableLanguages = [
+    { label: 'Français', value: 'fr' },
+    { label: 'English', value: 'en' },
+  ];
+
+  @action
+  onChange(value) {
+    this.selectedLanguage = value;
+    this.args.onLanguageChange(value);
+  }
+}

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -1,4 +1,4 @@
-<main class="sign-form__container" role="main">
+<div class="sign-form__container">
 
   <a href={{this.showcase.url}} class="pix-logo__link">
     <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
@@ -89,4 +89,4 @@
     {{/if}}
 
   </form>
-</main>
+</div>

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -7,19 +7,6 @@ export default class UserAccountPersonalInformationController extends Controller
   @service url;
   @service location;
 
-  get options() {
-    return [
-      {
-        value: 'fr',
-        label: this.intl.t('pages.user-account.language.fields.select.labels.french'),
-      },
-      {
-        value: 'en',
-        label: this.intl.t('pages.user-account.language.fields.select.labels.english'),
-      },
-    ];
-  }
-
   @action
   async onChangeLang(value) {
     if (!this.url.isFrenchDomainExtension) {

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -8,7 +8,7 @@ export default class UserAccountPersonalInformationController extends Controller
   @service location;
 
   @action
-  async onChangeLang(value) {
+  async onLanguageChange(value) {
     if (!this.url.isFrenchDomainExtension) {
       this.location.replace(`/mon-compte/langue?lang=${value}`);
     }

--- a/mon-pix/app/controllers/authentication/login.js
+++ b/mon-pix/app/controllers/authentication/login.js
@@ -1,0 +1,31 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+const DEFAULT_LOCALE = 'fr';
+
+export default class LoginController extends Controller {
+  @service intl;
+  @service dayjs;
+  @service currentDomain;
+  @service router;
+
+  @tracked selectedLanguage = this.intl.primaryLocale;
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
+
+  @action
+  onLanguageChange(value) {
+    this.selectedLanguage = value;
+    this._setLocale(this.selectedLanguage);
+    this.router.replaceWith('authentication.login', { queryParams: { lang: null } });
+  }
+
+  _setLocale(language) {
+    this.intl.setLocale([language, DEFAULT_LOCALE]);
+    this.dayjs.setLocale(language);
+  }
+}

--- a/mon-pix/app/controllers/inscription.js
+++ b/mon-pix/app/controllers/inscription.js
@@ -13,22 +13,15 @@ export default class InscriptionController extends Controller {
 
   @tracked selectedLanguage = this.intl.primaryLocale;
 
-  queryParams = ['lang'];
-  availableLanguages = [
-    { label: 'Français', value: 'fr' },
-    { label: 'English', value: 'en' },
-  ];
-
   get isInternationalDomain() {
     return !this.currentDomain.isFranceDomain;
   }
 
   @action
   onLanguageChange(value) {
-    const queryParams = { lang: null };
     this.selectedLanguage = value;
     this._setLocale(this.selectedLanguage);
-    this.router.replaceWith('inscription', { queryParams });
+    this.router.replaceWith('inscription', { queryParams: { lang: null } });
   }
 
   _setLocale(language) {

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -2,10 +2,19 @@ import Service, { inject as service } from '@ember/service';
 import config from 'mon-pix/config/environment';
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+export const DEFAULT_LOCALE = 'fr';
+export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
+
+  handleSupportedLanguage(language) {
+    if (!language) return;
+    const supportedLanguages = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
+    return supportedLanguages.includes(language) ? language : DEFAULT_LOCALE;
+  }
 
   hasLocaleCookie() {
     return this.cookies.exists('locale');

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -6,13 +6,14 @@ export const DEFAULT_LOCALE = 'fr';
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
+const supportedLanguages = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
+
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
 
-  handleSupportedLanguage(language) {
+  handleUnsupportedLanguage(language) {
     if (!language) return;
-    const supportedLanguages = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
     return supportedLanguages.includes(language) ? language : DEFAULT_LOCALE;
   }
 

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -64,7 +64,8 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleUserLanguageAndLocale(transition = null) {
-    await this._loadCurrentUserAndSetLocale(transition?.to?.queryParams?.lang);
+    const language = this.locale.handleUnsupportedLanguage(transition?.to?.queryParams?.lang);
+    await this._loadCurrentUserAndSetLocale(language);
   }
 
   requireAuthenticationAndApprovedTermsOfService(transition, authenticationRoute) {

--- a/mon-pix/app/templates/authenticated/user-account/language.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/language.hbs
@@ -2,6 +2,6 @@
   <LanguageSwitcher
     @label="{{t 'pages.user-account.language.lang'}}"
     @selectedLanguage={{@model.lang}}
-    @onLanguageChange={{this.onChangeLang}}
+    @onLanguageChange={{this.onLanguageChange}}
   />
 </div>

--- a/mon-pix/app/templates/authenticated/user-account/language.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/language.hbs
@@ -1,10 +1,7 @@
 <div class="language">
-  <PixSelect
-    @options={{this.options}}
-    @onChange={{this.onChangeLang}}
-    @value={{@model.lang}}
-    @label={{t "pages.user-account.language.lang"}}
-    @hideDefaultOption={{true}}
-    data-test-lang
+  <LanguageSwitcher
+    @label="{{t 'pages.user-account.language.lang'}}"
+    @selectedLanguage={{@model.lang}}
+    @onLanguageChange={{this.onChangeLang}}
   />
 </div>

--- a/mon-pix/app/templates/authentication/login.hbs
+++ b/mon-pix/app/templates/authentication/login.hbs
@@ -1,4 +1,4 @@
 {{page-title (t "pages.sign-in.title")}}
-<div class="sign-form-page">
+<main class="sign-form-page" role="main">
   <SigninForm />
-</div>
+</main>

--- a/mon-pix/app/templates/authentication/login.hbs
+++ b/mon-pix/app/templates/authentication/login.hbs
@@ -1,4 +1,10 @@
 {{page-title (t "pages.sign-in.title")}}
 <main class="sign-form-page" role="main">
-  <SigninForm />
+  <section class="sign-form-page__container">
+    <SigninForm />
+
+    {{#if this.isInternationalDomain}}
+      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+    {{/if}}
+  </section>
 </main>

--- a/mon-pix/app/templates/inscription.hbs
+++ b/mon-pix/app/templates/inscription.hbs
@@ -3,15 +3,7 @@
   <section class="sign-form-page__container">
     <SignupForm @user={{@model}} />
     {{#if this.isInternationalDomain}}
-      <PixSelect
-        @id="language-switcher"
-        @value={{this.selectedLanguage}}
-        aria-label={{t "pages.inscription.choose-language-aria-label"}}
-        @icon="earth-europe"
-        @options={{this.availableLanguages}}
-        @onChange={{this.onLanguageChange}}
-        @hideDefaultOption="true"
-      />
+      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
     {{/if}}
   </section>
 </main>

--- a/mon-pix/tests/acceptance/authentication/login_test.js
+++ b/mon-pix/tests/acceptance/authentication/login_test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | Login', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks, ['fr', 'en']);
+
+  module('when current url does not contain french tld (.fr)', function () {
+    module('when accessing the signin page with "Français" as default language', function () {
+      test('displays the signin page with "Français" as selected language', async function (assert) {
+        // when
+        const screen = await visit('/connexion');
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.sign-in.first-title'), level: 1 })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Français' })).exists();
+      });
+
+      module('when the user select "English" as his language', function () {
+        test('displays the login page with "English" as selected language', async function (assert) {
+          // when
+          const screen = await visit('/connexion');
+          await click(screen.getByRole('button', { name: 'Français' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'English' }));
+
+          // then
+          assert.strictEqual(currentURL(), '/connexion');
+          assert
+            .dom(screen.getByRole('heading', { name: this.intl.t('pages.sign-in.first-title'), level: 1 }))
+            .exists();
+          assert.dom(screen.getByRole('button', { name: 'English' })).exists();
+        });
+      });
+    });
+
+    module('when accessing the login page with "English" as selected language', function () {
+      test('displays the login page with "English"', async function (assert) {
+        // when
+        const screen = await visit('/connexion?lang=en');
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion?lang=en');
+        assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.sign-in.first-title'), level: 1 })).exists();
+        assert.dom(screen.getByRole('button', { name: 'English' })).exists();
+      });
+
+      module('when the user select "Français" as his language', function () {
+        test('displays the login page with "Français" as selected language', async function (assert) {
+          // given & when
+          const screen = await visit('/connexion?lang=en');
+          await click(screen.getByRole('button', { name: 'English' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Français' }));
+
+          // then
+          assert.strictEqual(currentURL(), '/connexion');
+          assert
+            .dom(screen.getByRole('heading', { name: this.intl.t('pages.sign-in.first-title'), level: 1 }))
+            .exists();
+          assert.dom(screen.getByRole('button', { name: 'Français' })).exists();
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/language-switcher_test.js
+++ b/mon-pix/tests/integration/components/language-switcher_test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { click } from '@ember/test-helpers';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Language Switcher', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when component renders', function () {
+    test('displays a button with default option selected', async function (assert) {
+      // when
+      const screen = await render(hbs`<LanguageSwitcher @selectedLanguage="en" />`);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'English' })).exists();
+    });
+  });
+
+  module('when component is clicked', function () {
+    test('displays a list of available languages', async function (assert) {
+      // given
+      const screen = await render(hbs`<LanguageSwitcher @selectedLanguage="en" />`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'English' }));
+      await screen.findByRole('listbox');
+
+      // then
+      assert.dom(screen.getByRole('option', { name: 'Français' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'English' })).exists();
+    });
+  });
+
+  module('when a language is selected', function () {
+    test('calls onLanguageChange callback', async function (assert) {
+      // given
+      const onLanguageChangeStub = sinon.stub();
+      this.set('onLanguageChange', onLanguageChangeStub);
+      const screen = await render(hbs`<LanguageSwitcher
+        @onLanguageChange={{this.onLanguageChange}}
+        @selectedLanguage="en"
+      />`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'English' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Français' }));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Français' })).exists();
+      assert.ok(onLanguageChangeStub.called);
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 module('Unit | Controller | user-account/language', function (hooks) {
   setupTest(hooks);
 
-  module('#onChangeLang', function () {
+  module('#onLanguageChange', function () {
     test('should refresh page on change lang if domain is not french', function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/user-account/language');
@@ -14,7 +14,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
       controller.location = { replace: replaceStub };
 
       // when
-      controller.onChangeLang('en');
+      controller.onLanguageChange('en');
 
       // then
       sinon.assert.calledWith(replaceStub, '/mon-compte/langue?lang=en');

--- a/mon-pix/tests/unit/services/locale_test.js
+++ b/mon-pix/tests/unit/services/locale_test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+import { DEFAULT_LOCALE, ENGLISH_INTERNATIONAL_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
+
 module('Unit | Services | locale', function (hooks) {
   setupTest(hooks);
 
@@ -16,6 +18,55 @@ module('Unit | Services | locale', function (hooks) {
     sinon.stub(cookiesService, 'exists');
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');
+  });
+
+  module('#handleUnsupportedLanguage', function () {
+    module('when language is not supported', function () {
+      test('returns default language', function (assert) {
+        // given
+        const language = 'es';
+
+        // when
+        const result = localeService.handleUnsupportedLanguage(language);
+
+        // then
+        assert.strictEqual(result, DEFAULT_LOCALE);
+      });
+    });
+
+    module('when language is supported', function () {
+      test('returns same language when language is fr', function (assert) {
+        // given
+        const language = FRENCH_INTERNATIONAL_LOCALE;
+
+        // when
+        const result = localeService.handleUnsupportedLanguage(language);
+
+        // then
+        assert.strictEqual(result, language);
+      });
+
+      test('returns same language when language is en', function (assert) {
+        // given
+        const language = ENGLISH_INTERNATIONAL_LOCALE;
+
+        // when
+        const result = localeService.handleUnsupportedLanguage(language);
+
+        // then
+        assert.strictEqual(result, language);
+      });
+    });
+
+    module('when no language is provided', function () {
+      test('returns "undefined"', function (assert) {
+        // given & when
+        const result = localeService.handleUnsupportedLanguage();
+
+        // then
+        assert.strictEqual(result, undefined);
+      });
+    });
   });
 
   module('#setLocaleCookie', function () {

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -16,7 +16,11 @@ module('Unit | Services | session', function (hooks) {
     sessionService.currentDomain = { getExtension: sinon.stub() };
     sessionService.intl = { setLocale: sinon.stub() };
     sessionService.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
-    sessionService.locale = { setLocaleCookie: sinon.stub(), hasLocaleCookie: sinon.stub() };
+    sessionService.locale = {
+      setLocaleCookie: sinon.stub(),
+      hasLocaleCookie: sinon.stub(),
+      handleUnsupportedLanguage: sinon.stub(),
+    };
     sessionService._getRouteAfterInvalidation = sinon.stub();
     sessionService._logoutUser = sinon.stub();
 
@@ -187,6 +191,7 @@ module('Unit | Services | session', function (hooks) {
             // given
             const transition = { to: { queryParams: { lang: 'de' } } };
             sessionService.currentDomain.getExtension.returns('org');
+            sessionService.locale.handleUnsupportedLanguage.returns('de');
 
             // when
             await sessionService.handleUserLanguageAndLocale(transition);
@@ -204,6 +209,7 @@ module('Unit | Services | session', function (hooks) {
               // given
               const transition = { to: { queryParams: { lang: 'de' } } };
               sessionService.currentDomain.getExtension.returns('org');
+              sessionService.locale.handleUnsupportedLanguage.returns('de');
               sessionService.currentUser.user = { lang: 'ru', save: sinon.stub() };
 
               // when
@@ -223,6 +229,7 @@ module('Unit | Services | session', function (hooks) {
                 // given
                 const transition = { to: { queryParams: { lang: 'de' } } };
                 sessionService.currentDomain.getExtension.returns('org');
+                sessionService.locale.handleUnsupportedLanguage.returns('de');
                 sessionService.currentUser.user = {
                   lang: 'ru',
                   save: sinon.stub().throws({ errors: [{ status: '400' }] }),


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible de changer la langue depuis la page de connexion de Pix App.

## :robot: Proposition

Ajouter le "language switcher" sur la page de connexion de Pix App.

## :rainbow: Remarques
- cette pr ajoute un composant language switcher, qui peut afficher son propre label. Voir si on ne mettrait pas le même label partout, par exemple 'Veuillez sélectionner votre langue".

## :100: Pour tester

- se rendre sur la mire de connexion sur le domaine .fr de pix app ([https://app-pr6062.review.pix.fr/connexion](https://app-pr6062.review.pix.fr/connexion))  et observer que le language switcher n'est pas visible
- se rendre sur la mire de connexion sur le domaine .org [https://app-pr6062.review.pix.org/connexion](https://app-pr6062.review.pix.org/)
  - sélectionner une langue et voir que la page s'affiche dans la langue sélectionnée (la langue sélectionnée reste affichée dans le sélecteur)
  - se connecter avec un compte exemple sco.admin@example.net, allez dans le menu et changer la langue de l'utilisateur par exemple English.
  - se déconnecter
  - sur la mire de connexion, changer la langue en français, voir que la page est traduite 
  - se connecter et, une fois connecté, observer que pix app est bien dans la langue de l'utilisateur, par exemple English si c'est la langue choisie par l'utilisateur
  
- Tester en rajoutant des query params `?lang=en` ou `?lang=fr`
 -  la page s'affiche dans la langue spécifiée dans le query params
 -  la valeur par défaut du sélecteur est celle du query params (Français si on a `?lang=fr`)
 -  avec ?lang=es, observez que l'app reste dans la langue par défaut qui est le français
 - refaire les parcours connexion/déconnexion ci-dessus
  