### PR TITLE
[TECH] Supprimer les colonnes non utilisées de la table `trainings`(PIX-7857).

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -9,8 +9,6 @@ function buildTraining({
   locale = 'fr-fr',
   editorName = "Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
-  prerequisiteThreshold = 30,
-  goalThreshold = 70,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -23,8 +21,6 @@ function buildTraining({
     locale,
     editorName,
     editorLogoUrl,
-    prerequisiteThreshold,
-    goalThreshold,
     createdAt,
     updatedAt,
   };
@@ -33,4 +29,5 @@ function buildTraining({
     values,
   });
 }
+
 module.exports = buildTraining;

--- a/api/db/migrations/20230425073218_remove-useless-trainings-columns.js
+++ b/api/db/migrations/20230425073218_remove-useless-trainings-columns.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'trainings';
+const COLUMN_NAME_PREREQUISITE_THRESHOLD = 'prerequisiteThreshold';
+const COLUMN_NAME_GOAL_THRESHOLD = 'goalThreshold';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME_PREREQUISITE_THRESHOLD);
+    table.dropColumn(COLUMN_NAME_GOAL_THRESHOLD);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME_PREREQUISITE_THRESHOLD).nullable().defaultTo(null);
+    table.integer(COLUMN_NAME_GOAL_THRESHOLD).nullable().defaultTo(null);
+  });
+};

--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -7,8 +7,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '06:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 20,
-    goalThreshold: 90,
   });
   const training2 = databaseBuilder.factory.buildTraining({
     title: 'Speed training',
@@ -18,8 +16,6 @@ function trainingBuilder({ databaseBuilder }) {
     locale: 'fr-fr',
     editorName: 'Autre ministère',
     editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/autre_logo_url.svg',
-    prerequisiteThreshold: null,
-    goalThreshold: 90,
   });
   const training3 = databaseBuilder.factory.buildTraining({
     title: 'Comment toiletter son chien',
@@ -27,8 +23,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '10:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 10,
-    goalThreshold: 10,
   });
   const training4 = databaseBuilder.factory.buildTraining({
     title: 'Créer un tabouret',
@@ -36,8 +30,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '47:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 20,
-    goalThreshold: null,
   });
   const training5 = databaseBuilder.factory.buildTraining({
     title: 'Manger bun\'s tous les midis',
@@ -45,8 +37,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '06:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 35,
-    goalThreshold: 40,
   });
   const training6 = databaseBuilder.factory.buildTraining({
     title: 'Apprendre à jouer à la coinche',
@@ -54,8 +44,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '50:00:50',
     locale: 'fr-fr',
-    prerequisiteThreshold: 20,
-    goalThreshold: 60,
   });
   const training7 = databaseBuilder.factory.buildTraining({
     title: 'Savoir coudre',
@@ -63,8 +51,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '00:05:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 20,
-    goalThreshold: 30,
   });
   const training8 = databaseBuilder.factory.buildTraining({
     title: 'Apprendre à faire du cidre breton',
@@ -72,8 +58,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '01:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 0,
-    goalThreshold: 20,
   });
   const training9 = databaseBuilder.factory.buildTraining({
     title: 'Apprendre à compter',
@@ -81,8 +65,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '10:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 50,
-    goalThreshold: 95,
   });
   const training10 = databaseBuilder.factory.buildTraining({
     title: 'Devenir influenceur de bonheur',
@@ -90,8 +72,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '10:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 20,
-    goalThreshold: 90,
   });
   const training11 = databaseBuilder.factory.buildTraining({
     title: 'Faire carrière dans la haute couture',
@@ -99,8 +79,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '07:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: null,
-    goalThreshold: null,
   });
   const training12 = databaseBuilder.factory.buildTraining({
     title: 'Devenir tiktokeur professionel',
@@ -108,8 +86,6 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '12:00:00',
     locale: 'fr-fr',
-    prerequisiteThreshold: 0,
-    goalThreshold: 0,
   });
   const trainingTrigger1 = databaseBuilder.factory.buildTrainingTrigger({
     trainingId: training1.id,

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -644,8 +644,6 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
-        prerequisiteThreshold: 10,
-        goalThreshold: 20,
       };
 
       // when
@@ -653,15 +651,13 @@ describe('Integration | Repository | training-repository', function () {
 
       // then
       const trainingNotUpdated = await knex('trainings')
-        .select('title', 'link', 'editorName', 'editorLogoUrl', 'prerequisiteThreshold', 'goalThreshold')
+        .select('title', 'link', 'editorName', 'editorLogoUrl')
         .where({ id: trainingNotToBeUpdated.id })
         .first();
       expect(trainingNotUpdated.title).to.equal(trainingNotToBeUpdated.title);
       expect(trainingNotUpdated.link).to.equal(trainingNotToBeUpdated.link);
       expect(trainingNotUpdated.editorName).to.equal(trainingNotToBeUpdated.editorName);
       expect(trainingNotUpdated.editorLogoUrl).to.equal(trainingNotToBeUpdated.editorLogoUrl);
-      expect(trainingNotUpdated.prerequisiteThreshold).to.equal(trainingNotToBeUpdated.prerequisiteThreshold);
-      expect(trainingNotUpdated.goalThreshold).to.equal(trainingNotToBeUpdated.goalThreshold);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
La table `trainings` contient toujours les colonnes `goalThreshold` et `prerequisiteThreshold` qui n'ont jamais été utilisé.

## :robot: Proposition
Supprimer ces colonnes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK 
- Récupérer en locale le code : 
	- Lancer `npm run db:migrate`
	- Vérifier que les colonnes ont disparu
	- Lancer le rollback `npm run db:rollback:latest`
	- Vérifier que les colonnes sont de nouveau présente 