### PR TITLE
[TECH] Supprime popper.js de admin

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -72,7 +72,6 @@
         "lodash": "^4.17.21",
         "npm-run-all": "^4.1.5",
         "p-queue": "^6.6.1",
-        "popper.js": "^1.16.1",
         "prettier": "^2.8.0",
         "query-string": "^7.1.1",
         "qunit": "^2.17.2",
@@ -30304,17 +30303,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/portfinder": {
@@ -61679,12 +61667,6 @@
       "requires": {
         "find-up": "^2.1.0"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "dev": true
     },
     "portfinder": {
       "version": "1.0.28",

--- a/admin/package.json
+++ b/admin/package.json
@@ -99,7 +99,6 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.1",
-    "popper.js": "^1.16.1",
     "prettier": "^2.8.0",
     "query-string": "^7.1.1",
     "qunit": "^2.17.2",


### PR DESCRIPTION
## :unicorn: Problème
Popper.js v1 est déprécié, mais surtout il ne semble pas être utilisé sur pix admin.

## :robot: Proposition
Le supprimer

## :rainbow: Remarques
On utilise bien popper js mais via ember-popperjs qui va chercher @popperjs/core.

## :100: Pour tester
Tests + tour dans l'appli
