### PR TITLE
[TECH] Ajout du feature toggle isDifferentiatedTimeInvigilatorPortalEnabled pour Pix Certif (PIX-7830).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -216,6 +216,9 @@ const configuration = (function () {
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT
       ),
       isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
+      isDifferentiatedTimeInvigilatorPortalEnabled: isFeatureEnabled(
+        process.env.FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL
+      ),
     },
 
     infra: {
@@ -356,6 +359,7 @@ const configuration = (function () {
     config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
     config.featureToggles.isMassiveSessionManagementEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
+    config.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled = true;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -29,6 +29,7 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
+  FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -845,6 +845,13 @@ FT_TRAINING_RECOMMENDATION=false
 # default: false
 # FT_PIX_1D_ENABLED=false
 
+# Enable the differentiated time invigilator feature
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL=true
+
 # =====
 # CPF
 # =====

--- a/api/sample.env
+++ b/api/sample.env
@@ -845,7 +845,7 @@ FT_TRAINING_RECOMMENDATION=false
 # default: false
 # FT_PIX_1D_ENABLED=false
 
-# Enable the differentiated time invigilator feature
+# Enable the differentiated time invigilator portal feature
 #
 # presence: optional
 # type: boolean

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
@@ -26,6 +26,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
             'is-massive-session-management-enabled': false,
             'is-pix1d-enabled': true,
+            'is-differentiated-time-invigilator-portal-enabled': true,
           },
         },
       };

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled;
   @attr('boolean') isMassiveSessionManagementEnabled;
+  @attr('boolean') isDifferentiatedTimeInvigilatorPortalEnabled;
 }

--- a/certif/mirage/factories/feature-toggle.js
+++ b/certif/mirage/factories/feature-toggle.js
@@ -2,8 +2,6 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,
-  certifPrescriptionSco: false,
-  reportsCategorization: false,
   isMassiveSessionManagementEnabled: true,
   isDifferentiatedTimeInvigilatorPortalEnabled: true,
 });

--- a/certif/mirage/factories/feature-toggle.js
+++ b/certif/mirage/factories/feature-toggle.js
@@ -5,4 +5,5 @@ export default Factory.extend({
   certifPrescriptionSco: false,
   reportsCategorization: false,
   isMassiveSessionManagementEnabled: true,
+  isDifferentiatedTimeInvigilatorPortalEnabled: true,
 });

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -15,7 +15,6 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
   let session;
 
   hooks.beforeEach(function () {
-    server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
     allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
       type: 'SCO',
       isRelatedToManagingStudentsOrganization: true,

--- a/certif/tests/unit/services/featureToggles_test.js
+++ b/certif/tests/unit/services/featureToggles_test.js
@@ -11,7 +11,7 @@ module('Unit | Service | feature toggles', function (hooks) {
     test('should load the feature toggles', async function (assert) {
       // Given
       const featureToggles = Object.create({
-        certifPrescriptionSco: false,
+        isDifferentiatedTimeInvigilatorPortalEnabled: false,
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(featureToggles),
@@ -23,7 +23,7 @@ module('Unit | Service | feature toggles', function (hooks) {
       await featureToggleService.load();
 
       // Then
-      assert.false(featureToggleService.featureToggles.certifPrescriptionSco);
+      assert.deepEqual(featureToggleService.featureToggles, featureToggles);
     });
   });
 });


### PR DESCRIPTION
## 🦄 Problème
Dans le cadre de l'épix actuelle concernant le MVP de la gestion des temps différenciés de certification par le surveillant, plusieurs modifications vont être apportées à l’Espace Surveillant afin d’aider le surveillant dans sa tâche.

Il est donc nécessaire de cacher les développements en cours derrière un feature toggle le temps que la formation/communication complète puisse être faite par le pôle certif métier.

## 🤖 Solution
Ajout du FT sur les différents environnements

## 💯 Pour tester
Vérifier que les tests passent.
Sur Pix Certif, ouvrir la console et vérifier que l'appel des FT retourne bien notre FT `isDifferentiatedTimeInvigilatorEnabled` à true

<img width="1387" alt="Capture d’écran 2023-04-25 à 10 49 50" src="https://user-images.githubusercontent.com/58915422/234225933-ffa51069-be88-4a9c-913b-a979d2a60d32.png">
