### PR TITLE
[TECH] Corrige un mauvais import dans pix-admin

### DIFF
--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
-import { STARTED, PROCESSED } from 'pix-admin/models/session';
+import { CREATED, PROCESSED } from 'pix-admin/models/session';
 
 module('Unit | Model | session', function (hooks) {
   setupTest(hooks);
@@ -28,11 +28,11 @@ module('Unit | Model | session', function (hooks) {
       });
     });
 
-    module('when the status is STARTED', function () {
+    module('when the status is CREATED', function () {
       test('isFinalized should be false', function (assert) {
         // given
         const sessionStarted = run(() => {
-          return store.createRecord('session', { status: STARTED });
+          return store.createRecord('session', { status: CREATED });
         });
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Dans les tests du model session sur pix-admin, on import la constance **STARTED**. Mais celle-ci n'existe dans le fichier source;

## :robot: Proposition
Je n'ai pas investigué la qualité du test, mais dans le doute je suis passé a un import qui parraissait similaire: CREATED.

## :rainbow: Remarques
Ceci pour préparer le passage vers embroider.

## :100: Pour tester
Tests verts.
