### PR TITLE
[FEATURE] Afficher l'image du profil cible dans l'encart de détails sur PixAdmin (PIX-7129)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -30,8 +30,6 @@
               {{@model.ownerOrganizationId}}
             </LinkTo>
           </div>
-        </div>
-        <div class="page-section__content">
           {{#if @model.description}}
             <div>
               Description :
@@ -44,6 +42,11 @@
               <MarkdownToHtml @markdown={{@model.comment}} />
             </div>
           {{/if}}
+        </div>
+        <div class="page-section__content">
+          <div>
+            <img src={{@model.imageUrl}} role="img" alt="Profil cible" />
+          </div>
         </div>
       </div>
       <div class="target-profile__actions">

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -84,6 +84,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       assert.dom(screen.getByText('456')).exists();
       assert.dom(screen.getByText('Top profil cible.')).exists();
       assert.dom(screen.getByText('Commentaire Privé.')).exists();
+      assert.dom(screen.getByAltText('Profil cible')).exists();
     });
 
     test('it should edit target profile information', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
L'image du profil cible n'était visible nulle part sur PixAdmin.

## :robot: Proposition
L'afficher dans l'encart de détails du PC.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur PixAdmin > Profil cibles > Choisir le profil cible de son choix > constater l'affichage de l'image dans l'encart de détails
