### PR TITLE
[TECH] Injecter les dépendances dans le use-case `start-writing-campaign-assessment-results-to-stream` pour préparer la migration ESM

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -11,7 +11,6 @@ const { constants } = require('../../infrastructure/constants.js');
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } = require('../errors.js');
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer.js');
 const CampaignLearningContent = require('../models/CampaignLearningContent.js');
-const stageCollectionRepository = require('../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js');
 
 module.exports = async function startWritingCampaignAssessmentResultsToStream({
   userId,
@@ -27,6 +26,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream({
   campaignCsvExportService,
   targetProfileRepository,
   learningContentRepository,
+  stageCollectionRepository,
 }) {
   const campaign = await campaignRepository.get(campaignId);
   const translate = i18n.__;

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -4,7 +4,6 @@ const startWritingCampaignAssessmentResultsToStream = require('../../../../lib/d
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } = require('../../../../lib/domain/errors');
 const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 const { getI18n } = require('../../../tooling/i18n/i18n');
-const stageCollectionRepository = require('../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository');
 const StageCollection = require('../../../../lib/domain/models/user-campaign-results/StageCollection');
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
@@ -16,6 +15,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
   const campaignParticipationInfoRepository = { findByCampaignId: () => undefined };
   const knowledgeElementRepository = { findGroupedByCompetencesForUsersWithinLearningContent: () => undefined };
   const badgeAcquisitionRepository = { getAcquiredBadgesByCampaignParticipations: () => undefined };
+  const stageCollectionRepository = { findStageCollection: () => undefined };
 
   let writableStream, csvPromise, i18n;
 
@@ -46,6 +46,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
 
     // then
@@ -74,6 +75,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
 
     // then
@@ -144,6 +146,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 
@@ -205,6 +208,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 
@@ -268,6 +272,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 
@@ -327,6 +332,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 
@@ -405,6 +411,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 
@@ -468,6 +475,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 
@@ -531,6 +539,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
         campaignParticipationInfoRepository,
         knowledgeElementRepository,
         campaignCsvExportService,
+        stageCollectionRepository,
       });
       const csv = await csvPromise;
 
@@ -592,6 +601,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
         campaignParticipationInfoRepository,
         knowledgeElementRepository,
         campaignCsvExportService,
+        stageCollectionRepository,
       });
       const csv = await csvPromise;
 
@@ -695,6 +705,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       knowledgeElementRepository,
       badgeAcquisitionRepository,
       campaignCsvExportService,
+      stageCollectionRepository,
     });
     const csv = await csvPromise;
 


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire.

## :rainbow: Remarques
RAS

## :100: Pour tester
CI OK
