### PR TITLE
[BUGFIX] Permettre la création de CF (PIX-7869).

### DIFF
--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -112,7 +112,16 @@ async function findWithTriggersByCampaignParticipationIdAndLocale({
 
 async function create({ training, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction?.knexTransaction || knex;
-  const [createdTraining] = await knexConn(TABLE_NAME).insert(training).returning('*');
+  const pickedAttributes = pick(training, [
+    'title',
+    'link',
+    'type',
+    'duration',
+    'locale',
+    'editorName',
+    'editorLogoUrl',
+  ]);
+  const [createdTraining] = await knexConn(TABLE_NAME).insert(pickedAttributes).returning('*');
   return new TrainingForAdmin(createdTraining);
 }
 

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -566,7 +566,12 @@ describe('Integration | Repository | training-repository', function () {
       };
 
       // when
-      const createdTraining = await trainingRepository.create({ training });
+      const createdTraining = await trainingRepository.create({
+        training: {
+          ...training,
+          anotherAttribute: 'anotherAttribute',
+        },
+      });
 
       // then
       expect(createdTraining).to.be.instanceOf(TrainingForAdmin);


### PR DESCRIPTION
## :unicorn: Problème
Depuis, l'ajout de l'attribut `isRecommandable` il n'est plus possible de créer un CF. 
Cet attribut est calculé en sql et revient au front. Le front a connaissance de cet attribut et du coup lors de la création d'un CF l'envoi également. Cependant, comme il ne s'agit pas d'une colonne en base la requête d'insertion échoue.

## :robot: Proposition
Insérer uniquement les champs qui nous intéressent. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Admin
- Aller dans l'onglet Contenus Formatifs
- Créer un CF 
