### PR TITLE
[TECH] Injecter des dépendances pour préparer la migration ESM

### DIFF
--- a/api/lib/application/preHandlers/authorization.js
+++ b/api/lib/application/preHandlers/authorization.js
@@ -2,23 +2,31 @@ const { NotFoundError } = require('../http-errors.js');
 const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository.js');
 const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository.js');
 
-module.exports.verifySessionAuthorization = async (request) => {
+module.exports.verifySessionAuthorization = async (request, h, dependencies = { sessionRepository }) => {
   const userId = request.auth.credentials.userId;
   const sessionId = request.params.id;
 
-  return await _isAuthorizedToAccessSession({ userId, sessionId });
+  return await _isAuthorizedToAccessSession({ userId, sessionId, sessionRepository: dependencies.sessionRepository });
 };
 
-module.exports.verifyCertificationSessionAuthorization = async (request) => {
+module.exports.verifyCertificationSessionAuthorization = async (
+  request,
+  h,
+  dependencies = { sessionRepository, certificationCourseRepository }
+) => {
   const userId = request.auth.credentials.userId;
   const certificationCourseId = request.params.id;
 
-  const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+  const certificationCourse = await dependencies.certificationCourseRepository.get(certificationCourseId);
 
-  return await _isAuthorizedToAccessSession({ userId, sessionId: certificationCourse.getSessionId() });
+  return await _isAuthorizedToAccessSession({
+    userId,
+    sessionId: certificationCourse.getSessionId(),
+    sessionRepository: dependencies.sessionRepository,
+  });
 };
 
-async function _isAuthorizedToAccessSession({ userId, sessionId }) {
+async function _isAuthorizedToAccessSession({ userId, sessionId, sessionRepository }) {
   const hasMembershipAccess = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(
     userId,
     sessionId

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -7,40 +7,43 @@ const localeService = require('../services/locale-service');
 const AuthenticationMethod = require('./AuthenticationMethod.js');
 
 class User {
-  constructor({
-    id,
-    cgu,
-    pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted,
-    email,
-    emailConfirmedAt,
-    username,
-    firstName,
-    knowledgeElements,
-    lastName,
-    lastTermsOfServiceValidatedAt,
-    lastPixOrgaTermsOfServiceValidatedAt,
-    lastPixCertifTermsOfServiceValidatedAt,
-    lastDataProtectionPolicySeenAt,
-    hasSeenAssessmentInstructions,
-    hasSeenNewDashboardInfo,
-    hasSeenFocusedChallengeTooltip,
-    hasSeenOtherChallengesTooltip,
-    mustValidateTermsOfService,
-    lang,
-    locale,
-    isAnonymous,
-    memberships = [],
-    certificationCenterMemberships = [],
-    pixScore,
-    scorecards = [],
-    campaignParticipations = [],
-    authenticationMethods = [],
-    hasBeenAnonymised,
-    hasBeenAnonymisedBy,
-  } = {}) {
+  constructor(
+    {
+      id,
+      cgu,
+      pixOrgaTermsOfServiceAccepted,
+      pixCertifTermsOfServiceAccepted,
+      email,
+      emailConfirmedAt,
+      username,
+      firstName,
+      knowledgeElements,
+      lastName,
+      lastTermsOfServiceValidatedAt,
+      lastPixOrgaTermsOfServiceValidatedAt,
+      lastPixCertifTermsOfServiceValidatedAt,
+      lastDataProtectionPolicySeenAt,
+      hasSeenAssessmentInstructions,
+      hasSeenNewDashboardInfo,
+      hasSeenFocusedChallengeTooltip,
+      hasSeenOtherChallengesTooltip,
+      mustValidateTermsOfService,
+      lang,
+      locale,
+      isAnonymous,
+      memberships = [],
+      certificationCenterMemberships = [],
+      pixScore,
+      scorecards = [],
+      campaignParticipations = [],
+      authenticationMethods = [],
+      hasBeenAnonymised,
+      hasBeenAnonymisedBy,
+    } = {},
+    dependencies = { config, localeService }
+  ) {
     if (locale) {
-      locale = localeService.getCanonicalLocale(locale);
+      locale = dependencies.localeService.getCanonicalLocale(locale);
     }
 
     this.id = id;
@@ -73,6 +76,7 @@ class User {
     this.authenticationMethods = authenticationMethods;
     this.hasBeenAnonymised = hasBeenAnonymised;
     this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
+    this.dependencies = dependencies;
   }
 
   get shouldChangePassword() {
@@ -86,13 +90,16 @@ class User {
   get shouldSeeDataProtectionPolicyInformationBanner() {
     const isNotOrganizationLearner = this.cgu === true;
     const parsedDate = new Date(this.lastDataProtectionPolicySeenAt);
-    return dayjs(parsedDate).isBefore(dayjs(config.dataProtectionPolicy.updateDate)) && isNotOrganizationLearner;
+    return (
+      dayjs(parsedDate).isBefore(dayjs(this.dependencies.config.dataProtectionPolicy.updateDate)) &&
+      isNotOrganizationLearner
+    );
   }
 
   setLocaleIfNotAlreadySet(newLocale) {
     this.hasBeenModified = false;
     if (newLocale && !this.locale) {
-      const canonicalLocale = localeService.getCanonicalLocale(newLocale);
+      const canonicalLocale = this.dependencies.localeService.getCanonicalLocale(newLocale);
       this.locale = canonicalLocale;
       this.hasBeenModified = true;
     }

--- a/api/lib/domain/usecases/create-target-profile.js
+++ b/api/lib/domain/usecases/create-target-profile.js
@@ -1,11 +1,12 @@
 const TargetProfileForCreation = require('../models/TargetProfileForCreation.js');
-const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
 const { TargetProfileCannotBeCreated } = require('../errors');
+
 module.exports = async function createTargetProfile({
   targetProfileCreationCommand,
   domainTransaction,
   targetProfileRepository,
   organizationRepository,
+  learningContentConversionService,
 }) {
   const targetProfileForCreation = TargetProfileForCreation.fromCreationCommand(targetProfileCreationCommand);
   try {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -179,6 +179,7 @@ const passwordValidator = require('../validators/password-validator.js');
 const stageCollectionRepository = require('../../infrastructure/repositories/user-campaign-results/stage-collection-repository');
 const campaignValidator = require('../validators/campaign-validator.js');
 const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
+const temporarySessionsStorageForMassImportService = require('../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -369,6 +370,7 @@ const dependencies = {
   stageCollectionRepository,
   campaignValidator,
   learningContentConversionService,
+  temporarySessionsStorageForMassImportService,
 };
 
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection.js');

--- a/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
@@ -1,7 +1,6 @@
 const { NotFoundError } = require('../../errors');
 const bluebird = require('bluebird');
 const DomainTransaction = require('../../../infrastructure/DomainTransaction.js');
-const temporarySessionsStorageForMassImportService = require('../../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
 const Session = require('../../models/Session');
 const CertificationCandidate = require('../../models/CertificationCandidate');
 
@@ -10,6 +9,7 @@ module.exports = async function createSessions({
   cachedValidatedSessionsKey,
   certificationCandidateRepository,
   sessionRepository,
+  temporarySessionsStorageForMassImportService,
 }) {
   const temporaryCachedSessions = await temporarySessionsStorageForMassImportService.getByKeyAndUserId({
     cachedValidatedSessionsKey,

--- a/api/lib/infrastructure/external-storage/cpf-external-storage.js
+++ b/api/lib/infrastructure/external-storage/cpf-external-storage.js
@@ -3,45 +3,50 @@ const { cpf } = require('../../config.js');
 const logger = require('../logger.js');
 
 module.exports = {
-  upload: async function ({ filename, readableStream }) {
-    logger.trace('cpfExternalStorage: start upload');
+  upload: async function ({ filename, readableStream, dependencies = { s3Utils, logger } }) {
+    dependencies.logger.trace('cpfExternalStorage: start upload');
 
     const { accessKeyId, secretAccessKey, endpoint, region, bucket } = cpf.storage;
-    const s3Client = s3Utils.getS3Client({
+    const s3Client = dependencies.s3Utils.getS3Client({
       accessKeyId,
       secretAccessKey,
       endpoint,
       region,
     });
 
-    const upload = s3Utils.startUpload({
+    const upload = dependencies.s3Utils.startUpload({
       client: s3Client,
       filename,
       bucket,
       readableStream,
     });
 
-    upload.on('httpUploadProgress', (progress) => logger.trace(progress));
+    upload.on('httpUploadProgress', (progress) => dependencies.logger.trace(progress));
 
     await upload.done();
-    logger.trace(`cpfExternalStorage: ${filename} upload done`);
+    dependencies.logger.trace(`cpfExternalStorage: ${filename} upload done`);
   },
 
-  getPreSignUrlsOfFilesModifiedAfter: async function ({ date }) {
+  getPreSignUrlsOfFilesModifiedAfter: async function ({ date, dependencies = { s3Utils } }) {
     const { accessKeyId, secretAccessKey, endpoint, region, bucket, preSignedExpiresIn: expiresIn } = cpf.storage;
-    const s3Client = s3Utils.getS3Client({
+    const s3Client = dependencies.s3Utils.getS3Client({
       accessKeyId,
       secretAccessKey,
       endpoint,
       region,
     });
 
-    const filesInBucket = await s3Utils.listFiles({ client: s3Client, bucket });
+    const filesInBucket = await dependencies.s3Utils.listFiles({ client: s3Client, bucket });
 
     const keysOfFilesModifiedAfter = filesInBucket?.Contents.filter(({ LastModified }) => LastModified >= date).map(
       ({ Key }) => Key
     );
 
-    return await s3Utils.preSignFiles({ client: s3Client, bucket, keys: keysOfFilesModifiedAfter, expiresIn });
+    return await dependencies.s3Utils.preSignFiles({
+      client: s3Client,
+      bucket,
+      keys: keysOfFilesModifiedAfter,
+      expiresIn,
+    });
   },
 };

--- a/api/tests/unit/domain/usecases/create-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/create-target-profile_test.js
@@ -1,13 +1,12 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const createTargetProfile = require('../../../../lib/domain/usecases/create-target-profile');
 const { categories } = require('../../../../lib/domain/models/TargetProfile');
-const learningContentConversionService = require('../../../../lib/domain/services/learning-content/learning-content-conversion-service');
-const usecases = require('../../../../lib/domain/usecases');
 const { TargetProfileCannotBeCreated } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-target-profile', function () {
   let targetProfileRepositoryStub;
   let organizationRepositoryStub;
+  let learningContentConversionService;
 
   beforeEach(function () {
     targetProfileRepositoryStub = {
@@ -16,6 +15,9 @@ describe('Unit | UseCase | create-target-profile', function () {
     };
     organizationRepositoryStub = {
       get: sinon.stub(),
+    };
+    learningContentConversionService = {
+      findActiveSkillsForCappedTubes: sinon.stub(),
     };
   });
 
@@ -36,11 +38,12 @@ describe('Unit | UseCase | create-target-profile', function () {
       tubes: [{ id: 'tubeId', level: 2 }],
     };
 
-    const error = await catchErr(usecases.createTargetProfile)({
+    const error = await catchErr(createTargetProfile)({
       targetProfileCreationCommand,
       domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
+      learningContentConversionService,
     });
 
     // then
@@ -51,7 +54,6 @@ describe('Unit | UseCase | create-target-profile', function () {
     // given
     organizationRepositoryStub.get.resolves();
     const domainTransaction = Symbol('DomainTransaction');
-    sinon.stub(learningContentConversionService, 'findActiveSkillsForCappedTubes');
     learningContentConversionService.findActiveSkillsForCappedTubes.resolves();
     targetProfileRepositoryStub.updateTargetProfileWithSkills.resolves();
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
@@ -82,6 +84,7 @@ describe('Unit | UseCase | create-target-profile', function () {
       domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
+      learningContentConversionService,
     });
 
     // then
@@ -95,7 +98,6 @@ describe('Unit | UseCase | create-target-profile', function () {
     // given
     organizationRepositoryStub.get.resolves();
     const domainTransaction = Symbol('DomainTransaction');
-    sinon.stub(learningContentConversionService, 'findActiveSkillsForCappedTubes');
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
       name: 'myFirstTargetProfile',
       category: categories.SUBJECT,
@@ -134,6 +136,7 @@ describe('Unit | UseCase | create-target-profile', function () {
       domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
+      learningContentConversionService,
     });
 
     // then
@@ -148,7 +151,6 @@ describe('Unit | UseCase | create-target-profile', function () {
     // given
     organizationRepositoryStub.get.resolves();
     const domainTransaction = Symbol('DomainTransaction');
-    sinon.stub(learningContentConversionService, 'findActiveSkillsForCappedTubes');
     const expectedTargetProfileForCreation = domainBuilder.buildTargetProfileForCreation({
       name: 'myFirstTargetProfile',
       category: categories.SUBJECT,
@@ -187,6 +189,7 @@ describe('Unit | UseCase | create-target-profile', function () {
       domainTransaction,
       targetProfileRepository: targetProfileRepositoryStub,
       organizationRepository: organizationRepositoryStub,
+      learningContentConversionService,
     });
 
     // then

--- a/api/tests/unit/domain/usecases/sessions-mass-import/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/create-sessions_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../../test-helper');
 const { NotFoundError } = require('../../../../../lib/domain/errors');
 const createSessions = require('../../../../../lib/domain/usecases/sessions-mass-import/create-sessions');
-const temporarySessionsStorageForMassImportService = require('../../../../../lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
 const DomainTransaction = require('../../../../../lib/infrastructure/DomainTransaction');
 const Session = require('../../../../../lib/domain/models/Session');
 
@@ -9,20 +8,23 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
   let certificationCandidateRepository;
   let sessionRepository;
   let dependencies;
+  let temporarySessionsStorageForMassImportService;
 
   beforeEach(function () {
     certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
     sessionRepository = { save: sinon.stub() };
+    temporarySessionsStorageForMassImportService = { getByKeyAndUserId: sinon.stub(), delete: sinon.stub() };
+
     dependencies = {
       certificationCandidateRepository,
       sessionRepository,
+      temporarySessionsStorageForMassImportService,
     };
   });
 
   context('when there are no cached sessions matching the key', function () {
     it('should throw a NotFound error', async function () {
       // given
-      temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon.stub();
       temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(undefined);
       const userId = 1234;
       const cachedValidatedSessionsKey = 'uuid';
@@ -60,9 +62,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
               certificationCandidates: [],
             },
           ];
-          temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon
-            .stub()
-            .resolves(temporaryCachedSessions);
+          temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
           const userId = 1234;
           const cachedValidatedSessionsKey = 'uuid';
           const domainTransaction = Symbol('trx');
@@ -103,9 +103,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
               certificationCandidates: [certificationCandidate],
             },
           ];
-          temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon
-            .stub()
-            .resolves(temporaryCachedSessions);
+          temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
           const userId = 1234;
           const cachedValidatedSessionsKey = 'uuid';
           const domainTransaction = Symbol('trx');
@@ -141,7 +139,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
             certificationCandidates: [{ ...certificationCandidate }],
           },
         ];
-        temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon.stub().resolves(temporaryCachedSessions);
+        temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
         const userId = 1234;
         const cachedValidatedSessionsKey = 'uuid';
         const domainTransaction = Symbol('trx');
@@ -176,8 +174,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           certificationCandidates: [{ ...certificationCandidate }],
         },
       ];
-      temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon.stub().resolves(temporaryCachedSessions);
-      temporarySessionsStorageForMassImportService.delete = sinon.stub();
+      temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(temporaryCachedSessions);
       const userId = 1234;
       const cachedValidatedSessionsKey = 'uuid';
       const domainTransaction = Symbol('trx');


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire.

## :rainbow: Remarques
Un service n'était pas injecté avec notre injecteur de dépendances (usecases/index.js) ! Si un problème fonctionnel appairait suite à cette PR, c'est que notre code n'est pas correctement testé.

Les prehandlers sont directement appelés par `hapi` et passent 2 paramètres dans les cas nominaux. Il a fallu faire attention à ça pour passer des dépendances en 3ème paramètre, sinon les tests d'acceptance (et accessoirement les fonctionnalités) cassent avec plein de 500 partout !

## :100: Pour tester
CI OK
