### PR TITLE
[TECH] Mettre en place l'injection de dépendance pour la migration ESM

### DIFF
--- a/api/lib/application/preHandlers/session-supervisor-authorization.js
+++ b/api/lib/application/preHandlers/session-supervisor-authorization.js
@@ -2,10 +2,14 @@ const supervisorAccessRepository = require('../../infrastructure/repositories/su
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  async verifyByCertificationCandidateId(request, h) {
-    const supervisorUserId = requestResponseUtils.extractUserIdFromRequest(request);
+  async verifyByCertificationCandidateId(
+    request,
+    h,
+    dependencies = { requestResponseUtils, supervisorAccessRepository }
+  ) {
+    const supervisorUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     const candidateId = request.params.id;
-    const isSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSessionCandidate({
+    const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSessionCandidate({
       supervisorId: supervisorUserId,
       certificationCandidateId: candidateId,
     });
@@ -17,11 +21,11 @@ module.exports = {
     return true;
   },
 
-  async verifyBySessionId(request, h) {
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  async verifyBySessionId(request, h, dependencies = { requestResponseUtils, supervisorAccessRepository }) {
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     const sessionId = request.params.id;
 
-    const isSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSession({
+    const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSession({
       sessionId,
       userId,
     });

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -110,12 +110,13 @@ module.exports = {
     line,
     certificationCpfCountryRepository,
     certificationCpfCityRepository,
+    dependencies = { certificationCpfService },
   }) {
     const certificationCandidateErrors = [];
     const errorCodes = candidate.validateForMassSessionImport(isSco);
     _addToErrorList({ errorList: certificationCandidateErrors, line, codes: errorCodes });
 
-    const cpfBirthInformation = await certificationCpfService.getBirthInformation({
+    const cpfBirthInformation = await dependencies.certificationCpfService.getBirthInformation({
       birthCountry: candidate.birthCountry,
       birthCity: candidate.birthCity,
       birthPostalCode: candidate.birthPostalCode,

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -9,8 +9,9 @@ module.exports = async function createSession({
   certificationCenterRepository,
   sessionRepository,
   userRepository,
+  dependencies = { sessionValidator, sessionCodeService },
 }) {
-  sessionValidator.validate(session);
+  dependencies.sessionValidator.validate(session);
 
   const certificationCenterId = session.certificationCenterId;
   const userWithCertifCenters = await userRepository.getWithCertificationCenterMemberships(userId);
@@ -20,7 +21,7 @@ module.exports = async function createSession({
     );
   }
 
-  const accessCode = sessionCodeService.getNewSessionCode();
+  const accessCode = dependencies.sessionCodeService.getNewSessionCode();
   const { name: certificationCenter } = await certificationCenterRepository.get(certificationCenterId);
   const domainSession = new Session({
     ...session,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -182,6 +182,7 @@ const campaignValidator = require('../validators/campaign-validator.js');
 const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
 const temporarySessionsStorageForMassImportService = require('../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
 const sessionValidator = require('../validators/session-validator.js');
+const sessionCodeService = require('../services/session-code-service.js');
 
 function requirePoleEmploiNotifier() {
   if (settings.poleEmploi.pushEnabled) {
@@ -330,6 +331,7 @@ const dependencies = {
   sessionForAttendanceSheetRepository,
   sessionsImportValidationService,
   sessionPublicationService,
+  sessionCodeService,
   sessionRepository,
   sessionForSupervisingRepository,
   sessionJuryCommentRepository,

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -1,6 +1,5 @@
 const Session = require('../../models/Session');
 const SessionMassImportReport = require('../../models/SessionMassImportReport');
-const sessionCodeService = require('../../services/session-code-service');
 const sessionsImportValidationService = require('../../services/sessions-mass-import/sessions-import-validation-service');
 const temporarySessionsStorageForMassImportService = require('../../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
 const CertificationCandidate = require('../../models/CertificationCandidate');
@@ -16,6 +15,7 @@ module.exports = async function validateSessions({
   certificationCpfCityRepository,
   complementaryCertificationRepository,
   certificationCourseRepository,
+  sessionCodeService,
 }) {
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
   const sessionsMassImportReport = new SessionMassImportReport();

--- a/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
@@ -1,20 +1,26 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
 const sessionSupervisorAuthorization = require('../../../../lib/application/preHandlers/session-supervisor-authorization');
-const supervisorAccessRepository = require('../../../../lib/infrastructure/repositories/supervisor-access-repository');
-const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Pre-handler | Supervisor Authorization', function () {
+  let supervisorAccessRepository;
+  let requestResponseUtils;
+  let dependencies;
+
+  beforeEach(function () {
+    supervisorAccessRepository = {
+      isUserSupervisorForSessionCandidate: sinon.stub(),
+      isUserSupervisorForSession: sinon.stub(),
+    };
+    requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
+    dependencies = { supervisorAccessRepository, requestResponseUtils };
+  });
+
   describe('#verifyByCertificationCandidateId', function () {
     const request = {
       params: {
         id: 8,
       },
     };
-
-    beforeEach(function () {
-      sinon.stub(supervisorAccessRepository, 'isUserSupervisorForSessionCandidate');
-      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
-    });
 
     describe('When user is the supervisor of the assessment session', function () {
       it('should return true', async function () {
@@ -28,7 +34,11 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
           .resolves(true);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyByCertificationCandidateId(request, hFake);
+        const response = await sessionSupervisorAuthorization.verifyByCertificationCandidateId(
+          request,
+          hFake,
+          dependencies
+        );
 
         // then
         expect(response).to.be.true;
@@ -47,7 +57,11 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
           .resolves(false);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyByCertificationCandidateId(request, hFake);
+        const response = await sessionSupervisorAuthorization.verifyByCertificationCandidateId(
+          request,
+          hFake,
+          dependencies
+        );
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -62,11 +76,6 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
       },
     };
 
-    beforeEach(function () {
-      sinon.stub(supervisorAccessRepository, 'isUserSupervisorForSession');
-      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
-    });
-
     describe('When user is the supervisor of the assessment session', function () {
       it('should return true', async function () {
         // given
@@ -75,7 +84,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
         supervisorAccessRepository.isUserSupervisorForSession.resolves(true);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake);
+        const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake, dependencies);
 
         // then
         sinon.assert.calledWith(supervisorAccessRepository.isUserSupervisorForSession, {
@@ -93,7 +102,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
         supervisorAccessRepository.isUserSupervisorForSession.resolves(false);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake);
+        const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake, dependencies);
 
         // then
         expect(response.statusCode).to.equal(401);

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -393,10 +393,6 @@ describe('Unit | Service | sessions import validation Service', function () {
   });
 
   describe('#getValidatedCandidateBirthInformation', function () {
-    beforeEach(function () {
-      sinon.stub(certificationCpfService, 'getBirthInformation');
-    });
-
     context('when the parsed data is valid', function () {
       it('should return an empty certificationCandidateErrors', async function () {
         // given
@@ -409,14 +405,16 @@ describe('Unit | Service | sessions import validation Service', function () {
         const candidate = _buildValidCandidateData();
         const cpfBirthInformationValidation = new CpfBirthInformationValidation();
         cpfBirthInformationValidation.success(candidateInformation);
-
-        certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
+        const certificationCpfServiceStub = {
+          getBirthInformation: sinon.stub().resolves(cpfBirthInformationValidation),
+        };
 
         // when
         const { certificationCandidateErrors } =
           await sessionsImportValidationService.getValidatedCandidateBirthInformation({
             candidate,
             isSco: false,
+            dependencies: { certificationCpfService: certificationCpfServiceStub },
           });
 
         // then
@@ -432,7 +430,9 @@ describe('Unit | Service | sessions import validation Service', function () {
         candidate.firstName = null;
         const cpfBirthInformationValidation = new CpfBirthInformationValidation();
         cpfBirthInformationValidation.success({ ...candidate });
-        certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
+        const certificationCpfServiceStub = {
+          getBirthInformation: sinon.stub().resolves(cpfBirthInformationValidation),
+        };
 
         // when
         const { certificationCandidateErrors } =
@@ -440,6 +440,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             candidate,
             isSco,
             line: 1,
+            dependencies: { certificationCpfService: certificationCpfServiceStub },
           });
 
         // then
@@ -463,7 +464,9 @@ describe('Unit | Service | sessions import validation Service', function () {
             candidate.billingMode = null;
             const cpfBirthInformationValidation = new CpfBirthInformationValidation();
             cpfBirthInformationValidation.success({ ...candidate });
-            certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
+            const certificationCpfServiceStub = {
+              getBirthInformation: sinon.stub().resolves(cpfBirthInformationValidation),
+            };
 
             // when
             const { certificationCandidateErrors } =
@@ -471,6 +474,7 @@ describe('Unit | Service | sessions import validation Service', function () {
                 candidate,
                 isSco,
                 line: 1,
+                dependencies: { certificationCpfService: certificationCpfServiceStub },
               });
 
             // then
@@ -492,14 +496,16 @@ describe('Unit | Service | sessions import validation Service', function () {
             candidate.billingMode = '';
             const cpfBirthInformationValidation = new CpfBirthInformationValidation();
             cpfBirthInformationValidation.success({ ...candidate });
-            certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
-
+            const certificationCpfServiceStub = {
+              getBirthInformation: sinon.stub().resolves(cpfBirthInformationValidation),
+            };
             // when
             const { certificationCandidateErrors } =
               await sessionsImportValidationService.getValidatedCandidateBirthInformation({
                 candidate,
                 isSco,
                 line: 1,
+                dependencies: { certificationCpfService: certificationCpfServiceStub },
               });
 
             // then
@@ -528,14 +534,16 @@ describe('Unit | Service | sessions import validation Service', function () {
           candidate.billingMode = null;
           const cpfBirthInformationValidation = new CpfBirthInformationValidation();
           cpfBirthInformationValidation.success(candidateInformation);
-
-          certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
+          const certificationCpfServiceStub = {
+            getBirthInformation: sinon.stub().resolves(cpfBirthInformationValidation),
+          };
 
           // when
           const { certificationCandidateErrors } =
             await sessionsImportValidationService.getValidatedCandidateBirthInformation({
               candidate,
               isSco,
+              dependencies: { certificationCpfService: certificationCpfServiceStub },
             });
 
           // then
@@ -555,16 +563,19 @@ describe('Unit | Service | sessions import validation Service', function () {
           const certificationCandidateError = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED;
           const cpfBirthInformationValidation = new CpfBirthInformationValidation();
           cpfBirthInformationValidation.failure({ certificationCandidateError });
-          certificationCpfService.getBirthInformation
-            .withArgs({
-              birthCountry: '',
-              birthCity: candidate.birthCity,
-              birthPostalCode: candidate.birthPostalCode,
-              birthINSEECode: candidate.birthINSEECode,
-              certificationCpfCountryRepository,
-              certificationCpfCityRepository,
-            })
-            .resolves(cpfBirthInformationValidation);
+          const certificationCpfServiceStub = {
+            getBirthInformation: sinon
+              .stub()
+              .withArgs({
+                birthCountry: '',
+                birthCity: candidate.birthCity,
+                birthPostalCode: candidate.birthPostalCode,
+                birthINSEECode: candidate.birthINSEECode,
+                certificationCpfCountryRepository,
+                certificationCpfCityRepository,
+              })
+              .resolves(cpfBirthInformationValidation),
+          };
 
           // when
           const result = await sessionsImportValidationService.getValidatedCandidateBirthInformation({
@@ -573,6 +584,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
             line: 1,
+            dependencies: { certificationCpfService: certificationCpfServiceStub },
           });
 
           // then
@@ -594,17 +606,20 @@ describe('Unit | Service | sessions import validation Service', function () {
           certificationCandidateError: certificationCandidateError,
         });
         cpfBirthInformationValidation.failure({ certificationCandidateError: certificationCandidateError2 });
-        certificationCpfService.getBirthInformation
-          .withArgs({
-            birthCountry: candidate.birthCountry,
-            birthCity: candidate.birthCity,
-            birthPostalCode: candidate.birthPostalCode,
-            birthINSEECode: candidate.birthINSEECode,
-            certificationCpfCountryRepository,
-            certificationCpfCityRepository,
-          })
-          .resolves(cpfBirthInformationValidation);
 
+        const certificationCpfServiceStub = {
+          getBirthInformation: sinon
+            .stub()
+            .withArgs({
+              birthCountry: candidate.birthCountry,
+              birthCity: candidate.birthCity,
+              birthPostalCode: candidate.birthPostalCode,
+              birthINSEECode: candidate.birthINSEECode,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            })
+            .resolves(cpfBirthInformationValidation),
+        };
         // when
         const result = await sessionsImportValidationService.getValidatedCandidateBirthInformation({
           candidate,
@@ -612,6 +627,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
           line: 1,
+          dependencies: { certificationCpfService: certificationCpfServiceStub },
         });
 
         // then

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon, domainBuilder } = require('../../../../test-helper');
 const sessionsImportValidationService = require('../../../../../lib/domain/services/sessions-mass-import/sessions-import-validation-service');
 const { CpfBirthInformationValidation } = require('../../../../../lib/domain/services/certification-cpf-service');
-const certificationCpfService = require('../../../../../lib/domain/services/certification-cpf-service');
 const {
   CERTIFICATION_CANDIDATES_ERRORS,
 } = require('../../../../../lib/domain/constants/certification-candidates-errors');

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -1,6 +1,5 @@
 const { domainBuilder, expect, sinon } = require('../../../../test-helper');
 const validateSessions = require('../../../../../lib/domain/usecases/sessions-mass-import/validate-sessions');
-const sessionCodeService = require('../../../../../lib/domain/services/session-code-service');
 const Session = require('../../../../../lib/domain/models/Session');
 const sessionsImportValidationService = require('../../../../../lib/domain/services/sessions-mass-import/sessions-import-validation-service');
 const temporarySessionsStorageForMassImportService = require('../../../../../lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
@@ -19,6 +18,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
   let certificationCourseRepository;
   let sessionRepository;
   let complementaryCertificationRepository;
+  let sessionCodeService;
 
   beforeEach(function () {
     accessCode = 'accessCode';
@@ -32,8 +32,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     complementaryCertificationRepository = { getByLabel: sinon.stub() };
     certificationCourseRepository = sinon.stub();
     sessionRepository = sinon.stub();
-    sinon.stub(sessionCodeService, 'getNewSessionCode');
-    sessionCodeService.getNewSessionCode.returns(accessCode);
+    sessionCodeService = { getNewSessionCode: sinon.stub().returns(accessCode) };
     sessionsImportValidationService.getValidatedCandidateBirthInformation = sinon.stub();
     sessionsImportValidationService.validateSession = sinon.stub();
     temporarySessionsStorageForMassImportService.save = sinon.stub();
@@ -78,6 +77,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         certificationCenterId,
         certificationCenterRepository,
         sessionRepository,
+        sessionCodeService,
       });
 
       // then
@@ -194,6 +194,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           certificationCandidateRepository,
           certificationCourseRepository,
           sessionRepository,
+          sessionCodeService,
         });
 
         // then
@@ -263,6 +264,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         certificationCenterId,
         certificationCenterRepository,
         sessionRepository,
+        sessionCodeService,
       });
 
       // then
@@ -294,6 +296,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           certificationCenterId,
           certificationCenterRepository,
           sessionRepository,
+          sessionCodeService,
         });
 
         // then
@@ -336,6 +339,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           certificationCenterId,
           certificationCenterRepository,
           sessionRepository,
+          sessionCodeService,
         });
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire.

## :rainbow: Remarques
RAS

## :100: Pour tester
CI OK