### PR TITLE
[TECH] Supprime la dépendance ember-cli-sri des apps embroider

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -43,7 +43,6 @@
         "ember-cli-mirage": "^2.4.0",
         "ember-cli-notifications": "^8.0.0",
         "ember-cli-sass": "^11.0.1",
-        "ember-cli-sri": "^2.1.1",
         "ember-composable-helpers": "^4.5.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
@@ -10774,102 +10773,6 @@
         "node": "8.* || 10.* || >= 12.*"
       }
     },
-    "node_modules/broccoli-sri-hash": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
-      "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-caching-writer": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "rsvp": "^3.1.0",
-        "sri-toolbox": "^0.2.0",
-        "symlink-or-copy": "^1.0.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-caching-writer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
-      "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-kitchen-sink-helpers": "^0.2.5",
-        "broccoli-plugin": "1.1.0",
-        "debug": "^2.1.1",
-        "rimraf": "^2.2.8",
-        "rsvp": "^3.0.17",
-        "walk-sync": "^0.2.5"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-kitchen-sink-helpers": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-      "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-      "dev": true,
-      "dependencies": {
-        "glob": "^5.0.10",
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
-      "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-      "dev": true,
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.0.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/walk-sync": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-      "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-      "dev": true,
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
     "node_modules/broccoli-stew": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
@@ -16084,18 +15987,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-cli-sri": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
-      "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-sri-hash": "^2.1.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/ember-cli-string-utils": {
@@ -32393,15 +32284,6 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
-    "node_modules/sri-toolbox": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
-      "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10.4"
-      }
-    },
     "node_modules/ssri": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
@@ -44337,98 +44219,6 @@
         "broccoli-node-api": "^1.6.0"
       }
     },
-    "broccoli-sri-hash": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
-      "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
-      "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "rsvp": "^3.1.0",
-        "sri-toolbox": "^0.2.0",
-        "symlink-or-copy": "^1.0.1"
-      },
-      "dependencies": {
-        "broccoli-caching-writer": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
-          "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "^0.2.5",
-            "broccoli-plugin": "1.1.0",
-            "debug": "^2.1.1",
-            "rimraf": "^2.2.8",
-            "rsvp": "^3.0.17",
-            "walk-sync": "^0.2.5"
-          }
-        },
-        "broccoli-kitchen-sink-helpers": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true,
-          "requires": {
-            "glob": "^5.0.10",
-            "mkdirp": "^0.5.1"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
-          "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-          "dev": true,
-          "requires": {
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.0.1"
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-          "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-          "dev": true,
-          "requires": {
-            "minimatch": "^3.0.2"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "walk-sync": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-          "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.0",
-            "matcher-collection": "^1.0.0"
-          }
-        }
-      }
-    },
     "broccoli-stew": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
@@ -49019,15 +48809,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "ember-cli-sri": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
-      "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "requires": {
-        "broccoli-sri-hash": "^2.1.0"
       }
     },
     "ember-cli-string-utils": {
@@ -61670,12 +61451,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
-    },
-    "sri-toolbox": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
-      "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
       "dev": true
     },
     "ssri": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -72,7 +72,6 @@
     "ember-cli-mirage": "^2.4.0",
     "ember-cli-notifications": "^8.0.0",
     "ember-cli-sass": "^11.0.1",
-    "ember-cli-sri": "^2.1.1",
     "ember-composable-helpers": "^4.5.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -50,7 +50,6 @@
         "ember-cli-matomo-tag-manager": "^1.3.1",
         "ember-cli-mirage": "^2.3.2",
         "ember-cli-sass": "^11.0.1",
-        "ember-cli-sri": "^2.1.1",
         "ember-cli-test-loader": "^3.0.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
@@ -13322,81 +13321,6 @@
         "heimdalljs": "^0.2.1"
       }
     },
-    "node_modules/broccoli-sri-hash": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
-      "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-caching-writer": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "rsvp": "^3.1.0",
-        "sri-toolbox": "^0.2.0",
-        "symlink-or-copy": "^1.0.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-caching-writer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
-      "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-kitchen-sink-helpers": "^0.2.5",
-        "broccoli-plugin": "1.1.0",
-        "debug": "^2.1.1",
-        "rimraf": "^2.2.8",
-        "rsvp": "^3.0.17",
-        "walk-sync": "^0.2.5"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-kitchen-sink-helpers": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-      "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-      "dev": true,
-      "dependencies": {
-        "glob": "^5.0.10",
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
-      "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-      "dev": true,
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.0.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/walk-sync": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-      "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-      "dev": true,
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
     "node_modules/broccoli-stew": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
@@ -19804,18 +19728,6 @@
       },
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ember-cli-sri": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
-      "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-sri-hash": "^2.1.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/ember-cli-string-utils": {
@@ -36932,15 +36844,6 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
-    "node_modules/sri-toolbox": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
-      "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10.4"
-      }
-    },
     "node_modules/ssri": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
@@ -51215,80 +51118,6 @@
         "heimdalljs": "^0.2.1"
       }
     },
-    "broccoli-sri-hash": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
-      "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
-      "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "rsvp": "^3.1.0",
-        "sri-toolbox": "^0.2.0",
-        "symlink-or-copy": "^1.0.1"
-      },
-      "dependencies": {
-        "broccoli-caching-writer": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
-          "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "^0.2.5",
-            "broccoli-plugin": "1.1.0",
-            "debug": "^2.1.1",
-            "rimraf": "^2.2.8",
-            "rsvp": "^3.0.17",
-            "walk-sync": "^0.2.5"
-          }
-        },
-        "broccoli-kitchen-sink-helpers": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true,
-          "requires": {
-            "glob": "^5.0.10",
-            "mkdirp": "^0.5.1"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
-          "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-          "dev": true,
-          "requires": {
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.0.1"
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "walk-sync": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-          "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.0",
-            "matcher-collection": "^1.0.0"
-          }
-        }
-      }
-    },
     "broccoli-stew": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
@@ -57163,15 +56992,6 @@
             "semver": "^5.3.0"
           }
         }
-      }
-    },
-    "ember-cli-sri": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
-      "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "requires": {
-        "broccoli-sri-hash": "^2.1.0"
       }
     },
     "ember-cli-string-utils": {
@@ -69610,12 +69430,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
-    },
-    "sri-toolbox": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
-      "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
       "dev": true
     },
     "ssri": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -78,7 +78,6 @@
     "ember-cli-matomo-tag-manager": "^1.3.1",
     "ember-cli-mirage": "^2.3.2",
     "ember-cli-sass": "^11.0.1",
-    "ember-cli-sri": "^2.1.1",
     "ember-cli-test-loader": "^3.0.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -50,7 +50,6 @@
         "ember-cli-notifications": "^8.0.0",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-showdown": "^6.0.1",
-        "ember-cli-sri": "^2.1.1",
         "ember-click-outside": "^6.0.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
@@ -11521,81 +11520,6 @@
       "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
       "dev": true
     },
-    "node_modules/broccoli-sri-hash": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
-      "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-caching-writer": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "rsvp": "^3.1.0",
-        "sri-toolbox": "^0.2.0",
-        "symlink-or-copy": "^1.0.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-caching-writer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
-      "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-kitchen-sink-helpers": "^0.2.5",
-        "broccoli-plugin": "1.1.0",
-        "debug": "^2.1.1",
-        "rimraf": "^2.2.8",
-        "rsvp": "^3.0.17",
-        "walk-sync": "^0.2.5"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-kitchen-sink-helpers": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-      "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-      "dev": true,
-      "dependencies": {
-        "glob": "^5.0.10",
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/broccoli-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
-      "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-      "dev": true,
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.0.1"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/broccoli-sri-hash/node_modules/walk-sync": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-      "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-      "dev": true,
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
     "node_modules/broccoli-stew": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
@@ -17248,18 +17172,6 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-cli-sri": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
-      "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "dependencies": {
-        "broccoli-sri-hash": "^2.1.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/ember-cli-string-utils": {
@@ -33442,15 +33354,6 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
-    "node_modules/sri-toolbox": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
-      "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10.4"
-      }
-    },
     "node_modules/ssri": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
@@ -45750,80 +45653,6 @@
       "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
       "dev": true
     },
-    "broccoli-sri-hash": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
-      "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
-      "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "rsvp": "^3.1.0",
-        "sri-toolbox": "^0.2.0",
-        "symlink-or-copy": "^1.0.1"
-      },
-      "dependencies": {
-        "broccoli-caching-writer": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
-          "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "^0.2.5",
-            "broccoli-plugin": "1.1.0",
-            "debug": "^2.1.1",
-            "rimraf": "^2.2.8",
-            "rsvp": "^3.0.17",
-            "walk-sync": "^0.2.5"
-          }
-        },
-        "broccoli-kitchen-sink-helpers": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true,
-          "requires": {
-            "glob": "^5.0.10",
-            "mkdirp": "^0.5.1"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
-          "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-          "dev": true,
-          "requires": {
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.0.1"
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "walk-sync": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-          "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.0",
-            "matcher-collection": "^1.0.0"
-          }
-        }
-      }
-    },
     "broccoli-stew": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
@@ -51182,15 +51011,6 @@
             "minimatch": "^3.0.4"
           }
         }
-      }
-    },
-    "ember-cli-sri": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
-      "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "requires": {
-        "broccoli-sri-hash": "^2.1.0"
       }
     },
     "ember-cli-string-utils": {
@@ -63117,12 +62937,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
-    },
-    "sri-toolbox": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
-      "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
       "dev": true
     },
     "ssri": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -75,7 +75,6 @@
     "ember-cli-notifications": "^8.0.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-showdown": "^6.0.1",
-    "ember-cli-sri": "^2.1.1",
     "ember-click-outside": "^6.0.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",


### PR DESCRIPTION
## :unicorn: Problème
ember-cli-sri n'est plus utilisé dans les apps qui utilisent embroider.
https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#v4120

## :robot: Proposition
Supprimer la dépendance de certif/orga/monpix

## :100: Pour tester
Tests verts
