### PR TITLE
[TECH] Permet de configurer le proxy de l'API des fronts pix vers une release de test  (PIX-7880)

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -26,6 +26,11 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+<%
+  canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
+  canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
+  server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
+%>
 upstream api {
     <%
     # We compute the API host from the front app name, examples:
@@ -33,7 +38,25 @@ upstream api {
     #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
     #   pix-orga-production        -> pix-api-production.scalingo.io
     %>
-    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% if canary_enabled %>
+upstream api-canary {
+  server <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% end %>
+
+split_clients "${request_id}" $upstream {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  api-canary;
+  <% end %>
+  * api;
+}
+split_clients "${request_id}" $upstream_host {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+  <% end %>
+  * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
 server {
@@ -86,9 +109,8 @@ server {
   }
 
   location /api/ {
-    proxy_pass https://api;
-    proxy_redirect default;
-    proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+    proxy_pass https://$upstream;
+    proxy_set_header Host $upstream_host;
   }
 
   <% end %>

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -26,6 +26,11 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+<%
+  canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
+  canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
+  server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
+%>
 upstream api {
     <%
     # We compute the API host from the front app name, examples:
@@ -33,7 +38,25 @@ upstream api {
     #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
     #   pix-orga-production        -> pix-api-production.scalingo.io
     %>
-    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% if canary_enabled %>
+upstream api-canary {
+  server <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% end %>
+
+split_clients "${request_id}" $upstream {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  api-canary;
+  <% end %>
+  * api;
+}
+split_clients "${request_id}" $upstream_host {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+  <% end %>
+  * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
 server {
@@ -103,9 +126,8 @@ server {
   }
 
   location /api/ {
-    proxy_pass https://api;
-    proxy_redirect default;
-    proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+    proxy_pass https://$upstream;
+    proxy_set_header Host $upstream_host;
   }
 
   <% end %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -26,6 +26,11 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+<%
+  canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
+  canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
+  server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
+%>
 upstream api {
     <%
     # We compute the API host from the front app name, examples:
@@ -33,7 +38,25 @@ upstream api {
     #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
     #   pix-orga-production        -> pix-api-production.scalingo.io
     %>
-    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% if canary_enabled %>
+upstream api-canary {
+  server <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% end %>
+
+split_clients "${request_id}" $upstream {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  api-canary;
+  <% end %>
+  * api;
+}
+split_clients "${request_id}" $upstream_host {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+  <% end %>
+  * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
 server {
@@ -110,9 +133,8 @@ server {
   }
 
   location /api/ {
-    proxy_pass https://api;
-    proxy_redirect default;
-    proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+    proxy_pass https://$upstream;
+    proxy_set_header Host $upstream_host;
   }
 
   <% end %>

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -26,6 +26,11 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+<%
+  canary_enabled = ENV['NGINX_UPSTREAM_CANARY'] == 'enabled' && ENV['NGINX_UPSTREAM_CANARY_WEIGHT'] && ENV['NGINX_UPSTREAM_CANARY_APP_NAME']
+  canary_weight  = ENV['NGINX_UPSTREAM_CANARY_WEIGHT'].to_i
+  server_options = "max_fails=#{ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3} fail_timeout=#{ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s'}"
+%>
 upstream api {
     <%
     # We compute the API host from the front app name, examples:
@@ -33,7 +38,25 @@ upstream api {
     #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
     #   pix-orga-production        -> pix-api-production.scalingo.io
     %>
-    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% if canary_enabled %>
+upstream api-canary {
+  server <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 <%= server_options %>;
+}
+<% end %>
+
+split_clients "${request_id}" $upstream {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  api-canary;
+  <% end %>
+  * api;
+}
+split_clients "${request_id}" $upstream_host {
+  <% if canary_enabled %>
+    <%= canary_weight %>%  <%= ENV['NGINX_UPSTREAM_CANARY_APP_NAME'] %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+  <% end %>
+  * <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
 }
 
 server {
@@ -103,9 +126,8 @@ server {
   }
 
   location /api/ {
-    proxy_pass https://api;
-    proxy_redirect default;
-    proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+    proxy_pass https://$upstream;
+    proxy_set_header Host $upstream_host;
   }
 
   <% end %>


### PR DESCRIPTION
## :unicorn: Problème
Pour déployer #5787, nous voulons pouvoir déployer une API avec ESM en n'impactant le moins possible la production.

## :robot: Proposition
L'idée serait de créer une application scalingo spécifique et de configurer sur chaque front PIX le pourcentage de traffic que nous voulons router vers celle ci.

## :rainbow: Remarques
Le ruby est bon pour la santé.

## :100: Pour tester

## review-app

Mettre les variables d'environnement correspondantes:

```
ADDITIONAL_NGINX_LOGS={"upstream": "$upstream", "upstream_host": "$upstream_host"} 
NGINX_UPSTREAM_CANARY=enabled	
NGINX_UPSTREAM_CANARY_APP_NAME=pix-api-recette	
NGINX_UPSTREAM_CANARY_WEIGHT=50
```

Faire une requete en boucle

    watch curl -s 'https://pix-front-review-pr6084.osc-fr1.scalingo.io/api/feature-toggles'

Regarder les logs nginx et voir que le upstream change a peut prêt 50% du temps:

```
XXXX method=GET path="/api/feature-toggles" XXX upstream="api" upstream_host="pix-api-review-pr6084.osc-fr1.scalingo.io"
XXXX method=GET path="/api/feature-toggles" XXX upstream="api-canary" upstream_host="pix-api-recette.osc-fr1.scalingo.io" 
```
## Local
En plus de la RA, voici quelques commandes pour tester la sortie du template nginx: 

Pas de traffic

    APP=pix-app-recette servers.conf.erb


Pas de traffic

    APP=pix-app-recette NGINX_UPSTREAM_CANARY=disabled NGINX_UPSTREAM_CANARY_WEIGHT=30 NGINX_UPSTREAM_CANARY_APP_NAME=pix-api-esm-recette  servers.conf.erb

Activer avec 30% de traffic sur pix-api-esm-recette:

    APP=pix-app-recette NGINX_UPSTREAM_CANARY=enabled NGINX_UPSTREAM_CANARY_WEIGHT=30 NGINX_UPSTREAM_CANARY_APP_NAME=pix-api-esm-recette erb servers.conf.erb


Activer avec 10% de traffic sur pix-api-esm-recette:

    APP=pix-app-recette NGINX_UPSTREAM_CANARY=enabled NGINX_UPSTREAM_CANARY_WEIGHT=10 NGINX_UPSTREAM_CANARY_APP_NAME=pix-api-esm-recette erb servers.conf.erb
