### PR TITLE
[BUGFIX] Afficher toutes les compétences lors de la sélection de tubes sur Pix Admin (PIX-7882).

### DIFF
--- a/admin/app/components/common/tubes-selection.js
+++ b/admin/app/components/common/tubes-selection.js
@@ -85,7 +85,7 @@ export default class TubesSelection extends Component {
     const selectedFrameworksAreas = (
       await Promise.all(
         this.selectedFrameworks.map(async (framework) => {
-          const frameworkAreas = await framework.areas;
+          const frameworkAreas = await framework.areas.reload();
           return frameworkAreas.toArray();
         })
       )

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -36,6 +36,7 @@ import {
   getTargetProfileSummariesForTraining,
   updateTraining,
 } from './handlers/trainings';
+import { findFrameworkAreas } from './handlers/frameworks';
 
 export default function () {
   this.logging = true;
@@ -285,6 +286,7 @@ export default function () {
   this.post('/admin/organizations/:id/archive', archiveOrganization);
 
   this.get('/admin/frameworks');
+  this.get('/admin/frameworks/:id/areas', findFrameworkAreas);
 
   this.post('/admin/target-profiles', createTargetProfile);
   this.get('/admin/target-profiles/:id');

--- a/admin/mirage/handlers/frameworks.js
+++ b/admin/mirage/handlers/frameworks.js
@@ -1,0 +1,6 @@
+function findFrameworkAreas(schema, request) {
+  const id = request.params.id;
+  return schema.frameworks.find(id).areas;
+}
+
+export { findFrameworkAreas };

--- a/admin/mirage/serializers/framework.js
+++ b/admin/mirage/serializers/framework.js
@@ -1,7 +1,11 @@
 import ApplicationSerializer from './application';
 
-const include = ['areas'];
-
 export default ApplicationSerializer.extend({
-  include,
+  links(framework) {
+    return {
+      areas: {
+        related: `/api/admin/frameworks/${framework.id}/areas`,
+      },
+    };
+  },
 });

--- a/admin/tests/integration/components/common/tubes-selection_test.js
+++ b/admin/tests/integration/components/common/tubes-selection_test.js
@@ -9,59 +9,54 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
   let screen;
 
   hooks.beforeEach(async function () {
+    const store = this.owner.lookup('service:store');
     const tubes1 = [
-      {
+      store.createRecord('tube', {
         id: 'tubeId1',
         name: '@tubeName1',
         practicalTitle: 'Tube 1',
         skills: [],
-      },
-      {
+      }),
+      store.createRecord('tube', {
         id: 'tubeId2',
         name: '@tubeName2',
         practicalTitle: 'Tube 2',
         skills: [],
-      },
+      }),
     ];
 
     const tubes2 = [
-      {
+      store.createRecord('tube', {
         id: 'tubeId3',
         name: '@tubeName3',
         practicalTitle: 'Tube 3',
         skills: [],
-      },
+      }),
     ];
 
     const thematics = [
-      { id: 'thematicId1', name: 'Thématique 1', tubes: tubes1 },
-      { id: 'thematicId2', name: 'Thématique 2', tubes: tubes2 },
+      store.createRecord('thematic', { id: 'thematicId1', name: 'Thématique 1', tubes: tubes1 }),
+      store.createRecord('thematic', { id: 'thematicId2', name: 'Thématique 2', tubes: tubes2 }),
     ];
 
     const competences = [
-      {
+      store.createRecord('competence', {
         id: 'competenceId',
         index: '1',
         name: 'Titre competence',
-        get sortedThematics() {
-          return thematics;
-        },
         thematics,
-      },
+      }),
     ];
 
     const areas = [
-      {
+      store.createRecord('area', {
         title: 'Titre domaine',
         code: 1,
-        get sortedCompetences() {
-          return competences;
-        },
         competences,
-      },
+      }),
     ];
 
-    const frameworks = [{ id: 'frameworkId', name: 'Pix', areas }];
+    const frameworks = [store.createRecord('framework', { id: 'frameworkId', name: 'Pix', areas })];
     this.set('frameworks', frameworks);
 
     const onChangeFunction = sinon.stub();

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
@@ -29,7 +29,8 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     };
     onCancel = sinon.stub();
 
-    const frameworks = [{ id: 'framework1', name: 'Pix', areas: [] }];
+    const store = this.owner.lookup('service:store');
+    const frameworks = [store.createRecord('framework', { id: 'framework1', name: 'Pix', areas: [] })];
 
     this.set('targetProfile', targetProfile);
     this.set('onSubmit', onSubmitWrapper);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix Admin lorsque nous créons un premier déclencheur puis que nous en créons un second, nous voyons que les compétences du premier déclencheur.  

![Screenshot 2023-04-26 at 14 36 16 2](https://user-images.githubusercontent.com/26384707/234579595-e1a817a3-4773-483e-a86b-814291fe71aa.gif)

Ce problème vient du fait que lors de la création d'un déclencheur l'API retourne uniquement les tubes sélectionnés avec leur domaine et leur compétence.
Le store d'Ember met donc à jour dans cache le domaine avec ces nouvelles infos et supprime les anciennes infos. Il a donc un nouveau domaine qui ne contient pas réellement tout. 

## :robot: Proposition
Plusieurs solutions peuvent être apportées : 
- Utiliser un modèle d'affichage et un modèle de retour
- Faire en sorte que les attributs d'un déclencheur ou d'un PC [soient des champs readonly ce qui implique de ne pas pouvoir faire des actions dessus ](https://guides.emberjs.com/release/models/relationships/#toc_readonly-nested-data)
- Changer les ids de retour des areas pour pas que ça n'interfère avec ceux existants
- Reload les areas avant de les afficher dans le composant

Chaque solution a son lot d'avantages et d'inconvénients. 
Je propose de recharger les compétences avant leur affichage pour la sélection des tubes, cette solution a le mérite de ne pas déléguer une quelconque charge mental aux devs lors de futur développement, car avec les autres solutions il faut que les devs réfléchissent à ce problème possible et le prévienne en appliquant la solution.

## :rainbow: Remarques
Il a fallu modifier les tests pour qu'en intégration il s'agisse de record du store ember et donc que la méthode `reload()` existe.
L’enchaînement de requêtes en acceptance ne respectait pas ce qu'il se passait réellement à savoir nous récupérons d'abord tous les frameworks puis nous allons chercher les areas de chaque framework quand on l'ouvre dans la liste. 
Alors que là mirage retournait directement les frameworks et leurs areas en une seule requête. 
Comme cet enchaînement n'était pas respecté la route `/api/admin/frameworks/:id/areas` n'existait pas et donc le reload ne fonctionnait pas dans les tests d'acceptance. Cette désormais bon.

## :100: Pour tester
- Se connecter sur Pix Admin 
- Se rendre sur "Contenus Formatifs"
- Aller dans le détail d'un CF qui n'a pas de déclencheur 
- Créer un premier déclencheur avec tous les tubes d'une compétence 
- Ouvrir le deuxième déclencheur et voir que toutes les compétences du domaine sont présentes.

- Le comportement devrait être le même avec la création de profil cible