### PR TITLE
[BUGFIX] Changer le wording de la pop up "Quitter" dans une épreuve PixApp (PIX-7839).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -153,7 +153,7 @@
     "assessment-banner": {
       "title": "Question for the assessment: ",
       "modal-title": "Do you need a break?",
-      "modal-content": "All your progress is saved. You will able to resume where you stopped."
+      "modal-content": "All your progress is saved. You will be able to resume where you stopped."
     },
     "assessment-results": {
       "title": "End of test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -153,7 +153,7 @@
     "assessment-banner": {
       "title": "Épreuve pour l'évaluation : ",
       "modal-title": "Besoin d'une pause ?",
-      "modal-content": "Tous tes progrès sont enregistrés. Tu pourras reprendre là où tu t’es arrêté."
+      "modal-content": "Tous vos progrès sont enregistrés. Vous pourrez reprendre là où vous vous êtes arrêté."
     },
     "assessment-results": {
       "title": "Fin du test",


### PR DESCRIPTION
## :unicorn: Problème

1. FR : On veut vouvoyer l’utilisateur et non le tutoyer. 
2. EN : Potentielle modification du wording de la traduction.

## :robot: Proposition

### FR

From “Tous tes progrès sont enregistrés. Tu pourras reprendre là où tu t’es arrêté.” 
To “Tous vos progrès sont enregistrés. Vous pourrez reprendre là où vous vous êtes arrêté”. 

### EN

From “You will able to resume where you stopped”
To “You will be able to resume where you stopped”

## :100: Pour tester

Au choix :
- Vérifier le différenciel des fichiers de traduction
- Visiter des pages d'épreuve dans les 2 langues pour vérifier fonctionnellement que les nouveaux textes sont bons
