### PR TITLE
[BUGFIX] Problème d'affichage de sujets à la création d'un profil cible (PIX-7808)

### DIFF
--- a/admin/app/components/common/tubes-selection.js
+++ b/admin/app/components/common/tubes-selection.js
@@ -85,6 +85,8 @@ export default class TubesSelection extends Component {
     const selectedFrameworksAreas = (
       await Promise.all(
         this.selectedFrameworks.map(async (framework) => {
+          // WORKAROUND: see https://1024pix.atlassian.net/browse/PIX-7808
+          if (framework.areas.isFulfilled) await framework.areas.reload();
           const frameworkAreas = await framework.areas;
           return frameworkAreas.toArray();
         })

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -60,6 +60,8 @@ module('Acceptance | Target profile creation', function (hooks) {
     test('it should create the target profile', async function (assert) {
       // given
       server.get('/admin/frameworks', (schema) => schema.frameworks.all());
+      server.get('/areas/1', (schema) => schema.areas.find(1));
+      server.get('/areas/2', (schema) => schema.areas.find(2));
       const screen = await visit('/target-profiles/list');
       await clickByName('Nouveau profil cible');
       await fillByLabel('Nom (obligatoire) :', 'Un profil cible, et vite !');


### PR DESCRIPTION
## :unicorn: Problème
1. Je crée un profil cible et sélectionne quelques sujets en modifiant le niveau max à évaluer
2. Je vais sur la page de création d’un nouveau profil cible

Alors, je ne vois que les sujets que j’avais sélectionné pour le précédent profil cible et le niveau max est limité au niveau sélectionné précédemment.

NB : le problème est également au niveau des contenu formatifs qui font appel au même composant

## :robot: Proposition
Forcer le rechargement des domaines du référentiel au chargement de la page.

## :rainbow: Remarques
N/A

## :100: Pour tester
1. Je crée un profil cible et sélectionne quelques sujets en modifiant le niveau max à évaluer
2. Je vais sur la page de création d’un nouveau profil cible
3. Je vérifie que j'ai bien tous les sujets de disponibles

Vérifier également côté contenus formatifs.