### PR TITLE
[FEATURE] Monter la version de pixUI en v33.1  sur PixOrga (PIX-7894)

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^32.0.0",
+        "@1024pix/pix-ui": "^33.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-32.0.0.tgz",
-      "integrity": "sha512-0XuRmP3Tw56m5TinwHMTec+NVo38zRE+j786lOWPicjPUrnxheh866tXP66wsmoMkhxvp75+5U7GbV0RW7rXLw==",
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-33.1.0.tgz",
+      "integrity": "sha512-V7dGFQk75pGlnk3ABUHLnrZ7lSsi/qXLbuSneEQOYNIl8xksjw7A+rO4QQ58RAjvqCRIXwBO8Vdx38VzE3aTxg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -36924,9 +36924,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-32.0.0.tgz",
-      "integrity": "sha512-0XuRmP3Tw56m5TinwHMTec+NVo38zRE+j786lOWPicjPUrnxheh866tXP66wsmoMkhxvp75+5U7GbV0RW7rXLw==",
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-33.1.0.tgz",
+      "integrity": "sha512-V7dGFQk75pGlnk3ABUHLnrZ7lSsi/qXLbuSneEQOYNIl8xksjw7A+rO4QQ58RAjvqCRIXwBO8Vdx38VzE3aTxg==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^32.0.0",
+    "@1024pix/pix-ui": "^33.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",


### PR DESCRIPTION
## :unicorn: Problème
Les tags ne sont pas lisibles

## :robot: Proposition
Mettre à jour pixUI sur pixOrga 

## :rainbow: Remarques

## :100: Pour tester

- Se connecter à pix orga
- Cliquer sur `Participants`
- Vérifier que les tags de la colonne `Certificabilité` sont bien en gras