### PR TITLE
[FEAUTRE] Afficher "Terminé" sur une participation partagé pour une campagne archivé (PIX-5626)

### DIFF
--- a/mon-pix/app/models/campaign-participation-overview.js
+++ b/mon-pix/app/models/campaign-participation-overview.js
@@ -15,8 +15,8 @@ export default class CampaignParticipationOverviews extends Model {
   @attr('number') validatedStagesCount;
 
   get cardStatus() {
-    if (this.disabledAt) return 'DISABLED';
-    else if (this.isShared) return 'ENDED';
+    if (this.isShared) return 'ENDED';
+    else if (this.disabledAt) return 'DISABLED';
     else if (this.status === 'TO_SHARE') return 'TO_SHARE';
     else return 'ONGOING';
   }

--- a/mon-pix/tests/unit/models/campaign-participation-overview_test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-overview_test.js
@@ -54,11 +54,23 @@ module('Unit | Model | Campaign-Participation-Overview', function (hooks) {
     });
 
     module('when the participation is disabled"', function () {
-      test('should return the status "disabled"', function (assert) {
+      test('should return the status "ENDED" if campaign "SHARED"', function (assert) {
         // given
         const model = store.createRecord('campaign-participation-overview', {
           status: 'SHARED',
           isShared: true,
+          disabledAt: new Date('2021-01-01'),
+        });
+
+        // when / then
+        assert.strictEqual(model.cardStatus, 'ENDED');
+      });
+
+      test('should return the status "DISABLED" if campaign not "SHARED"', function (assert) {
+        // given
+        const model = store.createRecord('campaign-participation-overview', {
+          status: 'TO_SHARE',
+          isShared: false,
           disabledAt: new Date('2021-01-01'),
         });
 


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur se perdait à ne plus avoir accès aux résultats d'une campagne archivé

## :robot: Proposition
Si une participation a été partagé, elle est prioritaire à l'affichage de la desactivation

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter avec jaune.attend@example.net et vérifier que les campagnes terminé sont accessible