### PR TITLE
[TECH] Utiliser le test helper mockLearningContent  à la place de sinon.stub quand c'est nécessaire

### DIFF
--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -1,12 +1,9 @@
-const { expect, knex, sinon } = require('../../../test-helper');
+const { expect, knex, mockLearningContent } = require('../../../test-helper');
 const _ = require('lodash');
 const {
   main,
   databaseBuilder: databaseBuilderCli,
 } = require('../../../../scripts/data-generation/generate-certif-cli');
-const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
-const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
-const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const databaseBuffer = require('../../../../db/database-builder/database-buffer');
 // FIXME Too hard to edit \o/
 describe('Integration | Scripts | generate-certif-cli.js', function () {
@@ -19,9 +16,12 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
   };
 
   beforeEach(async function () {
-    sinon.stub(skillRepository, 'findActiveByCompetenceId').resolves([]);
-    sinon.stub(competenceRepository, 'list').resolves([]);
-    sinon.stub(challengeRepository, 'list').resolves([]);
+    const learningContent = {
+      competences: [],
+      skills: [],
+      challenges: [],
+    };
+    mockLearningContent(learningContent);
   });
 
   afterEach(function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la migration ESM, nous devons fixer les erreurs de stub sinon. Nous avons constaté que le test du script en comportait, mais qu'on pouvait les fix en remplaçant l'usage de sinon par celui d'une methode de test helper. En effet, dans ce cas précis, on utilisait sinon pour stubber les méthodes de repository qui ramène de la data de lcms. Hors, il existe un moyen plus pratique pour récupérer un mock de lcms dans les tests : la méthode `mockLearningContent` exposée par le module `test-helper.js`.

## :robot: Proposition
Remplacer l'usage de `sinon.stub` par celui de `mockLearningContent`

## :rainbow: Remarques


## :100: Pour tester
Vérifier que la CI est OK