### PR TITLE
[FEATURE] Ajouter des liens vers la doc de création de contenu formatif (PIX-7881).

### DIFF
--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -1,6 +1,12 @@
 .training-trigger {
-  &__description {
-    margin-bottom: $pix-spacing-m;
+  &__link {
+    color: $pix-primary;
+
+    svg {
+      height: 0.75em;
+      vertical-align: -0.05em;
+      margin-left: 2px;
+    }
   }
 }
 

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -35,7 +35,17 @@
 
     .page-actions {
       display: flex;
+      align-items: center;
       gap: 1rem;
+
+      &__link {
+        font-size: 0.875rem;
+        color: $pix-primary;
+
+        svg {
+          margin-right: 2px;
+        }
+      }
     }
   }
 

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -2,6 +2,16 @@
   <h1 class="page-title">Tous les contenus formatifs</h1>
   {{#if this.canCreateTrainings}}
     <div class="page-actions">
+      <a
+        class="page-actions__link"
+        href="https://1024pix.atlassian.net/wiki/spaces/PROD/pages/3753476097/Cr+er+un+contenu+formatif+Mode+d+emploi"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Consulter la documentation de création de contenus formatifs"
+      >
+        <FaIcon @icon="arrow-up-right-from-square" />
+        <span>Consulter la documentation</span>
+      </a>
       <PixButton
         @route="authenticated.trainings.new"
         @backgroundColor="transparent-light"

--- a/admin/app/templates/authenticated/trainings/new.hbs
+++ b/admin/app/templates/authenticated/trainings/new.hbs
@@ -5,6 +5,18 @@
     <FaIcon @icon="chevron-right" />
     <h1>Création du contenu</h1>
   </div>
+  <div class="page-actions">
+    <a
+      class="page-actions__link"
+      href="https://1024pix.atlassian.net/wiki/spaces/PROD/pages/3753476097/Cr+er+un+contenu+formatif+Mode+d+emploi"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Consulter la documentation de création de contenus formatifs"
+    >
+      <FaIcon @icon="arrow-up-right-from-square" />
+      <span>Consulter la documentation</span>
+    </a>
+  </div>
 </header>
 
 <main class="page-body">

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -9,6 +9,18 @@
       {{@model.id}}
     </h1>
   </div>
+  <div class="page-actions">
+    <a
+      class="page-actions__link"
+      href="https://1024pix.atlassian.net/wiki/spaces/PROD/pages/3753476097/Cr+er+un+contenu+formatif+Mode+d+emploi"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Consulter la documentation de création de contenus formatifs"
+    >
+      <FaIcon @icon="arrow-up-right-from-square" />
+      <span>Consulter la documentation</span>
+    </a>
+  </div>
 </header>
 
 {{! template-lint-disable no-redundant-landmark-role }}

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -1,5 +1,3 @@
-<p class="training-trigger__description">En savoir plus sur les déclencheurs, consulter la documentation ici.</p>
-
 {{#if this.showTriggersEditForm}}
   {{outlet}}
 {{else if this.canCreateTriggers}}


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à présent, dans une page de contenu formatif, on indiquait la possible consultation d'une documentation mais sans aucun lien associé.

<img width="503" alt="image" src="https://user-images.githubusercontent.com/7335131/234891370-3d1b821e-58d6-4ac5-8ac0-181d00d80e11.png">


## :robot: Proposition

- Supprimer ce paragraphe
- Ajouter un lien dans le header de toutes les pages associées aux contenus relatifs dans Admin.

La cible du lien est : https://1024pix.atlassian.net/wiki/spaces/PROD/pages/3753476097/Cr+er+un+contenu+formatif+Mode+d+emploi

## :rainbow: Remarques

- Je me suis permis d'ajouter une icône indiquant que le lien est externe.

## :100: Pour tester

- Visiter les différentes pages des contenus formatifs [dans la RA](https://admin-pr6095.review.pix.fr/trainings/list) et attester de la présence d'un lien vers cette doc dans le header.
