### PR TITLE
[FEATURE] Afficher un bouton de confirmation de présence dans l'espace surveillant sur Pix Certif (PIX-7832)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -5,21 +5,14 @@
       class="session-supervising-candidate-in-list__checkbox"
       type="checkbox"
       checked={{@candidate.authorizedToStart}}
-      @ariaLabel="{{@candidate.lastName}} {{@candidate.firstName}}"
+      @ariaLabel={{this.authorizationButtonAriaLabel}}
       {{on "click" (fn this.toggleCandidate @candidate)}}
     />
   {{/if}}
   <div class="session-supervising-candidate-in-list__candidate-data">
     <div class="session-supervising-candidate-in-list__full-name">
-      {{#if @candidate.hasStarted}}
-        {{@candidate.lastName}}
-        {{@candidate.firstName}}
-      {{else}}
-        <label for={{concat "candidate-checkbox-" @candidate.id}}>
-          {{@candidate.lastName}}
-          {{@candidate.firstName}}
-        </label>
-      {{/if}}
+      {{@candidate.lastName}}
+      {{@candidate.firstName}}
     </div>
     <div class="session-supervising-candidate-in-list__details">
       {{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}
@@ -39,6 +32,17 @@
         </p>
       {{/if}}
     </div>
+    {{#if this.isConfirmButtonToBeDisplayed}}
+      <PixButton
+        aria-label={{this.authorizationButtonAriaLabel}}
+        @triggerAction={{fn this.toggleCandidate @candidate}}
+        @backgroundColor={{this.authorizationButtonBackgroundColor}}
+        @isBorderVisible={{@candidate.authorizedToStart}}
+        class="session-supervising-candidate-in-list__confirm-button"
+      >
+        {{this.authorizationButtonLabel}}
+      </PixButton>
+    {{/if}}
     {{#if @candidate.hasStarted}}
       {{#if @candidate.isAuthorizedToResume}}
         <span

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -18,8 +18,20 @@ export default class CandidateInList extends Component {
   @service intl;
   @service featureToggles;
 
+  get isConfirmButtonToBeDisplayed() {
+    return (
+      !this.args.candidate.hasStarted &&
+      !this.args.candidate.hasCompleted &&
+      this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
+    );
+  }
+
   get isCheckboxToBeDisplayed() {
-    return !this.args.candidate.hasStarted && !this.args.candidate.hasCompleted;
+    return (
+      !this.args.candidate.hasStarted &&
+      !this.args.candidate.hasCompleted &&
+      !this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
+    );
   }
 
   get optionsMenuShouldBeDisplayed() {
@@ -31,6 +43,35 @@ export default class CandidateInList extends Component {
       this.args.candidate.complementaryCertification &&
       this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
     );
+  }
+
+  get authorizationButtonLabel() {
+    const confirm = this.intl.t('pages.session-supervising.candidate-in-list.actions.confirm.label');
+    const cancel = this.intl.t('pages.session-supervising.candidate-in-list.actions.cancel-confirmation.label');
+
+    return this.args.candidate.authorizedToStart ? cancel : confirm;
+  }
+
+  get authorizationButtonAriaLabel() {
+    const candidateName = `${this.args.candidate.firstName} ${this.args.candidate.lastName}`;
+    const confirmAriaLabel = this.intl.t(
+      'pages.session-supervising.candidate-in-list.actions.confirm.extra-information',
+      {
+        candidate: candidateName,
+      }
+    );
+    const cancelAriaLabel = this.intl.t(
+      'pages.session-supervising.candidate-in-list.actions.cancel-confirmation.extra-information',
+      {
+        candidate: candidateName,
+      }
+    );
+
+    return this.args.candidate.authorizedToStart ? cancelAriaLabel : confirmAriaLabel;
+  }
+
+  get authorizationButtonBackgroundColor() {
+    return this.args.candidate.authorizedToStart ? 'transparent-dark' : 'blue';
   }
 
   @action

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -10,6 +10,10 @@
     width: calc(100% - 32px);
   }
 
+  &__confirm-button {
+    margin-top: $pix-spacing-s;
+  }
+
   &__details {
     color: $pix-neutral-22;
     font-size: 0.75rem;

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, find, fillIn } from '@ember/test-helpers';
-import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { authenticateSession } from '../helpers/test-init';
 import sinon from 'sinon';
 import { later } from '@ember/runloop';
@@ -22,6 +22,161 @@ module('Acceptance | Session supervising', function (hooks) {
       allowedCertificationCenterAccesses: [],
     });
     await authenticateSession(certificationPointOfContact.id);
+  });
+
+  module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function () {
+    module('When there are candidates on the session', function () {
+      test('it should display candidates entries', async function (assert) {
+        // given
+        const sessionId = 12345;
+        server.create('feature-toggle', { isDifferentiatedTimeInvigilatorPortalEnabled: true });
+        this.sessionForSupervising = server.create('session-for-supervising', {
+          id: sessionId,
+          certificationCandidates: [
+            server.create('certification-candidate-for-supervising', {
+              id: 123,
+              firstName: 'John',
+              lastName: 'Doe',
+              birthdate: '1984-05-28',
+              extraTimePercentage: '8',
+              authorizedToStart: true,
+            }),
+            server.create('certification-candidate-for-supervising', {
+              id: 456,
+              firstName: 'Star',
+              lastName: 'Lord',
+              birthdate: '1983-06-28',
+              extraTimePercentage: '12',
+              authorizedToStart: false,
+            }),
+            server.create('certification-candidate-for-supervising', {
+              id: 789,
+              firstName: 'Buffy',
+              lastName: 'Summers',
+              birthdate: '1987-05-28',
+              extraTimePercentage: '6',
+              authorizedToStart: true,
+            }),
+            server.create('certification-candidate-for-supervising', {
+              id: 1000,
+              firstName: 'Rupert',
+              lastName: 'Giles',
+              birthdate: '1934-06-28',
+              extraTimePercentage: '15',
+              authorizedToStart: false,
+            }),
+          ],
+        });
+
+        const screen = await visit('/connexion-espace-surveillant');
+        await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+        await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
+
+        // when
+        await click(screen.getByRole('button', { name: 'Surveiller la session' }));
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: "Confirmer la présence de l'élève Star Lord",
+            })
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: "Confirmer la présence de l'élève Rupert Giles",
+            })
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: "Annuler la confirmation de présence de l'élève John Doe",
+            })
+          )
+          .exists();
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: "Annuler la confirmation de présence de l'élève Buffy Summers",
+            })
+          )
+          .exists();
+      });
+    });
+
+    test('when supervisor checks the candidate, it should update authorizedToStart', async function (assert) {
+      // given
+      const sessionId = 12345;
+      server.create('feature-toggle', { isDifferentiatedTimeInvigilatorPortalEnabled: true });
+      this.sessionForSupervising = server.create('session-for-supervising', {
+        id: sessionId,
+        certificationCandidates: [
+          server.create('certification-candidate-for-supervising', {
+            id: 123,
+            firstName: 'John',
+            lastName: 'Doe',
+            birthdate: '1984-05-28',
+            extraTimePercentage: '8',
+            authorizedToStart: false,
+          }),
+        ],
+      });
+
+      const firstVisit = await visit('/connexion-espace-surveillant');
+      await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+      await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
+      await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
+
+      // when
+      await click(firstVisit.getByRole('button', { name: "Confirmer la présence de l'élève John Doe" }));
+
+      // then
+      const secondVisit = await visit('/connexion-espace-surveillant');
+      await fillIn(secondVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+      await fillIn(secondVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
+      await click(secondVisit.getByRole('button', { name: 'Surveiller la session' }));
+
+      assert
+        .dom(secondVisit.getByRole('button', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
+        .exists();
+      assert
+        .dom(secondVisit.queryByRole('button', { name: "Confirmer la présence de l'élève John Doe" }))
+        .doesNotExist();
+    });
+
+    test('when supervisor cancel the presence of the candidate, it should update authorizedToStart', async function (assert) {
+      // given
+      const sessionId = 12345;
+      server.create('feature-toggle', { isDifferentiatedTimeInvigilatorPortalEnabled: true });
+      this.sessionForSupervising = server.create('session-for-supervising', {
+        id: sessionId,
+        certificationCandidates: [
+          server.create('certification-candidate-for-supervising', {
+            id: 123,
+            firstName: 'John',
+            lastName: 'Doe',
+            birthdate: '1984-05-28',
+            extraTimePercentage: '8',
+            authorizedToStart: false,
+          }),
+        ],
+      });
+
+      const firstVisit = await visit('/connexion-espace-surveillant');
+      await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+      await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
+      await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
+
+      // when
+      await click(firstVisit.getByRole('button', { name: "Confirmer la présence de l'élève John Doe" }));
+      await click(firstVisit.getByRole('button', { name: "Annuler la confirmation de présence de l'élève John Doe" }));
+
+      // then
+      assert.false(server.schema.certificationCandidateForSupervisings.find(123).authorizedToStart);
+    });
   });
 
   module('When there are candidates on the session', function () {
@@ -50,7 +205,7 @@ module('Acceptance | Session supervising', function (hooks) {
         ],
       });
 
-      const screen = await visitScreen('/connexion-espace-surveillant');
+      const screen = await visit('/connexion-espace-surveillant');
       await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
       await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
 
@@ -58,8 +213,10 @@ module('Acceptance | Session supervising', function (hooks) {
       await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
-      assert.dom(screen.getByRole('checkbox', { name: 'Doe John' })).exists();
-      assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).exists();
+      assert
+        .dom(screen.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
+        .exists();
+      assert.dom(screen.getByRole('checkbox', { name: "Confirmer la présence de l'élève Star Lord" })).exists();
     });
 
     test('should refresh the candidate list periodically', async function (assert) {
@@ -95,7 +252,7 @@ module('Acceptance | Session supervising', function (hooks) {
       });
 
       // when
-      const screen = await visitScreen('/connexion-espace-surveillant');
+      const screen = await visit('/connexion-espace-surveillant');
       await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
       await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
       await click(screen.getByRole('button', { name: 'Surveiller la session' }));
@@ -125,20 +282,22 @@ module('Acceptance | Session supervising', function (hooks) {
       ],
     });
 
-    const firstVisit = await visitScreen('/connexion-espace-surveillant');
+    const firstVisit = await visit('/connexion-espace-surveillant');
     await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
     await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
     await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
 
     // when
-    await click(firstVisit.getByRole('checkbox', { name: 'Doe John' }));
+    await click(firstVisit.getByRole('checkbox', { name: "Confirmer la présence de l'élève John Doe" }));
 
     // then
-    const secondVisit = await visitScreen('/connexion-espace-surveillant');
+    const secondVisit = await visit('/connexion-espace-surveillant');
     await fillIn(secondVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
     await fillIn(secondVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
     await click(secondVisit.getByRole('button', { name: 'Surveiller la session' }));
-    assert.true(find('input[type="checkbox"]').checked);
+    assert
+      .dom(secondVisit.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
+      .isChecked();
   });
 
   test('when supervisor checks and unchecks the candidate, it should update authorizedToStart', async function (assert) {
@@ -158,14 +317,14 @@ module('Acceptance | Session supervising', function (hooks) {
       ],
     });
 
-    const firstVisit = await visitScreen('/connexion-espace-surveillant');
+    const firstVisit = await visit('/connexion-espace-surveillant');
     await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
     await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
     await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
 
     // when
-    await click(firstVisit.getByRole('checkbox', { name: 'Doe John' }));
-    await click(firstVisit.getByRole('checkbox', { name: 'Doe John' }));
+    await click(firstVisit.getByRole('checkbox', { name: "Confirmer la présence de l'élève John Doe" }));
+    await click(firstVisit.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève John Doe" }));
 
     // then
     assert.false(server.schema.certificationCandidateForSupervisings.find(123).authorizedToStart);
@@ -189,7 +348,7 @@ module('Acceptance | Session supervising', function (hooks) {
       ],
     });
 
-    const firstVisit = await visitScreen('/connexion-espace-surveillant');
+    const firstVisit = await visit('/connexion-espace-surveillant');
     await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
     await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
     await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -294,6 +294,16 @@
     },
     "session-supervising": {
       "candidate-in-list": {
+        "actions": {
+          "cancel-confirmation": {
+            "extra-information": "Cancel the confirmation of attendance of the student {candidate}",
+            "label":"Cancel the confirmation"
+          },
+          "confirm": {
+            "extra-information": "Confirm the attendance of the student {candidate}",
+            "label":"Confirm the attendance"
+          }
+        },
         "candidate-options": "Candidate's options",
         "complementary-certification-enrolment": "{complementaryCertification} enrolment",
         "display-candidate-options": "Display the candidate's options",
@@ -319,7 +329,7 @@
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",
         "clear-field": "Clear the field",
-        "indicate-candidates-attendance": "Check off each candidate present in the room to allow them to start their Pix certification exam.",
+        "indicate-candidates-attendance": "Please confirm the attendance of each candidate to allow them to start their certification exam.",
         "no-candidate": "No candidate enrolled in this session",
         "search-candidate": "Search for a candidate"
       },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -294,6 +294,16 @@
     },
     "session-supervising": {
       "candidate-in-list": {
+        "actions": {
+          "cancel-confirmation": {
+            "extra-information": "Annuler la confirmation de présence de l'élève {candidate}",
+            "label":"Annuler la confirmation"
+          },
+          "confirm": {
+            "extra-information": "Confirmer la présence de l'élève {candidate}",
+            "label":"Confirmer la présence"
+          }
+        },
         "candidate-options": "Options du candidat",
         "complementary-certification-enrolment": "Inscription à {complementaryCertification}",
         "display-candidate-options": "Afficher les options du candidat",
@@ -319,7 +329,7 @@
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}",
         "clear-field": "Vider le champ",
-        "indicate-candidates-attendance": "Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.",
+        "indicate-candidates-attendance": "Confirmez la présence de chaque candidat pour l'autoriser à commencer son test de certification.",
         "no-candidate": "Aucun candidat inscrit à cette session",
         "search-candidate": "Rechercher un candidat"
       },


### PR DESCRIPTION
## :unicorn: Problème
Dans l’Espace Surveillant, le surveillant doit confirmer la présence des candidats de la session sous sa surveillance avant le démarrage de celle-ci.

Actuellement, il réalise cette opération en cochant une case à côté de chaque nom de candidat.

Le système de coches n’est pas très intuitif car il implique souvent une action possible sur la sélection une fois celle-ci réalisée, ce qui n’est pas le cas ici.

## :robot: Proposition
- [x] Remplacer le texte explicatif situé entre le titre “Candidats” et la barre de recherche par “Confirmez la présence de chaque candidat pour l'autoriser à commencer son test de certification.”
- [x] Remplacer la coche vide par un bouton “Confirmer la présence”
- [x] Remplacer la coche pleine par un bouton “Annuler la confirmation”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

Session créée sur la RA
```
[
  {
    "sessionId": 108789,
    "accessCode": "TBQB33",
    "firstName": "pro108702",
    "lastName": "pro108702",
    "email": "pro108702@example.net",
    "birthdate": "2000-01-01",
  },
  {
    "sessionId": 108789,
    "accessCode": "TBQB33",
    "firstName": "pro108703",
    "lastName": "pro108703",
    "email": "pro108703@example.net",
    "birthdate": "2000-01-01",
  },
  {
    "sessionId": 108789,
    "accessCode": "TBQB33",
    "firstName": "pro108704",
    "lastName": "pro108704",
    "email": "pro108704@example.net",
    "birthdate": "2000-01-01",
  },
  {
    "sessionId": 108789,
    "accessCode": "TBQB33",
    "firstName": "pro108705",
    "lastName": "pro108705",
    "email": "pro108705@example.net",
    "birthdate": "2000-01-01",
  },
  {
    "sessionId": 108789,
    "accessCode": "TBQB33",
    "firstName": "pro108706",
    "lastName": "pro108706",
    "email": "pro108706@example.net",
    "birthdate": "2000-01-01",
  }
]

```

![Screenshot 2023-05-04 at 09-55-45 Surveiller la session n° 11 Pix Certif](https://user-images.githubusercontent.com/11388201/236143971-776d7f21-4b1f-4c4e-b753-72998f088e89.png)
