### PR TITLE
[TECH] Injection de dépendances pour préparer la migration ESM

### DIFF
--- a/api/lib/application/usecases/checkAdminMemberHasRoleCertif.js
+++ b/api/lib/application/usecases/checkAdminMemberHasRoleCertif.js
@@ -1,8 +1,8 @@
 const adminMemberRepository = require('../../infrastructure/repositories/admin-member-repository.js');
 
 module.exports = {
-  async execute(userId) {
-    const adminMember = await adminMemberRepository.get({ userId });
+  async execute(userId, dependencies = { adminMemberRepository }) {
+    const adminMember = await dependencies.adminMemberRepository.get({ userId });
     return adminMember.isCertif;
   },
 };

--- a/api/lib/application/usecases/checkAdminMemberHasRoleMetier.js
+++ b/api/lib/application/usecases/checkAdminMemberHasRoleMetier.js
@@ -1,8 +1,8 @@
 const adminMemberRepository = require('../../infrastructure/repositories/admin-member-repository.js');
 
 module.exports = {
-  async execute(userId) {
-    const adminMember = await adminMemberRepository.get({ userId });
+  async execute(userId, dependencies = { adminMemberRepository }) {
+    const adminMember = await dependencies.adminMemberRepository.get({ userId });
     return adminMember.isMetier;
   },
 };

--- a/api/lib/application/usecases/checkAdminMemberHasRoleSuperAdmin.js
+++ b/api/lib/application/usecases/checkAdminMemberHasRoleSuperAdmin.js
@@ -1,8 +1,8 @@
 const adminMemberRepository = require('../../infrastructure/repositories/admin-member-repository.js');
 
 module.exports = {
-  async execute(userId) {
-    const adminMember = await adminMemberRepository.get({ userId });
+  async execute(userId, dependencies = { adminMemberRepository }) {
+    const adminMember = await dependencies.adminMemberRepository.get({ userId });
     return adminMember.isSuperAdmin;
   },
 };

--- a/api/lib/application/usecases/checkAdminMemberHasRoleSupport.js
+++ b/api/lib/application/usecases/checkAdminMemberHasRoleSupport.js
@@ -1,8 +1,8 @@
 const adminMemberRepository = require('../../infrastructure/repositories/admin-member-repository.js');
 
 module.exports = {
-  async execute(userId) {
-    const adminMember = await adminMemberRepository.get({ userId });
+  async execute(userId, dependencies = { adminMemberRepository }) {
+    const adminMember = await dependencies.adminMemberRepository.get({ userId });
     return adminMember.isSupport;
   },
 };

--- a/api/lib/application/usecases/checkUserBelongsToLearnersOrganization.js
+++ b/api/lib/application/usecases/checkUserBelongsToLearnersOrganization.js
@@ -3,9 +3,9 @@ const membershipRepository = require('../../infrastructure/repositories/membersh
 const organizationLearnerRepository = require('../../infrastructure/repositories/organization-learner-repository.js');
 
 module.exports = {
-  async execute(userId, organizationLearnerId) {
-    const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
-    const memberships = await membershipRepository.findByUserIdAndOrganizationId({
+  async execute(userId, organizationLearnerId, dependencies = { membershipRepository, organizationLearnerRepository }) {
+    const organizationLearner = await dependencies.organizationLearnerRepository.get(organizationLearnerId);
+    const memberships = await dependencies.membershipRepository.findByUserIdAndOrganizationId({
       userId,
       organizationId: organizationLearner.organizationId,
     });

--- a/api/lib/application/usecases/checkUserBelongsToOrganization.js
+++ b/api/lib/application/usecases/checkUserBelongsToOrganization.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const membershipRepository = require('../../infrastructure/repositories/membership-repository.js');
 
 module.exports = {
-  execute(userId, organizationId) {
-    return membershipRepository
+  execute(userId, organizationId, dependencies = { membershipRepository }) {
+    return dependencies.membershipRepository
       .findByUserIdAndOrganizationId({ userId, organizationId })
       .then((memberships) => !_.isEmpty(memberships));
   },

--- a/api/lib/application/usecases/checkUserBelongsToOrganizationManagingStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToOrganizationManagingStudents.js
@@ -1,8 +1,8 @@
 const membershipRepository = require('../../infrastructure/repositories/membership-repository.js');
 
 module.exports = {
-  async execute(userId, organizationId) {
-    const memberships = await membershipRepository.findByUserIdAndOrganizationId({
+  async execute(userId, organizationId, dependencies = { membershipRepository }) {
+    const memberships = await dependencies.membershipRepository.findByUserIdAndOrganizationId({
       userId,
       organizationId,
       includeOrganization: true,

--- a/api/lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js
@@ -1,8 +1,8 @@
 const membershipRepository = require('../../infrastructure/repositories/membership-repository.js');
 
 module.exports = {
-  async execute(userId, organizationId) {
-    const memberships = await membershipRepository.findByUserIdAndOrganizationId({
+  async execute(userId, organizationId, dependencies = { membershipRepository }) {
+    const memberships = await dependencies.membershipRepository.findByUserIdAndOrganizationId({
       userId,
       organizationId,
       includeOrganization: true,

--- a/api/lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents.js
@@ -1,8 +1,8 @@
 const membershipRepository = require('../../infrastructure/repositories/membership-repository.js');
 
 module.exports = {
-  async execute(userId, organizationId) {
-    const memberships = await membershipRepository.findByUserIdAndOrganizationId({
+  async execute(userId, organizationId, dependencies = { membershipRepository }) {
+    const memberships = await dependencies.membershipRepository.findByUserIdAndOrganizationId({
       userId,
       organizationId,
       includeOrganization: true,

--- a/api/lib/application/usecases/checkUserIsAdminInOrganization.js
+++ b/api/lib/application/usecases/checkUserIsAdminInOrganization.js
@@ -1,8 +1,8 @@
 const membershipRepository = require('../../infrastructure/repositories/membership-repository.js');
 
 module.exports = {
-  execute(userId, organizationId) {
-    return membershipRepository
+  execute(userId, organizationId, dependencies = { membershipRepository }) {
+    return dependencies.membershipRepository
       .findByUserIdAndOrganizationId({ userId, organizationId })
       .then((memberships) =>
         memberships.reduce((isAdminInOrganization, membership) => isAdminInOrganization || membership.isAdmin, false)

--- a/api/lib/application/usecases/checkUserIsMemberOfCertificationCenter.js
+++ b/api/lib/application/usecases/checkUserIsMemberOfCertificationCenter.js
@@ -1,7 +1,8 @@
 const certificationCenterMembershipRepository = require('../../infrastructure/repositories/certification-center-membership-repository.js');
+
 module.exports = {
-  async execute(userId, certificationCenterId) {
-    return await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
+  async execute(userId, certificationCenterId, dependencies = { certificationCenterMembershipRepository }) {
+    return await dependencies.certificationCenterMembershipRepository.isMemberOfCertificationCenter({
       userId,
       certificationCenterId,
     });

--- a/api/lib/application/usecases/checkUserIsMemberOfCertificationCenterSession.js
+++ b/api/lib/application/usecases/checkUserIsMemberOfCertificationCenterSession.js
@@ -2,9 +2,13 @@ const certificationCourseRepository = require('../../infrastructure/repositories
 const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository.js');
 
 module.exports = {
-  async execute({ userId, certificationCourseId }) {
-    const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
-    return sessionRepository.doesUserHaveCertificationCenterMembershipForSession(
+  async execute({
+    userId,
+    certificationCourseId,
+    dependencies = { certificationCourseRepository, sessionRepository },
+  }) {
+    const certificationCourse = await dependencies.certificationCourseRepository.get(certificationCourseId);
+    return dependencies.sessionRepository.doesUserHaveCertificationCenterMembershipForSession(
       userId,
       certificationCourse.getSessionId()
     );

--- a/api/lib/application/usecases/checkUserOwnsCertificationCourse.js
+++ b/api/lib/application/usecases/checkUserOwnsCertificationCourse.js
@@ -1,8 +1,8 @@
 const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository.js');
 
 module.exports = {
-  async execute({ userId, certificationCourseId }) {
-    const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+  async execute({ userId, certificationCourseId, dependencies = { certificationCourseRepository } }) {
+    const certificationCourse = await dependencies.certificationCourseRepository.get(certificationCourseId);
     return certificationCourse.doesBelongTo(userId);
   },
 };

--- a/api/tests/unit/application/usecases/checkAdminMemberHasRoleCertif_test.js
+++ b/api/tests/unit/application/usecases/checkAdminMemberHasRoleCertif_test.js
@@ -1,22 +1,23 @@
 const { expect, sinon } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkAdminMemberHasRoleCertif');
 const tokenService = require('../../../../lib/domain/services/token-service');
-const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
 
 describe('Unit | Application | Use Case | checkAdminMemberHasRoleCertifUseCase', function () {
   const userId = '1234';
-
+  let adminMemberRepositoryStub;
   beforeEach(function () {
     sinon.stub(tokenService, 'extractUserId').resolves(userId);
-    sinon.stub(adminMemberRepository, 'get');
+    adminMemberRepositoryStub = {
+      get: sinon.stub(),
+    };
   });
 
   it('should resolve true when the admin member has role certif', async function () {
     // given
-    adminMemberRepository.get.resolves({ isCertif: true });
+    adminMemberRepositoryStub.get.resolves({ isCertif: true });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
 
     // then
     expect(result).to.be.true;
@@ -24,10 +25,10 @@ describe('Unit | Application | Use Case | checkAdminMemberHasRoleCertifUseCase',
 
   it('should resolve false when the admin member does not have role certif', async function () {
     // given
-    adminMemberRepository.get.resolves({ isCertif: false });
+    adminMemberRepositoryStub.get.resolves({ isCertif: false });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
 
     // then
     expect(result).to.be.false;

--- a/api/tests/unit/application/usecases/checkAdminMemberHasRolePixMetier_test.js
+++ b/api/tests/unit/application/usecases/checkAdminMemberHasRolePixMetier_test.js
@@ -1,22 +1,24 @@
 const { expect, sinon } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkAdminMemberHasRoleMetier');
 const tokenService = require('../../../../lib/domain/services/token-service');
-const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
 
 describe('Unit | Application | Use Case | checkAdminMemberHasRoleMetier', function () {
   const userId = '1234';
+  let adminMemberRepositoryStub;
 
   beforeEach(function () {
     sinon.stub(tokenService, 'extractUserId').resolves(userId);
-    sinon.stub(adminMemberRepository, 'get');
+    adminMemberRepositoryStub = {
+      get: sinon.stub(),
+    };
   });
 
   it('should resolve true when the admin member has role metier', async function () {
     // given
-    adminMemberRepository.get.resolves({ isMetier: true });
+    adminMemberRepositoryStub.get.resolves({ isMetier: true });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
 
     // then
     expect(result).to.be.true;
@@ -24,10 +26,10 @@ describe('Unit | Application | Use Case | checkAdminMemberHasRoleMetier', functi
 
   it('should resolve true when the admin member does not have role metier', async function () {
     // given
-    adminMemberRepository.get.resolves({ isMetier: false });
+    adminMemberRepositoryStub.get.resolves({ isMetier: false });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
     // then
     expect(result).to.be.false;
   });

--- a/api/tests/unit/application/usecases/checkAdminMemberHasRolePixSupport_test.js
+++ b/api/tests/unit/application/usecases/checkAdminMemberHasRolePixSupport_test.js
@@ -1,32 +1,34 @@
 const { expect, sinon } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkAdminMemberHasRoleSupport');
 const tokenService = require('../../../../lib/domain/services/token-service');
-const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
 
 describe('Unit | Application | Use Case | checkAdminMemberHasRoleSupport', function () {
   const userId = '1234';
+  let adminMemberRepositoryStub;
 
   beforeEach(function () {
     sinon.stub(tokenService, 'extractUserId').resolves(userId);
-    sinon.stub(adminMemberRepository, 'get');
+    adminMemberRepositoryStub = {
+      get: sinon.stub(),
+    };
   });
 
   it('should resolve true when the user has role support', async function () {
     // given
-    adminMemberRepository.get.resolves({ isSupport: true });
+    adminMemberRepositoryStub.get.resolves({ isSupport: true });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
     // then
     expect(result).to.be.true;
   });
 
   it('should resolve false when the user does not have role support', async function () {
     // given
-    adminMemberRepository.get.resolves({ isSupport: false });
+    adminMemberRepositoryStub.get.resolves({ isSupport: false });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
     // then
     expect(result).to.be.false;
   });

--- a/api/tests/unit/application/usecases/checkAdminMemberHasRoleSuperAdmin_test.js
+++ b/api/tests/unit/application/usecases/checkAdminMemberHasRoleSuperAdmin_test.js
@@ -1,32 +1,34 @@
 const { expect, sinon } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkAdminMemberHasRoleSuperAdmin');
 const tokenService = require('../../../../lib/domain/services/token-service');
-const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
 
 describe('Unit | Application | Use Case | checkAdminMemberHasRoleSuperAdmin', function () {
   const userId = '1234';
+  let adminMemberRepositoryStub;
 
   beforeEach(function () {
     sinon.stub(tokenService, 'extractUserId').resolves(userId);
-    sinon.stub(adminMemberRepository, 'get');
+    adminMemberRepositoryStub = {
+      get: sinon.stub(),
+    };
   });
 
   it('should resolve true when the admin member has role super admin', async function () {
     // given
-    adminMemberRepository.get.resolves({ isSuperAdmin: true });
+    adminMemberRepositoryStub.get.resolves({ isSuperAdmin: true });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
     // then
     expect(result).to.be.true;
   });
 
   it('should resolve false when the admin member does not have role admin', async function () {
     // given
-    adminMemberRepository.get.resolves({ isSuperAdmin: false });
+    adminMemberRepositoryStub.get.resolves({ isSuperAdmin: false });
 
     // when
-    const result = await useCase.execute(userId);
+    const result = await useCase.execute(userId, { adminMemberRepository: adminMemberRepositoryStub });
 
     // then
     expect(result).to.be.false;

--- a/api/tests/unit/application/usecases/checkUserBelongsToLearnersOrganization_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToLearnersOrganization_test.js
@@ -1,12 +1,17 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const usecase = require('../../../../lib/application/usecases/checkUserBelongsToLearnersOrganization');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
-const organizationLearnerRepository = require('../../../../lib/infrastructure/repositories/organization-learner-repository');
 
 describe('Unit | Application | Use Case | checkUserBelongsToLearnersOrganization', function () {
+  let membershipRepositoryStub;
+  let organizationLearnerRepositoryStub;
+
   beforeEach(function () {
-    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
-    organizationLearnerRepository.get = sinon.stub();
+    membershipRepositoryStub = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+    };
+    organizationLearnerRepositoryStub = {
+      get: sinon.stub(),
+    };
   });
 
   it('should return true when user belongs to the same organization as learner', async function () {
@@ -21,15 +26,18 @@ describe('Unit | Application | Use Case | checkUserBelongsToLearnersOrganization
       id: organizationLearnerId,
       organization: sharedOrganization,
     });
-    organizationLearnerRepository.get.resolves(organizationLearner);
-    membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+    organizationLearnerRepositoryStub.get.resolves(organizationLearner);
+    membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
     // when
-    const response = await usecase.execute(userId, organizationLearnerId);
+    const response = await usecase.execute(userId, organizationLearnerId, {
+      membershipRepository: membershipRepositoryStub,
+      organizationLearnerRepository: organizationLearnerRepositoryStub,
+    });
 
     // then
     expect(response).to.equal(true);
-    expect(membershipRepository.findByUserIdAndOrganizationId).to.have.been.calledWith({
+    expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.have.been.calledWith({
       userId,
       organizationId: sharedOrganization.id,
     });
@@ -46,15 +54,18 @@ describe('Unit | Application | Use Case | checkUserBelongsToLearnersOrganization
       id: organizationLearnerId,
       anotherOrganization,
     });
-    organizationLearnerRepository.get.resolves(organizationLearner);
-    membershipRepository.findByUserIdAndOrganizationId.resolves([]);
+    organizationLearnerRepositoryStub.get.resolves(organizationLearner);
+    membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([]);
 
     // when
-    const response = await usecase.execute(userId, organizationLearnerId);
+    const response = await usecase.execute(userId, organizationLearnerId, {
+      membershipRepository: membershipRepositoryStub,
+      organizationLearnerRepository: organizationLearnerRepositoryStub,
+    });
 
     // then
     expect(response).to.equal(false);
-    expect(membershipRepository.findByUserIdAndOrganizationId).to.have.been.calledWith({
+    expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.have.been.calledWith({
       userId,
       organizationId: anotherOrganization.id,
     });

--- a/api/tests/unit/application/usecases/checkUserBelongsToOrganizationManagingStudents_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToOrganizationManagingStudents_test.js
@@ -1,10 +1,13 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const usecase = require('../../../../lib/application/usecases/checkUserBelongsToOrganizationManagingStudents');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 
 describe('Unit | Application | Use Case | checkUserBelongsToOrganizationManagingStudents', function () {
+  let membershipRepositoryStub;
+
   beforeEach(function () {
-    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    membershipRepositoryStub = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+    };
   });
 
   it('should return true when user belongs to organization managing students', async function () {
@@ -13,10 +16,10 @@ describe('Unit | Application | Use Case | checkUserBelongsToOrganizationManaging
 
     const organization = domainBuilder.buildOrganization({ isManagingStudents: true });
     const membership = domainBuilder.buildMembership({ organization });
-    membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+    membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
     // when
-    const response = await usecase.execute(userId, organization.id);
+    const response = await usecase.execute(userId, organization.id, { membershipRepository: membershipRepositoryStub });
 
     // then
     expect(response).to.equal(true);
@@ -28,10 +31,10 @@ describe('Unit | Application | Use Case | checkUserBelongsToOrganizationManaging
 
     const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
     const membership = domainBuilder.buildMembership({ organization });
-    membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+    membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
     // when
-    const response = await usecase.execute(userId, organization.id);
+    const response = await usecase.execute(userId, organization.id, { membershipRepository: membershipRepositoryStub });
 
     // then
     expect(response).to.equal(false);
@@ -42,10 +45,10 @@ describe('Unit | Application | Use Case | checkUserBelongsToOrganizationManaging
     const userId = 1234;
 
     const organization = domainBuilder.buildOrganization({ isManagingStudents: true });
-    membershipRepository.findByUserIdAndOrganizationId.resolves([]);
+    membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([]);
 
     // when
-    const response = await usecase.execute(userId, organization.id);
+    const response = await usecase.execute(userId, organization.id, { membershipRepository: membershipRepositoryStub });
 
     // then
     expect(response).to.equal(false);

--- a/api/tests/unit/application/usecases/checkUserBelongsToOrganization_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToOrganization_test.js
@@ -1,10 +1,13 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkUserBelongsToOrganization');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 
 describe('Unit | Application | Use Case | checkUserBelongsToOrganization', function () {
+  let membershipRepositoryStub;
+
   beforeEach(function () {
-    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    membershipRepositoryStub = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+    };
   });
 
   context('When user is in the organization', function () {
@@ -13,10 +16,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToOrganization', funct
       const userId = 1234;
       const organization = domainBuilder.buildOrganization();
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -28,10 +33,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToOrganization', funct
       const organization = domainBuilder.buildOrganization();
       const membership1 = domainBuilder.buildMembership({ organization });
       const membership2 = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -43,10 +50,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToOrganization', funct
       // given
       const userId = 1234;
       const organization = domainBuilder.buildOrganization();
-      membershipRepository.findByUserIdAndOrganizationId.resolves([]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);

--- a/api/tests/unit/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents_test.js
@@ -1,10 +1,13 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 
 describe('Unit | Application | Use Case | checkUserBelongsToScoOrganizationAndManagesStudents', function () {
+  let membershipRepositoryStub;
+
   beforeEach(function () {
-    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    membershipRepositoryStub = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+    };
   });
 
   context('When user is in a SCO organization', function () {
@@ -14,10 +17,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToScoOrganizationAndMa
 
       const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true });
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -30,10 +35,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToScoOrganizationAndMa
       const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true });
       const membership1 = domainBuilder.buildMembership({ organization });
       const membership2 = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -46,10 +53,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToScoOrganizationAndMa
       const userId = 1234;
       const organization = domainBuilder.buildOrganization({ type: 'PRO', isManagingStudents: true });
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);
@@ -62,10 +71,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToScoOrganizationAndMa
       const userId = 1234;
       const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false });
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);

--- a/api/tests/unit/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents_test.js
@@ -1,10 +1,13 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 
 describe('Unit | Application | Use Case | checkUserBelongsToSupOrganizationAndManagesStudents', function () {
+  let membershipRepositoryStub;
+
   beforeEach(function () {
-    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    membershipRepositoryStub = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+    };
   });
 
   context('When user is in a SUP organization', function () {
@@ -14,10 +17,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToSupOrganizationAndMa
 
       const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -30,10 +35,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToSupOrganizationAndMa
       const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
       const membership1 = domainBuilder.buildMembership({ organization });
       const membership2 = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -46,10 +53,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToSupOrganizationAndMa
       const userId = 1234;
       const organization = domainBuilder.buildOrganization({ type: 'PRO', isManagingStudents: true });
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);
@@ -62,10 +71,12 @@ describe('Unit | Application | Use Case | checkUserBelongsToSupOrganizationAndMa
       const userId = 1234;
       const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: false });
       const membership = domainBuilder.buildMembership({ organization });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organization.id);
+      const response = await useCase.execute(userId, organization.id, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);

--- a/api/tests/unit/application/usecases/checkUserIsAdminInOrganization_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsAdminInOrganization_test.js
@@ -1,11 +1,14 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const useCase = require('../../../../lib/application/usecases/checkUserIsAdminInOrganization');
-const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 const Membership = require('../../../../lib/domain/models/Membership');
 
 describe('Unit | Application | Use Case | CheckUserIsAdminInOrganization', function () {
+  let membershipRepositoryStub;
+
   beforeEach(function () {
-    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    membershipRepositoryStub = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+    };
   });
 
   context('When user is admin in organization', function () {
@@ -15,10 +18,12 @@ describe('Unit | Application | Use Case | CheckUserIsAdminInOrganization', funct
       const organizationId = 789;
 
       const membership = domainBuilder.buildMembership({ organizationRole: Membership.roles.ADMIN });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
-      const response = await useCase.execute(userId, organizationId);
+      const response = await useCase.execute(userId, organizationId, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -31,10 +36,12 @@ describe('Unit | Application | Use Case | CheckUserIsAdminInOrganization', funct
 
       const membershipAdmin = domainBuilder.buildMembership({ organizationRole: Membership.roles.ADMIN });
       const membershipMember = domainBuilder.buildMembership({ organizationRole: Membership.roles.MEMBER });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membershipAdmin, membershipMember]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([membershipAdmin, membershipMember]);
 
       // when
-      const response = await useCase.execute(userId, organizationId);
+      const response = await useCase.execute(userId, organizationId, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -46,10 +53,12 @@ describe('Unit | Application | Use Case | CheckUserIsAdminInOrganization', funct
       // given
       const userId = 1234;
       const organizationId = 789;
-      membershipRepository.findByUserIdAndOrganizationId.resolves([]);
+      membershipRepositoryStub.findByUserIdAndOrganizationId.resolves([]);
 
       // when
-      const response = await useCase.execute(userId, organizationId);
+      const response = await useCase.execute(userId, organizationId, {
+        membershipRepository: membershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);

--- a/api/tests/unit/application/usecases/checkUserIsMemberOfCertificationCenterSession_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsMemberOfCertificationCenterSession_test.js
@@ -1,12 +1,17 @@
 const { expect, sinon } = require('../../../test-helper');
 const usecase = require('../../../../lib/application/usecases/checkUserIsMemberOfCertificationCenterSession');
-const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/sessions/session-repository');
 
 describe('Unit | Application | Use Case | CheckUserIsMemberOfCertificationCenterSession', function () {
+  let certificationCourseRepositoryStub;
+  let sessionRepositoryStub;
+
   beforeEach(function () {
-    sinon.stub(certificationCourseRepository, 'get');
-    sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession');
+    certificationCourseRepositoryStub = {
+      get: sinon.stub(),
+    };
+    sessionRepositoryStub = {
+      doesUserHaveCertificationCenterMembershipForSession: sinon.stub(),
+    };
   });
 
   context('When user is member of certification center session', function () {
@@ -19,11 +24,20 @@ describe('Unit | Application | Use Case | CheckUserIsMemberOfCertificationCenter
         getSessionId: () => sessionId,
       };
 
-      certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
-      sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).resolves(true);
+      certificationCourseRepositoryStub.get.withArgs(certificationCourseId).resolves(certificationCourse);
+      sessionRepositoryStub.doesUserHaveCertificationCenterMembershipForSession
+        .withArgs(userId, sessionId)
+        .resolves(true);
 
       // when
-      const response = await usecase.execute({ userId, certificationCourseId });
+      const response = await usecase.execute({
+        userId,
+        certificationCourseId,
+        dependencies: {
+          certificationCourseRepository: certificationCourseRepositoryStub,
+          sessionRepository: sessionRepositoryStub,
+        },
+      });
 
       // then
       expect(response).to.equal(true);

--- a/api/tests/unit/application/usecases/checkUserIsMemberOfCertificationCenter_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsMemberOfCertificationCenter_test.js
@@ -1,10 +1,13 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const usecase = require('../../../../lib/application/usecases/checkUserIsMemberOfCertificationCenter');
-const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
 
 describe('Unit | Application | Use Case | CheckUserIsMemberOfCertificationCenter', function () {
+  let certificationCenterMembershipRepositoryStub;
+
   beforeEach(function () {
-    certificationCenterMembershipRepository.isMemberOfCertificationCenter = sinon.stub();
+    certificationCenterMembershipRepositoryStub = {
+      isMemberOfCertificationCenter: sinon.stub(),
+    };
   });
 
   context('When user is member in certification center', function () {
@@ -14,10 +17,12 @@ describe('Unit | Application | Use Case | CheckUserIsMemberOfCertificationCenter
       const certificationCenter = domainBuilder.buildCertificationCenter();
 
       domainBuilder.buildCertificationCenterMembership({ user, certificationCenter });
-      certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(true);
+      certificationCenterMembershipRepositoryStub.isMemberOfCertificationCenter.resolves(true);
 
       // when
-      const response = await usecase.execute(user.id, certificationCenter.id);
+      const response = await usecase.execute(user.id, certificationCenter.id, {
+        certificationCenterMembershipRepository: certificationCenterMembershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(true);
@@ -29,10 +34,12 @@ describe('Unit | Application | Use Case | CheckUserIsMemberOfCertificationCenter
       // given
       const userId = 1234;
       const certificationCenterId = 789;
-      certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
+      certificationCenterMembershipRepositoryStub.isMemberOfCertificationCenter.resolves(false);
 
       // when
-      const response = await usecase.execute(userId, certificationCenterId);
+      const response = await usecase.execute(userId, certificationCenterId, {
+        certificationCenterMembershipRepository: certificationCenterMembershipRepositoryStub,
+      });
 
       // then
       expect(response).to.equal(false);

--- a/api/tests/unit/application/usecases/checkUserOwnsCertificationCourse_test.js
+++ b/api/tests/unit/application/usecases/checkUserOwnsCertificationCourse_test.js
@@ -1,28 +1,29 @@
 const { expect, sinon } = require('../../../test-helper');
 const usecase = require('../../../../lib/application/usecases/checkUserOwnsCertificationCourse');
-const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/sessions/session-repository');
 
 describe('Unit | Application | Use Case | checkUserOwnsCertificationCourse', function () {
-  beforeEach(function () {
-    sinon.stub(certificationCourseRepository, 'get');
-    sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession');
-  });
-
   context('When user is member of certification center session', function () {
     it('should return true', async function () {
       // given
       const userId = 7;
       const certificationCourseId = 1;
       const doesBelongToStub = sinon.stub();
-      const certificationCourse = {
+      const certificationCourseBookshelfStub = {
         doesBelongTo: doesBelongToStub.withArgs(userId).returns(true),
       };
 
-      certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
+      const certificationCourseRepositoryStub = {
+        get: sinon.stub(),
+      };
+
+      certificationCourseRepositoryStub.get.withArgs(certificationCourseId).resolves(certificationCourseBookshelfStub);
 
       // when
-      const response = await usecase.execute({ userId, certificationCourseId });
+      const response = await usecase.execute({
+        userId,
+        certificationCourseId,
+        dependencies: { certificationCourseRepository: certificationCourseRepositoryStub },
+      });
 
       // then
       expect(response).to.be.true;


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire.

## :rainbow: Remarques
Dans un second temps, on pourra mettre en place une injection de dépendances à la manière de celle pour les usecases de lib/domain

## :100: Pour tester
CI OK