### PR TITLE
[BUGFIX] Le rechargement d'un embed n'émet aucun evènement (PIX-7887)

### DIFF
--- a/mon-pix/app/utils/embed-allowed-origins.js
+++ b/mon-pix/app/utils/embed-allowed-origins.js
@@ -1,0 +1,9 @@
+import ENV from 'mon-pix/config/environment';
+
+export function isEmbedAllowedOrigin(origin) {
+  return getEmbedAllowedOriginsRegexps().some((allowedOrigin) => origin.match(allowedOrigin));
+}
+
+function getEmbedAllowedOriginsRegexps() {
+  return ENV.APP.EMBED_ALLOWED_ORIGINS.map((allowedOrigin) => new RegExp(allowedOrigin.replace('*', '[\\w-]+')));
+}

--- a/mon-pix/tests/unit/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc_test.js
@@ -2,9 +2,16 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import ENV from 'mon-pix/config/environment';
 
 module('Unit | Component | Challenge item QROC', function (hooks) {
   setupTest(hooks);
+
+  const originalEmbedAllowedOrigins = ENV.APP.EMBED_ALLOWED_ORIGINS;
+
+  hooks.afterEach(function () {
+    ENV.APP.EMBED_ALLOWED_ORIGINS = originalEmbedAllowedOrigins;
+  });
 
   let component;
   module('#_receiveEmbedMessage', function (hooks) {
@@ -15,7 +22,11 @@ module('Unit | Component | Challenge item QROC', function (hooks) {
       });
 
       component = createGlimmerComponent('component:challenge-item-qroc', { challenge });
-      component.embedOrigins = ['https://epreuves.pix.fr', 'https://1024pix.github.io', 'https://*.review.pix.fr'];
+      ENV.APP.EMBED_ALLOWED_ORIGINS = [
+        'https://epreuves.pix.fr',
+        'https://1024pix.github.io',
+        'https://*.review.pix.fr',
+      ];
     });
 
     module('when the event message is from Pix', function () {


### PR DESCRIPTION
## :unicorn: Problème
Les embeds écoutant le message de `launch` ne le recoive pas à nouveau lorsqu'ils sont rechargés.

## :robot: Proposition
Après le premier lancement, si l'embed envoit un message `ready`, on lui envoie à nouveau le message `launch`.

Voir https://github.com/1024pix/pix-epreuves/pull/846

## :rainbow: Remarques
Le message de `reload` est déprécié au profit du `launch`, il sera supprimé quand tous les embeds seront modifiés.

Cette PR doit être mise en production avant de merger les modifications sur les embeds.

## :100: Pour tester
Vérifier qu'on a pas de régressions sur les épreuves avec embed (notamment en autoanswer).