### PR TITLE
[BUGFIX] Empêcher le scrollTop lors de l'utilisation d'un filtre/pagination (PIX-7912)

### DIFF
--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -1,15 +1,16 @@
 import EmberRouter from '@ember/routing/router';
 import config from 'pix-admin/config/environment';
 
-class Router extends EmberRouter {
+export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 
-  // eslint-disable-next-line ember/classic-decorator-hooks
-  init() {
-    super.init(...arguments);
-    this.on('routeDidChange', () => {
-      window.scrollTo(0, 0);
+  constructor() {
+    super(...arguments);
+    this.on('routeDidChange', (transition) => {
+      if (transition.from && transition.to.name !== transition.from.name) {
+        window.scrollTo(0, 0);
+      }
     });
   }
 }
@@ -122,5 +123,3 @@ Router.map(function () {
     this.route('tools');
   });
 });
-
-export default Router;


### PR DESCRIPTION
## :unicorn: Problème
lorsque l'on change de page / ou que l'on change la nombre d'élement d'une liste. un scroll automatique vers le haut est déclenché

## :robot: Proposition
Ne pas revenir en haut de la page automatiquement

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que le scroll est reset en changeant de page. et vérifier que le scroll n'est pas remis en haut lorsque nous changons des paramètres dans l'url qui n'est pas un changement de route