### PR TITLE
[TECH] Mise à jour de la langue utilisateur depuis le controller language (PIX-7871)

### DIFF
--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -11,10 +11,10 @@ export default class UserAccountPersonalInformationController extends Controller
   @action
   async onLanguageChange(language) {
     if (!this.currentDomain.isFranceDomain) {
+      await this.currentUser.user.save({ adapterOptions: { lang: language } });
+
       this.intl.setLocale([language]);
       this.dayjs.setLocale(language);
-
-      await this.currentUser.user.save({ adapterOptions: { lang: language } });
     }
   }
 }

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -13,7 +13,7 @@ export default class UserAccountPersonalInformationController extends Controller
     if (!this.currentDomain.isFranceDomain) {
       await this.currentUser.user.save({ adapterOptions: { lang: language } });
 
-      this.intl.setLocale([language]);
+      this.intl.setLocale(language);
       this.dayjs.setLocale(language);
     }
   }

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -3,14 +3,18 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class UserAccountPersonalInformationController extends Controller {
+  @service currentUser;
+  @service dayjs;
   @service intl;
   @service currentDomain;
-  @service location;
 
   @action
-  async onLanguageChange(value) {
+  async onLanguageChange(language) {
     if (!this.currentDomain.isFranceDomain) {
-      this.location.replace(`/mon-compte/langue?lang=${value}`);
+      this.intl.setLocale([language]);
+      this.dayjs.setLocale(language);
+
+      await this.currentUser.user.save({ adapterOptions: { lang: language } });
     }
   }
 }

--- a/mon-pix/app/templates/authenticated/user-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account.hbs
@@ -27,7 +27,7 @@
             {{#if this.isInternationalDomain}}
               <li>
                 <LinkTo @route="authenticated.user-account.language" class="user-account-menu__link">
-                  <FaIcon @icon="globe" />
+                  <FaIcon @icon="earth-europe" />
                   {{t "pages.user-account.language.menu-link-title"}}
                 </LinkTo>
               </li>

--- a/mon-pix/tests/acceptance/user-account_test.js
+++ b/mon-pix/tests/acceptance/user-account_test.js
@@ -110,7 +110,7 @@ module('Acceptance | User account page', function (hooks) {
       });
 
       module('When in France domain', () => {
-        test('not display language menu link', async function (assert) {
+        test('does not display language menu link', async function (assert) {
           // given
           class CurrentDomainStubService extends Service {
             get isFranceDomain() {

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -5,20 +5,56 @@ import sinon from 'sinon';
 module('Unit | Controller | user-account/language', function (hooks) {
   setupTest(hooks);
 
+  let controller;
+  let dayjsSetLocaleStub;
+  let intlSetLocaleStub;
+  let userSaveStub;
+
+  hooks.beforeEach(function () {
+    dayjsSetLocaleStub = sinon.stub();
+    intlSetLocaleStub = sinon.stub();
+    userSaveStub = sinon.stub();
+
+    controller = this.owner.lookup('controller:authenticated/user-account/language');
+    controller.currentUser = { user: { save: userSaveStub } };
+    controller.dayjs = { setLocale: dayjsSetLocaleStub };
+    controller.intl = { setLocale: intlSetLocaleStub };
+  });
+
   module('#onLanguageChange', function () {
-    test('should refresh page on change lang if domain is not french', function (assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/user-account/language');
-      controller.url = { isFranceDomain: false };
-      const replaceStub = sinon.stub();
-      controller.location = { replace: replaceStub };
+    module('when domain is international', function () {
+      test('set app locale and save user language', async function (assert) {
+        // given
+        const language = 'en';
 
-      // when
-      controller.onLanguageChange('en');
+        controller.currentDomain = { isFranceDomain: false };
 
-      // then
-      sinon.assert.calledWith(replaceStub, '/mon-compte/langue?lang=en');
-      assert.ok(true);
+        // when
+        controller.onLanguageChange(language);
+
+        // then
+        sinon.assert.calledWith(dayjsSetLocaleStub, language);
+        sinon.assert.calledWith(intlSetLocaleStub, [language]);
+        sinon.assert.calledWith(userSaveStub, { adapterOptions: { lang: language } });
+        assert.ok(true);
+      });
+    });
+    module('when domain is french', function () {
+      test('not set locale and save user language', async function (assert) {
+        // given
+        const language = 'en';
+
+        controller.currentDomain = { isFranceDomain: true };
+
+        // when
+        controller.onLanguageChange(language);
+
+        // then
+        sinon.assert.notCalled(dayjsSetLocaleStub);
+        sinon.assert.notCalled(intlSetLocaleStub);
+        sinon.assert.notCalled(userSaveStub);
+        assert.ok(true);
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -30,12 +30,12 @@ module('Unit | Controller | user-account/language', function (hooks) {
         controller.currentDomain = { isFranceDomain: false };
 
         // when
-        controller.onLanguageChange(language);
+        await controller.onLanguageChange(language);
 
         // then
+        sinon.assert.calledWith(userSaveStub, { adapterOptions: { lang: language } });
         sinon.assert.calledWith(dayjsSetLocaleStub, language);
         sinon.assert.calledWith(intlSetLocaleStub, [language]);
-        sinon.assert.calledWith(userSaveStub, { adapterOptions: { lang: language } });
         assert.ok(true);
       });
     });
@@ -47,12 +47,12 @@ module('Unit | Controller | user-account/language', function (hooks) {
         controller.currentDomain = { isFranceDomain: true };
 
         // when
-        controller.onLanguageChange(language);
+        await controller.onLanguageChange(language);
 
         // then
+        sinon.assert.notCalled(userSaveStub);
         sinon.assert.notCalled(dayjsSetLocaleStub);
         sinon.assert.notCalled(intlSetLocaleStub);
-        sinon.assert.notCalled(userSaveStub);
         assert.ok(true);
       });
     });

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -35,7 +35,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
         // then
         sinon.assert.calledWith(userSaveStub, { adapterOptions: { lang: language } });
         sinon.assert.calledWith(dayjsSetLocaleStub, language);
-        sinon.assert.calledWith(intlSetLocaleStub, [language]);
+        sinon.assert.calledWith(intlSetLocaleStub, language);
         assert.ok(true);
       });
     });

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -23,7 +23,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
 
   module('#onLanguageChange', function () {
     module('when domain is international', function () {
-      test('set app locale and save user language', async function (assert) {
+      test('saves user language and update application locale', async function (assert) {
         // given
         const language = 'en';
 
@@ -39,8 +39,8 @@ module('Unit | Controller | user-account/language', function (hooks) {
         assert.ok(true);
       });
     });
-    module('when domain is french', function () {
-      test('not set locale and save user language', async function (assert) {
+    module('when in France domain', function () {
+      test('does not save user language and update application locale', async function (assert) {
         // given
         const language = 'en';
 


### PR DESCRIPTION
## :unicorn: Problème
Lors du changement de langue depuis Mon Compte dans Pix App, le controller user-account/language ne fait que rediriger vers l’url de la page courante en ajoutant le query param lang.  

On veut, dans les prochaines PRs, décommissionner cette manière de faire.

## :robot: Proposition
Mettre à jour directement la langue de l’utilisateur dans le controller sans redirection et donc sans appeler l’url historique.
Cela passe donc par un appel directement, dans le controller `language`, vers l'API pour mettre à jour la langue de l'utilisateur.

## :rainbow: Remarques
Des tests d'acceptance ont été ajouté pour tester l'affichage du language switcher sur la page Mon compte.
L'affichage est conditionnée par le domaine.  
Je n'ai pas trouvé d'autre solution que de stub le service `currentDomain` pour simuler l'affichage sur un domaine .fr et non français. A discuter si besoin !

## :100: Pour tester
- Aller sur la review app de Pix App domaine .org : https://app-pr6101.review.pix.org/
- Se connecter (ex: avec allorga@example.net)
- Aller sur `Mon Compte`
- Cliquer sur le sous menu `Choisir ma Langue`
- Ouvrir la console navigateur et se mettre sur l'onglet `Network`
- Sur le Language Switcher, changer la langue de Français à Anglais
- Vérifier : 
  - L'appel /api/users/:id/lang/:lang est bien visible dans la console
  - L'interface est bien passé en anglais
  - L'url n'a pas changé 😄 