### PR TITLE
[TECH] Renommage de enroll en enrol (PIX-7906).

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -85,7 +85,7 @@ module.exports = {
       filter.divisions = [filter.divisions];
     }
 
-    const { data, pagination } = await usecases.findStudentsForEnrollment({
+    const { data, pagination } = await usecases.findStudentsForEnrolment({
       certificationCenterId,
       sessionId,
       page,

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -434,7 +434,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 
-  if (error instanceof DomainErrors.UnknownCountryForStudentEnrollmentError) {
+  if (error instanceof DomainErrors.UnknownCountryForStudentEnrolmentError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -730,7 +730,7 @@ exports.register = async (server) => {
     },
     {
       method: 'PUT',
-      path: '/api/sessions/{id}/enroll-students-to-session',
+      path: '/api/sessions/{id}/enrol-students-to-session',
       config: {
         validate: {
           params: Joi.object({
@@ -743,7 +743,7 @@ exports.register = async (server) => {
             assign: 'authorizationCheck',
           },
         ],
-        handler: sessionController.enrollStudentsToSession,
+        handler: sessionController.enrolStudentsToSession,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
             '- Dans le cadre du SCO, inscrit un élève à une session de certification',

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -241,12 +241,12 @@ module.exports = {
     return null;
   },
 
-  async enrollStudentsToSession(request, h, dependencies = { certificationCandidateSerializer, requestResponseUtils }) {
+  async enrolStudentsToSession(request, h, dependencies = { certificationCandidateSerializer, requestResponseUtils }) {
     const referentId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     const sessionId = request.params.id;
     const studentIds = request.deserializedPayload.organizationLearnerIds;
 
-    await usecases.enrollStudentsToSession({ sessionId, referentId, studentIds });
+    await usecases.enrolStudentsToSession({ sessionId, referentId, studentIds });
     const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });
     const certificationCandidatesSerialized =
       dependencies.certificationCandidateSerializer.serialize(certificationCandidates);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1076,7 +1076,7 @@ class UserNotFoundError extends NotFoundError {
   }
 }
 
-class UnknownCountryForStudentEnrollmentError extends DomainError {
+class UnknownCountryForStudentEnrolmentError extends DomainError {
   constructor(
     { firstName, lastName },
     message = `L'élève ${firstName} ${lastName} a été inscrit avec un code pays de naissance invalide. Veuillez corriger ses informations sur l'espace PixOrga de l'établissement ou contacter le support Pix`
@@ -1463,7 +1463,7 @@ module.exports = {
   OidcMissingFieldsError,
   OidcUserInfoFormatError,
   UnexpectedUserAccountError,
-  UnknownCountryForStudentEnrollmentError,
+  UnknownCountryForStudentEnrolmentError,
   UserAlreadyExistsWithAuthenticationMethodError,
   UserAlreadyLinkedToCandidateInSessionError,
   UserCantBeCreatedError,

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -95,7 +95,7 @@ class Session {
     return this.supervisorPassword === supervisorPassword;
   }
 
-  canEnrollCandidate() {
+  canEnrolCandidate() {
     return _.isNull(this.finalizedAt);
   }
 

--- a/api/lib/domain/read-models/StudentForEnrolment.js
+++ b/api/lib/domain/read-models/StudentForEnrolment.js
@@ -1,4 +1,4 @@
-class StudentForEnrollment {
+class StudentForEnrolment {
   constructor({ id, firstName, lastName, birthdate, division, isEnrolled } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -11,7 +11,7 @@ class StudentForEnrollment {
   static fromStudentsAndCertificationCandidates({ student, certificationCandidates }) {
     const isEnrolled = certificationCandidates.some((candidate) => candidate.organizationLearnerId === student.id);
 
-    return new StudentForEnrollment({
+    return new StudentForEnrolment({
       id: student.id,
       firstName: student.firstName,
       lastName: student.lastName,
@@ -22,4 +22,4 @@ class StudentForEnrollment {
   }
 }
 
-module.exports = StudentForEnrollment;
+module.exports = StudentForEnrolment;

--- a/api/lib/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/lib/domain/usecases/add-certification-candidate-to-session.js
@@ -18,7 +18,7 @@ module.exports = async function addCertificationCandidateToSession({
   certificationCandidate.sessionId = sessionId;
 
   const session = await sessionRepository.get(sessionId);
-  if (!session.canEnrollCandidate()) {
+  if (!session.canEnrolCandidate()) {
     throw new CertificationCandidateOnFinalizedSessionError();
   }
 

--- a/api/lib/domain/usecases/enrol-students-to-session.js
+++ b/api/lib/domain/usecases/enrol-students-to-session.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { ForbiddenAccess, UnknownCountryForStudentEnrolmentError } = require('../errors.js');
 const INSEE_PREFIX_CODE = '99';
 
-module.exports = async function enrollStudentsToSession({
+module.exports = async function enrolStudentsToSession({
   sessionId,
   referentId,
   studentIds,

--- a/api/lib/domain/usecases/enroll-students-to-session.js
+++ b/api/lib/domain/usecases/enroll-students-to-session.js
@@ -1,6 +1,6 @@
 const SCOCertificationCandidate = require('../models/SCOCertificationCandidate.js');
 const _ = require('lodash');
-const { ForbiddenAccess, UnknownCountryForStudentEnrollmentError } = require('../errors.js');
+const { ForbiddenAccess, UnknownCountryForStudentEnrolmentError } = require('../errors.js');
 const INSEE_PREFIX_CODE = '99';
 
 module.exports = async function enrollStudentsToSession({
@@ -37,7 +37,7 @@ module.exports = async function enrollStudentsToSession({
     const studentCountry = countries.find((country) => country.code === studentInseeCountryCode);
 
     if (!studentCountry)
-      throw new UnknownCountryForStudentEnrollmentError({
+      throw new UnknownCountryForStudentEnrolmentError({
         firstName: student.firstName.trim(),
         lastName: student.lastName.trim(),
       });

--- a/api/lib/domain/usecases/find-students-for-enrolment.js
+++ b/api/lib/domain/usecases/find-students-for-enrolment.js
@@ -1,7 +1,7 @@
 const { NotFoundError } = require('../errors.js');
-const StudentForEnrollment = require('../read-models/StudentForEnrollment.js');
+const StudentForEnrolment = require('../read-models/StudentForEnrolment.js');
 
-module.exports = async function findStudentsForEnrollment({
+module.exports = async function findStudentsForEnrolment({
   certificationCenterId,
   sessionId,
   page,
@@ -19,7 +19,7 @@ module.exports = async function findStudentsForEnrollment({
     });
     const certificationCandidates = await certificationCandidateRepository.findBySessionId(sessionId);
     return {
-      data: _buildStudentsForEnrollment({ students: paginatedStudents.data, certificationCandidates }),
+      data: _buildStudentsForEnrolment({ students: paginatedStudents.data, certificationCandidates }),
       pagination: paginatedStudents.pagination,
     };
   } catch (error) {
@@ -32,9 +32,9 @@ module.exports = async function findStudentsForEnrollment({
   }
 };
 
-function _buildStudentsForEnrollment({ students, certificationCandidates }) {
+function _buildStudentsForEnrolment({ students, certificationCandidates }) {
   return students.map((student) =>
-    StudentForEnrollment.fromStudentsAndCertificationCandidates({ student, certificationCandidates })
+    StudentForEnrolment.fromStudentsAndCertificationCandidates({ student, certificationCandidates })
   );
 }
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -482,7 +482,7 @@ const disableCertificationCenterMembership = require('./disable-certification-ce
 const disableMembership = require('./disable-membership.js');
 const dissociateUserFromOrganizationLearner = require('./dissociate-user-from-organization-learner.js');
 const endAssessmentBySupervisor = require('./end-assessment-by-supervisor.js');
-const enrollStudentsToSession = require('./enroll-students-to-session.js');
+const enrolStudentsToSession = require('./enrol-students-to-session.js');
 const finalizeSession = require('./finalize-session.js');
 const findAllTags = require('./find-all-tags.js');
 const findAnswerByAssessment = require('./find-answer-by-assessment.js');
@@ -770,7 +770,7 @@ const usecasesWithoutInjectedDependencies = {
   disableMembership,
   dissociateUserFromOrganizationLearner,
   endAssessmentBySupervisor,
-  enrollStudentsToSession,
+  enrolStudentsToSession,
   finalizeSession,
   findAllTags,
   findAnswerByAssessment,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -525,7 +525,7 @@ const findPaginatedTrainingSummaries = require('./find-paginated-training-summar
 const findPaginatedUserRecommendedTrainings = require('./find-paginated-user-recommended-trainings.js');
 const findPendingCertificationCenterInvitations = require('./find-pending-certification-center-invitations.js');
 const findPendingOrganizationInvitations = require('./find-pending-organization-invitations.js');
-const findStudentsForEnrollment = require('./find-students-for-enrollment.js');
+const findStudentsForEnrolment = require('./find-students-for-enrolment.js');
 const findTargetProfileSummariesForTraining = require('./find-target-profile-summaries-for-training.js');
 const findTutorials = require('./find-tutorials.js');
 const findUserAuthenticationMethods = require('./find-user-authentication-methods.js');
@@ -813,7 +813,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedUserRecommendedTrainings,
   findPendingCertificationCenterInvitations,
   findPendingOrganizationInvitations,
-  findStudentsForEnrollment,
+  findStudentsForEnrolment,
   findTargetProfileSummariesForTraining,
   findTutorials,
   findUserAuthenticationMethods,

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -7,14 +7,14 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | session-controller-enroll-students-to-session', function () {
+describe('Acceptance | Controller | session-controller-enrol-students-to-session', function () {
   let server;
 
   beforeEach(async function () {
     server = await createServer();
   });
 
-  describe('#enrollStudentsToSession', function () {
+  describe('#enrolStudentsToSession', function () {
     let options;
     let payload;
     let userId;
@@ -23,7 +23,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       userId = databaseBuilder.factory.buildUser().id;
       options = {
         method: 'POST',
-        url: '/api/sessions/1/enroll-students-to-session',
+        url: '/api/sessions/1/enrol-students-to-session',
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
       return databaseBuilder.commit();
@@ -33,7 +33,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       beforeEach(function () {
         options = {
           method: 'PUT',
-          url: '/api/sessions/1/enroll-students-to-session',
+          url: '/api/sessions/1/enrol-students-to-session',
           headers: { authorization: 'invalid.access.token' },
         };
       });
@@ -51,7 +51,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       beforeEach(function () {
         options = {
           method: 'PUT',
-          url: '/api/sessions/2.1/enroll-students-to-session',
+          url: '/api/sessions/2.1/enrol-students-to-session',
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         };
       });
@@ -111,7 +111,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
         };
         options = {
           method: 'PUT',
-          url: `/api/sessions/${sessionId}/enroll-students-to-session`,
+          url: `/api/sessions/${sessionId}/enrol-students-to-session`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
           payload,
         };

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -776,9 +776,9 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
     });
 
-    it('responds UnprocessableEntity when a UnknownCountryForStudentEnrollmentError occurs', async function () {
+    it('responds UnprocessableEntity when a UnknownCountryForStudentEnrolmentError occurs', async function () {
       routeHandler.throws(
-        new DomainErrors.UnknownCountryForStudentEnrollmentError({ firstName: 'Paul', lastName: 'Preboist' })
+        new DomainErrors.UnknownCountryForStudentEnrolmentError({ firstName: 'Paul', lastName: 'Preboist' })
       );
       const response = await server.requestObject(request);
 

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -106,7 +106,7 @@ describe('Unit | Controller | certifications-center-controller', function () {
       };
 
       sinon
-        .stub(usecases, 'findStudentsForEnrollment')
+        .stub(usecases, 'findStudentsForEnrolment')
         .withArgs({
           certificationCenterId: 99,
           sessionId: 88,

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -361,16 +361,16 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('PUT /api/session/{id}/enroll-students-to-session', function () {
+  describe('PUT /api/session/{id}/enrol-students-to-session', function () {
     it('exists', async function () {
       // given
       sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+      sinon.stub(sessionController, 'enrolStudentsToSession').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('PUT', '/api/sessions/3/enroll-students-to-session');
+      const response = await httpTestServer.request('PUT', '/api/sessions/3/enrol-students-to-session');
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -379,12 +379,12 @@ describe('Unit | Application | Sessions | Routes', function () {
     it('validates the session id', async function () {
       // given
       sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+      sinon.stub(sessionController, 'enrolStudentsToSession').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('PUT', '/api/sessions/invalidId/enroll-students-to-session');
+      const response = await httpTestServer.request('PUT', '/api/sessions/invalidId/enrol-students-to-session');
 
       // then
       expect(response.statusCode).to.equal(400);
@@ -393,12 +393,12 @@ describe('Unit | Application | Sessions | Routes', function () {
     it('denies access if the session of the logged used is not authorized', async function () {
       // given
       sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
-      sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+      sinon.stub(sessionController, 'enrolStudentsToSession').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('PUT', '/api/sessions/3/enroll-students-to-session');
+      const response = await httpTestServer.request('PUT', '/api/sessions/3/enrol-students-to-session');
 
       // then
       expect(response.statusCode).to.equal(404);

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -453,7 +453,7 @@ describe('Unit | Controller | sessionController', function () {
     });
   });
 
-  describe('#enrollStudentsToSession', function () {
+  describe('#enrolStudentsToSession', function () {
     let request, studentIds, studentList, serializedCertificationCandidate;
     const sessionId = 1;
     const userId = 2;
@@ -479,7 +479,7 @@ describe('Unit | Controller | sessionController', function () {
         },
       };
       const requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
-      sinon.stub(usecases, 'enrollStudentsToSession');
+      sinon.stub(usecases, 'enrolStudentsToSession');
       sinon.stub(usecases, 'getSessionCertificationCandidates');
       const certificationCandidateSerializer = { serialize: sinon.stub() };
       dependencies = {
@@ -491,7 +491,7 @@ describe('Unit | Controller | sessionController', function () {
     context('when the user has access to session and there organizationLearnerIds are corrects', function () {
       beforeEach(function () {
         dependencies.requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(userId);
-        usecases.enrollStudentsToSession.withArgs({ sessionId, referentId: userId, studentIds }).resolves();
+        usecases.enrolStudentsToSession.withArgs({ sessionId, referentId: userId, studentIds }).resolves();
         usecases.getSessionCertificationCandidates.withArgs({ sessionId }).resolves(studentList);
         dependencies.certificationCandidateSerializer.serialize
           .withArgs(studentList)
@@ -500,7 +500,7 @@ describe('Unit | Controller | sessionController', function () {
 
       it('should return certificationCandidates', async function () {
         // when
-        const response = await sessionController.enrollStudentsToSession(request, hFake, dependencies);
+        const response = await sessionController.enrolStudentsToSession(request, hFake, dependencies);
 
         // then
         expect(response.statusCode).to.equal(201);

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -495,8 +495,8 @@ describe('Unit | Domain | Errors', function () {
     });
   });
 
-  it('should export a UnknownCountryForStudentEnrollmentError', function () {
-    expect(errors.UnknownCountryForStudentEnrollmentError).to.exist;
+  it('should export a UnknownCountryForStudentEnrolmentError', function () {
+    expect(errors.UnknownCountryForStudentEnrolmentError).to.exist;
   });
 
   it('should export a OrganizationLearnersCouldNotBeSavedError', function () {

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -245,13 +245,13 @@ describe('Unit | Domain | Models | Session', function () {
     });
   });
 
-  context('#canEnrollCandidate', function () {
+  context('#canEnrolCandidate', function () {
     it('should return true when session is not finalized', function () {
       // given
       const session = domainBuilder.buildSession.created();
 
       // when
-      const result = session.canEnrollCandidate();
+      const result = session.canEnrolCandidate();
 
       // then
       expect(result).to.be.true;
@@ -262,7 +262,7 @@ describe('Unit | Domain | Models | Session', function () {
       const session = domainBuilder.buildSession.finalized();
 
       // when
-      const result = session.canEnrollCandidate();
+      const result = session.canEnrolCandidate();
 
       // then
       expect(result).to.be.false;

--- a/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
+++ b/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
@@ -2,7 +2,7 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 
 const enrollStudentsToSession = require('../../../../lib/domain/usecases/enroll-students-to-session');
 const SCOCertificationCandidate = require('../../../../lib/domain/models/SCOCertificationCandidate');
-const { ForbiddenAccess, UnknownCountryForStudentEnrollmentError } = require('../../../../lib/domain/errors');
+const { ForbiddenAccess, UnknownCountryForStudentEnrolmentError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | enroll-students-to-session', function () {
   context('when referent is allowed to Pix Certif', function () {
@@ -143,7 +143,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
       ]);
     });
 
-    it('rejects enrollment if students do not belong to same organization as referent', async function () {
+    it('rejects enrolment if students do not belong to same organization as referent', async function () {
       // given
       const { session, certificationCenterMemberships } = _buildMatchingSessionAndCertificationCenterMembership();
 
@@ -181,7 +181,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
       expect(error).to.be.instanceof(ForbiddenAccess);
     });
 
-    it('rejects enrollment if session does not belong to same certification center as referent', async function () {
+    it('rejects enrolment if session does not belong to same certification center as referent', async function () {
       // given
       const { session, certificationCenterMemberships } = _buildNonMatchingSessionAndCertificationCenterMembership();
       const referentId = Symbol('a referent id');
@@ -209,7 +209,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
       expect(error).to.be.an.instanceOf(ForbiddenAccess);
     });
 
-    it('rejects enrollment if a student birth country is not found', async function () {
+    it('rejects enrolment if a student birth country is not found', async function () {
       // given
       const { session, certificationCenterMemberships } = _buildMatchingSessionAndCertificationCenterMembership();
       const sessionId = session.id;
@@ -254,7 +254,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
       });
 
       // then
-      expect(error).to.be.an.instanceOf(UnknownCountryForStudentEnrollmentError);
+      expect(error).to.be.an.instanceOf(UnknownCountryForStudentEnrolmentError);
       expect(error.message).to.contains(`${organizationLearners[0].firstName} ${organizationLearners[0].lastName}`);
     });
 

--- a/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
+++ b/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
@@ -1,12 +1,12 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 
-const enrollStudentsToSession = require('../../../../lib/domain/usecases/enroll-students-to-session');
+const enrolStudentsToSession = require('../../../../lib/domain/usecases/enrol-students-to-session');
 const SCOCertificationCandidate = require('../../../../lib/domain/models/SCOCertificationCandidate');
 const { ForbiddenAccess, UnknownCountryForStudentEnrolmentError } = require('../../../../lib/domain/errors');
 
-describe('Unit | UseCase | enroll-students-to-session', function () {
+describe('Unit | UseCase | enrol-students-to-session', function () {
   context('when referent is allowed to Pix Certif', function () {
-    it('enrolls n students to a session', async function () {
+    it('enrols n students to a session', async function () {
       // given
       const { session, certificationCenterMemberships } = _buildMatchingSessionAndCertificationCenterMembership();
       const sessionId = session.id;
@@ -54,7 +54,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
         .resolves(organizationForReferent.id);
 
       // when
-      await enrollStudentsToSession({
+      await enrolStudentsToSession({
         sessionId,
         studentIds,
         referentId,
@@ -73,7 +73,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
       expect(scoCertificationCandidateRepository.findBySessionId(anotherSessionId)).to.deep.equal(undefined);
     });
 
-    it('enrolls a student by trimming his first name and last name', async function () {
+    it('enrols a student by trimming his first name and last name', async function () {
       // given
       const { session, certificationCenterMemberships } = _buildMatchingSessionAndCertificationCenterMembership();
       const sessionId = session.id;
@@ -125,7 +125,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
         .resolves(organizationForReferent.id);
 
       // when
-      await enrollStudentsToSession({
+      await enrolStudentsToSession({
         sessionId,
         studentIds: [1],
         referentId,
@@ -167,7 +167,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
         .resolves(organizationForReferent.id);
 
       // when
-      const error = await catchErr(enrollStudentsToSession)({
+      const error = await catchErr(enrolStudentsToSession)({
         sessionId: session.id,
         studentIds,
         referentId,
@@ -195,7 +195,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
       sessionRepository.get.withArgs(session.id).resolves(session);
 
       // when
-      const error = await catchErr(enrollStudentsToSession)({
+      const error = await catchErr(enrolStudentsToSession)({
         sessionId: session.id,
         studentIds,
         referentId,
@@ -241,7 +241,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
         .resolves(organizationForReferent.id);
 
       // when
-      const error = await catchErr(enrollStudentsToSession)({
+      const error = await catchErr(enrolStudentsToSession)({
         sessionId,
         studentIds,
         referentId,
@@ -288,7 +288,7 @@ describe('Unit | UseCase | enroll-students-to-session', function () {
         .resolves(organizationForReferent.id);
 
       // when
-      await enrollStudentsToSession({
+      await enrolStudentsToSession({
         sessionId,
         studentIds,
         referentId,

--- a/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
@@ -1,11 +1,11 @@
 const _ = require('lodash');
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
-const StudentForEnrollment = require('../../../../lib/domain/read-models/StudentForEnrollment');
+const StudentForEnrolment = require('../../../../lib/domain/read-models/StudentForEnrolment');
 
-const findStudentsForEnrollment = require('../../../../lib/domain/usecases/find-students-for-enrollment');
+const findStudentsForEnrolment = require('../../../../lib/domain/usecases/find-students-for-enrolment');
 
-describe('Unit | UseCase | find-students-for-enrollment', function () {
+describe('Unit | UseCase | find-students-for-enrolment', function () {
   const certificationCenterId = 1;
   const userId = 'userId';
   let organization;
@@ -44,7 +44,7 @@ describe('Unit | UseCase | find-students-for-enrollment', function () {
           .rejects(new NotFoundError());
 
         // when
-        const studentsFounds = await findStudentsForEnrollment({
+        const studentsFounds = await findStudentsForEnrolment({
           userId,
           certificationCenterId,
           page: { size: 10, number: 1 },
@@ -80,7 +80,7 @@ describe('Unit | UseCase | find-students-for-enrollment', function () {
       certificationCandidateRepository.findBySessionId.withArgs(sessionId).resolves(certificationCandidates);
 
       // when
-      const studentsFounds = await findStudentsForEnrollment({
+      const studentsFounds = await findStudentsForEnrolment({
         userId,
         certificationCenterId,
         sessionId,
@@ -92,9 +92,9 @@ describe('Unit | UseCase | find-students-for-enrollment', function () {
       });
 
       // then
-      const expectedEnrolledStudent = new StudentForEnrollment({ ...enrolledStudent, isEnrolled: true });
+      const expectedEnrolledStudent = new StudentForEnrolment({ ...enrolledStudent, isEnrolled: true });
       const exepectedEnrollableStudents = enrollableStudents.map(
-        (student) => new StudentForEnrollment({ ...student, isEnrolled: false })
+        (student) => new StudentForEnrolment({ ...student, isEnrolled: false })
       );
       const expectedStudents = [expectedEnrolledStudent, ...exepectedEnrollableStudents];
       expect(studentsFounds).to.be.deep.equal({
@@ -114,7 +114,7 @@ describe('Unit | UseCase | find-students-for-enrollment', function () {
           });
 
         // when
-        const studentsFounds = await findStudentsForEnrollment({
+        const studentsFounds = await findStudentsForEnrolment({
           userId,
           certificationCenterId,
           page: { number: 1, size: 10 },

--- a/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
@@ -61,11 +61,11 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
       });
     });
 
-    it('should return all students, enrolled or enrollable, regarding a session', async function () {
+    it('should return all students, enrolled or enrolable, regarding a session', async function () {
       // given
       const sessionId = 3;
       const enrolledStudent = domainBuilder.buildOrganizationLearner({ id: 10, organization, division: '3A' });
-      const enrollableStudents = _.times(5, (iteration) =>
+      const enrolableStudents = _.times(5, (iteration) =>
         domainBuilder.buildOrganizationLearner({ id: iteration, organization })
       );
       const certificationCandidates = [
@@ -74,7 +74,7 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
       organizationLearnerRepository.findByOrganizationIdAndUpdatedAtOrderByDivision
         .withArgs({ page: { number: 1, size: 10 }, filter: { divisions: ['3A'] }, organizationId: organization.id })
         .resolves({
-          data: [enrolledStudent, ...enrollableStudents],
+          data: [enrolledStudent, ...enrolableStudents],
           pagination: { page: 1, pageSize: 10, rowCount: 5, pageCount: 1 },
         });
       certificationCandidateRepository.findBySessionId.withArgs(sessionId).resolves(certificationCandidates);
@@ -93,7 +93,7 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
 
       // then
       const expectedEnrolledStudent = new StudentForEnrolment({ ...enrolledStudent, isEnrolled: true });
-      const exepectedEnrollableStudents = enrollableStudents.map(
+      const exepectedEnrollableStudents = enrolableStudents.map(
         (student) => new StudentForEnrolment({ ...student, isEnrolled: false })
       );
       const expectedStudents = [expectedEnrolledStudent, ...exepectedEnrollableStudents];

--- a/api/tests/unit/infrastructure/serializers/jsonapi/student-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/student-certification-serializer_test.js
@@ -1,13 +1,13 @@
 const { domainBuilder, expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/student-certification-serializer');
-const StudentForEnrollment = require('../../../../../lib/domain/read-models/StudentForEnrollment');
+const StudentForEnrolment = require('../../../../../lib/domain/read-models/StudentForEnrolment');
 
 describe('Unit | Serializer | JSONAPI | student-certification-serializer', function () {
   describe('#serialize', function () {
-    it('should convert a StudentEnrollmentReadmodel model object into JSON API data', function () {
+    it('should convert a StudentEnrolmentReadmodel model object into JSON API data', function () {
       // given
       const student = domainBuilder.buildOrganizationLearner();
-      const studentEnrollmentReadmodel = new StudentForEnrollment({
+      const studentEnrolmentReadmodel = new StudentForEnrolment({
         ...student,
         isEnrolled: true,
       });
@@ -15,19 +15,19 @@ describe('Unit | Serializer | JSONAPI | student-certification-serializer', funct
       const expectedSerializedStudent = {
         data: {
           type: 'students',
-          id: `${studentEnrollmentReadmodel.id}`,
+          id: `${studentEnrolmentReadmodel.id}`,
           attributes: {
-            'first-name': studentEnrollmentReadmodel.firstName,
-            'last-name': studentEnrollmentReadmodel.lastName,
-            birthdate: studentEnrollmentReadmodel.birthdate,
-            division: studentEnrollmentReadmodel.division,
-            'is-enrolled': studentEnrollmentReadmodel.isEnrolled,
+            'first-name': studentEnrolmentReadmodel.firstName,
+            'last-name': studentEnrolmentReadmodel.lastName,
+            birthdate: studentEnrolmentReadmodel.birthdate,
+            division: studentEnrolmentReadmodel.division,
+            'is-enrolled': studentEnrolmentReadmodel.isEnrolled,
           },
         },
       };
 
       // when
-      const json = serializer.serialize(studentEnrollmentReadmodel);
+      const json = serializer.serialize(studentEnrolmentReadmodel);
 
       // then
       expect(json).to.deep.equal(expectedSerializedStudent);

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -43,7 +43,7 @@ export default class SessionAdapter extends ApplicationAdapter {
       }
 
       if (snapshot.adapterOptions.studentListToAdd) {
-        const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/enroll-students-to-session';
+        const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/enrol-students-to-session';
         const organizationLearnerIds = snapshot.adapterOptions.studentListToAdd.map((student) => student.id);
         const data = {
           data: {

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -94,7 +94,7 @@
             {{t "common.actions.cancel"}}
           </PixButtonLink>
           <PixButton
-            @triggerAction={{this.enrollStudents}}
+            @triggerAction={{this.enrolStudents}}
             type="button"
             class="bottom-action-bar__actions--add-button {{if this.shouldEnableAddButton '' 'button--disabled'}}"
           >

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -29,8 +29,8 @@ export default class AddStudentList extends Component {
   }
 
   get hasCheckedEverything() {
-    const enrollableStudentList = this.args.studentList.filter((student) => !student.isEnrolled);
-    const allCertifReportsAreCheck = enrollableStudentList.every((student) => student.isSelected);
+    const enrolableStudentList = this.args.studentList.filter((student) => !student.isEnrolled);
+    const allCertifReportsAreCheck = enrolableStudentList.every((student) => student.isSelected);
     return allCertifReportsAreCheck;
   }
 
@@ -66,7 +66,7 @@ export default class AddStudentList extends Component {
   }
 
   @action
-  async enrollStudents() {
+  async enrolStudents() {
     const sessionId = this.args.session.id;
     const studentListToAdd = this.store.peekAll('student').filter((student) => student.isSelected);
 

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -164,7 +164,7 @@ export default function () {
     return new Response(204);
   });
 
-  this.put('/sessions/:id/enroll-students-to-session', (schema, request) => {
+  this.put('/sessions/:id/enrol-students-to-session', (schema, request) => {
     const requestBody = JSON.parse(request.requestBody);
     const sessionId = request.params.id;
     const studentListToAdd = requestBody.data.attributes['organization-learner-ids'];

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -189,7 +189,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             assert.strictEqual(checkboxChecked.length, 3);
           });
 
-          test('it should cancel students enrollment', async function (assert) {
+          test('it should cancel students enrolment', async function (assert) {
             // given
             server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
             const screen = await visitScreen(`/sessions/${session.id}/candidats`);

--- a/certif/tests/unit/adapters/session_test.js
+++ b/certif/tests/unit/adapters/session_test.js
@@ -65,7 +65,7 @@ module('Unit | Adapter | session', function (hooks) {
         ];
 
         const expectedStudentIdList = [1, 2];
-        const expectedUrl = 'http://localhost:3000/api/sessions/123/enroll-students-to-session';
+        const expectedUrl = 'http://localhost:3000/api/sessions/123/enrol-students-to-session';
         const expectedMethod = 'PUT';
         const expectedData = {
           data: {

--- a/certif/tests/unit/components/add-student-list_test.js
+++ b/certif/tests/unit/components/add-student-list_test.js
@@ -91,7 +91,7 @@ module('Unit | Component | add-student-list', function (hooks) {
     });
   });
 
-  module('#action enrollStudents', function () {
+  module('#action enrolStudents', function () {
     test('it should save only selected students via the session', async function (assert) {
       // given
       const sessionId = 1;
@@ -105,7 +105,7 @@ module('Unit | Component | add-student-list', function (hooks) {
       sinon.stub(store, 'peekAll').withArgs('student').returns(selectedStudents);
 
       // when
-      await component.enrollStudents();
+      await component.enrolStudents();
 
       // then
       sinon.assert.calledWith(component.args.session.save, {
@@ -124,7 +124,7 @@ module('Unit | Component | add-student-list', function (hooks) {
       component.args.returnToSessionCandidates = sinon.spy();
 
       // when
-      await component.enrollStudents();
+      await component.enrolStudents();
 
       // then
       sinon.assert.calledOnce(component.notifications.error);


### PR DESCRIPTION
## :unicorn: Problème

Dans la codebase, nous souhaitons utiliser de l'anglais UK. 
Or le terme `enroll` est utilisé dans sa version anglaise US.  

## :robot: Proposition

Renommer les occurences de `Enroll` en `enrol` 

## :rainbow: Remarques

Le terme `enrolled` n'est pas renommé puisqu'il s'agit de la version correcte du participe passé de `enrol` (UK)

## :100: Pour tester

Pas de régression
CI OK
