### PR TITLE
[FEATURE] Amélioration de la page de détails des profils cibles (PIX-7907)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -19,35 +19,32 @@
         <TargetProfiles::Category @category={{@model.category}} />
       </div>
       <div class="page-section__container">
-        <div class="page-section__content">
-          <div>ID : {{@model.id}}</div>
-          <div>Date de création : {{format-date @model.createdAt}}</div>
-          <div>Public : {{this.isPublic}}</div>
-          <div>Parcours Accès Simplifié : {{this.isSimplifiedAccess}}</div>
-          <div>Obsolète : {{this.isOutdated}}</div>
-          <div>Organisation de référence :
+        <ul>
+          <li><span class="bold">ID : </span>{{@model.id}}</li>
+          <li><span class="bold">Date de création : </span>{{format-date @model.createdAt}}</li>
+          <li><span class="bold">Public : </span>{{this.isPublic}}</li>
+          <li><span class="bold">Parcours Accès Simplifié : </span>{{this.isSimplifiedAccess}}</li>
+          <li><span class="bold">Obsolète : </span>{{this.isOutdated}}</li>
+          <li><span class="bold">Organisation de référence : </span>
             <LinkTo @route="authenticated.organizations.get" @model={{@model.ownerOrganizationId}}>
               {{@model.ownerOrganizationId}}
             </LinkTo>
-          </div>
+          </li>
           {{#if @model.description}}
-            <div>
-              Description :
+            <li>
+              <span class="bold">Description : </span>
               <MarkdownToHtml @markdown={{@model.description}} />
-            </div>
+            </li>
           {{/if}}
           {{#if @model.comment}}
-            <div>
-              Commentaire (usage interne) :
+            <li>
+              <span class="bold">Commentaire (usage interne) : </span>
               <MarkdownToHtml @markdown={{@model.comment}} />
-            </div>
+            </li>
           {{/if}}
-        </div>
-        <div class="page-section__content">
-          <div>
-            <img src={{@model.imageUrl}} role="img" alt="Profil cible" />
-          </div>
-        </div>
+        </ul>
+
+        <img src={{@model.imageUrl}} role="img" alt="Profil cible" />
       </div>
       <div class="target-profile__actions">
         <PixButton

--- a/admin/app/styles/components/target-profiles/target-profile.scss
+++ b/admin/app/styles/components/target-profiles/target-profile.scss
@@ -3,10 +3,13 @@
 
   &__container {
     display: flex;
-  }
+    margin-bottom: 8px;
+    justify-content: space-between;
+    align-items: center;
 
-  &__content {
-    width: 50%;
+    li:not(:last-child) {
+      margin-bottom: .3em;
+    }
   }
 
   &:not(:first-of-type) {
@@ -40,4 +43,8 @@
       flex-grow: 1;
     }
   }
+}
+
+.bold {
+  font-weight: bold;
 }

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -85,10 +85,10 @@ module('Acceptance | Target Profile Management', function (hooks) {
       // then
       assert.dom(screen.getByRole('heading', { name: 'Profil Cible Fantastix', level: 2 })).exists();
       assert.dom(screen.getByText('Thématiques')).exists();
-      assert.dom(screen.getByText('ID : 1')).exists();
-      assert.dom(screen.getByText('Public : Oui')).exists();
-      assert.dom(screen.getByText('Obsolète : Non')).exists();
-      assert.dom(screen.getByText('Parcours Accès Simplifié : Oui')).exists();
+      assert.dom(_findByNestedText(screen, 'ID : 1')).exists();
+      assert.dom(_findByNestedText(screen, 'Public : Oui')).exists();
+      assert.dom(_findByNestedText(screen, 'Obsolète : Non')).exists();
+      assert.dom(_findByNestedText(screen, 'Parcours Accès Simplifié : Oui')).exists();
       assert.dom(screen.getByText('456')).exists();
       assert.dom(screen.getByText('Top profil cible.')).exists();
       assert.dom(screen.getByText('Commentaire Privé.')).exists();
@@ -160,7 +160,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       await clickByName('Oui, marquer comme accès simplifié');
 
       // then
-      assert.dom(screen.getByText('Parcours Accès Simplifié : Oui')).exists();
+      assert.dom(_findByNestedText(screen, 'Parcours Accès Simplifié : Oui')).exists();
     });
 
     test('it should outdate target profile', async function (assert) {
@@ -177,7 +177,14 @@ module('Acceptance | Target Profile Management', function (hooks) {
       await clickByName('Oui, marquer comme obsolète');
 
       // then
-      assert.dom(screen.getByText('Obsolète : Oui')).exists();
+      assert.dom(_findByNestedText(screen, 'Obsolète : Oui')).exists();
     });
   });
 });
+
+// workaround https://github.com/testing-library/dom-testing-library/issues/201#issuecomment-484890360
+function _findByNestedText(screen, text) {
+  return screen.getByText((content, element) => {
+    return element.textContent === text;
+  });
+}


### PR DESCRIPTION
## :unicorn: Problème
problème de design de la page de détail des profils cible.

## :robot: Proposition
aérer les textes, mettre l'image à droite de l'écran, mettre en gras les labels des éléments.

## :rainbow: Remarques
On a changé l'affichage pour de la liste <li>, pour un code plus clean.

## :100: Pour tester
Choisir un profil cible récent, afficher sa page de détail et observer.
