### PR TITLE
[FEATURE] Trier les profiles cibles dans PixAdmin par status puis par nom (PIX-7913)

### DIFF
--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -7,7 +7,8 @@ module.exports = {
   async findPaginatedFiltered({ filter, page }) {
     const query = knex('target-profiles')
       .select('id', 'name', 'outdated')
-      .orderBy('id', 'ASC')
+      .orderBy('outdated', 'ASC')
+      .orderBy('name', 'ASC')
       .modify(_applyFilters, filter);
 
     const { results, pagination } = await fetchPage(query, page);


### PR DESCRIPTION
## :unicorn: Problème
les profil cibles ont un tri par défaut qui n'est pas très user-friendly

## :robot: Proposition
Trier les profiles cibles par status activé / obsolète, puis par nom

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur PixAdmin est vérifier que les profil cibles obsolètes sont bien tout à la fin de la liste