### PR TITLE
[TECH] Renvoyer une erreur 422 au lieu d'une erreur 503 quand l'appel à la route /token de l'idp échoue (PIX-7915) 

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -426,6 +426,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.ServiceUnavailableError(error.message, error.code, error.meta);
   }
 
+  if (error instanceof DomainErrors.OidcInvokingTokenEndpointError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+  }
+
   if (error instanceof DomainErrors.InvalidIdentityProviderError) {
     return new HttpErrors.BadRequestError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1163,6 +1163,14 @@ class OidcUserInfoFormatError extends DomainError {
   }
 }
 
+class OidcInvokingTokenEndpointError extends DomainError {
+  constructor(message = 'Error in retrieving tokens from the partner.', code, meta) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class InvalidIdentityProviderError extends DomainError {
   constructor(identityProvider) {
     const message = `Identity provider ${identityProvider} is not supported.`;
@@ -1342,8 +1350,6 @@ module.exports = {
   AuthenticationMethodNotFoundError,
   AuthenticationMethodAlreadyExistsError,
   AuthenticationKeyExpired,
-  UncancellableOrganizationInvitationError,
-  UncancellableCertificationCenterInvitationError,
   CampaignCodeError,
   CampaignParticipationDeletedError,
   CampaignTypeError,
@@ -1427,20 +1433,23 @@ module.exports = {
   NotFoundError,
   DeletedError,
   NotImplementedError,
+  OidcInvokingTokenEndpointError,
+  OidcMissingFieldsError,
+  OidcUserInfoFormatError,
   ObjectValidationError,
   OrganizationArchivedError,
   OrganizationTagNotFound,
   OrganizationAlreadyExistError,
   OrganizationNotFoundError,
   OrganizationWithoutEmailError,
-  PasswordNotMatching,
-  PasswordResetDemandNotFoundError,
   OrganizationLearnerAlreadyLinkedToUserError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
   OrganizationLearnerCannotBeDissociatedError,
   OrganizationLearnerDisabledError,
   OrganizationLearnerNotFound,
   OrganizationLearnersCouldNotBeSavedError,
+  PasswordNotMatching,
+  PasswordResetDemandNotFoundError,
   SendingEmailError,
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
@@ -1459,9 +1468,9 @@ module.exports = {
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,
   TooManyRows,
+  UncancellableOrganizationInvitationError,
+  UncancellableCertificationCenterInvitationError,
   UnexpectedOidcStateError,
-  OidcMissingFieldsError,
-  OidcUserInfoFormatError,
   UnexpectedUserAccountError,
   UnknownCountryForStudentEnrolmentError,
   UserAlreadyExistsWithAuthenticationMethodError,

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -2,7 +2,12 @@ const jsonwebtoken = require('jsonwebtoken');
 const querystring = require('querystring');
 const { v4: uuidv4 } = require('uuid');
 
-const { InvalidExternalAPIResponseError, OidcMissingFieldsError, OidcUserInfoFormatError } = require('../../errors.js');
+const {
+  InvalidExternalAPIResponseError,
+  OidcInvokingTokenEndpointError,
+  OidcMissingFieldsError,
+  OidcUserInfoFormatError,
+} = require('../../errors.js');
 const AuthenticationMethod = require('../../models/AuthenticationMethod.js');
 const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent.js');
 const settings = require('../../../config.js');
@@ -77,7 +82,7 @@ class OidcAuthenticationService {
       const message = 'Erreur lors de la récupération des tokens du partenaire.';
       const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(httpResponse, message);
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
-      throw new InvalidExternalAPIResponseError(message);
+      throw new OidcInvokingTokenEndpointError(message);
     }
 
     return new AuthenticationSessionContent({

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -66,25 +66,25 @@ class OidcAuthenticationService {
       redirect_uri: redirectUri,
     };
 
-    const response = await httpAgent.post({
+    const httpResponse = await httpAgent.post({
       url: this.tokenUrl,
       payload: querystring.stringify(data),
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       timeout: settings.partner.fetchTimeOut,
     });
 
-    if (!response.isSuccessful) {
+    if (!httpResponse.isSuccessful) {
       const message = 'Erreur lors de la récupération des tokens du partenaire.';
-      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(response, message);
+      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(httpResponse, message);
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
       throw new InvalidExternalAPIResponseError(message);
     }
 
     return new AuthenticationSessionContent({
-      idToken: response.data['id_token'],
-      accessToken: response.data['access_token'],
-      expiresIn: response.data['expires_in'],
-      refreshToken: response.data['refresh_token'],
+      idToken: httpResponse.data['id_token'],
+      accessToken: httpResponse.data['access_token'],
+      expiresIn: httpResponse.data['expires_in'],
+      refreshToken: httpResponse.data['refresh_token'],
     });
   }
 
@@ -108,20 +108,20 @@ class OidcAuthenticationService {
   }
 
   async getUserInfoFromEndpoint({ accessToken, userInfoUrl }) {
-    const response = await httpAgent.get({
+    const httpResponse = await httpAgent.get({
       url: userInfoUrl,
       headers: { Authorization: `Bearer ${accessToken}` },
       timeout: settings.partner.fetchTimeOut,
     });
 
-    if (!response.isSuccessful) {
+    if (!httpResponse.isSuccessful) {
       const message = 'Une erreur est survenue en récupérant les informations des utilisateurs.';
-      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(response, message);
+      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(httpResponse, message);
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
       throw new InvalidExternalAPIResponseError(message);
     }
 
-    const userInfoContent = response.data;
+    const userInfoContent = httpResponse.data;
 
     if (!userInfoContent || typeof userInfoContent !== 'object') {
       const message = `Les informations utilisateur renvoyées par votre fournisseur d'identité ${this.organizationName} ne sont pas au format attendu.`;

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -151,8 +151,8 @@ describe('Acceptance | Route | oidc | token', function () {
       expect(response.result['logout_url_uuid']).to.match(uuidPattern);
     });
 
-    context('when the identity provider API does not respond within timeout', function () {
-      it('should return 503', async function () {
+    context('when the identity provider token route API does not respond within timeout', function () {
+      it('should return 422', async function () {
         // given
         const firstName = 'John';
         const lastName = 'Doe';
@@ -204,10 +204,10 @@ describe('Acceptance | Route | oidc | token', function () {
         });
 
         // then
-        expect(response.statusCode).to.equal(503);
+        expect(response.statusCode).to.equal(422);
         expect(getAccessTokenRequest.isDone()).to.be.true;
         expect(response.payload).to.equal(
-          '{"errors":[{"status":"503","title":"ServiceUnavailable","detail":"Erreur lors de la récupération des tokens du partenaire."}]}'
+          '{"errors":[{"status":"422","title":"Unprocessable entity","detail":"Erreur lors de la récupération des tokens du partenaire."}]}'
         );
       });
     });
@@ -245,7 +245,7 @@ describe('Acceptance | Route | oidc | token', function () {
       });
 
       context('When user has a valid token but with missing required data', function () {
-        context('When identity provider userinfo does not respond within timeout', function () {
+        context('When identity provider userinfo does not respond within timeout or fails', function () {
           it('should return 503', async function () {
             // given
             const firstName = 'John';

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -16,13 +16,16 @@ const {
   UserShouldChangePasswordError,
   MultipleOrganizationLearnersWithDifferentNationalStudentIdError,
   UserHasAlreadyLeftSCO,
-  OrganizationLearnerAlreadyLinkedToInvalidUserError,
   InvalidVerificationCodeError,
   InvalidSessionSupervisingLoginError,
   EmailModificationDemandNotFoundOrExpiredError,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   UncancellableOrganizationInvitationError,
+  OidcInvokingTokenEndpointError,
+  OidcMissingFieldsError,
+  OidcUserInfoFormatError,
+  OrganizationLearnerAlreadyLinkedToInvalidUserError,
   OrganizationLearnerCannotBeDissociatedError,
   UserShouldNotBeReconciledOnAnotherAccountError,
   CertificationCandidateOnFinalizedSessionError,
@@ -34,8 +37,6 @@ const {
   UnexpectedOidcStateError,
   InvalidIdentityProviderError,
   SendingEmailToInvalidDomainError,
-  OidcMissingFieldsError,
-  OidcUserInfoFormatError,
   SendingEmailToInvalidEmailAddressError,
   LocaleFormatError,
   LocaleNotSupportedError,
@@ -632,6 +633,23 @@ describe('Unit | Application | ErrorManager', function () {
 
         // then
         expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(
+          error.message,
+          error.code,
+          error.meta
+        );
+      });
+
+      it('instantiates UnprocessableEntityError when OidcInvokingTokenEndpointError', async function () {
+        // given
+        const error = new OidcInvokingTokenEndpointError('Some message', 'someCode', 'someMetaData');
+        sinon.stub(HttpErrors, 'UnprocessableEntityError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
           error.message,
           error.code,
           error.meta

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -7,6 +7,7 @@ const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const AuthenticationSessionContent = require('../../../../../lib/domain/models/AuthenticationSessionContent');
 const {
   InvalidExternalAPIResponseError,
+  OidcInvokingTokenEndpointError,
   OidcMissingFieldsError,
   OidcUserInfoFormatError,
 } = require('../../../../../lib/domain/errors');
@@ -198,7 +199,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
 
         // then
-        expect(error).to.be.an.instanceOf(InvalidExternalAPIResponseError);
+        expect(error).to.be.an.instanceOf(OidcInvokingTokenEndpointError);
         expect(error.message).to.equal('Erreur lors de la récupération des tokens du partenaire.');
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
           message: {


### PR DESCRIPTION
## :unicorn: Problème
La route `/api/oidc/token` est en erreur assez souvent lors d'une connexion avec un partenaire.
C'est un problème identifié depuis longtemps. 

Nous avons déjà remplacé les 503 lors de l'appel au endpoint /userInfo dans cette [PR](https://github.com/1024pix/pix/pull/5667).

Nous avions décidé de garder les 503 pour les appels à la route /access_token en erreur pour avoir une alerte de monitoring

Mais ceci rend le monitoring fastidieux pour la team Captains car les erreurs 500 sont suivies.
Or ici, un des partenaires a ces derniers temps eu environ une erreur par jour, une 400 avec la réponse suivante :

```
{
    "error_description":"The provided access grant is invalid, expired, or revoked.",
    "error":"invalid_grant"
}
```


## :robot: Proposition
Nous proposons donc de remplacer cette 503 par une 422.

## :rainbow: Remarques
Ce serait vraiment pas mal si on pouvait mettre en place l'ajout de log supplémentaires comme dans ce fichier
https://github.com/1024pix/pix/blob/b3af75b454eea37be920f6df82d1e39564a37951/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js#L34-L39
On pourrait filtrer sur datadog sur par exemple, un event qui serait oidc-login et mettre des éléments en plus pour savoir à quelle étape de la connexion on est, si elle est failed avant d'arriver au bout, le nom du partenaire idp....


## :100: Pour tester
Les tests devront se faire en local.
#### Simuler une indisponibilité de l'endpoint /acces_token


- Supprimer la condition  if (!response.isSuccessful) {https://github.com/1024pix/pix/blob/b3af75b454eea37be920f6df82d1e39564a37951/api/lib/domain/services/authentication/oidc-authentication-service.js#L76
- Se connecter sur pix app en .fr via Pole Emploi et observer qu'on a bien une 422

![Capture d’écran 2023-04-28 à 17 08 54](https://user-images.githubusercontent.com/7688741/235184930-3f3daaf3-fd9e-40e8-b3fe-3fa69fc4da90.png)

