### PR TITLE
[BUGFIX] Les menus de navigation sur Admin ne sont pas en surbrillances quand on est dans une sous page (PIX-7914)

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -13,7 +13,7 @@
     <li class="menu-bar__entry">
       <PixTooltip @position="right">
         <:triggerElement>
-          <LinkTo @route="authenticated.users.list" class="menu-bar__link">
+          <LinkTo @route="authenticated.users" class="menu-bar__link">
             <FaIcon @icon="user" @title="Utilisateurs" />
           </LinkTo>
         </:triggerElement>
@@ -23,7 +23,7 @@
     <li class="menu-bar__entry">
       <PixTooltip @position="right" @inline={{true}}>
         <:triggerElement>
-          <LinkTo @route="authenticated.certification-centers.list" class="menu-bar__link">
+          <LinkTo @route="authenticated.certification-centers" class="menu-bar__link">
             <FaIcon @icon="map-pin" @title="Centres de certification" />
           </LinkTo>
         </:triggerElement>
@@ -33,7 +33,7 @@
     <li class="menu-bar__entry">
       <PixTooltip @position="right" @inline={{true}}>
         <:triggerElement>
-          <LinkTo @route="authenticated.sessions.list.with-required-action" class="menu-bar__link">
+          <LinkTo @route="authenticated.sessions" class="menu-bar__link">
             <FaIcon @icon="chalkboard-user" @title="Sessions de certifications" />
           </LinkTo>
         </:triggerElement>
@@ -56,7 +56,7 @@
       <li class="menu-bar__entry">
         <PixTooltip @position="right" @inline={{true}}>
           <:triggerElement>
-            <LinkTo @route="authenticated.target-profiles.list" class="menu-bar__link">
+            <LinkTo @route="authenticated.target-profiles" class="menu-bar__link">
               <FaIcon @icon="clipboard-list" @title="Profils cibles" />
             </LinkTo>
           </:triggerElement>
@@ -80,7 +80,7 @@
       <li class="menu-bar__entry">
         <PixTooltip @position="right">
           <:triggerElement>
-            <LinkTo @route="authenticated.trainings.list" class="menu-bar__link">
+            <LinkTo @route="authenticated.trainings" class="menu-bar__link">
               <FaIcon @icon="book-open" @title="Contenus formatifs" />
             </LinkTo>
           </:triggerElement>

--- a/admin/app/routes/authenticated/sessions/index.js
+++ b/admin/app/routes/authenticated/sessions/index.js
@@ -4,6 +4,6 @@ export default class AuthenticatedSessionsRoute extends Route {
   @service router;
 
   beforeModel() {
-    this.router.transitionTo('authenticated.sessions.list');
+    this.router.transitionTo('authenticated.sessions.list.with-required-action');
   }
 }

--- a/admin/app/routes/authenticated/trainings/index.js
+++ b/admin/app/routes/authenticated/trainings/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.transitionTo('authenticated.trainings.list');
+  }
+}

--- a/admin/tests/acceptance/administration_test.js
+++ b/admin/tests/acceptance/administration_test.js
@@ -14,12 +14,20 @@ module('Acceptance | administration', function (hooks) {
   });
 
   module('Access', function () {
-    test('Administration page should be accessible from /tools', async function (assert) {
+    test('Administration page should be accessible from /administration', async function (assert) {
       // given & when
       await visit('/administration');
 
       // then
       assert.strictEqual(currentURL(), '/administration');
+    });
+
+    test('it should set administration menubar item active', async function (assert) {
+      // when
+      const screen = await visit(`/administration`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Administration' })).hasClass('active');
     });
   });
 

--- a/admin/tests/acceptance/authenticated/certification-centers/list_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list_test.js
@@ -34,6 +34,14 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       assert.strictEqual(currentURL(), '/certification-centers/list');
     });
 
+    test('it should set certification-centers menubar item active', async function (assert) {
+      // when
+      const screen = await visit('/certification-centers/list');
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Centres de certification' })).hasClass('active');
+    });
+
     test('it should list the certification-centers', async function (assert) {
       // given
       const certificationCenter = server.createList('certification-center', 3);

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -54,6 +54,17 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     assert.dom(screen.getByRole('textbox', { name: 'Rechercher une session avec un identifiant' })).exists();
   });
 
+  test('it should set certifications menubar item active', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+    // when
+    const screen = await visit(`/certifications/${certification.id}`);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Certifications' })).hasClass('active');
+  });
+
   module('certification information read', function () {
     test('it displays candidate information', async function (assert) {
       // given

--- a/admin/tests/acceptance/authenticated/organizations/create-organization_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization_test.js
@@ -13,6 +13,14 @@ module('Acceptance | Organizations | Create', function (hooks) {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
+  test('it should set organizations menubar item active', async function (assert) {
+    // when
+    const screen = await visit('/organizations/new');
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Organisations' })).hasClass('active');
+  });
+
   module('when an organization is created', function () {
     test('it redirects the user on the organization details page with the tags tab opened', async function (assert) {
       // given

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -33,6 +33,14 @@ module('Acceptance | Organizations | List', function (hooks) {
       assert.strictEqual(currentURL(), '/organizations/list');
     });
 
+    test('it should set organizations menubar item active', async function (assert) {
+      // when
+      const screen = await visit('/organizations/list');
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Organisations' })).hasClass('active');
+    });
+
     test('it should list the organizations', async function (assert) {
       // given
       server.create('organization', { name: 'Tic' });

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -24,6 +24,14 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
     assert.strictEqual(currentURL(), `/organizations/${organization.id}/team`);
   });
 
+  test('it should set organizations menubar item active', async function (assert) {
+    // when
+    const screen = await visit(`/organizations/${organization.id}`);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Organisations' })).hasClass('active');
+  });
+
   module('listing members', function () {
     test('it should display the current filter when memberships are filtered by firstName', async function (assert) {
       // when

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
@@ -34,6 +34,17 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
       assert.strictEqual(currentURL(), SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
     });
 
+    test('it should set sessions menubar item active', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Sessions de certifications' })).hasClass('active');
+    });
+
     test('it should display sessions to publish informations', async function (assert) {
       assert.expect(7);
       // given

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
@@ -46,6 +46,14 @@ module('Acceptance | authenticated/sessions/list/with required action', function
       assert.strictEqual(currentURL(), '/sessions/list/with-required-action');
     });
 
+    test('it should set sessions menubar item active', async function (assert) {
+      // when
+      const screen = await visit('/sessions/list/with-required-action');
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Sessions de certifications' })).hasClass('active');
+    });
+
     test('it should display sessions with required action informations', async function (assert) {
       assert.expect(8);
       // given

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -33,6 +33,14 @@ module('Acceptance | Target Profiles | List', function (hooks) {
         assert.strictEqual(currentURL(), '/target-profiles/list');
       });
 
+      test('it should set target-profiles menubar item active', async function (assert) {
+        // when
+        const screen = await visit(`/target-profiles/list`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Profils cibles' })).hasClass('active');
+      });
+
       test('it should list target profile summaries', async function (assert) {
         // given
         server.create('target-profile-summary', { id: 1, name: 'COUCOU', outdated: true });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -34,6 +34,18 @@ module('Acceptance | Target profile creation', function (hooks) {
           // then
           assert.strictEqual(currentURL(), '/target-profiles/new');
         });
+
+        test('it should set target-profiles menubar item active', async function (assert) {
+          // given
+          server.create('framework', { id: 'framework', name: 'Pix' });
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+          // when
+          const screen = await visit(`/target-profiles/new`);
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Profils cibles' })).hasClass('active');
+        });
       });
 
       module('when admin member has role "CERTIF"', function () {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -48,6 +48,17 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           await visit('/target-profiles/1/badges/200');
           assert.strictEqual(currentURL(), '/target-profiles/1/badges/200');
         });
+
+        test('it should set target-profiles menubar item active', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+          // when
+          const screen = await visit(`/target-profiles/1/insights`);
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Profils cibles' })).hasClass('active');
+        });
       });
 
       module('when admin member has role "CERTIF"', function () {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -34,6 +34,14 @@ module('Acceptance | Target Profile Management', function (hooks) {
           // then
           assert.strictEqual(currentURL(), '/target-profiles/1/details');
         });
+
+        test('it should set target-profiles menubar item active', async function (assert) {
+          // when
+          const screen = await visit(`/target-profiles/1/details`);
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Profils cibles' })).hasClass('active');
+        });
       });
 
       module('when admin member has role "CERTIF"', function () {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
@@ -35,6 +35,14 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
           // then
           assert.strictEqual(currentURL(), '/target-profiles/1/organizations');
         });
+
+        test('it should set target-profiles menubar item active', async function (assert) {
+          // when
+          const screen = await visit(`/target-profiles/1/organizations`);
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Profils cibles' })).hasClass('active');
+        });
       });
 
       module('when admin member has role "CERTIF"', function () {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/training-summaries_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/training-summaries_test.js
@@ -35,6 +35,14 @@ module('Acceptance | Target Profile Training Summaries', function (hooks) {
           // then
           assert.strictEqual(currentURL(), '/target-profiles/1/training-summaries');
         });
+
+        test('it should set target-profiles menubar item active', async function (assert) {
+          // when
+          const screen = await visit(`/target-profiles/1/training-summaries`);
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Profils cibles' })).hasClass('active');
+        });
       });
 
       module('when admin member has role "CERTIF"', function () {

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -31,6 +31,17 @@ module('Acceptance | Team | List', function (hooks) {
       assert.strictEqual(currentURL(), '/organizations/list');
     });
 
+    test('it should set team menubar item active', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/equipe`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Équipe' })).hasClass('active');
+    });
+
     test('it should be possible to change the role of an admin member', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -33,6 +33,14 @@ module('Acceptance | Trainings | List', function (hooks) {
         assert.strictEqual(currentURL(), '/trainings/list');
       });
 
+      test('it should set trainings menubar item active', async function (assert) {
+        // when
+        const screen = await visit(`/trainings/list`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).hasClass('active');
+      });
+
       test('it should list training summaries', async function (assert) {
         // given
         server.createList('training-summary', 10);

--- a/admin/tests/acceptance/authenticated/trainings/training_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training_test.js
@@ -63,6 +63,36 @@ module('Acceptance | Trainings | Training', function (hooks) {
       });
     });
 
+    module('creation page', function () {
+      test('it should set trainings menubar item active', async function (assert) {
+        // when
+        const screen = await visit(`/trainings/new`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).hasClass('active');
+      });
+    });
+
+    module('triggers details page', function () {
+      test('it should set trainings menubar item active', async function (assert) {
+        // when
+        const screen = await visit(`/trainings/${trainingId}/triggers`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).hasClass('active');
+      });
+    });
+
+    module('triggers target-profiles page', function () {
+      test('it should set trainings menubar item active', async function (assert) {
+        // when
+        const screen = await visit(`/trainings/${trainingId}/target-profiles`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).hasClass('active');
+      });
+    });
+
     test('should be redirected to training detail page after training creation', async function (assert) {
       // when
       await visit(`/trainings/list`);

--- a/admin/tests/acceptance/authenticated/users/list_test.js
+++ b/admin/tests/acceptance/authenticated/users/list_test.js
@@ -32,6 +32,14 @@ module('Acceptance | authenticated/users | list', function (hooks) {
       assert.strictEqual(currentURL(), '/users/list');
     });
 
+    test('it should set users menubar item active', async function (assert) {
+      // when
+      const screen = await visit('/users/list');
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Utilisateurs' })).hasClass('active');
+    });
+
     test('it should not list the users at loading page', async function (assert) {
       // when
       const screen = await visit('/users/list');

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Session page', function (hooks) {
       await visitSessionsPage();
 
       // then
-      assert.strictEqual(currentURL(), '/sessions/list');
+      assert.strictEqual(currentURL(), '/sessions/list/with-required-action');
     });
   });
 

--- a/admin/tests/acceptance/tools_test.js
+++ b/admin/tests/acceptance/tools_test.js
@@ -21,5 +21,13 @@ module('Acceptance | tools', function (hooks) {
       // then
       assert.strictEqual(currentURL(), '/tools');
     });
+
+    test('it should set tools menubar item active', async function (assert) {
+      // when
+      const screen = await visit(`/tools`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Outils' })).hasClass('active');
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les menus de navigation sur Admin ne sont pas en surbrillances quand on est dans une sous route.

Exemple : Sur le détail d’un contenu formatif, le menu qui correspond n’est plus considéré actif.

![image](https://user-images.githubusercontent.com/5855339/235164821-59df610c-8a42-4b3d-b435-ed0282b0803f.png)

## :robot: Proposition
Pour ajouter la classe `active` sur un composant `LinkTo`, Ember se base sur la valeur que l'on place dans l'attribut `@route` (voir `menu-bar.hbs`). Toutes les sous routes de cette route seront considérée comme appartenant à cette première et contiendront donc la classe `active`.

Pour bien envoyer l'utilisateur là où il faut, j'ai ajouté des fichiers `index.js` pour répondre aux nouvelles routes et rediriger vers la route souhaitée.

Ce correctif s'applique aux pages suivantes : 
- [Utilisateurs](https://admin-pr6107.review.pix.fr/users/303)
- [Centres de certification](https://admin-pr6107.review.pix.fr/certification-centers/2)
- [Sessions de certification](https://admin-pr6107.review.pix.fr/sessions/6)
- [Profils cibles](https://admin-pr6107.review.pix.fr/target-profiles/2/insights)
- [Contenus formatifs](https://admin-pr6107.review.pix.fr/trainings/101049/triggers)

## :rainbow: Remarques
J'ai ajouté quelques tests d'acceptance pour éviter de retomber dedans.

## :100: Pour tester
Vérifier que l'UX est améliorée :)
