### PR TITLE
[TECH] Tester unitairement le use-case sessions-mass-import

### DIFF
--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -1,7 +1,5 @@
 const Session = require('../../models/Session');
 const SessionMassImportReport = require('../../models/SessionMassImportReport');
-const sessionsImportValidationService = require('../../services/sessions-mass-import/sessions-import-validation-service');
-const temporarySessionsStorageForMassImportService = require('../../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
 const CertificationCandidate = require('../../models/CertificationCandidate');
 const bluebird = require('bluebird');
 
@@ -17,6 +15,8 @@ module.exports = async function validateSessions({
   certificationCourseRepository,
   sessionCodeService,
   i18n,
+  sessionsImportValidationService,
+  temporarySessionsStorageForMassImportService,
 }) {
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
   const sessionsMassImportReport = new SessionMassImportReport();
@@ -55,6 +55,7 @@ module.exports = async function validateSessions({
         certificationCpfCityRepository,
         complementaryCertificationRepository,
         translate,
+        sessionsImportValidationService,
       });
 
       session.certificationCandidates = validatedCertificationCandidates;
@@ -85,6 +86,7 @@ async function _createValidCertificationCandidates({
   certificationCpfCityRepository,
   complementaryCertificationRepository,
   translate,
+  sessionsImportValidationService,
 }) {
   const { uniqueCandidates, duplicateCandidateErrors } =
     sessionsImportValidationService.getUniqueCandidates(certificationCandidates);

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -21,7 +21,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
   let sessionCodeService;
 
   let sessionsImportValidationService;
-  let sessionRepository;
   let temporarySessionsStorageForMassImportService;
 
   beforeEach(function () {
@@ -42,9 +41,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       getValidatedCandidateBirthInformation: sinon.stub(),
       validateSession: sinon.stub(),
       getUniqueCandidates: sinon.stub(),
-    };
-    sessionRepository = {
-      isSessionExisting: sinon.stub(),
     };
     temporarySessionsStorageForMassImportService = {
       save: sinon.stub(),
@@ -93,10 +89,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         userId,
         certificationCenterId,
         certificationCenterRepository,
-        sessionRepository,
         sessionCodeService,
         i18n,
-
         sessionsImportValidationService,
         temporarySessionsStorageForMassImportService,
       });
@@ -188,15 +182,17 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           },
         ];
 
-        sessionsImportValidationService.getUniqueCandidates.onCall(0).returns({
-          uniqueCandidates: [candidate1],
-          duplicateCandidateErrors: [],
-        });
-
-        sessionsImportValidationService.getUniqueCandidates.onCall(1).returns({
-          uniqueCandidates: [candidate2, candidate3],
-          duplicateCandidateErrors: [],
-        });
+        sessionsImportValidationService.getUniqueCandidates
+          .onFirstCall()
+          .returns({
+            uniqueCandidates: [candidate1],
+            duplicateCandidateErrors: [],
+          })
+          .onSecondCall()
+          .returns({
+            uniqueCandidates: [candidate2, candidate3],
+            duplicateCandidateErrors: [],
+          });
 
         const cpfBirthInformationValidation1 = new CpfBirthInformationValidation();
         cpfBirthInformationValidation1.success({ ...candidate1 });
@@ -205,13 +201,11 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         const cpfBirthInformationValidation3 = new CpfBirthInformationValidation();
         cpfBirthInformationValidation3.success({ ...candidate3 });
         sessionsImportValidationService.getValidatedCandidateBirthInformation
-          .onCall(0)
-          .resolves({ cpfBirthInformation: cpfBirthInformationValidation1 });
-        sessionsImportValidationService.getValidatedCandidateBirthInformation
-          .onCall(1)
-          .resolves({ cpfBirthInformation: cpfBirthInformationValidation2 });
-        sessionsImportValidationService.getValidatedCandidateBirthInformation
-          .onCall(2)
+          .onFirstCall()
+          .resolves({ cpfBirthInformation: cpfBirthInformationValidation1 })
+          .onSecondCall()
+          .resolves({ cpfBirthInformation: cpfBirthInformationValidation2 })
+          .onThirdCall()
           .resolves({ cpfBirthInformation: cpfBirthInformationValidation3 });
 
         temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
@@ -224,10 +218,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           certificationCenterRepository,
           certificationCandidateRepository,
           certificationCourseRepository,
-          sessionRepository,
           sessionCodeService,
           i18n,
-
           sessionsImportValidationService,
           temporarySessionsStorageForMassImportService,
         });
@@ -303,10 +295,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         sessions,
         certificationCenterId,
         certificationCenterRepository,
-        sessionRepository,
         sessionCodeService,
         i18n,
-
         sessionsImportValidationService,
       });
 
@@ -343,10 +333,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           sessions,
           certificationCenterId,
           certificationCenterRepository,
-          sessionRepository,
           sessionCodeService,
           i18n,
-
           sessionsImportValidationService,
           temporarySessionsStorageForMassImportService,
         });
@@ -401,7 +389,6 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           sessions,
           certificationCenterId,
           certificationCenterRepository,
-          sessionRepository,
           sessionCodeService,
           i18n,
           sessionsImportValidationService,


### PR DESCRIPTION
## :unicorn: Problème
Deux dépendances ne sont pas importées dans le use-case d'import en masse des sessions de certification.
C'est un pré-requis pour https://github.com/1024pix/pix/pull/5787 .
De plus, le fichier est nommé "test unitaire" alors que c'est un test d'intégration.

## :robot: Proposition
Ne plus utiliser les implémentations en injectant les dépendances.

## :100: Pour tester
Vérifier que les dépendances ne sont plus importées dans l'implémentation.
Vérifier que l'intégration entre le use-case et les dépendances sont testés dans un test d'intégration ailleurs que dans ce fichier.
Vérifier que la CI passe.
