### PR TITLE
[TECH] Appeler session.setup de ember-simple-auth dans la route de l'application

### DIFF
--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -4,12 +4,14 @@ import Route from '@ember/routing/route';
 const defaultLocale = 'fr';
 
 export default class ApplicationRoute extends Route {
+  @service session;
   @service intl;
   @service currentUser;
   @service featureToggles;
   @service oidcIdentityProviders;
 
   async beforeModel() {
+    await this.session.setup();
     this.intl.setLocale([defaultLocale]);
 
     await this.featureToggles.load();

--- a/admin/ember-cli-build.js
+++ b/admin/ember-cli-build.js
@@ -11,14 +11,15 @@ module.exports = function (defaults) {
     babel: {
       sourceMaps: 'inline',
     },
+    'ember-simple-auth': {
+      useSessionSetupMethod: true,
+    },
     'ember-cli-template-lint': {
       testGenerator: 'qunit', // or 'mocha', etc.
     },
-
     flatpickr: {
       locales: ['fr'],
     },
-
     'ember-dayjs': {
       locales: ['fr'],
     },

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -8,6 +8,7 @@ export default class ApplicationRoute extends Route {
   @service session;
 
   async beforeModel(transition) {
+    await this.session.setup();
     await this.featureToggles.load();
     const isFranceDomain = this.currentDomain.isFranceDomain;
     const localeFromQueryParam = transition.to.queryParams.lang;

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -20,6 +20,9 @@ module.exports = function (defaults) {
     flatpickr: {
       locales: ['fr'],
     },
+    'ember-simple-auth': {
+      useSessionSetupMethod: true,
+    },
     'ember-cli-template-lint': {
       testGenerator: 'qunit',
     },

--- a/mon-pix/app/instance-initializers/session.js
+++ b/mon-pix/app/instance-initializers/session.js
@@ -31,6 +31,5 @@ function _removeCurrentSessionFromLocalStorage() {
 }
 
 export default {
-  before: 'ember-simple-auth',
   initialize,
 };

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -16,6 +16,7 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    await this.session.setup();
     /*
     Ce code permet de définir une locale par défaut différente de celle d'ember-intl.
 

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -16,6 +16,9 @@ module.exports = function (defaults) {
       exclude: ['png', 'svg'],
       extensions: ['js', 'css', 'jpg', 'gif', 'map'],
     },
+    'ember-simple-auth': {
+      useSessionSetupMethod: true,
+    },
     'ember-dayjs': {
       locales: ['fr', 'en'],
       plugins: ['duration', 'relativeTime'],

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -69,7 +69,7 @@
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^10.0.0",
         "ember-responsive": "^5.0.0",
-        "ember-simple-auth": "^4.0.2",
+        "ember-simple-auth": "^4.2.2",
         "ember-source": "^4.0.1",
         "ember-template-lint": "^4.18.0",
         "ember-template-lint-plugin-prettier": "^4.0.0",
@@ -25486,13 +25486,15 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.0.2.tgz",
-      "integrity": "sha512-6DoNfesB54ToDMv89r7KFtIR1EFYWurAAlD5KRnnerhBbRH0ws3EK2g7O/8wVJoBuPOuvHZlEnJVCtzp+oauyg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
+      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
       "dev": true,
       "dependencies": {
         "base-64": "^0.1.0",
+        "broccoli-file-creator": "^2.1.1",
         "broccoli-funnel": "^1.2.0 || ^2.0.0",
+        "broccoli-merge-trees": "^4.0.0",
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cookies": "^0.5.0",
@@ -25503,6 +25505,61 @@
       },
       "peerDependencies": {
         "ember-fetch": "^8.0.1"
+      }
+    },
+    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^4.0.2",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-simple-auth/node_modules/broccoli-plugin": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-output-wrapper": "^3.2.5",
+        "fs-merger": "^3.2.1",
+        "promise-map-series": "^0.3.0",
+        "quick-temp": "^0.1.8",
+        "rimraf": "^3.0.2",
+        "symlink-or-copy": "^1.3.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-simple-auth/node_modules/promise-map-series": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-simple-auth/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ember-source": {
@@ -61164,17 +61221,61 @@
       }
     },
     "ember-simple-auth": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.0.2.tgz",
-      "integrity": "sha512-6DoNfesB54ToDMv89r7KFtIR1EFYWurAAlD5KRnnerhBbRH0ws3EK2g7O/8wVJoBuPOuvHZlEnJVCtzp+oauyg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
+      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
       "dev": true,
       "requires": {
         "base-64": "^0.1.0",
+        "broccoli-file-creator": "^2.1.1",
         "broccoli-funnel": "^1.2.0 || ^2.0.0",
+        "broccoli-merge-trees": "^4.0.0",
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cookies": "^0.5.0",
         "silent-error": "^1.0.0"
+      },
+      "dependencies": {
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          }
+        },
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ember-source": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -97,7 +97,7 @@
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^10.0.0",
     "ember-responsive": "^5.0.0",
-    "ember-simple-auth": "^4.0.2",
+    "ember-simple-auth": "^4.2.2",
     "ember-source": "^4.0.1",
     "ember-template-lint": "^4.18.0",
     "ember-template-lint-plugin-prettier": "^4.0.0",

--- a/mon-pix/tests/unit/adapters/application_test.js
+++ b/mon-pix/tests/unit/adapters/application_test.js
@@ -111,20 +111,20 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       test('should invalidate the current session', function (assert) {
         // given
         const applicationAdapter = this.owner.lookup('adapter:application');
-        const session = this.owner.lookup('service:session');
+        applicationAdapter.session = {
+          invalidate: sinon.stub(),
+          isAuthenticated: true,
+        };
         const status = 401;
         const headers = {};
         const payload = {};
         const requestData = {};
 
-        sinon.stub(session, 'invalidate');
-        session.isAuthenticated = true;
-
         // when
         applicationAdapter.handleResponse(status, headers, payload, requestData);
 
         // then
-        sinon.assert.calledOnce(session.invalidate);
+        sinon.assert.calledOnce(applicationAdapter.session.invalidate);
         assert.ok(true);
       });
     });

--- a/mon-pix/tests/unit/routes/application_test.js
+++ b/mon-pix/tests/unit/routes/application_test.js
@@ -35,6 +35,7 @@ module('Unit | Route | application', function (hooks) {
         load: sinon.stub().resolves(catchStub),
       });
       sessionServiceStub = Service.create({
+        setup: sinon.stub().resolves(),
         handleUserLanguageAndLocale: sinon.stub().resolves(),
       });
       oidcIdentityProvidersStub = Service.create({
@@ -42,6 +43,21 @@ module('Unit | Route | application', function (hooks) {
       });
 
       this.intl = this.owner.lookup('service:intl');
+    });
+
+    test('should setup the session', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:application');
+      route.set('featureToggles', featureTogglesServiceStub);
+      route.set('session', sessionServiceStub);
+      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
+
+      // when
+      await route.beforeModel();
+
+      // then
+      sinon.assert.calledOnce(sessionServiceStub.setup);
+      assert.ok(true);
     });
 
     test('should set "fr" locale as default', async function (assert) {

--- a/mon-pix/tests/unit/routes/campaigns/join_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/join_test.js
@@ -13,7 +13,15 @@ module('Unit | Route | Join', function (hooks) {
     route.router = { replaceWith: sinon.stub() };
   });
 
-  module('#beforeModel', function () {
+  module('#beforeModel', function (hooks) {
+    hooks.beforeEach(function () {
+      route = this.owner.lookup('route:campaigns.join');
+      route.session = {
+        prohibitAuthentication: sinon.stub(),
+      };
+      route.router = { replaceWith: sinon.stub() };
+    });
+
     test('should redirect to entry point when /rejoindre is directly set in the url', async function (assert) {
       //when
       await route.beforeModel({ from: null });
@@ -40,6 +48,7 @@ module('Unit | Route | Join', function (hooks) {
 
       //then
       assert.strictEqual(route.routeIfAlreadyAuthenticated, 'campaigns.access');
+      sinon.assert.calledWith(route.session.prohibitAuthentication, 'authenticated.user-dashboard');
     });
   });
 

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -144,7 +144,8 @@ module('Unit | Services | session', function (hooks) {
 
     test('should replace the URL with the one set before the identity provider authentication', async function (assert) {
       // given
-      sessionService.data = { nextURL: '/campagnes', authenticated: { identityProviderCode: 'OIDC_PARTNER' } };
+      sessionService.data.nextURL = '/campagnes';
+      sessionService.data.authenticated = { identityProviderCode: 'OIDC_PARTNER' };
 
       // when
       await sessionService.handleAuthentication();
@@ -321,7 +322,8 @@ module('Unit | Services | session', function (hooks) {
       test('should redirect user to terms of service page', async function (assert) {
         // given
         const transition = { from: 'campaigns.campaign-landing-page' };
-        sessionService.isAuthenticated = true;
+        sessionService.setup();
+        sessionService.session.isAuthenticated = true;
         sessionService.currentUser.user = { mustValidateTermsOfService: true };
 
         // when

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -8,6 +8,7 @@ export default class ApplicationRoute extends Route {
   @service session;
 
   async beforeModel(transition) {
+    await this.session.setup();
     await this.featureToggles.load();
     const isFranceDomain = this.currentDomain.isFranceDomain;
     const localeFromQueryParam = transition.to.queryParams.lang;

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -11,10 +11,12 @@ module.exports = function (defaults) {
     babel: {
       sourceMaps: 'inline',
     },
+    'ember-simple-auth': {
+      useSessionSetupMethod: true,
+    },
     'ember-cli-template-lint': {
       testGenerator: 'qunit', // or 'mocha', etc.
     },
-
     'ember-cli-babel': {
       includePolyfill: true,
     },


### PR DESCRIPTION
## :unicorn: Problème
ember-simple-auth en version 4.1 a rajouté une fonction setup sur la session dans l'idée de supprimer l'initializer en v5. 

https://github.com/mainmatter/ember-simple-auth/blob/master/guides/upgrade-to-v4.md

## :robot: Proposition
S'assurer que l'on utilise bien ember-simple-auth en version >= 4.1 et utiliser la méthode setup sur tout les fronts.


## :100: Pour tester
1. Se connecter sur les différentes applications
2. Visiter quelques pages
3. Se déconnecter
