### PR TITLE
[TECH] Injection de dépendances dans les models pour préparer la migration ESM

### DIFF
--- a/api/lib/domain/models/UserToCreate.js
+++ b/api/lib/domain/models/UserToCreate.js
@@ -19,9 +19,10 @@ class UserToCreate {
     hasSeenOtherChallengesTooltip = false,
     createdAt,
     updatedAt,
+    dependencies = { localeService },
   } = {}) {
     if (locale) {
-      locale = localeService.getCanonicalLocale(locale);
+      locale = dependencies.localeService.getCanonicalLocale(locale);
     }
 
     this.firstName = firstName;

--- a/api/lib/domain/models/ValidatorQCM.js
+++ b/api/lib/domain/models/ValidatorQCM.js
@@ -6,12 +6,13 @@ const Validator = require('./Validator.js');
  * Traduction: Vérificateur de réponse pour un QCM
  */
 class ValidatorQCM extends Validator {
-  constructor({ solution } = {}) {
+  constructor({ solution, dependencies = { solutionServiceQCM } } = {}) {
     super({ solution });
+    this.dependencies = dependencies;
   }
 
   assess({ answer }) {
-    const result = solutionServiceQCM.match(answer.value, this.solution.value);
+    const result = this.dependencies.solutionServiceQCM.match(answer.value, this.solution.value);
 
     return new Validation({
       result,

--- a/api/lib/domain/models/ValidatorQCU.js
+++ b/api/lib/domain/models/ValidatorQCU.js
@@ -6,12 +6,13 @@ const Validator = require('./Validator.js');
  * Traduction: Vérificateur de réponse pour un QCU
  */
 class ValidatorQCU extends Validator {
-  constructor({ solution } = {}) {
+  constructor({ solution, dependencies = { solutionServiceQCU } } = {}) {
     super({ solution });
+    this.dependencies = dependencies;
   }
 
   assess({ answer }) {
-    const result = solutionServiceQCU.match(answer.value, this.solution.value);
+    const result = this.dependencies.solutionServiceQCU.match(answer.value, this.solution.value);
 
     return new Validation({
       result,

--- a/api/lib/domain/models/ValidatorQROCMDep.js
+++ b/api/lib/domain/models/ValidatorQROCMDep.js
@@ -6,12 +6,13 @@ const Validator = require('./Validator.js');
  * Traduction: Vérificateur de réponse pour un QROCM Dep
  */
 class ValidatorQROCMDep extends Validator {
-  constructor({ solution } = {}) {
+  constructor({ solution, dependencies = { solutionServiceQROCMDep } } = {}) {
     super({ solution });
+    this.dependencies = dependencies;
   }
 
   assess({ answer }) {
-    const result = solutionServiceQROCMDep.match({
+    const result = this.dependencies.solutionServiceQROCMDep.match({
       answerValue: answer.value,
       solution: this.solution,
     });

--- a/api/lib/domain/models/ValidatorQROCMInd.js
+++ b/api/lib/domain/models/ValidatorQROCMInd.js
@@ -6,12 +6,16 @@ const Validator = require('./Validator.js');
  * Traduction: Vérificateur de réponse pour un QROCM Ind
  */
 class ValidatorQROCMInd extends Validator {
-  constructor({ solution } = {}) {
+  constructor({ solution, dependencies = { solutionServiceQROCMInd } } = {}) {
     super({ solution });
+    this.dependencies = dependencies;
   }
 
   assess({ answer }) {
-    const resultObject = solutionServiceQROCMInd.match({ answerValue: answer.value, solution: this.solution });
+    const resultObject = this.dependencies.solutionServiceQROCMInd.match({
+      answerValue: answer.value,
+      solution: this.solution,
+    });
 
     return new Validation({
       result: resultObject.result,

--- a/api/scripts/add-tags-to-organizations.js
+++ b/api/scripts/add-tags-to-organizations.js
@@ -48,20 +48,23 @@ async function retrieveTagsByName({ checkedData }) {
   return tagByNames;
 }
 
-async function addTagsToOrganizations({ tagsByName, checkedData }) {
+async function addTagsToOrganizations({ tagsByName, checkedData, dependencies = { organizationTagRepository } }) {
   for (let i = 0; i < checkedData.length; i++) {
     if (require.main === module) process.stdout.write(`\n${i + 1}/${checkedData.length} `);
 
     const { organizationId, tagName } = checkedData[i];
     const tagId = tagsByName.get(tagName).id;
 
-    const isExisting = await organizationTagRepository.isExistingByOrganizationIdAndTagId({ organizationId, tagId });
+    const isExisting = await dependencies.organizationTagRepository.isExistingByOrganizationIdAndTagId({
+      organizationId,
+      tagId,
+    });
 
     if (!isExisting) {
       if (require.main === module) process.stdout.write(`Adding tag: ${tagName} to organization: ${organizationId} `);
 
       const organizationTag = new OrganizationTag({ organizationId, tagId });
-      await organizationTagRepository.create(organizationTag);
+      await dependencies.organizationTagRepository.create(organizationTag);
 
       if (require.main === module) process.stdout.write('===> ✔');
     } else {

--- a/api/tests/unit/domain/models/UserToCreate_test.js
+++ b/api/tests/unit/domain/models/UserToCreate_test.js
@@ -1,5 +1,4 @@
 const { expect, sinon } = require('../../../test-helper');
-const localeService = require('../../../../lib/domain/services/locale-service');
 const UserToCreate = require('../../../../lib/domain/models/UserToCreate');
 
 describe('Unit | Domain | Models | UserToCreate', function () {
@@ -18,14 +17,13 @@ describe('Unit | Domain | Models | UserToCreate', function () {
 
     it('validates and canonicalizes the locale', function () {
       // given
-      const getCanonicalLocaleStub = sinon.stub(localeService, 'getCanonicalLocale');
-      getCanonicalLocaleStub.returns('fr-BE');
+      const localeServiceStub = { getCanonicalLocale: sinon.stub().returns('fr-BE') };
 
       // when
-      const userToCreate = new UserToCreate({ locale: 'fr-be' });
+      const userToCreate = new UserToCreate({ locale: 'fr-be', dependencies: { localeService: localeServiceStub } });
 
       // then
-      expect(getCanonicalLocaleStub).to.have.been.calledWith('fr-be');
+      expect(localeServiceStub.getCanonicalLocale).to.have.been.calledWith('fr-be');
       expect(userToCreate.locale).to.equal('fr-BE');
     });
 

--- a/api/tests/unit/domain/models/ValidatorQCM_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCM_test.js
@@ -1,13 +1,15 @@
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
-const solutionServiceQcm = require('../../../../lib/domain/services/solution-service-qcm');
 const Validation = require('../../../../lib/domain/models/Validation');
 const ValidatorQCM = require('../../../../lib/domain/models/ValidatorQCM');
 
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQCM', function () {
+  let solutionServiceQcmStub;
   beforeEach(function () {
-    sinon.stub(solutionServiceQcm, 'match');
+    solutionServiceQcmStub = {
+      match: sinon.stub(),
+    };
   });
 
   describe('#assess', function () {
@@ -18,11 +20,14 @@ describe('Unit | Domain | Models | ValidatorQCM', function () {
 
     beforeEach(function () {
       // given
-      solutionServiceQcm.match.returns(AnswerStatus.OK);
+      solutionServiceQcmStub.match.returns(AnswerStatus.OK);
       solution = domainBuilder.buildSolution({ type: 'QCM' });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
-      validator = new ValidatorQCM({ solution: solution });
+      validator = new ValidatorQCM({
+        solution: solution,
+        dependencies: { solutionServiceQCM: solutionServiceQcmStub },
+      });
 
       // when
       validation = validator.assess({ answer: uncorrectedAnswer });
@@ -30,7 +35,7 @@ describe('Unit | Domain | Models | ValidatorQCM', function () {
 
     it('should call solutionServiceQCU', function () {
       // then
-      expect(solutionServiceQcm.match).to.have.been.calledWith(uncorrectedAnswer.value, solution.value);
+      expect(solutionServiceQcmStub.match).to.have.been.calledWith(uncorrectedAnswer.value, solution.value);
     });
     it('should return a validation object with the returned status', function () {
       const expectedValidation = domainBuilder.buildValidation({

--- a/api/tests/unit/domain/models/ValidatorQCU_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCU_test.js
@@ -1,13 +1,16 @@
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
-const solutionServiceQcu = require('../../../../lib/domain/services/solution-service-qcu');
 const Validation = require('../../../../lib/domain/models/Validation');
 const ValidatorQCU = require('../../../../lib/domain/models/ValidatorQCU');
 
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQCU', function () {
+  let solutionServiceQCUStub;
+
   beforeEach(function () {
-    sinon.stub(solutionServiceQcu, 'match');
+    solutionServiceQCUStub = {
+      match: sinon.stub(),
+    };
   });
 
   describe('#assess', function () {
@@ -18,11 +21,14 @@ describe('Unit | Domain | Models | ValidatorQCU', function () {
 
     beforeEach(function () {
       // given
-      solutionServiceQcu.match.returns(AnswerStatus.OK);
+      solutionServiceQCUStub.match.returns(AnswerStatus.OK);
       solution = domainBuilder.buildSolution({ type: 'QCU' });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
-      validator = new ValidatorQCU({ solution: solution });
+      validator = new ValidatorQCU({
+        solution: solution,
+        dependencies: { solutionServiceQCU: solutionServiceQCUStub },
+      });
 
       // when
       validation = validator.assess({ answer: uncorrectedAnswer });
@@ -30,7 +36,7 @@ describe('Unit | Domain | Models | ValidatorQCU', function () {
 
     it('should call solutionServiceQCU', function () {
       // then
-      expect(solutionServiceQcu.match).to.have.been.calledWith(uncorrectedAnswer.value, solution.value);
+      expect(solutionServiceQCUStub.match).to.have.been.calledWith(uncorrectedAnswer.value, solution.value);
     });
     it('should return a validation object with the returned status', function () {
       const expectedValidation = domainBuilder.buildValidation({

--- a/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
@@ -1,13 +1,16 @@
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
-const solutionServiceQrocmDep = require('../../../../lib/domain/services/solution-service-qrocm-dep');
 const Validation = require('../../../../lib/domain/models/Validation');
 const ValidatorQROCMDep = require('../../../../lib/domain/models/ValidatorQROCMDep');
 
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQROCMDep', function () {
+  let solutionServiceQROCMDepStub;
+
   beforeEach(function () {
-    sinon.stub(solutionServiceQrocmDep, 'match');
+    solutionServiceQROCMDepStub = {
+      match: sinon.stub(),
+    };
   });
 
   describe('#assess', function () {
@@ -18,7 +21,7 @@ describe('Unit | Domain | Models | ValidatorQROCMDep', function () {
 
     beforeEach(function () {
       // given
-      solutionServiceQrocmDep.match.returns(AnswerStatus.OK);
+      solutionServiceQROCMDepStub.match.returns(AnswerStatus.OK);
       solution = domainBuilder.buildSolution({
         type: 'QROCM-dep',
         value: 'Google:\n- abcd\n- efgh\n- hijk\nYahoo:\n- lmno\n- pqrs\n',
@@ -29,7 +32,10 @@ describe('Unit | Domain | Models | ValidatorQROCMDep', function () {
       });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
-      validator = new ValidatorQROCMDep({ solution: solution });
+      validator = new ValidatorQROCMDep({
+        solution: solution,
+        dependencies: { solutionServiceQROCMDep: solutionServiceQROCMDepStub },
+      });
 
       // when
       validation = validator.assess({ answer: uncorrectedAnswer });
@@ -37,7 +43,10 @@ describe('Unit | Domain | Models | ValidatorQROCMDep', function () {
 
     it('should call solutionServiceQROCMDep', function () {
       // then
-      expect(solutionServiceQrocmDep.match).to.have.been.calledWith({ answerValue: uncorrectedAnswer.value, solution });
+      expect(solutionServiceQROCMDepStub.match).to.have.been.calledWith({
+        answerValue: uncorrectedAnswer.value,
+        solution,
+      });
     });
     it('should return a validation object with the returned status', function () {
       const expectedValidation = domainBuilder.buildValidation({

--- a/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
@@ -1,13 +1,16 @@
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
-const solutionServiceQrocmInd = require('../../../../lib/domain/services/solution-service-qrocm-ind');
 const Validation = require('../../../../lib/domain/models/Validation');
 const ValidatorQROCMInd = require('../../../../lib/domain/models/ValidatorQROCMInd');
 
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQROCMInd', function () {
+  let solutionServiceQROCMIndStub;
+
   beforeEach(function () {
-    sinon.stub(solutionServiceQrocmInd, 'match');
+    solutionServiceQROCMIndStub = {
+      match: sinon.stub(),
+    };
   });
 
   describe('#assess', function () {
@@ -18,11 +21,14 @@ describe('Unit | Domain | Models | ValidatorQROCMInd', function () {
 
     beforeEach(function () {
       // given
-      solutionServiceQrocmInd.match.returns({ result: AnswerStatus.OK, resultDetails: 'resultDetailYAMLString' });
+      solutionServiceQROCMIndStub.match.returns({ result: AnswerStatus.OK, resultDetails: 'resultDetailYAMLString' });
       solution = domainBuilder.buildSolution({ type: 'QROCM-ind' });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
-      validator = new ValidatorQROCMInd({ solution: solution });
+      validator = new ValidatorQROCMInd({
+        solution: solution,
+        dependencies: { solutionServiceQROCMInd: solutionServiceQROCMIndStub },
+      });
 
       // when
       validation = validator.assess({ answer: uncorrectedAnswer });
@@ -30,7 +36,7 @@ describe('Unit | Domain | Models | ValidatorQROCMInd', function () {
 
     it('should call solutionServiceQROCMInd', function () {
       // then
-      expect(solutionServiceQrocmInd.match).to.have.been.calledWith({
+      expect(solutionServiceQROCMIndStub.match).to.have.been.calledWith({
         answerValue: uncorrectedAnswer.value,
         solution: solution,
       });

--- a/api/tests/unit/scripts/add-tags-to-organizations_test.js
+++ b/api/tests/unit/scripts/add-tags-to-organizations_test.js
@@ -1,6 +1,5 @@
 const { expect, sinon } = require('../../test-helper');
 const { addTagsToOrganizations } = require('../../../scripts/add-tags-to-organizations');
-const organizationTagRepository = require('../../../lib/infrastructure/repositories/organization-tag-repository');
 const Tag = require('../../../lib/domain/models/Tag');
 
 describe('Unit | Scripts | add-tags-to-organizations.js', function () {
@@ -9,12 +8,13 @@ describe('Unit | Scripts | add-tags-to-organizations.js', function () {
       // given
       const tagsByName = new Map([['tagName', new Tag({ name: 'tagName' })]]);
       const checkedData = [{ organizationId: 1, tagName: 'tagName' }];
-
-      organizationTagRepository.create = sinon.stub();
-      organizationTagRepository.isExistingByOrganizationIdAndTagId = sinon.stub().resolves(true);
+      const organizationTagRepository = {
+        create: sinon.stub(),
+        isExistingByOrganizationIdAndTagId: sinon.stub().resolves(true),
+      };
 
       // when
-      await addTagsToOrganizations({ tagsByName, checkedData });
+      await addTagsToOrganizations({ tagsByName, checkedData, dependencies: { organizationTagRepository } });
 
       // then
       expect(organizationTagRepository.create).to.not.have.been.called;


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire dans les models qui sont stub avec sinon.

## :rainbow: Remarques
On pourra par la suite revoir la manière dont sont injectées les dépendances de manière plus générale sur l'ensemble des modèles du domaine. Pour le moment, cela permet d'avancer la migration.

## :100: Pour tester
CI OK
