### PR TITLE
[TECH] Ajouter une erreur de lint si `render` ou `find` ne sont pas importés depuis `@1024pix/ember-testing-library` (PIX-7926)

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -25,7 +25,16 @@ module.exports = {
   },
   rules: {
     'no-console': 'error',
-    'no-restricted-imports': ['error', { paths: ['lodash'] }],
+    'no-restricted-imports': [
+      'error',
+      'lodash',
+      {
+        name: '@ember/test-helpers',
+        importNames: ['render', 'find'],
+        message:
+          "Please import 'render' from '@1024pix/ember-testing-library'.\n 'find' should be replaced with '@1024pix/ember-testing-library' 'find...'/'get...'/'query...' methods to enforce accessible usages",
+      },
+    ],
     'ember/avoid-leaking-state-in-ember-objects': 'off',
     'ember/no-get': ['error'],
     'ember/no-empty-attrs': 'error',

--- a/mon-pix/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/mon-pix/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -1,5 +1,6 @@
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+// eslint-disable-next-line no-restricted-imports
 import { click, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';

--- a/mon-pix/tests/acceptance/challenge-attachment_test.js
+++ b/mon-pix/tests/acceptance/challenge-attachment_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find, click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { blur, click, fillIn, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';

--- a/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
+++ b/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, find, findAll, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, find, findAll, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, find, findAll, currentURL, fillIn, triggerEvent, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, find, findAll, currentURL, fillIn, triggerEvent, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -3,6 +3,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { getPageTitle } from 'ember-page-title/test-support';
 import { authenticate } from '../helpers/authentication';
+// eslint-disable-next-line no-restricted-imports
 import { click, find, triggerEvent, visit } from '@ember/test-helpers';
 
 module('Acceptance | Displaying a challenge of any type', function (hooks) {

--- a/mon-pix/tests/acceptance/challenge-timed_test.js
+++ b/mon-pix/tests/acceptance/challenge-timed_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/checkpoint_test.js
+++ b/mon-pix/tests/acceptance/checkpoint_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find, click, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';

--- a/mon-pix/tests/acceptance/competences-results_test.js
+++ b/mon-pix/tests/acceptance/competences-results_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';

--- a/mon-pix/tests/acceptance/course-ending-screen_test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { currentURL, find, findAll, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/navigation_test.js
+++ b/mon-pix/tests/acceptance/navigation_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/profile_test.js
+++ b/mon-pix/tests/acceptance/profile_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, fillIn, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { click, fillIn, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';

--- a/mon-pix/tests/acceptance/user-trainings_test.js
+++ b/mon-pix/tests/acceptance/user-trainings_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+// eslint-disable-next-line no-restricted-imports
 import { visit, currentURL, find } from '@ember/test-helpers';
 import { authenticate } from '../helpers/authentication';
 

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+// eslint-disable-next-line no-restricted-imports
 import { find, click, currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticate } from '../../helpers/authentication';

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+// eslint-disable-next-line no-restricted-imports
 import { find, click } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticate } from '../../helpers/authentication';

--- a/mon-pix/tests/helpers/fill-in-by-label.js
+++ b/mon-pix/tests/helpers/fill-in-by-label.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { fillIn, findAll, find } from '@ember/test-helpers';
 
 export function fillInByLabel(labelText, value) {

--- a/mon-pix/tests/integration/components/account-recovery/recovery-errors-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/recovery-errors-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';

--- a/mon-pix/tests/integration/components/account-recovery/student-information-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/student-information-form-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
+// eslint-disable-next-line no-restricted-imports
 import { render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { contains } from '../../../../helpers/contains';
 import { hbs } from 'ember-cli-htmlbars';

--- a/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/certification-not-certifiable_test.js
+++ b/mon-pix/tests/integration/components/certification-not-certifiable_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/certifications-list-item_test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
+// eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';

--- a/mon-pix/tests/integration/components/certifications-list_test.js
+++ b/mon-pix/tests/integration/components/certifications-list_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';

--- a/mon-pix/tests/integration/components/challenge-actions_test.js
+++ b/mon-pix/tests/integration/components/challenge-actions_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../helpers/click-by-label';

--- a/mon-pix/tests/integration/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/integration/components/challenge-item-qroc_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
+// eslint-disable-next-line no-restricted-imports
 import { click, find, findAll } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';

--- a/mon-pix/tests/integration/components/challenge/item_test.js
+++ b/mon-pix/tests/integration/components/challenge/item_test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { click, render, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/circle-chart_test.js
+++ b/mon-pix/tests/integration/components/circle-chart_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/communication-banner_test.js
+++ b/mon-pix/tests/integration/components/communication-banner_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'mon-pix/config/environment';

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/competence-card-default_test.js
+++ b/mon-pix/tests/integration/components/competence-card-default_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/feedback-certification-section_test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/form-textfield-date_test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { fillIn, find, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/form-textfield_test.js
+++ b/mon-pix/tests/integration/components/form-textfield_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/inaccessible-campaign_test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign_test.js
@@ -4,6 +4,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/learning-more-panel_test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { A } from '@ember/array';
 import EmberObject from '@ember/object';

--- a/mon-pix/tests/integration/components/levelup-notif_test.js
+++ b/mon-pix/tests/integration/components/levelup-notif_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/no-certification-panel_test.js
+++ b/mon-pix/tests/integration/components/no-certification-panel_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/profile-content_test.js
+++ b/mon-pix/tests/integration/components/profile-content_test.js
@@ -3,6 +3,7 @@
 
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';

--- a/mon-pix/tests/integration/components/qcm-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcm-proposals_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/qcu-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/reset-password-form_test.js
+++ b/mon-pix/tests/integration/components/reset-password-form_test.js
@@ -2,6 +2,7 @@ import EmberObject from '@ember/object';
 import { resolve, reject } from 'rsvp';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, fillIn, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../helpers/click-by-label';

--- a/mon-pix/tests/integration/components/result-item-campaign_test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -4,6 +4,7 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 import { fillInByLabel } from '../../../../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
 import { contains } from '../../../../../helpers/contains';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import { contains } from '../../../../../helpers/contains';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/routes/login-form_test.js
+++ b/mon-pix/tests/integration/components/routes/login-form_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+// eslint-disable-next-line no-restricted-imports
 import { click, fillIn, render, find } from '@ember/test-helpers';
 import { fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';

--- a/mon-pix/tests/integration/components/routes/login-or-register_test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../../helpers/click-by-label';

--- a/mon-pix/tests/integration/components/timeout-gauge_test.js
+++ b/mon-pix/tests/integration/components/timeout-gauge_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';

--- a/mon-pix/tests/integration/components/tutorials/cards_test.js
+++ b/mon-pix/tests/integration/components/tutorials/cards_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { A as EmberArray } from '@ember/array';
 

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// eslint-disable-next-line no-restricted-imports
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/unit/helpers/contains_test.js
+++ b/mon-pix/tests/unit/helpers/contains_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+// eslint-disable-next-line no-restricted-imports
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js?rgh-link-date=2023-04-25T14%3A41%3A56Z).

Il est de plus en plus présent dans nos tests front mais nombre d'entre eux se basent toujours sur du html, du css.

Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :robot: Proposition
S'assurer de l'unification de nos tests sur Pix App en forçant l'utilisation des méthodes du package et de testing library.

Le linter nous indique ainsi l'erreur suivante si un import des méthodes `render` et `find` est fait depuis `@ember/test-helpers` (ce qu'on veut éviter) : 

```
error  'render' import from '@ember/test-helpers' is restricted.
Please import 'render' from '@1024pix/ember-testing-library'.
'find' should be replaced with '@1024pix/ember-testing-library' 'find...'/'get...'/'query...' methods to enforce accessible usages  no-restricted-imports
```

L'IDE peut également indiquer l'erreur. Exemple sur VS Code :

![image](https://user-images.githubusercontent.com/5855339/235696496-8d4cf1ae-026d-497d-af7c-8d7d4fe48253.png)

Ainsi, nous avons la possibilité de comptabiliser les erreurs restantes et ça nous donne une idée de l'effort à fournir pour les corriger.

En espérant ne pas venir en conflit de #6078.

## :rainbow: Remarques
Vu que plus de 100 tests ne passaient plus suite à l'ajout des règles, j'ai décidé d'ajouter l'ignore inline et ainsi déphaser leur correction.

La règle eslint `no-restricted-imports` ne permet pas de séparer les erreurs d'imports de plusieurs méthodes. J'ai donc du les mutualiser au même endroit, d'où le message d'erreur un peu générique.

J'ai beaucoup d'ambition sur cette outillage pour gérer la dette technique ^^.

## :100: Pour tester
Vérifier que la CI passe.