### PR TITLE
[FEATURE] Utiliser les design tokens de typographie pour l'entête des épreuves (PIX-7779)

### DIFF
--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -23,8 +23,9 @@
 }
 
 .assessment-banner__title {
+  @extend %pix-body-m;
+
   margin: 0;
-  font-size: 1rem;
 
   @include device-is('mobile') {
     position: absolute;
@@ -59,14 +60,12 @@
 }
 
 .assessment-banner__home-link {
+  @extend %pix-body-m;
+
   z-index: 1;
   height: 1.5rem;
   margin-left: auto;
   color: $pix-neutral-0;
-  font-weight: $font-medium;
-  font-size: 1rem;
-  font-family: $font-roboto;
-  letter-spacing: 0.016rem;
   text-align: right;
 
   &:hover {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -240,8 +240,7 @@
 }
 
 .challenge-statement__alternative-instruction {
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin: 20px;
 
   button {
     padding: 0;

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -9,11 +9,12 @@
 }
 
 .progress-bar-stepnums {
+  @extend %pix-body-m;
+
   display: flex;
   justify-content: space-between;
   margin-bottom: 7px;
   padding: 0 4px;
-  font-size: 1rem;
 }
 
 .progress-bar-stepnum {


### PR DESCRIPTION
## :unicorn: Problème
Le header des épreuves n'était pas cohérent avec les design tokens typographie.

## :robot: Proposition
Utiliser les design tokens présent dans le Design System.

## :rainbow: Remarques
J'en ai profité pour ajouter du margin autour de l'alternative textuelle en dessous des embeds.

## :100: Pour tester
Aller sur une épreuve.
Vérifier que le texte dans l'entête des épreuves correspond bien au maquette.

Aller sur une épreuve avec alternative textuelle. 
Vérifier l'espacement.
