### PR TITLE
[BUGFIX] Améliorer la lecture d'écran des boutons d'action d'une épreuve (PIX-7920)

### DIFF
--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -28,10 +28,10 @@
       @backgroundColor="blue"
       @shape="rounded"
       class="challenge-actions__action-continue"
+      aria-label={{t "pages.challenge.actions.continue-go-to-next"}}
     >
-      <span class="challenge-actions__action-continue-text">{{t "pages.challenge.actions.continue"}}<span
-          class="sr-only"
-        > {{t "pages.challenge.actions.go-to-next"}}</span>
+      <span class="challenge-actions__action-continue-text">
+        {{t "pages.challenge.actions.continue"}}
       </span>
     </PixButton>
 
@@ -66,10 +66,10 @@
         @shape="rounded"
         @iconAfter="arrow-right"
         class="challenge-actions__action-validate"
+        aria-label={{t "pages.challenge.actions.validate-go-to-next"}}
       >
         <span class="challenge-actions__action-validate-text">
-          {{t "pages.challenge.actions.validate"}}<span class="sr-only">
-            {{t "pages.challenge.actions.go-to-next"}}</span>
+          {{t "pages.challenge.actions.validate"}}
         </span>
       </PixButton>
 
@@ -80,9 +80,10 @@
         @backgroundColor="transparent-light"
         @shape="rounded"
         class="challenge-actions__action-skip"
+        aria-label={{t "pages.challenge.actions.skip-go-to-next"}}
       >
         <span class="challenge-actions__action-skip-text">
-          {{t "pages.challenge.actions.skip"}}<span class="sr-only"> {{t "pages.challenge.actions.go-to-next"}}</span>
+          {{t "pages.challenge.actions.skip"}}
         </span>
       </PixButton>
     </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -403,9 +403,11 @@
       },
       "actions": {
         "continue": "Continue",
-        "go-to-next": " and go to the next question",
+        "continue-go-to-next": "Continue and go to the next question",
         "skip": "Skip",
-        "validate": "Validate"
+        "skip-go-to-next": "Skip and go to the next question",
+        "validate": "Validate",
+        "validate-go-to-next": "Validate and go to the next question"
       },
       "already-answered": "You have already answered this question",
       "answer-input": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -403,9 +403,11 @@
       },
       "actions": {
         "continue": "Poursuivre",
-        "go-to-next": " et je vais à la prochaine question",
+        "continue-go-to-next": "Je continue et je vais à la prochaine question",
         "skip": "Je passe",
-        "validate": "Je valide"
+        "skip-go-to-next": "Je passe et je vais à la prochaine question",
+        "validate": "Je valide",
+        "validate-go-to-next": "Je valide et je vais à la prochaine question"
       },
       "already-answered": "Vous avez déjà répondu à cette question",
       "answer-input": {


### PR DESCRIPTION
## :unicorn: Problème

Pour les boutons d'action de la page épreuve, certains lecteurs d'écran ne prenaient pas en compte un espace et pouvait, par exemple, lire à tort `“Je valideet je vais à la prochaine question“`.

## :robot: Proposition

Ne plus utiliser de span avec `sr-only`, et utiliser directement l'attribut `aria-label` à la place.

## :100: Pour tester

- Visiter une page d'épreuve et vérifier l'attribut aria-label des boutons.
