### PR TITLE
[FEATURE][ORGA] Ajout du language switcher sur la double mire de connexion/inscription avec invitation (PIX-7743)

### DIFF
--- a/orga/app/components/auth/login-or-register.hbs
+++ b/orga/app/components/auth/login-or-register.hbs
@@ -64,4 +64,9 @@
       </div>
     </div>
   </div>
+  {{#if this.isInternationalDomain}}
+    <div>
+      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+    </div>
+  {{/if}}
 </div>

--- a/orga/app/components/auth/login-or-register.hbs
+++ b/orga/app/components/auth/login-or-register.hbs
@@ -65,7 +65,7 @@
     </div>
   </div>
   {{#if this.isInternationalDomain}}
-    <div>
+    <div class="login-or-register__language-switcher">
       <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
     </div>
   {{/if}}

--- a/orga/app/components/auth/login-or-register.js
+++ b/orga/app/components/auth/login-or-register.js
@@ -1,12 +1,33 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class LoginOrRegister extends Component {
+  @service currentDomain;
+  @service locale;
+  @service intl;
+  @service router;
   @tracked displayRegisterForm = true;
+  @tracked selectedLanguage = this.intl.primaryLocale;
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
 
   @action
   toggleFormsVisibility() {
     this.displayRegisterForm = !this.displayRegisterForm;
+  }
+
+  @action
+  onLanguageChange(value) {
+    this.selectedLanguage = value;
+    this.locale.setLocale(this.selectedLanguage);
+    this.router.replaceWith('join', {
+      queryParams: {
+        lang: null,
+      },
+    });
   }
 }

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -54,6 +54,7 @@ export default class RegisterForm extends Component {
   @tracked cguValidationMessage = null;
   @tracked errorMessage = null;
   @tracked validation = new SignupFormValidation();
+  @tracked selectedLanguage = this.intl.primaryLocale;
 
   get cguUrl() {
     return this.url.cguUrl;
@@ -71,6 +72,7 @@ export default class RegisterForm extends Component {
       return;
     }
     this.isLoading = true;
+
     try {
       await this.store
         .createRecord('user', {
@@ -79,6 +81,7 @@ export default class RegisterForm extends Component {
           email: this.email,
           password: this.password,
           cgu: true,
+          lang: this.selectedLanguage,
         })
         .save();
 
@@ -87,6 +90,7 @@ export default class RegisterForm extends Component {
         this.args.organizationInvitationCode,
         this.email
       );
+
       await this._authenticate(this.email, this.password);
 
       this.password = null;

--- a/orga/app/controllers/login.js
+++ b/orga/app/controllers/login.js
@@ -3,13 +3,12 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
-const DEFAULT_LOCALE = 'fr';
-
 export default class LoginController extends Controller {
   @service intl;
   @service dayjs;
   @service currentDomain;
   @service router;
+  @service locale;
 
   @tracked selectedLanguage = this.intl.primaryLocale;
 
@@ -20,12 +19,7 @@ export default class LoginController extends Controller {
   @action
   onLanguageChange(value) {
     this.selectedLanguage = value;
-    this._setLocale(this.selectedLanguage);
+    this.locale.setLocale(this.selectedLanguage);
     this.router.replaceWith('login', { queryParams: { lang: null } });
-  }
-
-  _setLocale(language) {
-    this.intl.setLocale([language, DEFAULT_LOCALE]);
-    this.dayjs.setLocale(language);
   }
 }

--- a/orga/app/models/user.js
+++ b/orga/app/models/user.js
@@ -5,6 +5,7 @@ export default class User extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('string') password;
+  @attr('string') lang;
   @attr('boolean') cgu;
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
   @hasMany('membership') memberships;

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -5,9 +5,9 @@ export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+const SUPPORTED_LANGUAGES = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
-const supportedLanguages = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
 
 export default class LocaleService extends Service {
   @service cookies;
@@ -17,7 +17,7 @@ export default class LocaleService extends Service {
 
   handleUnsupportedLanguage(language) {
     if (!language) return;
-    return supportedLanguages.includes(language) ? language : DEFAULT_LOCALE;
+    return SUPPORTED_LANGUAGES.includes(language) ? language : DEFAULT_LOCALE;
   }
 
   hasLocaleCookie() {

--- a/orga/app/styles/components/login-or-register.scss
+++ b/orga/app/styles/components/login-or-register.scss
@@ -1,10 +1,17 @@
 .login-or-register {
   margin: 20px 0;
 
+  &__language-switcher {
+    @include device-is('mobile') {
+      margin-left: 22px;
+    }
+  }
+
   &__panel {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    margin-bottom: 16px;
     border-radius: 10px;
     align-items: center;
     padding: 20px 2px;

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -189,6 +189,9 @@ export default function () {
     });
 
     prescriber.memberships = [membership];
+    if (code === 'ENGLISH_USER_INVITATION_CODE') {
+      prescriber.lang = 'en';
+    }
     prescriber.save();
 
     const organization = schema.organizations.find(organizationInvitation.organizationId);

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -29,93 +29,99 @@ module('Acceptance | join', function (hooks) {
   });
 
   module('When prescriber tries to go on join page', function () {
-    test('remains on join page when organization-invitation exists', async function (assert) {
-      // given
-      const code = 'ABCDEFGH01';
-      const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-      const organizationInvitationId = server.create('organizationInvitation', {
-        organizationId,
-        email: 'random@email.com',
-        status: 'pending',
-        code,
-      }).id;
+    module('when organization-invitation exists', function () {
+      test('remains on join page', async function (assert) {
+        // given
+        const code = 'ABCDEFGH01';
+        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+        const organizationInvitationId = server.create('organizationInvitation', {
+          organizationId,
+          email: 'random@email.com',
+          status: 'pending',
+          code,
+        }).id;
 
-      // when
-      await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+        // when
+        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
-      // then
-      assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        // then
+        assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+      });
     });
+    module('when organization-invitation exists but user tries to change language by url', function () {
+      test('redirects user to login page', async function (assert) {
+        // given
+        const code = 'ABCDEFGH01';
+        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+        const organizationInvitationId = server.create('organizationInvitation', {
+          organizationId,
+          email: 'random@email.com',
+          status: 'pending',
+          code,
+        }).id;
 
-    test('redirects user to login page when organization-invitation exists but user tries to change language by url', async function (assert) {
-      // given
-      const code = 'ABCDEFGH01';
-      const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-      const organizationInvitationId = server.create('organizationInvitation', {
-        organizationId,
-        email: 'random@email.com',
-        status: 'pending',
-        code,
-      }).id;
+        // when
+        await visit(`rejoindre?invitationId=${organizationInvitationId}&code=${code}?lang=en`);
 
-      // when
-      await visit(`rejoindre?invitationId=${organizationInvitationId}&code=${code}?lang=en`);
-
-      // then
-      assert.strictEqual(currentURL(), '/connexion');
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+      });
     });
+    module('when organization-invitation does not exist', function () {
+      test('redirects user to login page', async function (assert) {
+        // when
+        await visit('rejoindre?invitationId=123456&code=FAKE999');
 
-    test('redirects user to login page when organization-invitation does not exist', async function (assert) {
-      // when
-      await visit('rejoindre?invitationId=123456&code=FAKE999');
-
-      // then
-      assert.strictEqual(currentURL(), '/connexion');
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+      });
     });
+    module('when organization-invitation has already been accepted', function () {
+      test('redirects user to login page', async function (assert) {
+        // given
+        const code = 'ABCDEFGH01';
+        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+        const organizationInvitationId = server.create('organizationInvitation', {
+          organizationId,
+          email: 'random@email.com',
+          status: 'accepted',
+          code,
+        }).id;
+        const expectedErrorMessage = this.intl.t('pages.login-form.invitation-already-accepted');
 
-    test('redirects user to login page when organization-invitation has already been accepted', async function (assert) {
-      // given
-      const code = 'ABCDEFGH01';
-      const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-      const organizationInvitationId = server.create('organizationInvitation', {
-        organizationId,
-        email: 'random@email.com',
-        status: 'accepted',
-        code,
-      }).id;
-      const expectedErrorMessage = this.intl.t('pages.login-form.invitation-already-accepted');
+        // when
+        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
-      // when
-      await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-
-      // then
-      assert.strictEqual(currentURL(), '/connexion');
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-      assert.dom('.login-form__invitation-error').exists();
-      assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        assert.dom('.login-form__invitation-error').exists();
+        assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);
+      });
     });
+    module('when organization-invitation has been cancelled', function () {
+      test('redirects user to login page ', async function (assert) {
+        // given
+        const code = 'ABCDEFGH01';
+        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+        const organizationInvitationId = server.create('organizationInvitation', {
+          organizationId,
+          email: 'random@email.com',
+          status: 'cancelled',
+          code,
+        }).id;
 
-    test('redirects user to login page when organization-invitation has been cancelled', async function (assert) {
-      // given
-      const code = 'ABCDEFGH01';
-      const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-      const organizationInvitationId = server.create('organizationInvitation', {
-        organizationId,
-        email: 'random@email.com',
-        status: 'cancelled',
-        code,
-      }).id;
+        // when
+        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
-      // when
-      await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-
-      // then
-      assert.strictEqual(currentURL(), '/connexion');
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-      assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
+      });
     });
   });
 

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -68,6 +68,40 @@ module('Acceptance | join', function (hooks) {
         assert.strictEqual(currentURL(), '/connexion');
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       });
+      module(
+        'When accessing the login page with "English" as selected language in url query params and select another language',
+        function () {
+          test('remains on join page whithout the query params', async function (assert) {
+            // given
+            const code = 'ABCDEFGH01';
+            const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+            const organizationInvitationId = server.create('organizationInvitation', {
+              organizationId,
+              email: 'random@email.com',
+              status: 'pending',
+              code,
+              organizationName: 'Le collège fou fou fou',
+            }).id;
+
+            // when
+            const screen = await visitScreen(
+              `/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`
+            );
+
+            assert
+              .dom(screen.getByText('You have been invited to join the organisation Le collège fou fou fou'))
+              .exists();
+
+            await click(screen.getByRole('button', { name: 'English' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'Français' }));
+
+            // then
+            assert.strictEqual(currentURL(), `/rejoindre?code=${code}&invitationId=${organizationInvitationId}`);
+            assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+          });
+        }
+      );
     });
     module('when organization-invitation does not exist', function () {
       test('redirects user to login page', async function (assert) {

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -48,6 +48,25 @@ module('Acceptance | join', function (hooks) {
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
 
+    test('it should redirect user to login page when organization-invitation exists but user tries to change language by url', async function (assert) {
+      // given
+      const code = 'ABCDEFGH01';
+      const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+      const organizationInvitationId = server.create('organizationInvitation', {
+        organizationId,
+        email: 'random@email.com',
+        status: 'pending',
+        code,
+      }).id;
+
+      // when
+      await visit(`rejoindre?invitationId=${organizationInvitationId}&code=${code}?lang=en`);
+
+      // then
+      assert.strictEqual(currentURL(), '/connexion');
+      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+    });
+
     test('it should redirect user to login page when organization-invitation does not exist', async function (assert) {
       // when
       await visit('rejoindre?invitationId=123456&code=FAKE999');
@@ -183,7 +202,7 @@ module('Acceptance | join', function (hooks) {
         }).id;
       });
 
-      test('it should redirect user to the campaigns list', async function (assert) {
+      test('it redirects user to the campaigns list that contains prescriber name', async function (assert) {
         // given
         server.create('campaign');
 
@@ -199,23 +218,6 @@ module('Acceptance | join', function (hooks) {
 
         assert.strictEqual(currentURL(), '/campagnes/les-miennes');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-      });
-
-      test('it should show prescriber name', async function (assert) {
-        // given
-        server.create('campaign');
-
-        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByName(loginFormButton);
-        await fillByLabel(emailInputLabel, user.email);
-        await fillByLabel(passwordInputLabel, 'secret');
-
-        // when
-        await clickByName(loginButton);
-
-        // then
-        assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-
         assert.contains('Harry Cover');
       });
     });

--- a/orga/tests/integration/components/auth/login-or-register_test.js
+++ b/orga/tests/integration/components/auth/login-or-register_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
+import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
@@ -12,16 +13,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   hooks.beforeEach(function () {
     loginButton = this.intl.t('pages.login-or-register.login-form.button');
   });
-
-  test('it renders', async function (assert) {
-    // when
-    await render(hbs`<Auth::LoginOrRegister />`);
-
-    // then
-    assert.dom('.login-or-register').exists();
-  });
-
-  test('it display the organization name the user is invited to', async function (assert) {
+  test('it displays the organization name the user is invited to', async function (assert) {
     // when
     const invitationMessage = this.intl.t('pages.login-or-register.title', { organizationName: 'Organization Aztec' });
 
@@ -31,7 +23,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     assert.dom('.login-or-register-panel__invitation').hasText(`${invitationMessage}`);
   });
 
-  test('it toggle the register form by default', async function (assert) {
+  test('it toggles the register form by default', async function (assert) {
     // when
     await render(hbs`<Auth::LoginOrRegister />`);
 
@@ -39,7 +31,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     assert.dom('.register-form').exists();
   });
 
-  test('it toggle the login form on click on login button', async function (assert) {
+  test('it toggles the login form on click on login button', async function (assert) {
     // given
     await render(hbs`<Auth::LoginOrRegister />`);
 
@@ -50,7 +42,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     assert.dom('.login-form').exists();
   });
 
-  test('it toggle the register form on click on register button', async function (assert) {
+  test('it toggles the register form on click on register button', async function (assert) {
     // given
     const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.button');
 
@@ -62,5 +54,51 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
     // then
     assert.dom('.register-form').exists();
+  });
+
+  module('when domain is not .fr', function () {
+    test('displays the language switcher and translate to language selected', async function (assert) {
+      // given
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return false;
+        }
+      }
+      class routerServiceStub extends Service {
+        replaceWith() {
+          return false;
+        }
+      }
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+      this.owner.register('service:router', routerServiceStub);
+
+      // when
+      const screen = await renderScreen(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);
+
+      // then
+      await click(screen.getByRole('button', { name: 'Français' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'English' }));
+      assert.dom(screen.getByText('You have been invited to join the organisation Organization Aztec')).exists();
+    });
+  });
+
+  module('when domain is .fr', function () {
+    test('does not display the language switcher', async function (assert) {
+      // given
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return true;
+        }
+      }
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+      // when
+      const screen = await renderScreen(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);
+
+      // then
+      assert.dom(screen.getByText("Vous êtes invité(e) à rejoindre l'organisation Organization Aztec")).exists();
+      assert.dom(screen.queryByRole('button', { name: 'Français' })).doesNotExist();
+    });
   });
 });

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -90,9 +90,6 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
           save() {
             return resolve();
           },
-          unloadRecord() {
-            return resolve();
-          },
         });
       };
       SessionStub.prototype.authenticate = function (authenticator, email, password, scope) {
@@ -135,9 +132,6 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
       this.owner.register('service:store', StoreStub);
       StoreStub.prototype.createRecord = sinon.stub().returns({
         save: spy,
-        unloadRecord: () => {
-          return resolve();
-        },
       });
 
       screen = await renderScreen(

--- a/orga/tests/unit/components/auth/login-or-register_test.js
+++ b/orga/tests/unit/components/auth/login-or-register_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+import { ENGLISH_INTERNATIONAL_LOCALE } from 'pix-orga/services/locale';
+
+module('Unit | Component |  login-or-register', (hooks) => {
+  setupTest(hooks);
+
+  module('onLanguageChange', () => {
+    test('saves selected locale and remove lang from query params', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:auth/login-or-register');
+      const localeService = this.owner.lookup('service:locale');
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(localeService, 'setLocale');
+      sinon.stub(routerService, 'replaceWith');
+
+      component.args.organizationInvitationCode = 'ABCDE';
+      component.args.organizationInvitationId = '12345';
+
+      // when
+      component.onLanguageChange(ENGLISH_INTERNATIONAL_LOCALE);
+
+      // then
+      sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
+      sinon.assert.calledWith(routerService.replaceWith, 'join', {
+        queryParams: {
+          lang: null,
+        },
+      });
+
+      assert.ok(component.selectedLanguage, ENGLISH_INTERNATIONAL_LOCALE);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, il n'est pas possible de changer la langue depuis la double mire de connexion de Pix Orga. Il faut permettre aux utilisateurs non-francophones de naviguer facilement en anglais, car pour l'instant ils doivent :
- soit changer l’URL afin d'y inclure des query params `?lang=en` ou `&lang=en`
- soit changer leur langue dans Pix App


## :robot: Proposition
Ajouter un sélecteur de langue sur la double mire  de connexion / création de compte de Pix Orga (domaine international), afin de permettre à l'utilisateur :
- de changer la langue de navigation plus facilement 
- de créer son compte avec la langue d'affichage sélectionnée

## :rainbow: Remarques
- Le code de la double mire doit faire l'objet d'un refacto pour améliorer le process ticket PIX-6227 et n'a pas été amélioré ici
- Un commit manquant de refacto https://1024pix.slack.com/archives/CKS2SRZN2/p1683274105424789 a été ajouté (utilisation du service locale et de sa méthode setLocale)


## :100: Pour tester

En local, aller sur pix orga avec sco.admin@example.net par exemple et dans l'onglet équipe créer une nouvelle invitation (récupérer code et id en bdd ou par mail dans la table **organization-invitations** si vous avez activé l'envoi d'email)

**Tips** : mettre le status de l'invitation en **pending** pour la rejouer quand elle a été acceptée.


### Cas de choix de langue avec ?lang=en
- taper cette url `http://localhost:4201/rejoindre?invitationId=100057&code=INVIABC123?lang=en`, 
- observer que vous êtes redirigé(e) vers `/connexion`

### Cas de choix de langue avec &lang=en
- taper cette url `http://localhost:4201/rejoindre?invitationId=100057&code=INVIABC123&lang=en`, 
- observer que la page est traduite en anglaise
- sélectionner la langue française
- observer que la page est traduite en français
- constater que l'url ne contient plus le &lang=en

### Domaine français 
- aller sur la double mire, ex http://localhost.fr:4201/rejoindre?invitationId=100059&code=INVIABC123
- vérifier que le sélecteur de langues n'apparait pas

### Domaine international .org 

- aller sur la double mire, url du type `http://localhost:4201/rejoindre?invitationId=100059&code=INVIABC123`
- changer la langue avec le language switcher, choisir anglais, observer que c'est traduit

On peut accepter l'invitation avec un compte existant ou se créer un nouveau compte.

#### **se CREER un compte** 
- choisir anglais et remplir le formulaire d'inscription
- créer le compte
- observer que les cgu sont en anglais
- accepter les cgus
- observer que vous vous connectez et que la langue est celle que vous avec choisi précédemment, **l'anglais** qu'elle a été enregistrée en base de données comme langue de l'utilisateur

> NB : vous pouvez, sur la page des cgu, ajouter la langue http://localhost:4201/cgu?lang=fr, cela va modifier la langue de l'utilisateur.

##### Erreurs lors de la création de compte
Les erreurs s'affichent en anglais, tester en mettant un e-mail existant déjà en base

#### **se CONNECTER avec un compte existant** 
- sélectionner l'anglais comme langue
- se connecter avec un compte qui a comme langue le français
- observer que vous vous connectez et que **la langue est toujours celle de l'utilisateur**

##### Erreurs lors de l'inscription
- Changer la langue avec le language switcher, choisir anglais,
- Utiliser le compte temporary-blocked@example.net
- Entrer un mauvais mot de passe 2 fois et vérifier que **le message d'erreur s'affiche en anglais**

Essayer avec un email et un mauvais mot de passe et observer que l'erreur est bien traduite

##### compte avec cgu non validées pixOrgaTermsOfServiceAccepted
Il se peut qu'un utilisateur, doivent à la connexion revalider les cgus, l'écran va alors s'afficher mais dans la langue de l'utilisateur car à ce stage, l'utilisateur sera connecté.
- accéder à la double mire
- changer la langue avec le language switcher, choisir **anglais**
- se connecter avec un compte qui a  pixOrgaTermsOfServiceAccepted à false et la langue à fr
-  arriver sur la page des cgus et voir que la page est bien en **français**

> NB : vous pouvez, sur la page des cgu, ajouter la langue http://localhost:4201/cgu?lang=fr, cela va modifier la langue de l'utilisateur en base de données


