### PR TITLE
[FEATURE] Heure de fin de session théorique pour le surveillant (PIX-7834)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -10,6 +10,7 @@ function buildComplementaryCertification({
   minimumEarnedPix,
   hasComplementaryReferential = false,
   hasExternalJury = false,
+  sessionExtraTime = 45,
 } = {}) {
   const values = {
     id,
@@ -20,6 +21,7 @@ function buildComplementaryCertification({
     minimumEarnedPix,
     hasComplementaryReferential,
     hasExternalJury,
+    sessionExtraTime,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'complementary-certifications',
@@ -33,6 +35,7 @@ buildComplementaryCertification.clea = function ({
   minimumEarnedPix = 70,
   hasComplementaryReferential = false,
   hasExternalJury = false,
+  sessionExtraTime = 0,
 }) {
   return buildComplementaryCertification({
     id,
@@ -43,6 +46,7 @@ buildComplementaryCertification.clea = function ({
     minimumEarnedPix,
     hasComplementaryReferential,
     hasExternalJury,
+    sessionExtraTime,
   });
 };
 

--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -10,7 +10,7 @@ function buildComplementaryCertification({
   minimumEarnedPix,
   hasComplementaryReferential = false,
   hasExternalJury = false,
-  sessionExtraTime = 45,
+  sessionExtraTime = 12,
 } = {}) {
   const values = {
     id,

--- a/api/db/migrations/20230509103000_add-complementary-certifications-extratime.js
+++ b/api/db/migrations/20230509103000_add-complementary-certifications-extratime.js
@@ -1,0 +1,21 @@
+const TABLE_COMPLEMENTARY_CERTIFICATIONS = 'complementary-certifications';
+const COLUMN_KEY = 'key';
+const COLUMN_SESSION_EXTRATIME = 'sessionExtraTime';
+const VALUE_PIXPLUS_KEYS = ['DROIT', 'EDU_1ER_DEGRE', 'EDU_2ND_DEGRE'];
+const VALUE_PIXPLUS_EXTRATIME_MINUTES = 45;
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_COMPLEMENTARY_CERTIFICATIONS, function (table) {
+    table.integer(COLUMN_SESSION_EXTRATIME).defaultTo(0).notNullable();
+  });
+
+  await knex(TABLE_COMPLEMENTARY_CERTIFICATIONS)
+    .whereIn(COLUMN_KEY, VALUE_PIXPLUS_KEYS)
+    .update({ [COLUMN_SESSION_EXTRATIME]: VALUE_PIXPLUS_EXTRATIME_MINUTES });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_COMPLEMENTARY_CERTIFICATIONS, function (table) {
+    table.dropColumn(COLUMN_SESSION_EXTRATIME);
+  });
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -88,6 +88,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
     minimumReproducibilityRate: 75,
     minimumEarnedPix: null,
+    sessionExtraTime: 45,
   });
 
   databaseBuilder.factory.buildComplementaryCertification({
@@ -97,6 +98,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     minimumReproducibilityRate: 70,
     minimumEarnedPix: null,
     hasExternalJury: true,
+    sessionExtraTime: 45,
   });
 
   databaseBuilder.factory.buildComplementaryCertification({
@@ -106,6 +108,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     minimumReproducibilityRate: 70,
     minimumEarnedPix: null,
     hasExternalJury: true,
+    sessionExtraTime: 45,
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -48,6 +48,7 @@ const PIX_CERTIF = {
   SCOPE: 'pix-certif',
   NOT_LINKED_CERTIFICATION_MSG:
     "L'accès à Pix Certif est limité aux centres de certification Pix. Contactez le référent de votre centre de certification si vous pensez avoir besoin d'y accéder.",
+  DEFAULT_SESSION_DURATION_MINUTES: 105,
 };
 
 const LOCALE = {

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -13,7 +13,7 @@ class CertificationCandidateForSupervising {
     startDateTime,
     theoricalEndDateTime,
     enrolledComplementaryCertification,
-    enrolledComplementaryCertificationKey,
+    enrolledComplementaryCertificationSessionExtraTime,
     stillValidBadgeAcquisitions = [],
   } = {}) {
     this.id = id;
@@ -27,7 +27,7 @@ class CertificationCandidateForSupervising {
     this.startDateTime = startDateTime;
     this.theoricalEndDateTime = theoricalEndDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
-    this.enrolledComplementaryCertificationKey = enrolledComplementaryCertificationKey;
+    this.enrolledComplementaryCertificationSessionExtraTime = enrolledComplementaryCertificationSessionExtraTime;
     this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
   }
 

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -30,6 +30,13 @@ class CertificationCandidateForSupervising {
   authorizeToStart() {
     this.authorizedToStart = true;
   }
+
+  isStillEligibleToComplementaryCertification() {
+    return this.stillValidBadgeAcquisitions.some(
+      (stillValidBadgeAcquisition) =>
+        stillValidBadgeAcquisition.complementaryCertificationBadgeLabel === this.enrolledComplementaryCertification
+    );
+  }
 }
 
 module.exports = CertificationCandidateForSupervising;

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -11,7 +11,9 @@ class CertificationCandidateForSupervising {
     authorizedToStart,
     assessmentStatus,
     startDateTime,
+    theoricalEndDateTime,
     enrolledComplementaryCertification,
+    enrolledComplementaryCertificationKey,
     stillValidBadgeAcquisitions = [],
   } = {}) {
     this.id = id;
@@ -23,7 +25,9 @@ class CertificationCandidateForSupervising {
     this.authorizedToStart = authorizedToStart;
     this.assessmentStatus = assessmentStatus;
     this.startDateTime = startDateTime;
+    this.theoricalEndDateTime = theoricalEndDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
+    this.enrolledComplementaryCertificationKey = enrolledComplementaryCertificationKey;
     this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
   }
 

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -12,6 +12,7 @@ class CertificationCandidateForSupervising {
     assessmentStatus,
     startDateTime,
     enrolledComplementaryCertification,
+    stillValidBadgeAcquisitions = [],
   } = {}) {
     this.id = id;
     this.userId = userId;
@@ -23,6 +24,7 @@ class CertificationCandidateForSupervising {
     this.assessmentStatus = assessmentStatus;
     this.startDateTime = startDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
+    this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
   }
 
   authorizeToStart() {

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -3,6 +3,7 @@ const isNil = require('lodash/isNil');
 class CertificationCandidateForSupervising {
   constructor({
     id,
+    userId,
     firstName,
     lastName,
     birthdate,
@@ -13,6 +14,7 @@ class CertificationCandidateForSupervising {
     enrolledComplementaryCertification,
   } = {}) {
     this.id = id;
+    this.userId = userId;
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthdate = birthdate;

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -10,7 +10,7 @@ class CertificationCandidateForSupervising {
     authorizedToStart,
     assessmentStatus,
     startDateTime,
-    complementaryCertification,
+    enrolledComplementaryCertification,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -20,7 +20,7 @@ class CertificationCandidateForSupervising {
     this.authorizedToStart = authorizedToStart;
     this.assessmentStatus = assessmentStatus;
     this.startDateTime = startDateTime;
-    this.complementaryCertification = complementaryCertification;
+    this.enrolledComplementaryCertification = enrolledComplementaryCertification;
   }
 
   authorizeToStart() {

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -13,7 +13,6 @@ class CertificationCandidateForSupervising {
     startDateTime,
     theoricalEndDateTime,
     enrolledComplementaryCertification,
-    enrolledComplementaryCertificationSessionExtraTime,
     stillValidBadgeAcquisitions = [],
   } = {}) {
     this.id = id;
@@ -27,7 +26,6 @@ class CertificationCandidateForSupervising {
     this.startDateTime = startDateTime;
     this.theoricalEndDateTime = theoricalEndDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
-    this.enrolledComplementaryCertificationSessionExtraTime = enrolledComplementaryCertificationSessionExtraTime;
     this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
   }
 
@@ -38,7 +36,7 @@ class CertificationCandidateForSupervising {
   isStillEligibleToComplementaryCertification() {
     return this.stillValidBadgeAcquisitions.some(
       (stillValidBadgeAcquisition) =>
-        stillValidBadgeAcquisition.complementaryCertificationBadgeLabel === this.enrolledComplementaryCertification
+        stillValidBadgeAcquisition.complementaryCertificationKey === this.enrolledComplementaryCertification.key
     );
   }
 }

--- a/api/lib/domain/models/ComplementaryCertificationForSupervising.js
+++ b/api/lib/domain/models/ComplementaryCertificationForSupervising.js
@@ -1,0 +1,9 @@
+class ComplementaryCertificationForSupervising {
+  constructor({ label, key, sessionExtraTime }) {
+    this.label = label;
+    this.key = key;
+    this.sessionExtraTime = sessionExtraTime;
+  }
+}
+
+module.exports = ComplementaryCertificationForSupervising;

--- a/api/lib/domain/usecases/get-session-for-supervising.js
+++ b/api/lib/domain/usecases/get-session-for-supervising.js
@@ -36,7 +36,7 @@ function _computeTheoricalEndDateTime(candidate) {
   startDateTime.add(constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES, 'minutes');
 
   if (candidate.isStillEligibleToComplementaryCertification()) {
-    const extraMinutes = candidate.enrolledComplementaryCertificationSessionExtraTime ?? 0;
+    const extraMinutes = candidate.enrolledComplementaryCertification.sessionExtraTime ?? 0;
     startDateTime.add(extraMinutes, 'minutes');
   }
 

--- a/api/lib/domain/usecases/get-session-for-supervising.js
+++ b/api/lib/domain/usecases/get-session-for-supervising.js
@@ -1,4 +1,6 @@
-const bluebird = require('bluebird');
+const moment = require('moment');
+const { constants } = require('../constants');
+
 module.exports = async function getSessionForSupervising({
   sessionId,
   sessionForSupervisingRepository,
@@ -6,14 +8,31 @@ module.exports = async function getSessionForSupervising({
 }) {
   const sessionForSupervising = await sessionForSupervisingRepository.get(sessionId);
 
-  await bluebird.mapSeries(sessionForSupervising.certificationCandidates, async (certificationCandidate) => {
-    if (certificationCandidate.enrolledComplementaryCertification) {
-      certificationCandidate.stillValidBadgeAcquisitions =
-        await certificationBadgesService.findStillValidBadgeAcquisitions({
-          userId: certificationCandidate.userId,
-        });
-    }
-  });
+  await Promise.all(
+    sessionForSupervising.certificationCandidates
+      .filter((candidate) => candidate.enrolledComplementaryCertification)
+      .map(_computeComplementaryCertificationEligibility(certificationBadgesService))
+  );
+
+  sessionForSupervising.certificationCandidates.map(_computeTheoricalEndDateTime);
 
   return sessionForSupervising;
 };
+
+function _computeComplementaryCertificationEligibility(certificationBadgesService) {
+  return async (candidate) => {
+    candidate.stillValidBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
+      userId: candidate.userId,
+    });
+  };
+}
+
+function _computeTheoricalEndDateTime(candidate) {
+  const startDateTime = moment(candidate.startDateTime || null);
+  if (!startDateTime.isValid()) {
+    return;
+  }
+  candidate.theoricalEndDateTime = startDateTime
+    .add(constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES, 'minutes')
+    .toDate();
+}

--- a/api/lib/domain/usecases/get-session-for-supervising.js
+++ b/api/lib/domain/usecases/get-session-for-supervising.js
@@ -1,3 +1,19 @@
-module.exports = async function getSessionForSupervising({ sessionId, sessionForSupervisingRepository }) {
-  return await sessionForSupervisingRepository.get(sessionId);
+const bluebird = require('bluebird');
+module.exports = async function getSessionForSupervising({
+  sessionId,
+  sessionForSupervisingRepository,
+  certificationBadgesService,
+}) {
+  const sessionForSupervising = await sessionForSupervisingRepository.get(sessionId);
+
+  await bluebird.mapSeries(sessionForSupervising.certificationCandidates, async (certificationCandidate) => {
+    if (certificationCandidate.enrolledComplementaryCertification) {
+      certificationCandidate.stillValidBadgeAcquisitions =
+        await certificationBadgesService.findStillValidBadgeAcquisitions({
+          userId: certificationCandidate.userId,
+        });
+    }
+  });
+
+  return sessionForSupervising;
 };

--- a/api/lib/domain/usecases/get-session-for-supervising.js
+++ b/api/lib/domain/usecases/get-session-for-supervising.js
@@ -14,7 +14,7 @@ module.exports = async function getSessionForSupervising({
       .map(_computeComplementaryCertificationEligibility(certificationBadgesService))
   );
 
-  sessionForSupervising.certificationCandidates.map(_computeTheoricalEndDateTime);
+  sessionForSupervising.certificationCandidates.forEach(_computeTheoricalEndDateTime);
 
   return sessionForSupervising;
 };
@@ -32,7 +32,13 @@ function _computeTheoricalEndDateTime(candidate) {
   if (!startDateTime.isValid()) {
     return;
   }
-  candidate.theoricalEndDateTime = startDateTime
-    .add(constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES, 'minutes')
-    .toDate();
+
+  startDateTime.add(constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES, 'minutes');
+
+  if (candidate.isStillEligibleToComplementaryCertification()) {
+    const extraMinutes = candidate.enrolledComplementaryCertificationSessionExtraTime ?? 0;
+    startDateTime.add(extraMinutes, 'minutes');
+  }
+
+  candidate.theoricalEndDateTime = startDateTime.toDate();
 }

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -24,7 +24,7 @@ module.exports = {
             'authorizedToStart', "certification-candidates"."authorizedToStart",
             'assessmentStatus', "assessments"."state",
             'startDateTime', "certification-courses"."createdAt",
-            'complementaryCertification', "complementary-certifications"."label"
+            'enrolledComplementaryCertification', "complementary-certifications"."label"
           ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
       `),
       })

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -25,7 +25,8 @@ module.exports = {
             'authorizedToStart', "certification-candidates"."authorizedToStart",
             'assessmentStatus', "assessments"."state",
             'startDateTime', "certification-courses"."createdAt",
-            'enrolledComplementaryCertification', "complementary-certifications"."label"
+            'enrolledComplementaryCertification', "complementary-certifications"."label",
+            'enrolledComplementaryCertificationKey', "complementary-certifications"."key"
           ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
       `),
       })

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -16,6 +16,7 @@ module.exports = {
         certificationCenterName: 'certification-centers.name',
         certificationCandidates: knex.raw(`
           json_agg(json_build_object(
+            'userId', "certification-candidates"."userId",
             'firstName', "certification-candidates"."firstName",
             'lastName', "certification-candidates"."lastName",
             'birthdate', "certification-candidates"."birthdate",

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -1,6 +1,7 @@
 const { knex } = require('../../../../db/knex-database-connection.js');
 const { NotFoundError } = require('../../../domain/errors.js');
 const CertificationCandidateForSupervising = require('../../../domain/models/CertificationCandidateForSupervising.js');
+const ComplementaryCertificationForSupervising = require('../../../domain/models/ComplementaryCertificationForSupervising.js');
 const SessionForSupervising = require('../../../domain/read-models/SessionForSupervising.js');
 
 module.exports = {
@@ -25,8 +26,11 @@ module.exports = {
             'authorizedToStart', "certification-candidates"."authorizedToStart",
             'assessmentStatus', "assessments"."state",
             'startDateTime', "certification-courses"."createdAt",
-            'enrolledComplementaryCertification', "complementary-certifications"."label",
-            'enrolledComplementaryCertificationSessionExtraTime', "complementary-certifications"."sessionExtraTime"
+            'complementaryCertification', json_build_object(
+              'key', "complementary-certifications"."key",
+              'label', "complementary-certifications"."label",
+              'sessionExtraTime', "complementary-certifications"."sessionExtraTime"
+            )
           ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
       `),
       })
@@ -58,10 +62,23 @@ module.exports = {
   },
 };
 
+function _toDomainComplementaryCertification(complementaryCertification) {
+  if (complementaryCertification?.key) {
+    return new ComplementaryCertificationForSupervising(complementaryCertification);
+  }
+  return null;
+}
+
 function _toDomain(results) {
   const certificationCandidates = results.certificationCandidates
     .filter((candidate) => candidate?.id !== null)
-    .map((candidate) => new CertificationCandidateForSupervising({ ...candidate }));
+    .map(
+      (candidate) =>
+        new CertificationCandidateForSupervising({
+          ...candidate,
+          enrolledComplementaryCertification: _toDomainComplementaryCertification(candidate.complementaryCertification),
+        })
+    );
 
   return new SessionForSupervising({
     ...results,

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -26,7 +26,7 @@ module.exports = {
             'assessmentStatus', "assessments"."state",
             'startDateTime', "certification-courses"."createdAt",
             'enrolledComplementaryCertification', "complementary-certifications"."label",
-            'enrolledComplementaryCertificationKey', "complementary-certifications"."key"
+            'enrolledComplementaryCertificationSessionExtraTime', "complementary-certifications"."sessionExtraTime"
           ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
       `),
       })

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -15,6 +15,13 @@ const attributes = [
 module.exports = {
   serialize(sessions) {
     return new Serializer('sessionForSupervising', {
+      transform(currentSessionForSupervising) {
+        currentSessionForSupervising.certificationCandidates.forEach((certificationCandidate) => {
+          certificationCandidate.isStillEligibleToComplementaryCertification =
+            certificationCandidate.isStillEligibleToComplementaryCertification();
+        });
+        return currentSessionForSupervising;
+      },
       attributes: [
         'room',
         'examiner',
@@ -29,7 +36,7 @@ module.exports = {
       certificationCandidates: {
         included: true,
         ref: 'id',
-        attributes: [...attributes],
+        attributes: [...attributes, 'isStillEligibleToComplementaryCertification'],
       },
     }).serialize(sessions);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -36,7 +36,7 @@ module.exports = {
       certificationCandidates: {
         included: true,
         ref: 'id',
-        attributes: [...attributes, 'isStillEligibleToComplementaryCertification'],
+        attributes: [...attributes, 'isStillEligibleToComplementaryCertification', 'userId'],
       },
     }).serialize(sessions);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -9,6 +9,7 @@ const attributes = [
   'authorizedToStart',
   'assessmentStatus',
   'startDateTime',
+  'theoricalEndDateTime',
   'enrolledComplementaryCertification',
 ];
 

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -20,6 +20,9 @@ module.exports = {
         currentSessionForSupervising.certificationCandidates.forEach((certificationCandidate) => {
           certificationCandidate.isStillEligibleToComplementaryCertification =
             certificationCandidate.isStillEligibleToComplementaryCertification();
+
+          certificationCandidate.enrolledComplementaryCertification =
+            certificationCandidate.enrolledComplementaryCertification?.label ?? null;
         });
         return currentSessionForSupervising;
       },

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -9,7 +9,7 @@ const attributes = [
   'authorizedToStart',
   'assessmentStatus',
   'startDateTime',
-  'complementaryCertification',
+  'enrolledComplementaryCertification',
 ];
 
 module.exports = {

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -45,6 +45,7 @@ describe('Integration | Repository | certification candidate for supervising', f
             lastName: 'Joplin',
             assessmentStatus: 'started',
             startDateTime: new Date('2022-10-01T14:00:00Z'),
+            stillValidBadgeAcquisitions: undefined,
           })
         );
       });

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -36,7 +36,7 @@ describe('Integration | Repository | certification candidate for supervising', f
         expect(result).to.deep.equal(
           domainBuilder.buildCertificationCandidateForSupervising({
             sessionId: session.id,
-            userId: 1234,
+            userId: candidate.userId,
             authorizedToStart: false,
             birthdate: '2000-01-04',
             extraTimePercentage: '0.30',

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -192,7 +192,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
+        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification', 'enrolledComplementaryCertificationKey'])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
@@ -201,12 +201,14 @@ describe('Integration | Repository | SessionForSupervising', function () {
           lastName: 'Jackson',
           firstName: 'Janet',
           enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
+          enrolledComplementaryCertificationKey: 'EDU_1ER_DEGRE',
         },
         {
           userId: 22222,
           lastName: 'Joplin',
           firstName: 'Janis',
           enrolledComplementaryCertification: null,
+          enrolledComplementaryCertificationKey: null,
         },
       ]);
     });

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -192,7 +192,14 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification', 'enrolledComplementaryCertificationKey'])
+        _.pick(item, [
+          'userId',
+          'sessionId',
+          'lastName',
+          'firstName',
+          'enrolledComplementaryCertification',
+          'enrolledComplementaryCertificationSessionExtraTime',
+        ])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
@@ -201,14 +208,14 @@ describe('Integration | Repository | SessionForSupervising', function () {
           lastName: 'Jackson',
           firstName: 'Janet',
           enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
-          enrolledComplementaryCertificationKey: 'EDU_1ER_DEGRE',
+          enrolledComplementaryCertificationSessionExtraTime: 45,
         },
         {
           userId: 22222,
           lastName: 'Joplin',
           firstName: 'Janis',
           enrolledComplementaryCertification: null,
-          enrolledComplementaryCertificationKey: null,
+          enrolledComplementaryCertificationSessionExtraTime: null,
         },
       ]);
     });

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -52,18 +52,24 @@ describe('Integration | Repository | SessionForSupervising', function () {
         certificationCenterId: 1234,
       });
 
+      databaseBuilder.factory.buildUser({ id: 11111 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
         lastName: 'Jackson',
         firstName: 'Michael',
         sessionId: session.id,
         authorizedToStart: true,
       });
+      databaseBuilder.factory.buildUser({ id: 22222 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
         lastName: 'Stardust',
         firstName: 'Ziggy',
         sessionId: session.id,
       });
+      databaseBuilder.factory.buildUser({ id: 33333 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 33333,
         lastName: 'Jackson',
         firstName: 'Janet',
         sessionId: session.id,
@@ -95,10 +101,19 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart', 'assessmentStatus', 'startDateTime'])
+        _.pick(item, [
+          'userId',
+          'sessionId',
+          'lastName',
+          'firstName',
+          'authorizedToStart',
+          'assessmentStatus',
+          'startDateTime',
+        ])
       );
       expect(actualCandidates).to.have.deep.ordered.members([
         {
+          userId: 33333,
           lastName: 'Jackson',
           firstName: 'Janet',
           authorizedToStart: false,
@@ -106,6 +121,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           startDateTime: null,
         },
         {
+          userId: 11111,
           lastName: 'Jackson',
           firstName: 'Michael',
           authorizedToStart: true,
@@ -113,6 +129,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           startDateTime: null,
         },
         {
+          userId: 12345,
           lastName: 'Joplin',
           firstName: 'Janis',
           authorizedToStart: true,
@@ -120,6 +137,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           startDateTime: '2022-10-19T13:37:00+00:00',
         },
         {
+          userId: 22222,
           lastName: 'Stardust',
           firstName: 'Ziggy',
           authorizedToStart: false,
@@ -141,13 +159,17 @@ describe('Integration | Repository | SessionForSupervising', function () {
         certificationCenterId: 1234,
       });
 
+      databaseBuilder.factory.buildUser({ id: 11111 });
       const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
         lastName: 'Jackson',
         firstName: 'Janet',
         sessionId: session.id,
       });
 
+      databaseBuilder.factory.buildUser({ id: 22222 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
         lastName: 'Joplin',
         firstName: 'Janis',
         sessionId: session.id,
@@ -170,16 +192,18 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
+        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
         {
+          userId: 11111,
           lastName: 'Jackson',
           firstName: 'Janet',
           enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
         },
         {
+          userId: 22222,
           lastName: 'Joplin',
           firstName: 'Janis',
           enrolledComplementaryCertification: null,

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -178,6 +178,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
         label: 'Pix+ Édu 1er degré',
         key: 'EDU_1ER_DEGRE',
+        sessionExtraTime: 45,
       });
 
       databaseBuilder.factory.buildComplementaryCertificationSubscription({
@@ -192,14 +193,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, [
-          'userId',
-          'sessionId',
-          'lastName',
-          'firstName',
-          'enrolledComplementaryCertification',
-          'enrolledComplementaryCertificationSessionExtraTime',
-        ])
+        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
@@ -207,15 +201,17 @@ describe('Integration | Repository | SessionForSupervising', function () {
           userId: 11111,
           lastName: 'Jackson',
           firstName: 'Janet',
-          enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
-          enrolledComplementaryCertificationSessionExtraTime: 45,
+          enrolledComplementaryCertification: {
+            key: complementaryCertification.key,
+            label: complementaryCertification.label,
+            sessionExtraTime: complementaryCertification.sessionExtraTime,
+          },
         },
         {
           userId: 22222,
           lastName: 'Joplin',
           firstName: 'Janis',
           enrolledComplementaryCertification: null,
-          enrolledComplementaryCertificationSessionExtraTime: null,
         },
       ]);
     });

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -170,19 +170,19 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'complementaryCertification'])
+        _.pick(item, ['sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
         {
           lastName: 'Jackson',
           firstName: 'Janet',
-          complementaryCertification: 'Pix+ Édu 1er degré',
+          enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
         },
         {
           lastName: 'Joplin',
           firstName: 'Janis',
-          complementaryCertification: null,
+          enrolledComplementaryCertification: null,
         },
       ]);
     });

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -9,7 +9,8 @@ module.exports = function buildCertificationCandidateForSupervising({
   authorizedToStart = false,
   assessmentStatus = null,
   startDateTime = new Date('2022-10-01T12:00:00Z'),
-  complementaryCertification,
+  enrolledComplementaryCertification,
+  stillValidBadgeAcquisitions,
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,
@@ -20,6 +21,7 @@ module.exports = function buildCertificationCandidateForSupervising({
     authorizedToStart,
     assessmentStatus,
     startDateTime,
-    complementaryCertification,
+    enrolledComplementaryCertification,
+    stillValidBadgeAcquisitions,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -2,6 +2,7 @@ const CertificationCandidateForSupervising = require('../../../../lib/domain/mod
 
 module.exports = function buildCertificationCandidateForSupervising({
   id = 123,
+  userId = 345,
   firstName = 'Monkey',
   lastName = 'D Luffy',
   birthdate = '1997-07-22',
@@ -14,6 +15,7 @@ module.exports = function buildCertificationCandidateForSupervising({
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,
+    userId,
     firstName,
     lastName,
     birthdate,

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -12,7 +12,7 @@ module.exports = function buildCertificationCandidateForSupervising({
   startDateTime = new Date('2022-10-01T12:00:00Z'),
   theoricalEndDateTime,
   enrolledComplementaryCertification,
-  enrolledComplementaryCertificationKey,
+  enrolledComplementaryCertificationSessionExtraTime,
   stillValidBadgeAcquisitions = [],
 } = {}) {
   return new CertificationCandidateForSupervising({
@@ -27,7 +27,7 @@ module.exports = function buildCertificationCandidateForSupervising({
     startDateTime,
     theoricalEndDateTime,
     enrolledComplementaryCertification,
-    enrolledComplementaryCertificationKey,
+    enrolledComplementaryCertificationSessionExtraTime,
     stillValidBadgeAcquisitions,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -11,7 +11,7 @@ module.exports = function buildCertificationCandidateForSupervising({
   assessmentStatus = null,
   startDateTime = new Date('2022-10-01T12:00:00Z'),
   enrolledComplementaryCertification,
-  stillValidBadgeAcquisitions,
+  stillValidBadgeAcquisitions = [],
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -10,7 +10,9 @@ module.exports = function buildCertificationCandidateForSupervising({
   authorizedToStart = false,
   assessmentStatus = null,
   startDateTime = new Date('2022-10-01T12:00:00Z'),
+  theoricalEndDateTime,
   enrolledComplementaryCertification,
+  enrolledComplementaryCertificationKey,
   stillValidBadgeAcquisitions = [],
 } = {}) {
   return new CertificationCandidateForSupervising({
@@ -23,7 +25,9 @@ module.exports = function buildCertificationCandidateForSupervising({
     authorizedToStart,
     assessmentStatus,
     startDateTime,
+    theoricalEndDateTime,
     enrolledComplementaryCertification,
+    enrolledComplementaryCertificationKey,
     stillValidBadgeAcquisitions,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -12,7 +12,6 @@ module.exports = function buildCertificationCandidateForSupervising({
   startDateTime = new Date('2022-10-01T12:00:00Z'),
   theoricalEndDateTime,
   enrolledComplementaryCertification,
-  enrolledComplementaryCertificationSessionExtraTime,
   stillValidBadgeAcquisitions = [],
 } = {}) {
   return new CertificationCandidateForSupervising({
@@ -27,7 +26,6 @@ module.exports = function buildCertificationCandidateForSupervising({
     startDateTime,
     theoricalEndDateTime,
     enrolledComplementaryCertification,
-    enrolledComplementaryCertificationSessionExtraTime,
     stillValidBadgeAcquisitions,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-for-supervising.js
@@ -1,0 +1,13 @@
+const ComplementaryCertificationForSupervising = require('../../../../lib/domain/models/ComplementaryCertificationForSupervising');
+
+module.exports = function buildComplementaryCertificationForSupervising({
+  label = 'Complementary certification name',
+  key = 'COMPLEMENTARY_CERTIFICATION_KEY',
+  sessionExtraTime = 0,
+} = {}) {
+  return new ComplementaryCertificationForSupervising({
+    label,
+    key,
+    sessionExtraTime,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification.js
@@ -4,10 +4,12 @@ module.exports = function buildComplementaryCertification({
   id = 1,
   label = 'Complementary certification name',
   key = 'COMPLEMENTARY_CERTIFICATION_KEY',
+  sessionExtraTime = 0,
 } = {}) {
   return new ComplementaryCertification({
     id,
     label,
     key,
+    sessionExtraTime,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -66,6 +66,7 @@ const buildCompetenceMark = require('./build-competence-mark');
 const buildCompetenceResult = require('./build-competence-result');
 const buildCompetenceTree = require('./build-competence-tree');
 const buildComplementaryCertification = require('./build-complementary-certification');
+const buildComplementaryCertificationForSupervising = require('./build-complementary-certification-for-supervising');
 const buildComplementaryCertificationHabilitation = require('./build-complementary-certification-habilitation');
 const buildComplementaryCertificationScoringCriteria = require('./build-complementary-certification-scoring-criteria');
 const buildCountry = require('./build-country');
@@ -213,6 +214,7 @@ module.exports = {
   buildCompetenceResult,
   buildCompetenceTree,
   buildComplementaryCertification,
+  buildComplementaryCertificationForSupervising,
   buildComplementaryCertificationHabilitation,
   buildComplementaryCertificationScoringCriteria,
   buildCountry,

--- a/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -23,11 +23,15 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
         function () {
           it('Should return true', function () {
             // given
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+              key: 'aKey',
+            });
+
             const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-              enrolledComplementaryCertification: 'Une certif complémentaire',
+              enrolledComplementaryCertification: complementaryCertification,
               stillValidBadgeAcquisitions: [
                 domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationBadgeLabel: 'Une certif complémentaire',
+                  complementaryCertificationKey: 'aKey',
                 }),
               ],
             });
@@ -47,8 +51,9 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
         function () {
           it('Should return false', function () {
             // given
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising();
             const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-              enrolledComplementaryCertification: 'Une certif complémentaire',
+              enrolledComplementaryCertification: complementaryCertification,
               stillValidBadgeAcquisitions: [],
             });
 

--- a/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -33,7 +33,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
             });
 
             // when
-            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+            const isStillEligibleToComplementaryCertification =
+              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
 
             // then
             expect(isStillEligibleToComplementaryCertification).to.be.true;
@@ -52,7 +53,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
             });
 
             // when
-            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+            const isStillEligibleToComplementaryCertification =
+              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
 
             // then
             expect(isStillEligibleToComplementaryCertification).to.be.false;
@@ -75,7 +77,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
             });
 
             // when
-            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+            const isStillEligibleToComplementaryCertification =
+              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
 
             // then
             expect(isStillEligibleToComplementaryCertification).to.be.false;
@@ -93,7 +96,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
         });
 
         // when
-        const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+        const isStillEligibleToComplementaryCertification =
+          certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
 
         // then
         expect(isStillEligibleToComplementaryCertification).to.be.false;

--- a/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -15,4 +15,89 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
       expect(certificationCandidateForSupervising.authorizedToStart).to.be.true;
     });
   });
+
+  describe('#isStillEligibleToComplementaryCertification', function () {
+    context('when candidate has a complementary certification', function () {
+      context(
+        'when candidate has still valid badge acquisition related to his complementary certification',
+        function () {
+          it('Should return true', function () {
+            // given
+            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+              enrolledComplementaryCertification: 'Une certif complémentaire',
+              stillValidBadgeAcquisitions: [
+                domainBuilder.buildCertifiableBadgeAcquisition({
+                  complementaryCertificationBadgeLabel: 'Une certif complémentaire',
+                }),
+              ],
+            });
+
+            // when
+            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+
+            // then
+            expect(isStillEligibleToComplementaryCertification).to.be.true;
+          });
+        }
+      );
+
+      context(
+        'when candidate has no still valid badge acquisition related to his complementary certification',
+        function () {
+          it('Should return false', function () {
+            // given
+            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+              enrolledComplementaryCertification: 'Une certif complémentaire',
+              stillValidBadgeAcquisitions: [],
+            });
+
+            // when
+            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+
+            // then
+            expect(isStillEligibleToComplementaryCertification).to.be.false;
+          });
+        }
+      );
+
+      context(
+        'when candidate has still valid badge acquisition  not related to his complementary certification',
+        function () {
+          it('Should return false', function () {
+            // given
+            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+              enrolledComplementaryCertification: 'Une certif complémentaire',
+              stillValidBadgeAcquisitions: [
+                domainBuilder.buildCertifiableBadgeAcquisition({
+                  complementaryCertificationBadgeLabel: 'Une autre certif complémentaire',
+                }),
+              ],
+            });
+
+            // when
+            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+
+            // then
+            expect(isStillEligibleToComplementaryCertification).to.be.false;
+          });
+        }
+      );
+    });
+
+    context('when candidate has no complementary certification', function () {
+      it('Should return false', function () {
+        // given
+        const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+          enrolledComplementaryCertification: null,
+          stillValidBadgeAcquisitions: [],
+        });
+
+        // when
+        const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification();
+
+        // then
+        expect(isStillEligibleToComplementaryCertification).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
@@ -83,7 +83,14 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
           it("should return the session with the candidates' eligibility", async function () {
             // given
             const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+              complementaryCertificationKey: 'aKey',
               complementaryCertificationBadgeLabel: 'une certif complémentaire',
+            });
+
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+              key: 'aKey',
+              label: 'une certif complémentaire',
+              sessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
             });
 
             const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
@@ -91,8 +98,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                 domainBuilder.buildCertificationCandidateForSupervising({
                   userId: 1234,
                   startDateTime: START_DATETIME_STUB,
-                  enrolledComplementaryCertification: 'une certif complémentaire',
-                  enrolledComplementaryCertificationSessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+                  enrolledComplementaryCertification: complementaryCertification,
                   stillValidBadgeAcquisitions: [],
                 }),
               ],
@@ -125,8 +131,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                       constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES,
                       COMPLEMENTARY_EXTRATIME_STUB,
                     ]),
-                    enrolledComplementaryCertification: 'une certif complémentaire',
-                    enrolledComplementaryCertificationSessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+                    enrolledComplementaryCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
                   }),
                 ],
@@ -136,7 +141,12 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
 
           it('should compute a theorical end datetime with extratime if eligible to complementary certification extratime', async function () {
             const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-              complementaryCertificationBadgeLabel: 'une certif complémentaire',
+              complementaryCertificationKey: 'aKey',
+            });
+
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+              key: 'aKey',
+              sessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
             });
 
             sessionForSupervisingRepository.get.resolves(
@@ -145,8 +155,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                   domainBuilder.buildCertificationCandidateForSupervising({
                     userId: 1234,
                     startDateTime: START_DATETIME_STUB,
-                    enrolledComplementaryCertification: 'une certif complémentaire',
-                    enrolledComplementaryCertificationSessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+                    enrolledComplementaryCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],
@@ -180,13 +189,13 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
         context('when some candidates are not eligible to complementary certifications', function () {
           it("should return the session with the candidates' non eligibility", async function () {
             // given
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising();
             const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
               certificationCandidates: [
                 domainBuilder.buildCertificationCandidateForSupervising({
                   userId: 1234,
                   startDateTime: START_DATETIME_STUB,
-                  enrolledComplementaryCertification: 'une certif complémentaire',
-                  enrolledComplementaryCertificationSessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+                  enrolledComplementaryCertification: complementaryCertification,
                   stillValidBadgeAcquisitions: [],
                 }),
               ],
@@ -216,8 +225,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                     theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
                       constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES,
                     ]),
-                    enrolledComplementaryCertification: 'une certif complémentaire',
-                    enrolledComplementaryCertificationSessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+                    enrolledComplementaryCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],
@@ -227,14 +235,19 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
 
           it('should not compute a theorical end datetime with extratime if not eligible to complementary certification extratime', async function () {
             // given
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+              key: 'aKey',
+              label: 'une certif complémentaire',
+              sessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+            });
+
             sessionForSupervisingRepository.get.resolves(
               domainBuilder.buildSessionForSupervising({
                 certificationCandidates: [
                   domainBuilder.buildCertificationCandidateForSupervising({
                     userId: 1234,
                     startDateTime: START_DATETIME_STUB,
-                    enrolledComplementaryCertification: 'une certif complémentaire',
-                    enrolledComplementaryCertificationSessionExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+                    enrolledComplementaryCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],

--- a/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
@@ -15,5 +15,99 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
       // then
       expect(actualSession).to.equal(expectedSession);
     });
+
+    context('when there are candidates', function () {
+      context('when some candidates are still eligible to complementary certifications', function () {
+        it("should return the session with the candidates' eligibility", async function () {
+          // given
+          const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+            complementaryCertificationBadgeLabel: 'une certif complémentaire',
+          });
+
+          const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
+            certificationCandidates: [
+              domainBuilder.buildCertificationCandidateForSupervising({
+                userId: 1234,
+                enrolledComplementaryCertification: 'une certif complémentaire',
+                stillValidBadgeAcquisitions: [],
+              }),
+            ],
+          });
+
+          const sessionForSupervisingRepository = { get: sinon.stub() };
+          sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+          const certificationBadgesService = {
+            findStillValidBadgeAcquisitions: sinon.stub(),
+          };
+          certificationBadgesService.findStillValidBadgeAcquisitions
+            .withArgs({ userId: 1234 })
+            .resolves([stillValidBadgeAcquisition]);
+
+          // when
+          const actualSession = await getSessionForSupervising({
+            sessionId: 1,
+            sessionForSupervisingRepository,
+            certificationBadgesService,
+          });
+
+          // then
+          expect(actualSession).to.deep.equal(
+            domainBuilder.buildSessionForSupervising({
+              certificationCandidates: [
+                domainBuilder.buildCertificationCandidateForSupervising({
+                  userId: 1234,
+                  enrolledComplementaryCertification: 'une certif complémentaire',
+                  stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
+                }),
+              ],
+            })
+          );
+        });
+      });
+
+      context('when some candidates are not eligible to complementary certifications', function () {
+        it("should return the session with the candidates' non eligibility", async function () {
+          // given
+          const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
+            certificationCandidates: [
+              domainBuilder.buildCertificationCandidateForSupervising({
+                userId: 1234,
+                enrolledComplementaryCertification: 'une certif complémentaire',
+                stillValidBadgeAcquisitions: [],
+              }),
+            ],
+          });
+
+          const sessionForSupervisingRepository = { get: sinon.stub() };
+          sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+          const certificationBadgesService = {
+            findStillValidBadgeAcquisitions: sinon.stub(),
+          };
+          certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
+
+          // when
+          const actualSession = await getSessionForSupervising({
+            sessionId: 1,
+            sessionForSupervisingRepository,
+            certificationBadgesService,
+          });
+
+          // then
+          expect(actualSession).to.deep.equal(
+            domainBuilder.buildSessionForSupervising({
+              certificationCandidates: [
+                domainBuilder.buildCertificationCandidateForSupervising({
+                  userId: 1234,
+                  enrolledComplementaryCertification: 'une certif complémentaire',
+                  stillValidBadgeAcquisitions: [],
+                }),
+              ],
+            })
+          );
+        });
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
@@ -1,111 +1,193 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const getSessionForSupervising = require('../../../../lib/domain/usecases/get-session-for-supervising');
+const { constants } = require('../../../../lib/domain/constants');
+const moment = require('moment');
+
+const START_DATETIME_STUB = new Date('2022-10-01T13:00:00Z');
+const sessionForSupervisingRepository = { get: sinon.stub() };
+
+const expectedSessionEndDateTimeFromStartDateTime = (startDateTime, addedTime) => {
+  return moment(startDateTime).add(addedTime, 'minutes').toDate();
+};
 
 describe('Unit | UseCase | get-session-for-supervising', function () {
+  afterEach(function () {
+    sinon.reset();
+  });
+
   context('when the session exists', function () {
     it('should fetch and return the session from repository', async function () {
       // given
       const expectedSession = domainBuilder.buildSessionForSupervising();
-      const sessionForSupervisingRepository = { get: sinon.stub() };
       sessionForSupervisingRepository.get.resolves(expectedSession);
 
       // when
       const actualSession = await getSessionForSupervising({ sessionId: 1, sessionForSupervisingRepository });
 
       // then
-      expect(actualSession).to.equal(expectedSession);
+      expect(actualSession).to.deep.equal(expectedSession);
     });
 
     context('when there are candidates', function () {
-      context('when some candidates are still eligible to complementary certifications', function () {
-        it("should return the session with the candidates' eligibility", async function () {
+      context('when some candidates have no complementary certifications', function () {
+        it('should not compute a theorical end datetime if session has not started', async function () {
           // given
-          const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-            complementaryCertificationBadgeLabel: 'une certif complémentaire',
+          const certificationCandidateNotStarted = domainBuilder.buildCertificationCandidateForSupervising();
+          delete certificationCandidateNotStarted.startDateTime;
+
+          const session = domainBuilder.buildSessionForSupervising({
+            certificationCandidates: [certificationCandidateNotStarted],
           });
-
-          const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
-            certificationCandidates: [
-              domainBuilder.buildCertificationCandidateForSupervising({
-                userId: 1234,
-                enrolledComplementaryCertification: 'une certif complémentaire',
-                stillValidBadgeAcquisitions: [],
-              }),
-            ],
-          });
-
-          const sessionForSupervisingRepository = { get: sinon.stub() };
-          sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
-
-          const certificationBadgesService = {
-            findStillValidBadgeAcquisitions: sinon.stub(),
-          };
-          certificationBadgesService.findStillValidBadgeAcquisitions
-            .withArgs({ userId: 1234 })
-            .resolves([stillValidBadgeAcquisition]);
+          sessionForSupervisingRepository.get.resolves(session);
 
           // when
-          const actualSession = await getSessionForSupervising({
+          const sessionForSupervising = await getSessionForSupervising({
             sessionId: 1,
             sessionForSupervisingRepository,
-            certificationBadgesService,
           });
-
           // then
-          expect(actualSession).to.deep.equal(
-            domainBuilder.buildSessionForSupervising({
-              certificationCandidates: [
-                domainBuilder.buildCertificationCandidateForSupervising({
-                  userId: 1234,
-                  enrolledComplementaryCertification: 'une certif complémentaire',
-                  stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
-                }),
-              ],
-            })
+          expect(sessionForSupervising.certificationCandidates).to.have.lengthOf(1);
+          expect(sessionForSupervising.certificationCandidates[0].startDateTime).to.be.undefined;
+          expect(sessionForSupervising.certificationCandidates[0].theoricalEndDateTime).to.be.undefined;
+        });
+
+        it('should compute a theorical end datetime if session has started', async function () {
+          // given
+          const certificationCandidateWithNoComplementaryCertification =
+            domainBuilder.buildCertificationCandidateForSupervising({
+              complementaryCertification: undefined,
+              complementaryCertificationKey: undefined,
+            });
+
+          const session = domainBuilder.buildSessionForSupervising({
+            certificationCandidates: [certificationCandidateWithNoComplementaryCertification],
+          });
+          sessionForSupervisingRepository.get.resolves(session);
+          const expectedTheoricalEndDateTime = moment(
+            certificationCandidateWithNoComplementaryCertification.startDateTime
+          )
+            .add(constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES, 'minutes')
+            .toDate();
+
+          // when
+          const sessionForSupervising = await getSessionForSupervising({
+            sessionId: 1,
+            sessionForSupervisingRepository,
+          });
+          // then
+          expect(sessionForSupervising.certificationCandidates).to.have.lengthOf(1);
+          expect(sessionForSupervising.certificationCandidates[0]).to.have.deep.property(
+            'startDateTime',
+            certificationCandidateWithNoComplementaryCertification.startDateTime
+          );
+          expect(sessionForSupervising.certificationCandidates[0]).to.have.deep.property(
+            'theoricalEndDateTime',
+            expectedTheoricalEndDateTime
           );
         });
       });
 
-      context('when some candidates are not eligible to complementary certifications', function () {
-        it("should return the session with the candidates' non eligibility", async function () {
-          // given
-          const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
-            certificationCandidates: [
-              domainBuilder.buildCertificationCandidateForSupervising({
-                userId: 1234,
-                enrolledComplementaryCertification: 'une certif complémentaire',
-                stillValidBadgeAcquisitions: [],
-              }),
-            ],
-          });
+      context('when the candidate has complementary certifications', function () {
+        context('when some candidates are still eligible to complementary certifications', function () {
+          it("should return the session with the candidates' eligibility", async function () {
+            // given
+            const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+              complementaryCertificationBadgeLabel: 'une certif complémentaire',
+            });
 
-          const sessionForSupervisingRepository = { get: sinon.stub() };
-          sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
-
-          const certificationBadgesService = {
-            findStillValidBadgeAcquisitions: sinon.stub(),
-          };
-          certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
-
-          // when
-          const actualSession = await getSessionForSupervising({
-            sessionId: 1,
-            sessionForSupervisingRepository,
-            certificationBadgesService,
-          });
-
-          // then
-          expect(actualSession).to.deep.equal(
-            domainBuilder.buildSessionForSupervising({
+            const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
               certificationCandidates: [
                 domainBuilder.buildCertificationCandidateForSupervising({
                   userId: 1234,
+                  startDateTime: START_DATETIME_STUB,
                   enrolledComplementaryCertification: 'une certif complémentaire',
                   stillValidBadgeAcquisitions: [],
                 }),
               ],
-            })
-          );
+            });
+
+            sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+            const certificationBadgesService = {
+              findStillValidBadgeAcquisitions: sinon.stub(),
+            };
+            certificationBadgesService.findStillValidBadgeAcquisitions
+              .withArgs({ userId: 1234 })
+              .resolves([stillValidBadgeAcquisition]);
+
+            // when
+            const actualSession = await getSessionForSupervising({
+              sessionId: 1,
+              sessionForSupervisingRepository,
+              certificationBadgesService,
+            });
+
+            // then
+            expect(actualSession).to.deep.equal(
+              domainBuilder.buildSessionForSupervising({
+                certificationCandidates: [
+                  domainBuilder.buildCertificationCandidateForSupervising({
+                    userId: 1234,
+                    startDateTime: START_DATETIME_STUB,
+                    theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(
+                      START_DATETIME_STUB,
+                      constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES
+                    ),
+                    enrolledComplementaryCertification: 'une certif complémentaire',
+                    stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
+                  }),
+                ],
+              })
+            );
+          });
+        });
+
+        context('when some candidates are not eligible to complementary certifications', function () {
+          it("should return the session with the candidates' non eligibility", async function () {
+            // given
+            const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
+              certificationCandidates: [
+                domainBuilder.buildCertificationCandidateForSupervising({
+                  userId: 1234,
+                  startDateTime: START_DATETIME_STUB,
+                  enrolledComplementaryCertification: 'une certif complémentaire',
+                  stillValidBadgeAcquisitions: [],
+                }),
+              ],
+            });
+
+            sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+            const certificationBadgesService = {
+              findStillValidBadgeAcquisitions: sinon.stub(),
+            };
+            certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
+
+            // when
+            const actualSession = await getSessionForSupervising({
+              sessionId: 1,
+              sessionForSupervisingRepository,
+              certificationBadgesService,
+            });
+
+            // then
+            expect(actualSession).to.deep.equal(
+              domainBuilder.buildSessionForSupervising({
+                certificationCandidates: [
+                  domainBuilder.buildCertificationCandidateForSupervising({
+                    userId: 1234,
+                    startDateTime: START_DATETIME_STUB,
+                    theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(
+                      START_DATETIME_STUB,
+                      constants.PIX_CERTIF.DEFAULT_SESSION_DURATION_MINUTES
+                    ),
+                    enrolledComplementaryCertification: 'une certif complémentaire',
+                    stillValidBadgeAcquisitions: [],
+                  }),
+                ],
+              })
+            );
+          });
         });
       });
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -40,7 +40,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'authorized-to-start': true,
               'assessment-status': Assessment.states.STARTED,
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
-              'complementary-certification': 'Super Certification Complémentaire',
+              'enrolled-complementary-certification': 'Super Certification Complémentaire',
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -67,7 +67,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             authorizedToStart: true,
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
-            complementaryCertification: 'Super Certification Complémentaire',
+            enrolledComplementaryCertification: 'Super Certification Complémentaire',
           },
         ],
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -73,9 +73,13 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
             theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
-            enrolledComplementaryCertification: 'Super Certification Complémentaire',
+            enrolledComplementaryCertification: domainBuilder.buildComplementaryCertificationForSupervising({
+              key: 'aKey',
+              label: 'Super Certification Complémentaire',
+            }),
             stillValidBadgeAcquisitions: [
               domainBuilder.buildCertifiableBadgeAcquisition({
+                complementaryCertificationKey: 'aKey',
                 complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
               }),
             ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -1,6 +1,7 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer');
 const Assessment = require('../../../../../lib/domain/models/Assessment');
+const { CertificationCandidateForSupervising } = require('../../../../../lib/domain/models');
 
 describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', function () {
   describe('#serialize()', function () {
@@ -41,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'assessment-status': Assessment.states.STARTED,
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
               'enrolled-complementary-certification': 'Super Certification Complémentaire',
+              'is-still-eligible-to-complementary-certification': true,
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -58,7 +60,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
         time: '14:30',
         certificationCenterName: 'Toto',
         certificationCandidates: [
-          {
+          new CertificationCandidateForSupervising({
             id: 1234,
             firstName: 'toto',
             lastName: 'tata',
@@ -68,7 +70,12 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
             enrolledComplementaryCertification: 'Super Certification Complémentaire',
-          },
+            stillValidBadgeAcquisitions: [
+              domainBuilder.buildCertifiableBadgeAcquisition({
+                complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
+              }),
+            ],
+          }),
         ],
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -41,6 +41,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'authorized-to-start': true,
               'assessment-status': Assessment.states.STARTED,
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
+              'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
               'enrolled-complementary-certification': 'Super Certification Complémentaire',
               'is-still-eligible-to-complementary-certification': true,
               'user-id': 6789,
@@ -71,6 +72,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             authorizedToStart: true,
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
+            theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
             enrolledComplementaryCertification: 'Super Certification Complémentaire',
             stillValidBadgeAcquisitions: [
               domainBuilder.buildCertifiableBadgeAcquisition({

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -43,6 +43,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
               'enrolled-complementary-certification': 'Super Certification Complémentaire',
               'is-still-eligible-to-complementary-certification': true,
+              'user-id': 6789,
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -62,6 +63,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
         certificationCandidates: [
           new CertificationCandidateForSupervising({
             id: 1234,
+            userId: 6789,
             firstName: 'toto',
             lastName: 'tata',
             birthdate: '28/05/1984',

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -45,7 +45,7 @@
           @withIcon={{true}}
           class="session-supervising-candidate-in-list-details__eligibility"
         >
-          Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.
+          {{t "pages.session-supervising.candidate-in-list.complementary-certification-non-eligibility-warning"}}
         </PixMessage>
       {{/if}}
 

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -29,12 +29,12 @@
         :
         {{format-percentage @candidate.extraTimePercentage}}
       {{/if}}
-      {{#if this.shouldDisplayComplementaryCertification}}
+      {{#if this.shouldDisplayEnrolledComplementaryCertification}}
         <p class="session-supervising-candidate-in-list-details__enrolment">
           <span class="session-supervising-candidate-in-list-details-enrolment__icon"><FaIcon @icon="award" /></span>
           {{t
             "pages.session-supervising.candidate-in-list.complementary-certification-enrolment"
-            complementaryCertification=@candidate.complementaryCertification
+            complementaryCertification=@candidate.enrolledComplementaryCertification
           }}
         </p>
       {{/if}}

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -38,6 +38,17 @@
           }}
         </p>
       {{/if}}
+
+      {{#if this.shouldDisplayNonEligibilityWarning}}
+        <PixMessage
+          @type="warning"
+          @withIcon={{true}}
+          class="session-supervising-candidate-in-list-details__eligibility"
+        >
+          Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.
+        </PixMessage>
+      {{/if}}
+
     </div>
     {{#if @candidate.hasStarted}}
       {{#if @candidate.isAuthorizedToResume}}

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -26,9 +26,9 @@ export default class CandidateInList extends Component {
     return this.args.candidate.hasStarted;
   }
 
-  get shouldDisplayComplementaryCertification() {
+  get shouldDisplayEnrolledComplementaryCertification() {
     return (
-      this.args.candidate.complementaryCertification &&
+      this.args.candidate.enrolledComplementaryCertification &&
       this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
     );
   }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -33,6 +33,20 @@ export default class CandidateInList extends Component {
     );
   }
 
+  get shouldDisplayNonEligibilityWarning() {
+    return this._isReconciliated() && this._isNotEligibleToEnrolledComplementaryCertification();
+  }
+
+  _isNotEligibleToEnrolledComplementaryCertification() {
+    return !this.args.candidate.isStillEligibleToComplementaryCertification;
+  }
+
+  _isReconciliated() {
+    return (
+      this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled && this.args.candidate.userId
+    );
+  }
+
   @action
   async toggleCandidate(candidate) {
     await this.args.toggleCandidate(candidate);

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -16,7 +16,7 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('boolean') authorizedToStart;
   @attr('string') assessmentStatus;
   @attr('date') startDateTime;
-  @attr('string') complementaryCertification;
+  @attr('string') enrolledComplementaryCertification;
 
   get hasStarted() {
     return this.assessmentStatus === 'started';

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -17,6 +17,8 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('string') assessmentStatus;
   @attr('date') startDateTime;
   @attr('string') enrolledComplementaryCertification;
+  @attr('string') userId;
+  @attr('boolean') isStillEligibleToComplementaryCertification;
 
   get hasStarted() {
     return this.assessmentStatus === 'started';

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -75,6 +75,10 @@
     font-weight: normal;
     line-height: 1.3125rem;
   }
+
+  &__eligibility {
+    margin-top: 4px;
+  }
 }
 
 .session-supervising-candidate-in-list-details-enrolment {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -21,13 +21,16 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     this.owner.register('service:featureToggles', FeatureTogglesStub);
   });
 
-  module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function () {
-    test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
+  module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function (hooks) {
+    hooks.beforeEach(async function () {
+      store = this.owner.lookup('service:store');
       class FeatureTogglesStub extends Service {
         featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
       }
       this.owner.register('service:featureToggles', FeatureTogglesStub);
+    });
 
+    test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 123,
         enrolledComplementaryCertification: 'Super Certification Complémentaire',
@@ -40,6 +43,85 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
       // then
       assert.dom(screen.getByText('Inscription à Super Certification Complémentaire')).exists();
+    });
+
+    module('when the candidate is reconciliated before starting the session', function () {
+      module('when the candidate is no longer eligible to the complementary certification', function () {
+        test('should render a warning message', async function (assert) {
+          // given
+          this.candidate = store.createRecord('certification-candidate-for-supervising', {
+            id: 123,
+            enrolledComplementaryCertification: 'Super Certification Complémentaire',
+            userId: 678,
+            isStillEligibleToComplementaryCertification: false,
+          });
+
+          // when
+          const screen = await renderScreen(hbs`
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
+
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.'
+              )
+            )
+            .exists();
+        });
+      });
+
+      module('when the candidate is still eligible to the complementary certification', function () {
+        test('should not render a warning message', async function (assert) {
+          // given
+          this.candidate = store.createRecord('certification-candidate-for-supervising', {
+            id: 123,
+            enrolledComplementaryCertification: 'Super Certification Complémentaire',
+            userId: 678,
+            isStillEligibleToComplementaryCertification: true,
+          });
+
+          // when
+          const screen = await renderScreen(hbs`
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
+
+          // then
+          assert
+            .dom(
+              screen.queryByText(
+                'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.'
+              )
+            )
+            .doesNotExist();
+        });
+      });
+    });
+
+    module('when the candidate is not reconciliated before starting the session', function () {
+      test('should not render a warning message', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          enrolledComplementaryCertification: 'Super Certification Complémentaire',
+          isStillEligibleToComplementaryCertification: false,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
+
+        // then
+        assert
+          .dom(
+            screen.queryByText(
+              'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.'
+            )
+          )
+          .doesNotExist();
+      });
     });
   });
 
@@ -66,6 +148,13 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     assert.dom(screen.getByText('28/05/1984 · Temps majoré : 8 %')).exists();
     assert.dom(screen.queryByText('Inscription à Super Certification Complémentaire')).doesNotExist();
     assert.dom(screen.getByRole('checkbox', { name: 'Zen Whoberi Ben Titan Gamora' })).isNotChecked();
+    assert
+      .dom(
+        screen.queryByText(
+          'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.'
+        )
+      )
+      .doesNotExist();
   });
 
   module('when the candidate is authorized to start', function () {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -22,7 +22,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function () {
-    test('should render the complementary certification name of the candidate if he passes one', async function (assert) {
+    test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
       class FeatureTogglesStub extends Service {
         featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
       }
@@ -30,7 +30,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 123,
-        complementaryCertification: 'Super Certification Complémentaire',
+        enrolledComplementaryCertification: 'Super Certification Complémentaire',
       });
 
       // when
@@ -53,7 +53,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       extraTimePercentage: '8',
       authorizedToStart: false,
       assessmentStatus: null,
-      complementaryCertification: 'Super Certification Complémentaire',
+      enrolledComplementaryCertification: 'Super Certification Complémentaire',
     });
 
     // when

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -296,6 +296,7 @@
       "candidate-in-list": {
         "candidate-options": "Candidate's options",
         "complementary-certification-enrolment": "{complementaryCertification} enrolment",
+        "complementary-certification-non-eligibility-warning": "Candidate isn't or is no longer eligible for the additional certification. They are taking the Pix certification exam only.",
         "display-candidate-options": "Display the candidate's options",
         "resume-test-modal": {
           "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -296,6 +296,7 @@
       "candidate-in-list": {
         "candidate-options": "Options du candidat",
         "complementary-certification-enrolment": "Inscription à {complementaryCertification}",
+        "complementary-certification-non-eligibility-warning": "Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.",
         "display-candidate-options": "Afficher les options du candidat",
         "resume-test-modal": {
           "actions": {


### PR DESCRIPTION
## :unicorn: Problème

Afficher coté front l’heure théorique de fin dans un encadré avec l’heure de début.
Heure théorique de fin = heure de début de chaque candidat + durée de la certification qu’il est effectivement en train de passer

## :robot: Proposition

* API `/api/sessions/{id}/supervising`
  * `.included[].attributes.theorical-end-date-time` = `certification-courses.createdAt` + `105min` [`+45min`]

### A débattre

Il n'existe pas de notion de temps associé à une certif, ou au moins de temps supplémentaire pour une complémentaire. Or, il existe des différence par compélmentaire (0 minutes pour CLEA, +45min pour Pix+, et notre PO informe que pour NextGen il n'est pas exclut que il y ai d'autres variantes).
**Devons-nous songer à stocker cela en BDD (dans la table completementary-certifications)**


## :rainbow: Remarques

* Le calcul ne doit bien pas prendre le temps majoré, cette partie là du calcul reste à la charge du surveillant
* Ajout de 45 min pour certif complémentaire, sauf CLEA. Une seule complémentaire possible à ce jour.

## :100: Pour tester

