### PR TITLE
[TECH] Centraliser le code permettant de changer de locales dans localeService (PIX-7922).

### DIFF
--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -3,9 +3,16 @@ import config from 'pix-certif/config/environment';
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 
+export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+export const FRENCH_FRANCE_LOCALE = 'fr-FR';
+export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
+  @service intl;
+  @service dayjs;
 
   hasLocaleCookie() {
     return this.cookies.exists('locale');
@@ -18,5 +25,10 @@ export default class LocaleService extends Service {
       path: '/',
       sameSite: 'Strict',
     });
+  }
+
+  setLocale(locale) {
+    this.intl.setLocale(locale);
+    this.dayjs.setLocale(locale);
   }
 }

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -1,8 +1,6 @@
 import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
-
-const FRENCH_INTERNATIONAL_LOCALE = 'fr';
-const FRENCH_FRANCE_LOCALE = 'fr-FR';
+import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-certif/services/locale';
 
 export default class CurrentSessionService extends SessionService {
   @service currentDomain;
@@ -37,7 +35,7 @@ export default class CurrentSessionService extends SessionService {
     }
 
     if (isFranceDomain) {
-      this._setLocale(FRENCH_INTERNATIONAL_LOCALE);
+      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
 
       if (!this.locale.hasLocaleCookie()) {
         this.locale.setLocaleCookie(FRENCH_FRANCE_LOCALE);
@@ -47,16 +45,11 @@ export default class CurrentSessionService extends SessionService {
     }
 
     if (this._localeFromQueryParam) {
-      this._setLocale(this._localeFromQueryParam);
+      this.locale.setLocale(this._localeFromQueryParam);
       return;
     }
 
     const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
-    this._setLocale(locale);
-  }
-
-  _setLocale(locale) {
-    this.intl.setLocale([locale, FRENCH_INTERNATIONAL_LOCALE]);
-    this.dayjs.setLocale(locale);
+    this.locale.setLocale(locale);
   }
 }

--- a/certif/tests/helpers/setup-intl.js
+++ b/certif/tests/helpers/setup-intl.js
@@ -1,9 +1,7 @@
 export default function setupIntl(hooks, locale = ['fr']) {
   hooks.beforeEach(function () {
     this.intl = this.owner.lookup('service:intl');
-    this.intl.setLocale(locale);
-
-    this.dayjs = this.owner.lookup('service:dayjs');
-    this.dayjs.setLocale(locale[0]);
+    this.localeService = this.owner.lookup('service:locale');
+    this.localeService.setLocale(locale[0]);
   });
 }

--- a/certif/tests/unit/services/locale_test.js
+++ b/certif/tests/unit/services/locale_test.js
@@ -1,0 +1,95 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import { DEFAULT_LOCALE } from 'pix-certif/services/locale';
+
+module('Unit | Service | locale', function (hooks) {
+  setupTest(hooks);
+
+  let localeService;
+  let cookiesService;
+  let currentDomainService;
+  let dayjsService;
+  let intlService;
+
+  hooks.beforeEach(function () {
+    localeService = this.owner.lookup('service:locale');
+
+    cookiesService = this.owner.lookup('service:cookies');
+    sinon.stub(cookiesService, 'write');
+    sinon.stub(cookiesService, 'exists');
+
+    currentDomainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(currentDomainService, 'getExtension');
+
+    dayjsService = this.owner.lookup('service:dayjs');
+    sinon.stub(dayjsService, 'setLocale');
+
+    intlService = this.owner.lookup('service:intl');
+    sinon.stub(intlService, 'setLocale');
+  });
+
+  module('#setLocaleCookie', function () {
+    test('saves the locale in cookie locale', function (assert) {
+      // given
+      currentDomainService.getExtension.returns('fr');
+
+      // when
+      localeService.setLocaleCookie('fr-CA');
+
+      // then
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-CA', {
+        domain: 'pix.fr',
+        maxAge: 31536000,
+        path: '/',
+        sameSite: 'Strict',
+      });
+      assert.ok(true);
+    });
+  });
+
+  module('#hasLocaleCookie', function () {
+    module('when there is no cookie locale', function () {
+      test('returns "false"', function (assert) {
+        // given
+        cookiesService.exists.returns(false);
+
+        // when
+        const hasNoCookieLocale = localeService.hasLocaleCookie();
+
+        // then
+        sinon.assert.calledWith(cookiesService.exists, 'locale');
+        assert.notOk(hasNoCookieLocale);
+      });
+    });
+
+    module('when there is a cookie locale', function () {
+      test('returns "true"', function (assert) {
+        // given
+        cookiesService.exists.returns(true);
+
+        // when
+        const hasCookieLocale = localeService.hasLocaleCookie();
+
+        // then
+        sinon.assert.calledWith(cookiesService.exists, 'locale');
+        assert.ok(hasCookieLocale);
+      });
+    });
+  });
+
+  module('#setLocale', function () {
+    test('set app locale', function (assert) {
+      // given
+      const locale = DEFAULT_LOCALE;
+
+      // when
+      localeService.setLocale(locale);
+
+      // then
+      sinon.assert.calledWith(intlService.setLocale, locale);
+      sinon.assert.calledWith(dayjsService.setLocale, locale);
+      assert.ok(true);
+    });
+  });
+});

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -57,11 +57,11 @@ module('Unit | Service | session', function (hooks) {
         test('adds a cookie locale with "fr-FR" as value', async function (assert) {
           // given
           localeService.hasLocaleCookie.returns(false);
-
-          // when
           const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
+
+          // when
           await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
@@ -74,11 +74,11 @@ module('Unit | Service | session', function (hooks) {
         test('does not update cookie locale', async function (assert) {
           // given
           localeService.hasLocaleCookie.returns(true);
-
-          // when
           const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
+
+          // when
           await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
@@ -90,10 +90,12 @@ module('Unit | Service | session', function (hooks) {
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // when
+            // given
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -104,10 +106,12 @@ module('Unit | Service | session', function (hooks) {
 
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // when
+            // given
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = 'user’s lang';
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -120,10 +124,12 @@ module('Unit | Service | session', function (hooks) {
       module('when a lang query param is present', function () {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // when
+            // given
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
             const userLocale = undefined;
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -134,10 +140,12 @@ module('Unit | Service | session', function (hooks) {
 
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // when
+            // given
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
             const userLocale = 'user’s lang';
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -152,11 +160,11 @@ module('Unit | Service | session', function (hooks) {
       test('does not set the cookie locale', async function (assert) {
         // given
         localeService.hasLocaleCookie.returns(false);
-
-        // when
         const isFranceDomain = false;
         const localeFromQueryParam = undefined;
         const userLocale = undefined;
+
+        // when
         await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
@@ -167,10 +175,12 @@ module('Unit | Service | session', function (hooks) {
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
           test('sets the default locale', async function (assert) {
-            // when
+            // given
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -181,10 +191,12 @@ module('Unit | Service | session', function (hooks) {
 
         module('when user is loaded', function () {
           test('sets the locale to the user’s lang', async function (assert) {
-            // when
+            // given
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = 'en';
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -198,10 +210,12 @@ module('Unit | Service | session', function (hooks) {
         module('when the lang query param is invalid', function () {
           module('when user is not loaded', function () {
             test('sets the default locale', async function (assert) {
-              // when
+              // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
@@ -212,10 +226,12 @@ module('Unit | Service | session', function (hooks) {
 
           module('when user is loaded', function () {
             test('sets the locale to the user’s lang', async function (assert) {
-              // when
+              // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = 'en';
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
@@ -228,10 +244,12 @@ module('Unit | Service | session', function (hooks) {
         module('when the lang query param is valid', function () {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', async function (assert) {
-              // when
+              // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
               const userLocale = undefined;
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
@@ -242,10 +260,12 @@ module('Unit | Service | session', function (hooks) {
 
           module('when user is loaded', function () {
             test('sets the locale to the lang query param which wins over', async function (assert) {
-              // when
+              // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
               const userLocale = 'fr';
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -2,10 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
-
-const DEFAULT_LOCALE = 'fr';
-const FRENCH_INTERNATIONAL_LOCALE = 'fr';
-const FRENCH_FRANCE_LOCALE = 'fr-FR';
+import { DEFAULT_LOCALE, FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-certif/services/locale';
 
 module('Unit | Service | session', function (hooks) {
   setupTest(hooks);
@@ -25,6 +22,7 @@ module('Unit | Service | session', function (hooks) {
     Object.assign(localeService, {
       setLocaleCookie: sinon.stub(),
       hasLocaleCookie: sinon.stub(),
+      setLocale: sinon.stub(),
     });
   });
 
@@ -92,9 +90,6 @@ module('Unit | Service | session', function (hooks) {
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // given
-            service._setLocale = sinon.stub();
-
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
@@ -102,16 +97,13 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
 
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // given
-            service._setLocale = sinon.stub();
-
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
@@ -119,7 +111,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -128,9 +120,6 @@ module('Unit | Service | session', function (hooks) {
       module('when a lang query param is present', function () {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // given
-            service._setLocale = sinon.stub();
-
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
@@ -138,16 +127,13 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
 
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
-            // given
-            service._setLocale = sinon.stub();
-
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
@@ -155,7 +141,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -181,9 +167,6 @@ module('Unit | Service | session', function (hooks) {
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
           test('sets the default locale', async function (assert) {
-            // given
-            service._setLocale = sinon.stub();
-
             // when
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
@@ -191,16 +174,13 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
             assert.ok(true);
           });
         });
 
         module('when user is loaded', function () {
           test('sets the locale to the user’s lang', async function (assert) {
-            // given
-            service._setLocale = sinon.stub();
-
             // when
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
@@ -208,7 +188,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, 'en');
+            sinon.assert.calledWith(localeService.setLocale, 'en');
             assert.ok(true);
           });
         });
@@ -218,9 +198,6 @@ module('Unit | Service | session', function (hooks) {
         module('when the lang query param is invalid', function () {
           module('when user is not loaded', function () {
             test('sets the default locale', async function (assert) {
-              // given
-              service._setLocale = sinon.stub();
-
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
@@ -228,16 +205,13 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
+              sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
               assert.ok(true);
             });
           });
 
           module('when user is loaded', function () {
             test('sets the locale to the user’s lang', async function (assert) {
-              // given
-              service._setLocale = sinon.stub();
-
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
@@ -245,7 +219,7 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, 'en');
               assert.ok(true);
             });
           });
@@ -254,9 +228,6 @@ module('Unit | Service | session', function (hooks) {
         module('when the lang query param is valid', function () {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', async function (assert) {
-              // given
-              service._setLocale = sinon.stub();
-
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
@@ -264,16 +235,13 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, 'en');
               assert.ok(true);
             });
           });
 
           module('when user is loaded', function () {
             test('sets the locale to the lang query param which wins over', async function (assert) {
-              // given
-              service._setLocale = sinon.stub();
-
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
@@ -281,28 +249,12 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, 'en');
               assert.ok(true);
             });
           });
         });
       });
-    });
-  });
-
-  module('#_setLocale', function () {
-    test('calls intl and dayjs services', async function (assert) {
-      // given
-      service.intl = { setLocale: sinon.stub() };
-      service.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
-
-      // when
-      await service._setLocale('some locale');
-
-      // then
-      sinon.assert.calledWith(service.intl.setLocale, ['some locale', 'fr']);
-      sinon.assert.calledWith(service.dayjs.setLocale, 'some locale');
-      assert.ok(true);
     });
   });
 });

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -7,14 +7,14 @@ export default class UserAccountPersonalInformationController extends Controller
   @service dayjs;
   @service intl;
   @service currentDomain;
+  @service locale;
 
   @action
   async onLanguageChange(language) {
     if (!this.currentDomain.isFranceDomain) {
       await this.currentUser.user.save({ adapterOptions: { lang: language } });
 
-      this.intl.setLocale(language);
-      this.dayjs.setLocale(language);
+      this.locale.setLocale(language);
     }
   }
 }

--- a/mon-pix/app/controllers/authentication/login.js
+++ b/mon-pix/app/controllers/authentication/login.js
@@ -3,12 +3,10 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
-const DEFAULT_LOCALE = 'fr';
-
 export default class LoginController extends Controller {
-  @service intl;
-  @service dayjs;
   @service currentDomain;
+  @service intl;
+  @service locale;
   @service router;
 
   @tracked selectedLanguage = this.intl.primaryLocale;
@@ -18,14 +16,9 @@ export default class LoginController extends Controller {
   }
 
   @action
-  onLanguageChange(value) {
-    this.selectedLanguage = value;
-    this._setLocale(this.selectedLanguage);
+  onLanguageChange(language) {
+    this.selectedLanguage = language;
+    this.locale.setLocale(this.selectedLanguage);
     this.router.replaceWith('authentication.login', { queryParams: { lang: null } });
-  }
-
-  _setLocale(language) {
-    this.intl.setLocale([language, DEFAULT_LOCALE]);
-    this.dayjs.setLocale(language);
   }
 }

--- a/mon-pix/app/controllers/inscription.js
+++ b/mon-pix/app/controllers/inscription.js
@@ -3,12 +3,10 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
-const DEFAULT_LOCALE = 'fr';
-
 export default class InscriptionController extends Controller {
-  @service intl;
-  @service dayjs;
   @service currentDomain;
+  @service intl;
+  @service locale;
   @service router;
 
   @tracked selectedLanguage = this.intl.primaryLocale;
@@ -18,14 +16,9 @@ export default class InscriptionController extends Controller {
   }
 
   @action
-  onLanguageChange(value) {
-    this.selectedLanguage = value;
-    this._setLocale(this.selectedLanguage);
+  onLanguageChange(language) {
+    this.selectedLanguage = language;
+    this.locale.setLocale(this.selectedLanguage);
     this.router.replaceWith('inscription', { queryParams: { lang: null } });
-  }
-
-  _setLocale(language) {
-    this.intl.setLocale([language, DEFAULT_LOCALE]);
-    this.dayjs.setLocale(language);
   }
 }

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -2,15 +2,18 @@ import Service, { inject as service } from '@ember/service';
 import config from 'mon-pix/config/environment';
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
-export const DEFAULT_LOCALE = 'fr';
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+export const FRENCH_FRANCE_LOCALE = 'fr-FR';
+export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
 
 const supportedLanguages = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
 
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
+  @service intl;
+  @service dayjs;
 
   handleUnsupportedLanguage(language) {
     if (!language) return;
@@ -28,5 +31,10 @@ export default class LocaleService extends Service {
       path: '/',
       sameSite: 'Strict',
     });
+  }
+
+  setLocale(locale) {
+    this.intl.setLocale(locale);
+    this.dayjs.setLocale(locale);
   }
 }

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -1,9 +1,8 @@
 import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
+import { DEFAULT_LOCALE, FRENCH_FRANCE_LOCALE } from 'mon-pix/services/locale';
 
-const DEFAULT_LOCALE = 'fr';
-const FRENCH_FRANCE_LOCALE = 'fr-FR';
 const FRANCE_TLD = 'fr';
 
 export default class CurrentSessionService extends SessionService {
@@ -93,7 +92,7 @@ export default class CurrentSessionService extends SessionService {
     const domain = this.currentDomain.getExtension();
 
     if (domain === FRANCE_TLD) {
-      await this._setLocale(DEFAULT_LOCALE);
+      await this.locale.setLocale(DEFAULT_LOCALE);
 
       if (!this.locale.hasLocaleCookie()) {
         this.locale.setLocaleCookie(FRENCH_FRANCE_LOCALE);
@@ -106,31 +105,26 @@ export default class CurrentSessionService extends SessionService {
         this.currentUser.user.lang = localeFromQueryParam;
         try {
           await this.currentUser.user.save({ adapterOptions: { lang: this.currentUser.user.lang } });
-          await this._setLocale(this.currentUser.user.lang);
+          await this.locale.setLocale(this.currentUser.user.lang);
         } catch (error) {
           const status = get(error, 'errors[0].status');
           if (status === '400') {
             this.currentUser.user.rollbackAttributes();
-            await this._setLocale(this.currentUser.user.lang);
+            await this.locale.setLocale(this.currentUser.user.lang);
           } else {
             throw error;
           }
         }
       } else {
-        await this._setLocale(this.currentUser.user.lang);
+        await this.locale.setLocale(this.currentUser.user.lang);
       }
     } else {
       if (localeFromQueryParam) {
-        await this._setLocale(localeFromQueryParam);
+        await this.locale.setLocale(localeFromQueryParam);
       } else {
-        await this._setLocale(DEFAULT_LOCALE);
+        await this.locale.setLocale(DEFAULT_LOCALE);
       }
     }
-  }
-
-  _setLocale(locale) {
-    this.intl.setLocale([locale, DEFAULT_LOCALE]);
-    this.dayjs.setLocale(locale);
   }
 
   _getRouteAfterInvalidation() {

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -6,19 +6,16 @@ module('Unit | Controller | user-account/language', function (hooks) {
   setupTest(hooks);
 
   let controller;
-  let dayjsSetLocaleStub;
-  let intlSetLocaleStub;
   let userSaveStub;
+  let setLocaleStub;
 
   hooks.beforeEach(function () {
-    dayjsSetLocaleStub = sinon.stub();
-    intlSetLocaleStub = sinon.stub();
     userSaveStub = sinon.stub();
+    setLocaleStub = sinon.stub();
 
     controller = this.owner.lookup('controller:authenticated/user-account/language');
     controller.currentUser = { user: { save: userSaveStub } };
-    controller.dayjs = { setLocale: dayjsSetLocaleStub };
-    controller.intl = { setLocale: intlSetLocaleStub };
+    controller.locale = { setLocale: setLocaleStub };
   });
 
   module('#onLanguageChange', function () {
@@ -34,8 +31,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
 
         // then
         sinon.assert.calledWith(userSaveStub, { adapterOptions: { lang: language } });
-        sinon.assert.calledWith(dayjsSetLocaleStub, language);
-        sinon.assert.calledWith(intlSetLocaleStub, language);
+        sinon.assert.calledWith(setLocaleStub, language);
         assert.ok(true);
       });
     });
@@ -51,8 +47,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
 
         // then
         sinon.assert.notCalled(userSaveStub);
-        sinon.assert.notCalled(dayjsSetLocaleStub);
-        sinon.assert.notCalled(intlSetLocaleStub);
+        sinon.assert.notCalled(setLocaleStub);
         assert.ok(true);
       });
     });

--- a/mon-pix/tests/unit/services/locale_test.js
+++ b/mon-pix/tests/unit/services/locale_test.js
@@ -10,6 +10,8 @@ module('Unit | Services | locale', function (hooks) {
   let localeService;
   let cookiesService;
   let currentDomainService;
+  let dayjsService;
+  let intlService;
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
@@ -18,6 +20,12 @@ module('Unit | Services | locale', function (hooks) {
     sinon.stub(cookiesService, 'exists');
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');
+
+    dayjsService = this.owner.lookup('service:dayjs');
+    sinon.stub(dayjsService, 'setLocale');
+
+    intlService = this.owner.lookup('service:intl');
+    sinon.stub(intlService, 'setLocale');
   });
 
   module('#handleUnsupportedLanguage', function () {
@@ -115,6 +123,21 @@ module('Unit | Services | locale', function (hooks) {
         sinon.assert.calledWith(cookiesService.exists, 'locale');
         assert.ok(hasCookieLocale);
       });
+    });
+  });
+
+  module('#setLocale', function () {
+    test('set app locale', function (assert) {
+      // given
+      const locale = DEFAULT_LOCALE;
+
+      // when
+      localeService.setLocale(locale);
+
+      // then
+      sinon.assert.calledWith(intlService.setLocale, locale);
+      sinon.assert.calledWith(dayjsService.setLocale, locale);
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -2,11 +2,10 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
+import { DEFAULT_LOCALE, FRENCH_FRANCE_LOCALE } from 'mon-pix/services/locale';
 
 const FRANCE_TLD = 'fr';
 const INTERNATIONAL_TLD = 'org';
-const DEFAULT_LOCALE = 'fr';
-const FRENCH_FRANCE_LOCALE = 'fr-FR';
 
 module('Unit | Services | session', function (hooks) {
   setupTest(hooks);
@@ -19,12 +18,11 @@ module('Unit | Services | session', function (hooks) {
     sessionService = this.owner.lookup('service:session');
     sessionService.currentUser = { load: sinon.stub(), user: null };
     sessionService.currentDomain = { getExtension: sinon.stub() };
-    sessionService.intl = { setLocale: sinon.stub() };
-    sessionService.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
     sessionService.locale = {
       setLocaleCookie: sinon.stub(),
       hasLocaleCookie: sinon.stub(),
       handleUnsupportedLanguage: sinon.stub(),
+      setLocale: sinon.stub(),
     };
     sessionService._getRouteAfterInvalidation = sinon.stub();
     sessionService._logoutUser = sinon.stub();
@@ -110,8 +108,7 @@ module('Unit | Services | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(sessionService.currentUser.load);
-        sinon.assert.calledWith(sessionService.intl.setLocale, [DEFAULT_LOCALE, DEFAULT_LOCALE]);
-        sinon.assert.calledWith(sessionService.dayjs.setLocale, DEFAULT_LOCALE);
+        sinon.assert.calledWith(sessionService.locale.setLocale, DEFAULT_LOCALE);
         assert.ok(true);
       });
     });
@@ -126,8 +123,7 @@ module('Unit | Services | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(sessionService.currentUser.load);
-        sinon.assert.calledWith(sessionService.intl.setLocale, [DEFAULT_LOCALE, DEFAULT_LOCALE]);
-        sinon.assert.calledWith(sessionService.dayjs.setLocale, DEFAULT_LOCALE);
+        sinon.assert.calledWith(sessionService.locale.setLocale, DEFAULT_LOCALE);
         assert.ok(true);
       });
 
@@ -141,8 +137,7 @@ module('Unit | Services | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(sessionService.currentUser.load);
-        sinon.assert.calledWith(sessionService.intl.setLocale, ['nl', DEFAULT_LOCALE]);
-        sinon.assert.calledWith(sessionService.dayjs.setLocale, 'nl');
+        sinon.assert.calledWith(sessionService.locale.setLocale, 'nl');
         assert.ok(true);
       });
     });
@@ -234,8 +229,7 @@ module('Unit | Services | session', function (hooks) {
             await sessionService.handleUserLanguageAndLocale(transition);
 
             // then
-            sinon.assert.calledWith(sessionService.intl.setLocale, ['de', DEFAULT_LOCALE]);
-            sinon.assert.calledWith(sessionService.dayjs.setLocale, 'de');
+            sinon.assert.calledWith(sessionService.locale.setLocale, 'de');
             assert.ok(true);
           });
         });
@@ -254,8 +248,7 @@ module('Unit | Services | session', function (hooks) {
 
               // then
               sinon.assert.calledWith(sessionService.currentUser.user.save, { adapterOptions: { lang: 'de' } });
-              sinon.assert.calledWith(sessionService.intl.setLocale, ['de', DEFAULT_LOCALE]);
-              sinon.assert.calledWith(sessionService.dayjs.setLocale, 'de');
+              sinon.assert.calledWith(sessionService.locale.setLocale, 'de');
               assert.strictEqual(sessionService.currentUser.user.lang, 'de');
             });
           });
@@ -280,8 +273,7 @@ module('Unit | Services | session', function (hooks) {
 
                 // then
                 sinon.assert.calledWith(sessionService.currentUser.user.save, { adapterOptions: { lang: 'de' } });
-                sinon.assert.calledWith(sessionService.intl.setLocale, ['ru', DEFAULT_LOCALE]);
-                sinon.assert.calledWith(sessionService.dayjs.setLocale, 'ru');
+                sinon.assert.calledWith(sessionService.locale.setLocale, 'ru');
                 assert.ok(true);
               });
             });
@@ -301,8 +293,7 @@ module('Unit | Services | session', function (hooks) {
             await sessionService.handleUserLanguageAndLocale();
 
             // then
-            sinon.assert.calledWith(sessionService.intl.setLocale, [DEFAULT_LOCALE, DEFAULT_LOCALE]);
-            sinon.assert.calledWith(sessionService.dayjs.setLocale, DEFAULT_LOCALE);
+            sinon.assert.calledWith(sessionService.locale.setLocale, DEFAULT_LOCALE);
             assert.ok(true);
           });
         });
@@ -317,8 +308,7 @@ module('Unit | Services | session', function (hooks) {
             await sessionService.handleUserLanguageAndLocale();
 
             // then
-            sinon.assert.calledWith(sessionService.intl.setLocale, ['ru', DEFAULT_LOCALE]);
-            sinon.assert.calledWith(sessionService.dayjs.setLocale, 'ru');
+            sinon.assert.calledWith(sessionService.locale.setLocale, 'ru');
             assert.ok(true);
           });
         });

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -3,9 +3,16 @@ import config from 'pix-orga/config/environment';
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 
+export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+export const FRENCH_FRANCE_LOCALE = 'fr-FR';
+export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
+  @service intl;
+  @service dayjs;
 
   hasLocaleCookie() {
     return this.cookies.exists('locale');
@@ -18,5 +25,10 @@ export default class LocaleService extends Service {
       path: '/',
       sameSite: 'Strict',
     });
+  }
+
+  setLocale(locale) {
+    this.intl.setLocale(locale);
+    this.dayjs.setLocale(locale);
   }
 }

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -1,9 +1,7 @@
 import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
-
-const FRENCH_INTERNATIONAL_LOCALE = 'fr';
-const FRENCH_FRANCE_LOCALE = 'fr-FR';
+import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-orga/services/locale';
 
 export default class CurrentSessionService extends SessionService {
   @service currentDomain;
@@ -36,7 +34,7 @@ export default class CurrentSessionService extends SessionService {
     }
 
     if (isFranceDomain) {
-      this._setLocale(FRENCH_INTERNATIONAL_LOCALE);
+      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
 
       if (!this.locale.hasLocaleCookie()) {
         this.locale.setLocaleCookie(FRENCH_FRANCE_LOCALE);
@@ -48,17 +46,12 @@ export default class CurrentSessionService extends SessionService {
     if (this._localeFromQueryParam) {
       await this._updatePrescriberLanguage(this._localeFromQueryParam);
 
-      this._setLocale(this._localeFromQueryParam);
+      this.locale.setLocale(this._localeFromQueryParam);
       return;
     }
 
     const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
-    this._setLocale(locale);
-  }
-
-  _setLocale(locale) {
-    this.intl.setLocale([locale, FRENCH_INTERNATIONAL_LOCALE]);
-    this.dayjs.setLocale(locale);
+    this.locale.setLocale(locale);
   }
 
   async _updatePrescriberLanguage(lang) {

--- a/orga/tests/helpers/setup-intl.js
+++ b/orga/tests/helpers/setup-intl.js
@@ -1,9 +1,8 @@
 export default function setupIntl(hooks, locale = ['fr']) {
   hooks.beforeEach(function () {
     this.intl = this.owner.lookup('service:intl');
-    this.intl.setLocale(locale);
-
+    this.localeService = this.owner.lookup('service:locale');
+    this.localeService.setLocale(locale[0]);
     this.dayjs = this.owner.lookup('service:dayjs');
-    this.dayjs.setLocale(locale[0]);
   });
 }

--- a/orga/tests/unit/services/locale_test.js
+++ b/orga/tests/unit/services/locale_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import { DEFAULT_LOCALE } from 'pix-orga/services/locale';
 
 module('Unit | Service | locale', function (hooks) {
   setupTest(hooks);
@@ -8,6 +9,8 @@ module('Unit | Service | locale', function (hooks) {
   let localeService;
   let cookiesService;
   let currentDomainService;
+  let dayjsService;
+  let intlService;
 
   hooks.beforeEach(function () {
     localeService = this.owner.lookup('service:locale');
@@ -18,6 +21,12 @@ module('Unit | Service | locale', function (hooks) {
 
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');
+
+    dayjsService = this.owner.lookup('service:dayjs');
+    sinon.stub(dayjsService, 'setLocale');
+
+    intlService = this.owner.lookup('service:intl');
+    sinon.stub(intlService, 'setLocale');
   });
 
   module('#setLocaleCookie', function () {
@@ -66,6 +75,21 @@ module('Unit | Service | locale', function (hooks) {
         sinon.assert.calledWith(cookiesService.exists, 'locale');
         assert.ok(hasCookieLocale);
       });
+    });
+  });
+
+  module('#setLocale', function () {
+    test('set app locale', function (assert) {
+      // given
+      const locale = DEFAULT_LOCALE;
+
+      // when
+      localeService.setLocale(locale);
+
+      // then
+      sinon.assert.calledWith(intlService.setLocale, locale);
+      sinon.assert.calledWith(dayjsService.setLocale, locale);
+      assert.ok(true);
     });
   });
 });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -58,11 +58,11 @@ module('Unit | Service | session', function (hooks) {
         test('adds a cookie locale with "fr-FR" as value', async function (assert) {
           // given
           localeService.hasLocaleCookie.returns(false);
-
-          // when
           const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
+
+          // when
           await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
@@ -75,11 +75,11 @@ module('Unit | Service | session', function (hooks) {
         test('does not update cookie locale', async function (assert) {
           // given
           localeService.hasLocaleCookie.returns(true);
-
-          // when
           const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
+
+          // when
           await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
@@ -96,11 +96,11 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-
-            // when
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -119,11 +119,11 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-
-            // when
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = 'en';
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -142,11 +142,11 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-
-            // when
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
             const userLocale = undefined;
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -165,11 +165,11 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-
-            // when
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
             const userLocale = 'en';
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -185,11 +185,11 @@ module('Unit | Service | session', function (hooks) {
       test('does not set the cookie locale', async function (assert) {
         // given
         localeService.hasLocaleCookie.returns(false);
-
-        // when
         const isFranceDomain = false;
         const localeFromQueryParam = undefined;
         const userLocale = undefined;
+
+        // when
         await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
@@ -205,11 +205,11 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-
-            // when
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -228,11 +228,11 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-
-            // when
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = 'en';
+
+            // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
@@ -252,11 +252,11 @@ module('Unit | Service | session', function (hooks) {
                 load: sinon.stub(),
                 prescriber: null,
               };
-
-              // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
@@ -275,11 +275,11 @@ module('Unit | Service | session', function (hooks) {
                   save: sinon.stub(),
                 },
               };
-
-              // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = 'en';
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
@@ -298,11 +298,11 @@ module('Unit | Service | session', function (hooks) {
                 load: sinon.stub(),
                 prescriber: null,
               };
-
-              // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
               const userLocale = undefined;
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
@@ -321,11 +321,11 @@ module('Unit | Service | session', function (hooks) {
                   save: sinon.stub(),
                 },
               };
-
-              // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
               const userLocale = 'fr';
+
+              // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -1,10 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
-
-const DEFAULT_LOCALE = 'fr';
-const FRENCH_INTERNATIONAL_LOCALE = 'fr';
-const FRENCH_FRANCE_LOCALE = 'fr-FR';
+import { DEFAULT_LOCALE, FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-orga/services/locale';
 
 module('Unit | Service | session', function (hooks) {
   setupTest(hooks);
@@ -23,6 +20,7 @@ module('Unit | Service | session', function (hooks) {
     Object.assign(localeService, {
       setLocaleCookie: sinon.stub(),
       hasLocaleCookie: sinon.stub(),
+      setLocale: sinon.stub(),
     });
   });
 
@@ -98,7 +96,6 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
@@ -107,7 +104,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -122,7 +119,6 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
@@ -131,7 +127,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             sinon.assert.notCalled(service.currentUser.prescriber.save);
             assert.ok(true);
           });
@@ -146,7 +142,6 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
@@ -155,7 +150,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -170,7 +165,6 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
@@ -179,7 +173,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
             sinon.assert.notCalled(service.currentUser.prescriber.save);
             assert.ok(true);
           });
@@ -211,7 +205,6 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = false;
@@ -220,7 +213,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
+            sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
             assert.ok(true);
           });
         });
@@ -235,7 +228,6 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = false;
@@ -244,7 +236,7 @@ module('Unit | Service | session', function (hooks) {
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(service._setLocale, 'en');
+            sinon.assert.calledWith(localeService.setLocale, 'en');
             sinon.assert.notCalled(service.currentUser.prescriber.save);
             assert.ok(true);
           });
@@ -260,7 +252,6 @@ module('Unit | Service | session', function (hooks) {
                 load: sinon.stub(),
                 prescriber: null,
               };
-              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
@@ -269,7 +260,7 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
+              sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
               assert.ok(true);
             });
           });
@@ -284,7 +275,6 @@ module('Unit | Service | session', function (hooks) {
                   save: sinon.stub(),
                 },
               };
-              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
@@ -293,7 +283,7 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, 'en');
               sinon.assert.notCalled(service.currentUser.prescriber.save);
               assert.ok(true);
             });
@@ -308,7 +298,6 @@ module('Unit | Service | session', function (hooks) {
                 load: sinon.stub(),
                 prescriber: null,
               };
-              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
@@ -317,7 +306,7 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, 'en');
               assert.ok(true);
             });
           });
@@ -332,7 +321,6 @@ module('Unit | Service | session', function (hooks) {
                   save: sinon.stub(),
                 },
               };
-              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
@@ -341,7 +329,7 @@ module('Unit | Service | session', function (hooks) {
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, 'en');
               sinon.assert.calledWith(service.currentUser.prescriber.save, {
                 adapterOptions: { lang: 'en' },
               });
@@ -350,22 +338,6 @@ module('Unit | Service | session', function (hooks) {
           });
         });
       });
-    });
-  });
-
-  module('#_setLocale', function () {
-    test('calls intl and dayjs services', async function (assert) {
-      // given
-      service.intl = { setLocale: sinon.stub() };
-      service.dayjs = { setLocale: sinon.stub() };
-
-      // when
-      await service._setLocale('some locale');
-
-      // then
-      sinon.assert.calledWith(service.intl.setLocale, ['some locale', 'fr']);
-      sinon.assert.calledWith(service.dayjs.setLocale, 'some locale');
-      assert.ok(true);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le code permettant de changer, fixer une locale est un peu éparpillée et dupliquée dans tout les apps Pix.
  
```
this.intl.setLocale(locale)
this.dayjs.setLocale(locale)
```

## :robot: Proposition
Solution : 
Centraliser ce code dans le localeService (locale.js) pour chaque app fait pour ça.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
### Tests de non régression
#### Pix App 
- Vérifier que le langage switcher fonctionne bien sur les pages d'inscription / connexion
- Se connecter
- Aller sur Mon compte -> Choisir ma langue
- Changer la langue de l'utilisateur en français / anglais
- Vérifier que la page s'est bien mis à jour avec la bonne langue.
- En rafraîchissant la page, voir que la modification de la langue a bien été conservée.

#### Pix Certif
- Se connecter sur la [review app](https://certif-pr6136.review.pix.org/)
- Changer la langue de l'utilisateur en ajoutant, dans l'url, le query param ?lang=en
- Vérifier que la langue de la page a bien été modifié
- Rafraîchir et constater que les modifications sur la langue ont bien été conservé.

#### Pix Orga
- Se connecter sur la [review app](https://orga-pr6136.review.pix.org/)
- Changer la langue de l'utilisateur en ajoutant, dans l'url, le query param ?lang=en
- Vérifier que la langue de la page a bien été modifié
- Rafraîchir et constater que les modifications sur la langue ont bien été conservé.