### PR TITLE
[FEATURE] Vérification de l'égilibité des candidats à une certif compl. dans l'espace surveillant (PIX-7833).

### DIFF
--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -12,6 +12,7 @@ class CertificationCandidateForSupervising {
     assessmentStatus,
     startDateTime,
     enrolledComplementaryCertification,
+    stillValidBadgeAcquisitions = [],
   } = {}) {
     this.id = id;
     this.userId = userId;
@@ -23,6 +24,7 @@ class CertificationCandidateForSupervising {
     this.assessmentStatus = assessmentStatus;
     this.startDateTime = startDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
+    this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
   }
 
   authorizeToStart() {

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -3,6 +3,7 @@ const isNil = require('lodash/isNil');
 class CertificationCandidateForSupervising {
   constructor({
     id,
+    userId,
     firstName,
     lastName,
     birthdate,
@@ -13,6 +14,7 @@ class CertificationCandidateForSupervising {
     enrolledComplementaryCertification,
   } = {}) {
     this.id = id;
+    this.userId = userId;
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthdate = birthdate;

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -10,7 +10,7 @@ class CertificationCandidateForSupervising {
     authorizedToStart,
     assessmentStatus,
     startDateTime,
-    complementaryCertification,
+    enrolledComplementaryCertification,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -20,7 +20,7 @@ class CertificationCandidateForSupervising {
     this.authorizedToStart = authorizedToStart;
     this.assessmentStatus = assessmentStatus;
     this.startDateTime = startDateTime;
-    this.complementaryCertification = complementaryCertification;
+    this.enrolledComplementaryCertification = enrolledComplementaryCertification;
   }
 
   authorizeToStart() {

--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -30,6 +30,13 @@ class CertificationCandidateForSupervising {
   authorizeToStart() {
     this.authorizedToStart = true;
   }
+
+  get isStillEligibleToComplementaryCertification() {
+    return this.stillValidBadgeAcquisitions.some(
+      (stillValidBadgeAcquisition) =>
+        stillValidBadgeAcquisition.complementaryCertificationBadgeLabel === this.enrolledComplementaryCertification
+    );
+  }
 }
 
 module.exports = CertificationCandidateForSupervising;

--- a/api/lib/domain/usecases/get-session-for-supervising.js
+++ b/api/lib/domain/usecases/get-session-for-supervising.js
@@ -1,3 +1,19 @@
-module.exports = async function getSessionForSupervising({ sessionId, sessionForSupervisingRepository }) {
-  return await sessionForSupervisingRepository.get(sessionId);
+const bluebird = require('bluebird');
+module.exports = async function getSessionForSupervising({
+  sessionId,
+  sessionForSupervisingRepository,
+  certificationBadgesService,
+}) {
+  const sessionForSupervising = await sessionForSupervisingRepository.get(sessionId);
+
+  await bluebird.mapSeries(sessionForSupervising.certificationCandidates, async (certificationCandidate) => {
+    if (certificationCandidate.enrolledComplementaryCertification) {
+      certificationCandidate.stillValidBadgeAcquisitions =
+        await certificationBadgesService.findStillValidBadgeAcquisitions({
+          userId: certificationCandidate.userId,
+        });
+    }
+  });
+
+  return sessionForSupervising;
 };

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -24,7 +24,7 @@ module.exports = {
             'authorizedToStart', "certification-candidates"."authorizedToStart",
             'assessmentStatus', "assessments"."state",
             'startDateTime', "certification-courses"."createdAt",
-            'complementaryCertification', "complementary-certifications"."label"
+            'enrolledComplementaryCertification', "complementary-certifications"."label"
           ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
       `),
       })

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -16,6 +16,7 @@ module.exports = {
         certificationCenterName: 'certification-centers.name',
         certificationCandidates: knex.raw(`
           json_agg(json_build_object(
+            'userId', "certification-candidates"."userId",
             'firstName', "certification-candidates"."firstName",
             'lastName', "certification-candidates"."lastName",
             'birthdate', "certification-candidates"."birthdate",

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -29,7 +29,7 @@ module.exports = {
       certificationCandidates: {
         included: true,
         ref: 'id',
-        attributes: [...attributes],
+        attributes: [...attributes, 'isStillEligibleToComplementaryCertification'],
       },
     }).serialize(sessions);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -9,7 +9,7 @@ const attributes = [
   'authorizedToStart',
   'assessmentStatus',
   'startDateTime',
-  'complementaryCertification',
+  'enrolledComplementaryCertification',
 ];
 
 module.exports = {

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -29,7 +29,7 @@ module.exports = {
       certificationCandidates: {
         included: true,
         ref: 'id',
-        attributes: [...attributes, 'isStillEligibleToComplementaryCertification'],
+        attributes: [...attributes, 'isStillEligibleToComplementaryCertification', 'userId'],
       },
     }).serialize(sessions);
   },

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -45,6 +45,7 @@ describe('Integration | Repository | certification candidate for supervising', f
             lastName: 'Joplin',
             assessmentStatus: 'started',
             startDateTime: new Date('2022-10-01T14:00:00Z'),
+            stillValidBadgeAcquisitions: undefined,
           })
         );
       });

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -36,7 +36,7 @@ describe('Integration | Repository | certification candidate for supervising', f
         expect(result).to.deep.equal(
           domainBuilder.buildCertificationCandidateForSupervising({
             sessionId: session.id,
-            userId: 1234,
+            userId: candidate.userId,
             authorizedToStart: false,
             birthdate: '2000-01-04',
             extraTimePercentage: '0.30',

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -52,18 +52,24 @@ describe('Integration | Repository | SessionForSupervising', function () {
         certificationCenterId: 1234,
       });
 
+      databaseBuilder.factory.buildUser({ id: 11111 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
         lastName: 'Jackson',
         firstName: 'Michael',
         sessionId: session.id,
         authorizedToStart: true,
       });
+      databaseBuilder.factory.buildUser({ id: 22222 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
         lastName: 'Stardust',
         firstName: 'Ziggy',
         sessionId: session.id,
       });
+      databaseBuilder.factory.buildUser({ id: 33333 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 33333,
         lastName: 'Jackson',
         firstName: 'Janet',
         sessionId: session.id,
@@ -95,10 +101,19 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart', 'assessmentStatus', 'startDateTime'])
+        _.pick(item, [
+          'userId',
+          'sessionId',
+          'lastName',
+          'firstName',
+          'authorizedToStart',
+          'assessmentStatus',
+          'startDateTime',
+        ])
       );
       expect(actualCandidates).to.have.deep.ordered.members([
         {
+          userId: 33333,
           lastName: 'Jackson',
           firstName: 'Janet',
           authorizedToStart: false,
@@ -106,6 +121,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           startDateTime: null,
         },
         {
+          userId: 11111,
           lastName: 'Jackson',
           firstName: 'Michael',
           authorizedToStart: true,
@@ -113,6 +129,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           startDateTime: null,
         },
         {
+          userId: 12345,
           lastName: 'Joplin',
           firstName: 'Janis',
           authorizedToStart: true,
@@ -120,6 +137,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           startDateTime: '2022-10-19T13:37:00+00:00',
         },
         {
+          userId: 22222,
           lastName: 'Stardust',
           firstName: 'Ziggy',
           authorizedToStart: false,
@@ -141,13 +159,17 @@ describe('Integration | Repository | SessionForSupervising', function () {
         certificationCenterId: 1234,
       });
 
+      databaseBuilder.factory.buildUser({ id: 11111 });
       const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+        userId: 11111,
         lastName: 'Jackson',
         firstName: 'Janet',
         sessionId: session.id,
       });
 
+      databaseBuilder.factory.buildUser({ id: 22222 });
       databaseBuilder.factory.buildCertificationCandidate({
+        userId: 22222,
         lastName: 'Joplin',
         firstName: 'Janis',
         sessionId: session.id,
@@ -170,16 +192,18 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
+        _.pick(item, ['userId', 'sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
         {
+          userId: 11111,
           lastName: 'Jackson',
           firstName: 'Janet',
           enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
         },
         {
+          userId: 22222,
           lastName: 'Joplin',
           firstName: 'Janis',
           enrolledComplementaryCertification: null,

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -170,19 +170,19 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'complementaryCertification'])
+        _.pick(item, ['sessionId', 'lastName', 'firstName', 'enrolledComplementaryCertification'])
       );
 
       expect(actualCandidates).to.have.deep.ordered.members([
         {
           lastName: 'Jackson',
           firstName: 'Janet',
-          complementaryCertification: 'Pix+ Édu 1er degré',
+          enrolledComplementaryCertification: 'Pix+ Édu 1er degré',
         },
         {
           lastName: 'Joplin',
           firstName: 'Janis',
-          complementaryCertification: null,
+          enrolledComplementaryCertification: null,
         },
       ]);
     });

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -9,7 +9,8 @@ module.exports = function buildCertificationCandidateForSupervising({
   authorizedToStart = false,
   assessmentStatus = null,
   startDateTime = new Date('2022-10-01T12:00:00Z'),
-  complementaryCertification,
+  enrolledComplementaryCertification,
+  stillValidBadgeAcquisitions,
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,
@@ -20,6 +21,7 @@ module.exports = function buildCertificationCandidateForSupervising({
     authorizedToStart,
     assessmentStatus,
     startDateTime,
-    complementaryCertification,
+    enrolledComplementaryCertification,
+    stillValidBadgeAcquisitions,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -2,6 +2,7 @@ const CertificationCandidateForSupervising = require('../../../../lib/domain/mod
 
 module.exports = function buildCertificationCandidateForSupervising({
   id = 123,
+  userId = 345,
   firstName = 'Monkey',
   lastName = 'D Luffy',
   birthdate = '1997-07-22',
@@ -14,6 +15,7 @@ module.exports = function buildCertificationCandidateForSupervising({
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,
+    userId,
     firstName,
     lastName,
     birthdate,

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -11,7 +11,7 @@ module.exports = function buildCertificationCandidateForSupervising({
   assessmentStatus = null,
   startDateTime = new Date('2022-10-01T12:00:00Z'),
   enrolledComplementaryCertification,
-  stillValidBadgeAcquisitions,
+  stillValidBadgeAcquisitions = [],
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,

--- a/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -33,7 +33,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
             });
 
             // when
-            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+            const isStillEligibleToComplementaryCertification =
+              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
 
             // then
             expect(isStillEligibleToComplementaryCertification).to.be.true;
@@ -52,7 +53,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
             });
 
             // when
-            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+            const isStillEligibleToComplementaryCertification =
+              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
 
             // then
             expect(isStillEligibleToComplementaryCertification).to.be.false;
@@ -75,7 +77,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
             });
 
             // when
-            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+            const isStillEligibleToComplementaryCertification =
+              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
 
             // then
             expect(isStillEligibleToComplementaryCertification).to.be.false;
@@ -93,7 +96,8 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
         });
 
         // when
-        const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+        const isStillEligibleToComplementaryCertification =
+          certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
 
         // then
         expect(isStillEligibleToComplementaryCertification).to.be.false;

--- a/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -15,4 +15,89 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
       expect(certificationCandidateForSupervising.authorizedToStart).to.be.true;
     });
   });
+
+  describe('#isStillEligibleToComplementaryCertification', function () {
+    context('when candidate has a complementary certification', function () {
+      context(
+        'when candidate has still valid badge acquisition related to his complementary certification',
+        function () {
+          it('Should return true', function () {
+            // given
+            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+              enrolledComplementaryCertification: 'Une certif complémentaire',
+              stillValidBadgeAcquisitions: [
+                domainBuilder.buildCertifiableBadgeAcquisition({
+                  complementaryCertificationBadgeLabel: 'Une certif complémentaire',
+                }),
+              ],
+            });
+
+            // when
+            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+
+            // then
+            expect(isStillEligibleToComplementaryCertification).to.be.true;
+          });
+        }
+      );
+
+      context(
+        'when candidate has no still valid badge acquisition related to his complementary certification',
+        function () {
+          it('Should return false', function () {
+            // given
+            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+              enrolledComplementaryCertification: 'Une certif complémentaire',
+              stillValidBadgeAcquisitions: [],
+            });
+
+            // when
+            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+
+            // then
+            expect(isStillEligibleToComplementaryCertification).to.be.false;
+          });
+        }
+      );
+
+      context(
+        'when candidate has still valid badge acquisition  not related to his complementary certification',
+        function () {
+          it('Should return false', function () {
+            // given
+            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+              enrolledComplementaryCertification: 'Une certif complémentaire',
+              stillValidBadgeAcquisitions: [
+                domainBuilder.buildCertifiableBadgeAcquisition({
+                  complementaryCertificationBadgeLabel: 'Une autre certif complémentaire',
+                }),
+              ],
+            });
+
+            // when
+            const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+
+            // then
+            expect(isStillEligibleToComplementaryCertification).to.be.false;
+          });
+        }
+      );
+    });
+
+    context('when candidate has no complementary certification', function () {
+      it('Should return false', function () {
+        // given
+        const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+          enrolledComplementaryCertification: null,
+          stillValidBadgeAcquisitions: [],
+        });
+
+        // when
+        const isStillEligibleToComplementaryCertification = certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+
+        // then
+        expect(isStillEligibleToComplementaryCertification).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/unit/domain/usecases/get-session-for-supervising_test.js
@@ -15,5 +15,99 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
       // then
       expect(actualSession).to.equal(expectedSession);
     });
+
+    context('when there are candidates', function () {
+      context('when some candidates are still eligible to complementary certifications', function () {
+        it("should return the session with the candidates' eligibility", async function () {
+          // given
+          const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+            complementaryCertificationBadgeLabel: 'une certif complémentaire',
+          });
+
+          const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
+            certificationCandidates: [
+              domainBuilder.buildCertificationCandidateForSupervising({
+                userId: 1234,
+                enrolledComplementaryCertification: 'une certif complémentaire',
+                stillValidBadgeAcquisitions: [],
+              }),
+            ],
+          });
+
+          const sessionForSupervisingRepository = { get: sinon.stub() };
+          sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+          const certificationBadgesService = {
+            findStillValidBadgeAcquisitions: sinon.stub(),
+          };
+          certificationBadgesService.findStillValidBadgeAcquisitions
+            .withArgs({ userId: 1234 })
+            .resolves([stillValidBadgeAcquisition]);
+
+          // when
+          const actualSession = await getSessionForSupervising({
+            sessionId: 1,
+            sessionForSupervisingRepository,
+            certificationBadgesService,
+          });
+
+          // then
+          expect(actualSession).to.deep.equal(
+            domainBuilder.buildSessionForSupervising({
+              certificationCandidates: [
+                domainBuilder.buildCertificationCandidateForSupervising({
+                  userId: 1234,
+                  enrolledComplementaryCertification: 'une certif complémentaire',
+                  stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
+                }),
+              ],
+            })
+          );
+        });
+      });
+
+      context('when some candidates are not eligible to complementary certifications', function () {
+        it("should return the session with the candidates' non eligibility", async function () {
+          // given
+          const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
+            certificationCandidates: [
+              domainBuilder.buildCertificationCandidateForSupervising({
+                userId: 1234,
+                enrolledComplementaryCertification: 'une certif complémentaire',
+                stillValidBadgeAcquisitions: [],
+              }),
+            ],
+          });
+
+          const sessionForSupervisingRepository = { get: sinon.stub() };
+          sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+          const certificationBadgesService = {
+            findStillValidBadgeAcquisitions: sinon.stub(),
+          };
+          certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
+
+          // when
+          const actualSession = await getSessionForSupervising({
+            sessionId: 1,
+            sessionForSupervisingRepository,
+            certificationBadgesService,
+          });
+
+          // then
+          expect(actualSession).to.deep.equal(
+            domainBuilder.buildSessionForSupervising({
+              certificationCandidates: [
+                domainBuilder.buildCertificationCandidateForSupervising({
+                  userId: 1234,
+                  enrolledComplementaryCertification: 'une certif complémentaire',
+                  stillValidBadgeAcquisitions: [],
+                }),
+              ],
+            })
+          );
+        });
+      });
+    });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -40,7 +40,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'authorized-to-start': true,
               'assessment-status': Assessment.states.STARTED,
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
-              'complementary-certification': 'Super Certification Complémentaire',
+              'enrolled-complementary-certification': 'Super Certification Complémentaire',
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -67,7 +67,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             authorizedToStart: true,
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
-            complementaryCertification: 'Super Certification Complémentaire',
+            enrolledComplementaryCertification: 'Super Certification Complémentaire',
           },
         ],
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -1,6 +1,7 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer');
 const Assessment = require('../../../../../lib/domain/models/Assessment');
+const { CertificationCandidateForSupervising } = require('../../../../../lib/domain/models');
 
 describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', function () {
   describe('#serialize()', function () {
@@ -41,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'assessment-status': Assessment.states.STARTED,
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
               'enrolled-complementary-certification': 'Super Certification Complémentaire',
+              'is-still-eligible-to-complementary-certification': true,
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -58,7 +60,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
         time: '14:30',
         certificationCenterName: 'Toto',
         certificationCandidates: [
-          {
+          new CertificationCandidateForSupervising({
             id: 1234,
             firstName: 'toto',
             lastName: 'tata',
@@ -68,7 +70,12 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
             enrolledComplementaryCertification: 'Super Certification Complémentaire',
-          },
+            stillValidBadgeAcquisitions: [
+              domainBuilder.buildCertifiableBadgeAcquisition({
+                complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
+              }),
+            ],
+          }),
         ],
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -43,6 +43,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
               'enrolled-complementary-certification': 'Super Certification Complémentaire',
               'is-still-eligible-to-complementary-certification': true,
+              'user-id': 6789,
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -62,6 +63,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
         certificationCandidates: [
           new CertificationCandidateForSupervising({
             id: 1234,
+            userId: 6789,
             firstName: 'toto',
             lastName: 'tata',
             birthdate: '28/05/1984',

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -22,12 +22,12 @@
         :
         {{format-percentage @candidate.extraTimePercentage}}
       {{/if}}
-      {{#if this.shouldDisplayComplementaryCertification}}
+      {{#if this.shouldDisplayEnrolledComplementaryCertification}}
         <p class="session-supervising-candidate-in-list-details__enrolment">
           <span class="session-supervising-candidate-in-list-details-enrolment__icon"><FaIcon @icon="award" /></span>
           {{t
             "pages.session-supervising.candidate-in-list.complementary-certification-enrolment"
-            complementaryCertification=@candidate.complementaryCertification
+            complementaryCertification=@candidate.enrolledComplementaryCertification
           }}
         </p>
       {{/if}}

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -31,6 +31,17 @@
           }}
         </p>
       {{/if}}
+
+      {{#if this.shouldDisplayNonEligibilityWarning}}
+        <PixMessage
+          @type="warning"
+          @withIcon={{true}}
+          class="session-supervising-candidate-in-list-details__eligibility"
+        >
+          Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.
+        </PixMessage>
+      {{/if}}
+
     </div>
     {{#if this.isConfirmButtonToBeDisplayed}}
       <PixButton

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -38,7 +38,7 @@
           @withIcon={{true}}
           class="session-supervising-candidate-in-list-details__eligibility"
         >
-          Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.
+          {{t "pages.session-supervising.candidate-in-list.complementary-certification-non-eligibility-warning"}}
         </PixMessage>
       {{/if}}
 

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -38,9 +38,9 @@ export default class CandidateInList extends Component {
     return this.args.candidate.hasStarted;
   }
 
-  get shouldDisplayComplementaryCertification() {
+  get shouldDisplayEnrolledComplementaryCertification() {
     return (
-      this.args.candidate.complementaryCertification &&
+      this.args.candidate.enrolledComplementaryCertification &&
       this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
     );
   }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -1,6 +1,5 @@
-import { set } from '@ember/object';
+import { action, set } from '@ember/object';
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import dayjs from 'dayjs';
@@ -42,6 +41,23 @@ export default class CandidateInList extends Component {
     return (
       this.args.candidate.enrolledComplementaryCertification &&
       this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
+    );
+  }
+
+  get shouldDisplayNonEligibilityWarning() {
+    return this._isReconciliated() && this._isNotEligibleToEnrolledComplementaryCertification();
+  }
+
+  _isNotEligibleToEnrolledComplementaryCertification() {
+    return (
+      !this.args.candidate.isStillEligibleToComplementaryCertification &&
+      this.args.candidate.enrolledComplementaryCertification
+    );
+  }
+
+  _isReconciliated() {
+    return (
+      this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled && this.args.candidate.userId
     );
   }
 

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -16,7 +16,7 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('boolean') authorizedToStart;
   @attr('string') assessmentStatus;
   @attr('date') startDateTime;
-  @attr('string') complementaryCertification;
+  @attr('string') enrolledComplementaryCertification;
 
   get hasStarted() {
     return this.assessmentStatus === 'started';

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -17,6 +17,8 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('string') assessmentStatus;
   @attr('date') startDateTime;
   @attr('string') enrolledComplementaryCertification;
+  @attr('string') userId;
+  @attr('boolean') isStillEligibleToComplementaryCertification;
 
   get hasStarted() {
     return this.assessmentStatus === 'started';

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -79,6 +79,10 @@
     font-weight: normal;
     line-height: 1.3125rem;
   }
+
+  &__eligibility {
+    margin-top: $pix-spacing-xxs;
+  }
 }
 
 .session-supervising-candidate-in-list-details-enrolment {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -22,7 +22,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function () {
-    test('should render the complementary certification name of the candidate if he passes one', async function (assert) {
+    test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
       class FeatureTogglesStub extends Service {
         featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
       }
@@ -30,7 +30,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 123,
-        complementaryCertification: 'Super Certification Complémentaire',
+        enrolledComplementaryCertification: 'Super Certification Complémentaire',
       });
 
       // when
@@ -198,7 +198,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       extraTimePercentage: '8',
       authorizedToStart: false,
       assessmentStatus: null,
-      complementaryCertification: 'Super Certification Complémentaire',
+      enrolledComplementaryCertification: 'Super Certification Complémentaire',
     });
 
     // when

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -306,6 +306,7 @@
         },
         "candidate-options": "Candidate's options",
         "complementary-certification-enrolment": "{complementaryCertification} enrolment",
+        "complementary-certification-non-eligibility-warning": "Candidate isn't or is no longer eligible for the additional certification. They are taking the Pix certification exam only.",
         "display-candidate-options": "Display the candidate's options",
         "resume-test-modal": {
           "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -306,6 +306,7 @@
         },
         "candidate-options": "Options du candidat",
         "complementary-certification-enrolment": "Inscription à {complementaryCertification}",
+        "complementary-certification-non-eligibility-warning": "Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.",
         "display-candidate-options": "Afficher les options du candidat",
         "resume-test-modal": {
           "actions": {


### PR DESCRIPTION
## :unicorn: Problème

Le surveillant n’a actuellement aucun moyen d'être alerté en cas de différence entre la certification (complémentaire ou non) que le candidat est effectivement en train de passer et celle à pour laquelle il a été inscrit.

Impossible donc pour lui d’alerter à son tour le candidat ni de connaître/justifier de la nouvelle durée de certification et l’heure à laquelle doit terminer chaque candidat en se basant sur les informations de l’Espace Surveillant.

## :robot: Proposition

Vérification de l'éligibilité du candidat à la certif complémentaire qu'iel doit passer dans le usecase de récupération de la session.

## :rainbow: Remarques

On renvoie également le userId du candidat afin de déterminer si celui-ci est réconcilié ou non afin d'afficher l'avertissement.

## :100: Pour tester

Se connecter sur pix-certif avec le compte `certifsup@example.net`
Se connecter à l'espace surveillant  de la session `106420`

Dans cette session ont été ajoutés 3 candidats qui ont été réconciliés : 
- Tata (Pas de certification complémentaire)
- Titi (Inscrit à Pix+ Droit mais non éligible)
- Toto (Inscrit à Cléa et éligible)

Vérifier que seul Titi dispose d'un avertissement stipulant qu'il n'est plus éligible à la certification complémentaire.

(A réaliser en version `.fr` et `.org` avec `?lang=en`) 