### PR TITLE
[BUGFIX] Affichage du temps majoré dans l'Espace Surveillant (PIX-7835)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -27,7 +27,7 @@
         ·
         {{t "common.forms.certification-labels.extratime"}}
         :
-        {{@candidate.extraTimePercentage}}%
+        {{format-percentage @candidate.extraTimePercentage}}
       {{/if}}
       {{#if this.shouldDisplayComplementaryCertification}}
         <p class="session-supervising-candidate-in-list-details__enrolment">

--- a/certif/app/helpers/format-percentage.js
+++ b/certif/app/helpers/format-percentage.js
@@ -2,13 +2,11 @@ import { helper } from '@ember/component/helper';
 
 export function formatPercentage([value, ..._]) {
   if (value) {
-    return `${truncateDecimalPlaces(value)} %`;
+    const percentageValue = value < 1 ? value * 100 : value;
+
+    return `${Math.trunc(percentageValue)} %`;
   }
   return '';
-}
-
-function truncateDecimalPlaces(value) {
-  return Math.trunc(value * 100);
 }
 
 export default helper(formatPercentage);

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -76,7 +76,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     assert.dom(screen.getByRole('cell', { name: certificationCandidate.lastName })).exists();
     assert.dom(screen.getByRole('cell', { name: certificationCandidate.firstName })).exists();
     assert.dom(screen.getByRole('cell', { name: certificationCandidate.resultRecipientEmail })).exists();
-    assert.dom(screen.getByRole('cell', { name: '3000 %' })).exists();
+    assert.dom(screen.getByRole('cell', { name: '30 %' })).exists();
     assert.dom(screen.getByRole('cell', { name: 'Pix+Edu, Pix+Droit' })).exists();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCity })).doesNotExist();
     assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthProvinceCode })).doesNotExist();

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -63,7 +63,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
     // then
     assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
-    assert.dom(screen.getByText('28/05/1984 · Temps majoré : 8%')).exists();
+    assert.dom(screen.getByText('28/05/1984 · Temps majoré : 8 %')).exists();
     assert.dom(screen.queryByText('Inscription à Super Certification Complémentaire')).doesNotExist();
     assert.dom(screen.getByRole('checkbox', { name: 'Zen Whoberi Ben Titan Gamora' })).isNotChecked();
   });
@@ -88,7 +88,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
       // then
       assert.dom(screen.getByText('Lord Star')).exists();
-      assert.dom(screen.getByText('28/06/1983 · Temps majoré : 12%')).exists();
+      assert.dom(screen.getByText('28/06/1983 · Temps majoré : 12 %')).exists();
       assert.dom(screen.getByRole('checkbox', { name: 'Lord Star' })).isChecked();
     });
 

--- a/certif/tests/unit/helpers/format-percentage_test.js
+++ b/certif/tests/unit/helpers/format-percentage_test.js
@@ -13,6 +13,17 @@ module('Unit | Helpers | format-percentage', function () {
     assert.strictEqual(result, '28 %');
   });
 
+  test('it renders a percentage when value is above 1', function (assert) {
+    // given
+    const value = 33;
+
+    // when
+    const result = formatPercentage([value]);
+
+    // then
+    assert.strictEqual(result, '33 %');
+  });
+
   test('it renders a percentage symbol', function (assert) {
     // given
     const value = 0.3;


### PR DESCRIPTION
## :unicorn: Problème
Lors de la surveillance d’une session de certification, le surveillant se connecte sur l’Espace Surveillant. Il y dispose d’un certain nombre d’informations concernant les candidats et la session qui sont sous sa surveillance notamment les éventuels temps majorés accordés pour certains candidats.

## :robot: Proposition
Un temps majoré de 33% est affiché 0,33% dans l’Espace Surveillant.
