### PR TITLE
[FEATURE] Modifier le tri des participations d'un utilisateur pour les regrouper par code campagne (PIX-5389)

### DIFF
--- a/api/lib/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-user-management-repository.js
@@ -23,7 +23,8 @@ module.exports = {
       .innerJoin('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
       .leftJoin('users as deletedByUsers', 'deletedByUsers.id', 'campaign-participations.deletedBy')
       .where('campaign-participations.userId', userId)
-      .orderBy('createdAt', 'desc');
+      .orderBy('campaignCode', 'asc')
+      .orderBy('sharedAt', 'desc');
 
     return campaignParticipations.map((attributes) => new CampaignParticipationForUserManagement(attributes));
   },


### PR DESCRIPTION
## :unicorn: Problème
Dans la liste des participations d’un user dans pix admin, la liste est triée par date de ~~dernière participation~~ début de la participation.
Cependant on a du mal à retrouver toutes les participations d’un user pour une campagne à envoi multiple (pour voir rapidement si il y a eu des améliorations cf isImproved) 

## :robot: Proposition
 Trier par code campagne et ensuite par date de ~~création~~ partage de la dernière participation..

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter a Pix Admin
- Aller sur la liste des utilisateurs
- Chercher par exemple Jaune Attend
- Aller dans la liste de ses participations
- Verifier que le tri est bien fait par ordre alphabétique de code campagne
- (Et ensuite par date de dernier partage si plusieurs fois le même code campagne)
- 😺
