### PR TITLE
[FEATURE] Ajouter le sélecteur de langue sur la page app.pix.org/campagnes (PIX-7216)

### DIFF
--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -6,17 +6,20 @@ import Controller from '@ember/controller';
 const IDENTITY_PROVIDER_ID_GAR = 'GAR';
 
 export default class FillInCampaignCodeController extends Controller {
-  @service store;
+  @service currentDomain;
+  @service currentUser;
   @service intl;
+  @service locale;
   @service router;
   @service session;
-  @service currentUser;
+  @service store;
 
   campaignCode = null;
 
   @tracked errorMessage = null;
   @tracked showGARModal = false;
   @tracked campaign = null;
+  @tracked selectedLanguage = this.intl.primaryLocale;
 
   get isUserAuthenticatedByPix() {
     return this.session.isAuthenticated;
@@ -41,6 +44,18 @@ export default class FillInCampaignCodeController extends Controller {
 
   get showWarningMessage() {
     return this.isUserAuthenticatedByPix && !this.currentUser.user.isAnonymous;
+  }
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
+
+  get isUserNotAuthenticated() {
+    return !this.isUserAuthenticatedByPix && !this.isUserAuthenticatedByGAR;
+  }
+
+  get canDisplayLanguageSwitcher() {
+    return this.isInternationalDomain && this.isUserNotAuthenticated;
   }
 
   @action
@@ -101,6 +116,13 @@ export default class FillInCampaignCodeController extends Controller {
   navigateToCampaignEntryPoint() {
     this.closeModal();
     this.router.transitionTo('campaigns.entry-point', this.campaign.code);
+  }
+
+  @action
+  onLanguageChange(language) {
+    this.selectedLanguage = language;
+    this.locale.setLocale(this.selectedLanguage);
+    this.router.replaceWith('fill-in-campaign-code', { queryParams: { lang: null } });
   }
 }
 

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -72,6 +72,9 @@
         </a>
       </div>
     </PixBlock>
+    {{#if this.canDisplayLanguageSwitcher}}
+      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+    {{/if}}
   </PixBackgroundHeader>
 </main>
 

--- a/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
@@ -11,7 +11,7 @@ import { waitForDialog } from '../helpers/wait-for';
 module('Acceptance | Fill in campaign code page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, ['fr', 'en']);
 
   let user;
 
@@ -20,7 +20,7 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
   });
 
   module('When connected', function () {
-    test('should disconnect when cliking on the link', async function (assert) {
+    test('should disconnect when clicking on the link', async function (assert) {
       // given
       await authenticate(user);
       const screen = await visit('/campagnes');
@@ -128,6 +128,75 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+      });
+    });
+  });
+
+  module('on international domain (.org)', function () {
+    module('when connected', function () {
+      module('when accessing the fill in campaign code page with "Français" as default language', function () {
+        test('does not display the language switcher', async function (assert) {
+          // given & when
+          await authenticate(user);
+          const screen = await visit('/campagnes');
+
+          // then
+          assert.strictEqual(currentURL(), '/campagnes');
+          assert.dom(screen.getByRole('button', { name: 'Accéder au parcours' })).exists();
+          assert.dom(screen.queryByRole('button', { name: 'Français' })).doesNotExist();
+        });
+      });
+    });
+
+    module('when not connected', function () {
+      module('when accessing the fill in campaign code page with "Français" as default language', function () {
+        test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
+          // given & when
+          const screen = await visit('/campagnes');
+
+          // then
+          assert.strictEqual(currentURL(), '/campagnes');
+          assert.dom(screen.getByRole('button', { name: 'Accéder au parcours' })).exists();
+        });
+
+        module('when the user select "English" as his language', function () {
+          test('displays the fill in campaign code page with "English" as selected language', async function (assert) {
+            // given & when
+            const screen = await visit('/campagnes');
+            await click(screen.getByRole('button', { name: 'Français' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'English' }));
+
+            // then
+            assert.strictEqual(currentURL(), '/campagnes');
+            assert.dom(screen.getByRole('button', { name: 'Start' })).exists();
+          });
+        });
+      });
+
+      module('when accessing the fill in campaign code page with "English" as selected language', function () {
+        test('displays the fill in campaign code page with "English"', async function (assert) {
+          // given && when
+          const screen = await visit('/campagnes?lang=en');
+
+          // then
+          assert.strictEqual(currentURL(), '/campagnes?lang=en');
+          assert.dom(screen.getByRole('button', { name: 'Start' })).exists();
+        });
+
+        module('when the user select "Français" as his language', function () {
+          test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
+            // given & when
+            const screen = await visit('/campagnes?lang=en');
+            await click(screen.getByRole('button', { name: 'English' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'Français' }));
+
+            // then
+            assert.strictEqual(currentURL(), '/campagnes');
+            assert.dom(screen.getByRole('button', { name: 'Accéder au parcours' })).exists();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pour l'instant pas possible de changer la langue d'affichage une fois sur la page `/campagnes`. Le seul moyen que l'on a c'est de modifier l'URL en `/campagnes?lang=en`.

## :robot: Proposition

- Ajouter le sélecteur de langue sur la page `/campagnes`
- Ne pas afficher le sélecteur lorsqu'il y a une session en cours (un utilisateur est connecté)

## :rainbow: Remarques

RAS

## :100: Pour tester

### Pix App .fr

#### Non connecté

- Ouvrir la page campagne : https://app-pr6144.review.pix.fr/campagnes
- Vérifier que le sélecteur de langue ne s'affiche pas

#### Connecté

- Se connecter : https://app-pr6144.review.pix.fr/connexion
- Cliquer sur le bouton `J'ai un code`
- Vérifier que le sélecteur de langue ne s'affiche pas

### Pix App .org

#### Non connecté

- Ouvrir la page campagne : https://app-pr6144.review.pix.org/campagnes
- Vérifier que le sélecteur de langue s'affiche
- Sélectionner une nouvelle langue
- Vérifier que le choix a été pris en compte, le contenu a été modifié et le sélecteur affiche la langue sélectionnée

#### Connecté

- Se connecter : https://app-pr6144.review.pix.org/connexion
- Cliquer sur le bouton `J'ai un code`
- Vérifier que le sélecteur de langue ne s'affiche pas