### PR TITLE
[FEATURE] Permettre de sélectionner l'envoi multiple pour les campagnes d'évaluation dans pix orga (PIX-7473)

### DIFF
--- a/api/lib/domain/read-models/Prescriber.js
+++ b/api/lib/domain/read-models/Prescriber.js
@@ -9,6 +9,7 @@ class Prescriber {
     participantCount,
     memberships = [],
     userOrgaSettings,
+    enableMultipleSendingAssessment,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -19,6 +20,7 @@ class Prescriber {
     this.participantCount = participantCount;
     this.memberships = memberships;
     this.userOrgaSettings = userOrgaSettings;
+    this.enableMultipleSendingAssessment = enableMultipleSendingAssessment;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -29,6 +29,7 @@ module.exports = {
         'lang',
         'memberships',
         'userOrgaSettings',
+        'enableMultipleSendingAssessment',
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/prescribers/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescribers/prescriber-controller_test.js
@@ -26,6 +26,7 @@ describe('Acceptance | Controller | Prescriber-controller', function () {
           'are-new-year-organization-learners-imported': false,
           'participant-count': 0,
           lang: user.lang,
+          'enable-multiple-sending-assessment': false,
         },
         relationships: {
           memberships: {

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -9,6 +9,7 @@ const Membership = require('../../../../lib/domain/models/Membership');
 const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings');
 const Organization = require('../../../../lib/domain/models/Organization');
 const Tag = require('../../../../lib/domain/models/Tag');
+const apps = require('../../../../lib/domain/constants.js');
 
 describe('Integration | Infrastructure | Repository | Prescriber', function () {
   const userToInsert = {
@@ -323,6 +324,39 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
 
           // then
           expect(foundPrescriber.participantCount).to.equal(2);
+        });
+      });
+
+      describe('#enableMultipleSendingAssessment', function () {
+        it('should return activated feature for current organization', async function () {
+          // given
+          expectedPrescriber.userOrgaSettings = userOrgaSettings;
+          const feature = databaseBuilder.factory.buildFeature({
+            key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
+          });
+          databaseBuilder.factory.buildOrganizationFeature({ featureId: feature.id, organizationId: organization.id });
+          await databaseBuilder.commit();
+
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+          // then
+          expect(foundPrescriber.enableMultipleSendingAssessment).to.be.true;
+        });
+
+        it('should return deactivated feature for current organization', async function () {
+          // given
+          expectedPrescriber.userOrgaSettings = userOrgaSettings;
+          databaseBuilder.factory.buildFeature({
+            key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+          // then
+          expect(foundPrescriber.enableMultipleSendingAssessment).to.be.false;
         });
       });
     });

--- a/api/tests/tooling/domain-builder/factory/build-prescriber.js
+++ b/api/tests/tooling/domain-builder/factory/build-prescriber.js
@@ -53,6 +53,7 @@ module.exports = function buildPrescriber({
   areNewYearOrganizationLearnersImported = false,
   memberships = _buildMemberships(),
   userOrgaSettings = _buildUserOrgaSettings(),
+  enableMultipleSendingAssessment = false,
 } = {}) {
   return new Prescriber({
     id,
@@ -63,5 +64,6 @@ module.exports = function buildPrescriber({
     areNewYearOrganizationLearnersImported,
     memberships,
     userOrgaSettings,
+    enableMultipleSendingAssessment,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -165,6 +165,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
           pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
           memberships: [membership],
           userOrgaSettings,
+          enableMultipleSendingAssessment: true,
         });
 
         const expectedPrescriberSerialized = createExpectedPrescriberSerialized({
@@ -203,6 +204,7 @@ function createExpectedPrescriberSerializedWithOneMoreField({
         'are-new-year-organization-learners-imported': prescriber.areNewYearOrganizationLearnersImported,
         'participant-count': prescriber.participantCount,
         lang: prescriber.lang,
+        'enable-multiple-sending-assessment': false,
       },
       relationships: {
         memberships: {
@@ -307,6 +309,7 @@ function createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSe
         'are-new-year-organization-learners-imported': prescriber.areNewYearOrganizationLearnersImported,
         'participant-count': prescriber.participantCount,
         lang: prescriber.lang,
+        'enable-multiple-sending-assessment': true,
       },
       relationships: {
         memberships: {

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -134,11 +134,11 @@
     </div>
   {{/if}}
 
-  {{#if this.isCampaignGoalProfileCollection}}
+  {{#if this.isMultipleSendingEnabled}}
     <div class="form__field">
       <p id="multiple-sendings-label" class="label">
         <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.campaign-creation.multiple-sendings.question-label"}}
+        {{t this.multipleSendingWording.label}}
       </p>
       <div class="form__field-with-info" aria-labelledby="multiple-sendings-label" role="radiogroup">
         <PixRadioButton
@@ -164,7 +164,7 @@
             <FaIcon @icon="circle-info" class="form__field-info-icon" />
             <span>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</span>
           </span>
-          <span class="form__field-info-message">{{t "pages.campaign-creation.multiple-sendings.info"}}</span>
+          <span class="form__field-info-message">{{t this.multipleSendingWording.info}}</span>
         </div>
       </div>
     </div>

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -24,6 +24,7 @@ export default class CreateForm extends Component {
     };
     this._setTargetProfilesOptions(this.args.targetProfiles);
     this.ownerId = this.currentUser.prescriber.id;
+    this.isMultipleSendingAssessmentEnabled = this.currentUser.prescriber.enableMultipleSendingAssessment;
   }
 
   _setTargetProfilesOptions(targetProfiles) {
@@ -42,6 +43,26 @@ export default class CreateForm extends Component {
     if (!this.args.membersSortedByFullName) return [];
 
     return this.args.membersSortedByFullName.map((member) => ({ value: member.id, label: member.fullName }));
+  }
+
+  get isMultipleSendingEnabled() {
+    return (
+      this.isCampaignGoalProfileCollection || (this.isCampaignGoalAssessment && this.isMultipleSendingAssessmentEnabled)
+    );
+  }
+
+  get multipleSendingWording() {
+    if (this.isCampaignGoalProfileCollection) {
+      return {
+        label: 'pages.campaign-creation.multiple-sendings.profiles.question-label',
+        info: 'pages.campaign-creation.multiple-sendings.profiles.info',
+      };
+    } else {
+      return {
+        label: 'pages.campaign-creation.multiple-sendings.assessments.question-label',
+        info: 'pages.campaign-creation.multiple-sendings.assessments.info',
+      };
+    }
   }
 
   @action

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -7,6 +7,7 @@ export default class Prescriber extends Model {
   @attr('boolean') areNewYearOrganizationLearnersImported;
   @attr('number') participantCount;
   @attr('string') lang;
+  @attr('boolean') enableMultipleSendingAssessment;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -355,9 +355,15 @@
       },
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
-        "question-label": "Do you want to allow participants to submit their profile more than once?",
-        "info": "If you choose to allow multiple submissions, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile.",
-        "info-title": "Multiple submissions"
+        "info-title": "Multiple submissions",
+        "profiles": {
+          "question-label": "Do you want to allow participants to submit their profile more than once?",
+          "info": "If you choose to allow multiple submissions, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile."
+        },
+        "assessments": {
+          "question-label": "Do you want to allow participants to submit their results more than once?",
+          "info": "If you choose to allow multiple submissions, the participants will be able to take the test and submit their results several times by re-entering the campaign code. Within Pix Orga you will find the latest participation."
+        }
       },
       "name": {
         "label": "Name of the campaign"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -358,9 +358,15 @@
       },
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
       "multiple-sendings": {
-        "question-label": "Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
-        "info": "Si vous choisissez l’envoi multiple, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.",
-        "info-title": "Envoi multiple"
+        "info-title": "Envoi multiple",
+        "profiles": {
+          "question-label": "Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
+          "info": "Si vous choisissez l’envoi multiple, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé."
+        },
+        "assessments": {
+          "question-label": "Souhaitez-vous permettre aux participants d’envoyer plusieurs fois leurs résultats ?",
+          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne et envoyer ses résultats plusieurs fois, en saisissant à nouveau le code. Au sein de Pix Orga, vous verrez sa dernière participation."
+        }
       },
       "name": {
         "label": "Nom de la campagne"


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création d'une campagne dans Pix Orga, on veut permettre de sélectionner l'envoi multiple pour les campagnes d'évaluation quand les orga ont cette fonctionnalité dans Pix Admin

## :robot: Proposition

Dans Pix Orga, conditionner l’affichage du choix permettant aux participants d’envoyer plusieurs fois leurs résultats au fait que la fonctionnalité ait été activée pour l’orga depuis Pix Admin. Pour cela, nous allons adapter ce qui est en prod pour les campagnes de collecte de profils.


## :rainbow: Remarques


## :100: Pour tester
- Se connecter à Pix Admin et activer la feature d'envoie multiple des campagnes d'évaluation pour une organisation
- Se connecter à Pix Orga avec la bonne organisation
- Créer une nouvelle campagne d'évaluation
- Vérifier que le champs de formulaire pour sélectionner l'envoie multiple apparait
