### PR TITLE
[TECH] Compléter et documenter les outils génériques pour la création de profil cibles et clés de lecture dans les seeds (PIX-7951)

### DIFF
--- a/api/db/seeds/data/learning-content/target-profiles-builder.js
+++ b/api/db/seeds/data/learning-content/target-profiles-builder.js
@@ -1,4 +1,4 @@
-const { createTargetProfile, createBadge, createStages } = require('./tooling');
+const { createTargetProfile, createBadge, createStages } = require('../common/target-profile-tooling');
 const { PRO_COMPANY_ID } = require('../organizations-pro-builder');
 
 async function richTargetProfilesBuilder({ databaseBuilder }) {


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
On commence par la brique de base, les profil cibles. Il existait déjà un tooling développé récemment qui permettait de créer rapidement des profil cibles avec des RTs et des paliers.
On a complété ce tooling (l'interface des fonctions pour pouvoir "tout" faire) et on a documenté via de la JSDoc.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Créer un fichier de seed qui fait appel à ces fonctions et vérifier que la création subséquente est en accord avec ce que vous souhaitiez !
Pour avoir un exemple d'usage, on peut consulter le fichier learning-content/target-profiles-builder.js
