### PR TITLE
[FEATURE] Affiche la date de création des profil cibles dans la liste sur PixAdmin (PIX-7947)

### DIFF
--- a/admin/app/components/target-profiles/list-summary-items.hbs
+++ b/admin/app/components/target-profiles/list-summary-items.hbs
@@ -5,6 +5,7 @@
         <tr>
           <th class="table__column table__column--id" id="target-profile-id">ID</th>
           <th id="target-profile-name">Nom</th>
+          <th class="col-date">Date de création</th>
           <th class="col-status" id="target-profile-status">Statut</th>
         </tr>
         <tr>
@@ -27,6 +28,7 @@
             />
           </td>
           <td></td>
+          <td></td>
         </tr>
       </thead>
 
@@ -40,6 +42,7 @@
                   {{summary.name}}
                 </LinkTo>
               </td>
+              <td class="table__column">{{format-date summary.createdAt}}</td>
               <td headers="target-profile-status" class="target-profile-table-column__status">
                 {{if summary.outdated "Obsolète" "Actif"}}
               </td>

--- a/admin/app/models/target-profile-summary.js
+++ b/admin/app/models/target-profile-summary.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class TargetProfileSummary extends Model {
   @attr() name;
   @attr() outdated;
+  @attr() createdAt;
 }

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -33,7 +33,7 @@
     background-color: rgb(0 0 0 / 3%);
   }
 
-  .col-status {
+  .col-status, .col-date {
     width: 10%;
   }
 }

--- a/admin/tests/integration/components/target-profiles/list-summary-items_test.js
+++ b/admin/tests/integration/components/target-profiles/list-summary-items_test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | TargetProfiles::ListSummaryItems', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.triggerFiltering = () => {};
+  });
+
+  test('it should display target profile summary', async function (assert) {
+    // given
+    const summary = {
+      id: 123,
+      name: 'Profile Cible',
+      oudated: false,
+      createdAt: new Date('2021-01-01'),
+    };
+    const summaries = [summary];
+    summaries.meta = { page: 1, pageSize: 1 };
+    this.summaries = summaries;
+    this.id = undefined;
+    this.name = undefined;
+
+    // when
+    const screen = await render(
+      hbs`<TargetProfiles::ListSummaryItems
+      @id={{this.id}}
+      @summaries={{this.summaries}}
+      @name={{this.name}}
+  @triggerFiltering={{this.triggerFiltering}}
+/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('123')).exists();
+    assert.dom(screen.getByText('Profile Cible')).exists();
+    assert.dom(screen.getByText('Actif')).exists();
+    assert.dom(screen.getByText('01/01/2021')).exists();
+  });
+});

--- a/api/lib/domain/models/TargetProfileSummaryForAdmin.js
+++ b/api/lib/domain/models/TargetProfileSummaryForAdmin.js
@@ -1,8 +1,9 @@
 class TargetProfileSummaryForAdmin {
-  constructor({ id, name, outdated } = {}) {
+  constructor({ id, name, outdated, createdAt } = {}) {
     this.id = id;
     this.name = name;
     this.outdated = outdated;
+    this.createdAt = createdAt;
   }
 }
 

--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -6,7 +6,7 @@ const DomainTransaction = require('../DomainTransaction.js');
 module.exports = {
   async findPaginatedFiltered({ filter, page }) {
     const query = knex('target-profiles')
-      .select('id', 'name', 'outdated')
+      .select('id', 'name', 'outdated', 'createdAt')
       .orderBy('outdated', 'ASC')
       .orderBy('name', 'ASC')
       .modify(_applyFilters, filter);

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -3,7 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(targetProfileSummaries, meta) {
     return new Serializer('target-profile-summary', {
-      attributes: ['name', 'outdated'],
+      attributes: ['name', 'outdated', 'createdAt'],
       meta,
     }).serialize(targetProfileSummaries);
   },

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1619,6 +1619,7 @@ describe('Acceptance | Application | organization-controller', function () {
             attributes: {
               name: 'Super profil cible',
               outdated: false,
+              'created-at': undefined,
             },
           },
         ],

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -445,6 +445,7 @@ describe('Acceptance | Controller | training-controller', function () {
         name: 'Super profil cible',
         isPublic: true,
         outdated: false,
+        'created-at': undefined,
       });
       databaseBuilder.factory.buildTargetProfileTraining({
         trainingId: training.id,
@@ -458,6 +459,7 @@ describe('Acceptance | Controller | training-controller', function () {
         attributes: {
           name: targetProfile.name,
           outdated: false,
+          'created-at': undefined,
         },
       };
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -5,8 +5,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
   describe('#findPaginatedFiltered', function () {
     it('return TargetProfileSummaryForAdmins model', async function () {
       // given
-      const targetProfile = { id: 1, name: 'Go go target profile', outdated: false };
-      const expectedTargetProfileSummary = domainBuilder.buildTargetProfileSummaryForAdmin(targetProfile);
+      const targetProfile = { id: 1, name: 'Go go target profile', outdated: false, createdAt: new Date('2021-01-01') };
       databaseBuilder.factory.buildTargetProfile(targetProfile);
       await databaseBuilder.commit();
 
@@ -22,7 +21,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       });
 
       // then
-      expect(actualTargetProfileSummary).to.deepEqualInstance(expectedTargetProfileSummary);
+      expect(actualTargetProfileSummary).to.deep.equal(targetProfile);
     });
 
     context('ordered target profile list', function () {
@@ -146,10 +145,10 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
         let targetProfileData;
         beforeEach(function () {
           targetProfileData = [
-            { id: 1, name: 'paTtErN', outdated: false },
-            { id: 2, name: 'AApatterNOo', outdated: true },
-            { id: 3, name: 'NotUnderTheRadar', outdated: false },
-            { id: 4, name: 'PaTternXXXX', outdated: true },
+            { id: 1, name: 'paTtErN', outdated: false, createdAt: new Date('2021-01-01') },
+            { id: 2, name: 'AApatterNOo', outdated: true, createdAt: new Date('2021-01-01') },
+            { id: 3, name: 'NotUnderTheRadar', outdated: false, createdAt: new Date('2021-01-01') },
+            { id: 4, name: 'PaTternXXXX', outdated: true, createdAt: new Date('2021-01-01') },
           ];
           targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
           return databaseBuilder.commit();
@@ -169,9 +168,24 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 1, name: 'paTtErN', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 2, name: 'AApatterNOo', outdated: true }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 4, name: 'PaTternXXXX', outdated: true }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({
+              id: 1,
+              name: 'paTtErN',
+              outdated: false,
+              createdAt: new Date('2021-01-01'),
+            }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({
+              id: 2,
+              name: 'AApatterNOo',
+              outdated: true,
+              createdAt: new Date('2021-01-01'),
+            }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({
+              id: 4,
+              name: 'PaTternXXXX',
+              outdated: true,
+              createdAt: new Date('2021-01-01'),
+            }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -180,10 +194,10 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
         let targetProfileData;
         beforeEach(function () {
           targetProfileData = [
-            { id: 1, name: 'TPA', outdated: false },
-            { id: 11, name: 'TPB', outdated: true },
-            { id: 21, name: 'TPC', outdated: false },
-            { id: 4, name: 'TPD', outdated: true },
+            { id: 1, name: 'TPA', outdated: false, createdAt: new Date('2021-01-01') },
+            { id: 11, name: 'TPB', outdated: true, createdAt: new Date('2021-01-01') },
+            { id: 21, name: 'TPC', outdated: false, createdAt: new Date('2021-01-01') },
+            { id: 4, name: 'TPD', outdated: true, createdAt: new Date('2021-01-01') },
           ];
           targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
           return databaseBuilder.commit();
@@ -203,7 +217,12 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 1, name: 'TPA', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({
+              id: 1,
+              name: 'TPA',
+              outdated: false,
+              createdAt: new Date('2021-01-01'),
+            }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -534,8 +553,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
       // then
       const expectedTargetProfileSummaries = [
-        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile1 }),
-        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile2 }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile1, createdAt: undefined }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile2, createdAt: undefined }),
       ];
       expect(targetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
     });

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
@@ -4,10 +4,12 @@ module.exports = function buildTargetProfileSummaryForAdmin({
   id = 123,
   name = 'Profil cible super cool',
   outdated = false,
+  createdAt,
 } = {}) {
   return new TargetProfileSummaryForAdmin({
     id,
     name,
     outdated,
+    createdAt,
   });
 };

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -544,6 +544,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
             attributes: {
               name: 'Super profil cible',
               outdated: false,
+              'created-at': undefined,
             },
           },
         ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -6,8 +6,18 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
     it('should serialize target profile summaries to JSONAPI with meta data', function () {
       // given
       const targetProfileSummaries = [
-        domainBuilder.buildTargetProfileSummaryForAdmin({ id: 1, name: 'TPA', outdated: false }),
-        domainBuilder.buildTargetProfileSummaryForAdmin({ id: 2, name: 'TPB', outdated: true }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({
+          id: 1,
+          name: 'TPA',
+          outdated: false,
+          createdAt: new Date('2021-01-01'),
+        }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({
+          id: 2,
+          name: 'TPB',
+          outdated: true,
+          createdAt: new Date('2021-01-01'),
+        }),
       ];
       const meta = { page: 1, pageSize: 3, pageCount: 1, rowCount: 2 };
 
@@ -23,6 +33,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPA',
               outdated: false,
+              'created-at': new Date('2021-01-01'),
             },
           },
           {
@@ -31,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPB',
               outdated: true,
+              'created-at': new Date('2021-01-01'),
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de voir de quand date un profil cible sur la liste des profil cibles dans PixAdmin

## :robot: Proposition
Ajout d'une colonne date de création sur la liste des profil cibles

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixAdmin et aller sur la page /target-profiles/list
- Constater la présence d'une colonne date de création
