### PR TITLE
[FEATURE] Ordre aléatoire pour les propositions de QCU/QCM (PIX-7736)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -44,6 +44,7 @@ class Challenge {
    * @param difficulty
    * @param responsive
    * @param successProbabilityThreshold
+   * @param shuffled
    */
   constructor({
     id,
@@ -71,6 +72,7 @@ class Challenge {
     difficulty,
     successProbabilityThreshold,
     responsive,
+    shuffled,
   } = {}) {
     this.id = id;
     this.answer = answer;
@@ -97,6 +99,7 @@ class Challenge {
     this.difficulty = difficulty;
     this.responsive = responsive;
     this.successProbabilityThreshold = successProbabilityThreshold;
+    this.shuffled = shuffled;
   }
 
   isTimed() {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -147,6 +147,7 @@ function _toDomain({ challengeDataObject, skillDataObject, successProbabilityThr
     discriminant: challengeDataObject.alpha,
     difficulty: challengeDataObject.delta,
     responsive: challengeDataObject.responsive,
+    shuffled: challengeDataObject.shuffled,
     successProbabilityThreshold,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -21,6 +21,7 @@ module.exports = {
         'autoReply',
         'alternativeInstruction',
         'focused',
+        'shuffled',
       ],
       transform: (record) => {
         const challenge = _.pickBy(record, (value) => !_.isUndefined(value));

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -677,5 +677,6 @@ function _buildChallenge({ id, skill, status = 'validé' }) {
     alpha: 1,
     delta: 0,
     skill,
+    shuffled: false,
   };
 }

--- a/api/tests/tooling/domain-builder/factory/build-challenge-learning-content-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-learning-content-data-object.js
@@ -23,6 +23,7 @@ module.exports = function buildChallengeLearningContentDataObject({
   format = 'petit',
   illustrationAlt = "texte alternatif à l'image",
   locales = ['fr'],
+  shuffled = false,
 } = {}) {
   return {
     id,
@@ -46,5 +47,6 @@ module.exports = function buildChallengeLearningContentDataObject({
     illustrationAlt,
     format,
     locales,
+    shuffled,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -25,6 +25,7 @@ module.exports = function buildChallenge({
   successProbabilityThreshold,
   responsive = 'Smartphone/Tablette',
   focused = false,
+  shuffled = false,
   // includes
   answer,
   validator = new Validator(),
@@ -61,5 +62,6 @@ module.exports = function buildChallenge({
     // references
     competenceId,
     illustrationAlt,
+    shuffled,
   });
 };

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -42,6 +42,7 @@ describe('Unit | Domain | Models | Challenge', function () {
         difficulty: -0.23,
         successProbabilityThreshold: 0.85,
         responsive: 'Smartphone',
+        shuffled: false,
       };
 
       const expectedChallengeDataObject = {
@@ -74,6 +75,7 @@ describe('Unit | Domain | Models | Challenge', function () {
         difficulty: -0.23,
         minimumCapability: 2.0828014071841414,
         responsive: 'Smartphone',
+        shuffled: false,
       };
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -24,6 +24,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
         embedTitle: 'Epreuve de selection de dossier',
         embedHeight: 500,
         format: 'mots',
+        shuffled: false,
       });
 
       // when
@@ -46,6 +47,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
             'embed-title': 'Epreuve de selection de dossier',
             'embed-height': 500,
             format: 'mots',
+            shuffled: false,
           },
         },
       });

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -18,7 +18,7 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   get isAnswerFieldDisabled() {
-    return this.args.answer;
+    return !!this.args.answer;
   }
 
   get isTimedChallengeWithoutAnswer() {

--- a/mon-pix/app/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item-qcm.hbs
@@ -9,7 +9,9 @@
         @answerValue={{@answer.value}}
         @proposals={{@challenge.proposals}}
         @answerChanged={{this.answerChanged}}
+        @shuffleSeed={{@assessment.id}}
         @isAnswerFieldDisabled={{this.isAnswerFieldDisabled}}
+        @shuffled="{{@challenge.shuffled}}"
       />
     </div>
 

--- a/mon-pix/app/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item-qcu.hbs
@@ -10,6 +10,8 @@
         @proposals={{@challenge.proposals}}
         @answerChanged={{this.answerChanged}}
         @isAnswerFieldDisabled={{this.isAnswerFieldDisabled}}
+        @shuffleSeed={{@assessment.id}}
+        @shuffled={{@challenge.shuffled}}
       />
     </div>
 

--- a/mon-pix/app/components/qcm-proposals.hbs
+++ b/mon-pix/app/components/qcm-proposals.hbs
@@ -5,15 +5,15 @@
       <Input
         @type="checkbox"
         id="checkbox_{{inc index}}"
-        @checked={{get labeledCheckbox 1}}
+        @checked={{labeledCheckbox.checked}}
         data-test="challenge-response-proposal-selector"
         name="{{inc index}}"
-        {{on "click" (fn this.checkboxClicked (inc index))}}
+        {{on "click" (fn this.checkboxClicked labeledCheckbox.value)}}
         disabled={{@isAnswerFieldDisabled}}
       />
 
       <label for="checkbox_{{inc index}}" class="label-checkbox-proposal">
-        <MarkdownToHtml @class="proposal-text" @markdown={{get labeledCheckbox 0}} />
+        <MarkdownToHtml @class="proposal-text" @markdown={{labeledCheckbox.label}} />
       </label>
     </p>
   {{/each}}

--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import createProposalAnswerTuples from 'mon-pix/utils/labeled-checkboxes';
+import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 
@@ -9,7 +9,7 @@ export default class QcmProposals extends Component {
     const arrayOfProposals = proposalsAsArray(this.args.proposals);
     const arrayOfBoolean = valueAsArrayOfBoolean(this.args.answerValue);
 
-    return createProposalAnswerTuples(arrayOfProposals, arrayOfBoolean);
+    return labeledCheckboxes(arrayOfProposals, arrayOfBoolean);
   }
 
   @action

--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -3,13 +3,17 @@ import Component from '@glimmer/component';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
+import { pshuffle } from '../utils/pshuffle';
 
 export default class QcmProposals extends Component {
   get labeledCheckboxes() {
     const arrayOfProposals = proposalsAsArray(this.args.proposals);
     const arrayOfBoolean = valueAsArrayOfBoolean(this.args.answerValue);
-
-    return labeledCheckboxes(arrayOfProposals, arrayOfBoolean);
+    const labeledCheckboxesList = labeledCheckboxes(arrayOfProposals, arrayOfBoolean);
+    if (this.args.shuffled) {
+      pshuffle(labeledCheckboxesList, this.args.shuffleSeed);
+    }
+    return labeledCheckboxesList;
   }
 
   @action

--- a/mon-pix/app/components/qcm-solution-panel.hbs
+++ b/mon-pix/app/components/qcm-solution-panel.hbs
@@ -7,15 +7,15 @@
           <input
             type="checkbox"
             class="qcm-panel__proposal-checkbox"
-            checked={{if (get labeledCheckbox 1) "checked" ""}}
+            checked={{if labeledCheckbox.checked "checked" ""}}
             disabled="disabled"
           />
 
           <MarkdownToHtml
             @class="qcm-proposal-label__answer-details"
-            @markdown={{get labeledCheckbox 0}}
+            @markdown={{labeledCheckbox.label}}
             data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
-            data-checked={{if (get labeledCheckbox 1) "yes" "no"}}
+            data-checked={{if labeledCheckbox.checked "yes" "no"}}
           />
         </label>
       </p>

--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import isEmpty from 'lodash/isEmpty';
@@ -7,7 +8,11 @@ import isEmpty from 'lodash/isEmpty';
 export default class QcmSolutionPanel extends Component {
   get solutionArray() {
     const solution = this.args.solution;
-    return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
+    const solutionArray = !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
+    if (this.args.challenge.get('shuffled')) {
+      pshuffle(solutionArray, this.args.answer.assessment.get('id'));
+    }
+    return solutionArray;
   }
 
   get isNotCorrectlyAnswered() {
@@ -22,6 +27,9 @@ export default class QcmSolutionPanel extends Component {
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
       checkboxes = labeledCheckboxes(proposalsArray, answerArray);
+      if (this.args.challenge.get('shuffled')) {
+        pshuffle(checkboxes, this.args.answer.assessment.get('id'));
+      }
     }
     return checkboxes;
   }

--- a/mon-pix/app/components/qcu-proposals.hbs
+++ b/mon-pix/app/components/qcu-proposals.hbs
@@ -1,17 +1,17 @@
 {{! template-lint-disable builtin-component-arguments }}
-{{#each this.labeledRadios as |labeledRadio index|}}
+{{#each this.labeledRadios as |labeledRadio|}}
   <p class="proposal-paragraph qcu-proposals">
     <PixRadioButton
       name="radio"
-      @value={{inc index}}
+      @value={{labeledRadio.value}}
       disabled={{@isAnswerFieldDisabled}}
-      checked={{get labeledRadio 1}}
-      {{on "click" (fn this.radioClicked index)}}
-      data-value="{{inc index}}"
+      checked={{labeledRadio.checked}}
+      {{on "click" (fn this.radioClicked labeledRadio.value)}}
+      data-value="{{labeledRadio.value}}"
       class="qcu-proposals__radio"
       data-test="challenge-response-proposal-selector"
     >
-      <MarkdownToHtml @class="qcu-panel__text proposal-text" @markdown={{get labeledRadio 0}} />
+      <MarkdownToHtml @class="qcu-panel__text proposal-text" @markdown={{labeledRadio.label}} />
     </PixRadioButton>
   </p>
 {{/each}}

--- a/mon-pix/app/components/qcu-proposals.js
+++ b/mon-pix/app/components/qcu-proposals.js
@@ -3,11 +3,16 @@ import Component from '@glimmer/component';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
 
 export default class QcuProposals extends Component {
   get labeledRadios() {
     const arrayOfProposals = proposalsAsArray(this.args.proposals);
-    return labeledCheckboxes(arrayOfProposals, valueAsArrayOfBoolean(this.args.answerValue));
+    const labeledCheckboxesList = labeledCheckboxes(arrayOfProposals, valueAsArrayOfBoolean(this.args.answerValue));
+    if (this.args.shuffled) {
+      pshuffle(labeledCheckboxesList, this.args.shuffleSeed);
+    }
+    return labeledCheckboxesList;
   }
 
   @action

--- a/mon-pix/app/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/components/qcu-solution-panel.hbs
@@ -2,7 +2,7 @@
   {{#each this.labeledRadios as |labeledItemRadio index|}}
     <p class="qcu-solution-panel__proposal-item">
       <span class="qcu-solution-panel__radio-button">
-        {{#if (get labeledItemRadio 1)}}
+        {{#if labeledItemRadio.checked}}
           <svg
             width="18px"
             height="18px"
@@ -35,8 +35,8 @@
       <MarkdownToHtml
         @class="qcu-solution-panel__proposition"
         data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
-        data-checked={{if (get labeledItemRadio 1) "yes" "no"}}
-        @markdown="{{get labeledItemRadio 0}}"
+        data-checked={{if labeledItemRadio.checked "yes" "no"}}
+        @markdown="{{labeledItemRadio.label}}"
       />
     </p>
   {{/each}}

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import isEmpty from 'lodash/isEmpty';
@@ -33,6 +34,9 @@ export default class QcuSolutionPanel extends Component {
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
       radiosArray = labeledCheckboxes(proposalsArray, answerArray);
+      if (this.args.challenge.get('shuffled')) {
+        pshuffle(radiosArray, this.args.answer.assessment.get('id'));
+      }
     }
 
     return radiosArray;

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -22,7 +22,7 @@ export default class QcuSolutionPanel extends Component {
     const correctAnswerIndex = this.solutionArray.indexOf(true);
     const solutionAndStatus = answersProposedByUser[correctAnswerIndex];
 
-    return solutionAndStatus[0];
+    return solutionAndStatus.label;
   }
 
   get labeledRadios() {

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -25,6 +25,7 @@ export default class Challenge extends Model {
   @attr('string') type;
   @attr('boolean') autoReply;
   @attr('boolean') focused;
+  @attr('boolean') shuffled;
 
   // includes
   @belongsTo('answer') answer;

--- a/mon-pix/app/utils/labeled-checkboxes.js
+++ b/mon-pix/app/utils/labeled-checkboxes.js
@@ -1,18 +1,10 @@
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import size from 'lodash/size';
-import times from 'lodash/times';
-import constant from 'lodash/constant';
 import isArray from 'lodash/isArray';
 import every from 'lodash/every';
 import isBoolean from 'lodash/isBoolean';
 import isString from 'lodash/isString';
-
-import flow from 'lodash/fp/flow';
-import concat from 'lodash/fp/concat';
-import zip from 'lodash/fp/zip';
-
-const concatToEnd = concat.convert({ rearg: true });
 
 /*
  * Example :
@@ -25,10 +17,10 @@ const concatToEnd = concat.convert({ rearg: true });
  *           all others have implicitly the boolean value "false"
  *
  * => Output :
- *    [['is sky red ?', false],
- *     ['is sun red ?', true],
- *     ['is grass red ?', false],
- *     ['are clouds red ?' false]]
+ *    [{ label: 'is sky red ?', checked: false, value: 1 },
+ *     { label: 'is sun red ?', checked: true, value: 2 },
+ *     { label: 'is grass red ?', checked: false, value: 3 },
+ *     { label: 'are clouds red ?' checked: false, value: 4 }]
  */
 export default function labeledCheckboxes(proposals, userAnswers) {
   // accept that user didn't give any answer yet
@@ -40,16 +32,11 @@ export default function labeledCheckboxes(proposals, userAnswers) {
   if (_isNotArrayOfBoolean(definedUserAnswers)) return [];
   if (size(definedUserAnswers) > size(proposals)) return [];
 
-  const sizeDifference = size(proposals) - size(definedUserAnswers); // 2
-  const arrayOfFalse = times(sizeDifference, constant(false)); // [false, false]
-
-  const propsBuilder = flow(
-    // [false, true]
-    concatToEnd(arrayOfFalse), // [false, true, false, false]
-    zip(proposals) // [['prop 1', false], ['prop 2', true], ['prop 3', false], ['prop 4', false]]
-  );
-
-  return propsBuilder(definedUserAnswers);
+  return proposals.map((s, i) => ({
+    label: s,
+    value: i + 1,
+    checked: definedUserAnswers[i] ?? false,
+  }));
 }
 
 function _isNotArrayOfBoolean(collection) {

--- a/mon-pix/app/utils/proposals-as-array.js
+++ b/mon-pix/app/utils/proposals-as-array.js
@@ -1,16 +1,9 @@
 import isString from 'lodash/isString';
 import isEmpty from 'lodash/isEmpty';
 
-import flow from 'lodash/fp/flow';
-import split from 'lodash/fp/split';
-import thru from 'lodash/fp/thru';
-import drop from 'lodash/fp/drop';
-
-const calculate = flow(
-  thru((e) => '\n' + e),
-  split(/\n\s*-\s*/),
-  drop(1)
-);
+function parseProposals(proposals) {
+  return `\n${proposals}`.split(/\n\s*-\s*/).slice(1);
+}
 
 export default function proposalsAsArray(proposals) {
   // check pre-conditions
@@ -19,5 +12,5 @@ export default function proposalsAsArray(proposals) {
   if (!isString(proposals)) return DEFAULT_RETURN_VALUE;
   if (isEmpty(proposals)) return DEFAULT_RETURN_VALUE;
 
-  return calculate(proposals);
+  return parseProposals(proposals);
 }

--- a/mon-pix/app/utils/pshuffle.js
+++ b/mon-pix/app/utils/pshuffle.js
@@ -1,0 +1,36 @@
+/**
+ * Pseudo randomly shuffle arr based on seed (same seed gives same order).
+ * @param {any[]} arr
+ * @param {number} seed
+ */
+export function pshuffle(arr, seed) {
+  let m = arr.length;
+  const random = makeRandom(seed);
+
+  // While there remain elements to shuffle...
+  while (m) {
+    // Pick a remaining element...
+    const i = random() % m--;
+
+    // And swap it with the current element.
+    const t = arr[m];
+    arr[m] = arr[i];
+    arr[i] = t;
+  }
+}
+
+/**
+ * Basic and fast pseudo random number generator.
+ * @param {number} seed
+ * @returns A function returning pseudo-random numbers between 1 and 2^32 - 2.
+ */
+function makeRandom(seed) {
+  seed %= 2147483647;
+  if (seed <= 0) seed += 2147483646;
+  const next = () => {
+    seed = (seed * 48271) % 2147483647;
+    return seed;
+  };
+  next();
+  return next;
+}

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -4,6 +4,7 @@ import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
 
 module('Acceptance | Displaying a QCM challenge', function (hooks) {
   setupApplicationTest(hooks);
@@ -30,18 +31,18 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
 
       const proposalsText = findAll('.proposal-text');
 
-      assert.strictEqual(proposalsText[0].innerHTML.trim(), '<p><em>possibilite</em> 1, et/ou</p>');
-      assert.strictEqual(proposalsText[1].textContent.trim(), 'possibilite 2, et/ou');
-      assert.strictEqual(
-        proposalsText[1].innerHTML.trim(),
-        '<p><a href="/test" rel="noopener noreferrer" target="_blank">possibilite 2</a>, et/ou</p>'
-      );
-      assert.strictEqual(proposalsText[2].textContent.trim(), ', et/ou');
-      assert.strictEqual(
-        proposalsText[2].innerHTML.trim(),
-        '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3">, et/ou</p>'
-      );
-      assert.strictEqual(proposalsText[3].textContent.trim(), 'possibilite 4');
+      const expectedProposalsText = [
+        '<p><em>possibilite</em> 1, et/ou</p>',
+        '<p><a href="/test" rel="noopener noreferrer" target="_blank">possibilite 2</a>, et/ou</p>',
+        '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3">, et/ou</p>',
+        '<p>possibilite 4</p>',
+      ];
+
+      assert.strictEqual(proposalsText[0].innerHTML.trim(), expectedProposalsText[0]);
+      assert.strictEqual(proposalsText[1].innerHTML.trim(), expectedProposalsText[1]);
+      assert.strictEqual(proposalsText[2].innerHTML.trim(), expectedProposalsText[2]);
+      assert.strictEqual(proposalsText[3].innerHTML.trim(), expectedProposalsText[3]);
+
       assert.dom('.challenge-response__alert').doesNotExist();
     });
 
@@ -95,15 +96,22 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
     });
 
     test('should mark checkboxes corresponding to the answer and propose to continue', async function (assert) {
+      const expectedCheckboxes = [
+        { checked: false, disabled: true },
+        { checked: true, disabled: true },
+        { checked: false, disabled: true },
+        { checked: true, disabled: true },
+      ];
+
       // then
-      assert.false(findAll('input[type="checkbox"]')[0].checked);
-      assert.true(findAll('input[type="checkbox"]')[0].disabled);
-      assert.true(findAll('input[type="checkbox"]')[1].checked);
-      assert.true(findAll('input[type="checkbox"]')[1].disabled);
-      assert.false(findAll('input[type="checkbox"]')[2].checked);
-      assert.true(findAll('input[type="checkbox"]')[2].disabled);
-      assert.true(findAll('input[type="checkbox"]')[3].checked);
-      assert.true(findAll('input[type="checkbox"]')[3].disabled);
+      assert.strictEqual(expectedCheckboxes[0].checked, findAll('input[type="checkbox"]')[0].checked);
+      assert.strictEqual(expectedCheckboxes[0].disabled, findAll('input[type="checkbox"]')[0].disabled);
+      assert.strictEqual(expectedCheckboxes[1].checked, findAll('input[type="checkbox"]')[1].checked);
+      assert.strictEqual(expectedCheckboxes[1].disabled, findAll('input[type="checkbox"]')[1].disabled);
+      assert.strictEqual(expectedCheckboxes[2].checked, findAll('input[type="checkbox"]')[2].checked);
+      assert.strictEqual(expectedCheckboxes[2].disabled, findAll('input[type="checkbox"]')[2].disabled);
+      assert.strictEqual(expectedCheckboxes[3].checked, findAll('input[type="checkbox"]')[3].checked);
+      assert.strictEqual(expectedCheckboxes[3].disabled, findAll('input[type="checkbox"]')[3].disabled);
 
       assert.dom('.challenge-actions__action-continue').exists();
       assert.dom('.challenge-actions__action-validate').doesNotExist();

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -4,7 +4,6 @@ import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { pshuffle } from 'mon-pix/utils/pshuffle';
 
 module('Acceptance | Displaying a QCM challenge', function (hooks) {
   setupApplicationTest(hooks);

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -24,22 +24,21 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
 
     test('should render challenge information and question', function (assert) {
       // then
+      const expectedProposals = [
+        '<p>1ere <em>possibilite</em></p>',
+        '<p>2eme <a href="/test" rel="noopener noreferrer" target="_blank">possibilite</a></p>',
+        '<p><img src="/images/pix-logo-blanc.svg" alt="3eme possibilite"></p>',
+        '<p>4eme possibilite</p>',
+      ];
+
+      const actualProposals = findAll('.proposal-text');
 
       assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), qcuChallenge.instruction);
       assert.dom('input[type=radio][name="radio"]').exists({ count: 4 });
-      assert.strictEqual(findAll('.proposal-text')[0].textContent.trim(), '1ere possibilite');
-      assert.strictEqual(findAll('.proposal-text')[0].innerHTML.trim(), '<p>1ere <em>possibilite</em></p>');
-      assert.strictEqual(findAll('.proposal-text')[1].textContent.trim(), '2eme possibilite');
-      assert.strictEqual(
-        findAll('.proposal-text')[1].innerHTML.trim(),
-        '<p>2eme <a href="/test" rel="noopener noreferrer" target="_blank">possibilite</a></p>'
-      );
-      assert.strictEqual(findAll('.proposal-text')[2].textContent.trim(), '');
-      assert.strictEqual(
-        findAll('.proposal-text')[2].innerHTML.trim(),
-        '<p><img src="/images/pix-logo-blanc.svg" alt="3eme possibilite"></p>'
-      );
-      assert.strictEqual(findAll('.proposal-text')[3].textContent.trim(), '4eme possibilite');
+      assert.strictEqual(actualProposals[0].innerHTML.trim(), expectedProposals[0]);
+      assert.strictEqual(actualProposals[1].innerHTML.trim(), expectedProposals[1]);
+      assert.strictEqual(actualProposals[2].innerHTML.trim(), expectedProposals[2]);
+      assert.strictEqual(actualProposals[3].innerHTML.trim(), expectedProposals[3]);
       assert.dom('.challenge-reponse__alert').doesNotExist();
     });
 

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -5,8 +5,16 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
 
-const assessment = {};
+const assessmentId = 64;
+const assessment = {
+  get(key) {
+    if (key === 'id') {
+      return assessmentId;
+    }
+  },
+};
 let challenge = null;
 let answer = null;
 let solution = null;
@@ -14,115 +22,216 @@ let solution = null;
 module('Integration | Component | qcm-solution-panel.js', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('#Component should renders: ', function () {
-    test('Should renders', async function (assert) {
-      this.set('answer', {});
+  module('Should show the answers', function (hooks) {
+    const correctAnswer = {
+      id: 'answer_id',
+      assessment,
+      challenge,
+      value: '2,4',
+      result: 'ok',
+    };
 
-      await render(hbs`<QcmSolutionPanel @answer={{this.answer}} />`);
+    const unCorrectAnswer = {
+      id: 'answer_id',
+      assessment,
+      challenge,
+      value: '1,4',
+      result: 'ko',
+    };
 
-      assert.dom('.qcm-solution-panel').exists();
-      assert.dom('.qcm-proposal-label__answer-details').doesNotExist();
+    hooks.before(function () {
+      challenge = EmberObject.create({
+        id: 'challenge_id',
+        proposals: '-*possibilite* 1\n-[possibilite 2](/test)\n- ![possibilite 3](/images/pix-logo-blanc.svg)\n- yon',
+        type: 'QCM',
+        shuffled: false,
+      });
+
+      solution = '2,3';
+
+      answer = EmberObject.create(correctAnswer);
     });
 
-    module('Should show the answers', function (hooks) {
-      const correctAnswer = {
-        id: 'answer_id',
-        assessment,
-        challenge,
-        value: '2,4',
-        result: 'ok',
-      };
+    module('when user has not answerd correctly', function () {
+      module('when solutionToDisplay is indicated', function () {
+        test('should show the solution text', async function (assert) {
+          // Given
+          answer = EmberObject.create(unCorrectAnswer);
+          const solutionToDisplay = 'La bonne réponse est TADA !';
+          this.set('answer', answer);
+          this.set('solution', solution);
+          this.set('solutionToDisplay', solutionToDisplay);
+          this.set('challenge', challenge);
 
-      const unCorrectAnswer = {
-        id: 'answer_id',
-        assessment,
-        challenge,
-        value: '1,4',
-        result: 'ko',
-      };
+          // When
+          await render(
+            hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
+          );
 
-      hooks.before(function () {
-        challenge = EmberObject.create({
-          id: 'challenge_id',
-          proposals: '-*possibilite* 1\n-[possibilite 2](/test)\n- ![possibilite 3](/images/pix-logo-blanc.svg)\n- yon',
-          type: 'QCM',
-        });
-
-        solution = '2,3';
-
-        answer = EmberObject.create(correctAnswer);
-      });
-
-      module('when user has not answerd correctly', function () {
-        module('when solutionToDisplay is indicated', function () {
-          test('should show the solution text', async function (assert) {
-            // Given
-            answer = EmberObject.create(unCorrectAnswer);
-            const solutionToDisplay = 'La bonne réponse est TADA !';
-            this.set('answer', answer);
-            this.set('solution', solution);
-            this.set('solutionToDisplay', solutionToDisplay);
-            this.set('challenge', challenge);
-
-            // When
-            await render(
-              hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
-            );
-
-            // Then
-            assert.dom('.comparison-window-solution').exists();
-            assert.ok(find('.comparison-window-solution__text').textContent.includes(solutionToDisplay));
-          });
-        });
-
-        module('when solutionToDisplay is not indicated', function () {
-          test('should not show the solution text', async function (assert) {
-            // Given
-            answer = EmberObject.create(unCorrectAnswer);
-            const solutionToDisplay = null;
-            this.set('answer', answer);
-            this.set('solution', solution);
-            this.set('solutionToDisplay', solutionToDisplay);
-            this.set('challenge', challenge);
-
-            // When
-            await render(
-              hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
-            );
-
-            // Then
-            assert.dom('.comparison-window-solution').doesNotExist();
-          });
+          // Then
+          assert.dom('.comparison-window-solution').exists();
+          assert.ok(find('.comparison-window-solution__text').textContent.includes(solutionToDisplay));
         });
       });
 
-      module('when user has answerd correctly', function () {
-        module('when solutionToDisplay is indicated', function () {
-          test('should not show the solution text', async function (assert) {
-            // Given
-            answer = EmberObject.create(correctAnswer);
-            const solutionToDisplay = 'La bonne réponse est TADA !';
-            this.set('answer', answer);
-            this.set('solution', solution);
-            this.set('solutionToDisplay', solutionToDisplay);
-            this.set('challenge', challenge);
+      module('when solutionToDisplay is not indicated', function () {
+        test('should not show the solution text', async function (assert) {
+          // Given
+          answer = EmberObject.create(unCorrectAnswer);
+          const solutionToDisplay = null;
+          this.set('answer', answer);
+          this.set('solution', solution);
+          this.set('solutionToDisplay', solutionToDisplay);
+          this.set('challenge', challenge);
 
-            // When
-            await render(
-              hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
-            );
+          // When
+          await render(
+            hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
+          );
 
-            // Then
-            assert.dom('.comparison-window-solution').doesNotExist();
-          });
+          // Then
+          assert.dom('.comparison-window-solution').doesNotExist();
         });
       });
+    });
 
-      test('should display the correct answer as ticked', async function (assert) {
+    module('when user has answerd correctly', function () {
+      module('when solutionToDisplay is indicated', function () {
+        test('should not show the solution text', async function (assert) {
+          // Given
+          answer = EmberObject.create(correctAnswer);
+          const solutionToDisplay = 'La bonne réponse est TADA !';
+          this.set('answer', answer);
+          this.set('solution', solution);
+          this.set('solutionToDisplay', solutionToDisplay);
+          this.set('challenge', challenge);
+
+          // When
+          await render(
+            hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
+          );
+
+          // Then
+          assert.dom('.comparison-window-solution').doesNotExist();
+        });
+      });
+    });
+
+    test('should display the correct answer as ticked', async function (assert) {
+      // Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(
+        hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
+      );
+
+      // Then
+      const labels = findAll('.qcm-proposal-label__answer-details');
+      assert.strictEqual(labels[1].getAttribute('data-checked'), 'yes');
+      assert.strictEqual(findAll('input[type=checkbox]')[1].getAttribute('disabled'), 'disabled');
+      assert.strictEqual(labels[1].getAttribute('data-goodness'), 'good');
+      assert.strictEqual(
+        labels[1].innerHTML.trim(),
+        '<p><a href="/test" rel="noopener noreferrer" target="_blank">possibilite 2</a></p>'
+      );
+    });
+
+    test('should display an incorrect answer as not ticked', async function (assert) {
+      //Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(
+        hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
+      );
+
+      // Then
+      const labels = findAll('.qcm-proposal-label__answer-details');
+
+      assert.strictEqual(labels[0].getAttribute('data-checked'), 'no');
+      assert.strictEqual(labels[0].getAttribute('data-goodness'), 'bad');
+      assert.strictEqual(labels[0].innerHTML.trim(), '<p><em>possibilite</em> 1</p>');
+    });
+
+    test('should display at least one of the correct answers as not ticked', async function (assert) {
+      //Given
+      answer = EmberObject.create(unCorrectAnswer);
+
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(
+        hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
+      );
+
+      // Then
+      const labels = findAll('.qcm-proposal-label__answer-details');
+
+      assert.strictEqual(labels[2].getAttribute('data-checked'), 'no');
+      assert.strictEqual(labels[2].getAttribute('data-goodness'), 'good');
+      assert.strictEqual(
+        labels[2].innerHTML.trim(),
+        '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3"></p>'
+      );
+    });
+
+    test('should display at least one of the incorrect answers as ticked', async function (assert) {
+      //Given
+      answer = EmberObject.create(unCorrectAnswer);
+
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(
+        hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
+      );
+
+      // Then
+      const labels = findAll('.qcm-proposal-label__answer-details');
+
+      assert.strictEqual(labels[0].getAttribute('data-checked'), 'yes');
+      assert.strictEqual(labels[0].getAttribute('data-goodness'), 'bad');
+    });
+
+    test('should display no clickable input', async function (assert) {
+      //Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(
+        hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
+      );
+
+      // Then
+      assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[0].getAttribute('disabled'), 'disabled');
+      assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[1].getAttribute('disabled'), 'disabled');
+      assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[2].getAttribute('disabled'), 'disabled');
+      assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[3].getAttribute('disabled'), 'disabled');
+    });
+
+    module('when proposals are shuffled', function () {
+      test('should shuffle the answers', async function (assert) {
         // Given
+        answer = EmberObject.create(correctAnswer);
+        challenge.shuffled = true;
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
+
+        const expectedAnswers = ['possibilite 1', 'possibilite 2', '', 'yon'];
+
+        pshuffle(expectedAnswers, assessmentId);
 
         // When
         await render(
@@ -130,95 +239,10 @@ module('Integration | Component | qcm-solution-panel.js', function (hooks) {
         );
 
         // Then
-        const labels = findAll('.qcm-proposal-label__answer-details');
-        assert.strictEqual(labels[1].getAttribute('data-checked'), 'yes');
-        assert.strictEqual(findAll('input[type=checkbox]')[1].getAttribute('disabled'), 'disabled');
-        assert.strictEqual(labels[1].getAttribute('data-goodness'), 'good');
-        assert.strictEqual(
-          labels[1].innerHTML.trim(),
-          '<p><a href="/test" rel="noopener noreferrer" target="_blank">possibilite 2</a></p>'
-        );
-      });
-
-      test('should display an incorrect answer as not ticked', async function (assert) {
-        //Given
-        this.set('answer', answer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(
-          hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
-        );
-
-        // Then
-        const labels = findAll('.qcm-proposal-label__answer-details');
-
-        assert.strictEqual(labels[0].getAttribute('data-checked'), 'no');
-        assert.strictEqual(labels[0].getAttribute('data-goodness'), 'bad');
-        assert.strictEqual(labels[0].innerHTML.trim(), '<p><em>possibilite</em> 1</p>');
-      });
-
-      test('should display at least one of the correct answers as not ticked', async function (assert) {
-        //Given
-        answer = EmberObject.create(unCorrectAnswer);
-
-        this.set('answer', answer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(
-          hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
-        );
-
-        // Then
-        const labels = findAll('.qcm-proposal-label__answer-details');
-
-        assert.strictEqual(labels[2].getAttribute('data-checked'), 'no');
-        assert.strictEqual(labels[2].getAttribute('data-goodness'), 'good');
-        assert.strictEqual(
-          labels[2].innerHTML.trim(),
-          '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3"></p>'
-        );
-      });
-
-      test('should display at least one of the incorrect answers as ticked', async function (assert) {
-        //Given
-        answer = EmberObject.create(unCorrectAnswer);
-
-        this.set('answer', answer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(
-          hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
-        );
-
-        // Then
-        const labels = findAll('.qcm-proposal-label__answer-details');
-
-        assert.strictEqual(labels[0].getAttribute('data-checked'), 'yes');
-        assert.strictEqual(labels[0].getAttribute('data-goodness'), 'bad');
-      });
-
-      test('should display no clickable input', async function (assert) {
-        //Given
-        this.set('answer', answer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(
-          hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`
-        );
-
-        // Then
-        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[0].getAttribute('disabled'), 'disabled');
-        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[1].getAttribute('disabled'), 'disabled');
-        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[2].getAttribute('disabled'), 'disabled');
-        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[3].getAttribute('disabled'), 'disabled');
+        const actualAnswers = findAll('.qcm-panel__proposal-item');
+        assert.strictEqual(actualAnswers[0].textContent.trim(), expectedAnswers[0]);
+        assert.strictEqual(actualAnswers[1].textContent.trim(), expectedAnswers[1]);
+        assert.strictEqual(actualAnswers[2].textContent.trim(), expectedAnswers[2]);
       });
     });
   });

--- a/mon-pix/tests/unit/components/qcm-proposals_test.js
+++ b/mon-pix/tests/unit/components/qcm-proposals_test.js
@@ -38,7 +38,7 @@ module('Unit | Component | QCM proposals', function (hooks) {
       });
     }
 
-    module('when shuffled is false', function (hooks) {
+    module('when shuffled is false', function () {
       test('should return', function (assert) {
         // Given
         const expectedLabeledRadios = [

--- a/mon-pix/tests/unit/components/qcm-proposals_test.js
+++ b/mon-pix/tests/unit/components/qcm-proposals_test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
+
+module('Unit | Component | QCM proposals', function (hooks) {
+  setupTest(hooks);
+
+  module('shuffled', function (hooks) {
+    const DEFAULT_PROPOSALS = '- prop 1\n- prop 2\n- prop 3';
+
+    let answer;
+    let answerChanged;
+    const isAnswerFieldDisabled = false;
+    let proposals;
+    let component;
+    let shuffleSeed;
+    let shuffled;
+
+    hooks.beforeEach(function () {
+      proposals = DEFAULT_PROPOSALS;
+      answer = {
+        value: '2',
+      };
+      shuffleSeed = 64;
+      shuffled = false;
+    });
+
+    function initComponent() {
+      component = createGlimmerComponent('component:qcm-proposals', {
+        answer,
+        proposals,
+        answerValue: answer.value,
+        shuffleSeed,
+        shuffled,
+        isAnswerFieldDisabled,
+        answerChanged,
+      });
+    }
+
+    module('when shuffled is false', function (hooks) {
+      test('should return', function (assert) {
+        // Given
+        const expectedLabeledRadios = [
+          { checked: false, label: 'prop 1', value: 1 },
+          { checked: true, label: 'prop 2', value: 2 },
+          { checked: false, label: 'prop 3', value: 3 },
+        ];
+        initComponent.call(this);
+
+        // When
+        const labeledCheckboxes = component.labeledCheckboxes;
+
+        // Then
+        assert.deepEqual(labeledCheckboxes, expectedLabeledRadios);
+      });
+    });
+
+    module('when shuffled is true', function (hooks) {
+      hooks.beforeEach(function () {
+        shuffled = true;
+      });
+
+      test('should return', function (assert) {
+        // Given
+        const expectedLabeledRadios = [
+          { checked: false, label: 'prop 1', value: 1 },
+          { checked: true, label: 'prop 2', value: 2 },
+          { checked: false, label: 'prop 3', value: 3 },
+        ];
+        pshuffle(expectedLabeledRadios, shuffleSeed);
+        initComponent.call(this);
+
+        // When
+        const labeledCheckboxes = component.labeledCheckboxes;
+
+        // Then
+        assert.deepEqual(labeledCheckboxes, expectedLabeledRadios);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/qcu-proposals_test.js
+++ b/mon-pix/tests/unit/components/qcu-proposals_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
 
 module('Unit | Component | QCU proposals', function (hooks) {
   setupTest(hooks);
@@ -11,77 +12,102 @@ module('Unit | Component | QCU proposals', function (hooks) {
     let answerValue;
     let proposals;
     let component;
+    let shuffleSeed;
+    let shuffled;
 
     hooks.beforeEach(function () {
       proposals = DEFAULT_PROPOSALS;
       answerValue = '2';
+      shuffleSeed = 64;
+      shuffled = false;
     });
 
     function initComponent() {
-      component = createGlimmerComponent('component:qcu-proposals', { proposals, answerValue });
+      component = createGlimmerComponent('component:qcu-proposals', { proposals, answerValue, shuffleSeed, shuffled });
     }
+    module('when shuffled is false', function () {
+      test('should return an array of [<proposal_text>, <boolean_answer>]', function (assert) {
+        // Given
+        answerValue = '2';
+        const expectedLabeledRadios = [
+          { checked: false, label: 'prop 1', value: 1 },
+          { checked: true, label: 'prop 2', value: 2 },
+          { checked: false, label: 'prop 3', value: 3 },
+        ];
+        initComponent.call(this);
 
-    test('should return an array of [<proposal_text>, <boolean_answer>]', function (assert) {
-      // Given
-      answerValue = '2';
-      const expectedLabeledRadios = [
-        { checked: false, label: 'prop 1', value: 1 },
-        { checked: true, label: 'prop 2', value: 2 },
-        { checked: false, label: 'prop 3', value: 3 },
-      ];
-      initComponent.call(this);
+        // When
+        const labeledRadios = component.labeledRadios;
 
-      // When
-      const labeledRadios = component.labeledRadios;
+        // Then
+        assert.deepEqual(labeledRadios, expectedLabeledRadios);
+      });
 
-      // Then
-      assert.deepEqual(labeledRadios, expectedLabeledRadios);
+      test('should return an array of [<proposal_text>, <boolean_answer>] with as many items as challenge proposals', function (assert) {
+        // given
+        proposals = '- prop 1\n- prop 2\n- prop 3\n- prop 4\n- prop 5';
+        initComponent.call(this);
+
+        // when
+        const labeledRadios = component.labeledRadios;
+
+        // then
+        assert.strictEqual(labeledRadios.length, 5);
+      });
+
+      test('should not select a radio when given answer is null', function (assert) {
+        // given
+        answerValue = null;
+        const expectedLabeledRadios = [
+          { checked: false, label: 'prop 1', value: 1 },
+          { checked: false, label: 'prop 2', value: 2 },
+          { checked: false, label: 'prop 3', value: 3 },
+        ];
+        initComponent.call(this);
+
+        // when
+        const labeledRadios = component.labeledRadios;
+
+        // then
+        assert.deepEqual(labeledRadios, expectedLabeledRadios);
+      });
+
+      test('should not select a radio when no answer is given', function (assert) {
+        // given
+        answerValue = '';
+        const expectedLabeledRadios = [
+          { checked: false, label: 'prop 1', value: 1 },
+          { checked: false, label: 'prop 2', value: 2 },
+          { checked: false, label: 'prop 3', value: 3 },
+        ];
+        initComponent.call(this);
+
+        // when
+        const labeledRadios = component.labeledRadios;
+
+        // then
+        assert.deepEqual(labeledRadios, expectedLabeledRadios);
+      });
     });
+    module('when shuffled is true', function () {
+      test('should return an array of [<proposal_text>, <boolean_answer>]', function (assert) {
+        // Given
+        shuffled = true;
+        answerValue = '2';
+        const expectedLabeledRadios = [
+          { checked: false, label: 'prop 1', value: 1 },
+          { checked: true, label: 'prop 2', value: 2 },
+          { checked: false, label: 'prop 3', value: 3 },
+        ];
+        initComponent.call(this);
+        pshuffle(expectedLabeledRadios, shuffleSeed);
 
-    test('should return an array of [<proposal_text>, <boolean_answer>] with as many items as challenge proposals', function (assert) {
-      // given
-      proposals = '- prop 1\n- prop 2\n- prop 3\n- prop 4\n- prop 5';
-      initComponent.call(this);
+        // When
+        const labeledRadios = component.labeledRadios;
 
-      // when
-      const labeledRadios = component.labeledRadios;
-
-      // then
-      assert.strictEqual(labeledRadios.length, 5);
-    });
-
-    test('should not select a radio when given answer is null', function (assert) {
-      // given
-      answerValue = null;
-      const expectedLabeledRadios = [
-        { checked: false, label: 'prop 1', value: 1 },
-        { checked: false, label: 'prop 2', value: 2 },
-        { checked: false, label: 'prop 3', value: 3 },
-      ];
-      initComponent.call(this);
-
-      // when
-      const labeledRadios = component.labeledRadios;
-
-      // then
-      assert.deepEqual(labeledRadios, expectedLabeledRadios);
-    });
-
-    test('should not select a radio when no answer is given', function (assert) {
-      // given
-      answerValue = '';
-      const expectedLabeledRadios = [
-        { checked: false, label: 'prop 1', value: 1 },
-        { checked: false, label: 'prop 2', value: 2 },
-        { checked: false, label: 'prop 3', value: 3 },
-      ];
-      initComponent.call(this);
-
-      // when
-      const labeledRadios = component.labeledRadios;
-
-      // then
-      assert.deepEqual(labeledRadios, expectedLabeledRadios);
+        // Then
+        assert.deepEqual(labeledRadios, expectedLabeledRadios);
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/components/qcu-proposals_test.js
+++ b/mon-pix/tests/unit/components/qcu-proposals_test.js
@@ -25,9 +25,9 @@ module('Unit | Component | QCU proposals', function (hooks) {
       // Given
       answerValue = '2';
       const expectedLabeledRadios = [
-        ['prop 1', false],
-        ['prop 2', true],
-        ['prop 3', false],
+        { checked: false, label: 'prop 1', value: 1 },
+        { checked: true, label: 'prop 2', value: 2 },
+        { checked: false, label: 'prop 3', value: 3 },
       ];
       initComponent.call(this);
 
@@ -54,9 +54,9 @@ module('Unit | Component | QCU proposals', function (hooks) {
       // given
       answerValue = null;
       const expectedLabeledRadios = [
-        ['prop 1', false],
-        ['prop 2', false],
-        ['prop 3', false],
+        { checked: false, label: 'prop 1', value: 1 },
+        { checked: false, label: 'prop 2', value: 2 },
+        { checked: false, label: 'prop 3', value: 3 },
       ];
       initComponent.call(this);
 
@@ -71,9 +71,9 @@ module('Unit | Component | QCU proposals', function (hooks) {
       // given
       answerValue = '';
       const expectedLabeledRadios = [
-        ['prop 1', false],
-        ['prop 2', false],
-        ['prop 3', false],
+        { checked: false, label: 'prop 1', value: 1 },
+        { checked: false, label: 'prop 2', value: 2 },
+        { checked: false, label: 'prop 3', value: 3 },
       ];
       initComponent.call(this);
 

--- a/mon-pix/tests/unit/utils/labeled-checkboxes_test.js
+++ b/mon-pix/tests/unit/utils/labeled-checkboxes_test.js
@@ -9,10 +9,10 @@ module('Unit | Utility | labeled checkboxes', function () {
         proposals: ['prop 1', 'prop 2', 'prop 3', 'prop 4'],
         answers: [false, true],
         output: [
-          ['prop 1', false],
-          ['prop 2', true],
-          ['prop 3', false],
-          ['prop 4', false],
+          { label: 'prop 1', checked: false, value: 1 },
+          { label: 'prop 2', checked: true, value: 2 },
+          { label: 'prop 3', checked: false, value: 3 },
+          { label: 'prop 4', checked: false, value: 4 },
         ],
       },
       {
@@ -20,10 +20,37 @@ module('Unit | Utility | labeled checkboxes', function () {
         proposals: ['prop 1', 'prop 2', 'prop 3', 'prop 4'],
         answers: undefined,
         output: [
-          ['prop 1', false],
-          ['prop 2', false],
-          ['prop 3', false],
-          ['prop 4', false],
+          { label: 'prop 1', checked: false, value: 1 },
+          { label: 'prop 2', checked: false, value: 2 },
+          { label: 'prop 3', checked: false, value: 3 },
+          { label: 'prop 4', checked: false, value: 4 },
+        ],
+      },
+      {
+        when: 'nominal case, non-existing answers (undefined)',
+        proposals: ['prop 1', 'prop 2', 'prop 3', 'prop 4'],
+        answers: undefined,
+        output: [
+          {
+            label: 'prop 1',
+            checked: false,
+            value: 1,
+          },
+          {
+            label: 'prop 2',
+            checked: false,
+            value: 2,
+          },
+          {
+            label: 'prop 3',
+            checked: false,
+            value: 3,
+          },
+          {
+            label: 'prop 4',
+            checked: false,
+            value: 4,
+          },
         ],
       },
       {
@@ -31,10 +58,10 @@ module('Unit | Utility | labeled checkboxes', function () {
         proposals: ['prop 1', 'prop 2', 'prop 3', 'prop 4'],
         answers: null,
         output: [
-          ['prop 1', false],
-          ['prop 2', false],
-          ['prop 3', false],
-          ['prop 4', false],
+          { label: 'prop 1', checked: false, value: 1 },
+          { label: 'prop 2', checked: false, value: 2 },
+          { label: 'prop 3', checked: false, value: 3 },
+          { label: 'prop 4', checked: false, value: 4 },
         ],
       },
       {
@@ -42,10 +69,10 @@ module('Unit | Utility | labeled checkboxes', function () {
         proposals: ['prop 1', 'prop 2', 'prop 3', 'prop 4'],
         answers: [],
         output: [
-          ['prop 1', false],
-          ['prop 2', false],
-          ['prop 3', false],
-          ['prop 4', false],
+          { label: 'prop 1', checked: false, value: 1 },
+          { label: 'prop 2', checked: false, value: 2 },
+          { label: 'prop 3', checked: false, value: 3 },
+          { label: 'prop 4', checked: false, value: 4 },
         ],
       },
       {
@@ -53,10 +80,10 @@ module('Unit | Utility | labeled checkboxes', function () {
         proposals: ['prop 1', 'prop 2', 'prop 3', 'prop 4'],
         answers: [true],
         output: [
-          ['prop 1', true],
-          ['prop 2', false],
-          ['prop 3', false],
-          ['prop 4', false],
+          { label: 'prop 1', checked: true, value: 1 },
+          { label: 'prop 2', checked: false, value: 2 },
+          { label: 'prop 3', checked: false, value: 3 },
+          { label: 'prop 4', checked: false, value: 4 },
         ],
       },
       {
@@ -100,10 +127,7 @@ module('Unit | Utility | labeled checkboxes', function () {
           ' when ' +
           testCase.when,
         function (assert) {
-          assert.strictEqual(
-            JSON.stringify(labeledCheckboxes(testCase.proposals, testCase.answers)),
-            JSON.stringify(testCase.output)
-          );
+          assert.deepEqual(labeledCheckboxes(testCase.proposals, testCase.answers), testCase.output);
         }
       );
     });

--- a/mon-pix/tests/unit/utils/pshuffle_test.js
+++ b/mon-pix/tests/unit/utils/pshuffle_test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { pshuffle } from 'mon-pix/utils/pshuffle';
+
+const shuffleWithSeed = (arr, seed) => {
+  pshuffle(arr, seed);
+  return arr;
+};
+
+module('Unit | Utility | pshuffle', function () {
+  test('shuffles the given array', function (assert) {
+    const arr = shuffleWithSeed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 123);
+
+    assert.notDeepEqual(arr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert.deepEqual(
+      arr.sort((a, b) => a - b),
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    );
+  });
+
+  test('shuffles stably with the same seed', function (assert) {
+    const arr1 = shuffleWithSeed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 456);
+    const arr2 = shuffleWithSeed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 456);
+
+    assert.deepEqual(arr1, arr2);
+  });
+
+  test('shuffles differently with a different seed', function (assert) {
+    const arr1 = shuffleWithSeed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 789);
+    const arr2 = shuffleWithSeed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 987);
+
+    assert.notDeepEqual(arr1, arr2);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lors de l’affichage d’une épreuve de type QCU / QCM, il faudrait afficher de manière aléatoire les différentes propositions si l’option est cochée au niveau de l'épreuve dans pix Editor.

## :robot: Proposition
Mélanger les propositions des QCU/QCM si le booléen `shuffled` est `true` sur le challenge.

## :rainbow: Remarques
L'ordre des propositions pour une épreuve donnée est aléatoire mais stable au sein d'un même parcours (assessment).

## :100: Pour tester
Les deux questions suivantes sont configurées pour être mélangées :
QCM : recLt9uwa2dR3IYpi
QCU : recT0Ks2EDgoDgEKc

Vérifier que les autres questinos QCM/QCU ne sont *pas* mélangées.