### PR TITLE
[BUGFIX] Erreur lors ajout individuel d'un 2ème candidat à une session de certification sur Pix Certif (PIX-7935).

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -88,6 +88,7 @@
           @options={{this.query}}
           class="input"
           id="birthdate"
+          autocomplete="hidden"
           @value={{this.maskedBirthdate}}
           @update={{this.updateBirthdate}}
         />


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'ajout de candidat avec la modale, le premier ajout se fait correctement mais le second monte une erreur.
Le payload nous indique qu'il manque la date de naissance et l'ajout se fait bien lorsqu'on refresh la page.
Après plusieurs tests l'erreur se produit lorsque l'on remplit le champ date avec les proposition de l'autocomplete.
Apparement lors du second ajout avec l'autocomplete l'update ne se fait pas (alors que le premier oui).

## :robot: Proposition
 Bloquer l'autocomplete qui n'est pas pertinent sur cet input.

## :100: Pour tester
- Se connecter sur pix certif avec le compte `certifpro@example.net`
- Ajouter un candidat sur une session déjà existante
- Ajouter un second candidat 
-> Ne pas observer d'erreur ni de proposition de date sur le champ date lors du click