### PR TITLE
[TECH] Compléter et documenter les outils génériques pour la création de contenus formatifs dans les seeds (PIX-7959)

### DIFF
--- a/api/db/seeds/data/common/tooling/index.js
+++ b/api/db/seeds/data/common/tooling/index.js
@@ -1,7 +1,9 @@
 const campaign = require('./campaign-tooling');
 const targetProfile = require('./target-profile-tooling');
+const training = require('./training-tooling');
 
 module.exports = {
   campaign,
   targetProfile,
+  training,
 };

--- a/api/db/seeds/data/common/tooling/training-tooling.js
+++ b/api/db/seeds/data/common/tooling/training-tooling.js
@@ -1,0 +1,144 @@
+const _ = require('lodash');
+const bluebird = require('bluebird');
+const learningContent = require('./learning-content');
+
+module.exports = {
+  createTraining,
+};
+
+const tubeIdsByFramework = {};
+let frameworkNames;
+
+/**
+ * Fonction générique pour créer un contenu formatif selon une configuration donnée.
+ * Retourne l'ID du contenu formatif.
+ *
+ * @param databaseBuilder{DatabaseBuilder}
+ * @param trainingId{number}
+ * @param title{string}
+ * @param link{string}
+ * @param type{string}
+ * @param duration{string}
+ * @param locale{string}
+ * @param editorName{string}
+ * @param editorLogoUrl{string}
+ * @param attachedTargetProfileIds{Array<number>}
+ * @param configTriggers
+ *        [
+ *          {
+ *            type: {('goal','prerequisite')},
+ *            threshold: number,
+ *            frameworks: [
+ *              {
+ *                 chooseCoreFramework: boolean,
+ *                 countTubes: number,
+ *                 minLevel: number,
+ *                 maxLevel: number,
+ *              },
+ *            ],
+ *          },
+ *        ]
+ * @returns {Promise<{trainingId: number}>}
+ */
+async function createTraining({
+  databaseBuilder,
+  trainingId,
+  title,
+  link,
+  type,
+  duration,
+  locale,
+  editorName,
+  editorLogoUrl,
+  attachedTargetProfileIds = [],
+  configTriggers,
+}) {
+  if (!frameworkNames) {
+    const allCompetences = await learningContent.getAllCompetences();
+    await bluebird.map(
+      allCompetences,
+      async (competence) => {
+        if (!tubeIdsByFramework[competence.origin]) tubeIdsByFramework[competence.origin] = [];
+        const skillsForCompetence = await learningContent.findActiveSkillsByCompetenceId(competence.id);
+        tubeIdsByFramework[competence.origin] = _(skillsForCompetence)
+          .flatMap('tubeId')
+          .concat(tubeIdsByFramework[competence.origin])
+          .uniq()
+          .value();
+      },
+      { concurrency: 3 },
+    );
+    frameworkNames = Object.keys(tubeIdsByFramework);
+  }
+  databaseBuilder.factory.buildTraining({
+    id: trainingId,
+    title,
+    link,
+    type,
+    duration,
+    locale,
+    editorName,
+    editorLogoUrl,
+  });
+  attachedTargetProfileIds.map((targetProfileId) =>
+    databaseBuilder.factory.buildTargetProfileTraining({
+      targetProfileId,
+      trainingId,
+    }),
+  );
+  const cappedTubesDTO = [];
+  for (const configTrigger of configTriggers) {
+    const trainingTriggerId = databaseBuilder.factory.buildTrainingTrigger({
+      type: configTrigger.type,
+      threshold: configTrigger.threshold,
+      trainingId,
+    }).id;
+    for (const framework of configTrigger.frameworks) {
+      const frameworkName = _getFrameworkName(framework);
+      for (let i = 0; i < framework.countTubes; ++i) {
+        const tubeId = _pickRandomTube(
+          frameworkName,
+          cappedTubesDTO.map(({ id }) => id),
+        );
+        if (tubeId) {
+          const level = _.random(framework.minLevel, framework.maxLevel);
+          cappedTubesDTO.push({
+            id: tubeId,
+            level,
+          });
+          databaseBuilder.factory.buildTrainingTriggerTube({
+            trainingTriggerId,
+            tubeId,
+            level,
+          });
+        }
+      }
+    }
+  }
+  return { trainingId };
+}
+
+function _getFrameworkName({ chooseCoreFramework }) {
+  if (chooseCoreFramework) return 'Pix';
+  return _pickOneRandomAmong(frameworkNames);
+}
+
+function _pickRandomTube(frameworkName, alreadyPickedTubeIds) {
+  let attempt = 0;
+  while (attempt < 10) {
+    const tubeId = _pickOneRandomAmong(tubeIdsByFramework[frameworkName]);
+    if (!alreadyPickedTubeIds.includes(tubeId)) return tubeId;
+    ++attempt;
+  }
+  return null;
+}
+
+function _pickOneRandomAmong(collection) {
+  const items = _pickRandomAmong(collection, 1);
+  return items[0];
+}
+
+function _pickRandomAmong(collection, howMuch) {
+  const shuffledCollection = _.sortBy(collection, () => _.random(0, 100));
+  return _.slice(shuffledCollection, 0, howMuch);
+}

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -17,6 +17,7 @@ async function teamContenuDataBuilder({ databaseBuilder }) {
   _createProOrganization(databaseBuilder);
   await _createCoreTargetProfile(databaseBuilder);
   await _createDiverseTargetProfile(databaseBuilder);
+  await _createTraining(databaseBuilder);
   await databaseBuilder.commit();
   await _createAssessmentCampaign(databaseBuilder);
   await _createProfilesCollectionCampaign(databaseBuilder);
@@ -201,5 +202,53 @@ async function _createDiverseTargetProfile(databaseBuilder) {
     cappedTubesDTO,
     type: 'THRESHOLD',
     countStages: 4,
+  });
+}
+
+async function _createTraining(databaseBuilder) {
+  const configTriggers = [
+    {
+      type: 'goal',
+      threshold: 80,
+      frameworks: [
+        {
+          chooseCoreFramework: true,
+          countTubes: 15,
+          minLevel: 1,
+          maxLevel: 2,
+        },
+        {
+          chooseCoreFramework: false,
+          countTubes: 2,
+          minLevel: 5,
+          maxLevel: 7,
+        },
+      ],
+    },
+    {
+      type: 'prerequisite',
+      threshold: 10,
+      frameworks: [
+        {
+          chooseCoreFramework: true,
+          countTubes: 5,
+          minLevel: 1,
+          maxLevel: 4,
+        },
+      ],
+    },
+  ];
+  await tooling.training.createTraining({
+    databaseBuilder,
+    trainingId: TEAM_CONTENU_OFFSET_ID,
+    title: 'Contenu formatif / équipe contenu',
+    link: 'https://www.youtube.com/watch?v=qq09UkPRdFY',
+    type: 'Webinaire',
+    duration: '00:04:08',
+    locale: 'fr-fr',
+    editorName: 'Mariah Carey',
+    editorLogoUrl: 'some-butterfly-logo.svg',
+    attachedTargetProfileIds: [TARGET_PROFILE_PIX_ID],
+    configTriggers,
   });
 }


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
Creer un tooling documenté via de la JSDoc afin de génerer des contenus formatifs.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Créer un fichier de seed qui fait appel à ces fonctions et vérifier que la création subséquente est en accord avec ce que vous souhaitiez !
Pour avoir un exemple d'usage, on peut consulter le fichier team-contenu/data-builder.js
