### PR TITLE
[FEATURE][MON-PIX] Ajouter le sélecteur de langue sur la page de présentation d'une campagne (PIX-7744)

### DIFF
--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -1,9 +1,43 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class CampaignLandingPageController extends Controller {
+  @service currentDomain;
+  @service intl;
+  @service locale;
   @service router;
+  @service session;
+
+  @tracked selectedLanguage = this.intl.primaryLocale;
+
+  get shouldDisplayLanguageSwitcher() {
+    return this.isInternationalDomain && this.isUserNotAuthenticated;
+  }
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
+
+  get isUserAuthenticatedByGAR() {
+    return !!this.session.get('data.externalUser');
+  }
+
+  get isUserAuthenticatedByPix() {
+    return this.session.isAuthenticated;
+  }
+
+  get isUserNotAuthenticated() {
+    return !this.isUserAuthenticatedByPix && !this.isUserAuthenticatedByGAR;
+  }
+
+  @action
+  onLanguageChange(language) {
+    this.selectedLanguage = language;
+    this.locale.setLocale(this.selectedLanguage);
+    this.router.replaceWith('campaigns.campaign-landing-page', { queryParams: { lang: null } });
+  }
 
   @action
   startCampaignParticipation() {

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -1,11 +1,14 @@
 /* ------------------------ START ------------------------ */
+.campaign-landing-page__container {
+  margin-bottom: $pix-spacing-xxl;
+}
 
 .campaign-landing-page__container__start {
   display: flex;
   flex-direction: column;
   align-items: center;
   margin-bottom: 25px;
-  padding-bottom: 40px;
+  padding-bottom: $pix-spacing-xl;
 }
 
 .campaign-landing-page__start__image__container {
@@ -56,7 +59,7 @@
   }
 
   &__announcement {
-    margin-top: 16px;
+    margin-top: $pix-spacing-s;
     font-size: 1.125rem;
   }
 
@@ -102,7 +105,7 @@
 }
 
 .campaign-landing-page__start__warning {
-  margin-top: 40px;
+  margin-top: $pix-spacing-xl;
   color: $pix-neutral-90;
   font-size: 0.875rem;
   text-align: center;
@@ -176,7 +179,7 @@
 }
 
 .campaign-landing-page__details__article-side {
-  padding: 0 40px;
+  padding: 0 $pix-spacing-xl;
 }
 
 .campaign-landing-page__details__article-image {

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -59,5 +59,9 @@
         </div>
       </div>
     {{/if}}
+
+    {{#if this.shouldDisplayLanguageSwitcher}}
+      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+    {{/if}}
   </main>
 </div>

--- a/mon-pix/tests/acceptance/campaigns/campaign-landing-page_test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-landing-page_test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../../helpers/setup-intl';
+import { authenticate } from '../../helpers/authentication';
+
+module('Acceptance | Campaigns | campaign-landing-page', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks, ['fr', 'en']);
+
+  let campaign;
+
+  hooks.beforeEach(function () {
+    campaign = server.create('campaign');
+  });
+
+  module('on international domain (.org)', function () {
+    module('when connected', function () {
+      module('when accessing the campaign landing page with "Français" as default language', function () {
+        test('does not display the language switcher', async function (assert) {
+          // given
+          const user = server.create('user', 'withEmail');
+
+          // when
+          await authenticate(user);
+          const screen = await visit(`/campagnes/${campaign.code}`);
+
+          // then
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
+          assert.dom(screen.queryByRole('button', { name: 'Français' })).doesNotExist();
+        });
+      });
+    });
+
+    module('when not connected', function () {
+      module('when accessing the fill in campaign code page with "Français" as default language', function () {
+        test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
+          // given & when
+          const screen = await visit(`/campagnes/${campaign.code}`);
+
+          // then
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
+        });
+
+        module('when the user select "English" language', function () {
+          test('displays the fill in campaign code page with "English" as selected language', async function (assert) {
+            // given & when
+            const screen = await visit(`/campagnes/${campaign.code}`);
+            await click(screen.getByRole('button', { name: 'Français' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'English' }));
+
+            // then
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.dom(screen.getByRole('button', { name: 'Begin' })).exists();
+          });
+        });
+      });
+
+      module('when accessing the fill in campaign code page with "English" as selected language', function () {
+        test('displays the fill in campaign code page with "English"', async function (assert) {
+          // given && when
+          const screen = await visit(`/campagnes/${campaign.code}?lang=en`);
+
+          // then
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.dom(screen.getByRole('button', { name: 'Begin' })).exists();
+        });
+
+        module('when the user select "Français" language', function () {
+          test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
+            // given & when
+            const screen = await visit(`/campagnes/${campaign.code}?lang=en`);
+            await click(screen.getByRole('button', { name: 'English' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'Français' }));
+
+            // then
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pour l'instant pas possible de changer la langue d'affichage une fois sur la page de présentation d'une campagne `/campagnes/<campaign-code>`. Le seul moyen que l'on a c'est de modifier l'URL en `/campagnes/<campaign-code>?lang=en`.

## :robot: Proposition

- Afficher le sélecteur de langue sur la page `/campagnes/<campaign-code>/presentation`
- Ne pas afficher le sélecteur
  - quand une session est en cours (un utilisateur est connecté)
  - quand on se trouve sur le domaine Français (.fr)

## :rainbow: Remarques

L'URL `/campagnes/<campaign-code>` fait une redirection vers la page `/campagnes/<campaign-code>/presentation`.

## :100: Pour tester

### Pix app (.fr)

#### Connecté

- Se connecter : https://app-pr6156.review.pix.fr/
- Aller sur la page de présentation d'une campagne
  - via le bouton `J'ai un code` et fournir le code `SCOBADGE1`
  - ou en modifiant l'URL https://app-pr6156.review.pix.fr/campagnes/SCOBADGE1
- Vérifier que le sélecteur de langue ne s'affiche pas

#### Non connecté

- Ouvrir la page : https://app-pr6156.review.pix.fr/campagnes/SCOBADGE1
- Vérifier que le sélecteur de langue ne s'affiche pas

### Pix app (.org)

#### Connecté

- Se connecter : https://app-pr6156.review.pix.org/
- Aller sur la page de présentation d'une campagne
  - via le bouton `J'ai un code` et fournir le code `SCOBADGE1`
  - ou en modifiant l'URL https://app-pr6156.review.pix.org/campagnes/SCOBADGE1
- Vérifier que le sélecteur de langue ne s'affiche pas

#### Non connecté

- Ouvrir la page : https://app-pr6156.review.pix.org/campagnes/SCOBADGE1
- Vérifier que le sélecteur de langue s'affiche
- Sélectionner une nouvelle langue
- Vérifier que le choix a été pris en compte, le contenu a été modifié et le sélecteur affiche la langue sélectionnée