### PR TITLE
[TECH] Utilise exclusivement l'API history dans les apps Ember

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
     modulePrefix: 'pix-admin',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -24,7 +24,7 @@ module.exports = function (environment) {
     modulePrefix: 'pix-certif',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -23,7 +23,7 @@ module.exports = function (environment) {
     modulePrefix: 'mon-pix',
     environment: environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
     modulePrefix: 'pix-orga',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
## :unicorn: Problème
Nous avons des deprecations warning lorsque nous lancons les applications ember. La méthode *auto* pour déterminer si l'API history est supporté ou non est déprécié.
Voir: https://deprecations.emberjs.com/v4.x/#toc_deprecate-auto-location

## :robot: Proposition
Passer explicitement a la méthode history pour éviter ces warnings.
D'après MDN, l'history API est supporté dans tout les navigateurs que nous supportons: https://developer.mozilla.org/en-US/docs/Web/API/History_API

## :100: Pour tester
1. Lancer les applications mon-pix, certif, admin et orga.
1. Aller sur leurs page d'accueil
1. Ouvrir les developers tools
1. Constater que le deprecation warning sur l'history API n'est plus présent