### PR TITLE
[FEATURE] Amélioration de message de validation de suppression d'une participation (PIX-5625)

### DIFF
--- a/orga/app/components/campaign/activity/delete-participation-modal.hbs
+++ b/orga/app/components/campaign/activity/delete-participation-modal.hbs
@@ -1,16 +1,16 @@
 <PixModal
-  @title={{t "pages.campaign-activity.delete-participation-modal.title"}}
+  @title={{t
+    "pages.campaign-activity.delete-participation-modal.title"
+    lastName=@participation.lastName
+    firstName=@participation.firstName
+    htmlSafe=true
+  }}
   @onCloseButtonClick={{@closeModal}}
   @showModal={{@isModalOpen}}
 >
   <:content>
     <p>
-      {{t
-        "pages.campaign-activity.delete-participation-modal.text"
-        lastName=@participation.lastName
-        firstName=@participation.firstName
-        htmlSafe=true
-      }}
+      {{this.deleteParticipationModalText}}
     </p>
     <p class="warning-text">
       {{t "pages.campaign-activity.delete-participation-modal.warning"}}
@@ -20,7 +20,7 @@
     <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{@closeModal}}>
       {{t "pages.campaign-activity.delete-participation-modal.actions.cancel"}}
     </PixButton>
-    <PixButton @backgroundColor="red" @triggerAction={{this.deleteCampaignParticipation}}>
+    <PixButton @backgroundColor="red" @triggerAction={{@deleteCampaignParticipation}}>
       {{t "pages.campaign-activity.delete-participation-modal.actions.confirmation"}}
     </PixButton>
   </:footer>

--- a/orga/app/components/campaign/activity/delete-participation-modal.js
+++ b/orga/app/components/campaign/activity/delete-participation-modal.js
@@ -1,10 +1,32 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { service } from '@ember/service';
 
-export default class deleteParticipantModal extends Component {
-  @action
-  deleteCampaignParticipation() {
-    this.args.deleteCampaignParticipant(this.args.campaign.id, this.args.participation);
-    this.args.closeModal();
+export default class deleteParticipationModal extends Component {
+  @service intl;
+
+  get deleteParticipationModalText() {
+    if (!this.args.participation) {
+      return null;
+    }
+    return this.intl.t(
+      `${DELETE_PARTICIPATION_MODAL_CONTENT[this.args.campaign.type][this.args.participation.status]}`
+    );
   }
 }
+
+const DELETE_PARTICIPATION_MODAL_CONTENT = {
+  ASSESSMENT: {
+    STARTED:
+      'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.started-participation',
+    TO_SHARE:
+      'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.to-share-participation',
+    SHARED:
+      'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.shared-participation',
+  },
+  PROFILES_COLLECTION: {
+    TO_SHARE:
+      'pages.campaign-activity.delete-participation-modal.text.profiles-collection-campaign-participation.to-share-participation',
+    SHARED:
+      'pages.campaign-activity.delete-participation-modal.text.profiles-collection-campaign-participation.shared-participation',
+  },
+};

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -109,7 +109,7 @@
   <Campaign::Activity::DeleteParticipationModal
     @participation={{this.participationToDelete}}
     @campaign={{@campaign}}
-    @deleteCampaignParticipant={{@deleteCampaignParticipant}}
+    @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
     @closeModal={{this.closeModal}}
     @isModalOpen={{this.isModalOpen}}
   />

--- a/orga/app/components/campaign/activity/participants-list.js
+++ b/orga/app/components/campaign/activity/participants-list.js
@@ -33,4 +33,11 @@ export default class ParticipantsList extends Component {
     this.participationToDelete = null;
     this.isModalOpen = false;
   }
+
+  @action
+  deleteCampaignParticipation() {
+    this.isModalOpen = false;
+    this.args.deleteCampaignParticipation(this.args.campaign.id, this.participationToDelete);
+    this.participationToDelete = null;
+  }
 }

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -42,7 +42,7 @@ export default class ActivityController extends Controller {
   }
 
   @action
-  async deleteCampaignParticipant(campaignId, campaignParticipantActivity) {
+  async deleteCampaignParticipation(campaignId, campaignParticipantActivity) {
     try {
       await campaignParticipantActivity.destroyRecord({
         adapterOptions: { campaignId, campaignParticipationId: campaignParticipantActivity.id },

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -21,7 +21,7 @@
     @searchFilter={{this.search}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}
-    @deleteCampaignParticipant={{this.deleteCampaignParticipant}}
+    @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
     class="activity__participants-list"
   />
 {{else}}

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -31,7 +31,7 @@ module('Acceptance | Campaign Activity', function (hooks) {
       campaignAssessmentParticipationResult,
       lastName: 'Bacri',
     });
-    server.create('campaign-participant-activity', { id: 1, lastName: 'Bacri' });
+    server.create('campaign-participant-activity', { id: 1, lastName: 'Bacri', status: 'SHARED' });
 
     await authenticateSession(user.id);
   });
@@ -41,6 +41,7 @@ module('Acceptance | Campaign Activity', function (hooks) {
       test('it could click on user to go to details', async function (assert) {
         // when
         await visit('/campagnes/1');
+
         await clickByName('Voir les résultats de Bacri');
 
         // then
@@ -87,14 +88,15 @@ module('Acceptance | Campaign Activity', function (hooks) {
     test('Success case: should display empty sentence and success notification', async function (assert) {
       // when
       const screen = await visit('/campagnes/1');
+
       await click(screen.getByLabelText('Supprimer la participation'));
 
       await screen.findByRole('dialog');
 
       await clickByName('Oui, je supprime');
       // then
-      assert.contains('Aucun participant');
       assert.contains('La participation a été supprimée avec succès.');
+      assert.contains('Aucun participant');
     });
 
     test('Error case: should display an error notification', async function (assert) {

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -91,12 +91,12 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
     });
   });
 
-  module('#deleteCampaignParticipant', function (hooks) {
+  module('#deleteCampaignParticipation', function (hooks) {
     hooks.beforeEach(function () {
       controller.model = { campaign: { isTypeAssessment: false, id: 7 } };
     });
 
-    module('when the deleteCampaignParticipant works', function () {
+    module('when the deleteCampaignParticipation works', function () {
       test('it should called destroyRecord', async function (assert) {
         // given
         const campaignParticipantActivity = {
@@ -106,7 +106,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         const campaignId = controller.model.campaign.id;
         controller.send = sinon.stub();
         // when
-        await controller.deleteCampaignParticipant(campaignId, campaignParticipantActivity);
+        await controller.deleteCampaignParticipation(campaignId, campaignParticipantActivity);
 
         //then
         assert.true(

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -313,8 +313,18 @@
         },
         "error": "An error occurred while removing this participation.",
         "success": "The participation has been successfully deleted",
-        "title": "Delete this participation ?",
-        "text": "You are about to delete the participation of <strong>{firstName} {lastName}</strong>, it will no longer be visible nor included in the statistics of the campaign.",
+        "title": "Delete the participation of <strong>{firstName} {lastName}</strong>?",
+        "text": {
+          "assessment-campaign-participation": {
+            "started-participation": "You are about to delete a participation, it will no longer be visible nor included in the statistics of the campaign.",
+            "to-share-participation": "The participant will no longer be able to submit their results nor to take the test again.",
+            "shared-participation": "The participant will not be able to take the test again."
+          },
+          "profiles-collection-campaign-participation": {
+            "to-share-participation": "The participant will no longer be able to submit their profile through this campaign.",
+            "shared-participation": "The participant will no longer be able to submit their profile through this campaign."    
+          }
+        },
         "warning": "The participant will be able to complete their customised test but will no longer be able to submit their results. They will also not be able to participate in the campaign again."
       }
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -316,8 +316,18 @@
         },
         "error": "Un problème est survenu lors de la suppression de la participation.",
         "success": "La participation a été supprimée avec succès.",
-        "title": "Supprimer cette participation ?",
-        "text": "Vous êtes sur le point de supprimer la participation de <strong>{firstName} {lastName}</strong>, celle-ci ne sera plus visible ni comprise dans les statistiques de la campagne.",
+        "title": "Supprimer la participation de <strong>{firstName} {lastName}</strong> ?",
+        "text": {
+          "assessment-campaign-participation": {
+            "started-participation": "Vous êtes sur le point de supprimer une participation, celle-ci ne sera plus visible ni comprise dans les statistiques de la campagne.",
+            "to-share-participation": "Le participant ne pourra pas envoyer ses résultats et il ne pourra pas non plus participer de nouveau à cette campagne.",
+            "shared-participation": "Le participant ne pourra plus participer de nouveau à cette campagne."    
+          },
+          "profiles-collection-campaign-participation": {
+            "to-share-participation": "Le participant ne pourra pas envoyer son profil et il ne pourra pas non plus participer de nouveau à cette collecte de profil.",
+            "shared-participation": "Le participant ne pourra plus participer de nouveau à cette collecte de profil."    
+          }
+        },
         "warning": "Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne."
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, onglet “activité” d’une campagne, lorsque l’utilisateur veut supprimer une participation, la fenêtre qui lui demande confirmation comporte toujours le même second paragraphe, quel que soit le statut de la participation :

> “Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne.”



Il serait préférable de distinguer plusieurs cas, selon le statut de la participation et le type de campagne :

- la participation est en cours,
- la participation est en attente d’envoi des résultats,
- les résultats on été envoyés.

et cela selon le type de campagne : évaluation et collecte de profils.

## :robot: Proposition
Conditionner le second paragraphe par le statut de la participation et le type de la campagne.

### Pour les campagnes d'évaluation

#### Si la participation est en cours
**FR :** garder le texte actuel
**EN :** inchangé

#### Si la participation est en attente d’envoi des résultats
**FR :** “Le participant ne pourra pas envoyer ses résultats et il ne pourra pas non plus participer de nouveau à cette campagne."
**EN :** "The participant will no longer be able to submit their results nor to take the test again."

#### Si les résultats ont été envoyés 
**FR :** “Le participant ne pourra plus participer de nouveau à cette campagne.” 
**EN :** "The participant will not be able to take the test again."

### Pour les collectes de profil

#### Si la participation est en attente d’envoi du profil**
**FR :** “Le participant ne pourra pas envoyer son profil et il ne pourra pas non plus participer de nouveau à cette collecte de profil.”
**EN :** "The participant will no longer be able to submit their profile through this campaign'

#### Si le profil est reçu 
**FR :** “Le participant ne pourra plus participer de nouveau à cette collecte de profil.” 
**EN :** "The participant will no longer be able to submit their profile through this campaign"

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga
- Aller sur une campagne qui a des participations
- Vérifier les messages dans les modales lors de tentative de suppression d'une participation à une campagne de collecte de profile EN COURS et ENVOYÉ
- Vérifier les messages dans les modales lors de tentative de suppression d'une participation à une campagne d'évaluation EN COURS, EN ATTENTE D'ENVOI et ENVOYÉ
- Bien sûr, vérifier tout ça en français ET en anglais 😇 
- La review est terminée 🎉 