### PR TITLE
[TECH] montée de version pix-ui : 34.1.0 (PIX-7899)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/demo.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/demo.feature
@@ -9,7 +9,7 @@ Fonctionnalité: Demo
     Lorsque je vois l'épreuve "Combien font 2 + 2 ?"
     Et je clique sur "Je passe"
     Et je vois l'épreuve "Quel mot est synonyme de « regarder » ?"
-    Et je choisis la réponse "radio_3"
+    Et je clique sur "jouer"
     Et je clique sur "Je valide"
     Et je vois l'épreuve "quel est le verbe ?"
     Et je saisis "manger" dans le champ "Réponse :"

--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -1,14 +1,14 @@
 // Given
 Given(`je me connecte avec le compte {string}`, (email) => {
   cy.get('input[name="login"]').type(email);
-  cy.get('input[name="password"]').type('pix123');
-  cy.get('button[type=submit]').click();
+  cy.get('input[name="password"]').type("pix123");
+  cy.get("button[type=submit]").click();
 });
 
 Given(`je me connecte avec un mot de passe temporaire`, () => {
-  cy.get('input[name="login"]').type('tommen.baratheon1234');
-  cy.get('input[name="password"]').type('Pix12345');
-  cy.get('button[type=submit]').click();
+  cy.get('input[name="login"]').type("tommen.baratheon1234");
+  cy.get('input[name="password"]').type("Pix12345");
+  cy.get("button[type=submit]").click();
 });
 
 Given(
@@ -16,19 +16,19 @@ Given(
   (firstname, lastname, email, password) => {
     cy.get('input[id="firstName"]').type(firstname);
     cy.get('input[id="lastName"]').type(lastname);
-    cy.get('input[id=email]').type(email);
-    cy.get('input[id=password]').type(password);
-    cy.get('input[id=checkbox]').check();
-    cy.get('button[type=submit]').click();
+    cy.get("input[id=email]").type(email);
+    cy.get("input[id=password]").type(password);
+    cy.get("input[type=checkbox]").check();
+    cy.get("button[type=submit]").click();
   }
 );
 
 // When
-When('je me connecte à Pix via le GAR', () => {
+When("je me connecte à Pix via le GAR", () => {
   cy.loginExternalPlatformForTheFirstTime();
 });
 
-When('je me connecte sur Pix pour la seconde fois via le GAR', () => {
+When("je me connecte sur Pix pour la seconde fois via le GAR", () => {
   cy.loginExternalPlatformForTheSecondTime();
 });
 
@@ -36,7 +36,7 @@ When(`je vais sur l'inscription de Pix`, () => {
   cy.visitMonPix(`/inscription`);
 });
 
-When('je suis connecté avec un compte dont le token expire bientôt', () => {
+When("je suis connecté avec un compte dont le token expire bientôt", () => {
   cy.loginWithAlmostExpiredToken();
 });
 
@@ -46,33 +46,33 @@ When(`j'attends {int} ms`, (duration) => {
 
 // Then
 Then(`je suis redirigé vers la page d'accueil de {string}`, (firstName) => {
-  cy.url().should('include', '/accueil');
-  cy.get('.logged-user-name').should((userName) => {
+  cy.url().should("include", "/accueil");
+  cy.get(".logged-user-name").should((userName) => {
     expect(userName.text()).to.contains(firstName);
   });
 });
 
 Then(`je suis redirigé vers le profil de {string}`, (firstName) => {
-  cy.url().should('include', '/competences');
-  cy.get('.logged-user-name').should((userName) => {
+  cy.url().should("include", "/competences");
+  cy.get(".logged-user-name").should((userName) => {
     expect(userName.text()).to.contains(firstName);
   });
-  cy.get('.rounded-panel-title').should((title) => {
-    expect(title.text()).to.contains('Vous avez 16 compétences à tester.');
+  cy.get(".rounded-panel-title").should((title) => {
+    expect(title.text()).to.contains("Vous avez 16 compétences à tester.");
   });
 });
 
 Then(`je suis redirigé vers le compte Orga de {string}`, (fullName) => {
-  cy.url().should('include', '/campagnes');
-  cy.contains(fullName).should('be.visible');
-  cy.get('.list-campaigns-page').should((list) => {
+  cy.url().should("include", "/campagnes");
+  cy.contains(fullName).should("be.visible");
+  cy.get(".list-campaigns-page").should((list) => {
     expect(list).to.exist;
   });
 });
 
 When(`je me déconnecte`, () => {
-  cy.get('.logged-user-name__link').click();
-  cy.get('ul.logged-user-menu__actions')
+  cy.get(".logged-user-name__link").click();
+  cy.get("ul.logged-user-menu__actions")
     .children()
     .children("[href*='deconnexion']")
     .click();
@@ -80,17 +80,17 @@ When(`je me déconnecte`, () => {
 
 When(`je me déconnecte de Pix Orga`, () => {
   cy.get('[aria-label="Ouvrir le menu utilisateur"]').click();
-  cy.contains('Se déconnecter').click();
+  cy.contains("Se déconnecter").click();
 });
 
 Then(`je suis redirigé vers la page {string}`, (pathname) => {
-  cy.url().should('include', pathname);
+  cy.url().should("include", pathname);
 });
 
 When(`j'accepte les CGU de Pix`, () => {
-  cy.get('input[type=checkbox]').click();
+  cy.get("input[type=checkbox]").click();
 });
 
 When(`j'accepte les CGU de Pix Orga`, () => {
-  cy.get('button').contains('J’accepte les conditions d’utilisation').click();
+  cy.get("button").contains("J’accepte les conditions d’utilisation").click();
 });

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
@@ -28,10 +28,7 @@
     />
 
     <div class="update-sco-record-form__cgu-container">
-      <PixCheckbox @id="checkbox" @screenReaderOnly="true" {{on "change" this.onChange}}>
-        {{t "common.cgu.label"}}
-      </PixCheckbox>
-      <p class="account-recovery__content--information-text--details">
+      <PixCheckbox {{on "change" this.onChange}}>
         {{t "common.cgu.accept"}}
         <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
           {{t "common.cgu.cgu"}}
@@ -41,7 +38,7 @@
           {{t "common.cgu.data-protection-policy"}}
         </a>
         {{t "common.cgu.pix"}}
-      </p>
+      </PixCheckbox>
     </div>
 
     <PixButton

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -16,10 +16,7 @@
       </div>
     </div>
     <div class="login-or-register-oidc-form__cgu-container">
-      <PixCheckbox @id="checkbox" @screenReaderOnly="true" {{on "change" this.onChange}}>
-        {{t "common.cgu.label"}}
-      </PixCheckbox>
-      <p class="login-or-register-oidc-form__cgu-label">
+      <PixCheckbox {{on "change" this.onChange}}>
         {{t "common.cgu.accept"}}
         <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
           {{t "common.cgu.cgu"}}
@@ -29,7 +26,7 @@
           {{t "common.cgu.data-protection-policy"}}
         </a>
         {{t "common.cgu.pix"}}
-      </p>
+      </PixCheckbox>
     </div>
 
     {{#if this.registerError}}

--- a/mon-pix/app/components/qcu-proposals.hbs
+++ b/mon-pix/app/components/qcu-proposals.hbs
@@ -2,20 +2,16 @@
 {{#each this.labeledRadios as |labeledRadio index|}}
   <p class="proposal-paragraph qcu-proposals">
     <PixRadioButton
-      id="radio_{{inc index}}"
       name="radio"
-      @label={{this.label}}
       @value={{inc index}}
-      @isDisabled={{@isAnswerFieldDisabled}}
+      disabled={{@isAnswerFieldDisabled}}
       checked={{get labeledRadio 1}}
       {{on "click" (fn this.radioClicked index)}}
       data-value="{{inc index}}"
       class="qcu-proposals__radio"
       data-test="challenge-response-proposal-selector"
-    />
-
-    <label for="radio_{{inc index}}" class="qcu-proposals__label">
+    >
       <MarkdownToHtml @class="qcu-panel__text proposal-text" @markdown={{get labeledRadio 0}} />
-    </label>
+    </PixRadioButton>
   </p>
 {{/each}}

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -79,7 +79,7 @@
       </div>
 
       <div class="signup-form__cgu-container">
-        <p class="signup-form__cgu-label">
+        <PixCheckbox {{on "change" this.onChange}} aria-describedby="sign-up-cgu-error-message">
           {{t "common.cgu.accept"}}
           <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
             {{t "common.cgu.cgu"}}
@@ -89,14 +89,6 @@
             {{t "common.cgu.data-protection-policy"}}
           </a>
           {{t "common.cgu.pix"}}
-        </p>
-        <PixCheckbox
-          @id="checkbox"
-          @screenReaderOnly="true"
-          {{on "change" this.onChange}}
-          aria-describedby="sign-up-cgu-error-message"
-        >
-          {{t "common.cgu.label"}}
         </PixCheckbox>
       </div>
       <p class="sign-form__validation-error" aria-live="polite" role="alert" id="sign-up-cgu-error-message">

--- a/mon-pix/app/styles/components/_qcu-proposals.scss
+++ b/mon-pix/app/styles/components/_qcu-proposals.scss
@@ -21,14 +21,4 @@
       @include external-link;
     }
   }
-
-  &__label {
-    position: relative;
-    display: inline-block;
-    width: 100%;
-    padding-left: 20px;
-    font-weight: $font-normal;
-    line-height: 21px;
-    cursor: pointer;
-  }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^31.1.0",
+        "@1024pix/pix-ui": "^34.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -253,14 +253,13 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
-      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
+      "version": "34.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.1.0.tgz",
+      "integrity": "sha512-GhVS7hE4JO0mGkS9vS/pNvRAjQCDcg5zTJwPW08tPV94O5LHXwfH6zdSAbZr2cv4VZY8eVrVZQxF8vnclhhjLQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@formatjs/intl": "^2.5.1",
-        "color": "^4.2.3",
         "ember-auto-import": "^2.5.0",
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
@@ -14596,19 +14595,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -14624,16 +14610,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -14642,24 +14618,6 @@
       "bin": {
         "color-support": "bin.js"
       }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -36309,21 +36267,6 @@
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
-    },
     "node_modules/sinon": {
       "version": "15.0.3",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.3.tgz",
@@ -40900,13 +40843,12 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
-      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
+      "version": "34.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.1.0.tgz",
+      "integrity": "sha512-GhVS7hE4JO0mGkS9vS/pNvRAjQCDcg5zTJwPW08tPV94O5LHXwfH6zdSAbZr2cv4VZY8eVrVZQxF8vnclhhjLQ==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
-        "color": "^4.2.3",
         "ember-auto-import": "^2.5.0",
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
@@ -52205,33 +52147,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -52246,16 +52161,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -69163,23 +69068,6 @@
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
-        }
-      }
     },
     "sinon": {
       "version": "15.0.3",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^31.1.0",
+    "@1024pix/pix-ui": "^34.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
@@ -15,9 +15,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
       test('should redirect the user to logout url', async function (assert) {
         // given
         const screen = await visit('/connexion/oidc-partner?code=code&state=state');
-        await click(
-          screen.getByLabelText('Accepter les conditions d’utilisation de Pix et la politique de confidentialité')
-        );
+        await click(screen.getByLabelText(this.intl.t('common.cgu.label')));
         await click(screen.getByRole('button', { name: 'Je créé mon compte' }));
         await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
 

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -37,13 +37,7 @@ module('Integration | Component | account-recovery | update-sco-record', functio
     assert.ok(submitButton);
     assert.true(submitButton.disabled);
 
-    assert
-      .dom(
-        screen.getByRole('checkbox', {
-          name: 'Accepter les conditions d’utilisation de Pix et la politique de confidentialité',
-        })
-      )
-      .exists();
+    assert.dom(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') })).exists();
     assert.ok(screen.getByRole('link', { name: this.intl.t('common.cgu.cgu') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('common.cgu.data-protection-policy') }));
   });

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -59,7 +59,7 @@
       "data-protection-policy": "politique de confidentialité",
       "pix": " de Pix",
       "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
-      "label": "Accepter les conditions d’utilisation de Pix et la politique de confidentialité"
+      "label": "J'accepte les conditions d'utilisation et la politique de confidentialité de Pix"
     },
     "error": "Une erreur est survenue. Veuillez recommencer ou contacter le support.",
     "form": {


### PR DESCRIPTION
## :unicorn: Problème

On a besoin de la dernière version de Pix-ui pour entamer la mise à jour du style du bloc réponse des écrans d'épreuve.

## :robot: Proposition

Passer à la version 34.1.0 de pix-ui et prendre en compte les breaking changes qui concernent les labels des composants PixRadioButton et PixCheckbox (ils doivent être passés en slot dans les deux cas).

## :rainbow: Remarques

Ce changement de comportement permet de rectifier des problématiques d'accessibilité (labels qui n'étaient pas associés techniquement à leur input).

## :100: Pour tester

Vérifier les pages de PixApp comportant des checkbox et radio
