### PR TITLE
[TECH] Utiliser la méthode `render` d'`ember-testing-library` plutôt que celle de `@ember/test-helpers` (PIX-7998)

### DIFF
--- a/mon-pix/blueprints/component-test/files/tests/integration/components/__name___test.js
+++ b/mon-pix/blueprints/component-test/files/tests/integration/components/__name___test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component |  <%= dasherizedModuleName %>', function (hooks) {

--- a/mon-pix/tests/integration/components/account-recovery/student-information-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/student-information-form-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-// eslint-disable-next-line no-restricted-imports
-import { render, triggerEvent } from '@ember/test-helpers';
+
+import { triggerEvent } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { contains } from '../../../helpers/contains';

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/to-share_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { contains } from '../../../../helpers/contains';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-// eslint-disable-next-line no-restricted-imports
-import { findAll, render } from '@ember/test-helpers';
+import { findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';

--- a/mon-pix/tests/integration/components/certification-not-certifiable_test.js
+++ b/mon-pix/tests/integration/components/certification-not-certifiable_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { render, find } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | certification-not-certifiable', function (hooks) {

--- a/mon-pix/tests/integration/components/certifications-list_test.js
+++ b/mon-pix/tests/integration/components/certifications-list_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { findAll, render } from '@ember/test-helpers';
+import { findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 

--- a/mon-pix/tests/integration/components/challenge-actions_test.js
+++ b/mon-pix/tests/integration/components/challenge-actions_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | challenge actions', function (hooks) {

--- a/mon-pix/tests/integration/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/integration/components/challenge-item-qroc_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Challenge item QROC', function (hooks) {

--- a/mon-pix/tests/integration/components/challenge/item_test.js
+++ b/mon-pix/tests/integration/components/challenge/item_test.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
+++ b/mon-pix/tests/integration/components/challenge/statement/tooltip_test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-// eslint-disable-next-line no-restricted-imports
-import { click, render, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
+import { click, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/circle-chart_test.js
+++ b/mon-pix/tests/integration/components/circle-chart_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | circle-chart', function (hooks) {

--- a/mon-pix/tests/integration/components/communication-banner_test.js
+++ b/mon-pix/tests/integration/components/communication-banner_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'mon-pix/config/environment';
 

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | comparison-window', function (hooks) {

--- a/mon-pix/tests/integration/components/competence-card-default_test.js
+++ b/mon-pix/tests/integration/components/competence-card-default_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | competence-card-default', function (hooks) {

--- a/mon-pix/tests/integration/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | competence-card-mobile', function (hooks) {

--- a/mon-pix/tests/integration/components/feedback-certification-section_test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { render, find } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | feedback-certification-section', function (hooks) {

--- a/mon-pix/tests/integration/components/form-textfield-date_test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { fillIn, find, render, triggerEvent } from '@ember/test-helpers';
+import { fillIn, find, triggerEvent } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | form textfield date', function (hooks) {

--- a/mon-pix/tests/integration/components/form-textfield_test.js
+++ b/mon-pix/tests/integration/components/form-textfield_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
+import { click, fillIn, find, triggerEvent } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | form textfield', function (hooks) {

--- a/mon-pix/tests/integration/components/inaccessible-campaign_test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign_test.js
@@ -4,8 +4,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | inaccessible-campaign', function (hooks) {

--- a/mon-pix/tests/integration/components/learning-more-panel_test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { A } from '@ember/array';
 import EmberObject from '@ember/object';
 import { hbs } from 'ember-cli-htmlbars';

--- a/mon-pix/tests/integration/components/levelup-notif_test.js
+++ b/mon-pix/tests/integration/components/levelup-notif_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | levelup-notif', function (hooks) {

--- a/mon-pix/tests/integration/components/no-certification-panel_test.js
+++ b/mon-pix/tests/integration/components/no-certification-panel_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | no certification panel', function (hooks) {

--- a/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render, click } from '@ember/test-helpers';
+import { find, click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pix-toggle-deprecated', function (hooks) {

--- a/mon-pix/tests/integration/components/profile-content_test.js
+++ b/mon-pix/tests/integration/components/profile-content_test.js
@@ -3,8 +3,7 @@
 
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { setBreakpoint } from 'ember-responsive/test-support';

--- a/mon-pix/tests/integration/components/qcm-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcm-proposals_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | QCM proposals', function (hooks) {

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, findAll, render } from '@ember/test-helpers';
+import { find, findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 const assessment = {};

--- a/mon-pix/tests/integration/components/qcu-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | QCU proposals', function (hooks) {

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, findAll, render } from '@ember/test-helpers';
+import { find, findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 const assessment = {};

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | QROC solution panel', function (hooks) {

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, findAll, render } from '@ember/test-helpers';
+import { find, findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 const ANSWER = '.correction-qrocm__answer';

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, findAll, render } from '@ember/test-helpers';
+import { find, findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 const ANSWER = '.correction-qrocm__answer';

--- a/mon-pix/tests/integration/components/result-item-campaign_test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | result-item', function (hooks) {

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -4,8 +4,7 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 import { fillInByLabel } from '../../../../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
 import { contains } from '../../../../../helpers/contains';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { render, find } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/campaigns/invited/fill-in-participant-external-id', function (hooks) {

--- a/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
@@ -3,8 +3,7 @@ import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import { contains } from '../../../../../helpers/contains';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | routes/campaigns/profiles_collection/send-profile', function (hooks) {

--- a/mon-pix/tests/integration/components/routes/login-form_test.js
+++ b/mon-pix/tests/integration/components/routes/login-form_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 // eslint-disable-next-line no-restricted-imports
-import { click, fillIn, render, find } from '@ember/test-helpers';
+import { click, fillIn, find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';

--- a/mon-pix/tests/integration/components/routes/login-or-register_test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { clickByLabel } from '../../../helpers/click-by-label';
 

--- a/mon-pix/tests/integration/components/timeout-gauge_test.js
+++ b/mon-pix/tests/integration/components/timeout-gauge_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | TimeoutGauge', function (hooks) {

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -2,7 +2,8 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Tutorial Panel', function (hooks) {

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';

--- a/mon-pix/tests/integration/components/tutorials/cards_test.js
+++ b/mon-pix/tests/integration/components/tutorials/cards_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-// eslint-disable-next-line no-restricted-imports
-import { findAll, render } from '@ember/test-helpers';
+
+import { findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
@@ -3,7 +3,8 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { A as EmberArray } from '@ember/array';
 
 module('Integration | Component | user-certifications-detail-competence', function (hooks) {

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 // eslint-disable-next-line no-restricted-imports
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 

--- a/mon-pix/tests/unit/helpers/contains_test.js
+++ b/mon-pix/tests/unit/helpers/contains_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 import { contains } from '../../helpers/contains';


### PR DESCRIPTION
## :unicorn: Problème
Nous avons [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js?rgh-link-date=2023-05-02T14%3A34%3A10Z).

Il est de plus en plus présent dans nos tests front mais nombre d'entre eux se basent toujours sur du html, du css.

Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :robot: Proposition
Importer notre méthode `render` de `ember-testing-library` qui donne accès notamment aux sélecteurs par role pour répondre aux problèmes ci-dessus.

## :rainbow: Remarques
C'est la suite de #6122.

## :100: Pour tester
Vérifier que la CI passe.
