### PR TITLE
[TECH] Fournir des outils génériques et documentés orientés "Organisations" et "Centres de certification" (PIX-7995)

### DIFF
--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -11,9 +11,7 @@ const {
   PIX_DROIT_SESSION_ID,
   COMPLEMENTARY_CERTIFICATIONS_SESSION_ID,
 } = require('./certification-sessions-builder');
-const {
-  SCO_STUDENT_ID: SCO_STUDENT_ORGANIZATION_LEARNER_ID,
-} = require('../organizations-sco-builder');
+const { SCO_STUDENT_ID: SCO_STUDENT_ORGANIZATION_LEARNER_ID } = require('../organizations-sco-builder');
 const {
   CERTIF_SUCCESS_USER_ID,
   CERTIF_FAILED_USER_ID,
@@ -24,7 +22,7 @@ const {
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-} = require('./certification-centers-builder');
+} = require('../common/common-builder');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { BILLING_MODES } = require('../../../../lib/domain/models/CertificationCandidate');
 

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -1,5 +1,11 @@
 const _ = require('lodash');
 const { DEFAULT_PASSWORD } = require('../users-builder');
+const {
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+} = require('../common/common-builder');
 
 const SCO_COLLEGE_CERTIF_CENTER_ID = 1;
 const GREAT_OAK_CERTIF_CENTER_ID = 23;
@@ -24,10 +30,6 @@ const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
 const GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID = '1237457M';
 const AGRI_SCO_MANAGING_STUDENT_ID = 9;
 const AGRI_SCO_MANAGING_STUDENT_NAME = 'Centre AGRI des Anne-Etoiles';
-const CLEA_COMPLEMENTARY_CERTIFICATION_ID = 52;
-const PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID = 53;
-const PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 54;
-const PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 55;
 const PIX_CLEA_V3_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 56;
 const PIX_DROIT_MAITRE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 57;
 const PIX_EDU_1ER_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 58;
@@ -51,9 +53,6 @@ const {
 } = require('../badges-builder');
 
 function certificationCentersBuilder({ databaseBuilder }) {
-  databaseBuilder.factory.buildComplementaryCertification.clea({
-    id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
-  });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V1,
     level: 1,
@@ -80,32 +79,6 @@ function certificationCentersBuilder({ databaseBuilder }) {
     imageUrl: 'https://images.pix.fr/badges/CleA_Num_certif.svg',
     stickerUrl: 'https://images.pix.fr/stickers/macaron_clea.pdf',
     label: 'CléA Numérique',
-  });
-
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'Pix+ Droit',
-    key: 'DROIT',
-    id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 75,
-    minimumEarnedPix: null,
-  });
-
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'Pix+ Édu 2nd degré',
-    key: 'EDU_2ND_DEGRE',
-    id: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 70,
-    minimumEarnedPix: null,
-    hasExternalJury: true,
-  });
-
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'Pix+ Édu 1er degré',
-    key: 'EDU_1ER_DEGRE',
-    id: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 70,
-    minimumEarnedPix: null,
-    hasExternalJury: true,
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
+++ b/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
@@ -7,13 +7,16 @@ const {
 const { PIX_DROIT_MAITRE_BADGE_ID } = require('../badges-builder');
 const { CERTIF_DROIT_USER5_ID } = require('./users');
 const {
-  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
-  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
-  PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_CLEA_V3_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_DROIT_MAITRE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_1ER_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
 } = require('./certification-centers-builder');
+
+const {
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+} = require('../common/common-builder');
 const { participateToAssessmentCampaign } = require('../campaign-participations-builder');
 const { TARGET_PROFILE_PIX_DROIT_ID } = require('../target-profiles-builder');
 const { SUP_STUDENT_ASSOCIATED_ID, SUP_UNIVERSITY_ID } = require('../organizations-sup-builder');

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -1,16 +1,24 @@
 const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
 
-module.exports = {
-  commonBuilder,
-};
-
 // IDS
 /// USERS
+const CLEA_COMPLEMENTARY_CERTIFICATION_ID = 52;
+const PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID = 53;
+const PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 54;
+const PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 55;
 const REAL_PIX_SUPER_ADMIN = 90000;
 
+module.exports = {
+  commonBuilder,
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+};
 function commonBuilder({ databaseBuilder }) {
   _createSuperAdmin(databaseBuilder);
   _createTags(databaseBuilder);
+  _createComplementaryCertifications(databaseBuilder);
 }
 
 function _createSuperAdmin(databaseBuilder) {
@@ -34,4 +42,36 @@ function _createTags(databaseBuilder) {
   databaseBuilder.factory.buildTag({ id: 7, name: 'MEDNUM' });
   databaseBuilder.factory.buildTag({ id: 8, name: 'COLLEGE' });
   databaseBuilder.factory.buildTag({ id: 9, name: 'LYCEE' });
+}
+
+function _createComplementaryCertifications(databaseBuilder) {
+  databaseBuilder.factory.buildComplementaryCertification.clea({
+    id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  });
+
+  databaseBuilder.factory.buildComplementaryCertification({
+    label: 'Pix+ Droit',
+    key: 'DROIT',
+    id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+    minimumReproducibilityRate: 75,
+    minimumEarnedPix: null,
+  });
+
+  databaseBuilder.factory.buildComplementaryCertification({
+    label: 'Pix+ Édu 2nd degré',
+    key: 'EDU_2ND_DEGRE',
+    id: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    minimumReproducibilityRate: 70,
+    minimumEarnedPix: null,
+    hasExternalJury: true,
+  });
+
+  databaseBuilder.factory.buildComplementaryCertification({
+    label: 'Pix+ Édu 1er degré',
+    key: 'EDU_1ER_DEGRE',
+    id: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    minimumReproducibilityRate: 70,
+    minimumEarnedPix: null,
+    hasExternalJury: true,
+  });
 }

--- a/api/db/seeds/data/common/tooling/certification-center-tooling.js
+++ b/api/db/seeds/data/common/tooling/certification-center-tooling.js
@@ -1,0 +1,97 @@
+module.exports = {
+  createCertificationCenter,
+};
+
+/**
+ * Fonction générique pour créer un centre de certification selon une configuration donnée.
+ * Retourne l'ID du centre de certification.
+ *
+ * @param {DatabaseBuilder} databaseBuilder
+ * @param {number} certificationCenterId
+ * @param {string} name
+ * @param {string} type
+ * @param {string} externalId
+ * @param {Date} createdAt
+ * @param {Date} updatedAt
+ * @param {Array<number>} memberIds
+ * @param {Array<number>} complementaryCertificationIds
+ * @returns {Promise<{certificationCenterId: number}>}
+ */
+async function createCertificationCenter({
+  databaseBuilder,
+  certificationCenterId,
+  name,
+  type,
+  externalId,
+  createdAt,
+  updatedAt,
+  memberIds = [],
+  complementaryCertificationIds,
+}) {
+  _buildCertificationCenter({
+    databaseBuilder,
+    certificationCenterId,
+    name,
+    type,
+    externalId,
+    createdAt,
+    updatedAt,
+  });
+
+  _buildCertificationCenterMemberships({
+    databaseBuilder,
+    certificationCenterId,
+    memberIds,
+  });
+
+  _buildCertificationCenterHabilitations({
+    databaseBuilder,
+    certificationCenterId,
+    complementaryCertificationIds,
+  });
+
+  return { certificationCenterId };
+}
+
+function _buildCertificationCenterHabilitations({
+  databaseBuilder,
+  certificationCenterId,
+  complementaryCertificationIds,
+}) {
+  complementaryCertificationIds.forEach((complementaryCertificationId) =>
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId,
+      complementaryCertificationId,
+    }),
+  );
+}
+
+function _buildCertificationCenterMemberships({ databaseBuilder, certificationCenterId, memberIds }) {
+  memberIds.forEach((memberId) =>
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      userId: memberId,
+      certificationCenterId,
+      createdAt: new Date(),
+      isReferer: false,
+    }),
+  );
+}
+
+function _buildCertificationCenter({
+  databaseBuilder,
+  certificationCenterId,
+  name,
+  type,
+  externalId,
+  createdAt,
+  updatedAt,
+}) {
+  databaseBuilder.factory.buildCertificationCenter({
+    id: certificationCenterId,
+    name,
+    type,
+    externalId,
+    createdAt,
+    updatedAt,
+  });
+}

--- a/api/db/seeds/data/common/tooling/index.js
+++ b/api/db/seeds/data/common/tooling/index.js
@@ -2,9 +2,11 @@ const campaign = require('./campaign-tooling');
 const targetProfile = require('./target-profile-tooling');
 const training = require('./training-tooling');
 const organization = require('./organization-tooling');
+const certificationCenter = require('./certification-center-tooling');
 
 module.exports = {
   campaign,
+  certificationCenter,
   organization,
   targetProfile,
   training,

--- a/api/db/seeds/data/common/tooling/index.js
+++ b/api/db/seeds/data/common/tooling/index.js
@@ -1,9 +1,11 @@
 const campaign = require('./campaign-tooling');
 const targetProfile = require('./target-profile-tooling');
 const training = require('./training-tooling');
+const organization = require('./organization-tooling');
 
 module.exports = {
   campaign,
+  organization,
   targetProfile,
   training,
 };

--- a/api/db/seeds/data/common/tooling/organization-tooling.js
+++ b/api/db/seeds/data/common/tooling/organization-tooling.js
@@ -1,0 +1,219 @@
+module.exports = {
+  createOrganization,
+};
+
+/**
+ * Fonction générique pour créer une organisation selon une configuration donnée.
+ * Retourne l'ID de l'organisation.
+ *
+ * @param {DatabaseBuilder} databaseBuilder
+ * @param {number} organizationId
+ * @param {string} type
+ * @param {string} name
+ * @param {string} logoUrl
+ * @param {string} externalId
+ * @param {string} provinceCode
+ * @param {boolean} isManagingStudents
+ * @param {number} credit
+ * @param {Date} createdAt
+ * @param {Date} updatedAt
+ * @param {email} email
+ * @param {string} documentationUrl
+ * @param {number} createdBy
+ * @param {boolean} showNPS
+ * @param {string} formNPSUrl
+ * @param {boolean} showSkills
+ * @param {number} archivedBy
+ * @param {Date} archivedAt
+ * @param {string} identityProviderForCampaigns
+ * @param {number} adminUserId
+ * @param {Array<number>} memberIds
+ * @param {Array<number>} tagIds
+ * @param {Array<number>} featureIds
+ * @param configOrganization {learnerCount: number }
+ * @returns {Promise<{organizationId: number}>}
+ */
+async function createOrganization({
+  databaseBuilder,
+  organizationId,
+  type,
+  name,
+  logoUrl,
+  externalId,
+  provinceCode,
+  isManagingStudents,
+  credit,
+  createdAt,
+  updatedAt,
+  email,
+  documentationUrl,
+  createdBy,
+  showNPS,
+  formNPSUrl,
+  showSkills,
+  archivedBy,
+  archivedAt,
+  identityProviderForCampaigns,
+  adminUserId,
+  memberIds = [],
+  tagIds = [],
+  featureIds = [],
+  configOrganization,
+}) {
+  _buildOrganization({
+    databaseBuilder,
+    organizationId,
+    type,
+    name,
+    logoUrl,
+    externalId,
+    provinceCode,
+    isManagingStudents,
+    credit,
+    createdAt,
+    updatedAt,
+    email,
+    documentationUrl,
+    createdBy,
+    showNPS,
+    formNPSUrl,
+    showSkills,
+    archivedBy,
+    archivedAt,
+    identityProviderForCampaigns,
+    adminUserId,
+    memberIds,
+    tagIds,
+    featureIds,
+  });
+
+  _buildMemberships({
+    databaseBuilder,
+    adminUserId,
+    memberIds,
+  });
+
+  _buildOrganizationTags({
+    databaseBuilder,
+    tagIds,
+    organizationId,
+  });
+
+  _buildOrganizationFeatures({
+    databaseBuilder,
+    organizationId,
+    featureIds,
+  });
+
+  _buildOrganizationLearners({
+    databaseBuilder,
+    organizationId,
+    configOrganization,
+  });
+
+  return { organizationId };
+}
+
+function _buildOrganizationLearners({ databaseBuilder, organizationId, configOrganization }) {
+  const divisions = ['1ere A', '2nde B', 'Terminale C'];
+  if (configOrganization && configOrganization.learnerCount > 0) {
+    for (let index = 0; index < configOrganization.learnerCount; index++) {
+      databaseBuilder.factory.buildOrganizationLearner({
+        firstName: `first-name${index}`,
+        lastName: `last-name${index}`,
+        sex: 'M',
+        birthdate: '2000-01-01',
+        birthCity: null,
+        birthCityCode: '75115',
+        birthCountryCode: '100',
+        birthProvinceCode: null,
+        division: divisions[index % divisions.length],
+        isDisabled: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        organizationId,
+      });
+    }
+  }
+}
+
+function _buildOrganizationFeatures({ databaseBuilder, organizationId, featureIds }) {
+  featureIds.forEach((featureId) =>
+    databaseBuilder.factory.buildOrganizationFeature({
+      organizationId,
+      featureId,
+    }),
+  );
+}
+
+function _buildOrganizationTags({ databaseBuilder, organizationId, tagIds }) {
+  tagIds.forEach((tagId) =>
+    databaseBuilder.factory.buildOrganizationTag({
+      organizationId,
+      tagId,
+    }),
+  );
+}
+
+function _buildMemberships({ databaseBuilder, organizationId, adminUserId, memberIds }) {
+  if (adminUserId) {
+    databaseBuilder.factory.buildMembership({
+      userId: adminUserId,
+      organizationId,
+      organizationRole: 'ADMIN',
+    });
+  }
+
+  memberIds.forEach((memberId) =>
+    databaseBuilder.factory.buildMembership({
+      userId: memberId,
+      organizationId,
+      organizationRole: 'MEMBER',
+    }),
+  );
+}
+
+function _buildOrganization({
+  databaseBuilder,
+  organizationId,
+  type,
+  name,
+  logoUrl,
+  externalId,
+  provinceCode,
+  isManagingStudents,
+  credit,
+  createdAt,
+  updatedAt,
+  email,
+  documentationUrl,
+  createdBy,
+  showNPS,
+  formNPSUrl,
+  showSkills,
+  archivedBy,
+  archivedAt,
+  identityProviderForCampaigns,
+}) {
+  databaseBuilder.factory.buildOrganization({
+    id: organizationId,
+    type,
+    name,
+    logoUrl,
+    externalId,
+    provinceCode,
+    isManagingStudents,
+    credit,
+    createdAt,
+    updatedAt,
+    email,
+    documentationUrl,
+    createdBy,
+    showNPS,
+    formNPSUrl,
+    showSkills,
+    archivedBy,
+    archivedAt,
+    identityProviderForCampaigns,
+  });
+}

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -1,0 +1,166 @@
+const tooling = require('../common/tooling');
+const {
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+} = require('../common/common-builder');
+
+const TEAM_CERTIFICATION_OFFSET_ID = 7000;
+// IDS
+/// USERS
+const SCO_CERTIFICATION_MANAGING_STUDENTS_ORGANIZATION_USER_ID = TEAM_CERTIFICATION_OFFSET_ID;
+const PRO_ORGANIZATION_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 3;
+const SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 1;
+const PRO_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
+/// ORGAS
+const SCO_MANAGING_STUDENTS_ORGANIZATION_ID = TEAM_CERTIFICATION_OFFSET_ID;
+const PRO_ORGANIZATION_ID = TEAM_CERTIFICATION_OFFSET_ID + 1;
+/// CERTIFICATION CENTERS
+const SCO_CERTIFICATION_CENTER_ID = TEAM_CERTIFICATION_OFFSET_ID + 1;
+const PRO_CERTIFICATION_CENTER_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
+/// EXTERNAL IDS
+const CERTIFICATION_SCO_MANAGING_STUDENTS_EXTERNAL_ID = 'CERTIFICATION_SCO_MANAGING_STUDENTS_EXTERNAL_ID';
+const PRO_EXTERNAL_ID = 'PRO_EXTERNAL_ID';
+
+async function teamCertificationDataBuilder({ databaseBuilder }) {
+  _createScoOrganization({ databaseBuilder });
+  _createScoCertificationCenter({ databaseBuilder });
+  _createProOrganization({ databaseBuilder });
+  _createProCertificationCenter({ databaseBuilder });
+
+  await databaseBuilder.commit();
+}
+
+module.exports = {
+  teamCertificationDataBuilder,
+};
+
+function _createScoCertificationCenter({ databaseBuilder }) {
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID,
+    firstName: 'Centre de certif SCO managing student',
+    lastName: 'Certification',
+    email: 'certif-sco@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+
+  tooling.certificationCenter.createCertificationCenter({
+    databaseBuilder,
+    certificationCenterId: SCO_CERTIFICATION_CENTER_ID,
+    name: 'Centre de certification sco managing students',
+    type: 'SCO',
+    externalId: CERTIFICATION_SCO_MANAGING_STUDENTS_EXTERNAL_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    memberIds: [SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID],
+    complementaryCertificationIds: [],
+  });
+}
+
+function _createProCertificationCenter({ databaseBuilder }) {
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: PRO_CERTIFICATION_CENTER_USER_ID,
+    firstName: 'Centre de certif Pro',
+    lastName: 'Certification',
+    email: 'certif-pro@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+
+  tooling.certificationCenter.createCertificationCenter({
+    databaseBuilder,
+    certificationCenterId: PRO_CERTIFICATION_CENTER_ID,
+    name: 'Centre de certification pro',
+    type: 'PRO',
+    externalId: PRO_EXTERNAL_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    memberIds: [PRO_CERTIFICATION_CENTER_USER_ID],
+    complementaryCertificationIds: [
+      CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+      PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+      PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+      PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    ],
+  });
+}
+
+function _createScoOrganization({ databaseBuilder }) {
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: SCO_CERTIFICATION_MANAGING_STUDENTS_ORGANIZATION_USER_ID,
+    firstName: 'Orga SCO managing Student',
+    lastName: 'Certification',
+    email: 'orga-sco-managing-students@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+  tooling.organization.createOrganization({
+    databaseBuilder,
+    organizationId: SCO_MANAGING_STUDENTS_ORGANIZATION_ID,
+    type: 'SCO',
+    name: 'Orga team Certification',
+    isManagingStudents: true,
+    externalId: CERTIFICATION_SCO_MANAGING_STUDENTS_EXTERNAL_ID,
+    adminUserId: SCO_CERTIFICATION_MANAGING_STUDENTS_ORGANIZATION_USER_ID,
+    configOrganization: {
+      learnerCount: 8,
+    },
+  });
+}
+
+function _createProOrganization({ databaseBuilder }) {
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: PRO_ORGANIZATION_USER_ID,
+    firstName: 'Orga Pro',
+    lastName: 'Certification',
+    email: 'orga-pro@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+  tooling.organization.createOrganization({
+    databaseBuilder,
+    organizationId: PRO_ORGANIZATION_ID,
+    type: 'PRO',
+    name: 'Orga team Certification',
+    isManagingStudents: true,
+    externalId: PRO_EXTERNAL_ID,
+    adminUserId: PRO_ORGANIZATION_USER_ID,
+    configOrganization: {
+      learnerCount: 8,
+    },
+  });
+}

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -47,6 +47,7 @@ const poleEmploiSendingsBuilder = require('./data/pole-emploi-sendings-builder')
 const { trainingBuilder } = require('./data/trainings-builder');
 const { commonBuilder } = require('./data/common/common-builder');
 const { teamContenuDataBuilder } = require('./data/team-contenu/data-builder');
+const { teamCertificationDataBuilder } = require('./data/team-certification/data-builder');
 const { fillCampaignSkills } = require('./data/fill-campaign-skills');
 const {
   addLastAssessmentResultCertificationCourse,
@@ -111,6 +112,7 @@ exports.seed = async (knex) => {
   userLoginsBuilder({ databaseBuilder });
 
   await teamContenuDataBuilder({ databaseBuilder });
+  await teamCertificationDataBuilder({ databaseBuilder });
 
   await databaseBuilder.commit();
   await databaseBuilder.fixSequences();


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
Creer un tooling documenté via de la JSDoc afin de génerer des organisations et centres de certification.

## :rainbow: Remarques
introduction du data builder certification

## :100: Pour tester
Créer un fichier de seed qui fait appel à ces fonctions et vérifier que la création subséquente est en accord avec ce que vous souhaitiez !
Pour avoir un exemple d'usage, on peut consulter le fichier team-contenu/data-builder.js
