### PR TITLE
[BUGFIX] Affichage du temps majoré dans la liste des candidats de Pix Certif. (PIX-8008)

### DIFF
--- a/certif/app/helpers/format-percentage.js
+++ b/certif/app/helpers/format-percentage.js
@@ -2,9 +2,9 @@ import { helper } from '@ember/component/helper';
 
 export function formatPercentage([value, ..._]) {
   if (value) {
-    const percentageValue = value * 100;
+    const percentageValue = Math.round(value * 100);
 
-    return `${Math.trunc(percentageValue)} %`;
+    return `${percentageValue} %`;
   }
   return '';
 }

--- a/certif/app/helpers/format-percentage.js
+++ b/certif/app/helpers/format-percentage.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 export function formatPercentage([value, ..._]) {
   if (value) {
-    const percentageValue = value < 1 ? value * 100 : value;
+    const percentageValue = value * 100;
 
     return `${Math.trunc(percentageValue)} %`;
   }

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -311,7 +311,7 @@ function _buildCertificationCandidate({
   email = 'bob.leponge@la.mer',
   resultRecipientEmail = 'recipient@college.fr',
   externalId = 'an external id',
-  extraTimePercentage = 30,
+  extraTimePercentage = 0.3,
   isLinked = false,
   complementaryCertifications = [
     {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -56,7 +56,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         firstName: 'Gamora',
         lastName: 'Zen Whoberi Ben Titan',
         birthdate: '1984-05-28',
-        extraTimePercentage: '8',
+        extraTimePercentage: 0.08,
         authorizedToStart: false,
         assessmentStatus: null,
         complementaryCertification: null,
@@ -94,7 +94,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           firstName: 'Star',
           lastName: 'Lord',
           birthdate: '1983-06-28',
-          extraTimePercentage: '12',
+          extraTimePercentage: 0.12,
           authorizedToStart: true,
           assessmentStatus: null,
         });
@@ -127,7 +127,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             firstName: 'Toto',
             lastName: 'Tutu',
             birthdate: '1984-05-28',
-            extraTimePercentage: '8',
+            extraTimePercentage: 0.08,
             authorizedToStart: true,
             assessmentResult: null,
           });
@@ -164,7 +164,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             firstName: 'Toto',
             lastName: 'Tutu',
             birthdate: '1984-05-28',
-            extraTimePercentage: '8',
+            extraTimePercentage: 0.08,
             authorizedToStart: false,
             assessmentResult: null,
           });
@@ -277,7 +277,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       firstName: 'Gamora',
       lastName: 'Zen Whoberi Ben Titan',
       birthdate: '1984-05-28',
-      extraTimePercentage: '8',
+      extraTimePercentage: 0.08,
       authorizedToStart: false,
       assessmentStatus: null,
       enrolledComplementaryCertification: 'Super Certification Complémentaire',
@@ -312,7 +312,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         firstName: 'Star',
         lastName: 'Lord',
         birthdate: '1983-06-28',
-        extraTimePercentage: '12',
+        extraTimePercentage: 0.12,
         authorizedToStart: true,
         assessmentStatus: null,
       });
@@ -876,7 +876,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           firstName: 'Toto',
           lastName: 'Tutu',
           birthdate: '1984-05-28',
-          extraTimePercentage: '8',
+          extraTimePercentage: 0.08,
           authorizedToStart: true,
           assessmentResult: null,
         });
@@ -906,7 +906,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           firstName: 'Toto',
           lastName: 'Tutu',
           birthdate: '1984-05-28',
-          extraTimePercentage: '8',
+          extraTimePercentage: 0.08,
           authorizedToStart: false,
           assessmentResult: null,
         });

--- a/certif/tests/unit/helpers/format-percentage_test.js
+++ b/certif/tests/unit/helpers/format-percentage_test.js
@@ -2,38 +2,20 @@ import { module, test } from 'qunit';
 import { formatPercentage } from 'pix-certif/helpers/format-percentage';
 
 module('Unit | Helpers | format-percentage', function () {
-  test('it truncate decimal places', function (assert) {
-    // given
-    const value = 0.2899999;
+  [
+    { value: 1.15, expectedResult: '115 %' },
+    { value: 0.15, expectedResult: '15 %' },
+    { value: 1.5, expectedResult: '150 %' },
+  ].forEach(({ value, expectedResult }) =>
+    test(`it renders a percentage ${expectedResult} for value ${value}`, function (assert) {
+      // given
+      // when
+      const result = formatPercentage([value]);
 
-    // when
-    const result = formatPercentage([value]);
-
-    // then
-    assert.strictEqual(result, '28 %');
-  });
-
-  test('it renders a percentage when value is above 1', function (assert) {
-    // given
-    const value = 1.5;
-
-    // when
-    const result = formatPercentage([value]);
-
-    // then
-    assert.strictEqual(result, '150 %');
-  });
-
-  test('it renders a percentage symbol', function (assert) {
-    // given
-    const value = 0.3;
-
-    // when
-    const result = formatPercentage([value]);
-
-    // then
-    assert.strictEqual(result, '30 %');
-  });
+      // then
+      assert.strictEqual(result, expectedResult);
+    })
+  );
 
   test('it renders an empty string if value is null', function (assert) {
     // given

--- a/certif/tests/unit/helpers/format-percentage_test.js
+++ b/certif/tests/unit/helpers/format-percentage_test.js
@@ -15,13 +15,13 @@ module('Unit | Helpers | format-percentage', function () {
 
   test('it renders a percentage when value is above 1', function (assert) {
     // given
-    const value = 33;
+    const value = 1.5;
 
     // when
     const result = formatPercentage([value]);
 
     // then
-    assert.strictEqual(result, '33 %');
+    assert.strictEqual(result, '150 %');
   });
 
   test('it renders a percentage symbol', function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Un candidat peut être inscrit à une session de certification dans l’onglet Candidats d’une session soit individuellement, soit parmi une liste de candidats.

Dans les deux cas, si le candidat en bénéficie, l’utilisateur Pix Certif doit indiquer le temps majoré qui lui est accordé pour passer sa certification. Cette information est ensuite affichée dans la liste des candidats inscrits dans la session.

Lorsque le pourcentage de temps majoré dépasse 99%, seul le premier chiffre est affiché (1 pour 120%, 2 pour 200%, 9 pour 999%).

## :robot: Proposition
Changer le helper coté ember "format-percentage" pour que si il recoit un chiffre au dessus de 1 il soit gérer de la même manière.

## :100: Pour tester
1. Se connecter à l'app certif avec le compte `certif-sup@example.net`
2. Aller sur une session
3. Ajouter un candidat en important un ods avec une valeur au dessus de 99 pour la colonne "temps majoré"
4. Voir dans le détail du candidat que le pourcentage est bien affiché
5. Voir dans l'espace surveillant que ce même pourcentage est bien affiché également