### PR TITLE
[TECH] Utiliser la méthode `visit` d'`ember-testing-library` plutôt que celle de `@ember/test-helpers` (PIX-8017)

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -30,9 +30,9 @@ module.exports = {
       'lodash',
       {
         name: '@ember/test-helpers',
-        importNames: ['render', 'find'],
+        importNames: ['render', 'visit', 'find'],
         message:
-          "Please import 'render' from '@1024pix/ember-testing-library'.\n 'find' should be replaced with '@1024pix/ember-testing-library' 'find...'/'get...'/'query...' methods to enforce accessible usages",
+          "Please import 'render' from '@1024pix/ember-testing-library'.\n Please import 'visit' from '@1024pix/ember-testing-library'.\n. 'find' should be replaced with '@1024pix/ember-testing-library' 'find...'/'get...'/'query...' methods to enforce accessible usages.",
       },
     ],
     'ember/avoid-leaking-state-in-ember-objects': 'off',

--- a/mon-pix/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/mon-pix/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | <%= dasherizedModuleName %>', function (hooks) {
   setupApplicationTest(hooks);

--- a/mon-pix/tests/acceptance/challenge-attachment_test.js
+++ b/mon-pix/tests/acceptance/challenge-attachment_test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { find, click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { blur, click, fillIn, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
+++ b/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import environment from '../../config/environment';

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { click, find, findAll, currentURL, visit } from '@ember/test-helpers';
+import { click, find, findAll, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { click, find, findAll, currentURL, visit } from '@ember/test-helpers';
+import { click, find, findAll, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line no-restricted-imports
-import { click, find, findAll, currentURL, fillIn, triggerEvent, visit } from '@ember/test-helpers';
+import { click, find, findAll, currentURL, fillIn, triggerEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Displaying a QROC challenge', function (hooks) {
   setupApplicationTest(hooks);
@@ -384,7 +384,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
     module('When challenge is not already answered', function () {
       test('should render challenge information and question', async function (assert) {
         // given
-        await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // then
         assert.strictEqual(
@@ -398,7 +398,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should hide the alert error after the user interact with input text', async function (assert) {
         // given
-        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
         await click('.challenge-actions__action-validate');
         assert.dom('.challenge-response__alert').exists();
 
@@ -413,7 +413,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should go to checkpoint when user validated', async function (assert) {
         // given
-        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
         await clickByName('saladAriaLabel');

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line no-restricted-imports
-import { click, find, findAll, currentURL, fillIn, triggerEvent, visit } from '@ember/test-helpers';
+import { click, find, findAll, currentURL, fillIn, triggerEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Displaying a QROCM challenge', function (hooks) {
   setupApplicationTest(hooks);
@@ -81,7 +81,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       test('should not be able to validate with the initial option', async function (assert) {
         // given
         server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
-        await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
         await click(find('.challenge-actions__action-validate'));
@@ -94,7 +94,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       test('should not be able to validate the empty option', async function (assert) {
         // given
         server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
-        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
         await clickByName('saladAriaLabel');
@@ -109,7 +109,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       test('should validate an option and redirect to next page', async function (assert) {
         // given
         server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
-        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
         await clickByName('saladAriaLabel');
@@ -166,7 +166,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         });
 
         // when
-        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // then
         assert.strictEqual(screen.getByLabelText('saladAriaLabel').innerText, 'mango');

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -4,7 +4,8 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { getPageTitle } from 'ember-page-title/test-support';
 import { authenticate } from '../helpers/authentication';
 // eslint-disable-next-line no-restricted-imports
-import { click, find, triggerEvent, visit } from '@ember/test-helpers';
+import { click, find, triggerEvent } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Displaying a challenge of any type', function (hooks) {
   setupApplicationTest(hooks);

--- a/mon-pix/tests/acceptance/challenge-timed_test.js
+++ b/mon-pix/tests/acceptance/challenge-timed_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { click, find, visit } from '@ember/test-helpers';
+import { click, find } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/checkpoint_test.js
+++ b/mon-pix/tests/acceptance/checkpoint_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { find, visit } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/competence-profile_test.js
+++ b/mon-pix/tests/acceptance/competence-profile_test.js
@@ -1,4 +1,5 @@
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { find, click, currentURL, visit } from '@ember/test-helpers';
+import { find, click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/competences-results_test.js
+++ b/mon-pix/tests/acceptance/competences-results_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { find, visit } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/course-ending-screen_test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { currentURL, find, findAll, visit } from '@ember/test-helpers';
+import { currentURL, find, findAll } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/error-redirection_test.js
+++ b/mon-pix/tests/acceptance/error-redirection_test.js
@@ -1,4 +1,5 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit, fillIn, currentURL } from '@ember/test-helpers';
+import { fillIn, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticate } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Footer', function (hooks) {

--- a/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
+++ b/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
@@ -1,4 +1,5 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/navigation_test.js
+++ b/mon-pix/tests/acceptance/navigation_test.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
-import { click, currentURL, find, visit } from '@ember/test-helpers';
+import { click, currentURL, find } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/not-found-redirect-to-index_test.js
+++ b/mon-pix/tests/acceptance/not-found-redirect-to-index_test.js
@@ -1,4 +1,5 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/starting-a-course_test.js
+++ b/mon-pix/tests/acceptance/starting-a-course_test.js
@@ -1,4 +1,5 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -1,4 +1,5 @@
-import { click, visit } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/user-certifications_test.js
+++ b/mon-pix/tests/acceptance/user-certifications_test.js
@@ -1,4 +1,5 @@
-import { currentURL, findAll, visit } from '@ember/test-helpers';
+import { currentURL, findAll } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';

--- a/mon-pix/tests/acceptance/user-trainings_test.js
+++ b/mon-pix/tests/acceptance/user-trainings_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 // eslint-disable-next-line no-restricted-imports
-import { visit, currentURL, find } from '@ember/test-helpers';
+import { currentURL, find } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { authenticate } from '../helpers/authentication';
 
 module('Acceptance | mes-formations', function (hooks) {

--- a/mon-pix/tests/acceptance/user-tutorials_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { visit, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { authenticate } from '../helpers/authentication';
 
 module('Acceptance | mes-tutos', function (hooks) {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js?rgh-link-date=2023-05-09T13%3A29%3A26Z).

Il est de plus en plus présent dans nos tests front mais nombre d'entre eux se basent toujours sur du html, du css.

Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :robot: Proposition
S'assurer de notre import de la méthode `visit` de `ember-testing-library` qui donne accès notamment aux sélecteurs par role pour répondre aux problèmes ci-dessus.

## :rainbow: Remarques
C'est la suite de #6122 et #6163.

## :100: Pour tester
Vérifier que la CI passe.