### PR TITLE
[FEATURE] Suppression de toutes références à Gravitee (PIX-7940)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -294,14 +294,14 @@ const configuration = (function () {
 
     apimRegisterApplicationsCredentials: [
       {
-        clientId: process.env.APIM_OSMOSE_CLIENT_ID || process.env.GRAVITEE_OSMOSE_CLIENT_ID,
-        clientSecret: process.env.APIM_OSMOSE_CLIENT_SECRET || process.env.GRAVITEE_OSMOSE_CLIENT_SECRET,
+        clientId: process.env.APIM_OSMOSE_CLIENT_ID,
+        clientSecret: process.env.APIM_OSMOSE_CLIENT_SECRET,
         scope: 'organizations-certifications-result',
         source: 'livretScolaire',
       },
       {
-        clientId: process.env.APIM_POLE_EMPLOI_CLIENT_ID || process.env.GRAVITEE_POLE_EMPLOI_CLIENT_ID,
-        clientSecret: process.env.APIM_POLE_EMPLOI_CLIENT_SECRET || process.env.GRAVITEE_POLE_EMPLOI_CLIENT_SECRET,
+        clientId: process.env.APIM_POLE_EMPLOI_CLIENT_ID,
+        clientSecret: process.env.APIM_POLE_EMPLOI_CLIENT_SECRET,
         scope: 'pole-emploi-participants-result',
         source: 'poleEmploi',
       },


### PR DESCRIPTION
## :unicorn: Problème
Gravitee a été entièrement supprimé. Pour des raisons de compatibilité, il avait été laissé la lecture des variables d'environnements qui débutait par `GRAVITEE_` (remplacé par `APIM_`)

## :robot: Proposition
Suppression de la rétrocompatibilité

## :rainbow: Remarques
aucune

## :100: Pour tester

