### PR TITLE
[TECH] Éviter les imports dupliqués sur Pix App (PIX-8018)

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   },
   rules: {
     'no-console': 'error',
+    'no-duplicate-imports': 'error',
     'no-restricted-imports': [
       'error',
       'lodash',

--- a/mon-pix/app/mixins/progression-tracker.js
+++ b/mon-pix/app/mixins/progression-tracker.js
@@ -1,7 +1,6 @@
 /* eslint ember/require-computed-property-dependencies: 0 */
 
-import { set } from '@ember/object';
-import EmberObject, { computed } from '@ember/object';
+import EmberObject, { computed, set } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 
 const STEPS = {

--- a/mon-pix/app/services/authentication.js
+++ b/mon-pix/app/services/authentication.js
@@ -1,5 +1,4 @@
-import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 import get from 'lodash/get';
 
 const ALLOWED_ROUTES_FOR_ANONYMOUS_ACCESS = [

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -1,5 +1,4 @@
-import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
 const FRENCH_INTERNATIONAL_LOCALE = 'fr';

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -1,9 +1,8 @@
-import { findAll, currentURL } from '@ember/test-helpers';
+import { findAll, currentURL, click, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
-import { click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';


### PR DESCRIPTION
## :unicorn: Problème
On peut aujourd'hui importer plusieurs fois le même module.

## :robot: Proposition
L'utilisation d'une seule instruction d'import par module rendra le code plus clair car vous pouvez voir tout ce qui est importé depuis ce module sur une seule ligne.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la CI passe