### PR TITLE
[TECH][MON-PIX] Ne pas modifier la langue de l'utilisateur quand le paramètre lang se trouve dans l'url (PIX-7851)

### DIFF
--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -1,7 +1,7 @@
 import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
-import { DEFAULT_LOCALE, FRENCH_FRANCE_LOCALE } from 'mon-pix/services/locale';
+import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'mon-pix/services/locale';
 
 const FRANCE_TLD = 'fr';
 
@@ -92,7 +92,7 @@ export default class CurrentSessionService extends SessionService {
     const domain = this.currentDomain.getExtension();
 
     if (domain === FRANCE_TLD) {
-      await this.locale.setLocale(DEFAULT_LOCALE);
+      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
 
       if (!this.locale.hasLocaleCookie()) {
         this.locale.setLocaleCookie(FRENCH_FRANCE_LOCALE);
@@ -100,31 +100,17 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    if (isUserLoaded) {
-      if (localeFromQueryParam) {
-        this.currentUser.user.lang = localeFromQueryParam;
-        try {
-          await this.currentUser.user.save({ adapterOptions: { lang: this.currentUser.user.lang } });
-          await this.locale.setLocale(this.currentUser.user.lang);
-        } catch (error) {
-          const status = get(error, 'errors[0].status');
-          if (status === '400') {
-            this.currentUser.user.rollbackAttributes();
-            await this.locale.setLocale(this.currentUser.user.lang);
-          } else {
-            throw error;
-          }
-        }
-      } else {
-        await this.locale.setLocale(this.currentUser.user.lang);
-      }
-    } else {
-      if (localeFromQueryParam) {
-        await this.locale.setLocale(localeFromQueryParam);
-      } else {
-        await this.locale.setLocale(DEFAULT_LOCALE);
-      }
+    if (localeFromQueryParam) {
+      this.locale.setLocale(localeFromQueryParam);
+      return;
     }
+
+    if (isUserLoaded) {
+      this.locale.setLocale(this.currentUser.user.lang);
+      return;
+    }
+
+    this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
   }
 
   _getRouteAfterInvalidation() {

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
-import { DEFAULT_LOCALE, FRENCH_FRANCE_LOCALE } from 'mon-pix/services/locale';
+import { DEFAULT_LOCALE, FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'mon-pix/services/locale';
 
 const FRANCE_TLD = 'fr';
 const INTERNATIONAL_TLD = 'org';
@@ -237,46 +237,19 @@ module('Unit | Services | session', function (hooks) {
 
         module('when user is loaded', function () {
           module('when there is no error', function () {
-            test('should set the current language with the value from the query parameter', async function (assert) {
+            test('sets the current language with the value from the query parameter', async function (assert) {
               // given
               const transition = { to: { queryParams: { lang: 'de' } } };
               sessionService.locale.handleUnsupportedLanguage.returns('de');
               sessionService.currentDomain.getExtension.returns(INTERNATIONAL_TLD);
-              sessionService.currentUser.user = { lang: 'ru', save: sinon.stub() };
+              sessionService.currentUser.user = { lang: FRENCH_INTERNATIONAL_LOCALE };
 
               // when
               await sessionService.handleUserLanguageAndLocale(transition);
 
               // then
-              sinon.assert.calledWith(sessionService.currentUser.user.save, { adapterOptions: { lang: 'de' } });
               sinon.assert.calledWith(sessionService.locale.setLocale, 'de');
-              assert.strictEqual(sessionService.currentUser.user.lang, 'de');
-            });
-          });
-
-          module('when an error occurs', function () {
-            module('with an HTTP status code 400', function () {
-              test('should set the current language with the user language value', async function (assert) {
-                // given
-                const transition = { to: { queryParams: { lang: 'de' } } };
-                sessionService.locale.handleUnsupportedLanguage.returns('de');
-                sessionService.currentDomain.getExtension.returns(INTERNATIONAL_TLD);
-                sessionService.currentUser.user = {
-                  lang: 'ru',
-                  save: sinon.stub().throws({ errors: [{ status: '400' }] }),
-                  rollbackAttributes: function () {
-                    sessionService.currentUser.user.lang = 'ru';
-                  },
-                };
-
-                // when
-                await sessionService.handleUserLanguageAndLocale(transition);
-
-                // then
-                sinon.assert.calledWith(sessionService.currentUser.user.save, { adapterOptions: { lang: 'de' } });
-                sinon.assert.calledWith(sessionService.locale.setLocale, 'ru');
-                assert.ok(true);
-              });
+              assert.ok(true);
             });
           });
         });


### PR DESCRIPTION
## :unicorn: Problème

Sur le domaine international (.org), lorsqu'un utilisateur connecté à l'application Pix App suit un lien ayant le paramètre `lang=??` dans l'URL, alors la langue de l'utilisateur en base de données est modifiée automatiquement suivant la valeur de ce paramètre. Cette action de modification automatique via un paramètre dans l'URL ne devrait pas se faire car : 
* cette action est faite sans demander son consentement à l'utilisateur
* cette action est réalisable très facilement par l'utilisateur lui-même via le menu _« Mon Compte > Choisir ma langue »_
* cette action génère une modification systématique en base de données, même lorsque c'est inutile, ce qui peut avoir des impacts sur les performances si un lien avec `lang=??` est diffusé auprès d'une grande population d'utilisateurs
* tout changement, de langue ou de toute autre propriété/préférence de l'utilisateur, par le simple fait de visiter un URL (qui est donc une requête `GET`) ayant certains query params (ici lang) est une mauvaise pratique, cf. sources :
   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
   * https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods

Ce comportement de modification automatique de la langue de l'utilisateur date d'une époque où la gestion des langues et des locales dans Pix était moins utilisable, moins pratique, moins généralisée. Ce comportement n'a maintenant plus lieux d'être.

On rappelle ci-dessous la règle de priorité de la lang/locale des différents éléments.

**Règle de priorité** : `lang` utilisateur < `lang` query param < `lang` domaine `.fr`

## :robot: Proposition

Retirer la modification de la langue de l'utilisateur se trouvant dans le service session.

## :rainbow: Remarques

RAS

## :100: Pour tester

⚠️ Faire attention de ne pas être plusieurs à faire le test sur la RA avec le même utilisateur en même temps !

1. Aller sur https://app-pr6179.review.pix.org/
2. Se connecter avec un utilisateur ayant comme langue de choix `Français`
3. Constater que le site web est en français
4. Aller sur le même URL en passant en plus le paramètre `lang=en` https://app-pr6179.review.pix.org/?lang=en
5. Constater que le site web passe en anglais
6. Vérifier que la lange de choix de l'utilisateur, via le menu _« My account > Language »_ ou en base de données , n'a pas été modifiée et que c'est toujours `Français`
7. Recharger la page (`F5`) (ceci va charger une nouvelle instance de l'application Ember avec une nouvelle session)
8. Constater que le site web passe en français
9. Modifier la langue de choix de l'utilisateur, via le menu _« Mon Compte > Choisir ma langue »_, en `English`
10. Constater que le site web passe en anglais
11. Se déconnecter
12. Aller sur https://app-pr6179.review.pix.org/
13. Constater que le site web est en français
14. Se connecter toujours avec le même utilisateur
15. Constater que le site web passe en anglais
