### PR TITLE
[FEATURE] Afficher une notification de confirmation lors du changement de langue sur Pix App > Mon compte (PIX-7893).

### DIFF
--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -1,13 +1,14 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class UserAccountPersonalInformationController extends Controller {
   @service currentUser;
-  @service dayjs;
-  @service intl;
   @service currentDomain;
   @service locale;
+
+  @tracked shouldDisplayLanguageUpdatedMessage = false;
 
   @action
   async onLanguageChange(language) {
@@ -15,6 +16,11 @@ export default class UserAccountPersonalInformationController extends Controller
       await this.currentUser.user.save({ adapterOptions: { lang: language } });
 
       this.locale.setLocale(language);
+      this._displayLanguageUpdatedMessage();
     }
+  }
+
+  _displayLanguageUpdatedMessage() {
+    this.shouldDisplayLanguageUpdatedMessage = true;
   }
 }

--- a/mon-pix/app/routes/authenticated/user-account/language.js
+++ b/mon-pix/app/routes/authenticated/user-account/language.js
@@ -4,4 +4,9 @@ export default class UserAccountLanguageRoute extends Route {
   model() {
     return this.modelFor('authenticated.user-account');
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.showLanguageUpdatedMessage = false;
+  }
 }

--- a/mon-pix/app/styles/pages/_language.scss
+++ b/mon-pix/app/styles/pages/_language.scss
@@ -1,7 +1,8 @@
 .language {
   display: flex;
-  align-items: center;
-  padding: 8px 0;
+  flex-direction: column;
+  gap: $pix-spacing-s;
+  padding: $pix-spacing-xs 0;
 
   &__label {
     min-width: 200px;

--- a/mon-pix/app/templates/authenticated/user-account/language.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/language.hbs
@@ -4,4 +4,10 @@
     @selectedLanguage={{@model.lang}}
     @onLanguageChange={{this.onLanguageChange}}
   />
+
+  {{#if this.shouldDisplayLanguageUpdatedMessage}}
+    <PixMessage @type="success" @withIcon={{true}}>
+      {{t "pages.user-account.language.update-successful"}}
+    </PixMessage>
+  {{/if}}
 </div>

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -16,6 +16,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
     controller = this.owner.lookup('controller:authenticated/user-account/language');
     controller.currentUser = { user: { save: userSaveStub } };
     controller.locale = { setLocale: setLocaleStub };
+    controller.set('shouldDisplayLanguageUpdatedMessage', false);
   });
 
   module('#onLanguageChange', function () {
@@ -32,6 +33,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
         // then
         sinon.assert.calledWith(userSaveStub, { adapterOptions: { lang: language } });
         sinon.assert.calledWith(setLocaleStub, language);
+        assert.true(controller.shouldDisplayLanguageUpdatedMessage);
         assert.ok(true);
       });
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1572,7 +1572,8 @@
       },
       "language": {
         "lang": "Language",
-        "menu-link-title": "Language"
+        "menu-link-title": "Choose my language",
+        "update-successful": "Your language has been updated!"
       },
       "personal-information": {
         "first-name": "First name",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1572,7 +1572,8 @@
       },
       "language": {
         "lang": "Langue",
-        "menu-link-title": "Choisir ma langue"
+        "menu-link-title": "Choisir ma langue",
+        "update-successful": "Votre langue a été changée !"
       },
       "personal-information": {
         "first-name": "Prénom",


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur change la langue dans les paramètres de son compte, il n'y a pas de message informant que la modification a été faite et que tout s'est déroulé avec succès.

## :robot: Proposition
Afficher une notification lors du changement de langue comme lors du changement d'email.

## :rainbow: Remarques
La notification ne disparait pas au bout de quelques secondes. Elle disparaît seulement si on change de page.

## :100: Pour tester
- Se connecter à Pix App (.org) - https://app-pr6180.review.pix.org/
- Se rendre sur la page mon compte puis 'Choisir ma langue'
- Changer de langue
- Constater l'affichage de la notification indiquant le changement de langue.
- Changer de page et revenir sur la page 'Choisir ma langue' et constater que la notification n'apparaît plus. 
