### PR TITLE
[FEATURE] Uniformiser le formulaire de signalement sur Pix-App (PIX-7711)

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -29,34 +29,26 @@
         {{else}}
           <p>{{t "pages.challenge.feedback-panel.description"}}</p>
           <div class="feedback-panel__form-wrapper">
-            <form class="feedback-panel__form" {{on "submit" this.sendFeedback}}>
+            <form class="feedback-panel__form" {{on "submit" this.sendFeedback}} novalidate>
               <div class="feedback-panel__group">
                 <div class="feedback-panel__category-selection">
-                  <select
-                    class="feedback-panel__dropdown"
-                    {{on "change" this.displayCategoryOptions}}
-                    aria-label={{t "pages.challenge.feedback-panel.form.fields.detail-selection.aria-first"}}
-                  >
-                    <option value="" disabled selected>{{t
-                        "pages.challenge.feedback-panel.form.fields.category-selection.label"
-                      }}</option>
-                    {{#each this.categories as |category|}}
-                      <option value={{category.value}}>{{t category.name}}</option>
-                    {{/each}}
-                  </select>
+                  <PixSelect
+                    @label={{t "pages.challenge.feedback-panel.form.fields.detail-selection.aria-first"}}
+                    @screenReaderOnly={{true}}
+                    @placeholder={{t "pages.challenge.feedback-panel.form.fields.category-selection.label"}}
+                    @options={{this.categories}}
+                    @onChange={{this.displayCategoryOptions}}
+                    @value={{this._currentMajorCategory}}
+                  />
                   {{#if this.displayQuestionDropdown}}
-                    <select
-                      class="feedback-panel__dropdown"
-                      {{on "change" this.showFeedback}}
-                      aria-label={{t "pages.challenge.feedback-panel.form.fields.detail-selection.aria-secondary"}}
-                    >
-                      <option value="default" selected>{{t
-                          "pages.challenge.feedback-panel.form.fields.detail-selection.label"
-                        }}</option>
-                      {{#each this.nextCategory as |question index|}}
-                        <option value={{index}}>{{t question.name}}</option>
-                      {{/each}}
-                    </select>
+                    <PixSelect
+                      @label={{t "pages.challenge.feedback-panel.form.fields.detail-selection.aria-secondary"}}
+                      @screenReaderOnly={{true}}
+                      @placeholder={{t "pages.challenge.feedback-panel.form.fields.detail-selection.label"}}
+                      @onChange={{this.showFeedback}}
+                      @options={{this.nextCategories}}
+                      @value={{this._currentNextCategory}}
+                    />
                   {{/if}}
                   {{#if this.quickHelpInstructions}}
                     <div class="feedback-panel__quick-help">
@@ -71,22 +63,20 @@
                   <p class="feedback-panel__field-notice">
                     {{t "pages.challenge.feedback-panel.form.status.error.max-characters"}}
                   </p>
-                  <Textarea
-                    class="feedback-panel__field feedback-panel__field--content"
-                    @value={{this.content}}
-                    placeholder={{t "pages.challenge.feedback-panel.form.fields.detail-selection.label"}}
-                    maxlength="10000"
-                    rows="5"
-                    aria-label={{t
+                  <label class="screen-reader-only" for="feedback-panel__field">{{t
                       "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
-                    }}
+                    }}</label>
+                  <PixTextarea
+                    class="feedback-panel__field--content"
+                    @value={{this.content}}
+                    @id="feedback-panel__field"
+                    @maxlength="10000"
+                    rows="5"
+                    placeholder={{t "pages.challenge.feedback-panel.form.fields.detail-selection.label"}}
+                    @errorMessage={{this.emptyTextBoxMessageError}}
+                    required
                   />
                 </div>
-                {{#if this.emptyTextBoxMessageError}}
-                  <PixMessage class="feedback-panel__alert" @type="error" @withIcon={{true}}>
-                    {{this.emptyTextBoxMessageError}}
-                  </PixMessage>
-                {{/if}}
                 <PixButton @type="submit" @backgroundColor="grey" @isDisabled={{this.isSendButtonDisabled}}>
                   {{t "pages.challenge.feedback-panel.form.actions.submit"}}
                 </PixButton>

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -170,7 +170,6 @@ export default class FeedbackPanel extends Component {
     this.quickHelpInstructions = null;
     this._currentMajorCategory = null;
     this.displayTextBox = false;
-    this.tutorialContent = null;
     this.displayQuestionDropdown = false;
   }
 

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -74,16 +74,6 @@
   margin-bottom: $pix-spacing-xs;
 }
 
-.feedback-panel__field {
-  box-sizing: border-box;
-  width: 100%;
-  padding: 8px;
-  font-size: 0.875rem;
-  background-color: $pix-neutral-0;
-  border: solid 1px $pix-neutral-20;
-  border-radius: 3px;
-}
-
 .feedback-panel__field-notice {
   margin: $pix-spacing-s 0 $pix-spacing-xxs;
   font-size: 0.75rem;
@@ -93,18 +83,17 @@
   display: flex;
   flex-direction: column;
   gap: $pix-spacing-s;
-}
 
-.feedback-panel__dropdown {
-  width: 100%;
-  padding: 0.5rem;
-  color: $pix-neutral-80;
-  font-family: $font-roboto;
-  border-color: $pix-neutral-50;
-  border-radius: 0.25rem;
+  > div {
+    max-width: 100%;
 
-  @include device-is('desktop') {
-    width: 40%;
+    > button {
+      width: auto;
+    }
+
+    @include device-is('mobile') {
+      width: auto;
+    }
   }
 }
 

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -6,12 +6,6 @@ import { click, fillIn } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
-const PICK_SELECT_OPTION_WITH_NESTED_LEVEL = 'question';
-const PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL = 'embed';
-const PICK_SELECT_OPTION_WITH_TEXTAREA = 'accessibility';
-const PICK_SELECT_OPTION_WITH_TUTORIAL = 'picture';
-const PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL = '3';
-
 module('Integration | Component | feedback-panel', function (hooks) {
   setupIntlRenderingTest(hooks);
 
@@ -53,9 +47,12 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      await fillIn(
-        screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
-        PICK_SELECT_OPTION_WITH_TEXTAREA
+      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+        })
       );
 
       const contentValue = 'Prêtes-moi ta plume, pour écrire un mot';
@@ -82,9 +79,12 @@ module('Integration | Component | feedback-panel', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-        await fillIn(
-          screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
-          PICK_SELECT_OPTION_WITH_NESTED_LEVEL
+        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.question'),
+          })
         );
 
         // then
@@ -93,10 +93,8 @@ module('Integration | Component | feedback-panel', function (hooks) {
         assert.dom(textareaLabel).doesNotExist();
         assert.dom(submitButtonLabel).doesNotExist();
 
-        assert.dom(screen.getByRole('option', { name: 'Je ne comprends pas la question' })).exists();
-        assert
-          .dom(screen.getByRole('option', { name: 'Je souhaite proposer une amélioration de la question' }))
-          .exists();
+        assert.dom(screen.getByText('Je ne comprends pas la question')).exists();
+        assert.dom(screen.getByText('Je souhaite proposer une amélioration de la question')).exists();
       });
 
       test('should directly display the message box and the submit button when category has a textarea', async function (assert) {
@@ -108,9 +106,12 @@ module('Integration | Component | feedback-panel', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-        await fillIn(
-          screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
-          PICK_SELECT_OPTION_WITH_TEXTAREA
+        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+          })
         );
 
         // then
@@ -129,9 +130,12 @@ module('Integration | Component | feedback-panel', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-        await fillIn(
-          screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
-          PICK_SELECT_OPTION_WITH_TUTORIAL
+        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.picture'),
+          })
         );
 
         // then
@@ -140,8 +144,8 @@ module('Integration | Component | feedback-panel', function (hooks) {
         assert.dom(textareaLabel).doesNotExist();
         assert.dom(submitButtonLabel).doesNotExist();
 
-        assert.dom(screen.getByRole('option', { name: "L'image ne s'affiche pas" })).exists();
-        assert.dom(screen.getByRole('option', { name: "L'image a un autre problème" })).exists();
+        assert.dom(screen.getByText("L'image ne s'affiche pas")).exists();
+        assert.dom(screen.getByText("L'image a un autre problème")).exists();
       });
 
       test('should show the correct feedback action when selecting two different categories', async function (assert) {
@@ -152,11 +156,18 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
         // when
-        const selectInputLabel = screen.getByRole('combobox', {
-          name: 'Sélectionner la catégorie du problème rencontré',
-        });
-        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TUTORIAL);
-        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
+        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.picture'),
+          })
+        );
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+          })
+        );
 
         // then
         assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
@@ -175,11 +186,18 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
         // when
-        const selectInputLabel = screen.getByRole('combobox', {
-          name: 'Sélectionner la catégorie du problème rencontré',
-        });
-        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
-        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
+        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.question'),
+          })
+        );
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+          })
+        );
 
         // then
         assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
@@ -198,15 +216,21 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
         // when
-        const firstSelectInputLabel = screen.getByRole('combobox', {
-          name: 'Sélectionner la catégorie du problème rencontré',
-        });
-        await fillIn(firstSelectInputLabel, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
-
-        const secondSelectInputLabel = screen.getByRole('combobox', {
-          name: 'Sélectionner une option pour préciser votre problème',
-        });
-        await fillIn(secondSelectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
+        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.embed'),
+          })
+        );
+        await click(screen.getByRole('button', { name: 'Sélectionner une option pour préciser votre problème' }));
+        await click(
+          await screen.findByRole('option', {
+            name: this.intl.t(
+              'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-displayed-on-mobile-devices-with-problems.label'
+            ),
+          })
+        );
 
         // then
         assert
@@ -217,7 +241,6 @@ module('Integration | Component | feedback-panel', function (hooks) {
             )
           )
           .exists();
-
         const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
         const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
         assert.dom(textareaLabel).exists();
@@ -297,7 +320,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       );
 
       // then
-      const selectInputLabel = screen.getByRole('combobox', {
+      const selectInputLabel = screen.getByRole('button', {
         name: 'Sélectionner la catégorie du problème rencontré',
       });
       assert.dom(selectInputLabel).exists();
@@ -366,10 +389,13 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      const selectInputLabel = screen.getByRole('combobox', {
-        name: 'Sélectionner la catégorie du problème rencontré',
-      });
-      await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
+      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+        })
+      );
 
       // when
       await click(screen.getByRole('button', { name: 'Envoyer' }));
@@ -383,11 +409,13 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      const selectInputLabel = screen.getByRole('combobox', {
-        name: 'Sélectionner la catégorie du problème rencontré',
-      });
-      await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
-
+      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+        })
+      );
       await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '');
 
       // when
@@ -402,10 +430,13 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      const selectInputLabel = screen.getByRole('combobox', {
-        name: 'Sélectionner la catégorie du problème rencontré',
-      });
-      await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
+      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+        })
+      );
 
       await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '    ');
 


### PR DESCRIPTION
## :unicorn: Problème
Le formulaire de signalement n'était pas uniforme avec les composants du Design System.

## :robot: Proposition
Utiliser le PixSelect et PixTextarea.

## :rainbow: Remarques
Ajout d'un attribut required sur le `textarea` pour l'accessibilité.

## :100: Pour tester
Vérifier le bon fonctionnement du formulaire sur une épreuve et sur la page de checkpoint.
