### PR TITLE
[FEATURE] Ajout language switcher sur la double mire de la page d'invitation pour rejoindre certif (PIX-7217)

### DIFF
--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -63,4 +63,11 @@
       </div>
     </div>
   </div>
+  {{#if this.isInternationalDomain}}
+    <LanguageSwitcher
+      class="login-or-register__language-switcher"
+      @selectedLanguage={{this.selectedLanguage}}
+      @onLanguageChange={{this.onLanguageChange}}
+    />
+  {{/if}}
 </div>

--- a/certif/app/components/auth/login-or-register.js
+++ b/certif/app/components/auth/login-or-register.js
@@ -22,8 +22,6 @@ export default class LoginOrRegister extends Component {
     this.locale.setLocale(this.selectedLanguage);
     this.router.replaceWith('join', {
       queryParams: {
-        code: this.args.certificationCenterInvitationCode,
-        invitationId: this.args.certificationCenterInvitationId,
         lang: null,
       },
     });

--- a/certif/app/components/auth/login-or-register.js
+++ b/certif/app/components/auth/login-or-register.js
@@ -1,9 +1,33 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class LoginOrRegister extends Component {
+  @service currentDomain;
+  @service locale;
+  @service intl;
+  @service router;
+
   @tracked displayRegisterForm = true;
+  @tracked selectedLanguage = this.intl.primaryLocale;
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
+
+  @action
+  onLanguageChange(value) {
+    this.selectedLanguage = value;
+    this.locale.setLocale(this.selectedLanguage);
+    this.router.replaceWith('join', {
+      queryParams: {
+        code: this.args.certificationCenterInvitationCode,
+        invitationId: this.args.certificationCenterInvitationId,
+        lang: null,
+      },
+    });
+  }
 
   @action
   toggleFormsVisibility() {

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -41,10 +41,12 @@ class SignupFormValidation {
 }
 
 export default class RegisterForm extends Component {
+  @service currentDomain;
   @service intl;
-  @service url;
-  @service store;
+  @service locale;
   @service session;
+  @service store;
+  @service url;
 
   @tracked isLoading = false;
   @tracked firstName = null;
@@ -53,6 +55,7 @@ export default class RegisterForm extends Component {
   @tracked password = null;
   @tracked cguValidationMessage = null;
   @tracked errorMessage = null;
+  @tracked selectedLanguage = this.intl.primaryLocale;
   @tracked validation = new SignupFormValidation();
 
   get cguUrl() {
@@ -78,6 +81,7 @@ export default class RegisterForm extends Component {
       lastName: this.lastName,
       firstName: this.firstName,
       email: this.email,
+      lang: this.selectedLanguage,
       password: this.password,
       cgu: true,
     });

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -41,9 +41,7 @@ class SignupFormValidation {
 }
 
 export default class RegisterForm extends Component {
-  @service currentDomain;
   @service intl;
-  @service locale;
   @service session;
   @service store;
   @service url;

--- a/certif/app/components/language-switcher.hbs
+++ b/certif/app/components/language-switcher.hbs
@@ -1,0 +1,11 @@
+<PixSelect
+  @id="language-switcher"
+  @label={{@label}}
+  aria-label={{t "common.forms.login.choose-language-aria-label"}}
+  @icon="earth-europe"
+  @value={{this.selectedLanguage}}
+  @options={{this.availableLanguages}}
+  @onChange={{this.onChange}}
+  @hideDefaultOption="true"
+  ...attributes
+/>

--- a/certif/app/components/language-switcher.js
+++ b/certif/app/components/language-switcher.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class LanguageSwitcher extends Component {
+  @tracked selectedLanguage = this.args.selectedLanguage;
+
+  availableLanguages = [
+    { label: 'Français', value: 'fr' },
+    { label: 'English', value: 'en' },
+  ];
+
+  @action
+  onChange(value) {
+    this.selectedLanguage = value;
+    this.args.onLanguageChange(value);
+  }
+}

--- a/certif/app/models/user.js
+++ b/certif/app/models/user.js
@@ -4,6 +4,7 @@ export default class User extends Model {
   @attr('string') email;
   @attr('string') firstName;
   @attr('string') lastName;
-  @attr('string') password;
   @attr('boolean') cgu;
+  @attr('string') lang;
+  @attr('string') password;
 }

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -1,18 +1,24 @@
 import Service, { inject as service } from '@ember/service';
 import config from 'pix-certif/config/environment';
 
-const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
-
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+
+const SUPPORTED_LANGUAGES = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 
 export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
   @service intl;
   @service dayjs;
+
+  handleUnsupportedLanguage(language) {
+    if (!language) return;
+    return SUPPORTED_LANGUAGES.includes(language) ? language : DEFAULT_LOCALE;
+  }
 
   hasLocaleCookie() {
     return this.cookies.exists('locale');

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -30,8 +30,8 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
-    if (localeFromQueryParam && this.intl.get('locales').includes(localeFromQueryParam)) {
-      this._localeFromQueryParam = localeFromQueryParam;
+    if (localeFromQueryParam) {
+      this._localeFromQueryParam = this.locale.handleUnsupportedLanguage(localeFromQueryParam);
     }
 
     if (isFranceDomain) {

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -6,8 +6,6 @@ export default class CurrentSessionService extends SessionService {
   @service currentDomain;
   @service currentUser;
   @service locale;
-  @service intl;
-  @service dayjs;
 
   _localeFromQueryParam;
 

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -1,4 +1,7 @@
 .login-or-register {
+  display: flex;
+  flex-direction: column;
+  gap: $pix-spacing-s;
   margin: 20px 0;
 
   &__panel {
@@ -17,10 +20,15 @@
       padding: 40px 100px;
     }
   }
+
+  &__language-switcher {
+    @include device-is('mobile') {
+      margin-left: $pix-spacing-s;
+    }
+  }
 }
 
 .login-or-register-panel {
-
   &__logo {
     margin: auto;
   }
@@ -76,7 +84,6 @@
 }
 
 .login-or-register-panel-form {
-
   &__expandable {
     display: flex;
     flex-direction: column;

--- a/certif/tests/acceptance/routes/join_test.js
+++ b/certif/tests/acceptance/routes/join_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { currentURL, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { visit, clickByName } from '@1024pix/ember-testing-library';
 import setupIntl from '../../helpers/setup-intl';
 
@@ -83,6 +83,87 @@ module('Acceptance | Routes | join', function (hooks) {
             })
           )
           .exists();
+      });
+    });
+
+    module('when current url does not contain french tld (.fr)', function () {
+      module('When accessing the login page with "Français" as default language', function () {
+        test('displays the login page with "Français" as selected language', async function (assert) {
+          // given
+          const certificationCenterInvitation = server.create('certification-center-invitation', {
+            id: 1,
+            certificationCenterName: 'Super Centre de Certif',
+          });
+          const path = `/rejoindre?code=ABCDEF123&invitationId=${certificationCenterInvitation.id}`;
+
+          // when
+          const screen = await visit(path);
+
+          // then
+          assert.strictEqual(currentURL(), path);
+          assert.dom(screen.getByRole('heading', { name: 'Je m’inscris', level: 1 })).exists();
+        });
+
+        module('When the user select "English" as his language', function () {
+          test('displays the login page with "English" as selected language', async function (assert) {
+            // given
+            const certificationCenterInvitation = server.create('certification-center-invitation', {
+              id: 1,
+              certificationCenterName: 'Super Centre de Certif',
+            });
+            const path = `/rejoindre?code=ABCDEF123&invitationId=${certificationCenterInvitation.id}`;
+
+            // when
+            const screen = await visit(path);
+            await click(screen.getByRole('button', { name: 'Français' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'English' }));
+
+            // then
+            assert.strictEqual(currentURL(), path);
+            assert.dom(screen.getByRole('heading', { name: 'Sign up', level: 1 })).exists();
+          });
+        });
+      });
+
+      module('When accessing the login page with "English" as selected language', function () {
+        test('displays the login page with "English"', async function (assert) {
+          // given
+          const certificationCenterInvitation = server.create('certification-center-invitation', {
+            id: 1,
+            certificationCenterName: 'Super Centre de Certif',
+          });
+          const path = `/rejoindre?code=ABCDEF123&invitationId=${certificationCenterInvitation.id}&lang=en`;
+
+          // when
+          const screen = await visit(path);
+
+          // then
+          assert.strictEqual(currentURL(), path);
+          assert.dom(screen.getByRole('heading', { name: 'Sign up', level: 1 })).exists();
+        });
+
+        module('When the user select "Français" as his language', function () {
+          test('displays the login page with "Français" as selected language', async function (assert) {
+            // given
+            const certificationCenterInvitation = server.create('certification-center-invitation', {
+              id: 1,
+              certificationCenterName: 'Super Centre de Certif',
+            });
+            const path = `/rejoindre?invitationId=${certificationCenterInvitation.id}&code=ABCDEF123&lang=en`;
+            const pathWithoutLangParam = `/rejoindre?code=ABCDEF123&invitationId=${certificationCenterInvitation.id}`;
+
+            // when
+            const screen = await visit(path);
+            await click(screen.getByRole('button', { name: 'English' }));
+            await screen.findByRole('listbox');
+            await click(screen.getByRole('option', { name: 'Français' }));
+
+            // then
+            assert.strictEqual(currentURL(), pathWithoutLangParam);
+            assert.dom(screen.getByRole('heading', { name: 'Je m’inscris', level: 1 })).exists();
+          });
+        });
       });
     });
   });

--- a/certif/tests/integration/components/auth/login-or-register_test.js
+++ b/certif/tests/integration/components/auth/login-or-register_test.js
@@ -1,6 +1,8 @@
-import { module, test } from 'qunit';
-import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
@@ -76,5 +78,48 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('textbox', { name: emailInputLabelFromRegisterForm })).exists();
+  });
+
+  module('When domain is international tld (.org)', function () {
+    test('does display the language switcher', async function (assert) {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return false;
+        }
+
+        getExtension() {
+          return 'org';
+        }
+      }
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+      // when
+      const screen = await render(hbs`<Auth::LoginOrRegister @certificationCenterName='Centre de Certif'/>`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Français' })).exists();
+    });
+  });
+
+  module('When domain is french tld (.fr)', function () {
+    test('does not display the language switcher', async function (assert) {
+      // given
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return true;
+        }
+
+        getExtension() {
+          return 'fr';
+        }
+      }
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+      // when
+      const screen = await render(hbs`<Auth::LoginOrRegister @certificationCenterName='Centre de Certif'/>`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Français' })).doesNotExist();
+    });
   });
 });

--- a/certif/tests/integration/components/language-switcher_test.js
+++ b/certif/tests/integration/components/language-switcher_test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { click } from '@ember/test-helpers';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Language Switcher', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when component renders', function () {
+    test('displays a button with default option selected', async function (assert) {
+      // when
+      const screen = await render(hbs`<LanguageSwitcher @selectedLanguage='en' />`);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'English' })).exists();
+    });
+  });
+
+  module('when component is clicked', function () {
+    test('displays a list of available languages', async function (assert) {
+      // given
+      const screen = await render(hbs`<LanguageSwitcher @selectedLanguage='en' />`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'English' }));
+      await screen.findByRole('listbox');
+
+      // then
+      assert.dom(screen.getByRole('option', { name: 'Français' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'English' })).exists();
+    });
+  });
+
+  module('when a language is selected', function () {
+    test('calls onLanguageChange callback', async function (assert) {
+      // given
+      const onLanguageChangeStub = sinon.stub();
+      this.set('onLanguageChange', onLanguageChangeStub);
+      const screen = await render(
+        hbs`<LanguageSwitcher @onLanguageChange={{this.onLanguageChange}} @selectedLanguage='en' />`
+      );
+
+      // when
+      await click(screen.getByRole('button', { name: 'English' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Français' }));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Français' })).exists();
+      assert.ok(onLanguageChangeStub.called);
+    });
+  });
+});

--- a/certif/tests/unit/components/auth/login-or-register_test.js
+++ b/certif/tests/unit/components/auth/login-or-register_test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+import { ENGLISH_INTERNATIONAL_LOCALE } from 'pix-certif/services/locale';
+
+module('Unit | Component | login-or-register', (hooks) => {
+  setupTest(hooks);
+
+  module('onLanguageChange', () => {
+    test('saves selected locale and removes lang param from url', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:auth/login-or-register');
+      const localeService = this.owner.lookup('service:locale');
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(localeService, 'setLocale');
+      sinon.stub(router, 'replaceWith');
+
+      // when
+      component.onLanguageChange(ENGLISH_INTERNATIONAL_LOCALE);
+
+      // then
+      sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
+      sinon.assert.calledWith(router.replaceWith, 'join', { queryParams: { lang: null } });
+      assert.ok(component.selectedLanguage, ENGLISH_INTERNATIONAL_LOCALE);
+    });
+  });
+});

--- a/certif/tests/unit/components/auth/register-form_test.js
+++ b/certif/tests/unit/components/auth/register-form_test.js
@@ -1,6 +1,8 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+
+import { FRENCH_INTERNATIONAL_LOCALE } from 'pix-certif/services/locale';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import setupIntl from '../../../helpers/setup-intl';
 
@@ -23,8 +25,8 @@ module('Unit | Component | register-form', (hooks) => {
   });
 
   module('#register', () => {
-    module('when form is invalid', () => {
-      test('should not call the store', async function (assert) {
+    module('When form is invalid', () => {
+      test('does not call the store', async function (assert) {
         // given
         const incorrectEmail = 'alainternational';
         component.firstName = 'Alain';
@@ -41,29 +43,43 @@ module('Unit | Component | register-form', (hooks) => {
       });
     });
 
-    module('when form is valid', () => {
-      test('should create pix account, membership and validate invitation', async function (assert) {
+    module('When form is valid', () => {
+      test('creates pix account, membership and validate invitation', async function (assert) {
         // given
+        const certificationCenterInvitationCode = 'AZERTY123';
+        const certificationCenterInvitationId = 1234;
+        const cgu = true;
+        const email = 'alainternational@example.net';
         const firstName = 'Alain';
         const lastName = 'Ternational';
-        const email = 'alainternational@example.net';
         const password = 'Password123';
-        const cgu = true;
-        const certificationCenterInvitationId = 1234;
-        const certificationCenterInvitationCode = 'AZERTY123';
+        const selectedLanguage = FRENCH_INTERNATIONAL_LOCALE;
+
+        component.args = {
+          ...component.args,
+          certificationCenterInvitationCode,
+          certificationCenterInvitationId,
+        };
+
+        component.cgu = cgu;
+        component.email = email;
         component.firstName = firstName;
         component.lastName = lastName;
-        component.email = email;
+        component.selectedLanguage = selectedLanguage;
         component.password = password;
-        component.cgu = cgu;
-        component.args.certificationCenterInvitationId = certificationCenterInvitationId;
-        component.args.certificationCenterInvitationCode = certificationCenterInvitationCode;
 
         // when
         await component.register(eventStub);
 
         // then
-        sinon.assert.calledWith(component.store.createRecord, 'user', { firstName, lastName, password, email, cgu });
+        sinon.assert.calledWith(component.store.createRecord, 'user', {
+          cgu,
+          email,
+          firstName,
+          lastName,
+          lang: selectedLanguage,
+          password,
+        });
         sinon.assert.calledWith(component.store.createRecord, 'certification-center-invitation-response', {
           id: certificationCenterInvitationId,
           code: certificationCenterInvitationCode,
@@ -74,7 +90,7 @@ module('Unit | Component | register-form', (hooks) => {
     });
 
     module('error cases', () => {
-      test('should throw default error', async function (assert) {
+      test('Throws default error', async function (assert) {
         // given
         const deleteRecord = sinon.stub();
         component.store = {
@@ -97,8 +113,8 @@ module('Unit | Component | register-form', (hooks) => {
         sinon.assert.calledOnce(deleteRecord);
       });
 
-      module('when email already exists', () => {
-        test('should throw an error', async function (assert) {
+      module('When email already exists', () => {
+        test('Throws an error', async function (assert) {
           // given
           const deleteRecord = sinon.stub();
           component.store = {

--- a/certif/tests/unit/services/locale_test.js
+++ b/certif/tests/unit/services/locale_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { DEFAULT_LOCALE } from 'pix-certif/services/locale';
+import { DEFAULT_LOCALE, ENGLISH_INTERNATIONAL_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'pix-certif/services/locale';
 
 module('Unit | Service | locale', function (hooks) {
   setupTest(hooks);
@@ -45,6 +45,55 @@ module('Unit | Service | locale', function (hooks) {
         sameSite: 'Strict',
       });
       assert.ok(true);
+    });
+  });
+
+  module('#handleUnsupportedLanguage', function () {
+    module('When language is not supported', function () {
+      test('returns default language', function (assert) {
+        // given
+        const language = 'es';
+
+        // when
+        const result = localeService.handleUnsupportedLanguage(language);
+
+        // then
+        assert.strictEqual(result, DEFAULT_LOCALE);
+      });
+    });
+
+    module('When language is supported', function () {
+      test('returns same language when language is fr', function (assert) {
+        // given
+        const language = FRENCH_INTERNATIONAL_LOCALE;
+
+        // when
+        const result = localeService.handleUnsupportedLanguage(language);
+
+        // then
+        assert.strictEqual(result, language);
+      });
+
+      test('returns same language when language is en', function (assert) {
+        // given
+        const language = ENGLISH_INTERNATIONAL_LOCALE;
+
+        // when
+        const result = localeService.handleUnsupportedLanguage(language);
+
+        // then
+        assert.strictEqual(result, language);
+      });
+    });
+
+    module('when no language is provided', function () {
+      test('returns "undefined"', function (assert) {
+        // given & when
+        const result = localeService.handleUnsupportedLanguage();
+
+        // then
+        assert.strictEqual(result, undefined);
+      });
     });
   });
 

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -2,7 +2,12 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
-import { DEFAULT_LOCALE, FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-certif/services/locale';
+import {
+  DEFAULT_LOCALE,
+  ENGLISH_INTERNATIONAL_LOCALE,
+  FRENCH_INTERNATIONAL_LOCALE,
+  FRENCH_FRANCE_LOCALE,
+} from 'pix-certif/services/locale';
 
 module('Unit | Service | session', function (hooks) {
   setupTest(hooks);
@@ -22,6 +27,7 @@ module('Unit | Service | session', function (hooks) {
     Object.assign(localeService, {
       setLocaleCookie: sinon.stub(),
       hasLocaleCookie: sinon.stub(),
+      handleUnsupportedLanguage: sinon.stub(),
       setLocale: sinon.stub(),
     });
   });
@@ -126,7 +132,7 @@ module('Unit | Service | session', function (hooks) {
           test('sets the locale to be French international in every case', async function (assert) {
             // given
             const isFranceDomain = true;
-            const localeFromQueryParam = 'en';
+            const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
             const userLocale = undefined;
 
             // when
@@ -142,7 +148,7 @@ module('Unit | Service | session', function (hooks) {
           test('sets the locale to be French international in every case', async function (assert) {
             // given
             const isFranceDomain = true;
-            const localeFromQueryParam = 'en';
+            const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
             const userLocale = 'user’s lang';
 
             // when
@@ -194,13 +200,13 @@ module('Unit | Service | session', function (hooks) {
             // given
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
-            const userLocale = 'en';
+            const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when
             await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, 'en');
+            sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -229,13 +235,13 @@ module('Unit | Service | session', function (hooks) {
               // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
-              const userLocale = 'en';
+              const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
               // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
               assert.ok(true);
             });
           });
@@ -246,14 +252,16 @@ module('Unit | Service | session', function (hooks) {
             test('sets the locale to the lang query param', async function (assert) {
               // given
               const isFranceDomain = false;
-              const localeFromQueryParam = 'en';
+              const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = undefined;
+
+              localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
               assert.ok(true);
             });
           });
@@ -262,14 +270,16 @@ module('Unit | Service | session', function (hooks) {
             test('sets the locale to the lang query param which wins over', async function (assert) {
               // given
               const isFranceDomain = false;
-              const localeFromQueryParam = 'en';
-              const userLocale = 'fr';
+              const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
+              const userLocale = FRENCH_INTERNATIONAL_LOCALE;
+
+              localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
               await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, 'en');
+              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
               assert.ok(true);
             });
           });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -57,6 +57,7 @@
         "pricing": "Pricing of Pix’s share"
       },
       "login": {
+        "choose-language-aria-label": "Select a language",
         "email": "Email address",
         "forgot-password": "Forgot your password?",
         "password": "Password"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -57,6 +57,7 @@
         "pricing": "Tarification part Pix"
       },
       "login": {
+        "choose-language-aria-label": "Sélectionnez une langue",
         "email": "Adresse e-mail",
         "forgot-password": "Mot de passe oublié ?",
         "password": "Mot de passe"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'est pas possible de changer la langue de l'utilisateur sur certif sans passer par une modification dans l'url en ajoutant ?lang=en.

## :robot: Proposition
Ajouter un language switcher sur la page d'invitation pour rejoindre un centre de certification. La suite viendra plus tard 😄 

## :rainbow: Remarques
RAS

## :100: Pour tester
### Pour tester sur la RA 
- Se connecter sur Pix Admin
- Sélectionner un centre de certification
- Aller dans l'onglet Invitations et envoyer un email d'invitation à une adresse à laquelle vous avez accès
- Récupérer le lien dans le mail, changer le domaine pour avoir celui de la RA (.org)

### Pour tester en local
- Ajouter la variable suivante `DEBUG="pix:mailer:email"` dans le fichier .env du dossier api
- Se connecter à Pix admin
- Sélectionner un centre de certification
- Aller dans l'onglet Invitations puis envoyer un email d'invitation à une adresse email quelconque
- Récupérer le lien de l'email dans la requête de votre terminal et modifier l'url pour avoir l'url des local-domains en préfixe (ex: http://certif.dev.pix.org/rejoindre?invitationId=101294&code=ABCDEF123)

💡 Pour pouvoir facilement réutiliser une invitation déjà acceptée, on peut remettre cette invitation au `status` `pending`. Ou encore on peut remettre le `status` de toutes les invitations en `pending`, c'est bien sûr une requête qui modifie toutes les invitations des centres de certification mais c'est pratique si on n'a pas besoin de ces invitations par ailleurs et qu'on ne craint pas les effets secondaires :
```sql
update "certification-center-invitations" set "status" = 'pending';
```

### Test sur le domaine .org
#### Language Switcher
- Changer la langue de la page avec le language switcher (ex: Français -> Anglais)
- Vérifier que le contenu s'est bien mis à jour

#### Avec le paramètre ?lang=en
- Ajouter en paramètre de l'url `&lang=en`
- Vérifier que la page s'est bien mise à jour en anglais et que le language switcher affiche `English`
- Changer la langue en Français
- Vérifier que le paramètre `lang=en` n'est plus présent dans l'url.

#### Connexion
- Sélectionner English dans le language switcher
- Se connecter avec un compte existant (ex: sco.admin@example.net)
- Vérifier que la langue du site n'a pas changé

#### Inscription et CGU (à faire avec un language switcher en français puis en anglais)
- S'inscrire 
- Vérifier que les CGU s'affiche bien dans la langue sélectionnée
- Accepter les CGU et voir que le site s'affiche bien dans la langue sélectionnée

### Test sur le domaine .fr
- Vérifier que le language switcher ne s'affiche pas sur la page
