### PR TITLE
[TECH] Améliorer les tests sur la vérification d'accès à un assessment.

### DIFF
--- a/api/lib/application/preHandlers/assessment-authorization.js
+++ b/api/lib/application/preHandlers/assessment-authorization.js
@@ -1,16 +1,16 @@
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository.js');
 const validationErrorSerializer = require('../../infrastructure/serializers/jsonapi/validation-error-serializer.js');
-const { extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils.js');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  verify(request, h) {
-    const userId = extractUserIdFromRequest(request);
+  verify(request, h, dependencies = { requestResponseUtils, assessmentRepository, validationErrorSerializer }) {
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     // eslint-disable-next-line no-restricted-syntax
     const assessmentId = parseInt(request.params.id);
 
-    return assessmentRepository.getByAssessmentIdAndUserId(assessmentId, userId).catch(() => {
+    return dependencies.assessmentRepository.getByAssessmentIdAndUserId(assessmentId, userId).catch(() => {
       const buildError = _handleWhenInvalidAuthorization('Vous n’êtes pas autorisé à accéder à cette évaluation');
-      return h.response(validationErrorSerializer.serialize(buildError)).code(401).takeover();
+      return h.response(dependencies.validationErrorSerializer.serialize(buildError)).code(401).takeover();
     });
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Les tests du fichier `assessment-authorization` ne stub pas directement les méthodes utilisées mais un niveau plus profond et ne font pas l'injection de dépendances comme nous avons pu le faire ailleurs.

## :robot: Proposition
Mettre en place l'injection de dépendances et les stubs nécessaires.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
CI OK

- Accéder à des challenges sur Pix App et constater le bon fonctionnement