### PR TITLE
[FEATURE] Traduire le mail des résultats de certification en anglais (PIX-6687).

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -297,8 +297,9 @@ module.exports = {
 
   async publish(request, h, dependencies = { sessionSerializer }) {
     const sessionId = request.params.id;
+    const i18n = request.i18n;
 
-    const session = await usecases.publishSession({ sessionId });
+    const session = await usecases.publishSession({ sessionId, i18n });
 
     return dependencies.sessionSerializer.serialize({ session });
   },

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -19,6 +19,10 @@ const PIX_NAME_EN = 'PIX - Noreply';
 const HELPDESK_FRENCH_FRANCE = 'https://support.pix.fr';
 const HELPDESK_ENGLISH_SPOKEN = 'https://support.pix.org/en/support/home';
 const HELPDESK_FRENCH_SPOKEN = 'https://support.pix.org';
+const PIX_HOME_NAME_INTERNATIONAL = `pix${settings.domain.tldOrg}`;
+const PIX_HOME_NAME_FRENCH_FRANCE = `pix${settings.domain.tldFr}`;
+const PIX_HOME_URL_ENGLISH_SPOKEN = `${settings.domain.pix + settings.domain.tldOrg}/en-gb`;
+const PIX_HOME_URL_FRENCH_FRANCE = `${settings.domain.pix + settings.domain.tldFr}`;
 
 const EMAIL_VERIFICATION_CODE_TAG = 'EMAIL_VERIFICATION_CODE';
 const SCO_ACCOUNT_RECOVERY_TAG = 'SCO_ACCOUNT_RECOVERY';
@@ -83,9 +87,8 @@ function sendCertificationResultEmail({
   certificationCenterName,
   resultRecipientEmail,
   daysBeforeExpiration,
+  translate,
 }) {
-  const pixName = PIX_NAME_FR;
-  const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
   const token = tokenService.createCertificationResultsByRecipientEmailLinkToken({
     sessionId,
     resultRecipientEmail,
@@ -93,19 +96,33 @@ function sendCertificationResultEmail({
   });
   const link = `${settings.domain.pixApp + settings.domain.tldOrg}/api/sessions/download-results/${token}`;
 
-  const variables = {
+  const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
+
+  const templateParams = {
     link,
+    certificationCenterName,
     sessionId,
     sessionDate: formattedSessionDate,
-    certificationCenterName,
+    fr: {
+      ...frTranslations['certification-result-email'].params,
+      homeName: PIX_HOME_NAME_FRENCH_FRANCE,
+      homeUrl: PIX_HOME_URL_FRENCH_FRANCE,
+      title: translate({ phrase: 'certification-result-email.title', locale: 'fr' }, { sessionId }),
+    },
+    en: {
+      ...enTranslations['certification-result-email'].params,
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_ENGLISH_SPOKEN,
+      title: translate({ phrase: 'certification-result-email.title', locale: 'en' }, { sessionId }),
+    },
   };
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixName,
+    fromName: `${PIX_NAME_FR} / ${PIX_NAME_EN}`,
     to: email,
     template: mailer.certificationResultTemplateId,
-    variables,
+    variables: templateParams,
   });
 }
 

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -1,4 +1,5 @@
 module.exports = async function publishSession({
+  i18n,
   sessionId,
   certificationRepository,
   certificationCenterRepository,
@@ -8,6 +9,7 @@ module.exports = async function publishSession({
   publishedAt = new Date(),
 }) {
   await sessionPublicationService.publishSession({
+    i18n,
     sessionId,
     certificationRepository,
     certificationCenterRepository,

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -8,9 +8,11 @@ const {
   SendingEmailToRefererError,
 } = require('../../../../lib/domain/errors');
 const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 describe('Unit | UseCase | session-publication-service', function () {
   const sessionId = 123;
+  let i18n;
   let certificationRepository;
   let sessionRepository;
   let finalizedSessionRepository;
@@ -20,6 +22,7 @@ describe('Unit | UseCase | session-publication-service', function () {
   let clock;
   let mailService;
   beforeEach(function () {
+    i18n = getI18n();
     clock = sinon.useFakeTimers(now);
     certificationRepository = {
       publishCertificationCoursesBySessionId: sinon.stub(),
@@ -129,6 +132,7 @@ describe('Unit | UseCase | session-publication-service', function () {
 
         // when
         await publishSession({
+          i18n,
           sessionId,
           certificationCenterRepository,
           certificationRepository,
@@ -157,6 +161,7 @@ describe('Unit | UseCase | session-publication-service', function () {
 
         // when
         await publishSession({
+          i18n,
           sessionId,
           certificationCenterRepository,
           certificationRepository,
@@ -194,16 +199,27 @@ describe('Unit | UseCase | session-publication-service', function () {
         });
         finalizedSessionRepository.get.withArgs({ sessionId }).resolves(finalizedSession);
         mailService.sendCertificationResultEmail
-          .withArgs({ sessionId, resultRecipientEmail: 'email1@example.net', daysBeforeExpiration: 30 })
+          .withArgs({
+            sessionId,
+            resultRecipientEmail: 'email1@example.net',
+            daysBeforeExpiration: 30,
+            translate: i18n,
+          })
           .returns('token-1');
         mailService.sendCertificationResultEmail
-          .withArgs({ sessionId, resultRecipientEmail: 'email2@example.net', daysBeforeExpiration: 30 })
+          .withArgs({
+            sessionId,
+            resultRecipientEmail: 'email2@example.net',
+            daysBeforeExpiration: 30,
+            translate: i18n,
+          })
           .returns('token-2');
         mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipient1));
         mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipient2));
 
         // when
         await publishSession({
+          i18n,
           sessionId,
           certificationCenterRepository,
           certificationRepository,
@@ -248,6 +264,7 @@ describe('Unit | UseCase | session-publication-service', function () {
 
           // when
           await publishSession({
+            i18n,
             sessionId,
             certificationCenterRepository,
             certificationRepository,
@@ -442,6 +459,7 @@ describe('Unit | UseCase | session-publication-service', function () {
 
         // when
         const error = await catchErr(publishSession)({
+          i18n,
           sessionId,
           certificationCenterRepository,
           certificationRepository,
@@ -459,6 +477,7 @@ describe('Unit | UseCase | session-publication-service', function () {
           certificationCenterName: 'certificationCenter',
           sessionDate: originalSession.date,
           email: 'email1@example.net',
+          translate: i18n.__,
         });
         expect(mailService.sendCertificationResultEmail).to.have.been.calledWith({
           sessionId,
@@ -467,6 +486,7 @@ describe('Unit | UseCase | session-publication-service', function () {
           certificationCenterName: 'certificationCenter',
           sessionDate: originalSession.date,
           email: 'email2@example.net',
+          translate: i18n.__,
         });
         expect(sessionRepository.flagResultsAsSentToPrescriber).to.not.have.been.called;
         expect(error).to.be.an.instanceOf(SendingEmailToResultRecipientError);

--- a/api/tests/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/unit/domain/usecases/publish-session_test.js
@@ -5,6 +5,7 @@ const publishSession = require('../../../../lib/domain/usecases/publish-session'
 describe('Unit | UseCase | publish-session', function () {
   it('delegates the action to the session-publication-service and return the session', async function () {
     // given
+    const i18n = Symbol('i18n');
     const sessionId = Symbol('a session id');
     const session = Symbol('a session');
     const certificationRepository = Symbol('the certification repository');
@@ -26,6 +27,7 @@ describe('Unit | UseCase | publish-session', function () {
 
     // when
     const result = await publishSession({
+      i18n,
       sessionId,
       certificationRepository,
       certificationCenterRepository,
@@ -37,6 +39,7 @@ describe('Unit | UseCase | publish-session', function () {
 
     // then
     expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
+      i18n,
       sessionId,
       certificationRepository,
       certificationCenterRepository,

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -123,6 +123,21 @@
     },
     "subject": "Invitation à rejoindre Pix Certif"
   },
+  "certification-result-email": {
+    "params": {
+      "FindOutMore": "Find out more about",
+      "doNotReply": "This is an automatic email, please do not reply.",
+      "download": "Download the results",
+      "emailValidFor": "This link is valid for thirty days.",
+      "guidelines": "The reporting transmitted by the certification centre has been taken into account - if need be - by the Pix examining body. You will find guidelines to help you read these results here.",
+      "guidelinesLinkName": "Interpretation of specifiers' results",
+      "overviewText": "Hello, here are the results of the certifications that you have recommended to your audiences",
+      "resultsAvailable": "The results of the Pix certifications that you have recommended to your audiences are available.",
+      "subject": "[Pix] Certification session",
+      "viewResultsInProfile": "The candidates can view their result in their Pix profile."
+    },
+    "title": "View the results of the certification session n° {{ sessionId }} !"
+  },
   "csv-import-values": {
     "sup-organization-learner": {
       "diplomas": {

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -134,6 +134,21 @@
     },
     "subject": "Invitation à rejoindre Pix Certif"
   },
+  "certification-result-email": {
+    "params": {
+      "FindOutMore": "En savoir plus sur",
+      "doNotReply": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
+      "download": "Télécharger les résultats",
+      "emailValidFor": "Ce lien est valable trente jours.",
+      "guidelines": "Les signalements rapportés par le centre de certifications ont bien été pris en compte - le cas échéant - dans le cadre du jury Pix. Vous trouverez des indications pour interpréter ces résultats ici.",
+      "guidelinesLinkName": "Interprétation des résultats prescripteur",
+      "overviewText": "Bonjour, voici les résultats des certifications que vous avez prescrites à vos publics",
+      "resultsAvailable": "Les résultats des certifications Pix que vous avez prescrites à vos publics sont disponibles.",
+      "subject": "[Pix] Certification session",
+      "viewResultsInProfile": "Les candidats peuvent consulter leur résultat depuis leur profil Pix."
+    },
+    "title": "Consultez les résultats de la session de certification n° {{ sessionId }} !"
+  },
   "csv-import-values": {
     "sup-organization-learner": {
       "diplomas": {


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Une fois sur la session de certification finalisée, le pôle certif publie les résultats depuis Pix Admin ce qui déclenche l’envoi d’un mail permettant de télécharger un fichier csv reprenant les résultats des candidats à cette session.

## :robot: Proposition
Traduire le mail des résultats de certification en anglais

Un nouveau template sur Brevo a été créé pour ne pas impacter le mail en prod. Lorsque ce ticket sera merge, l'ID du template sera remplacé dans les autres environnements.

le csv sera traduit dans un autre ticket.

## :100: Pour tester
Si vous testez en local, s'assurer que les variables suivantes sont présents dans votre .env: 
```
SENDINBLUE_CERTIFICATION_RESULT_TEMPLATE_ID=
MAILING_PROVIDER=sendinblue
MAILING_ENABLED=true
```

Les variables sont à jours en RA.

- Se connecter dans Pix Admin (superadmin@example.net)
- Aller dans sessions de certification
- Cliquer dans l'onglet Sessions à publier
- En BDD, s'assurer d'avoir un resultRecipientEmail d'un des candidats avec votre adresse e-mail pour recevoir le mail
- publier la session qui contient votre candidat
- Aller voir le mail et s'assurer d'avoir le message en français ET en anglais


<img width="1359" alt="Capture d’écran 2023-05-15 à 17 06 18" src="https://github.com/1024pix/pix/assets/58915422/b81e037b-8c14-4502-97e2-885be1876934">
