### PR TITLE
[FEATURE] Amélioration de message de validation de suppression d'une participation (PIX-8049)

### DIFF
--- a/orga/app/components/campaign/activity/delete-participation-modal.hbs
+++ b/orga/app/components/campaign/activity/delete-participation-modal.hbs
@@ -10,10 +10,10 @@
 >
   <:content>
     <p>
-      {{this.deleteParticipationModalText}}
+      {{t "pages.campaign-activity.delete-participation-modal.text"}}
     </p>
     <p class="warning-text">
-      {{t "pages.campaign-activity.delete-participation-modal.warning"}}
+      {{this.deleteParticipationModalWarning}}
     </p>
   </:content>
   <:footer>

--- a/orga/app/components/campaign/activity/delete-participation-modal.js
+++ b/orga/app/components/campaign/activity/delete-participation-modal.js
@@ -4,29 +4,29 @@ import { service } from '@ember/service';
 export default class deleteParticipationModal extends Component {
   @service intl;
 
-  get deleteParticipationModalText() {
+  get deleteParticipationModalWarning() {
     if (!this.args.participation) {
       return null;
     }
     return this.intl.t(
-      `${DELETE_PARTICIPATION_MODAL_CONTENT[this.args.campaign.type][this.args.participation.status]}`
+      `${DELETE_PARTICIPATION_MODAL_WARNING[this.args.campaign.type][this.args.participation.status]}`
     );
   }
 }
 
-const DELETE_PARTICIPATION_MODAL_CONTENT = {
+const DELETE_PARTICIPATION_MODAL_WARNING = {
   ASSESSMENT: {
     STARTED:
-      'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.started-participation',
+      'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.started-participation',
     TO_SHARE:
-      'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.to-share-participation',
+      'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.to-share-participation',
     SHARED:
-      'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.shared-participation',
+      'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.shared-participation',
   },
   PROFILES_COLLECTION: {
     TO_SHARE:
-      'pages.campaign-activity.delete-participation-modal.text.profiles-collection-campaign-participation.to-share-participation',
+      'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.to-share-participation',
     SHARED:
-      'pages.campaign-activity.delete-participation-modal.text.profiles-collection-campaign-participation.shared-participation',
+      'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.shared-participation',
   },
 };

--- a/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
+++ b/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
@@ -55,6 +55,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
             })
           )
           .exists();
+        assert.contains(this.intl.t('pages.campaign-activity.delete-participation-modal.text'));
         assert.contains(this.intl.t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
         assert.contains(this.intl.t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
       });
@@ -90,7 +91,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
         });
       });
 
-      module('When the text is different according to the campaign type and the participation status', function () {
+      module('When the warning is different according to the campaign type and the participation status', function () {
         test('it is a started participation for an assessment campaign', async function (assert) {
           this.set('campaign.type', 'ASSESSMENT');
           this.set('participation.status', 'STARTED');
@@ -105,7 +106,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
 
           assert.contains(
             this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.started-participation'
+              'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.started-participation'
             )
           );
         });
@@ -124,7 +125,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
 
           assert.contains(
             this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.to-share-participation'
+              'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.to-share-participation'
             )
           );
         });
@@ -143,7 +144,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
 
           assert.contains(
             this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.text.assessment-campaign-participation.shared-participation'
+              'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.shared-participation'
             )
           );
         });
@@ -162,7 +163,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
 
           assert.contains(
             this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.text.profiles-collection-campaign-participation.to-share-participation'
+              'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.to-share-participation'
             )
           );
         });
@@ -181,7 +182,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
 
           assert.contains(
             this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.text.profiles-collection-campaign-participation.shared-participation'
+              'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.shared-participation'
             )
           );
         });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -314,9 +314,10 @@
         "error": "An error occurred while removing this participation.",
         "success": "The participation has been successfully deleted",
         "title": "Delete the participation of <strong>{firstName} {lastName}</strong>?",
-        "text": {
+        "text": "You are about to delete a participation, it will no longer be visible nor included in the statistics of the campaign.",
+        "warning": {
           "assessment-campaign-participation": {
-            "started-participation": "You are about to delete a participation, it will no longer be visible nor included in the statistics of the campaign.",
+            "started-participation": "The participant will be able to complete their customised test but will no longer be able to submit their results. They will also not be able to participate in the campaign again.",
             "to-share-participation": "The participant will no longer be able to submit their results nor to take the test again.",
             "shared-participation": "The participant will not be able to take the test again."
           },
@@ -324,8 +325,7 @@
             "to-share-participation": "The participant will no longer be able to submit their profile through this campaign.",
             "shared-participation": "The participant will no longer be able to submit their profile through this campaign."    
           }
-        },
-        "warning": "The participant will be able to complete their customised test but will no longer be able to submit their results. They will also not be able to participate in the campaign again."
+        }
       }
     },
     "campaign-creation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -317,9 +317,10 @@
         "error": "Un problème est survenu lors de la suppression de la participation.",
         "success": "La participation a été supprimée avec succès.",
         "title": "Supprimer la participation de <strong>{firstName} {lastName}</strong> ?",
-        "text": {
+        "text": "Vous êtes sur le point de supprimer une participation, celle-ci ne sera plus visible ni comprise dans les statistiques de la campagne.",
+        "warning": {
           "assessment-campaign-participation": {
-            "started-participation": "Vous êtes sur le point de supprimer une participation, celle-ci ne sera plus visible ni comprise dans les statistiques de la campagne.",
+            "started-participation": "Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne.",
             "to-share-participation": "Le participant ne pourra pas envoyer ses résultats et il ne pourra pas non plus participer de nouveau à cette campagne.",
             "shared-participation": "Le participant ne pourra plus participer de nouveau à cette campagne."    
           },
@@ -327,8 +328,7 @@
             "to-share-participation": "Le participant ne pourra pas envoyer son profil et il ne pourra pas non plus participer de nouveau à cette collecte de profil.",
             "shared-participation": "Le participant ne pourra plus participer de nouveau à cette collecte de profil."    
           }
-        },
-        "warning": "Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne."
+        }
       }
     },
     "campaign-creation": {


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, onglet “activité” d’une campagne, lorsque l’utilisateur veut supprimer une participation, la fenêtre qui lui demande confirmation comporte toujours le même second paragraphe, quel que soit le statut de la participation :

> “Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne.”



Il serait préférable de distinguer plusieurs cas, selon le statut de la participation et le type de campagne :

- la participation est en cours,
- la participation est en attente d’envoi des résultats,
- les résultats on été envoyés.

et cela selon le type de campagne : évaluation et collecte de profils.

## :robot: Proposition
Conditionner le second paragraphe par le statut de la participation et le type de la campagne.

### Pour les campagnes d'évaluation

#### Si la participation est en cours
**FR :** garder le texte actuel
**EN :** inchangé

#### Si la participation est en attente d’envoi des résultats
**FR :** “Le participant ne pourra pas envoyer ses résultats et il ne pourra pas non plus participer de nouveau à cette campagne."
**EN :** "The participant will no longer be able to submit their results nor to take the test again."

#### Si les résultats ont été envoyés 
**FR :** “Le participant ne pourra plus participer de nouveau à cette campagne.” 
**EN :** "The participant will not be able to take the test again."

### Pour les collectes de profil

#### Si la participation est en attente d’envoi du profil**
**FR :** “Le participant ne pourra pas envoyer son profil et il ne pourra pas non plus participer de nouveau à cette collecte de profil.”
**EN :** "The participant will no longer be able to submit their profile through this campaign'

#### Si le profil est reçu 
**FR :** “Le participant ne pourra plus participer de nouveau à cette collecte de profil.” 
**EN :** "The participant will no longer be able to submit their profile through this campaign"

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga
- Aller sur une campagne qui a des participations
- Vérifier les messages dans les modales lors de tentative de suppression d'une participation à une campagne de collecte de profile EN COURS et ENVOYÉ
- Vérifier les messages dans les modales lors de tentative de suppression d'une participation à une campagne d'évaluation EN COURS, EN ATTENTE D'ENVOI et ENVOYÉ
- Bien sûr, vérifier tout ça en français ET en anglais 😇 
- La review est terminée 🎉 