### PR TITLE
[BUGFIX] Améliorer le responsive du select dans le formulaire de signalement (PIX-8056)

### DIFF
--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -89,6 +89,7 @@
 
     > button {
       width: auto;
+      max-width: 100%;
     }
 
     @include device-is('mobile') {


### PR DESCRIPTION
## :unicorn: Problème
En mobile, le select dépasse si le texte de l'option est longue.
<img width="394" alt="Capture d’écran 2023-05-12 à 11 38 46" src="https://github.com/1024pix/pix/assets/49011144/94e03b0e-e25c-4d12-965e-c77de31973e7">


## :robot: Proposition
Ajouter une `max-width`.

## :100: Pour tester
Tester le responsive avec différents types de devices.
