### PR TITLE
[FEATURE] Modifier les requêtes en lecture pour utiliser la vue sur les prescrits actifs (PIX-7683)

### DIFF
--- a/api/db/database-builder/factory/build-organization-learner.js
+++ b/api/db/database-builder/factory/build-organization-learner.js
@@ -31,6 +31,8 @@ module.exports = function buildOrganizationLearner({
   updatedAt = new Date('2021-02-01'), // for BEGINNING_OF_THE_2020_SCHOOL_YEAR, can outdate very fast! ;)
   organizationId,
   userId,
+  deletedBy = null,
+  deletedAt = null,
 } = {}) {
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -63,6 +65,8 @@ module.exports = function buildOrganizationLearner({
     updatedAt,
     organizationId,
     userId,
+    deletedBy,
+    deletedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -365,6 +365,7 @@ function _buildParticipations({ databaseBuilder }) {
     { firstName: 'Antoine', lastName: 'Boiduvin', createdAt: new Date('2022-02-07') },
     { firstName: 'Brandone', lastName: 'Bro', createdAt: new Date('2022-02-07') },
     { firstName: 'Jean', lastName: 'Sérien', createdAt: new Date('2022-02-07') },
+    { firstName: 'Alex', lastName: 'Deleted', createdAt: new Date('2022-02-07'), deletedBy: 1, deletedAt: new Date('2023-05-01') },
   ] });
 
   _buildParticipationsInDifferentStatus({ databaseBuilder, user: users[0] });
@@ -377,7 +378,7 @@ function _buildParticipations({ databaseBuilder }) {
 function _buildUsers({ databaseBuilder, users }) {
   return users.map((user) => {
     const databaseUser = databaseBuilder.factory.buildUser.withRawPassword({ ...user, rawPassword: DEFAULT_PASSWORD });
-    databaseBuilder.factory.buildOrganizationLearner({ firstName: user.firstName + '-Prescrit', lastName: user.lastName + '-Prescrit', id: databaseUser.id, userId: databaseUser.id, organizationId: PRO_COMPANY_ID });
+    databaseBuilder.factory.buildOrganizationLearner({ firstName: user.firstName + '-Prescrit', lastName: user.lastName + '-Prescrit', id: databaseUser.id, userId: databaseUser.id, organizationId: PRO_COMPANY_ID, deletedBy: user.deletedBy, deletedAt: user.deletedAt });
     return databaseUser;
   });
 }

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-repository.js
@@ -23,8 +23,8 @@ async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campa
     .with('campaignAssessmentParticipation', (qb) => {
       qb.select([
         'campaign-participations.userId',
-        'organization-learners.firstName',
-        'organization-learners.lastName',
+        'view-active-organization-learners.firstName',
+        'view-active-organization-learners.lastName',
         'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.campaignId',
         'campaign-participations.createdAt',
@@ -33,13 +33,17 @@ async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campa
         'campaign-participations.participantExternalId',
         'campaign-participations.masteryRate',
         'campaign-participations.validatedSkillsCount',
-        'organization-learners.id AS organizationLearnerId',
+        'view-active-organization-learners.id AS organizationLearnerId',
         'assessments.state AS assessmentState',
         _assessmentRankByCreationDate(),
       ])
         .from('campaign-participations')
         .join('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
-        .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+        .join(
+          'view-active-organization-learners',
+          'view-active-organization-learners.id',
+          'campaign-participations.organizationLearnerId'
+        )
         .where({
           'campaign-participations.id': campaignParticipationId,
           'campaign-participations.deletedAt': null,

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -34,8 +34,8 @@ function _getParticipantsResultList(campaignId, stageCollection, filters) {
 
 function _getParticipations(qb, campaignId, stageCollection, filters) {
   qb.select(
-    'organization-learners.firstName',
-    'organization-learners.lastName',
+    'view-active-organization-learners.firstName',
+    'view-active-organization-learners.lastName',
     'campaign-participations.participantExternalId',
     'campaign-participations.masteryRate',
     'campaign-participations.validatedSkillsCount',
@@ -43,7 +43,11 @@ function _getParticipations(qb, campaignId, stageCollection, filters) {
     'campaign-participations.userId'
   )
     .from('campaign-participations')
-    .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+    .join(
+      'view-active-organization-learners',
+      'view-active-organization-learners.id',
+      'campaign-participations.organizationLearnerId'
+    )
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.status', '=', SHARED)
     .where('campaign-participations.isImproved', '=', false)
@@ -58,7 +62,7 @@ function _getParticipations(qb, campaignId, stageCollection, filters) {
 function _filterByDivisions(queryBuilder, filters) {
   if (filters.divisions) {
     const divisionsLowerCase = filters.divisions.map((division) => division.toLowerCase());
-    queryBuilder.whereRaw('LOWER("organization-learners"."division") = ANY(:divisionsLowerCase)', {
+    queryBuilder.whereRaw('LOWER("view-active-organization-learners"."division") = ANY(:divisionsLowerCase)', {
       divisionsLowerCase,
     });
   }
@@ -67,7 +71,7 @@ function _filterByDivisions(queryBuilder, filters) {
 function _filterByGroups(queryBuilder, filters) {
   if (filters.groups) {
     const groupsLowerCase = filters.groups.map((group) => group.toLowerCase());
-    queryBuilder.whereIn(knex.raw('LOWER("organization-learners"."group")'), groupsLowerCase);
+    queryBuilder.whereIn(knex.raw('LOWER("view-active-organization-learners"."group")'), groupsLowerCase);
   }
 }
 
@@ -76,12 +80,15 @@ function _filterBySearch(queryBuilder, filters) {
     const search = filters.search.trim().toLowerCase();
     queryBuilder.where(function () {
       this.where(
-        knex.raw(`CONCAT ("organization-learners"."firstName", ' ', "organization-learners"."lastName") <-> ?`, search),
+        knex.raw(
+          `CONCAT ("view-active-organization-learners"."firstName", ' ', "view-active-organization-learners"."lastName") <-> ?`,
+          search
+        ),
         '<=',
         0.8
       )
-        .orWhereILike('organization-learners.lastName', `%${search}%`)
-        .orWhereILike('organization-learners.firstName', `%${search}%`);
+        .orWhereILike('view-active-organization-learners.lastName', `%${search}%`)
+        .orWhereILike('view-active-organization-learners.firstName', `%${search}%`);
     });
   }
 }

--- a/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -30,8 +30,8 @@ function _buildCampaignParticipationByParticipant(queryBuilder, campaignId, filt
     .select(
       'campaign-participations.id AS campaignParticipationId',
       'campaign-participations.userId',
-      'organization-learners.firstName',
-      'organization-learners.lastName',
+      'view-active-organization-learners.firstName',
+      'view-active-organization-learners.lastName',
       'campaign-participations.participantExternalId',
       'campaign-participations.sharedAt',
       'campaign-participations.status',
@@ -39,7 +39,11 @@ function _buildCampaignParticipationByParticipant(queryBuilder, campaignId, filt
     )
     .from('campaign-participations')
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+    .join(
+      'view-active-organization-learners',
+      'view-active-organization-learners.id',
+      'campaign-participations.organizationLearnerId'
+    )
     .modify(_filterParticipations, filters, campaignId);
 }
 
@@ -56,14 +60,19 @@ function _filterParticipations(queryBuilder, filters, campaignId) {
 
 function _filterBySearch(queryBuilder, filters) {
   if (filters.search) {
-    filterByFullName(queryBuilder, filters.search, 'organization-learners.firstName', 'organization-learners.lastName');
+    filterByFullName(
+      queryBuilder,
+      filters.search,
+      'view-active-organization-learners.firstName',
+      'view-active-organization-learners.lastName'
+    );
   }
 }
 
 function _filterByDivisions(queryBuilder, filters) {
   if (filters.divisions) {
     const divisionsLowerCase = filters.divisions.map((division) => division.toLowerCase());
-    queryBuilder.whereRaw('LOWER("organization-learners"."division") = ANY(:divisionsLowerCase)', {
+    queryBuilder.whereRaw('LOWER("view-active-organization-learners"."division") = ANY(:divisionsLowerCase)', {
       divisionsLowerCase,
     });
   }
@@ -78,7 +87,7 @@ function _filterByStatus(queryBuilder, filters) {
 function _filterByGroup(queryBuilder, filters) {
   if (filters.groups) {
     const groupsLowerCase = filters.groups.map((group) => group.toLowerCase());
-    queryBuilder.whereIn(knex.raw('LOWER("organization-learners"."group")'), groupsLowerCase);
+    queryBuilder.whereIn(knex.raw('LOWER("view-active-organization-learners"."group")'), groupsLowerCase);
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -134,22 +134,26 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
   const organizationLearner = { id: null, hasParticipated: false };
   const row = await domainTransaction
     .knexTransaction('campaigns')
-    .select({ id: 'organization-learners.id', campaignParticipationId: 'campaign-participations.id' })
-    .join('organization-learners', 'organization-learners.organizationId', 'campaigns.organizationId')
+    .select({ id: 'view-active-organization-learners.id', campaignParticipationId: 'campaign-participations.id' })
+    .join(
+      'view-active-organization-learners',
+      'view-active-organization-learners.organizationId',
+      'campaigns.organizationId'
+    )
     .leftJoin(
       'campaign-participations',
       function () {
-        this.on('campaign-participations.organizationLearnerId', 'organization-learners.id');
+        this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id');
         this.on('campaign-participations.campaignId', 'campaigns.id');
         this.on('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
         this.on('campaign-participations.isImproved', knex.raw('false'));
-        this.on('campaign-participations.userId', '!=', 'organization-learners.userId');
+        this.on('campaign-participations.userId', '!=', 'view-active-organization-learners.userId');
       },
-      'organization-learners.id'
+      'view-active-organization-learners.id'
     )
     .where({
       'campaigns.id': campaignId,
-      'organization-learners.userId': userId,
+      'view-active-organization-learners.userId': userId,
       isDisabled: false,
     })
     .first();

--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -10,15 +10,19 @@ module.exports = {
           'campaign-participations.*',
           'assessments.state',
           _assessmentRankByCreationDate(),
-          'organization-learners.firstName',
-          'organization-learners.lastName',
-          'organization-learners.studentNumber',
-          'organization-learners.division',
-          'organization-learners.group',
+          'view-active-organization-learners.firstName',
+          'view-active-organization-learners.lastName',
+          'view-active-organization-learners.studentNumber',
+          'view-active-organization-learners.division',
+          'view-active-organization-learners.group',
         ])
           .from('campaign-participations')
           .join('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
-          .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+          .join(
+            'view-active-organization-learners',
+            'view-active-organization-learners.id',
+            'campaign-participations.organizationLearnerId'
+          )
           .where({ campaignId, isImproved: false, 'campaign-participations.deletedAt': null });
       })
       .from('campaignParticipationWithUserAndRankedAssessment')

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -57,13 +57,17 @@ module.exports = {
     const results = await knex('campaign-participations')
       .select([
         'campaign-participations.*',
-        'organization-learners.studentNumber',
-        'organization-learners.division',
-        'organization-learners.group',
-        'organization-learners.firstName',
-        'organization-learners.lastName',
+        'view-active-organization-learners.studentNumber',
+        'view-active-organization-learners.division',
+        'view-active-organization-learners.group',
+        'view-active-organization-learners.firstName',
+        'view-active-organization-learners.lastName',
       ])
-      .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+      .join(
+        'view-active-organization-learners',
+        'view-active-organization-learners.id',
+        'campaign-participations.organizationLearnerId'
+      )
       .where({ campaignId, isImproved: false, 'campaign-participations.deletedAt': null });
 
     return results.map(_rowToResult);

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -28,9 +28,9 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
     .with('campaignProfile', (qb) => {
       qb.select([
         'campaign-participations.userId',
-        'organization-learners.firstName',
-        'organization-learners.id AS organizationLearnerId',
-        'organization-learners.lastName',
+        'view-active-organization-learners.firstName',
+        'view-active-organization-learners.id AS organizationLearnerId',
+        'view-active-organization-learners.lastName',
         'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.campaignId',
         'campaign-participations.createdAt',
@@ -40,7 +40,11 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
         'campaign-participations.pixScore',
       ])
         .from('campaign-participations')
-        .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+        .join(
+          'view-active-organization-learners',
+          'view-active-organization-learners.id',
+          'campaign-participations.organizationLearnerId'
+        )
         .where({
           campaignId,
           'campaign-participations.id': campaignParticipationId,

--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -14,16 +14,20 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
       .select(
         'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.userId AS userId',
-        knex.raw('LOWER("organization-learners"."firstName") AS "lowerFirstName"'),
-        knex.raw('LOWER("organization-learners"."lastName") AS "lowerLastName"'),
-        'organization-learners.firstName AS firstName',
-        'organization-learners.lastName AS lastName',
+        knex.raw('LOWER("view-active-organization-learners"."firstName") AS "lowerFirstName"'),
+        knex.raw('LOWER("view-active-organization-learners"."lastName") AS "lowerLastName"'),
+        'view-active-organization-learners.firstName AS firstName',
+        'view-active-organization-learners.lastName AS lastName',
         'campaign-participations.participantExternalId',
         'campaign-participations.sharedAt',
         'campaign-participations.pixScore AS pixScore'
       )
       .from('campaign-participations')
-      .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+      .join(
+        'view-active-organization-learners',
+        'view-active-organization-learners.id',
+        'campaign-participations.organizationLearnerId'
+      )
       .where('campaign-participations.campaignId', '=', campaignId)
       .where('campaign-participations.isImproved', '=', false)
       .where('campaign-participations.deletedAt', 'IS', null)
@@ -80,16 +84,21 @@ async function _makeMemoizedGetPlacementProfileForUser(results) {
 function _filterQuery(queryBuilder, filters) {
   if (filters.divisions) {
     const divisionsLowerCase = filters.divisions.map((division) => division.toLowerCase());
-    queryBuilder.whereRaw('LOWER("organization-learners"."division") = ANY(:divisionsLowerCase)', {
+    queryBuilder.whereRaw('LOWER("view-active-organization-learners"."division") = ANY(:divisionsLowerCase)', {
       divisionsLowerCase,
     });
   }
   if (filters.groups) {
     const groupsLowerCase = filters.groups.map((group) => group.toLowerCase());
-    queryBuilder.whereIn(knex.raw('LOWER("organization-learners"."group")'), groupsLowerCase);
+    queryBuilder.whereIn(knex.raw('LOWER("view-active-organization-learners"."group")'), groupsLowerCase);
   }
   if (filters.search) {
-    filterByFullName(queryBuilder, filters.search, 'organization-learners.firstName', 'organization-learners.lastName');
+    filterByFullName(
+      queryBuilder,
+      filters.search,
+      'view-active-organization-learners.firstName',
+      'view-active-organization-learners.lastName'
+    );
   }
 }
 

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -6,12 +6,12 @@ module.exports = {
     const result = await knex
       .select({
         id: 'certification-courses.id',
-        firstName: 'organization-learners.firstName',
-        middleName: 'organization-learners.middleName',
-        thirdName: 'organization-learners.thirdName',
-        lastName: 'organization-learners.lastName',
-        birthdate: 'organization-learners.birthdate',
-        nationalStudentId: 'organization-learners.nationalStudentId',
+        firstName: 'view-active-organization-learners.firstName',
+        middleName: 'view-active-organization-learners.middleName',
+        thirdName: 'view-active-organization-learners.thirdName',
+        lastName: 'view-active-organization-learners.lastName',
+        birthdate: 'view-active-organization-learners.birthdate',
+        nationalStudentId: 'view-active-organization-learners.nationalStudentId',
         date: 'certification-courses.createdAt',
         verificationCode: 'certification-courses.verificationCode',
         deliveredAt: 'sessions.publishedAt',
@@ -26,7 +26,11 @@ module.exports = {
         )`),
       })
       .from('certification-courses')
-      .innerJoin('organization-learners', 'organization-learners.userId', 'certification-courses.userId')
+      .innerJoin(
+        'view-active-organization-learners',
+        'view-active-organization-learners.userId',
+        'certification-courses.userId'
+      )
       .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
       .innerJoin(
         'certification-courses-last-assessment-results',
@@ -50,15 +54,21 @@ module.exports = {
       )
 
       .where({ 'certification-courses.isCancelled': false })
-      .where({ 'organization-learners.isDisabled': false })
+      .where({ 'view-active-organization-learners.isDisabled': false })
       .where(
-        'organization-learners.organizationId',
+        'view-active-organization-learners.organizationId',
         '=',
         knex.select('id').from('organizations').whereRaw('LOWER("externalId") = LOWER(?)', uai)
       )
 
       .groupBy(
-        'organization-learners.id',
+        'view-active-organization-learners.id',
+        'view-active-organization-learners.firstName',
+        'view-active-organization-learners.middleName',
+        'view-active-organization-learners.thirdName',
+        'view-active-organization-learners.lastName',
+        'view-active-organization-learners.birthdate',
+        'view-active-organization-learners.nationalStudentId',
         'certification-courses.id',
         'sessions.id',
         'assessments.id',

--- a/api/lib/infrastructure/repositories/division-repository.js
+++ b/api/lib/infrastructure/repositories/division-repository.js
@@ -2,19 +2,23 @@ const Division = require('../../domain/models/Division.js');
 const { knex } = require('../../../db/knex-database-connection.js');
 
 async function findByCampaignId(campaignId) {
-  const divisions = await knex('organization-learners')
+  const divisions = await knex('view-active-organization-learners')
     .where({ campaignId })
     .whereNotNull('division')
     .where({ 'campaign-participations.deletedAt': null })
     .distinct('division')
     .orderBy('division', 'asc')
-    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId');
+    .join(
+      'campaign-participations',
+      'view-active-organization-learners.id',
+      'campaign-participations.organizationLearnerId'
+    );
 
   return divisions.map(({ division }) => _toDomain(division));
 }
 
 async function findByOrganizationIdForCurrentSchoolYear({ organizationId }) {
-  const divisionRows = await knex('organization-learners')
+  const divisionRows = await knex('view-active-organization-learners')
     .distinct('division')
     .where({ organizationId, isDisabled: false })
     .whereNotNull('division')

--- a/api/lib/infrastructure/repositories/group-repository.js
+++ b/api/lib/infrastructure/repositories/group-repository.js
@@ -2,19 +2,23 @@ const Group = require('../../domain/models/Group.js');
 const { knex } = require('../../../db/knex-database-connection.js');
 
 async function findByCampaignId(campaignId) {
-  const groups = await knex('organization-learners')
+  const groups = await knex('view-active-organization-learners')
     .where({ campaignId })
     .where({ 'campaign-participations.deletedAt': null })
     .distinct('group')
     .whereNotNull('group')
     .orderBy('group', 'asc')
-    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId');
+    .join(
+      'campaign-participations',
+      'view-active-organization-learners.id',
+      'campaign-participations.organizationLearnerId'
+    );
 
   return groups.map(({ group }) => _toDomain(group));
 }
 
 async function findByOrganizationId({ organizationId }) {
-  const groupRows = await knex('organization-learners')
+  const groupRows = await knex('view-active-organization-learners')
     .distinct('group')
     .where({ organizationId, isDisabled: false })
     .whereNotNull('group')

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -45,7 +45,7 @@ module.exports = {
   async findByIds({ ids }) {
     const rawOrganizationLearners = await knex
       .select('*')
-      .from('organization-learners')
+      .from('view-active-organization-learners')
       .whereIn('id', ids)
       .orderBy('id');
 
@@ -54,7 +54,7 @@ module.exports = {
 
   findByOrganizationId({ organizationId }, transaction = DomainTransaction.emptyTransaction()) {
     const knexConn = transaction.knexTransaction || knex;
-    return knexConn('organization-learners')
+    return knexConn('view-active-organization-learners')
       .where({ organizationId })
       .orderByRaw('LOWER("lastName") ASC, LOWER("firstName") ASC')
       .then((organizationLearners) =>
@@ -64,7 +64,7 @@ module.exports = {
 
   async findByOrganizationIdAndUpdatedAtOrderByDivision({ organizationId, page, filter }) {
     const BEGINNING_OF_THE_2020_SCHOOL_YEAR = '2020-08-15';
-    const query = knex('organization-learners')
+    const query = knex('view-active-organization-learners')
       .where({
         organizationId,
         isDisabled: false,
@@ -87,7 +87,7 @@ module.exports = {
   async findByUserId({ userId }) {
     const rawOrganizationLearners = await knex
       .select('*')
-      .from('organization-learners')
+      .from('view-active-organization-learners')
       .where({ userId })
       .orderBy('id');
 
@@ -95,10 +95,10 @@ module.exports = {
   },
 
   async isOrganizationLearnerIdLinkedToUserAndSCOOrganization({ userId, organizationLearnerId }) {
-    const exist = await knex('organization-learners')
-      .select('organization-learners.id')
-      .join('organizations', 'organization-learners.organizationId', 'organizations.id')
-      .where({ userId, type: 'SCO', 'organization-learners.id': organizationLearnerId })
+    const exist = await knex('view-active-organization-learners')
+      .select('view-active-organization-learners.id')
+      .join('organizations', 'view-active-organization-learners.organizationId', 'organizations.id')
+      .where({ userId, type: 'SCO', 'view-active-organization-learners.id': organizationLearnerId })
       .first();
 
     return Boolean(exist);
@@ -180,7 +180,7 @@ module.exports = {
   async findByOrganizationIdAndBirthdate({ organizationId, birthdate }) {
     const rawOrganizationLearners = await knex
       .select('*')
-      .from('organization-learners')
+      .from('view-active-organization-learners')
       .where({ organizationId, birthdate, isDisabled: false })
       .orderBy('id');
 
@@ -219,9 +219,9 @@ module.exports = {
   },
 
   async getOrganizationLearnerForAdmin(organizationLearnerId) {
-    const organizationLearner = await knex('organization-learners')
+    const organizationLearner = await knex('view-active-organization-learners')
       .select(
-        'organization-learners.id as id',
+        'view-active-organization-learners.id as id',
         'firstName',
         'lastName',
         'birthdate',
@@ -229,13 +229,13 @@ module.exports = {
         'group',
         'organizationId',
         'organizations.name as organizationName',
-        'organization-learners.createdAt as createdAt',
-        'organization-learners.updatedAt as updatedAt',
+        'view-active-organization-learners.createdAt as createdAt',
+        'view-active-organization-learners.updatedAt as updatedAt',
         'isDisabled',
         'organizations.isManagingStudents as organizationIsManagingStudents'
       )
-      .innerJoin('organizations', 'organizations.id', 'organization-learners.organizationId')
-      .where({ 'organization-learners.id': organizationLearnerId })
+      .innerJoin('organizations', 'organizations.id', 'view-active-organization-learners.organizationId')
+      .where({ 'view-active-organization-learners.id': organizationLearnerId })
       .first();
 
     if (!organizationLearner) {
@@ -264,7 +264,7 @@ module.exports = {
     organizationId,
     domainTransaction = DomainTransaction.emptyTransaction(),
   }) {
-    const organizationLearner = await knex('organization-learners')
+    const organizationLearner = await knex('view-active-organization-learners')
       .transacting(domainTransaction)
       .where({ userId, organizationId })
       .first('*');
@@ -275,7 +275,7 @@ module.exports = {
   async get(organizationLearnerId) {
     const organizationLearner = await knex
       .select('*')
-      .from('organization-learners')
+      .from('view-active-organization-learners')
       .where({ id: organizationLearnerId })
       .first();
 
@@ -290,7 +290,7 @@ module.exports = {
       .where({ nationalStudentId, birthdate })
       .whereNotNull('userId')
       .select()
-      .from('organization-learners')
+      .from('view-active-organization-learners')
       .orderBy('updatedAt', 'desc')
       .first();
 
@@ -321,12 +321,12 @@ module.exports = {
   },
 
   async isActive({ userId, campaignId }) {
-    const learner = await knex('organization-learners')
-      .select('organization-learners.isDisabled')
-      .join('organizations', 'organizations.id', 'organization-learners.organizationId')
+    const learner = await knex('view-active-organization-learners')
+      .select('view-active-organization-learners.isDisabled')
+      .join('organizations', 'organizations.id', 'view-active-organization-learners.organizationId')
       .join('campaigns', 'campaigns.organizationId', 'organizations.id')
       .where({ 'campaigns.id': campaignId })
-      .andWhere({ 'organization-learners.userId': userId })
+      .andWhere({ 'view-active-organization-learners.userId': userId })
       .first();
     return !learner?.isDisabled;
   },

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -225,12 +225,12 @@ async function _isCampaignArchived(campaignId) {
 }
 
 async function _isOrganizationLearnerActive(userId, campaignId) {
-  const organizationLearner = await knex('organization-learners')
-    .select('organization-learners.isDisabled')
-    .join('organizations', 'organizations.id', 'organization-learners.organizationId')
+  const organizationLearner = await knex('view-active-organization-learners')
+    .select('view-active-organization-learners.isDisabled')
+    .join('organizations', 'organizations.id', 'view-active-organization-learners.organizationId')
     .join('campaigns', 'campaigns.organizationId', 'organizations.id')
     .where({ 'campaigns.id': campaignId })
-    .andWhere({ 'organization-learners.userId': userId })
+    .andWhere({ 'view-active-organization-learners.userId': userId })
     .first();
   return !organizationLearner?.isDisabled;
 }

--- a/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -8,8 +8,8 @@ module.exports = {
     const query = knex('campaign-participations')
       .select({
         id: 'campaign-participations.id',
-        lastName: 'organization-learners.lastName',
-        firstName: 'organization-learners.firstName',
+        lastName: 'view-active-organization-learners.lastName',
+        firstName: 'view-active-organization-learners.firstName',
         userId: 'users.id',
         userFirstName: 'users.firstName',
         userLastName: 'users.lastName',
@@ -22,7 +22,11 @@ module.exports = {
         deletedByFirstName: 'deletedByUsers.firstName',
         deletedByLastName: 'deletedByUsers.lastName',
       })
-      .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+      .join(
+        'view-active-organization-learners',
+        'view-active-organization-learners.id',
+        'campaign-participations.organizationLearnerId'
+      )
       .leftJoin('users as deletedByUsers', 'deletedByUsers.id', 'campaign-participations.deletedBy')
       .innerJoin('users', 'users.id', 'campaign-participations.userId')
       .where('campaignId', campaignId)

--- a/api/lib/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-user-management-repository.js
@@ -16,11 +16,15 @@ module.exports = {
         deletedBy: 'deletedByUsers.id',
         deletedByFirstName: 'deletedByUsers.firstName',
         deletedByLastName: 'deletedByUsers.lastName',
-        organizationLearnerFirstName: 'organization-learners.firstName',
-        organizationLearnerLastName: 'organization-learners.lastName',
+        organizationLearnerFirstName: 'view-active-organization-learners.firstName',
+        organizationLearnerLastName: 'view-active-organization-learners.lastName',
       })
       .innerJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-      .innerJoin('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+      .innerJoin(
+        'view-active-organization-learners',
+        'view-active-organization-learners.id',
+        'campaign-participations.organizationLearnerId'
+      )
       .leftJoin('users as deletedByUsers', 'deletedByUsers.id', 'campaign-participations.deletedBy')
       .where('campaign-participations.userId', userId)
       .orderBy('campaignCode', 'asc')

--- a/api/lib/infrastructure/repositories/prescriber-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-repository.js
@@ -32,11 +32,15 @@ async function _areNewYearOrganizationLearnersImportedForPrescriber(prescriber) 
   const currentOrganizationId = prescriber.userOrgaSettings.currentOrganization.id;
   const atLeastOneOrganizationLearner = await knex('organizations')
     .select('organizations.id')
-    .join('organization-learners', 'organization-learners.organizationId', 'organizations.id')
+    .join('view-active-organization-learners', 'view-active-organization-learners.organizationId', 'organizations.id')
     .where((qb) => {
       qb.where('organizations.id', currentOrganizationId);
       if (settings.features.newYearOrganizationLearnersImportDate) {
-        qb.where('organization-learners.createdAt', '>=', settings.features.newYearOrganizationLearnersImportDate);
+        qb.where(
+          'view-active-organization-learners.createdAt',
+          '>=',
+          settings.features.newYearOrganizationLearnersImportDate
+        );
       }
     })
     .first();
@@ -47,9 +51,9 @@ async function _areNewYearOrganizationLearnersImportedForPrescriber(prescriber) 
 async function _getParticipantCount(prescriber) {
   const currentOrganizationId = prescriber.userOrgaSettings.currentOrganization.id;
 
-  const { count: allCounts } = await knex('organization-learners')
-    .count('organization-learners.id')
-    .leftJoin('users', 'users.id', 'organization-learners.userId')
+  const { count: allCounts } = await knex('view-active-organization-learners')
+    .count('view-active-organization-learners.id')
+    .leftJoin('users', 'users.id', 'view-active-organization-learners.userId')
     .where('isAnonymous', false)
     .where('organizationId', currentOrganizationId)
     .where('isDisabled', false)

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -26,12 +26,16 @@ module.exports = {
     const rows = await knex
       .select(['certification-candidates.id'])
       .from('certification-candidates')
-      .join('organization-learners', 'organization-learners.id', 'certification-candidates.organizationLearnerId')
+      .join(
+        'view-active-organization-learners',
+        'view-active-organization-learners.id',
+        'certification-candidates.organizationLearnerId'
+      )
       .where({
-        'organization-learners.organizationId': organizationId,
-        'organization-learners.isDisabled': false,
+        'view-active-organization-learners.organizationId': organizationId,
+        'view-active-organization-learners.isDisabled': false,
       })
-      .whereRaw('LOWER("organization-learners"."division") = ?', division.toLowerCase())
+      .whereRaw('LOWER("view-active-organization-learners"."division") = ?', division.toLowerCase())
       .orderBy('certification-candidates.lastName', 'ASC')
       .orderBy('certification-candidates.firstName', 'ASC');
 

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -10,7 +10,12 @@ const CampaignParticipationStatuses = require('../../domain/models/CampaignParti
 
 function _setFilters(qb, { search, divisions, connectionTypes, certificability } = {}) {
   if (search) {
-    filterByFullName(qb, search, 'organization-learners.firstName', 'organization-learners.lastName');
+    filterByFullName(
+      qb,
+      search,
+      'view-active-organization-learners.firstName',
+      'view-active-organization-learners.lastName'
+    );
   }
   if (!_.isEmpty(divisions)) {
     qb.whereIn('division', divisions);
@@ -49,22 +54,26 @@ function _setFilters(qb, { search, divisions, connectionTypes, certificability }
 
 function _buildIsCertifiable(queryBuilder, organizationId) {
   queryBuilder
-    .distinct('organization-learners.id')
+    .distinct('view-active-organization-learners.id')
     .select([
-      'organization-learners.id as organizationLearnerId',
+      'view-active-organization-learners.id as organizationLearnerId',
       knex.raw(
-        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
+        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
       ),
       knex.raw(
-        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"'
+        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"'
       ),
     ])
-    .from('organization-learners')
-    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+    .from('view-active-organization-learners')
+    .join(
+      'campaign-participations',
+      'view-active-organization-learners.id',
+      'campaign-participations.organizationLearnerId'
+    )
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
     .where('campaign-participations.status', CampaignParticipationStatuses.SHARED)
     .where('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
-    .where('organization-learners.organizationId', organizationId)
+    .where('view-active-organization-learners.organizationId', organizationId)
     .where('campaigns.organizationId', organizationId)
     .where('campaign-participations.deletedAt', null);
 }
@@ -73,14 +82,14 @@ module.exports = {
   async findPaginatedFilteredScoParticipants({ organizationId, filter, page = {}, sort = {} }) {
     const { totalScoParticipants } = await knex
       .count('id', { as: 'totalScoParticipants' })
-      .from('organization-learners')
+      .from('view-active-organization-learners')
       .where({ organizationId: organizationId, isDisabled: false })
       .first();
 
     const orderByClause = [
-      'organization-learners.lastName',
-      'organization-learners.firstName',
-      'organization-learners.id',
+      'view-active-organization-learners.lastName',
+      'view-active-organization-learners.firstName',
+      'view-active-organization-learners.id',
     ];
     if (sort?.participationCount) {
       orderByClause.unshift({
@@ -90,53 +99,53 @@ module.exports = {
     }
     if (sort?.lastnameSort) {
       orderByClause.unshift({
-        column: 'organization-learners.lastName',
+        column: 'view-active-organization-learners.lastName',
         order: sort.lastnameSort == 'desc' ? 'desc' : 'asc',
       });
     }
 
     const query = knex
       .with('subquery', (qb) => _buildIsCertifiable(qb, organizationId))
-      .distinct('organization-learners.id')
+      .distinct('view-active-organization-learners.id')
       .select([
-        'organization-learners.id',
-        'organization-learners.firstName',
-        'organization-learners.lastName',
-        knex.raw('LOWER("organization-learners"."firstName") AS "lowerFirstName"'),
-        knex.raw('LOWER("organization-learners"."lastName") AS "lowerLastName"'),
-        'organization-learners.birthdate',
-        'organization-learners.division',
-        'organization-learners.userId',
-        'organization-learners.organizationId',
+        'view-active-organization-learners.id',
+        'view-active-organization-learners.firstName',
+        'view-active-organization-learners.lastName',
+        knex.raw('LOWER("view-active-organization-learners"."firstName") AS "lowerFirstName"'),
+        knex.raw('LOWER("view-active-organization-learners"."lastName") AS "lowerLastName"'),
+        'view-active-organization-learners.birthdate',
+        'view-active-organization-learners.division',
+        'view-active-organization-learners.userId',
+        'view-active-organization-learners.organizationId',
         'users.username',
         'users.email',
         'authentication-methods.externalIdentifier as samlId',
         'subquery.isCertifiable',
         'subquery.certifiableAt',
         knex.raw(
-          'FIRST_VALUE("name") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"'
+          'FIRST_VALUE("name") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"'
         ),
         knex.raw(
-          'FIRST_VALUE("campaign-participations"."status") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "participationStatus"'
+          'FIRST_VALUE("campaign-participations"."status") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "participationStatus"'
         ),
         knex.raw(
-          'FIRST_VALUE("type") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignType"'
+          'FIRST_VALUE("type") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignType"'
         ),
         knex.raw(
-          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organization-learners"."id") AS "participationCount"'
+          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "view-active-organization-learners"."id") AS "participationCount"'
         ),
         knex.raw(
-          'max("campaign-participations"."createdAt") OVER(PARTITION BY "organization-learners"."id") AS "lastParticipationDate"'
+          'max("campaign-participations"."createdAt") OVER(PARTITION BY "view-active-organization-learners"."id") AS "lastParticipationDate"'
         ),
       ])
-      .from('organization-learners')
-      .leftJoin('subquery', 'subquery.organizationLearnerId', 'organization-learners.id')
+      .from('view-active-organization-learners')
+      .leftJoin('subquery', 'subquery.organizationLearnerId', 'view-active-organization-learners.id')
       .leftJoin('campaign-participations', function () {
-        this.on('campaign-participations.organizationLearnerId', 'organization-learners.id')
+        this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
           .andOn('campaign-participations.isImproved', '=', knex.raw('false'))
           .andOn('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
       })
-      .leftJoin('users', 'users.id', 'organization-learners.userId')
+      .leftJoin('users', 'users.id', 'view-active-organization-learners.userId')
       .leftJoin('authentication-methods', function () {
         this.on('users.id', 'authentication-methods.userId').andOnVal(
           'authentication-methods.identityProvider',
@@ -146,11 +155,11 @@ module.exports = {
       .leftJoin('campaigns', function () {
         this.on('campaigns.id', 'campaign-participations.campaignId').andOn(
           'campaigns.organizationId',
-          'organization-learners.organizationId'
+          'view-active-organization-learners.organizationId'
         );
       })
-      .where('organization-learners.isDisabled', false)
-      .where('organization-learners.organizationId', organizationId)
+      .where('view-active-organization-learners.isDisabled', false)
+      .where('view-active-organization-learners.organizationId', organizationId)
       .modify(_setFilters, filter)
       .orderBy(orderByClause);
 

--- a/api/lib/infrastructure/repositories/sessions/session-for-attendance-sheet-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-attendance-sheet-repository.js
@@ -25,7 +25,7 @@ module.exports = {
         'birthdate', "certification-candidates"."birthdate",
         'externalId', "certification-candidates"."externalId",
         'extraTimePercentage', "certification-candidates"."extraTimePercentage",
-        'division', "organization-learners".division)
+        'division', "view-active-organization-learners".division)
         order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
         `),
       })
@@ -38,7 +38,11 @@ module.exports = {
         );
       })
       .leftJoin('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
-      .leftJoin('organization-learners', 'organization-learners.id', 'certification-candidates.organizationLearnerId')
+      .leftJoin(
+        'view-active-organization-learners',
+        'view-active-organization-learners.id',
+        'certification-candidates.organizationLearnerId'
+      )
       .groupBy('sessions.id', 'certification-centers.id', 'organizations.id')
       .where({ 'sessions.id': idSession })
       .first();

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -32,22 +32,22 @@ module.exports = {
     const knexConn = domainTransaction.knexTransaction || knex;
     const results = await knexConn
       .select({
-        nationalStudentId: 'organization-learners.nationalStudentId',
+        nationalStudentId: 'view-active-organization-learners.nationalStudentId',
         userId: 'users.id',
-        birthdate: 'organization-learners.birthdate',
-        organizationId: 'organization-learners.organizationId',
+        birthdate: 'view-active-organization-learners.birthdate',
+        organizationId: 'view-active-organization-learners.organizationId',
         updatedAt: 'users.updatedAt',
       })
       .count('certification-courses.id as certificationCount')
-      .from('organization-learners')
-      .join('users', 'users.id', 'organization-learners.userId')
+      .from('view-active-organization-learners')
+      .join('users', 'users.id', 'view-active-organization-learners.userId')
       .leftJoin('certification-courses', 'certification-courses.userId', 'users.id')
       .whereIn('nationalStudentId', nationalStudentIds)
       .groupBy(
-        'organization-learners.nationalStudentId',
+        'view-active-organization-learners.nationalStudentId',
         'users.id',
-        'organization-learners.organizationId',
-        'organization-learners.birthdate',
+        'view-active-organization-learners.organizationId',
+        'view-active-organization-learners.birthdate',
         'users.updatedAt'
       )
       .orderBy('users.id');

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -134,13 +134,13 @@ module.exports = {
       .join('users', 'users.id', 'authentication-methods.userId')
       .where({ userId });
 
-    const organizationLearnersDTO = await knex('organization-learners')
+    const organizationLearnersDTO = await knex('view-active-organization-learners')
       .select([
-        'organization-learners.*',
+        'view-active-organization-learners.*',
         'organizations.name AS organizationName',
         'organizations.isManagingStudents AS organizationIsManagingStudents',
       ])
-      .join('organizations', 'organizations.id', 'organization-learners.organizationId')
+      .join('organizations', 'organizations.id', 'view-active-organization-learners.organizationId')
       .where({ userId })
       .orderBy('id');
 


### PR DESCRIPTION
## :unicorn: Problème
Pour permettre de supprimer des prescrits tout en conservant des statistiques consolidées, nous avons retenu la solution avec “vue”.

## :robot: Proposition
Maintenant que la vue à été crée, nous pouvons l'utiliser pour remplacer toutes les requêtes faites (en lecture seulement) pour utiliser 'view-active-organization-learners'

## :rainbow: Remarques
Revue à faire en mob :siffle:

## :100: Pour tester
1er test : 
- Aller sur Pix Orga & Pix Admin
- Verifier que tout fonctionne "normalement", que les pages se chargent bien, et que les learners s'affichent correctement.

2nd test : 
- Un prescrit à été supprimé via les seed " Alex Deleted " dans l'organization 'Dragon&Co'
- Vérifier sur Pix Orga avec Dragon&Co, que ce learner n'apparait pas du tout
- Vérifier sur Pix Admin que l'utilisateur 'Alex Deleted' existe bien, mais que rien n'apparait dans les Informations prescrit

- 😺
