### PR TITLE
[FEATURE] Améliorer le style du bloc de réponse des épreuves Pix-App (PIX-7717)

### DIFF
--- a/mon-pix/app/components/qcm-proposals.hbs
+++ b/mon-pix/app/components/qcm-proposals.hbs
@@ -2,19 +2,16 @@
   {{#each this.labeledCheckboxes as |labeledCheckbox index|}}
     <p class="proposal-paragraph">
 
-      <Input
-        @type="checkbox"
-        id="checkbox_{{inc index}}"
-        @checked={{labeledCheckbox.checked}}
-        data-test="challenge-response-proposal-selector"
+      <PixCheckbox
         name="{{inc index}}"
-        {{on "click" (fn this.checkboxClicked labeledCheckbox.value)}}
         disabled={{@isAnswerFieldDisabled}}
-      />
-
-      <label for="checkbox_{{inc index}}" class="label-checkbox-proposal">
+        checked={{labeledCheckbox.checked}}
+        {{on "click" (fn this.checkboxClicked labeledCheckbox.value)}}
+        data-test="challenge-response-proposal-selector"
+      >
         <MarkdownToHtml @class="proposal-text" @markdown={{labeledCheckbox.label}} />
-      </label>
+      </PixCheckbox>
+
     </p>
   {{/each}}
 </div>

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -40,8 +40,6 @@
   }
 
   &__proposal {
-    margin-top: 10px;
-    margin-bottom: 10px;
     color: $pix-neutral-80;
     font-size: 1.25rem;
 

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -10,13 +10,11 @@
 }
 
 .challenge-response {
-  margin: 4px;
-  font-size: 0.938rem;
-  background-color: $pix-neutral-10;
+  @extend %pix-body-m;
 
-  @include device-is('desktop') {
-    font-size: 1.25rem;
-  }
+  margin: 4px;
+  color: $pix-neutral-90;
+  background-color: $pix-neutral-10;
 
   label {
     font-weight: $font-normal;
@@ -100,9 +98,10 @@ form .challenge-response {
   }
 
   .challenge-response__instructions {
+    @extend %pix-body-s;
+
     margin-top: 0;
-    font-weight: $font-normal;
-    font-size: 1rem;
+    color: $pix-neutral-60;
 
     &:not(:last-child) {
       margin-bottom: 1rem;

--- a/mon-pix/app/styles/components/_qcm-proposals.scss
+++ b/mon-pix/app/styles/components/_qcm-proposals.scss
@@ -3,64 +3,9 @@
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
-  margin-left: 7px;
+  margin-left: $pix-spacing-xs;
 
   & + .proposal-paragraph {
-    margin-top: 1rem;
+    margin-top: $pix-spacing-s;
   }
-
-  input[type='checkbox'] {
-    flex-shrink: 0;
-  }
-
-  input[type='checkbox']::before {
-    position: relative;
-    top: -3px;
-    display: block;
-    box-sizing: border-box;
-    width: 18px;
-    height: 18px;
-    background-color: $pix-neutral-0;
-    border: 2px solid $pix-neutral-40;
-    border-radius: 10%;
-    content: ' ';
-  }
-
-  input[type='checkbox']:checked::before {
-    background-color: $pix-primary;
-    border-color: $pix-primary;
-  }
-
-  input[type='checkbox']:checked::after {
-    position: relative;
-    top: -21px;
-    display: block;
-    width: 18px;
-    height: 18px;
-    color: $pix-neutral-0;
-    font-weight: $font-bold;
-    font-size: 0.875rem;
-    text-align: center;
-    content: '✓';
-  }
-
-  input[type='checkbox']:focus::before,
-  input[type='checkbox']:hover::before {
-    border-color: $pix-primary;
-    box-shadow: 0 0 0 8px rgba($pix-primary, 0.1);
-  }
-
-  input[type='checkbox']:active::before {
-    box-shadow: 0 0 0 8px rgba($pix-primary, 0.3);
-  }
-}
-
-.label-checkbox-proposal {
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  padding-left: 20px;
-  font-weight: $font-normal;
-  line-height: 21px;
-  cursor: pointer;
 }

--- a/mon-pix/app/styles/components/_qcu-proposals.scss
+++ b/mon-pix/app/styles/components/_qcu-proposals.scss
@@ -1,8 +1,4 @@
 .qcu-proposals {
-  & + .qcu-proposals {
-    margin-top: 0.5rem;
-  }
-
   a {
     color: $pix-primary;
     text-decoration: underline;

--- a/mon-pix/app/styles/components/_qrocm-proposals.scss
+++ b/mon-pix/app/styles/components/_qrocm-proposals.scss
@@ -3,4 +3,16 @@
   &__label {
     display: inline;
   }
+
+  > input {
+    margin: $pix-spacing-xs;
+  }
+
+  input:first-of-type {
+    margin-top: 0;
+  }
+
+  input:last-of-type {
+    margin-bottom: 0;
+  }
 }

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -27,6 +27,7 @@
 
   &__row {
     padding: 16px;
+    border-radius: 8px;
   }
 
   &__row label {

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -78,8 +78,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
               test('should enable input and buttons', async function (assert) {
                 // then
-                assert.notOk(find('.challenge-actions__action-skip').getAttribute('disabled'));
-                assert.notOk(find('.challenge-actions__action-validate').getAttribute('disabled'));
+                assert.ok(find('.challenge-actions__action-skip').getAttribute('aria-disabled').includes('false'));
+                assert.ok(find('.challenge-actions__action-validate').getAttribute('aria-disabled').includes('false'));
                 assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
               });
 
@@ -143,8 +143,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
             test('should enable input and buttons', async function (assert) {
               // then
-              assert.notOk(find('.challenge-actions__action-skip').getAttribute('disabled'));
-              assert.notOk(find('.challenge-actions__action-validate').getAttribute('disabled'));
+              assert.ok(find('.challenge-actions__action-skip').getAttribute('aria-disabled').includes('false'));
+              assert.ok(find('.challenge-actions__action-validate').getAttribute('aria-disabled').includes('false'));
               assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
             });
           });
@@ -255,8 +255,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
           test('should enable input and buttons', async function (assert) {
             // then
-            assert.notOk(find('.challenge-actions__action-skip').getAttribute('disabled'));
-            assert.notOk(find('.challenge-actions__action-validate').getAttribute('disabled'));
+            assert.ok(find('.challenge-actions__action-skip').getAttribute('aria-disabled').includes('false'));
+            assert.ok(find('.challenge-actions__action-validate').getAttribute('aria-disabled').includes('false'));
             assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
           });
 
@@ -362,8 +362,10 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
                 test('should enable input and buttons', async function (assert) {
                   // then
-                  assert.notOk(find('.challenge-actions__action-skip').getAttribute('disabled'));
-                  assert.notOk(find('.challenge-actions__action-validate').getAttribute('disabled'));
+                  assert.ok(find('.challenge-actions__action-skip').getAttribute('aria-disabled').includes('false'));
+                  assert.ok(
+                    find('.challenge-actions__action-validate').getAttribute('aria-disabled').includes('false')
+                  );
                   assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
                 });
               });
@@ -390,8 +392,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
               test('should enable input and buttons', async function (assert) {
                 // then
-                assert.notOk(find('.challenge-actions__action-skip').getAttribute('disabled'));
-                assert.notOk(find('.challenge-actions__action-validate').getAttribute('disabled'));
+                assert.ok(find('.challenge-actions__action-skip').getAttribute('aria-disabled').includes('false'));
+                assert.ok(find('.challenge-actions__action-validate').getAttribute('aria-disabled').includes('false'));
                 assert.notOk(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled'));
               });
             });


### PR DESCRIPTION
## :unicorn: Problème

Le bloc de réponse méritait des améliorations visuelles.

## :robot: Proposition

- Vérifier les différents espaces du bloc
![image](https://github.com/1024pix/pix/assets/7335131/0439c032-e288-4cf2-9eb7-6050fbed3834)

- Utiliser le composant PixCheckbox

## :rainbow: Remarques

Il pourra être pertinent d'utiliser le composant PixInput pour tous les champs des épreuves QROC.

## :100: Pour tester

Tester sur la RA les différentes épreuves listées dans [sos-recid-challenges](https://1024pix.github.io/sos-recid-challenges/) et vérifier que tout soit conforme au design Figma.
