### PR TITLE
[BUGFIX] L'envoi de message échoue car le nom du channel est utilisé à la place de l'identifiant

### DIFF
--- a/.github/workflows/on-dev-merge.yaml
+++ b/.github/workflows/on-dev-merge.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify team on config file change
-        uses: 1024pix/notify-team-on-config-file-change@v1.0.3
+        uses: 1024pix/notify-team-on-config-file-change@v1.0.4
         with:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
https://github.com/1024pix/notify-team-on-config-file-change/pull/8

## :robot: Proposition
https://github.com/1024pix/notify-team-on-config-file-change/pull/8

## :rainbow: Remarques
Y'a de tests auto sur le repo de l'action

## :100: Pour tester
Merger
