### PR TITLE
[BUGFIX] La notification de changement de configuration ne fonctionne plus

### DIFF
--- a/.github/workflows/on-dev-merge.yaml
+++ b/.github/workflows/on-dev-merge.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify team on config file change
-        uses: 1024pix/notify-team-on-config-file-change@v1.0.4
+        uses: 1024pix/notify-team-on-config-file-change@v1.0.3
         with:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
https://github.com/1024pix/notify-team-on-config-file-change/pull/12

## :robot: Proposition
https://github.com/1024pix/notify-team-on-config-file-change/pull/12

## :100: Pour tester
Merger
