### PR TITLE
[TECH] Utilise la version v1 de l'action notify-file-change

### DIFF
--- a/.github/workflows/on-dev-merge.yaml
+++ b/.github/workflows/on-dev-merge.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify team on config file change
-        uses: 1024pix/notify-team-on-config-file-change@v1.1.0
+        uses: 1024pix/notify-team-on-config-file-change@v1
         with:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
On utilise une version spécifique du notify-file-change. Ce n'est pas pratique lorsque nous faisons évoluer le dépot sous jascent.

## :robot: Proposition
Créer un tag v1 sur le dépot notify-file-change et l'utiliser ici.

## :rainbow: Remarques
Voir la documentation sur comment tagger une github action https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management

## :100: Pour tester
Faut merge :(
