### PR TITLE
[TECH] Met à jour ember-cli-notifications pour corriger les tests dans le navigateur

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -47,7 +47,7 @@
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-matomo-tag-manager": "^1.3.1",
         "ember-cli-mirage": "^2.4.0",
-        "ember-cli-notifications": "^8.0.0",
+        "ember-cli-notifications": "https://github.com/francois2metz/ember-cli-notifications.git#get-current-config",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-showdown": "^6.0.1",
         "ember-click-outside": "^6.0.0",
@@ -16644,9 +16644,9 @@
     },
     "node_modules/ember-cli-notifications": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-notifications/-/ember-cli-notifications-8.0.0.tgz",
-      "integrity": "sha512-kvAp97ODHQEyOInsVxRGfccrwaEoKZCT6ALL6Ej8E140S1yoZAepxVDphWnQJ/BxViR0Hp5sMiE01v8SdvdrMA==",
+      "resolved": "git+ssh://git@github.com/francois2metz/ember-cli-notifications.git#10aa770b8d54dc1864e1c686826e40cb4da41e27",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "broccoli-funnel": "^3.0.2",
         "broccoli-merge-trees": "^4.1.0",
@@ -16654,7 +16654,6 @@
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^6.0.0",
         "ember-decorators-polyfill": "^1.1.5",
-        "ember-get-config": "^0.5.0",
         "ember-on-modifier": "^1.0.0",
         "lodash.get": "^4.4.2",
         "postcss-import": "^14.0.2",
@@ -50610,10 +50609,9 @@
       }
     },
     "ember-cli-notifications": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-notifications/-/ember-cli-notifications-8.0.0.tgz",
-      "integrity": "sha512-kvAp97ODHQEyOInsVxRGfccrwaEoKZCT6ALL6Ej8E140S1yoZAepxVDphWnQJ/BxViR0Hp5sMiE01v8SdvdrMA==",
+      "version": "git+ssh://git@github.com/francois2metz/ember-cli-notifications.git#10aa770b8d54dc1864e1c686826e40cb4da41e27",
       "dev": true,
+      "from": "ember-cli-notifications@https://github.com/francois2metz/ember-cli-notifications.git#get-current-config",
       "requires": {
         "broccoli-funnel": "^3.0.2",
         "broccoli-merge-trees": "^4.1.0",
@@ -50621,7 +50619,6 @@
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^6.0.0",
         "ember-decorators-polyfill": "^1.1.5",
-        "ember-get-config": "^0.5.0",
         "ember-on-modifier": "^1.0.0",
         "lodash.get": "^4.4.2",
         "postcss-import": "^14.0.2",

--- a/orga/package.json
+++ b/orga/package.json
@@ -72,7 +72,7 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-matomo-tag-manager": "^1.3.1",
     "ember-cli-mirage": "^2.4.0",
-    "ember-cli-notifications": "^8.0.0",
+    "ember-cli-notifications": "https://github.com/francois2metz/ember-cli-notifications.git#get-current-config",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-showdown": "^6.0.1",
     "ember-click-outside": "^6.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Les tests de pix orga qui testent les notifications sont systématiquement en erreur lorsqu'on les lance via le navigateur.

## :robot: Proposition
Utiliser une version de ember-cli-notification qui corrige ce problème (en attendant un patch sur embroider).

## :rainbow: Remarques
https://github.com/mansona/ember-cli-notifications/pull/360

## :100: Pour tester
Lancer les tests dans le navigateurs (/tests) et voir qu'ils sont vert.

Voir la RA et constater que les notifications s'affichent correctement et disparaissent au bout de 5s.
