### PR TITLE
[FEATURE] Améliorer le responsive des résultats des compétences en fin de campagne sur Pix-App (PIX-7972)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/components/campaigns/assessment/campaign-skill-review-competence-result.hbs
@@ -1,19 +1,23 @@
-<table class="default-table skill-review-competence__table">
+<table class="skill-review-competence__table">
   <caption class="sr-only">{{t "pages.skill-review.details.caption"}}</caption>
   <thead>
     <tr>
-      <th scope="col">{{t "pages.skill-review.details.header-skill"}}</th>
-      <th scope="col">{{t "pages.skill-review.details.header-result"}}</th>
+      <th class="skill-review-competence__column-header" scope="col">
+        {{t "pages.skill-review.details.header-skill"}}
+      </th>
+      <th class="skill-review-competence__column-header" scope="col">
+        {{t "pages.skill-review.details.header-result"}}
+      </th>
     </tr>
   </thead>
 
   <tbody>
     {{#if @showCleaCompetences}}
       {{#each @skillSetResults as |skillSet|}}
-        <tr>
-          <th scope="row">
+        <tr class="skill-review-competence__row">
+          <th scope="row" class="skill-review-competence__row-header">
             <span class="skill-review-competence__border" aria-hidden="true"></span>
-            <span>{{skillSet.name}}</span>
+            <span class="skill-review-competence__name">{{skillSet.name}}</span>
           </th>
           <td>
             <PixProgressGauge @value={{skillSet.masteryPercentage}} @tooltipText="{{skillSet.masteryPercentage}}%" />
@@ -23,12 +27,12 @@
     {{else}}
       {{#each @competenceResults as |competence|}}
         <tr class="skill-review-competence__row">
-          <th scope="row">
+          <th scope="row" class="skill-review-competence__row-header">
             <span
               class="skill-review-competence__border skill-review-competence__border--{{competence.areaColor}}"
               aria-hidden="true"
             ></span>
-            <span>{{competence.name}}</span>
+            <span class="skill-review-competence__name">{{competence.name}}</span>
           </th>
           <td>
             {{#if competence.flashPixScore}}

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -206,14 +206,31 @@
 
 .skill-review-competence {
   &__table {
+    width: 100%;
+
     tr {
       height: 76px;
     }
   }
 
+  &__column-header {
+    text-align: left;
+  }
+
+  &__row-header {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: $pix-spacing-s $pix-spacing-s $pix-spacing-s 0;
+  }
+
+  &__name {
+    margin-left: $pix-spacing-s;
+    text-align: left;
+  }
+
   &__border {
-    margin-right: 1rem;
-    padding: 0.5rem 0;
+    padding: $pix-spacing-s 0;
     border-style: solid;
     border-width: 1.5px;
     border-radius: 1.5px;


### PR DESCRIPTION
## :unicorn: Problème
Le détails des résultats des compétences n'était pas responsive.
<img width="307" alt="Capture d’écran 2023-05-15 à 16 20 30" src="https://github.com/1024pix/pix/assets/49011144/4e01ed8e-b952-4398-9e6c-8f0a28a69228">


## :robot: Proposition
Améliorer le design du bloc. 

## :rainbow: Remarques

## :100: Pour tester
Tester avec différents devices si le responsive est ok.
Tester avec une compétence avec du texte long.

Tester sur une campagne non Cléa type `PIXEDUINI`.
Tester sur une campagne Cléa type `CAMPCLEA1`.
