### PR TITLE
[FEATURE] Renvoyer le détail de validation de QRCOM-dep depuis l'API (PIX-7919)

### DIFF
--- a/api/lib/domain/models/Correction.js
+++ b/api/lib/domain/models/Correction.js
@@ -1,11 +1,20 @@
 class Correction {
-  constructor({ id, solution, solutionToDisplay, hint, tutorials = [], learningMoreTutorials = [] } = {}) {
+  constructor({
+    id,
+    solution,
+    solutionToDisplay,
+    hint,
+    tutorials = [],
+    learningMoreTutorials = [],
+    solutionBlocks = [],
+  } = {}) {
     this.id = id;
     this.solution = solution;
     this.solutionToDisplay = solutionToDisplay;
     this.hint = hint;
     this.tutorials = tutorials;
     this.learningMoreTutorials = learningMoreTutorials;
+    this.solutionBlocks = solutionBlocks;
   }
 }
 

--- a/api/lib/domain/models/Correction.js
+++ b/api/lib/domain/models/Correction.js
@@ -6,7 +6,7 @@ class Correction {
     hint,
     tutorials = [],
     learningMoreTutorials = [],
-    solutionBlocks = [],
+    correctionBlocks = [],
   } = {}) {
     this.id = id;
     this.solution = solution;
@@ -14,7 +14,7 @@ class Correction {
     this.hint = hint;
     this.tutorials = tutorials;
     this.learningMoreTutorials = learningMoreTutorials;
-    this.solutionBlocks = solutionBlocks;
+    this.correctionBlocks = correctionBlocks;
   }
 }
 

--- a/api/lib/domain/models/CorrectionBlockQROCMDep.js
+++ b/api/lib/domain/models/CorrectionBlockQROCMDep.js
@@ -9,18 +9,20 @@ class CorrectionBlockQROCMDep {
   /**
    * @type {string[]}
    */
-  #alternativeSolutions;
+  #alternativeSolutions = [];
 
   /**
    * @param {boolean} validated
-   * @param {string[]} alternativeSolutions
+   * @param {string[]} [alternativeSolutions]
    */
-  constructor(validated = false, alternativeSolutions = []) {
+  constructor(validated, alternativeSolutions) {
     this.#validateValidatedArgument(validated);
-    this.#validateAlternativeSolutionsArgument(alternativeSolutions);
-
     this.#validated = validated;
-    this.#alternativeSolutions = alternativeSolutions;
+
+    if (alternativeSolutions) {
+      this.#validateAlternativeSolutionsArgument(alternativeSolutions);
+      this.#alternativeSolutions = alternativeSolutions;
+    }
   }
 
   /**

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -19,7 +19,12 @@ const getCorrectionForAnswer = async function ({
 
   _validateCorrectionIsAccessible(assessment);
 
-  return correctionRepository.getByChallengeId({ challengeId: answer.challengeId, userId, locale });
+  return correctionRepository.getByChallengeId({
+    challengeId: answer.challengeId,
+    answerValue: answer.value,
+    userId,
+    locale,
+  });
 };
 
 export { getCorrectionForAnswer };

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -5,12 +5,12 @@ import { Hint } from '../../domain/models/Hint.js';
 import { challengeDatasource } from '../datasources/learning-content/challenge-datasource.js';
 import { skillDatasource } from '../datasources/learning-content/skill-datasource.js';
 import * as tutorialRepository from './tutorial-repository.js';
-const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { getSolution } from '../../domain/services/solution-service-qrocm-dep.js';
-import { Challenge } from '../../domain/models/Challenge';
-import { fromDatasourceObject } from '../adapters/solution-adapter';
-import { Answer } from '../../domain/models/Answer';
+import { Challenge } from '../../domain/models/Challenge.js';
+import { fromDatasourceObject } from '../adapters/solution-adapter.js';
+import { Answer } from '../../domain/models/Answer.js';
+const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
 
 const getByChallengeId = async function ({
   challengeId,

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -10,6 +10,7 @@ import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { getSolution } from '../../domain/services/solution-service-qrocm-dep.js';
 import { Challenge } from '../../domain/models/Challenge';
 import { fromDatasourceObject } from '../adapters/solution-adapter';
+import { Answer } from '../../domain/models/Answer';
 
 const getByChallengeId = async function ({
   challengeId,
@@ -39,7 +40,7 @@ const getByChallengeId = async function ({
     tutorialRepository: dependencies.tutorialRepository,
   });
 
-  if (challenge.type === Challenge.Type.QROCM_DEP) {
+  if (challenge.type === Challenge.Type.QROCM_DEP && answerValue !== Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
     correctionBlocks = dependencies.getSolution({ solution, answerValue });
   }
 
@@ -53,7 +54,6 @@ const getByChallengeId = async function ({
     correctionBlocks,
   });
 };
-
 export { getByChallengeId };
 
 async function _getHint({ skill, locale }) {

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -7,11 +7,21 @@ import { skillDatasource } from '../datasources/learning-content/skill-datasourc
 import * as tutorialRepository from './tutorial-repository.js';
 const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { getSolution } from '../../domain/services/solution-service-qrocm-dep.js';
+import { Challenge } from '../../domain/models/Challenge';
+import { fromDatasourceObject } from '../adapters/solution-adapter';
 
-const getByChallengeId = async function ({ challengeId, userId, locale, dependencies = { tutorialRepository } } = {}) {
+const getByChallengeId = async function ({
+  challengeId,
+  answerValue,
+  userId,
+  locale,
+  dependencies = { tutorialRepository, fromDatasourceObject, getSolution },
+} = {}) {
   const challenge = await challengeDatasource.get(challengeId);
   const skill = await _getSkill(challenge);
   const hint = await _getHint({ skill, locale });
+  const solution = dependencies.fromDatasourceObject(challenge);
 
   const tutorials = await _getTutorials({
     userId,
@@ -28,6 +38,11 @@ const getByChallengeId = async function ({ challengeId, userId, locale, dependen
     tutorialRepository: dependencies.tutorialRepository,
   });
 
+  let solutionBlocks = [];
+  if (challenge.type === Challenge.Type.QROCM_DEP) {
+    solutionBlocks = dependencies.getSolution({ solution, answerValue });
+  }
+
   return new Correction({
     id: challenge.id,
     solution: challenge.solution,
@@ -35,6 +50,7 @@ const getByChallengeId = async function ({ challengeId, userId, locale, dependen
     hint,
     tutorials,
     learningMoreTutorials: learningMoreTutorials,
+    solutionBlocks,
   });
 };
 

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -22,6 +22,7 @@ const getByChallengeId = async function ({
   const skill = await _getSkill(challenge);
   const hint = await _getHint({ skill, locale });
   const solution = dependencies.fromDatasourceObject(challenge);
+  let correctionBlocks;
 
   const tutorials = await _getTutorials({
     userId,
@@ -38,9 +39,8 @@ const getByChallengeId = async function ({
     tutorialRepository: dependencies.tutorialRepository,
   });
 
-  let solutionBlocks = [];
   if (challenge.type === Challenge.Type.QROCM_DEP) {
-    solutionBlocks = dependencies.getSolution({ solution, answerValue });
+    correctionBlocks = dependencies.getSolution({ solution, answerValue });
   }
 
   return new Correction({
@@ -50,7 +50,7 @@ const getByChallengeId = async function ({
     hint,
     tutorials,
     learningMoreTutorials: learningMoreTutorials,
-    solutionBlocks,
+    correctionBlocks,
   });
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/correction-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/correction-serializer.js
@@ -1,7 +1,6 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
-
 import { tutorialAttributes } from './tutorial-attributes.js';
 
 const serialize = function (correction) {
@@ -19,8 +18,12 @@ const serialize = function (correction) {
         userSavedTutorial: { ...tutorial.userSavedTutorial },
         tutorialEvaluation: { ...tutorial.tutorialEvaluation },
       })),
+      correctionBlocks: correction.correctionBlocks.map((correctionBlock) => ({
+        validated: correctionBlock.validated,
+        alternativeSolutions: correctionBlock.alternativeSolutions,
+      })),
     }),
-    attributes: ['solution', 'solutionToDisplay', 'hint', 'tutorials', 'learningMoreTutorials'],
+    attributes: ['solution', 'solutionToDisplay', 'hint', 'tutorials', 'learningMoreTutorials', 'correctionBlocks'],
     tutorials: tutorialAttributes,
     learningMoreTutorials: tutorialAttributes,
     typeForAttribute(attribute) {
@@ -31,6 +34,8 @@ const serialize = function (correction) {
           return 'user-saved-tutorial';
         case 'learningMoreTutorials':
           return 'tutorials';
+        case 'correctionBlocks':
+          return 'correction-blocks';
         default:
           return attribute;
       }

--- a/api/tests/unit/domain/models/CorrectionBlockQROCMDep_test.js
+++ b/api/tests/unit/domain/models/CorrectionBlockQROCMDep_test.js
@@ -4,19 +4,17 @@ import { expect } from '../../../test-helper.js';
 describe('Unit | Domain | Models | CorrectionBlockQROCMDep', function () {
   describe('#constructor', function () {
     describe('when not passing parameters', function () {
-      it('should have a validated key that equals false', function () {
-        const correctionBlock = new CorrectionBlockQROCMDep();
-        expect(correctionBlock.validated).to.equal(false);
-      });
-
-      it('should have a alternativeSolutions key which is an empty array', function () {
-        const correctionBlock = new CorrectionBlockQROCMDep();
-        expect(correctionBlock.alternativeSolutions).to.have.length(0);
+      it('should throw an error', function () {
+        expect(() => new CorrectionBlockQROCMDep()).to.throw();
       });
     });
 
     describe('when passing parameters', function () {
       describe('validated param', function () {
+        it('should throw if is undefined', function () {
+          expect(() => new CorrectionBlockQROCMDep()).to.throw();
+        });
+
         it('should throw if is null', function () {
           expect(() => new CorrectionBlockQROCMDep(null)).to.throw();
         });
@@ -32,10 +30,6 @@ describe('Unit | Domain | Models | CorrectionBlockQROCMDep', function () {
       });
 
       describe('alternativeSolutions param', function () {
-        it('should throw if is null', function () {
-          expect(() => new CorrectionBlockQROCMDep(true, null)).to.throw();
-        });
-
         it('should throw if is not an array', function () {
           expect(() => new CorrectionBlockQROCMDep(true, 'not-array')).to.throw();
         });
@@ -55,7 +49,7 @@ describe('Unit | Domain | Models | CorrectionBlockQROCMDep', function () {
   describe('set alternativeSolutions', function () {
     let correctionBlock;
     beforeEach(function () {
-      correctionBlock = new CorrectionBlockQROCMDep();
+      correctionBlock = new CorrectionBlockQROCMDep(true);
     });
 
     it('should throw if is null', function () {

--- a/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
     sinon.stub(answerRepository, 'get');
     sinon.stub(correctionRepository, 'getByChallengeId');
 
-    answer = new Answer({ assessmentId, challengeId: 12 });
+    answer = new Answer({ assessmentId, challengeId: 12, value: 'lareponse' });
     answerRepository.get.withArgs(answerId).resolves(answer);
   });
 
@@ -59,7 +59,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
 
         const correction = Symbol('A correction');
         correctionRepository.getByChallengeId
-          .withArgs({ challengeId, userId: assessment.userId, locale })
+          .withArgs({ challengeId, answerValue: answer.value, userId: assessment.userId, locale })
           .resolves(correction);
 
         // when
@@ -88,7 +88,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
 
         const correction = Symbol('A correction');
         correctionRepository.getByChallengeId
-          .withArgs({ challengeId, userId: assessment.userId, locale })
+          .withArgs({ challengeId, answerValue: answer.value, userId: assessment.userId, locale })
           .resolves(correction);
 
         // when
@@ -115,7 +115,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
 
       const correction = Symbol('A correction');
       correctionRepository.getByChallengeId
-        .withArgs({ challengeId, userId: assessment.userId, locale })
+        .withArgs({ challengeId, answerValue: answer.value, userId: assessment.userId, locale })
         .resolves(correction);
 
       // when

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -162,8 +162,8 @@ describe('Unit | Repository | correction-repository', function () {
           const solution = Symbol('solution');
           fromDatasourceObject.withArgs(challengeDataObject).returns(solution);
           const getSolutionStub = sinon.stub();
-          const solutionBlocks = Symbol('solutionBlocks');
-          getSolutionStub.withArgs({ solution, answerValue }).returns(solutionBlocks);
+          const correctionBlocks = Symbol('correctionBlocks');
+          getSolutionStub.withArgs({ solution, answerValue }).returns(correctionBlocks);
 
           // when
           const correction = await correctionRepository.getByChallengeId({
@@ -176,7 +176,7 @@ describe('Unit | Repository | correction-repository', function () {
 
           // then
           expect(getSolutionStub).to.have.been.calledWithExactly({ solution, answerValue });
-          expect(correction.solutionBlocks).to.equal(solutionBlocks);
+          expect(correction.correctionBlocks).to.equal(correctionBlocks);
         });
       });
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
@@ -90,6 +90,12 @@ describe('Unit | Serializer | JSONAPI | correction-serializer', function () {
             skillId: 'skill1',
           }),
         ],
+        correctionBlocks: [
+          {
+            validated: true,
+            alternativeSolutions: ['solution1', 'solution2'],
+          },
+        ],
       });
 
       // when
@@ -99,6 +105,12 @@ describe('Unit | Serializer | JSONAPI | correction-serializer', function () {
       expect(json).to.deep.equal({
         data: {
           attributes: {
+            'correction-blocks': [
+              {
+                alternativeSolutions: ['solution1', 'solution2'],
+                validated: true,
+              },
+            ],
             hint: 'Indice Facile',
             solution: 'Correction value',
             'solution-to-display': 'Correction to be displayed',


### PR DESCRIPTION
## :unicorn: Problème
Dans le cas où le challenge est un QROCM-dep et la réponse de l'utilisateur est fausse, il ne nous est pas possible d'indiquer quel champ rempli par l'utilisateur est faux.

![d5a79d1f-7d8c-48ad-8ede-6ea64fb0fea7](https://github.com/1024pix/pix/assets/6728051/b82c9ab9-111b-4296-be0a-3677e6d71427)

L'API ne nous donne pas cette information, ni lors de la sauvegarde du résultat (`POST /api/answers`), ni dans le retour de la correction (`GET /api/answers/{id}/correction`)
 
## :robot: Proposition
Nous avons ajouté, assez grossièrement il faut l'avouer, une méthode dans le service `solution-service-qrocm-dep`  qui réutilise la logique existante mais retourne un tableau d'objets `CorrectionBlockQROCMDep`.
Cette méthode est ensuite appelée par le `correctionRepository` lors de l'appel à l'API sur `GET /api/answers/{id}/correction` Ces _blocs_ nous permetteront ainsi dans l'app de barrer ou non les champs.

## :rainbow: Remarques
Cette solution est loin d'être idéale, elle ressemble plus à un hack un peu brutal qu'à une vraie solution pérenne. Cependant elle répond au besoin et ajoute de la valeur métier. Toute suggestion pour repenser l'approche du problème est la bienvenue.

## :100: Pour tester

**1. Tester les QROCM-dep:**
  - Aller sur la review et accéder à un challenge QROCM-dep.
  - Répondre nimpnawak ou à moitié nimpnawak ou correctement
  - Ouvrir la console de debug
  - Accéder à la correction
  - Vérifier dans la console que la réponse de l'API contient bien la propriété `correction-blocks` et que celle ci correspond bien à la réponse ( validated true/false )
  - ➰ Répéter ce test avec un autre challenge QROCM-dep ou en donnant d'autres réponses

**2. Tester le reste**
  - Essayer d'autres modalités de challenge
  - Vérifier qu'il n'y a pas de régressions
  - Dans la console, vérifier que `correction-blocks` est toujours un tableau vide