### PR TITLE
[TECH][Pix Orga] Ne pas modifier la langue de l'utilisateur quand le paramètre lang se trouve dans l'url (PIX-8009)

### DIFF
--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -27,7 +27,7 @@ export default class CurrentSessionService extends SessionService {
     super.handleInvalidation('/connexion');
   }
 
-  async handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
+  handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
     if (localeFromQueryParam) {
       this._localeFromQueryParam = this.locale.handleUnsupportedLanguage(localeFromQueryParam);
     }

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -60,7 +60,7 @@ module('Unit | Service | session', function (hooks) {
   module('#handleLocale', function () {
     module('when domain is .fr', function () {
       module('when there is no cookie locale', function () {
-        test('adds a cookie locale with "fr-FR" as value', async function (assert) {
+        test('adds a cookie locale with "fr-FR" as value', function (assert) {
           // given
           localeService.hasLocaleCookie.returns(false);
           const isFranceDomain = true;
@@ -68,7 +68,7 @@ module('Unit | Service | session', function (hooks) {
           const userLocale = undefined;
 
           // when
-          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+          service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
           sinon.assert.calledWith(localeService.setLocaleCookie, FRENCH_FRANCE_LOCALE);
@@ -77,7 +77,7 @@ module('Unit | Service | session', function (hooks) {
       });
 
       module('when there is a cookie locale', function () {
-        test('does not update cookie locale', async function (assert) {
+        test('does not update cookie locale', function (assert) {
           // given
           localeService.hasLocaleCookie.returns(true);
           const isFranceDomain = true;
@@ -85,7 +85,7 @@ module('Unit | Service | session', function (hooks) {
           const userLocale = undefined;
 
           // when
-          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+          service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
           sinon.assert.notCalled(localeService.setLocaleCookie);
@@ -95,14 +95,14 @@ module('Unit | Service | session', function (hooks) {
 
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -111,14 +111,14 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = 'user’s lang';
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -129,14 +129,14 @@ module('Unit | Service | session', function (hooks) {
 
       module('when a lang query param is present', function () {
         module('when user is not loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             const isFranceDomain = true;
             const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
             const userLocale = undefined;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -145,14 +145,14 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             const isFranceDomain = true;
             const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
             const userLocale = 'user’s lang';
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -163,7 +163,7 @@ module('Unit | Service | session', function (hooks) {
     });
 
     module('when domain is .org', function () {
-      test('does not set the cookie locale', async function (assert) {
+      test('does not set the cookie locale', function (assert) {
         // given
         localeService.hasLocaleCookie.returns(false);
         const isFranceDomain = false;
@@ -171,7 +171,7 @@ module('Unit | Service | session', function (hooks) {
         const userLocale = undefined;
 
         // when
-        await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+        service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
         sinon.assert.notCalled(localeService.setLocaleCookie);
@@ -180,14 +180,14 @@ module('Unit | Service | session', function (hooks) {
 
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
-          test('sets the default locale', async function (assert) {
+          test('sets the default locale', function (assert) {
             // given
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
@@ -196,14 +196,14 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
-          test('sets the locale to the user’s lang', async function (assert) {
+          test('sets the locale to the user’s lang', function (assert) {
             // given
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
@@ -215,14 +215,14 @@ module('Unit | Service | session', function (hooks) {
       module('when a lang query param is present', function () {
         module('when the lang query param is invalid', function () {
           module('when user is not loaded', function () {
-            test('sets the default locale', async function (assert) {
+            test('sets the default locale', function (assert) {
               // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
@@ -231,14 +231,14 @@ module('Unit | Service | session', function (hooks) {
           });
 
           module('when user is loaded', function () {
-            test('sets the locale to the user’s lang', async function (assert) {
+            test('sets the locale to the user’s lang', function (assert) {
               // given
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
@@ -249,7 +249,7 @@ module('Unit | Service | session', function (hooks) {
 
         module('when the lang query param is valid', function () {
           module('when user is not loaded', function () {
-            test('sets the locale to the lang query param', async function (assert) {
+            test('sets the locale to the lang query param', function (assert) {
               // given
               const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
@@ -258,7 +258,7 @@ module('Unit | Service | session', function (hooks) {
               localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
@@ -267,7 +267,7 @@ module('Unit | Service | session', function (hooks) {
           });
 
           module('when user is loaded', function () {
-            test('sets the locale to the lang query param which wins over', async function (assert) {
+            test('sets the locale to the lang query param which wins over', function (assert) {
               // given
               const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
@@ -276,7 +276,7 @@ module('Unit | Service | session', function (hooks) {
               localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
-import get from 'lodash/get';
 import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-orga/services/locale';
 
 export default class CurrentSessionService extends SessionService {
@@ -28,7 +27,7 @@ export default class CurrentSessionService extends SessionService {
     await super.handleInvalidation(routeAfterInvalidation);
   }
 
-  async handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
+  handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
     this._localeFromQueryParam = this.locale.handleUnsupportedLanguage(localeFromQueryParam);
 
     if (isFranceDomain) {
@@ -42,32 +41,12 @@ export default class CurrentSessionService extends SessionService {
     }
 
     if (this._localeFromQueryParam) {
-      await this._updatePrescriberLanguage(this._localeFromQueryParam);
-
       this.locale.setLocale(this._localeFromQueryParam);
       return;
     }
 
     const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
     this.locale.setLocale(locale);
-  }
-
-  async _updatePrescriberLanguage(lang) {
-    const prescriber = this.currentUser.prescriber;
-
-    if (!prescriber || prescriber.lang === lang) return;
-
-    try {
-      prescriber.lang = lang;
-      await prescriber.save({ adapterOptions: { lang } });
-    } catch (error) {
-      const status = get(error, 'errors[0].status');
-      if (status === '400') {
-        prescriber.rollbackAttributes();
-      } else {
-        throw error;
-      }
-    }
   }
 
   _getRouteAfterInvalidation() {

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -61,7 +61,7 @@ module('Unit | Service | session', function (hooks) {
   module('#handleLocale', function () {
     module('when domain is .fr', function () {
       module('when there is no cookie locale', function () {
-        test('adds a cookie locale with "fr-FR" as value', async function (assert) {
+        test('adds a cookie locale with "fr-FR" as value', function (assert) {
           // given
           localeService.hasLocaleCookie.returns(false);
           const isFranceDomain = true;
@@ -69,7 +69,7 @@ module('Unit | Service | session', function (hooks) {
           const userLocale = undefined;
 
           // when
-          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+          service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
           sinon.assert.calledWith(localeService.setLocaleCookie, FRENCH_FRANCE_LOCALE);
@@ -78,7 +78,7 @@ module('Unit | Service | session', function (hooks) {
       });
 
       module('when there is a cookie locale', function () {
-        test('does not update cookie locale', async function (assert) {
+        test('does not update cookie locale', function (assert) {
           // given
           localeService.hasLocaleCookie.returns(true);
           const isFranceDomain = true;
@@ -86,7 +86,7 @@ module('Unit | Service | session', function (hooks) {
           const userLocale = undefined;
 
           // when
-          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+          service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
           sinon.assert.notCalled(localeService.setLocaleCookie);
@@ -96,7 +96,7 @@ module('Unit | Service | session', function (hooks) {
 
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             service.currentUser = {
               load: sinon.stub(),
@@ -107,7 +107,7 @@ module('Unit | Service | session', function (hooks) {
             const userLocale = undefined;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -116,7 +116,7 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             service.currentUser = {
               load: sinon.stub(),
@@ -130,7 +130,7 @@ module('Unit | Service | session', function (hooks) {
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -142,7 +142,7 @@ module('Unit | Service | session', function (hooks) {
 
       module('when a lang query param is present', function () {
         module('when user is not loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             service.currentUser = {
               load: sinon.stub(),
@@ -153,7 +153,7 @@ module('Unit | Service | session', function (hooks) {
             const userLocale = undefined;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -162,7 +162,7 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
-          test('sets the locale to be French international in every case', async function (assert) {
+          test('sets the locale to be French international in every case', function (assert) {
             // given
             service.currentUser = {
               load: sinon.stub(),
@@ -176,7 +176,7 @@ module('Unit | Service | session', function (hooks) {
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
@@ -188,7 +188,7 @@ module('Unit | Service | session', function (hooks) {
     });
 
     module('when domain is .org', function () {
-      test('does not set the cookie locale', async function (assert) {
+      test('does not set the cookie locale', function (assert) {
         // given
         localeService.hasLocaleCookie.returns(false);
         const isFranceDomain = false;
@@ -196,7 +196,7 @@ module('Unit | Service | session', function (hooks) {
         const userLocale = undefined;
 
         // when
-        await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+        service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
         sinon.assert.notCalled(localeService.setLocaleCookie);
@@ -205,7 +205,7 @@ module('Unit | Service | session', function (hooks) {
 
       module('when no lang query param', function () {
         module('when user is not loaded', function () {
-          test('sets the default locale', async function (assert) {
+          test('sets the default locale', function (assert) {
             // given
             service.currentUser = {
               load: sinon.stub(),
@@ -216,7 +216,7 @@ module('Unit | Service | session', function (hooks) {
             const userLocale = undefined;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
@@ -225,7 +225,7 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
-          test('sets the locale to the user’s lang', async function (assert) {
+          test('sets the locale to the user’s lang', function (assert) {
             // given
             service.currentUser = {
               load: sinon.stub(),
@@ -239,7 +239,7 @@ module('Unit | Service | session', function (hooks) {
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when
-            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
             sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
@@ -252,7 +252,7 @@ module('Unit | Service | session', function (hooks) {
       module('when a lang query param is present', function () {
         module('when the lang query param is invalid', function () {
           module('when user is not loaded', function () {
-            test('sets the default locale', async function (assert) {
+            test('sets the default locale', function (assert) {
               // given
               service.currentUser = {
                 load: sinon.stub(),
@@ -263,7 +263,7 @@ module('Unit | Service | session', function (hooks) {
               const userLocale = undefined;
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
@@ -272,7 +272,7 @@ module('Unit | Service | session', function (hooks) {
           });
 
           module('when user is loaded', function () {
-            test('sets the locale to the user’s lang', async function (assert) {
+            test('sets the locale to the user’s lang', function (assert) {
               // given
               service.currentUser = {
                 load: sinon.stub(),
@@ -286,7 +286,7 @@ module('Unit | Service | session', function (hooks) {
               const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
@@ -298,7 +298,7 @@ module('Unit | Service | session', function (hooks) {
 
         module('when the lang query param is valid', function () {
           module('when user is not loaded', function () {
-            test('sets the locale to the lang query param', async function (assert) {
+            test('sets the locale to the lang query param', function (assert) {
               // given
               service.currentUser = {
                 load: sinon.stub(),
@@ -312,7 +312,7 @@ module('Unit | Service | session', function (hooks) {
               const userLocale = undefined;
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
@@ -321,28 +321,18 @@ module('Unit | Service | session', function (hooks) {
           });
 
           module('when user is loaded', function () {
-            test('sets the locale to the lang query param which wins over', async function (assert) {
+            test('sets the locale to the lang query param which wins over', function (assert) {
               // given
-              service.currentUser = {
-                load: sinon.stub(),
-                prescriber: {
-                  lang: FRENCH_INTERNATIONAL_LOCALE,
-                  save: sinon.stub(),
-                },
-              };
               const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = FRENCH_INTERNATIONAL_LOCALE;
               localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
-              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
               sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-              sinon.assert.calledWith(service.currentUser.prescriber.save, {
-                adapterOptions: { lang: ENGLISH_INTERNATIONAL_LOCALE },
-              });
               assert.ok(true);
             });
           });


### PR DESCRIPTION
## :unicorn: Problème

Sur le domaine international (.org), lorsqu'un utilisateur connecté à l'application Pix Orga suit un lien ayant le paramètre `lang=??` dans l'URL, alors la langue de l'utilisateur en base de données est modifiée automatiquement suivant la valeur de ce paramètre. Cette action de modification automatique via un paramètre dans l'URL ne devrait pas se faire car : 
* cette action est faite sans demander son consentement à l'utilisateur
* cette action est réalisable très facilement par l'utilisateur lui-même via le menu _« Mon Compte > Choisir ma langue »_
* cette action génère une modification systématique en base de données, même lorsque c'est inutile, ce qui peut avoir des impacts sur les performances si un lien avec `lang=??` est diffusé auprès d'une grande population d'utilisateurs
* tout changement, de langue ou de toute autre propriété/préférence de l'utilisateur, par le simple fait de visiter un URL (qui est donc une requête `GET`) ayant certains query params (ici lang) est une mauvaise pratique, cf. sources :
   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
   * https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods

Ce comportement de modification automatique de la langue de l'utilisateur date d'une époque où la gestion des langues et des locales dans Pix était moins utilisable, moins pratique, moins généralisée. Ce comportement n'a maintenant plus lieux d'être.

On rappelle ci-dessous la règle de priorité de la lang/locale des différents éléments.

**Règle de priorité** : `lang` utilisateur < `lang` query param < `lang` domaine `.fr`

## :robot: Proposition

Retirer la modification de la langue de l'utilisateur se trouvant dans le service session.

## :rainbow: Remarques

* Cette PR est dans Pix Orga le pendant de #6179
* Cette PR inclut un commit de SR pour supprimer des async-await dans Pix Certif qui sont maintenant devenus inutiles

## :100: Pour tester

⚠️ Faire attention de ne pas être plusieurs à faire le test sur la RA avec le même utilisateur en même temps !

1. Aller sur https://orga-pr6212.review.pix.org/
2. Se connecter avec un utilisateur, par exemple `allorga@example.net`, ayant comme langue de choix `Français`
3. Constater que le site web est en français
4. Aller sur le même URL en passant en plus le paramètre `lang=en` https://orga-pr6212.review.pix.org/?lang=en
5. Constater que le site web passe en anglais
6. Vérifier que la langue de choix de l'utilisateur n'a pas été modifiée et que c'est toujours `Français`. Cela peut être fait soit directement en base de données, soit **dans un nouvel onglet** par Pix App https://app-pr6212.review.pix.org/ ou Pix Admin https://admin-pr6212.review.pix.fr/
7. Revenir sur l'onglet initial dans lequel Pix Orga a été chargée et recharger la page (`F5`) (ceci va charger une nouvelle instance de l'application Ember avec une nouvelle session)
8. Constater que le site web passe en français
9. Modifier la langue de choix de l'utilisateur en anglais, soit directement en base de données (`en`), soit **dans un nouvel onglet** par Pix App https://app-pr6212.review.pix.org/ (`English`) ou Pix Admin https://admin-pr6212.review.pix.fr/ (`Anglais`)
10. Revenir sur l'onglet initial dans lequel Pix Orga a été chargée et recharger la page (`F5`) (ceci va charger une nouvelle instance de l'application Ember avec une nouvelle session)
11. Constater que le site web passe en anglais
12. Se déconnecter
13. Aller sur https://orga-pr6212.review.pix.org/
14. Constater que le site web est en français
15. Se connecter toujours avec le même utilisateur
16. Constater que le site web passe en anglais
