### PR TITLE
[TECH] Tracer les événements wip de pg-boss

### DIFF
--- a/api/worker.js
+++ b/api/worker.js
@@ -29,6 +29,9 @@ async function runJobs() {
   pgBoss.on('error', (err) => {
     logger.error({ event: 'pg-boss-error' }, err);
   });
+  pgBoss.on('wip', (data) => {
+    logger.info({ event: 'pg-boss-wip' }, data);
+  });
   await pgBoss.start();
   const jobQueue = new JobQueue(pgBoss);
   const monitoredJobQueue = new MonitoredJobQueue(jobQueue);


### PR DESCRIPTION
## :unicorn: Problème
Les jobs ne sont pas dépilés dans la version ESM, et nous cherchons à savoir pourquoi.

Les événements "wip" de pg-boss nous aideraient, mais ils ne sont pas tracés.
> Emitted at most once every 2 seconds when workers are active and jobs are entering or leaving active state. The payload is an array that represents each worker in this instance of pg-boss.

https://github.com/timgit/pg-boss/blob/master/docs/readme.md#wip

## :robot: Proposition
Les tracer

## :100: Pour tester

### Review-app
Déclencher un job (fin de parcours).
Vérifier que les événements suivants sont tracés.
