### PR TITLE
[FEATURE] Elaboration d'un simulateur de scénarios déterministes pour le nouvel algo (PIX-8037).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -1,0 +1,38 @@
+import Joi from 'joi';
+import { securityPreHandlers } from '../security-pre-handlers.js';
+import { scenarioSimulatorController } from './scenario-simulator-controller.js';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/scenario-simulator',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            assessmentId: Joi.string().required(),
+            simulationAnswers: Joi.array().items(Joi.string().allow('ok', 'ko', 'aband')).required(),
+          }).required(),
+        },
+        handler: scenarioSimulatorController.simulateFlashDeterministicAssessmentScenario,
+        tags: ['api'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle renvoie la liste de challenges passés avec le nouvel algorithme ainsi que le niveau estimé, pour une liste de réponses données',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'scenario-simulator-api';
+export { register, name }

--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -35,4 +35,4 @@ const register = async (server) => {
 };
 
 const name = 'scenario-simulator-api';
-export { register, name }
+export { register, name };

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -1,20 +1,31 @@
-const usecases = require('../../domain/usecases');
-const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+import { usecases } from '../../domain/usecases/index.js';
+import { extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
+import { scenarioSimulatorSerializer } from '../../infrastructure/serializers/jsonapi/scenario-simulator-serializer.js';
 
-module.exports = {
-  async simulateFlashDeterministicAssessmentScenario(request, h) {
-    const { assessmentId, simulationAnswers } = request.payload;
-    const locale = extractLocaleFromRequest(request);
+async function simulateFlashDeterministicAssessmentScenario(
+  request,
+  h,
+  dependencies = { scenarioSimulatorSerializer }
+) {
+  const { assessmentId, simulationAnswers } = request.payload;
+  const locale = extractLocaleFromRequest(request);
 
-    const { challenges, estimatedLevel } = await usecases.simulateFlashDeterministicAssessmentScenario({
-      simulationAnswers,
-      assessmentId,
-      locale,
-    });
+  const result = await usecases.simulateFlashDeterministicAssessmentScenario({
+    simulationAnswers,
+    assessmentId,
+    locale,
+  });
 
-    return h.response({
-      challenges,
-      estimatedLevel,
-    });
-  },
-};
+  const simulatorResponse = result.map((answer, index) => {
+    return {
+      ...answer,
+      id: answer.challenge.id,
+      minimumCapability: answer.challenge.minimumCapability,
+      simulationAnswer: simulationAnswers[index],
+    };
+  });
+
+  return dependencies.scenarioSimulatorSerializer.serialize(simulatorResponse);
+}
+
+export const scenarioSimulatorController = { simulateFlashDeterministicAssessmentScenario };

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -1,0 +1,20 @@
+const usecases = require('../../domain/usecases');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+
+module.exports = {
+  async simulateFlashDeterministicAssessmentScenario(request, h) {
+    const { assessmentId, simulationAnswers } = request.payload;
+    const locale = extractLocaleFromRequest(request);
+
+    const { challenges, estimatedLevel } = await usecases.simulateFlashDeterministicAssessmentScenario({
+      simulationAnswers,
+      assessmentId,
+      locale,
+    });
+
+    return h.response({
+      challenges,
+      estimatedLevel,
+    });
+  },
+};

--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -10,11 +10,11 @@ export class AssessmentSimulator {
 
   run() {
     const challengesAnswers = [];
-    const takenChallenges = [];
-    let estimatedLevel;
+    const result = [];
+    let estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({ allAnswers: [] }).estimatedLevel;
 
     for (let i = 0; i < this.answers.length; i++) {
-      const result = this.answers[i];
+      const answer = this.answers[i];
       const possibleChallenges = this.algorithm.getPossibleNextChallenges({
         allAnswers: challengesAnswers,
         challenges: this.challenges,
@@ -22,18 +22,32 @@ export class AssessmentSimulator {
 
       const nextChallenge = this.pickChallenge({ possibleChallenges });
 
-      takenChallenges.push(nextChallenge);
-      challengesAnswers.push(new Answer({ result, challengeId: nextChallenge.id }));
+      challengesAnswers.push(new Answer({ result: answer, challengeId: nextChallenge.id }));
+
+      const reward = this.algorithm.getReward({
+        estimatedLevel,
+        difficulty: nextChallenge.difficulty,
+        discriminant: nextChallenge.discriminant,
+      });
 
       estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({
         allAnswers: challengesAnswers,
         challenges: this.challenges,
       }).estimatedLevel;
+
+      const errorRate = this.algorithm.getEstimatedLevelAndErrorRate({
+        allAnswers: challengesAnswers,
+        challenges: this.challenges,
+      }).errorRate;
+
+      result.push({
+        challenge: nextChallenge,
+        errorRate,
+        estimatedLevel,
+        reward,
+      });
     }
 
-    return {
-      estimatedLevel,
-      challenges: takenChallenges,
-    };
+    return result;
   }
-};
+}

--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -1,0 +1,39 @@
+import { Answer } from './Answer.js';
+
+export class AssessmentSimulator {
+  constructor({ answers, algorithm, challenges, pickChallenge }) {
+    this.answers = answers;
+    this.algorithm = algorithm;
+    this.challenges = challenges;
+    this.pickChallenge = pickChallenge;
+  }
+
+  run() {
+    const challengesAnswers = [];
+    const takenChallenges = [];
+    let estimatedLevel;
+
+    for (let i = 0; i < this.answers.length; i++) {
+      const result = this.answers[i];
+      const possibleChallenges = this.algorithm.getPossibleNextChallenges({
+        allAnswers: challengesAnswers,
+        challenges: this.challenges,
+      });
+
+      const nextChallenge = this.pickChallenge({ possibleChallenges });
+
+      takenChallenges.push(nextChallenge);
+      challengesAnswers.push(new Answer({ result, challengeId: nextChallenge.id }));
+
+      estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({
+        allAnswers: challengesAnswers,
+        challenges: this.challenges,
+      }).estimatedLevel;
+    }
+
+    return {
+      estimatedLevel,
+      challenges: takenChallenges,
+    };
+  }
+};

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -1,5 +1,9 @@
 import { AssessmentEndedError } from '../errors.js';
-import { getPossibleNextChallenges, getEstimatedLevelAndErrorRate } from '../services/algorithm-methods/flash.js';
+import {
+  getPossibleNextChallenges,
+  getEstimatedLevelAndErrorRate,
+  getReward,
+} from '../services/algorithm-methods/flash.js';
 
 class FlashAssessmentAlgorithm {
   getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel }) {
@@ -18,6 +22,10 @@ class FlashAssessmentAlgorithm {
 
   getEstimatedLevelAndErrorRate({ allAnswers, challenges }) {
     return getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+  }
+
+  getReward({ estimatedLevel, discriminant, difficulty }) {
+    return getReward({ estimatedLevel, discriminant, difficulty });
   }
 }
 

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -1,5 +1,5 @@
 import { AssessmentEndedError } from '../errors.js';
-import { getPossibleNextChallenges } from '../services/algorithm-methods/flash.js';
+import { getPossibleNextChallenges, getEstimatedLevelAndErrorRate } from '../services/algorithm-methods/flash.js';
 
 class FlashAssessmentAlgorithm {
   getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel }) {
@@ -14,6 +14,10 @@ class FlashAssessmentAlgorithm {
     }
 
     return possibleChallenges;
+  }
+
+  getEstimatedLevelAndErrorRate({ allAnswers, challenges }) {
+    return getEstimatedLevelAndErrorRate({ allAnswers, challenges });
   }
 }
 

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -7,6 +7,7 @@ import { Area } from './Area.js';
 import { Assessment } from './Assessment.js';
 import { FlashAssessmentAlgorithm } from './FlashAssessmentAlgorithm.js';
 import { AssessmentResult } from './AssessmentResult.js';
+import { AssessmentSimulator } from './AssessmentSimulator.js';
 import { Authentication } from './Authentication.js';
 import { AuthenticationMethod } from './AuthenticationMethod.js';
 import { AuthenticationSessionContent } from './AuthenticationSessionContent.js';
@@ -159,6 +160,7 @@ export {
   Assessment,
   FlashAssessmentAlgorithm,
   AssessmentResult,
+  AssessmentSimulator,
   Authentication,
   AuthenticationMethod,
   AuthenticationSessionContent,

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -18,6 +18,7 @@ export {
   getEstimatedLevelAndErrorRate,
   getChallengesForNonAnsweredSkills,
   calculateTotalPixScoreAndScoreByCompetence,
+  getReward,
 };
 
 function getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel = DEFAULT_ESTIMATED_LEVEL } = {}) {
@@ -32,7 +33,7 @@ function getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel = DE
   const challengesWithReward = nonAnsweredChallenges.map((challenge) => {
     return {
       challenge,
-      reward: _getReward({ estimatedLevel, discriminant: challenge.discriminant, difficulty: challenge.difficulty }),
+      reward: getReward({ estimatedLevel, discriminant: challenge.discriminant, difficulty: challenge.difficulty }),
     };
   });
 
@@ -198,7 +199,7 @@ function _sumPixScoreAndScoreByCompetence(challenges) {
   return { pixScore, pixScoreByCompetence };
 }
 
-function _getReward({ estimatedLevel, discriminant, difficulty }) {
+function getReward({ estimatedLevel, discriminant, difficulty }) {
   const probability = _getProbability({ estimatedLevel, discriminant, difficulty });
   return probability * (1 - probability) * Math.pow(discriminant, 2);
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -655,6 +655,7 @@ import { sendScoInvitation } from './send-sco-invitation.js';
 import { sendSharedParticipationResultsToPoleEmploi } from './send-shared-participation-results-to-pole-emploi.js';
 import { sendVerificationCode } from './send-verification-code.js';
 import { shareCampaignResult } from './share-campaign-result.js';
+import { simulateFlashDeterministicAssessmentScenario } from './simulate-flash-deterministic-assessment-scenario.js';
 import { simulateFlashScoring } from './simulate-flash-scoring.js';
 import { simulateOldScoring } from './simulate-old-scoring.js';
 import { startCampaignParticipation } from './start-campaign-participation.js';
@@ -945,6 +946,7 @@ const usecasesWithoutInjectedDependencies = {
   sendVerificationCode,
   shareCampaignResult,
   simulateFlashScoring,
+  simulateFlashDeterministicAssessmentScenario,
   simulateOldScoring,
   startCampaignParticipation,
   startOrResumeCompetenceEvaluation,

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -1,0 +1,28 @@
+import { AssessmentSimulator, FlashAssessmentAlgorithm } from '../models/index.js';
+
+export async function simulateFlashDeterministicAssessmentScenario({
+  challengeRepository,
+  locale,
+  simulationAnswers,
+  pickChallengeService,
+  assessmentId,
+}) {
+  const challenges = await challengeRepository.findOperativeFlashCompatible({ locale });
+
+  const flashAssessmentAlgorithm = new FlashAssessmentAlgorithm();
+
+  const pickChallenge = ({ possibleChallenges }) =>
+    pickChallengeService.chooseNextChallenge({
+      possibleChallenges,
+      assessmentId,
+    });
+
+  const simulator = new AssessmentSimulator({
+    answers: simulationAnswers,
+    algorithm: flashAssessmentAlgorithm,
+    challenges,
+    pickChallenge,
+  });
+
+  return simulator.run();
+};

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -25,4 +25,4 @@ export async function simulateFlashDeterministicAssessmentScenario({
   });
 
   return simulator.run();
-};
+}

--- a/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-serializer.js
@@ -1,0 +1,9 @@
+import { Serializer } from 'jsonapi-serializer';
+
+function serialize(scenarioSimulator = {}) {
+  return new Serializer('scenario-simulator-challenge', {
+    attributes: ['minimumCapability', 'reward', 'errorRate', 'estimatedLevel', 'simulationAnswer'],
+  }).serialize(scenarioSimulator);
+}
+
+export const scenarioSimulatorSerializer = { serialize };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -42,6 +42,7 @@ import * as saml from './application/saml/index.js';
 import * as stageCollection from './application/stage-collections/index.js';
 import * as scoringSimulator from './application/scoring-simulator/index.js';
 import * as organizationLearners from './application/organization-learners/index.js';
+import * as scenarioSimulator from './application/scenarios-simulator/index.js';
 import * as scorecards from './application/scorecards/index.js';
 import * as scoOrganizationLearners from './application/sco-organization-learners/index.js';
 import * as supOrganizationLearners from './application/sup-organization-learners/index.js';
@@ -97,6 +98,7 @@ const routes = [
   prescribers,
   progressions,
   saml,
+  scenarioSimulator,
   scoringSimulator,
   organizationInvitations,
   scorecards,

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -1,0 +1,165 @@
+const { expect } = require('chai');
+const createServer = require('../../../../server');
+const {
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+} = require('../../../test-helper');
+const {
+  ROLES: { SUPER_ADMIN },
+} = require('../../../../lib/domain/constants').PIX_ADMIN;
+
+// eslint-disable-next-line mocha/no-skipped-tests
+describe.skip('Acceptance | Controller | scenario-simulator-controller', function () {
+  let server;
+  let adminAuthorization;
+
+  beforeEach(async function () {
+    server = await createServer();
+
+    const { id: adminId } = databaseBuilder.factory.buildUser.withRole({
+      role: SUPER_ADMIN,
+    });
+    adminAuthorization = generateValidRequestAuthorizationHeader(adminId);
+    await databaseBuilder.commit();
+
+    const learningContent = {
+      competences: [
+        {
+          id: 'rec1',
+          name_i18n: {
+            fr: 'comp1Fr',
+            en: 'comp1En',
+          },
+          index: '1.1',
+          color: 'rec1Color',
+          skillIds: ['skill1', 'skill2'],
+        },
+        {
+          id: 'rec2',
+          name_i18n: {
+            fr: 'comp2Fr',
+            en: 'comp2En',
+          },
+          index: '2.1',
+          color: 'rec2Color',
+          skillIds: ['skill3', 'skill4', 'skill5'],
+        },
+      ],
+      tubes: [
+        { id: 'recTube1', competenceId: 'rec1' },
+        { id: 'recTube2', competenceId: 'rec2' },
+      ],
+      skills: [
+        // tube 1
+        { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', level: 1, pixValue: 1 },
+        { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', level: 3, pixValue: 10 },
+        // tube 2
+        { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 2, pixValue: 100 },
+        { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 3, pixValue: 1000 },
+        { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 5, pixValue: 10000 },
+        { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', level: 6, pixValue: 100000 },
+      ],
+      challenges: [
+        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: ['fr-fr'] },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: ['fr-fr'] },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: ['fr-fr'] },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: ['fr-fr'] },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr-fr'] },
+        { id: 'challenge6', skillId: 'skill5', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr-fr'] },
+      ],
+    };
+
+    mockLearningContent(learningContent);
+  });
+
+  describe('#simulateFlashDeterministicAssessmentScenario', function () {
+    let options;
+
+    beforeEach(async function () {
+      options = {
+        method: 'POST',
+        url: `/api/scenario-simulator`,
+        payload: {},
+        headers: {},
+      };
+    });
+
+    it('should return a payload with simulation deterministic scenario results', async function () {
+      // given
+      const assessmentId = '1234';
+      const simulationAnswers = ['ok', 'ko', 'aband'];
+      options.headers.authorization = adminAuthorization;
+      options.payload = {
+        assessmentId,
+        simulationAnswers,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response).to.have.property('statusCode', 200);
+      expect(response.result).to.have.property('challenges');
+      expect(response.result).to.have.property('estimatedLevel');
+      expect(response.result.challenges).to.deep.equal([]);
+    });
+
+    // describe('when there is no connected user', function () {
+    //   it('should return status code 401', async function () {
+    //     // given
+    //     options.headers.authorization = undefined;
+    //
+    //     // when
+    //     const response = await server.inject(options);
+    //
+    //     // then
+    //     expect(response).to.have.property('statusCode', 401);
+    //   });
+    // });
+    //
+    // describe('when connected user does not have role SUPER_ADMIN', function () {
+    //   it('should return status code 403', async function () {
+    //     // given
+    //     const { id: userId } = databaseBuilder.factory.buildUser();
+    //     options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+    //     await databaseBuilder.commit();
+    //     options.payload = {
+    //       dataset: {
+    //         simulations: [
+    //           {
+    //             estimatedLevel: 1,
+    //           },
+    //         ],
+    //       },
+    //     };
+    //
+    //     // when
+    //     const response = await server.inject(options);
+    //
+    //     // then
+    //     expect(response).to.have.property('statusCode', 403);
+    //   });
+    // });
+    //
+    // describe('when request payload is invalid', function () {
+    //   it('should return status code 400', async function () {
+    //     // given
+    //     options.headers.authorization = adminAuthorization;
+    //     options.payload = {
+    //       wrongField: [
+    //         {
+    //           simulations: [],
+    //         },
+    //       ],
+    //     };
+    //
+    //     // when
+    //     const response = await server.inject(options);
+    //
+    //     // then
+    //     expect(response).to.have.property('statusCode', 400);
+    //   });
+    // });
+  });
+});

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -1,11 +1,15 @@
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
-const usecases = require('../../../../lib/domain/usecases/index.js');
-const moduleUnderTest = require('../../../../lib/application/scenarios-simulator');
-const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+import { expect, sinon, HttpTestServer, domainBuilder } from '../../../test-helper.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+import * as moduleUnderTest from '../../../../lib/application/scenarios-simulator/index.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
 
 describe('Integration | Application | Scoring-simulator | scenario-simulator-controller', function () {
   let httpTestServer;
   let simulationResults;
+  let reward1;
+  let errorRate1;
+  let challenge1;
+  let estimatedLevel1;
 
   beforeEach(async function () {
     sinon.stub(usecases, 'simulateFlashDeterministicAssessmentScenario');
@@ -17,16 +21,24 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
   describe('/api/scenario-simulator', function () {
     describe('#post', function () {
       beforeEach(async function () {
-        simulationResults = {
-          challenges: [],
-          estimatedLevel: 2.39201,
-        };
+        challenge1 = domainBuilder.buildChallenge({ id: 'chall1', successProbabilityThreshold: 0.65 });
+        reward1 = 0.2;
+        errorRate1 = 0.3;
+        estimatedLevel1 = 0.4;
+        simulationResults = [
+          {
+            challenge: challenge1,
+            reward: reward1,
+            errorRate: errorRate1,
+            estimatedLevel: estimatedLevel1,
+          },
+        ];
       });
 
       context('When the route is called with correct arguments', function () {
         it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
           // given
-          const simulationAnswers = ['ok', 'aband', 'ko'];
+          const simulationAnswers = ['ok'];
           const assessmentId = '13802DK';
           usecases.simulateFlashDeterministicAssessmentScenario
             .withArgs({
@@ -51,7 +63,21 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.deep.equal(simulationResults);
+          expect(response.result).to.deep.equal({
+            data: [
+              {
+                attributes: {
+                  'error-rate': errorRate1,
+                  'estimated-level': estimatedLevel1,
+                  'minimum-capability': 0.6190392084062237,
+                  'simulation-answer': 'ok',
+                  reward: reward1,
+                },
+                id: 'chall1',
+                type: 'scenario-simulator-challenges',
+              },
+            ],
+          });
         });
       });
     });

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -1,0 +1,59 @@
+const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases/index.js');
+const moduleUnderTest = require('../../../../lib/application/scenarios-simulator');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+describe('Integration | Application | Scoring-simulator | scenario-simulator-controller', function () {
+  let httpTestServer;
+  let simulationResults;
+
+  beforeEach(async function () {
+    sinon.stub(usecases, 'simulateFlashDeterministicAssessmentScenario');
+    sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('/api/scenario-simulator', function () {
+    describe('#post', function () {
+      beforeEach(async function () {
+        simulationResults = {
+          challenges: [],
+          estimatedLevel: 2.39201,
+        };
+      });
+
+      context('When the route is called with correct arguments', function () {
+        it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+          // given
+          const simulationAnswers = ['ok', 'aband', 'ko'];
+          const assessmentId = '13802DK';
+          usecases.simulateFlashDeterministicAssessmentScenario
+            .withArgs({
+              simulationAnswers,
+              assessmentId,
+              locale: 'en',
+            })
+            .resolves(simulationResults);
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/scenario-simulator',
+            {
+              assessmentId,
+              simulationAnswers,
+            },
+            null,
+            { 'accept-language': 'en' }
+          );
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result).to.deep.equal(simulationResults);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/unit/domain/models/AssessmentSimulator_test.js
@@ -92,7 +92,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           .returns([challenge1]);
 
         pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
-        pickChallenge.withArgs({ possibleChallenges: [ challenge1] }).returns(challenge1);
+        pickChallenge.withArgs({ possibleChallenges: [challenge1] }).returns(challenge1);
 
         // when
         const { challenges, estimatedLevel } = new AssessmentSimulator({

--- a/api/tests/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/unit/domain/models/AssessmentSimulator_test.js
@@ -1,0 +1,111 @@
+import { expect, domainBuilder } from '../../../test-helper.js';
+import sinon from 'sinon';
+import { AnswerStatus, AssessmentSimulator } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Models | AssessmentSimulator', function () {
+  describe('#run', function () {
+    context('when no answers are provided', function () {
+      it('returns an empty challenges array', function () {
+        // given
+        const answers = [];
+        const algorithm = {
+          getPossibleNextChallenges: sinon.stub(),
+        };
+
+        // when
+        const { challenges } = new AssessmentSimulator({ answers, algorithm }).run();
+
+        // then
+        expect(challenges).to.be.empty;
+      });
+    });
+
+    context('when 1 answer is provided', function () {
+      it('returns a list of one challenge and a correct estimated level', function () {
+        // given
+        const answers = ['ok'];
+        const expectedEstimatedLevel = 2;
+        const allChallenges = [domainBuilder.buildChallenge({ id: 'rec1' })];
+        const algorithm = {
+          getPossibleNextChallenges: ({ challenges }) => challenges,
+          getEstimatedLevelAndErrorRate: () => ({
+            estimatedLevel: 2,
+          }),
+        };
+        const pickChallenge = ({ possibleChallenges }) => possibleChallenges[0];
+
+        // when
+        const { challenges, estimatedLevel } = new AssessmentSimulator({
+          answers,
+          algorithm,
+          challenges: allChallenges,
+          pickChallenge,
+        }).run();
+
+        // then
+        expect(challenges).to.deep.equal([allChallenges[0]]);
+        expect(estimatedLevel).to.equal(expectedEstimatedLevel);
+      });
+    });
+
+    context('when 2 answers are provided', function () {
+      it('return a list of 2 challenges', function () {
+        // given
+        const answersForSimulator = [AnswerStatus.OK, AnswerStatus.KO];
+        const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+        const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+        const answer1 = { challengeId: challenge2.id, result: answersForSimulator[0] };
+        const answer2 = { challengeId: challenge1.id, result: answersForSimulator[1] };
+        const allChallenges = [challenge1, challenge2];
+        const expectedEstimatedLevel = 4;
+        const algorithm = {
+          getPossibleNextChallenges: sinon.stub(),
+          getEstimatedLevelAndErrorRate: sinon.stub(),
+        };
+        const pickChallenge = sinon.stub();
+
+        algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            allAnswers: [sinon.match(answer1)],
+            challenges: allChallenges,
+          })
+          .returns({ estimatedLevel: 5 });
+
+        algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            allAnswers: [sinon.match(answer1), sinon.match(answer2)],
+            challenges: allChallenges,
+          })
+          .returns({ estimatedLevel: 4 });
+
+        algorithm.getPossibleNextChallenges
+          .withArgs({
+            allAnswers: [],
+            challenges: allChallenges,
+          })
+          .returns([challenge2, challenge1]);
+        algorithm.getPossibleNextChallenges
+          .withArgs({
+            allAnswers: [sinon.match(answer1)],
+            challenges: allChallenges,
+          })
+          .returns([challenge1]);
+
+        pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
+        pickChallenge.withArgs({ possibleChallenges: [ challenge1] }).returns(challenge1);
+
+        // when
+        const { challenges, estimatedLevel } = new AssessmentSimulator({
+          answers: answersForSimulator,
+          algorithm,
+          challenges: allChallenges,
+          pickChallenge,
+        }).run();
+
+        // then
+        expect(challenges).to.deep.equal([challenge2, challenge1]);
+        expect(estimatedLevel).to.equal(expectedEstimatedLevel);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -1,0 +1,127 @@
+const { domainBuilder, expect } = require('../../../test-helper');
+const simulateFlashDeterministicAssessmentScenario = require('../../../../lib/domain/usecases/simulate-flash-deterministic-assessment-scenario');
+const sinon = require('sinon');
+const { AssessmentEndedError } = require('../../../../lib/domain/errors');
+
+const locale = 'fr-fr';
+
+describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', function () {
+  context('when there are enough flash challenges left', function () {
+    it('should return an estimated level and challenges array', async function () {
+      // given
+      const simulationAnswers = ['ok', 'ko', 'aband'];
+      const assessmentId = '123';
+
+      const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill' });
+      const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill' });
+      const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill' });
+      const firstChallenge = domainBuilder.buildChallenge({
+        id: 'one',
+        skill: firstSkill,
+        difficulty: -2,
+        discriminant: 0.16,
+      });
+      const secondChallenge = domainBuilder.buildChallenge({
+        id: 'two',
+        skill: secondSkill,
+        difficulty: 6,
+        discriminant: 3,
+      });
+      const thirdChallenge = domainBuilder.buildChallenge({
+        id: 'three',
+        skill: thirdSkill,
+        difficulty: 8.5,
+        discriminant: 1.587,
+      });
+
+      const challengeRepository = {
+        findOperativeFlashCompatible: sinon.stub(),
+      };
+      const pickChallengeService = { chooseNextChallenge: sinon.stub() };
+
+      challengeRepository.findOperativeFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
+
+      pickChallengeService.chooseNextChallenge
+        .withArgs({
+          possibleChallenges: [firstChallenge, thirdChallenge, secondChallenge],
+          assessmentId,
+        })
+        .returns(firstChallenge);
+
+      pickChallengeService.chooseNextChallenge
+        .withArgs({
+          possibleChallenges: [thirdChallenge, secondChallenge],
+          assessmentId,
+        })
+        .returns(secondChallenge);
+
+      pickChallengeService.chooseNextChallenge
+        .withArgs({
+          possibleChallenges: [thirdChallenge],
+          assessmentId,
+        })
+        .returns(thirdChallenge);
+
+      const pseudoRandom = {
+        create: () => ({
+          binaryTreeRandom: () => 0,
+        }),
+      };
+
+      // when
+      const { estimatedLevel, challenges } = await simulateFlashDeterministicAssessmentScenario({
+        challengeRepository,
+        locale,
+        simulationAnswers,
+        pseudoRandom,
+        assessmentId,
+        pickChallengeService,
+      });
+
+      // then
+      expect(estimatedLevel).to.equal(0.29766782658030516);
+      expect(challenges).to.deep.equal([firstChallenge, secondChallenge, thirdChallenge]);
+    });
+  });
+
+  context('when there are not enough flash challenges left', function () {
+    it('should throw an error', async function () {
+      // given
+      const simulationAnswers = ['ok', 'ko', 'aband'];
+      const assessmentId = '123';
+
+      const challenge = domainBuilder.buildChallenge({ id: 1 });
+      const challengeRepository = {
+        findOperativeFlashCompatible: sinon.stub(),
+      };
+      challengeRepository.findOperativeFlashCompatible.resolves([challenge]);
+
+      const pickChallengeService = { chooseNextChallenge: sinon.stub() };
+      pickChallengeService.chooseNextChallenge
+        .withArgs({
+          possibleChallenges: [challenge],
+          assessmentId,
+        })
+        .returns(challenge);
+
+      const pseudoRandom = {
+        create: () => ({
+          binaryTreeRandom: () => 0,
+        }),
+      };
+
+      // when
+      const promise = simulateFlashDeterministicAssessmentScenario({
+        challengeRepository,
+        locale,
+        simulationAnswers,
+        pseudoRandom,
+        assessmentId,
+        pickChallengeService,
+      });
+
+      // then
+      await expect(promise).to.be.rejectedWith(AssessmentEndedError);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -1,13 +1,12 @@
-const { domainBuilder, expect } = require('../../../test-helper');
-const simulateFlashDeterministicAssessmentScenario = require('../../../../lib/domain/usecases/simulate-flash-deterministic-assessment-scenario');
-const sinon = require('sinon');
-const { AssessmentEndedError } = require('../../../../lib/domain/errors');
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { simulateFlashDeterministicAssessmentScenario } from '../../../../lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js';
+import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
 
 const locale = 'fr-fr';
 
 describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', function () {
   context('when there are enough flash challenges left', function () {
-    it('should return an estimated level and challenges array', async function () {
+    it('should return an array of estimated level, challenge, reward and error rate for each answer', async function () {
       // given
       const simulationAnswers = ['ok', 'ko', 'aband'];
       const assessmentId = '123';
@@ -69,7 +68,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
       };
 
       // when
-      const { estimatedLevel, challenges } = await simulateFlashDeterministicAssessmentScenario({
+      const result = await simulateFlashDeterministicAssessmentScenario({
         challengeRepository,
         locale,
         simulationAnswers,
@@ -79,8 +78,13 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
       });
 
       // then
-      expect(estimatedLevel).to.equal(0.29766782658030516);
-      expect(challenges).to.deep.equal([firstChallenge, secondChallenge, thirdChallenge]);
+      expect(result).to.have.lengthOf(3);
+      result.forEach((answer) => {
+        expect(answer.challenge).not.to.be.undefined;
+        expect(answer.errorRate).not.to.be.undefined;
+        expect(answer.estimatedLevel).not.to.be.undefined;
+        expect(answer.reward).not.to.be.undefined;
+      });
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-serializer_test.js
@@ -1,0 +1,41 @@
+import { expect, domainBuilder } from '../../../../test-helper.js';
+import { scenarioSimulatorSerializer } from '../../../../../lib/infrastructure/serializers/jsonapi/scenario-simulator-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | scenario-simulator-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an scenario simulator object into JSON API data', function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({
+        id: '1',
+        successProbabilityThreshold: 0.5,
+        difficulty: 0.6,
+        discriminant: 0.5,
+      });
+      const scenarioSimulator = {
+        ...challenge,
+        reward: 2,
+        estimatedLevel: 1,
+        errorRate: 1.5,
+        simulationAnswer: 'ok',
+      };
+
+      // when
+      const scenarioSimulatorMember = scenarioSimulatorSerializer.serialize(scenarioSimulator);
+
+      // then
+      expect(scenarioSimulatorMember).to.deep.equal({
+        data: {
+          attributes: {
+            'error-rate': 1.5,
+            'estimated-level': 1,
+            'minimum-capability': 0.6,
+            'simulation-answer': 'ok',
+            reward: 2,
+          },
+          id: '1',
+          type: 'scenario-simulator-challenges',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Pour évaluer l’impact des modifications du déroulé des épreuves, il faut pouvoir jouer artificiellement des certifications et il ne faut pas que les résultats soient tous bons ou tous mauvais, mais plutôt proches de ce que répondraient de vrais candidats.
Pouvoir lancer une certification où les réponses aux épreuves sont données dans un scénario. 
Par exemple l’algorithme choisit la meilleure prochaine question pour la 7ème question, et la réponse à cette question sera donnée par la 7e réponse du scénario parmi ok, ko, aband.

## :robot: Proposition

Ajout d'une nouvelle route permettant la création d'un scénario déterministes à partir d'un challengeId (fictif) et d'un ensemble de réponses prédéfinies à des questions ( ['ok', 'ko', 'aband'] )

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Utiliser une requête curl semblable à celle-ci : 
```
TOKEN=$(curl 'https://api-pr6218.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6218.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "assessmentId": "1234", "simulationAnswers": ["ok", "ko", "aband"] }' | jq '.'
```

Vous pouvez modifier les réponses données aux questions parmi `ok, ko, aband`
`jq` doit être installé pour exécuter cette requête.