### PR TITLE
[TECH] Fournir des outils génériques et documentés orientés "Profil Utilisateur" (PIX-7960)

### DIFF
--- a/api/db/seeds/data/common/tooling/index.js
+++ b/api/db/seeds/data/common/tooling/index.js
@@ -1,5 +1,6 @@
 const campaign = require('./campaign-tooling');
 const session = require('./session-tooling');
+const profile = require('./profile-tooling');
 const targetProfile = require('./target-profile-tooling');
 const training = require('./training-tooling');
 const organization = require('./organization-tooling');
@@ -12,4 +13,5 @@ module.exports = {
   session,
   targetProfile,
   training,
+  profile,
 };

--- a/api/db/seeds/data/common/tooling/profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/profile-tooling.js
@@ -1,0 +1,116 @@
+const _ = require('lodash');
+const learningContent = require('./learning-content');
+const generic = require('./generic');
+const Assessment = require('../../../../../lib/domain/models/Assessment');
+const CompetenceEvaluation = require('../../../../../lib/domain/models/CompetenceEvaluation');
+const { PIX_COUNT_BY_LEVEL } = require('../../../../../lib/domain/constants');
+
+module.exports = {
+  createCertifiableProfile,
+  createPerfectProfile,
+};
+
+/**
+ * Fonction générique pour créer un profil ayant 5 compétences Pix au niveau 1
+ * @param {DatabaseBuilder} databaseBuilder
+ * @param {number} userId
+ * @returns {Promise<void>}
+ */
+async function createCertifiableProfile({
+  databaseBuilder,
+  userId,
+}) {
+  const pixCompetences = await learningContent.getCoreCompetences();
+  const fiveRandomCompetences = generic.pickRandomAmong(pixCompetences, 5);
+  _makeUserReachPixScoreForCompetences({
+    databaseBuilder,
+    userId,
+    competences: fiveRandomCompetences,
+    pixScoreByCompetence: PIX_COUNT_BY_LEVEL,
+  });
+}
+
+/**
+ * Fonction générique pour créer un profil ayant toutes les compétences Pix au niveau maximum
+ * @param {DatabaseBuilder} databaseBuilder
+ * @param {number} userId
+ * @returns {Promise<void>}
+ */
+async function createPerfectProfile({
+  databaseBuilder,
+  userId,
+}) {
+  const UNREACHABLE_PIX_SCORE = 99999999;
+  const pixCompetences = await learningContent.getCoreCompetences();
+  _makeUserReachPixScoreForCompetences({
+    databaseBuilder,
+    userId,
+    competences: pixCompetences,
+    pixScoreByCompetence: UNREACHABLE_PIX_SCORE,
+  });
+}
+
+function _makeCompetenceEvaluation({
+  databaseBuilder,
+  userId,
+  competenceId,
+}) {
+  const assessmentId = databaseBuilder.factory.buildAssessment({
+    userId,
+    competenceId,
+    type: Assessment.types.COMPETENCE_EVALUATION,
+    state: Assessment.states.COMPLETED,
+  }).id;
+  databaseBuilder.factory.buildCompetenceEvaluation({
+    userId,
+    competenceId,
+    assessmentId,
+    status: CompetenceEvaluation.statuses.STARTED,
+  },
+  );
+  return assessmentId;
+}
+
+async function _makeUserReachPixScoreForCompetences({
+  databaseBuilder,
+  userId,
+  competences,
+  pixScoreByCompetence,
+}) {
+  for (const competence of competences) {
+    const assessmentId = _makeCompetenceEvaluation({ databaseBuilder, userId, competenceId: competence.id });
+
+    const skills = await learningContent.findActiveSkillsByCompetenceId(competence.id);
+    const orderedSkills = _.sortBy(skills, 'level');
+    let currentPixScore = 0;
+    for (const skill of orderedSkills) {
+      const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+      const answerId = databaseBuilder.factory.buildAnswer({
+        value: 'dummy value',
+        result: 'ok',
+        assessmentId,
+        challengeId: challenge.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        timeout: null,
+        resultDetails: 'dummy value',
+      }).id;
+      databaseBuilder.factory.buildKnowledgeElement({
+        source: 'direct',
+        status: 'validated',
+        answerId,
+        assessmentId,
+        skillId: skill.id,
+        createdAt: new Date(),
+        earnedPix: skill.pixValue,
+        userId,
+        competenceId: skill.competenceId,
+      });
+
+      currentPixScore += skill.pixValue;
+      if (currentPixScore >= pixScoreByCompetence) {
+        break;
+      }
+    }
+  }
+}

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -5,6 +5,8 @@ const TEAM_CONTENU_OFFSET_ID = 5000;
 /// USERS
 const PRO_ORGANIZATION_USER_ID = TEAM_CONTENU_OFFSET_ID;
 const PRO_CERTIFICATION_CENTER_USER_ID = TEAM_CONTENU_OFFSET_ID + 1;
+const CERTIFIABLE_USER_ID = TEAM_CONTENU_OFFSET_ID + 2;
+const PERFECT_PROFILE_USER_ID = TEAM_CONTENU_OFFSET_ID + 3;
 /// ORGAS
 const PRO_ORGANIZATION_ID = TEAM_CONTENU_OFFSET_ID;
 // TARGET PROFILES
@@ -25,6 +27,9 @@ async function teamContenuDataBuilder({ databaseBuilder }) {
   await databaseBuilder.commit();
   await _createAssessmentCampaign(databaseBuilder);
   await _createProfilesCollectionCampaign(databaseBuilder);
+
+  await _createCertifiableUser(databaseBuilder);
+  await _createPerfectProfileUser(databaseBuilder);
 }
 
 module.exports = {
@@ -234,6 +239,52 @@ async function _createDiverseTargetProfile(databaseBuilder) {
     cappedTubesDTO,
     type: 'THRESHOLD',
     countStages: 4,
+  });
+}
+
+async function _createCertifiableUser(databaseBuilder) {
+  const userId = databaseBuilder.factory.buildUser.withRawPassword({
+    id: CERTIFIABLE_USER_ID,
+    firstName: 'Certifiable',
+    lastName: 'Contenu',
+    email: 'certifiable-contenu-user@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    shouldChangePassword: false,
+  }).id;
+
+  await tooling.profile.createCertifiableProfile({
+    databaseBuilder,
+    userId,
+  });
+}
+
+async function _createPerfectProfileUser(databaseBuilder) {
+  const userId = databaseBuilder.factory.buildUser.withRawPassword({
+    id: PERFECT_PROFILE_USER_ID,
+    firstName: 'Perfect',
+    lastName: 'Profile User',
+    email: 'perfect-profile-user@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    shouldChangePassword: false,
+  }).id;
+
+  await tooling.profile.createPerfectProfile({
+    databaseBuilder,
+    userId,
   });
 }
 

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -112,15 +112,14 @@ exports.seed = async (knex) => {
   await generateKnowledgeElementSnapshots(campaignParticipationData, 1);
   await computeParticipationsResults(10, false);
 
-  /* COMMENT ABOVE AND UNCOMMENT THIS FOR SEEDS EPIC
-  const { commonBuilder } = require('./data/common/common-builder');
-  const { teamContenuDataBuilder } = require('./data/team-contenu/data-builder');
-  const { teamCertificationDataBuilder } = require('./data/team-certification/data-builder');
-  const databaseBuilder = new DatabaseBuilder({ knex });
-  commonBuilder({ databaseBuilder });
-  await teamContenuDataBuilder({ databaseBuilder });
-  await teamCertificationDataBuilder({ databaseBuilder });
-  await databaseBuilder.commit();
-  await databaseBuilder.fixSequences();
-*/
+  // const { commonBuilder } = require('./data/common/common-builder');
+  // const { teamContenuDataBuilder } = require('./data/team-contenu/data-builder');
+  // const { teamCertificationDataBuilder } = require('./data/team-certification/data-builder');
+  // const databaseBuilder = new DatabaseBuilder({ knex });
+  // commonBuilder({ databaseBuilder });
+  // await teamContenuDataBuilder({ databaseBuilder });
+  // await teamCertificationDataBuilder({ databaseBuilder });
+  // await databaseBuilder.commit();
+  // await databaseBuilder.fixSequences();
+
 };


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
Creer un tooling documenté via de la JSDoc afin de génerer des profils utilisateurs.

## :100: Pour tester
Créer un fichier de seed qui fait appel à ces fonctions et vérifier que la création subséquente est en accord avec ce que vous souhaitiez !
Pour avoir un exemple d'usage, on peut consulter le fichier team-contenu/data-builder.js
