### PR TITLE
[BUGFIX] Corriger l'affichage de la partie "J'ai déjà un compte" sur la double mire Pix Orga (PIX-8086)

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -1,10 +1,5 @@
 <div class="login-form">
 
-  <header class="login-form__header">
-    <img src="/pix-orga.svg" alt="Pix Orga" />
-    <h1 class="login-form__title">{{t "pages.login.title"}}</h1>
-  </header>
-
   {{#unless @isWithInvitation}}
     <p class="login-form__information">{{t "pages.login-form.is-only-accessible"}}</p>
   {{/unless}}

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -2,35 +2,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 550px;
-  background-color: $pix-neutral-0;
-  border-radius: 10px;
-  padding: 20px 30px;
-  margin: $pix-spacing-s 0;
-
-  @include device-is('tablet') {
-    padding: 40px 60px;
-  }
-
-  &__header {
-    text-align: center;
-  }
-
-  &__title {
-    @extend %pix-title-m;
-
-    font-family: $font-open-sans;
-    font-weight: $font-normal;
-    color: $pix-neutral-80;
-    margin-top: $pix-spacing-m;
-  }
+  max-width: 440px;
 
   &__information {
     @extend %pix-body-s;
 
     text-align: center;
     color: $pix-neutral-90;
-    margin-top: $pix-spacing-m;
+    margin-top: $pix-spacing-s;
   }
 
   &__error-message {

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -6,5 +6,29 @@
   background: $pix-secondary-orga-gradient;
   align-items: center;
   justify-content: center;
-  padding: $pix-spacing-s;
+
+  &__header {
+    text-align: center;
+  }
+
+  &__title {
+    @extend %pix-title-m;
+
+    font-family: $font-open-sans;
+    font-weight: $font-normal;
+    color: $pix-neutral-80;
+    margin-top: $pix-spacing-m;
+  }
+
+  &__container {
+    background-color: $pix-neutral-0;
+    border-radius: 10px;
+    padding: $pix-spacing-xl 60px;
+    margin-bottom: $pix-spacing-s;
+
+    @include device-is('mobile') {
+      padding: $pix-spacing-xl $pix-spacing-s;
+      border-radius: 0px;
+    }
+  }
 }

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -1,14 +1,21 @@
 {{page-title (t "pages.login.title")}}
 <main class="login-page">
-  <section>
-    <Auth::LoginForm
-      @isWithInvitation={{false}}
-      @hasInvitationAlreadyBeenAccepted={{this.hasInvitationAlreadyBeenAccepted}}
-      @isInvitationCancelled={{this.isInvitationCancelled}}
-    />
+  <div>
+    <section class="login-page__container">
+      <header class="login-page__header">
+        <img src="/pix-orga.svg" alt="Pix Orga" />
+        <h1 class="login-page__title">{{t "pages.login.title"}}</h1>
+      </header>
+
+      <Auth::LoginForm
+        @isWithInvitation={{false}}
+        @hasInvitationAlreadyBeenAccepted={{this.hasInvitationAlreadyBeenAccepted}}
+        @isInvitationCancelled={{this.isInvitationCancelled}}
+      />
+    </section>
 
     {{#if this.isInternationalDomain}}
       <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
     {{/if}}
-  </section>
+  </div>
 </main>


### PR DESCRIPTION
## :unicorn: Problème
Suite à un commit de refacto sur la PR #6113, on retrouve deux headers sur la double mire Pix Orga lorsqu’on souhaite se connecter à un compte existant.

## :robot: Proposition
Déplacer le header en dehors du composant, c'est à dire, dans la page de connexion (template login).

## :rainbow: Remarques
RAS.

## :100: Pour tester

- Se rendre sur la page de connexion Pix Orga, vérifier que l'affichage correspond bien à celui que l'on a en production.
- Se rendre sur la double mire de Pix Orga, dans la partie "J'ai déjà un compte" et vérifier qu'on a plus deux titres et deux logos.
- Bien tester avec différentes tailles d'écran
