### PR TITLE
[FEATURE] Traduire la modale de confirmation de finalisation de session sur Pix Certif (PIX-8012).

### DIFF
--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -29,7 +29,7 @@
                   @state={{this.headerCheckboxStatus}}
                 />
               </div>
-              Écran de fin du test vu
+              {{t "pages.session-finalization.reporting.table.labels.end-of-test-screen"}}
             </div>
           </th>
         {{/if}}

--- a/certif/app/components/session-finalization/finalization-confirmation-modal.hbs
+++ b/certif/app/components/session-finalization/finalization-confirmation-modal.hbs
@@ -1,20 +1,24 @@
 <PixModal
-  @title="Finalisation de la session"
+  @title={{t "pages.session-finalization.confirm-finalisation-modal.title"}}
   @onCloseButtonClick={{@closeModal}}
   class="finalization-confirmation-modal"
   @showModal={{@showModal}}
 >
   <:content>
     {{#if (and @hasUncheckedHasSeenEndTestScreen @shouldDisplayHasSeenEndTestScreenCheckbox)}}
-      <p class="app-modal-body__contextual finalization-confirmation-modal__unchecked-has-seen-end-test-screen">La case
-        "Écran de fin du test vu" n'est pas cochée pour
-        {{@uncheckedHasSeenEndTestScreenCount}}
-        candidat(s)</p>
+      <p class="app-modal-body__contextual finalization-confirmation-modal__unchecked-has-seen-end-test-screen">
+        {{t
+          "pages.session-finalization.confirm-finalisation-modal.end-of-test-screen"
+          candidatesCount=@uncheckedHasSeenEndTestScreenCount
+        }}
+      </p>
     {{/if}}
-    <p><span class="finalization-confirmation-modal__warning">Attention :</span>
-      il ne vous sera plus possible de modifier ces informations par la suite.</p>
-    <p>Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement
-      pouvant varier d'une session à l'autre).</p>
+    <p>
+      <span class="finalization-confirmation-modal__warning">
+        {{t "pages.session-finalization.confirm-finalisation-modal.warning"}}
+      </span>
+      {{t "pages.session-finalization.confirm-finalisation-modal.information"}}
+    </p>
   </:content>
   <:footer>
     <PixButton
@@ -26,7 +30,7 @@
       {{t "common.actions.cancel"}}
     </PixButton>
     <PixButton data-test-id="finalize-session-modal__confirm-button" @triggerAction={{@finalizeSession}} @size="small">
-      Confirmer la finalisation
+      {{t "pages.session-finalization.confirm-finalisation-modal.actions.confirm"}}
     </PixButton>
   </:footer>
 </PixModal>

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -257,7 +257,7 @@ module('Acceptance | Session Finalization', function (hooks) {
             // then
             assert.dom(screen.getByText(MODAL_TITLE)).exists();
             assert
-              .dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)'))
+              .dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat'))
               .exists();
           });
         });
@@ -327,7 +327,7 @@ module('Acceptance | Session Finalization', function (hooks) {
               // then
               assert.dom(screen.getByText(MODAL_TITLE)).exists();
               assert
-                .dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)'))
+                .dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat'))
                 .exists();
             });
           });

--- a/certif/tests/integration/components/session-finalization/finalization-confirmation-modal_test.js
+++ b/certif/tests/integration/components/session-finalization/finalization-confirmation-modal_test.js
@@ -33,7 +33,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
     assert
       .dom(
         screen.getByText(
-          "Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement pouvant varier d'une session à l'autre)."
+          "il ne vous sera plus possible de modifier ces informations par la suite. Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement pouvant varier d'une session à l'autre)."
         )
       )
       .exists();
@@ -60,7 +60,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
       `);
 
       // then
-      assert.dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidat(s)')).exists();
+      assert.dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidats')).exists();
     });
   });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -274,6 +274,7 @@
         "table": {
           "labels": {
             "certification-number": "Certification No.",
+            "end-of-test-screen": "End of test screen seen",
             "reporting": "Reporting"
           },
           "reporting-count": "{reportingsCount, plural,one {1 reporting} other {# reportings}}"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -240,6 +240,15 @@
         "incident": "Despite an incident having occurred during the session, the candidates have been able to finish their Pix certification exam. Additional time has been granted to at least one of the candidates.",
         "title": "Additional information (optional)"
       },
+      "confirm-finalisation-modal": {
+        "actions": {
+          "confirm": "Confirm the finalisation"
+        },
+        "end-of-test-screen": "The “End of test screen seen” box isn’t ticked for {candidatesCount, plural,one {1 candidate} other {# candidates}}",
+        "information": "you won’t be able to edit these informations thereafter. Processing time is needed before the results can be made available by Pix (this processing time may vary from one session to another).",
+        "title": "Session finalisation",
+        "warning": "Warning :"
+      },
       "issue-reports-modal": {
         "actions": {
           "add-reporting": "Add a reporting",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -240,6 +240,15 @@
         "incident": "Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats.",
         "title": "Informations complémentaires (facultatif)"
       },
+      "confirm-finalisation-modal": {
+        "actions": {
+          "confirm": "Confirmer la finalisation"
+        },
+        "end-of-test-screen": "La case \"Écran de fin du test vu\" n'est pas cochée pour {candidatesCount, plural,one {1 candidat} other {# candidats}}",
+        "information": "il ne vous sera plus possible de modifier ces informations par la suite. Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement pouvant varier d'une session à l'autre).",
+        "title": "Finalisation de la session",
+        "warning": "Attention :"
+      },
       "issue-reports-modal": {
         "actions": {
           "add-reporting": "Ajouter un signalement",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -274,6 +274,7 @@
         "table": {
           "labels": {
             "certification-number": "N° de certification",
+            "end-of-test-screen": "Écran de fin du test vu",
             "reporting": "Signalement"
           },
           "reporting-count": "{reportingsCount, plural,one {1 signalement} other {# signalements}}"


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Une fois sur la page de détails d’une session de certification Pix dont au moins un candidat a commencé son test, un utilisateur anglophone peut cliquer sur le bouton “Finaliser la session” afin de finaliser ladite session et transmettre les résultats à Pix.

Une modale s’affiche alors pour demander la confirmation de la finalisation à l’utilisateur.

## :robot: Proposition
Traduire cette modale

- Les toasters de validation sont déjà traités dans la PR de Quentin https://github.com/1024pix/pix/pull/6002/files (finalize.js)

## :100: Pour tester

- Se connecter avec certifsco sur Pix Certif
- Cliquer sur la session avec les 156 candidats puis cliquer sur le bouton, finaliser la session
- Remplir les motifs d'abandon
- Cliquer sur le bouton finaliser
- Constater que la modale est bien traduite.

<img width="610" alt="Capture d’écran 2023-05-17 à 17 23 02" src="https://github.com/1024pix/pix/assets/58915422/c4f6d630-f337-496f-89e2-c47c55b208a3">
