### PR TITLE
[TECH] [Pix Orga] Aligner la double mire sur la maquette et nos standards (PIX-8073)

### DIFF
--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -1,6 +1,6 @@
 <div class="register-form">
   <form {{on "submit" this.register}}>
-    <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
+    <p class="register-form__information">{{t "common.form.mandatory-all-fields"}}</p>
     <div class="input-container">
       <PixInput
         @id="register-firstName"

--- a/orga/app/styles/components/login-or-register.scss
+++ b/orga/app/styles/components/login-or-register.scss
@@ -1,5 +1,9 @@
 .login-or-register {
-  margin: 20px 0;
+  margin: $pix-spacing-m 0;
+
+  @include device-is('mobile') {
+    margin: 12px 0;
+  }
 
   &__language-switcher {
     @include device-is('mobile') {
@@ -11,7 +15,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    margin-bottom: 16px;
+    margin-bottom: $pix-spacing-s;
     border-radius: 10px;
     align-items: center;
     padding: 20px 2px;
@@ -21,7 +25,7 @@
     }
 
     @include device-is('large-screen') {
-      padding: 40px 100px;
+      padding: $pix-spacing-xl 100px;
     }
   }
 }
@@ -69,6 +73,10 @@
 
     .form-title {
       margin: $pix-spacing-m 0;
+
+      @include device-is('mobile') {
+        text-align: center;
+      }
     }
   }
 

--- a/orga/app/styles/components/register-form.scss
+++ b/orga/app/styles/components/register-form.scss
@@ -13,8 +13,15 @@
     margin-top: 20px;
   }
 
+  &__information {
+    @extend %pix-body-s;
+
+    text-align: center;
+    color: $pix-neutral-90;
+  }
+
   .input-container {
-    margin: 16px 2px 25px 2px;
+    margin: $pix-spacing-s 2px $pix-spacing-s 2px;
   }
 
   .pix-input-password > .pix-input__error-message {

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -49,60 +49,38 @@ module('Acceptance | join', function (hooks) {
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       });
     });
-    module('when organization-invitation exists but user tries to change language by url', function () {
-      test('redirects user to login page', async function (assert) {
-        // given
-        const code = 'ABCDEFGH01';
-        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-        const organizationInvitationId = server.create('organizationInvitation', {
-          organizationId,
-          email: 'random@email.com',
-          status: 'pending',
-          code,
-        }).id;
+    module(
+      'When accessing the login page with "English" as selected language in url query params and select another language',
+      function () {
+        test('remains on join page whithout the query params', async function (assert) {
+          // given
+          const code = 'ABCDEFGH01';
+          const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+          const organizationInvitationId = server.create('organizationInvitation', {
+            organizationId,
+            email: 'random@email.com',
+            status: 'pending',
+            code,
+            organizationName: 'Le collège fou fou fou',
+          }).id;
 
-        // when
-        await visit(`rejoindre?invitationId=${organizationInvitationId}&code=${code}?lang=en`);
+          // when
+          const screen = await visitScreen(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`);
 
-        // then
-        assert.strictEqual(currentURL(), '/connexion');
-        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-      });
-      module(
-        'When accessing the login page with "English" as selected language in url query params and select another language',
-        function () {
-          test('remains on join page whithout the query params', async function (assert) {
-            // given
-            const code = 'ABCDEFGH01';
-            const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-            const organizationInvitationId = server.create('organizationInvitation', {
-              organizationId,
-              email: 'random@email.com',
-              status: 'pending',
-              code,
-              organizationName: 'Le collège fou fou fou',
-            }).id;
+          assert
+            .dom(screen.getByText('You have been invited to join the organisation Le collège fou fou fou'))
+            .exists();
 
-            // when
-            const screen = await visitScreen(
-              `/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`
-            );
+          await click(screen.getByRole('button', { name: 'English' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Français' }));
 
-            assert
-              .dom(screen.getByText('You have been invited to join the organisation Le collège fou fou fou'))
-              .exists();
-
-            await click(screen.getByRole('button', { name: 'English' }));
-            await screen.findByRole('listbox');
-            await click(screen.getByRole('option', { name: 'Français' }));
-
-            // then
-            assert.strictEqual(currentURL(), `/rejoindre?code=${code}&invitationId=${organizationInvitationId}`);
-            assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-          });
-        }
-      );
-    });
+          // then
+          assert.strictEqual(currentURL(), `/rejoindre?code=${code}&invitationId=${organizationInvitationId}`);
+          assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        });
+      }
+    );
     module('when organization-invitation does not exist', function () {
       test('redirects user to login page', async function (assert) {
         // when

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Response from 'ember-cli-mirage/response';
-import { visit, currentURL, click } from '@ember/test-helpers';
-import { fillByLabel, clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import { currentURL, click } from '@ember/test-helpers';
+import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 
 import { currentSession } from 'ember-simple-auth/test-support';
@@ -65,7 +65,7 @@ module('Acceptance | join', function (hooks) {
           }).id;
 
           // when
-          const screen = await visitScreen(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`);
+          const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`);
 
           assert
             .dom(screen.getByText('You have been invited to join the organisation Le collège fou fou fou'))
@@ -184,7 +184,7 @@ module('Acceptance | join', function (hooks) {
 
       test("redirects user to the terms-of-service page in the user's language even if another language selected in join page", async function (assert) {
         // given
-        const screen = await visitScreen(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+        const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
         await click(screen.getByRole('button', { name: 'Français' }));
         await screen.findByRole('listbox');
@@ -467,7 +467,7 @@ module('Acceptance | join', function (hooks) {
               code,
             }).id;
 
-            const screen = await visitScreen(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+            const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
             await click(screen.getByRole('button', { name: 'Français' }));
             await screen.findByRole('listbox');
             await click(screen.getByRole('option', { name: 'English' }));

--- a/orga/tests/integration/components/auth/login-or-register_test.js
+++ b/orga/tests/integration/components/auth/login-or-register_test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
-import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
@@ -13,7 +13,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   hooks.beforeEach(function () {
     loginButton = this.intl.t('pages.login-or-register.login-form.button');
   });
-  test('it displays the organization name the user is invited to', async function (assert) {
+  test('displays the organization name the user is invited to', async function (assert) {
     // when
     const invitationMessage = this.intl.t('pages.login-or-register.title', { organizationName: 'Organization Aztec' });
 
@@ -23,7 +23,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     assert.dom('.login-or-register-panel__invitation').hasText(`${invitationMessage}`);
   });
 
-  test('it toggles the register form by default', async function (assert) {
+  test('toggles the register form by default', async function (assert) {
     // when
     await render(hbs`<Auth::LoginOrRegister />`);
 
@@ -31,7 +31,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     assert.dom('.register-form').exists();
   });
 
-  test('it toggles the login form on click on login button', async function (assert) {
+  test('toggles the login form on click on login button', async function (assert) {
     // given
     await render(hbs`<Auth::LoginOrRegister />`);
 
@@ -42,7 +42,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     assert.dom('.login-form').exists();
   });
 
-  test('it toggles the register form on click on register button', async function (assert) {
+  test('toggles the register form on click on register button', async function (assert) {
     // given
     const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.button');
 
@@ -73,7 +73,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
       this.owner.register('service:router', routerServiceStub);
 
       // when
-      const screen = await renderScreen(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);
+      const screen = await render(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);
 
       // then
       await click(screen.getByRole('button', { name: 'Français' }));
@@ -94,7 +94,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
       this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
       // when
-      const screen = await renderScreen(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);
+      const screen = await render(hbs`<Auth::LoginOrRegister @organizationName='Organization Aztec' />`);
 
       // then
       assert.dom(screen.getByText("Vous êtes invité(e) à rejoindre l'organisation Organization Aztec")).exists();

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -38,7 +38,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     registerButtonLabel = this.intl.t('pages.login-or-register.register-form.fields.button.label');
   });
 
-  test('it renders', async function (assert) {
+  test('renders', async function (assert) {
     // when
     await renderScreen(hbs`<Auth::RegisterForm />`);
 
@@ -54,7 +54,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
   });
 
-  test('it should display legal mentions with related links', async function (assert) {
+  test('displays legal mentions with related links', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
     service.currentDomain = { isFranceDomain: true };
@@ -101,7 +101,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
       };
     });
 
-    test('it should call authentication service with appropriate parameters, when all things are ok and form is submitted', async function (assert) {
+    test('calls authentication service with appropriate parameters, when all things are ok and form is submitted', async function (assert) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
       await renderScreen(hbs`<Auth::RegisterForm @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`);
@@ -123,7 +123,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     });
   });
 
-  module('errors management', function (hooks) {
+  module('error management', function (hooks) {
     let spy, screen;
 
     hooks.beforeEach(async function () {
@@ -140,7 +140,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     });
 
     module('When first name is not valid', () => {
-      test('it should prevent submission and display error message', async function (assert) {
+      test('prevents submission and display error message', async function (assert) {
         // given
         await fillByLabel(firstNameInputLabel, '');
 
@@ -154,7 +154,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     });
 
     module('When last name is not valid', () => {
-      test('it should prevent submission and display error message', async function (assert) {
+      test('prevents submission and display error message', async function (assert) {
         // given
         await fillByLabel(lastNameInputLabel, '');
 
@@ -168,7 +168,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     });
 
     module('When email is not valid', () => {
-      test('it should prevent submission and display error message', async function (assert) {
+      test('prevents submission and display error message', async function (assert) {
         // given
         await fillByLabel(emailInputLabel, 'email');
 
@@ -182,7 +182,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     });
 
     module('When password is not valid', () => {
-      test('it should prevent submission and display error message', async function (assert) {
+      test('prevents submission and display error message', async function (assert) {
         // given
         await fillByLabel(passwordInputLabel, '');
 
@@ -196,7 +196,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     });
 
     module('When cgu have not been accepted', () => {
-      test('it should prevent submission', async function (assert) {
+      test('prevents submission', async function (assert) {
         // given
         await clickByName(cguAriaLabel);
 
@@ -204,7 +204,6 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
-        // assert.strictEqual
         assert.strictEqual(spy.callCount, 0);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Quelques standards n'ont pas été appliqués lors de la PR https://github.com/1024pix/pix/pull/6126

## :robot: Proposition
- Se rapprocher un peu plus du design sur Figma
- Corriger les tests qui n'étaient pas à jour (supprimer les should)
- Pour éviter les effets de bord, malheureusement on reste pour l'instant sur l'utilisation d'instructions CSS avec l'unité en `px`, car le _Design System_ n'est malheureusement pas encore en `rem`/`em`


## :rainbow: Remarques
Ce n'est pas un alignement complet sur la maquette actuellement disponible sur Figma. Comme celui-ci a été modifié depuis la mise en place de la double mire, cela n'est pas l'objet de ce ticket. Cela traité ultérieurement

J'ai supprimé le test introduit dans ce [commit](https://github.com/1024pix/pix/pull/6126/commits/0e08f7317d33705a7311737f0f5de949cd107cd2).
 ça fait un GET sur http://localhost:4201/api/organization-invitations/100057?code=INVIABC123%3Flang qui répond une 404
avec `Not found organization-invitation for ID 100057 and code INVIABC123?lang` c'est le comportement attendu quand le code d'une invitation d'existe pas.
C'est un comportement "normal"
[Doc](https://guides.emberjs.com/release/routing/query-params/#toc_specifying-query-parameters)

## :100: Pour tester
- Aller sur la double mire en utilisant le lien http://localhost:4201/rejoindre?invitationId=100057&code=INVIABC123 (si votre base est reset, c'est l'invitation existante par défaut)
- Observer que :
  - le titre je m'inscris est centré en version mobile
  - l'espacement entre le titre Je m'inscris et 'Tous les champs sont obligatoires.' a été réduit
  - l'espacement entre les champs de formulaire est de `24px` (spécifié avec `margin: 12px 0` où `24px = 12px * 2`, car [avec deux valeurs, la première s'appliquera aux côtés haut et bas et la seconde aux côtés gauche et droit](https://developer.mozilla.org/fr/docs/Web/CSS/margin#syntaxe)) et les [design token](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_spacing.scss) ont été utilisés
  - en mobile, on voit toujours la petite bande bleu en haut (fait qu'on voit le radius du form) mais la taille a été réduite


