### PR TITLE
[FEATURE] Vide le pixCertificationStatus pour les certifications annulées (PIX-8096)

### DIFF
--- a/api/db/migrations/20230516201749_remove-cancelled-pixCertificationStatus.js
+++ b/api/db/migrations/20230516201749_remove-cancelled-pixCertificationStatus.js
@@ -1,0 +1,7 @@
+exports.up = function (knex) {
+  return knex('certification-courses').update({ pixCertificationStatus: null }).where({ isCancelled: true });
+};
+
+exports.down = function () {
+  // no need for rollback
+};

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -120,7 +120,7 @@ function _buildStartedCertification({ id, sessionId, isPublished, pixCertificati
 }
 
 function _buildCancelledCertification({ id, sessionId, isPublished }) {
-  _buildCertification({ id, sessionId, isPublished, isCancelled: true, status: null });
+  _buildCertification({ id, sessionId, isPublished, status: 'CANCELLED', isCancelled: true });
 }
 
 function _buildCertification({


### PR DESCRIPTION
## :unicorn: Problème
La PR PIX-6071 a initiée un champs pixCertificationStatus qui permet de stocker le status de l’assessment result à la publication. Celui-ci ne devrait pas avoir de valeur pour une certification publiée ou annulée. 

## :robot: Proposition
Vider ce champs pour les certifications annulées (migration)
Ne pas mettre à jour lors de la publication si la certification est annulée

## :rainbow: Remarques
Pas de rollback
Le probleme ne devrait plus arriver suite à la resolution de https://1024pix.atlassian.net/browse/PIX-7002
Mais il est preferable de s'assurer que cela ne se reproduise pas

## :100: Pour tester
Publier une session et s'assurer que le champs pixCertificationStatus est bien à jour
Annuler la session et s'assurer que le champs pixCertificationStatus vide


https://github.com/1024pix/pix/assets/58915422/7d08724a-4068-4df1-a953-c34d0f876c23


