### PR TITLE
[TECH] Enrichir les outils "Campagnes" afin de permettre la création à la volée de participants (PIX-7961)

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -103,6 +103,7 @@ async function createAssessmentCampaign({
       databaseBuilder.factory.buildCampaignSkill({ campaignId: realCampaignId, skillId: skill.id }),
     );
   }
+  const badgeIds = await databaseBuilder.knex('badges').pluck('id').where({ targetProfileId });
 
   const userAndLearnerIds = await _createOrRetrieveUsersAndLearners(
     databaseBuilder,
@@ -167,6 +168,13 @@ async function createAssessmentCampaign({
             createdAt: dayjs().subtract(1, 'day'),
           }),
         );
+      }
+      for (const badgeId of badgeIds) {
+        databaseBuilder.factory.buildBadgeAcquisition({
+          badgeId,
+          userId,
+          campaignParticipationId,
+        });
       }
     } else if (hasValidatedOneSkill) {
       const { answerData, keData } = answersAndKnowledgeElementsForProfile[0];

--- a/api/db/seeds/data/common/tooling/profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/profile-tooling.js
@@ -4,10 +4,15 @@ const generic = require('./generic');
 const Assessment = require('../../../../../lib/domain/models/Assessment');
 const CompetenceEvaluation = require('../../../../../lib/domain/models/CompetenceEvaluation');
 const { PIX_COUNT_BY_LEVEL } = require('../../../../../lib/domain/constants');
+const UNREACHABLE_PIX_SCORE = 999999;
 
 module.exports = {
   createCertifiableProfile,
   createPerfectProfile,
+  getAnswersAndKnowledgeElementsForAdvancedProfile,
+  getAnswersAndKnowledgeElementsForBeginnerProfile,
+  getAnswersAndKnowledgeElementsForIntermediateProfile,
+  getAnswersAndKnowledgeElementsForPerfectProfile,
 };
 
 /**
@@ -16,17 +21,12 @@ module.exports = {
  * @param {number} userId
  * @returns {Promise<void>}
  */
-async function createCertifiableProfile({
-  databaseBuilder,
-  userId,
-}) {
-  const pixCompetences = await learningContent.getCoreCompetences();
-  const fiveRandomCompetences = generic.pickRandomAmong(pixCompetences, 5);
+async function createCertifiableProfile({ databaseBuilder, userId }) {
+  const answersAndKnowledgeElementsCollection = await getAnswersAndKnowledgeElementsForBeginnerProfile();
   _makeUserReachPixScoreForCompetences({
     databaseBuilder,
     userId,
-    competences: fiveRandomCompetences,
-    pixScoreByCompetence: PIX_COUNT_BY_LEVEL,
+    answersAndKnowledgeElementsCollection,
   });
 }
 
@@ -36,25 +36,119 @@ async function createCertifiableProfile({
  * @param {number} userId
  * @returns {Promise<void>}
  */
-async function createPerfectProfile({
-  databaseBuilder,
-  userId,
-}) {
-  const UNREACHABLE_PIX_SCORE = 99999999;
-  const pixCompetences = await learningContent.getCoreCompetences();
+async function createPerfectProfile({ databaseBuilder, userId }) {
+  const answersAndKnowledgeElementsCollection = await getAnswersAndKnowledgeElementsForPerfectProfile();
+
   _makeUserReachPixScoreForCompetences({
     databaseBuilder,
     userId,
-    competences: pixCompetences,
-    pixScoreByCompetence: UNREACHABLE_PIX_SCORE,
+    answersAndKnowledgeElementsCollection,
   });
 }
 
-function _makeCompetenceEvaluation({
-  databaseBuilder,
-  userId,
-  competenceId,
+const ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_BEGINNER_PROFILE = [];
+async function getAnswersAndKnowledgeElementsForBeginnerProfile() {
+  if (ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_BEGINNER_PROFILE.length === 0) {
+    const pixCompetences = await learningContent.getCoreCompetences();
+    const fiveRandomCompetences = generic.pickRandomAmong(pixCompetences, 5);
+
+    await _getAnswersAndKnowledgeElementsForProfile({
+      competences: fiveRandomCompetences,
+      answersAndKnowledgeElementsCollection: ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_BEGINNER_PROFILE,
+      pixScoreByCompetence: PIX_COUNT_BY_LEVEL,
+    });
+  }
+
+  return ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_BEGINNER_PROFILE;
+}
+
+const ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_INTERMEDIATE_PROFILE = [];
+async function getAnswersAndKnowledgeElementsForIntermediateProfile() {
+  if (ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_INTERMEDIATE_PROFILE.length === 0) {
+    const pixCompetences = await learningContent.getCoreCompetences();
+    const eightRandomCompetences = generic.pickRandomAmong(pixCompetences, 8);
+
+    await _getAnswersAndKnowledgeElementsForProfile({
+      competences: eightRandomCompetences,
+      answersAndKnowledgeElementsCollection: ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_INTERMEDIATE_PROFILE,
+      pixScoreByCompetence: PIX_COUNT_BY_LEVEL * 3,
+    });
+  }
+
+  return ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_INTERMEDIATE_PROFILE;
+}
+
+const ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_ADVANCED_PROFILE = [];
+async function getAnswersAndKnowledgeElementsForAdvancedProfile() {
+  if (ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_ADVANCED_PROFILE.length === 0) {
+    const pixCompetences = await learningContent.getCoreCompetences();
+    const twelveRandomCompetences = generic.pickRandomAmong(pixCompetences, 12);
+
+    await _getAnswersAndKnowledgeElementsForProfile({
+      competences: twelveRandomCompetences,
+      answersAndKnowledgeElementsCollection: ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_ADVANCED_PROFILE,
+      pixScoreByCompetence: PIX_COUNT_BY_LEVEL * 4,
+    });
+  }
+
+  return ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_ADVANCED_PROFILE;
+}
+
+const ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_PERFECT_PROFILE = [];
+async function getAnswersAndKnowledgeElementsForPerfectProfile() {
+  if (ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_PERFECT_PROFILE.length === 0) {
+    const pixCompetences = await learningContent.getCoreCompetences();
+
+    await _getAnswersAndKnowledgeElementsForProfile({
+      competences: pixCompetences,
+      answersAndKnowledgeElementsCollection: ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_PERFECT_PROFILE,
+      pixScoreByCompetence: UNREACHABLE_PIX_SCORE,
+    });
+  }
+
+  return ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_PERFECT_PROFILE;
+}
+
+async function _getAnswersAndKnowledgeElementsForProfile({
+  competences,
+  pixScoreByCompetence,
+  answersAndKnowledgeElementsCollection,
 }) {
+  for (const competence of competences) {
+    const skills = await learningContent.findActiveSkillsByCompetenceId(competence.id);
+    const orderedSkills = _.sortBy(skills, 'level');
+    let currentPixScore = 0;
+    for (const skill of orderedSkills) {
+      const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+      const answerData = {
+        value: 'dummy value',
+        result: 'ok',
+        challengeId: challenge.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        timeout: null,
+        resultDetails: 'dummy value',
+      };
+
+      const keData = {
+        source: 'direct',
+        status: 'validated',
+        skillId: skill.id,
+        createdAt: new Date(),
+        earnedPix: skill.pixValue,
+        competenceId: skill.competenceId,
+      };
+      answersAndKnowledgeElementsCollection.push({ answerData, keData });
+
+      currentPixScore += skill.pixValue;
+      if (currentPixScore >= pixScoreByCompetence) {
+        break;
+      }
+    }
+  }
+}
+
+function _makeCompetenceEvaluation({ databaseBuilder, userId, competenceId }) {
   const assessmentId = databaseBuilder.factory.buildAssessment({
     userId,
     competenceId,
@@ -66,51 +160,29 @@ function _makeCompetenceEvaluation({
     competenceId,
     assessmentId,
     status: CompetenceEvaluation.statuses.STARTED,
-  },
-  );
+  });
   return assessmentId;
 }
 
-async function _makeUserReachPixScoreForCompetences({
-  databaseBuilder,
-  userId,
-  competences,
-  pixScoreByCompetence,
-}) {
-  for (const competence of competences) {
-    const assessmentId = _makeCompetenceEvaluation({ databaseBuilder, userId, competenceId: competence.id });
+function _makeUserReachPixScoreForCompetences({ databaseBuilder, userId, answersAndKnowledgeElementsCollection }) {
+  const answersAndKnowledgeElementsByCompetenceId = _.groupBy(
+    answersAndKnowledgeElementsCollection,
+    ({ keData }) => keData.competenceId,
+  );
+  for (const [competenceId, answersAndKnowledgeElements] of Object.entries(answersAndKnowledgeElementsByCompetenceId)) {
+    const assessmentId = _makeCompetenceEvaluation({ databaseBuilder, userId, competenceId });
 
-    const skills = await learningContent.findActiveSkillsByCompetenceId(competence.id);
-    const orderedSkills = _.sortBy(skills, 'level');
-    let currentPixScore = 0;
-    for (const skill of orderedSkills) {
-      const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+    for (const { answerData, keData } of answersAndKnowledgeElements) {
       const answerId = databaseBuilder.factory.buildAnswer({
-        value: 'dummy value',
-        result: 'ok',
         assessmentId,
-        challengeId: challenge.id,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        timeout: null,
-        resultDetails: 'dummy value',
+        ...answerData,
       }).id;
       databaseBuilder.factory.buildKnowledgeElement({
-        source: 'direct',
-        status: 'validated',
-        answerId,
         assessmentId,
-        skillId: skill.id,
-        createdAt: new Date(),
-        earnedPix: skill.pixValue,
         userId,
-        competenceId: skill.competenceId,
+        answerId,
+        ...keData,
       });
-
-      currentPixScore += skill.pixValue;
-      if (currentPixScore >= pixScoreByCompetence) {
-        break;
-      }
     }
   }
 }

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -721,6 +721,9 @@ async function _makeCandidatesComplementaryCertificationCertifiable(
   const { campaignId } = await campaignTooling.createAssessmentCampaign({
     databaseBuilder,
     targetProfileId,
+    configCampaign: {
+      participantCount: 0,
+    },
   });
   const badgeAndComplementaryCertificationBadgeIds = await databaseBuilder
     .knex('complementary-certification-badges')

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -145,6 +145,10 @@ async function _createProfilesCollectionCampaign(databaseBuilder) {
     customResultPageButtonUrl: 'customResultPageButtonUrl',
     multipleSendings: false,
     assessmentMethod: 'SMART_RANDOM',
+    configCampaign: {
+      participantCount: 20,
+      profileDistribution: { beginner: 5, intermediate: 5, advanced: 9, perfect: 1 },
+    },
   });
 }
 

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -203,6 +203,20 @@ async function _createCoreTargetProfile(databaseBuilder) {
     isAlwaysVisible: false,
     configBadge,
   });
+  tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 601,
+    altMessage: '1 RT simple critère Campaign',
+    imageUrl: 'some_other_image.svg',
+    message: '1 RT simple critère Campaign',
+    title: '1 RT simple critère Campaign',
+    key: 'SOME_KEY_FOR_RT_601',
+    isCertifiable: false,
+    isAlwaysVisible: false,
+    configBadge,
+  });
   tooling.targetProfile.createStages({
     databaseBuilder,
     targetProfileId,

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -119,6 +119,9 @@ async function _createAssessmentCampaign(databaseBuilder) {
     customResultPageButtonUrl: 'customResultPageButtonUrl',
     multipleSendings: false,
     assessmentMethod: 'SMART_RANDOM',
+    configCampaign: {
+      participantCount: 30,
+    },
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
Permettre la création de participants ayant partagé leur participant dans les deux types de campagnes : évaluation et collecte de profils + gérer obtention de badge le cas échéant

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Créer un fichier de seed qui fait appel à ces fonctions et vérifier que la création subséquente est en accord avec ce que vous souhaitiez !
Pour avoir un exemple d'usage, on peut consulter le fichier team-contenu/data-builder.js
