### PR TITLE
[TECH] Pouvoir switcher entre vieilles et nouvelles seeds grâce à une variable d'environnement (PIX-8104)

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -48,78 +48,78 @@ const { fillCampaignSkills } = require('./data/fill-campaign-skills');
 const {
   addLastAssessmentResultCertificationCourse,
 } = require('../../scripts/certification/fill-last-assessment-result-certification-course-table');
+const { commonBuilder } = require('./data/common/common-builder');
+const { teamContenuDataBuilder } = require('./data/team-contenu/data-builder');
+const { teamCertificationDataBuilder } = require('./data/team-certification/data-builder');
 
 exports.seed = async (knex) => {
+  const shouldUseNewSeeds = process.env.USE_NEW_SEEDS === 'true';
   const databaseBuilder = new DatabaseBuilder({ knex });
+  if (shouldUseNewSeeds) {
+    commonBuilder({ databaseBuilder });
+    await teamContenuDataBuilder({ databaseBuilder });
+    await teamCertificationDataBuilder({ databaseBuilder });
+    await databaseBuilder.commit();
+    await databaseBuilder.fixSequences();
+  } else {
+    // Feature list
+    featuresBuilder({ databaseBuilder });
 
-  // Feature list
-  featuresBuilder({ databaseBuilder });
+    // Users
+    usersBuilder({ databaseBuilder });
+    pixAdminRolesBuilder({ databaseBuilder });
 
-  // Users
-  usersBuilder({ databaseBuilder });
-  pixAdminRolesBuilder({ databaseBuilder });
+    // Organizations
+    tagsBuilder({ databaseBuilder });
+    organizationsProBuilder({ databaseBuilder });
+    organizationPlacesProBuilder({ databaseBuilder });
 
-  // Organizations
-  tagsBuilder({ databaseBuilder });
-  organizationsProBuilder({ databaseBuilder });
-  organizationPlacesProBuilder({ databaseBuilder });
+    organizationsScoBuilder({ databaseBuilder });
 
-  organizationsScoBuilder({ databaseBuilder });
+    organizationsSupBuilder({ databaseBuilder });
 
-  organizationsSupBuilder({ databaseBuilder });
+    // Target Profiles
+    targetProfilesBuilder({ databaseBuilder });
+    badgesBuilder({ databaseBuilder });
+    stagesBuilder({ databaseBuilder });
 
-  // Target Profiles
-  targetProfilesBuilder({ databaseBuilder });
-  badgesBuilder({ databaseBuilder });
-  stagesBuilder({ databaseBuilder });
+    // Trainings
+    trainingBuilder({ databaseBuilder });
 
-  // Trainings
-  trainingBuilder({ databaseBuilder });
+    // Certifications
+    certificationCentersBuilder({ databaseBuilder });
+    certificationCenterInvitationsBuilder({ databaseBuilder });
+    certificationUsersBuilder({ databaseBuilder });
+    certificationCenterMembershipsBuilder({ databaseBuilder });
+    await certificationUserProfilesBuilder({ databaseBuilder });
+    certificationSessionsBuilder({ databaseBuilder });
+    certificationCandidatesBuilder({ databaseBuilder });
+    await certificationCoursesBuilder({ databaseBuilder });
+    certificationScoresBuilder({ databaseBuilder });
+    badgeAcquisitionBuilder({ databaseBuilder });
+    complementaryCertificationCourseResultsBuilder({ databaseBuilder });
+    issueReportCategoriesBuilder({ databaseBuilder });
 
-  // Certifications
-  certificationCentersBuilder({ databaseBuilder });
-  certificationCenterInvitationsBuilder({ databaseBuilder });
-  certificationUsersBuilder({ databaseBuilder });
-  certificationCenterMembershipsBuilder({ databaseBuilder });
-  await certificationUserProfilesBuilder({ databaseBuilder });
-  certificationSessionsBuilder({ databaseBuilder });
-  certificationCandidatesBuilder({ databaseBuilder });
-  await certificationCoursesBuilder({ databaseBuilder });
-  certificationScoresBuilder({ databaseBuilder });
-  badgeAcquisitionBuilder({ databaseBuilder });
-  complementaryCertificationCourseResultsBuilder({ databaseBuilder });
-  issueReportCategoriesBuilder({ databaseBuilder });
+    // Éléments de parcours
+    campaignsProBuilder({ databaseBuilder });
+    campaignsSupBuilder({ databaseBuilder });
+    campaignsScoBuilder({ databaseBuilder });
+    assessmentsBuilder({ databaseBuilder });
+    answersBuilder({ databaseBuilder });
 
-  // Éléments de parcours
-  campaignsProBuilder({ databaseBuilder });
-  campaignsSupBuilder({ databaseBuilder });
-  campaignsScoBuilder({ databaseBuilder });
-  assessmentsBuilder({ databaseBuilder });
-  answersBuilder({ databaseBuilder });
+    // Éléments de parcours pour l'utilisateur Pix Aile
+    buildPixAileProfile({ databaseBuilder });
 
-  // Éléments de parcours pour l'utilisateur Pix Aile
-  buildPixAileProfile({ databaseBuilder });
+    // Création d'envois pole emploi
+    poleEmploiSendingsBuilder({ databaseBuilder });
 
-  // Création d'envois pole emploi
-  poleEmploiSendingsBuilder({ databaseBuilder });
-
-  userLoginsBuilder({ databaseBuilder });
-  await databaseBuilder.commit();
-  await databaseBuilder.fixSequences();
-  await fillCampaignSkills();
-  await addLastAssessmentResultCertificationCourse();
-  const campaignParticipationData = await getEligibleCampaignParticipations(50000);
-  await generateKnowledgeElementSnapshots(campaignParticipationData, 1);
-  await computeParticipationsResults(10, false);
-
-  // const { commonBuilder } = require('./data/common/common-builder');
-  // const { teamContenuDataBuilder } = require('./data/team-contenu/data-builder');
-  // const { teamCertificationDataBuilder } = require('./data/team-certification/data-builder');
-  // const databaseBuilder = new DatabaseBuilder({ knex });
-  // commonBuilder({ databaseBuilder });
-  // await teamContenuDataBuilder({ databaseBuilder });
-  // await teamCertificationDataBuilder({ databaseBuilder });
-  // await databaseBuilder.commit();
-  // await databaseBuilder.fixSequences();
-
+    userLoginsBuilder({ databaseBuilder });
+    await databaseBuilder.commit();
+    await databaseBuilder.fixSequences();
+    await fillCampaignSkills();
+    await addLastAssessmentResultCertificationCourse();
+    const campaignParticipationData = await getEligibleCampaignParticipations(50000);
+    await generateKnowledgeElementSnapshots(campaignParticipationData, 1);
+    await computeParticipationsResults(10, false);
+  }
 };


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
USE_NEW_SEEDS=true si on veut utiliser les nouvelles seeds

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
