### PR TITLE
[BUGFIX] Corriger à nouveau la taille du logo Pix sur les pages d'épreuve de Certification (PIX-8033).

### DIFF
--- a/mon-pix/app/components/certification-banner.hbs
+++ b/mon-pix/app/components/certification-banner.hbs
@@ -1,8 +1,6 @@
 <div class="assessment-banner--certification {{if @shouldBlurBanner 'blur-banner'}}" role="banner">
   <div class="assessment-banner-container">
-    <div class="assessment-banner__pix-logo">
-      <img src="/images/pix-logo-blanc.svg" role="none" alt="" />
-    </div>
+    <img class="assessment-banner__pix-logo" src="/images/pix-logo-blanc.svg" role="none" alt="" />
     <div class="assessment-banner__splitter"></div>
     <h1 class="assessment-banner__title">{{this.candidateFullName}}</h1>
 


### PR DESCRIPTION
## :unicorn: Problème
Le logo Pix présent lors du passage d'une certification est trop grand. 
![image](https://github.com/1024pix/pix/assets/35962680/7ae1dd8a-94aa-4d60-98b4-4312e095030a).

[Une première PR](https://github.com/1024pix/pix/pull/6190) a été faite sur le sujet mais pour d'obscures raisons, celle-ci n'est pas passée en dev.

## :robot: Proposition
On a opté pour la solution de facilité qui consiste à recréer une PR identique. (NDLR : Car si ça ne rate pas deux fois d'affilée, c'est que ce n'était pas vraiment cassé.)

## :100: Pour tester
- Démarrer une certification sur Pix App, constater que le logo présent en haut à gauche n'est pas gigantesque mais d'une taille plutôt modeste, qui suffit amplement.