### PR TITLE
[FEATURE] Import de CSV pour génération de scénarios déterministes (PIX-8038).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -31,6 +31,29 @@ const register = async (server) => {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/scenario-simulator/csv-import',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: scenarioSimulatorController.importScenarios,
+        payload: {
+          maxBytes: 20715200,
+          output: 'file',
+          parse: 'gunzip',
+        },
+        tags: ['api'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Elle permet de générer la liste de challenges passés avec le nouvel algorithme ainsi que le niveau estimé, pour une liste de réponses données via un import de fichier CSV',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -45,6 +45,7 @@ export class AssessmentSimulator {
         errorRate,
         estimatedLevel,
         reward,
+        answer,
       });
     }
 

--- a/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js
@@ -1,0 +1,20 @@
+import { SCENARIO_SIMULATOR_SERIALIZER_CONFIGURATION } from './scenario-simulator-serializer.js';
+import { Serializer } from 'jsonapi-serializer';
+
+const SERIALIZER_CONFIGURATION = {
+  id: 'index',
+  attributes: ['simulationReport'],
+  transform: (record) => {
+    return {
+      ...record,
+      simulationReport: record.simulationReport.map(SCENARIO_SIMULATOR_SERIALIZER_CONFIGURATION.transform),
+    };
+  },
+  simulationReport: SCENARIO_SIMULATOR_SERIALIZER_CONFIGURATION,
+};
+
+function serialize(scenarioSimulator = {}) {
+  return new Serializer('scenario-simulator-batch', SERIALIZER_CONFIGURATION).serialize(scenarioSimulator);
+}
+
+export const scenarioSimulatorBatchSerializer = { serialize };

--- a/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-serializer.js
@@ -1,9 +1,19 @@
 import { Serializer } from 'jsonapi-serializer';
 
+export const SCENARIO_SIMULATOR_SERIALIZER_CONFIGURATION = {
+  transform: ({ simulationAnswer, ...answer }) => ({
+    ...answer,
+    id: answer.challenge.id,
+    minimumCapability: answer.challenge.minimumCapability,
+    simulationAnswer: simulationAnswer,
+  }),
+  attributes: ['minimumCapability', 'reward', 'errorRate', 'estimatedLevel', 'answer'],
+};
+
 function serialize(scenarioSimulator = {}) {
-  return new Serializer('scenario-simulator-challenge', {
-    attributes: ['minimumCapability', 'reward', 'errorRate', 'estimatedLevel', 'simulationAnswer'],
-  }).serialize(scenarioSimulator);
+  return new Serializer('scenario-simulator-challenge', SCENARIO_SIMULATOR_SERIALIZER_CONFIGURATION).serialize(
+    scenarioSimulator
+  );
 }
 
 export const scenarioSimulatorSerializer = { serialize };

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -14,6 +14,20 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
   beforeEach(async function () {
     sinon.stub(usecases, 'simulateFlashDeterministicAssessmentScenario');
     sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+
+    challenge1 = domainBuilder.buildChallenge({ id: 'chall1', successProbabilityThreshold: 0.65 });
+    reward1 = 0.2;
+    errorRate1 = 0.3;
+    estimatedLevel1 = 0.4;
+    simulationResults = [
+      {
+        challenge: challenge1,
+        reward: reward1,
+        errorRate: errorRate1,
+        estimatedLevel: estimatedLevel1,
+      },
+    ];
+
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
   });
@@ -31,6 +45,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
             reward: reward1,
             errorRate: errorRate1,
             estimatedLevel: estimatedLevel1,
+            answer: 'ok',
           },
         ];
       });
@@ -70,7 +85,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                   'error-rate': errorRate1,
                   'estimated-level': estimatedLevel1,
                   'minimum-capability': 0.6190392084062237,
-                  'simulation-answer': 'ok',
+                  answer: 'ok',
                   reward: reward1,
                 },
                 id: 'chall1',
@@ -78,6 +93,156 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
               },
             ],
           });
+        });
+      });
+    });
+  });
+
+  describe('/api/scenario-simulator/csv-import', function () {
+    describe('#post', function () {
+      context('when the route is called with a csv file and correct headers', function () {
+        it('should call the usecase to validate sessions', async function () {
+          // given
+          const csvToImport = 'ok;ok\nko;ok';
+          const challenge2 = domainBuilder.buildChallenge({ id: 'chall2', successProbabilityThreshold: 0.5 });
+          const reward1 = 0.2;
+          const errorRate1 = 0.3;
+          const estimatedLevel1 = 0.4;
+          const reward2 = 0.6;
+          const errorRate2 = 0.7;
+          const estimatedLevel2 = 0.8;
+          const simulationResults1 = [
+            {
+              challenge: challenge1,
+              reward: reward1,
+              errorRate: errorRate1,
+              estimatedLevel: estimatedLevel1,
+              answer: 'ok',
+            },
+            {
+              challenge: challenge2,
+              reward: reward2,
+              errorRate: errorRate2,
+              estimatedLevel: estimatedLevel2,
+              answer: 'ok',
+            },
+          ];
+
+          const simulationResults2 = [
+            {
+              challenge: challenge1,
+              reward: reward1,
+              errorRate: errorRate1,
+              estimatedLevel: estimatedLevel1,
+              answer: 'ko',
+            },
+            {
+              challenge: challenge2,
+              reward: reward2,
+              errorRate: errorRate2,
+              estimatedLevel: estimatedLevel2,
+              answer: 'ok',
+            },
+          ];
+
+          usecases.simulateFlashDeterministicAssessmentScenario
+            .withArgs({
+              simulationAnswers: ['ok', 'ok'],
+              assessmentId: 0,
+              locale: 'en',
+            })
+            .resolves(simulationResults1);
+
+          usecases.simulateFlashDeterministicAssessmentScenario
+            .withArgs({
+              simulationAnswers: ['ko', 'ok'],
+              assessmentId: 1,
+              locale: 'en',
+            })
+            .resolves(simulationResults2);
+
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/scenario-simulator/csv-import',
+            csvToImport,
+            null,
+            { 'accept-language': 'en', 'Content-Type': 'text/csv;charset=utf-8' }
+          );
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result).to.deep.equal({
+            data: [
+              {
+                type: 'scenario-simulator-batches',
+                id: '0',
+                attributes: {
+                  'simulation-report': [
+                    {
+                      'minimum-capability': 0.6190392084062237,
+                      reward: 0.2,
+                      'error-rate': 0.3,
+                      'estimated-level': 0.4,
+                      answer: 'ok',
+                    },
+                    {
+                      'minimum-capability': 0,
+                      reward: 0.6,
+                      'error-rate': 0.7,
+                      'estimated-level': 0.8,
+                      answer: 'ok',
+                    },
+                  ],
+                },
+              },
+              {
+                type: 'scenario-simulator-batches',
+                id: '1',
+                attributes: {
+                  'simulation-report': [
+                    {
+                      'minimum-capability': 0.6190392084062237,
+                      reward: 0.2,
+                      'error-rate': 0.3,
+                      'estimated-level': 0.4,
+                      answer: 'ko',
+                    },
+                    {
+                      'minimum-capability': 0,
+                      reward: 0.6,
+                      'error-rate': 0.7,
+                      'estimated-level': 0.8,
+                      answer: 'ok',
+                    },
+                  ],
+                },
+              },
+            ],
+          });
+        });
+      });
+
+      context('when the route is called with a wrong csv file and correct headers', function () {
+        it('should send an error message', async function () {
+          // given
+          const csvToImport = 'ok;error';
+
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/scenario-simulator/csv-import',
+            csvToImport,
+            null,
+            { 'accept-language': 'en', 'Content-Type': 'text/csv;charset=utf-8' }
+          );
+
+          // then
+          expect(response.statusCode).to.equal(400);
         });
       });
     });

--- a/api/tests/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/unit/domain/models/AssessmentSimulator_test.js
@@ -49,6 +49,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             estimatedLevel: expectedEstimatedLevel,
             errorRate: expectedErrorRate,
             reward: expectedReward,
+            answer: answers[0],
           },
         ];
 
@@ -149,12 +150,14 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             estimatedLevel: expectedEstimatedLevels[0],
             errorRate: expectedErrorRates[0],
             reward: expectedRewards[0],
+            answer: answersForSimulator[0],
           },
           {
             challenge: challenge1,
             estimatedLevel: expectedEstimatedLevels[1],
             errorRate: expectedErrorRates[1],
             reward: expectedRewards[1],
+            answer: answersForSimulator[1],
           },
         ];
 

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -84,6 +84,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         expect(answer.errorRate).not.to.be.undefined;
         expect(answer.estimatedLevel).not.to.be.undefined;
         expect(answer.reward).not.to.be.undefined;
+        expect(answer.answer).not.to.be.undefined;
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer_test.js
@@ -1,0 +1,54 @@
+import { expect, domainBuilder } from '../../../../test-helper.js';
+import { scenarioSimulatorBatchSerializer } from '../../../../../lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | scenario-simulator-batch-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert scenario simulator objects into JSON API data', function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({
+        id: '1',
+        successProbabilityThreshold: 0.5,
+        difficulty: 0.6,
+        discriminant: 0.5,
+      });
+      const scenarioSimulator = [
+        {
+          index: 0,
+          simulationReport: [
+            {
+              challenge,
+              reward: 2,
+              estimatedLevel: 1,
+              errorRate: 1.5,
+              answer: 'ok',
+            },
+          ],
+        },
+      ];
+
+      // when
+      const scenarioSimulatorMember = scenarioSimulatorBatchSerializer.serialize(scenarioSimulator);
+
+      // then
+      expect(scenarioSimulatorMember).to.deep.equal({
+        data: [
+          {
+            attributes: {
+              'simulation-report': [
+                {
+                  answer: 'ok',
+                  'error-rate': 1.5,
+                  'estimated-level': 1,
+                  'minimum-capability': 0.6,
+                  reward: 2,
+                },
+              ],
+            },
+            id: '0',
+            type: 'scenario-simulator-batches',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-serializer_test.js
@@ -12,11 +12,11 @@ describe('Unit | Serializer | JSONAPI | scenario-simulator-serializer', function
         discriminant: 0.5,
       });
       const scenarioSimulator = {
-        ...challenge,
+        challenge,
         reward: 2,
         estimatedLevel: 1,
         errorRate: 1.5,
-        simulationAnswer: 'ok',
+        answer: 'ok',
       };
 
       // when
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | scenario-simulator-serializer', function
             'error-rate': 1.5,
             'estimated-level': 1,
             'minimum-capability': 0.6,
-            'simulation-answer': 'ok',
+            answer: 'ok',
             reward: 2,
           },
           id: '1',


### PR DESCRIPTION
## :unicorn: Problème

La PR #6218 ne nous permet pas de générer de rapports de scénarios déterministes pour plus d'un seul scénario.

## :robot: Proposition

Nous ajoutons une route permettant d'importer un CSV contenant plusieurs scénarios afin d'obtenir plusieurs rapports en une seule fois.

## :rainbow: Remarques

Contrairement à la route générant un seul rapport de scénario où il était passé en payload, nous générons ici l' `assessmentId` (n'a que peu d'importance car il ne sert qu'à la génération semi-aléatoire) afin de ne pas surcharger le payload

## :100: Pour tester

Créer un fichier CSV en respectant le format suivant : (ne peut contenir que `ok`, `ko` et `aband` 
```
ok,ko,aband
aband,ko,ko
```

```
TOKEN=$(curl 'https://api-pr6233.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6233.review.pix.fr/api/scenario-simulator/csv-import \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: text/csv" \
    -H "Accept-language: fr-fr" \
    -X POST \
    --data-binary @file.csv | jq '.'
```

Où `file` représente le nom du fichier. (garder le @)