### PR TITLE
[TECH] Persister les données créées par le tooling des seeds à chaque fin d'appel (PIX-8107)

### DIFF
--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -64,12 +64,13 @@ export {
   PIX_EDU_2ND_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
 };
 
-function commonBuilder({ databaseBuilder }) {
+async function commonBuilder({ databaseBuilder }) {
   _createSuperAdmin(databaseBuilder);
   _createTags(databaseBuilder);
   _createComplementaryCertifications(databaseBuilder);
   _createCountries(databaseBuilder);
   _createCities(databaseBuilder);
+  await databaseBuilder.commit();
 }
 
 function _createSuperAdmin(databaseBuilder) {

--- a/api/db/seeds/data/common/tooling/certification-center-tooling.js
+++ b/api/db/seeds/data/common/tooling/certification-center-tooling.js
@@ -48,6 +48,7 @@ async function createCertificationCenter({
     complementaryCertificationIds,
   });
 
+  await databaseBuilder.commit();
   return { certificationCenterId };
 }
 

--- a/api/db/seeds/data/common/tooling/organization-tooling.js
+++ b/api/db/seeds/data/common/tooling/organization-tooling.js
@@ -109,6 +109,7 @@ async function createOrganization({
     configOrganization,
   });
 
+  await databaseBuilder.commit();
   return { organizationId };
 }
 

--- a/api/db/seeds/data/common/tooling/profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/profile-tooling.js
@@ -28,6 +28,8 @@ async function createCertifiableProfile({ databaseBuilder, userId }) {
     userId,
     answersAndKnowledgeElementsCollection,
   });
+
+  await databaseBuilder.commit();
 }
 
 /**
@@ -44,6 +46,8 @@ async function createPerfectProfile({ databaseBuilder, userId }) {
     userId,
     answersAndKnowledgeElementsCollection,
   });
+
+  await databaseBuilder.commit();
 }
 
 const ANSWERS_AND_KNOWLEDGE_ELEMENTS_FOR_BEGINNER_PROFILE = [];

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -87,6 +87,7 @@ async function createDraftScoSession({
     configSession,
   });
 
+  await databaseBuilder.commit();
   return { sessionId };
 }
 
@@ -161,6 +162,7 @@ async function createDraftSession({
     certificationCenterId,
   });
 
+  await databaseBuilder.commit();
   return { sessionId };
 }
 
@@ -269,6 +271,7 @@ async function createPublishedScoSession({
   const { coreProfileData } = await _makeCandidatesCertifiable(databaseBuilder, certificationCandidates);
   await _makeCandidatesPassCertification(databaseBuilder, sessionId, certificationCandidates, coreProfileData);
 
+  await databaseBuilder.commit();
   return { sessionId };
 }
 
@@ -384,6 +387,7 @@ async function createPublishedSession({
     complementaryCertificationsProfileData
   );
 
+  await databaseBuilder.commit();
   return { sessionId };
 }
 

--- a/api/db/seeds/data/common/tooling/target-profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/target-profile-tooling.js
@@ -81,6 +81,8 @@ async function createTargetProfile({
     attachedOrganizationIds,
   });
   const cappedTubesDTO = _createTargetProfileTubes({ databaseBuilder, targetProfileId, configTargetProfile });
+
+  await databaseBuilder.commit();
   return {
     targetProfileId,
     cappedTubesDTO,
@@ -111,9 +113,9 @@ async function createTargetProfile({
  *         threshold: number,
  *       },
  *     ]}
- * @returns {badgeId: number}
+ * @returns {Promise<{badgeId: number}>} badgeId
  */
-function createBadge({
+async function createBadge({
   databaseBuilder,
   badgeId,
   targetProfileId,
@@ -140,6 +142,7 @@ function createBadge({
     isAlwaysVisible,
   });
   _createBadgeCriteria({ databaseBuilder, badgeId, configBadge, cappedTubesDTO });
+  await databaseBuilder.commit();
   return {
     badgeId,
   };
@@ -159,9 +162,9 @@ function createBadge({
  * @param includeFirstSkill<boolean>
  * @param countStages<number>
  * @param shouldInsertPrescriberTitleAndDescription<boolean>
- * @returns {stageIds: Array<number>}
+ * @returns {Promise<{stageIds: *[]}>}
  */
-function createStages({
+async function createStages({
   databaseBuilder,
   targetProfileId,
   cappedTubesDTO,
@@ -209,6 +212,7 @@ function createStages({
       })
     );
   }
+  await databaseBuilder.commit();
   return { stageIds };
 }
 

--- a/api/db/seeds/data/common/tooling/training-tooling.js
+++ b/api/db/seeds/data/common/tooling/training-tooling.js
@@ -113,6 +113,8 @@ async function createTraining({
       }
     }
   }
+
+  await databaseBuilder.commit();
   return { trainingId };
 }
 

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -30,10 +30,10 @@ const DRAFT_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
 const PUBLISHED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 3;
 
 async function teamCertificationDataBuilder({ databaseBuilder }) {
-  _createScoOrganization({ databaseBuilder });
-  _createScoCertificationCenter({ databaseBuilder });
-  _createProOrganization({ databaseBuilder });
-  _createProCertificationCenter({ databaseBuilder });
+  await _createScoOrganization({ databaseBuilder });
+  await _createScoCertificationCenter({ databaseBuilder });
+  await _createProOrganization({ databaseBuilder });
+  await _createProCertificationCenter({ databaseBuilder });
   await databaseBuilder.commit();
   await _createScoSession({ databaseBuilder });
   await _createPublishedScoSession({ databaseBuilder });
@@ -43,7 +43,7 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
 
 export { teamCertificationDataBuilder };
 
-function _createScoCertificationCenter({ databaseBuilder }) {
+async function _createScoCertificationCenter({ databaseBuilder }) {
   databaseBuilder.factory.buildUser.withRawPassword({
     id: SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID,
     firstName: 'Centre de certif SCO managing student',
@@ -61,7 +61,7 @@ function _createScoCertificationCenter({ databaseBuilder }) {
     shouldChangePassword: false,
   });
 
-  tooling.certificationCenter.createCertificationCenter({
+  await tooling.certificationCenter.createCertificationCenter({
     databaseBuilder,
     certificationCenterId: SCO_CERTIFICATION_CENTER_ID,
     name: 'Centre de certification sco managing students',
@@ -74,7 +74,7 @@ function _createScoCertificationCenter({ databaseBuilder }) {
   });
 }
 
-function _createProCertificationCenter({ databaseBuilder }) {
+async function _createProCertificationCenter({ databaseBuilder }) {
   databaseBuilder.factory.buildUser.withRawPassword({
     id: PRO_CERTIFICATION_CENTER_USER_ID,
     firstName: 'Centre de certif Pro',
@@ -92,7 +92,7 @@ function _createProCertificationCenter({ databaseBuilder }) {
     shouldChangePassword: false,
   });
 
-  tooling.certificationCenter.createCertificationCenter({
+  await tooling.certificationCenter.createCertificationCenter({
     databaseBuilder,
     certificationCenterId: PRO_CERTIFICATION_CENTER_ID,
     name: 'Centre de certification pro',
@@ -110,7 +110,7 @@ function _createProCertificationCenter({ databaseBuilder }) {
   });
 }
 
-function _createScoOrganization({ databaseBuilder }) {
+async function _createScoOrganization({ databaseBuilder }) {
   databaseBuilder.factory.buildUser.withRawPassword({
     id: SCO_CERTIFICATION_MANAGING_STUDENTS_ORGANIZATION_USER_ID,
     firstName: 'Orga SCO managing Student',
@@ -127,7 +127,7 @@ function _createScoOrganization({ databaseBuilder }) {
     rawPassword: 'pix123',
     shouldChangePassword: false,
   });
-  tooling.organization.createOrganization({
+  await tooling.organization.createOrganization({
     databaseBuilder,
     organizationId: SCO_MANAGING_STUDENTS_ORGANIZATION_ID,
     type: 'SCO',
@@ -141,7 +141,7 @@ function _createScoOrganization({ databaseBuilder }) {
   });
 }
 
-function _createProOrganization({ databaseBuilder }) {
+async function _createProOrganization({ databaseBuilder }) {
   databaseBuilder.factory.buildUser.withRawPassword({
     id: PRO_ORGANIZATION_USER_ID,
     firstName: 'Orga Pro',
@@ -158,7 +158,7 @@ function _createProOrganization({ databaseBuilder }) {
     rawPassword: 'pix123',
     shouldChangePassword: false,
   });
-  tooling.organization.createOrganization({
+  await tooling.organization.createOrganization({
     databaseBuilder,
     organizationId: PRO_ORGANIZATION_ID,
     type: 'PRO',
@@ -194,7 +194,7 @@ async function _createScoSession({ databaseBuilder }) {
 }
 
 async function _createPublishedScoSession({ databaseBuilder }) {
-  tooling.session.createPublishedScoSession({
+  await tooling.session.createPublishedScoSession({
     databaseBuilder,
     sessionId: SCO_PUBLISHED_SESSION_ID,
     organizationId: SCO_MANAGING_STUDENTS_ORGANIZATION_ID,
@@ -246,7 +246,7 @@ async function _createSession({ databaseBuilder }) {
 }
 
 async function _createPublishedSession({ databaseBuilder }) {
-  tooling.session.createPublishedSession({
+  await tooling.session.createPublishedSession({
     databaseBuilder,
     sessionId: PUBLISHED_SESSION_ID,
     accessCode: 'SCOS78',

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -34,7 +34,6 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createScoCertificationCenter({ databaseBuilder });
   await _createProOrganization({ databaseBuilder });
   await _createProCertificationCenter({ databaseBuilder });
-  await databaseBuilder.commit();
   await _createScoSession({ databaseBuilder });
   await _createPublishedScoSession({ databaseBuilder });
   await _createSession({ databaseBuilder });

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -24,10 +24,8 @@ async function teamContenuDataBuilder({ databaseBuilder }) {
   await _createCoreTargetProfile(databaseBuilder);
   await _createDiverseTargetProfile(databaseBuilder);
   await _createTraining(databaseBuilder);
-  await databaseBuilder.commit();
   await _createAssessmentCampaign(databaseBuilder);
   await _createProfilesCollectionCampaign(databaseBuilder);
-
   await _createCertifiableUser(databaseBuilder);
   await _createPerfectProfileUser(databaseBuilder);
 }

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -187,7 +187,7 @@ async function _createCoreTargetProfile(databaseBuilder) {
       'Profil cible pur pix (Niv3 ~ 5) avec 1 RT double critère (tube et participation) et des paliers NIVEAUX',
     configTargetProfile,
   });
-  tooling.targetProfile.createBadge({
+  await tooling.targetProfile.createBadge({
     databaseBuilder,
     targetProfileId,
     cappedTubesDTO,
@@ -201,7 +201,7 @@ async function _createCoreTargetProfile(databaseBuilder) {
     isAlwaysVisible: false,
     configBadge,
   });
-  tooling.targetProfile.createBadge({
+  await tooling.targetProfile.createBadge({
     databaseBuilder,
     targetProfileId,
     cappedTubesDTO,
@@ -215,7 +215,7 @@ async function _createCoreTargetProfile(databaseBuilder) {
     isAlwaysVisible: false,
     configBadge,
   });
-  tooling.targetProfile.createStages({
+  await tooling.targetProfile.createStages({
     databaseBuilder,
     targetProfileId,
     cappedTubesDTO,
@@ -252,7 +252,7 @@ async function _createDiverseTargetProfile(databaseBuilder) {
     description: 'Profil cible pur pix et un autre réf (Niv1 ~ 8) et des paliers SEUILS',
     configTargetProfile,
   });
-  tooling.targetProfile.createStages({
+  await tooling.targetProfile.createStages({
     databaseBuilder,
     targetProfileId,
     cappedTubesDTO,

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -46,7 +46,7 @@ const seed = async function (knex) {
   const shouldUseNewSeeds = process.env.USE_NEW_SEEDS === 'true';
   const databaseBuilder = new DatabaseBuilder({ knex });
   if (shouldUseNewSeeds) {
-    commonBuilder({ databaseBuilder });
+    await commonBuilder({ databaseBuilder });
     await teamContenuDataBuilder({ databaseBuilder });
     await teamCertificationDataBuilder({ databaseBuilder });
     await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

## :robot: Proposition
Appeler le commit dans le tooling comme ça on enlève la responsabilité aux teams de savoir si il faut avoir la donnée en base.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
