### PR TITLE
[TECH] Spécifie la version minimale de node 16 sur l'API pour que cela fonctionne

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
+    "node": ">=16.15 <18",
     "npm": ">=8.13.2 <9"
   },
   "type": "module",


### PR DESCRIPTION
## :unicorn: Problème
Avec le passage aux modules ESM, nous avons besoin d'importer des modules json. Ceux ci sont disponible sans flag a partir de la version 16.15.

## :robot: Proposition
Spécifier dans le package.json que la version 16.15 est la minimum compatible.

## :rainbow: Remarques
Voir la PR qui enleve le flag:
https://github.com/nodejs/node/pull/41736

## :100: Pour tester
1. Tester en 16.14 et voir que l'API ne démarre pas
2.  Tester en 16.15 et voir que l'API démarre
