### PR TITLE
[BUGFIX] Corrige le traitement des taches Pole Emploi (PIX-8079)

### DIFF
--- a/api/lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js
+++ b/api/lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js
@@ -2,8 +2,8 @@ import { JobPgBoss } from '../JobPgBoss.js';
 
 class SendSharedParticipationResultsToPoleEmploiJob extends JobPgBoss {
   constructor(queryBuilder) {
-    super({ name: 'SendSharedParticipationResultsToPoleEmploi', retryLimit: 0 }, queryBuilder);
+    super({ name: 'SendSharedParticipationResultsToPoleEmploiJob', retryLimit: 0 }, queryBuilder);
   }
 }
 
-export { SendSharedParticipationResultsToPoleEmploiJob as SendSharedParticipationResultsToPoleEmploiJob };
+export { SendSharedParticipationResultsToPoleEmploiJob };

--- a/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
@@ -1,7 +1,7 @@
 import { expect, knex } from '../../../../test-helper.js';
 import { SendSharedParticipationResultsToPoleEmploiJob } from '../../../../../lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
 
-describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationResultCalculation', function () {
+describe('Integration | Infrastructure | Jobs | CampaignResult | SendSharedParticipationResultsToPoleEmploiJob', function () {
   afterEach(async function () {
     await knex('pgboss.job').delete();
   });
@@ -12,7 +12,7 @@ describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationRe
 
       await job.schedule({ params: 12 });
 
-      const jobBDD = await knex('pgboss.job').where({ name: 'SendSharedParticipationResultsToPoleEmploi' }).first();
+      const jobBDD = await knex('pgboss.job').where({ name: 'SendSharedParticipationResultsToPoleEmploiJob' }).first();
 
       expect(jobBDD.retrylimit).to.equal(0);
       expect(jobBDD.data).to.deep.equal({ params: 12 });

--- a/api/worker.js
+++ b/api/worker.js
@@ -47,6 +47,10 @@ async function runJobs() {
     SendSharedParticipationResultsToPoleEmploiJob.name,
     SendSharedParticipationResultsToPoleEmploiHandler
   );
+  monitoredJobQueue.performJob(
+    'SendSharedParticipationResultsToPoleEmploi',
+    SendSharedParticipationResultsToPoleEmploiHandler
+  );
 
   await scheduleCpfJobs(pgBoss);
 }


### PR DESCRIPTION
## :unicorn: Problème
Depuis la version ESM de l'API, les jobs de pole emploi ne se dépilent plus. Cela est du a une différence de nommage du job.

## :robot: Proposition
Harmoniser les queues pour que les queues pgboss finissent par Job. Pour des raisons de compatibilité, on laisse un handler 'SendSharedParticipationResultsToPoleEmploi' tourner le temps de la transition.


## :100: Pour tester
TBD
