### PR TITLE
[FEATURE] Création du endpoint pour la suppression de prescrits (PIX-7948)

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -459,7 +459,7 @@ function _buildAssessmentParticipations({ databaseBuilder, users }) {
   const userIdsNotShared2 = [users[6], users[7]];
   const userIdsCompletedShared = [users[10], users[12]];
   const userIdsCompletedShared2 = [users[0], users[9]];
-  const userIdsCompletedSharedWith2Badges = [users[3], users[11]];
+  const userIdsCompletedSharedWith2Badges = [users[3], users[11], users[14]];
 
   userIdsNotCompleted.forEach((user) =>
     participateToAssessmentCampaign({
@@ -595,11 +595,12 @@ function _buildProfilesCollectionParticipations({ databaseBuilder, users }) {
   const certifRegularUser4 = { id: CERTIF_REGULAR_USER4_ID, createdAt: new Date('2022-02-06') };
   const certifRegularUser5 = { id: CERTIF_REGULAR_USER5_ID, createdAt: new Date('2022-02-07') };
   const userIdsNotShared = [users[1], users[2], users[3], users[4], users[5], users[6], users[7], users[8]];
-  const userIdsShared = [users[0], users[9], users[10], users[11], users[12]];
+  const userIdsShared = [users[0], users[9], users[10], users[11], users[12], users[14]];
   const userIdsCertifiable = [
     users[10].id,
     users[11].id,
     users[12].id,
+    users[14].id,
     certifRegularUser1.id,
     certifRegularUser2.id,
     certifRegularUser3.id,

--- a/api/lib/application/organization-learners-management/index.js
+++ b/api/lib/application/organization-learners-management/index.js
@@ -1,0 +1,43 @@
+import { securityPreHandlers } from '../security-pre-handlers.js';
+import Joi from 'joi';
+import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { organizationLearnersController } from './organization-learners-controller.js';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'DELETE',
+      path: '/api/organizations/{id}/organization-learners',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+          {
+            method: securityPreHandlers.checkUserDoesNotBelongsToScoOrganizationManagingStudents,
+            assign: 'isNotFromScoOrganizationManagingStudents',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+          payload: Joi.object({
+            listLearners: Joi.array().required().items(Joi.number().required()),
+          }),
+        },
+        handler: organizationLearnersController.deleteOrganizationLearners,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation**\n" +
+            "- Elle permet l'ajout d'un deletedAt et d'un deletedBy aux prescrits",
+        ],
+        tags: ['api', 'organization-learners'],
+      },
+    },
+  ]);
+};
+
+const name = 'organization-learners-management-api';
+
+export { register, name };

--- a/api/lib/application/organization-learners-management/organization-learners-controller.js
+++ b/api/lib/application/organization-learners-management/organization-learners-controller.js
@@ -1,0 +1,35 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learners-management/organization-learner-repository.js';
+import * as campaignParticipationRepository from '../../infrastructure/repositories/organization-learners-management/campaign-participation-repository.js';
+import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
+
+/* 
+Pour séparer le code par contexte nous avons introduit un niveau de dossier. 
+Pour ce controller, le dossier s'appelle organization-learners-management.
+Il existe des repositories "organizationLearnersRepository" et "campaignParticipationRepository" dans le dossier repositories.
+Notre injection de dépendances ne permet pas d'avoir deux repositories avec le même nom.
+Nous sommes donc obligés d'injecter ces dépendances au niveau de ce controller.
+*/
+const deleteOrganizationLearners = async function (
+  request,
+  h,
+  dependencies = { organizationLearnerRepository, campaignParticipationRepository }
+) {
+  const authenticatedUserId = request.auth.credentials.userId;
+  const listLearners = request.payload.listLearners;
+
+  await DomainTransaction.execute(async (domainTransaction) => {
+    await usecases.deleteOrganizationLearners({
+      organizationLearnerIds: listLearners,
+      userId: authenticatedUserId,
+      organizationLearnerRepository: dependencies.organizationLearnerRepository,
+      campaignParticipationRepository: dependencies.campaignParticipationRepository,
+      domainTransaction,
+    });
+  });
+  return h.response().code(200);
+};
+
+const organizationLearnersController = { deleteOrganizationLearners };
+
+export { organizationLearnersController };

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -336,6 +336,31 @@ async function checkCertificationCenterIsNotScoManagingStudents(
   return h.response(true);
 }
 
+async function checkUserDoesNotBelongsToScoOrganizationManagingStudents(
+  request,
+  h,
+  dependencies = {
+    checkOrganizationIsScoAndManagingStudentUsecase,
+    organizationRepository,
+  }
+) {
+  if (_noCredentials(request)) {
+    return _replyForbiddenError(h);
+  }
+
+  const organizationId = request.params.id;
+
+  const isOrganizationScoManagingStudent = await dependencies.checkOrganizationIsScoAndManagingStudentUsecase.execute({
+    organizationId,
+  });
+
+  if (isOrganizationScoManagingStudent) {
+    return _replyForbiddenError(h);
+  }
+
+  return h.response(true);
+}
+
 function _noCredentials(request) {
   return !request?.auth?.credentials || !request.auth.credentials.userId;
 }
@@ -544,6 +569,7 @@ const securityPreHandlers = {
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkCertificationCenterIsNotScoManagingStudents,
   checkUserBelongsToSupOrganizationAndManagesStudents,
+  checkUserDoesNotBelongsToScoOrganizationManagingStudents,
   checkAdminMemberHasRoleSuperAdmin,
   checkAdminMemberHasRoleCertif,
   checkAdminMemberHasRoleSupport,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -270,6 +270,7 @@ import { deactivateAdminMember } from './deactivate-admin-member.js';
 import { deleteCampaignParticipation } from './delete-campaign-participation.js';
 import { deleteCampaignParticipationForAdmin } from './delete-campaign-participation-for-admin.js';
 import { deleteCertificationIssueReport } from './delete-certification-issue-report.js';
+import { deleteOrganizationLearners } from './organization-learners-management/delete-organization-learners.js';
 import { deleteOrganizationPlaceLot } from './delete-organization-place-lot.js';
 import { deleteSession } from './delete-session.js';
 import { deleteSessionJuryComment } from './delete-session-jury-comment.js';
@@ -769,6 +770,7 @@ const usecasesWithoutInjectedDependencies = {
   deleteCampaignParticipation,
   deleteCampaignParticipationForAdmin,
   deleteCertificationIssueReport,
+  deleteOrganizationLearners,
   deleteOrganizationPlaceLot,
   deleteSession,
   deleteSessionJuryComment,

--- a/api/lib/domain/usecases/organization-learners-management/delete-organization-learners.js
+++ b/api/lib/domain/usecases/organization-learners-management/delete-organization-learners.js
@@ -1,0 +1,17 @@
+const deleteOrganizationLearners = async function ({
+  organizationLearnerIds,
+  userId,
+  organizationLearnerRepository,
+  campaignParticipationRepository,
+  domainTransaction,
+}) {
+  await campaignParticipationRepository.removeByOrganizationLearnerIds({
+    organizationLearnerIds,
+    userId,
+    domainTransaction,
+  });
+
+  await organizationLearnerRepository.removeByIds({ organizationLearnerIds, userId, domainTransaction });
+};
+
+export { deleteOrganizationLearners };

--- a/api/lib/infrastructure/repositories/organization-learners-management/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learners-management/campaign-participation-repository.js
@@ -1,0 +1,8 @@
+const removeByOrganizationLearnerIds = function ({ organizationLearnerIds, userId, domainTransaction }) {
+  return domainTransaction
+    .knexTransaction('campaign-participations')
+    .whereIn('organizationLearnerId', organizationLearnerIds)
+    .update({ deletedAt: new Date(), deletedBy: userId });
+};
+
+export { removeByOrganizationLearnerIds };

--- a/api/lib/infrastructure/repositories/organization-learners-management/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learners-management/organization-learner-repository.js
@@ -1,0 +1,8 @@
+const removeByIds = function ({ organizationLearnerIds, userId, domainTransaction }) {
+  return domainTransaction
+    .knexTransaction('organization-learners')
+    .whereIn('id', organizationLearnerIds)
+    .update({ deletedAt: new Date(), deletedBy: userId });
+};
+
+export { removeByIds };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -34,6 +34,8 @@ import * as memberships from './application/memberships/index.js';
 import * as organizationInvitations from './application/organization-invitations/index.js';
 import * as organizations from './application/organizations/index.js';
 import * as organizationsAdministration from './application/organizations-administration/index.js';
+import * as organizationLearners from './application/organization-learners/index.js';
+import * as organizationLearnersManagement from './application/organization-learners-management/index.js';
 import * as passwords from './application/passwords/index.js';
 import * as poleEmploi from './application/pole-emploi/index.js';
 import * as prescribers from './application/prescribers/index.js';
@@ -41,7 +43,7 @@ import * as progressions from './application/progressions/index.js';
 import * as saml from './application/saml/index.js';
 import * as stageCollection from './application/stage-collections/index.js';
 import * as scoringSimulator from './application/scoring-simulator/index.js';
-import * as organizationLearners from './application/organization-learners/index.js';
+
 import * as scenarioSimulator from './application/scenarios-simulator/index.js';
 import * as scorecards from './application/scorecards/index.js';
 import * as scoOrganizationLearners from './application/sco-organization-learners/index.js';
@@ -92,6 +94,7 @@ const routes = [
   lcms,
   memberships,
   organizationLearners,
+  organizationLearnersManagement,
   organizations,
   organizationsAdministration,
   passwords,

--- a/api/tests/acceptance/application/organization-learners-management/organization-learners-controller_test.js
+++ b/api/tests/acceptance/application/organization-learners-management/organization-learners-controller_test.js
@@ -1,0 +1,41 @@
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | Controller | organization-learners-management', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('DELETE /organizations/{id}/organization-learners', function () {
+    let options;
+
+    it('should return a 200 status after having successfully deleted organization learners', async function () {
+      // given
+      const { id: firstOrganizationLearnerId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const secondOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId, organizationRole: 'ADMIN' });
+
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'DELETE',
+        url: `/api/organizations/${organizationId}/organization-learners`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+        payload: {
+          listLearners: [firstOrganizationLearnerId, secondOrganizationLearnerId],
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/application/organization-learners-management/index_test.js
+++ b/api/tests/integration/application/organization-learners-management/index_test.js
@@ -1,0 +1,119 @@
+import {
+  expect,
+  sinon,
+  HttpTestServer,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+} from '../../../test-helper.js';
+
+import { organizationLearnersController } from '../../../../lib/application/organization-learners-management/organization-learners-controller.js';
+import * as moduleUnderTest from '../../../../lib/application/organization-learners-management/index.js';
+
+describe('Integration | Application | Organization Learners Management | Routes', function () {
+  describe('DELETE /organizations/{id}/organization-learners', function () {
+    const method = 'DELETE';
+
+    let headers, httpTestServer, organizationId, url, payload;
+    beforeEach(async function () {
+      sinon.stub(organizationLearnersController, 'deleteOrganizationLearners').returns('ok');
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      httpTestServer.setupAuthentication();
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+    });
+
+    it('return a 401 status code when trying to call route unauthenticated', async function () {
+      url = '/api/organizations/2/organization-learners';
+      // given
+      headers = {
+        authorization: null,
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('return a 403 status code when trying to call route but user is not admin', async function () {
+      // given
+      url = `/api/organizations/${organizationId}/organization-learners`;
+      const simpleUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId: simpleUserId, organizationRole: 'MEMBER' });
+      await databaseBuilder.commit();
+      headers = {
+        authorization: generateValidRequestAuthorizationHeader(simpleUserId),
+      };
+      payload = {
+        listLearners: [123],
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('return a 403 status code when trying to call route with admin user but organization is sco managing student', async function () {
+      // given
+      url = `/api/organizations/${organizationId}/organization-learners`;
+      const adminUser = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId: adminUser, organizationRole: 'ADMIN' });
+      await databaseBuilder.commit();
+      headers = {
+        authorization: generateValidRequestAuthorizationHeader(adminUser),
+      };
+      payload = {
+        listLearners: [123],
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('return a 400 status code when trying to call route with illegal organization id', async function () {
+      // given
+      const wrongUrl = `/api/organizations/diabloIV/organization-learners`;
+      const adminUser = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId: adminUser, organizationRole: 'ADMIN' });
+      await databaseBuilder.commit();
+      headers = {
+        authorization: generateValidRequestAuthorizationHeader(adminUser),
+      };
+      payload = {
+        listLearners: [123],
+      };
+
+      // when
+      const response = await httpTestServer.request(method, wrongUrl, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('return a 400 status code when trying to call route with illegal payload', async function () {
+      // given
+      url = `/api/organizations/${organizationId}/organization-learners`;
+      const adminUser = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId: adminUser, organizationRole: 'ADMIN' });
+      await databaseBuilder.commit();
+      headers = {
+        authorization: generateValidRequestAuthorizationHeader(adminUser),
+      };
+      payload = {
+        listLearners: ['VIVEDIABLO'],
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/organization-learners-management/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learners-management/campaign-participation-repository_test.js
@@ -1,0 +1,76 @@
+import { expect, knex, databaseBuilder, sinon } from '../../../../test-helper.js';
+import { removeByOrganizationLearnerIds } from '../../../../../lib/infrastructure/repositories/organization-learners-management/campaign-participation-repository.js';
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+
+describe('Integration | Repository | Organization Learners Management | Campaign Participation', function () {
+  describe('#removeByOrganizationLearnerIds', function () {
+    let clock;
+    const now = new Date('2023-02-02');
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now);
+    });
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('delete participations of one organization learner', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ userId });
+      const { organizationLearnerId } = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, isImproved: true, organizationLearnerId });
+
+      await databaseBuilder.commit();
+
+      // when
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await removeByOrganizationLearnerIds({
+          organizationLearnerIds: [organizationLearnerId],
+          userId,
+          domainTransaction,
+        });
+      });
+      // then
+      const campaignParticipationResult = await knex('campaign-participations')
+        .select('deletedAt', 'deletedBy')
+        .where({ organizationLearnerId })
+        .first();
+
+      expect(campaignParticipationResult.deletedAt).to.deep.equal(now);
+      expect(campaignParticipationResult.deletedBy).to.equal(userId);
+    });
+
+    it('delete participations of more than one organization learner', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ userId });
+      const { organizationLearnerId: organizationLearnerId1 } = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+      const { organizationLearnerId: organizationLearnerId2 } = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await removeByOrganizationLearnerIds({
+          organizationLearnerIds: [organizationLearnerId1, organizationLearnerId2],
+          userId,
+          domainTransaction,
+        });
+      });
+
+      // then
+      const campaignParticipationResult = await knex('campaign-participations')
+        .select('deletedAt', 'deletedBy')
+        .whereIn('organizationLearnerId', [organizationLearnerId1, organizationLearnerId2])
+        .whereNull('deletedAt');
+
+      expect(campaignParticipationResult.length).to.equal(0);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/organization-learners-management/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learners-management/organization-learner-repository_test.js
@@ -1,0 +1,72 @@
+import { expect, knex, databaseBuilder, sinon } from '../../../../test-helper.js';
+import { removeByIds } from '../../../../../lib/infrastructure/repositories/organization-learners-management/organization-learner-repository.js';
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+
+describe('Integration | Repository | Organization Learner Management | Organization Learner', function () {
+  describe('#removeByIds', function () {
+    let clock;
+    const now = new Date('2023-02-02');
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now);
+    });
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('delete one organization learner', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      }).id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const organizationLearnersIdsToDelete = [organizationLearnerId];
+
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await removeByIds({ organizationLearnerIds: organizationLearnersIdsToDelete, userId, domainTransaction });
+      });
+
+      // then
+      const organizationLearnerResult = await knex('organization-learners')
+        .select('deletedAt', 'deletedBy')
+        .where('id', organizationLearnerId)
+        .first();
+
+      expect(organizationLearnerResult.deletedAt).to.deep.equal(now);
+      expect(organizationLearnerResult.deletedBy).to.equal(userId);
+    });
+
+    it('delete more than one organization learners at the same time', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const firstOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      }).id;
+      const secondOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      }).id;
+      const thirdOrganisationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      }).id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const organizationLearnersIdToDelete = [firstOrganizationLearnerId, secondOrganizationLearnerId];
+
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await removeByIds({ organizationLearnerIds: organizationLearnersIdToDelete, userId, domainTransaction });
+      });
+
+      // then
+      const learners = await knex('view-active-organization-learners').where({ organizationId });
+      expect(learners.length).to.equal(1);
+      expect(learners[0].id).to.equal(thirdOrganisationLearnerId);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/organization-learners-management/delete-organization-learners_test.js
+++ b/api/tests/unit/domain/usecases/organization-learners-management/delete-organization-learners_test.js
@@ -1,0 +1,45 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { deleteOrganizationLearners } from '../../../../../lib/domain/usecases/organization-learners-management/delete-organization-learners.js';
+
+describe('Unit | UseCase | Organization Learners Management | Delete Organization Learners', function () {
+  let campaignParticipationRepository;
+  let organizationLearnerRepository;
+
+  beforeEach(function () {
+    campaignParticipationRepository = {
+      removeByOrganizationLearnerIds: sinon.stub(),
+    };
+    organizationLearnerRepository = {
+      removeByIds: sinon.stub(),
+    };
+  });
+
+  it('should delete organization learners and their participations', async function () {
+    // given
+    const userId = 777;
+    const domainTransaction = Symbol('transaction');
+    const organizationLearnerIds = [123, 456, 789];
+
+    // when
+    await deleteOrganizationLearners({
+      organizationLearnerIds,
+      userId,
+      campaignParticipationRepository,
+      organizationLearnerRepository,
+      domainTransaction,
+    });
+
+    // then
+    expect(campaignParticipationRepository.removeByOrganizationLearnerIds).to.have.been.calledWith({
+      organizationLearnerIds,
+      userId,
+      domainTransaction,
+    });
+
+    expect(organizationLearnerRepository.removeByIds).to.have.been.calledWith({
+      organizationLearnerIds,
+      userId,
+      domainTransaction,
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous avons réalisé les tickets back nécessaire pour rendre possible de supprimer des prescrits. Nous pouvons maintenant passer à l’API et au front, sachant que cet ensemble de tickets doivent être réalisés dans une même branche et partir en prod en simultané.

## :robot: Proposition
Créer un endpoint pour supprimer un prescrit.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
