### PR TITLE
[FEATURE] Empêcher la soumission du formulaire d'inscription de Pix App si des erreurs n'ont pas été corrigées (PIX-7815)

### DIFF
--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -120,6 +120,7 @@ export default class SignupForm extends Component {
   async signup(event) {
     event && event.preventDefault();
 
+    if (this.args.user.errors?.length) return;
     if (!this.validation.isValid) return;
 
     this.isLoading = true;
@@ -132,7 +133,6 @@ export default class SignupForm extends Component {
     try {
       await this.args.user.save({ adapterOptions: { campaignCode } });
       await this.session.authenticateUser(this.args.user.email, this.args.user.password);
-      this._tokenHasBeenUsed = true;
       this.args.user.password = null;
     } catch (errorResponse) {
       const error = get(errorResponse, 'errors[0]');
@@ -141,6 +141,7 @@ export default class SignupForm extends Component {
       } else {
         this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
       }
+    } finally {
       this._tokenHasBeenUsed = true;
       this.isLoading = false;
     }

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -57,6 +57,7 @@ export default class SignupForm extends Component {
   @tracked errorMessage = null;
   @tracked isLoading = false;
   @tracked validation = new SignupFormValidation();
+
   _tokenHasBeenUsed = null;
 
   get showcase() {
@@ -69,45 +70,6 @@ export default class SignupForm extends Component {
 
   get dataProtectionPolicyUrl() {
     return this.url.dataProtectionPolicyUrl;
-  }
-
-  _getErrorMessage(status, key) {
-    return status === 'error' ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
-  }
-
-  _getValidationStatus(isValidField) {
-    return isValidField ? 'error' : 'success';
-  }
-
-  _isValuePresent(value) {
-    return value.trim() ? true : false;
-  }
-
-  _updateValidationStatus(key, status, message) {
-    this.validation[key].status = status;
-    this.validation[key].message = message;
-  }
-
-  _updateInputsStatus() {
-    const errors = this.args.user.errors;
-    errors.forEach(({ attribute, message }) => {
-      this._updateValidationStatus(attribute, 'error', message);
-    });
-  }
-
-  _executeFieldValidation(key, isValid) {
-    const modelAttrValue = this.args.user[key];
-    const isValidInput = !isValid(modelAttrValue);
-    const status = this._getValidationStatus(isValidInput);
-    const message = this._getErrorMessage(status, key);
-    this._updateValidationStatus(key, status, message);
-  }
-
-  _trimNamesAndEmailOfUser() {
-    const { firstName, lastName, email } = this.args.user;
-    this.args.user.firstName = firstName.trim();
-    this.args.user.lastName = lastName.trim();
-    this.args.user.email = email.trim();
   }
 
   @action
@@ -203,5 +165,44 @@ export default class SignupForm extends Component {
       default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY,
     };
     return this.intl.t(httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default']);
+  }
+
+  _getErrorMessage(status, key) {
+    return status === 'error' ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
+  }
+
+  _getValidationStatus(isValidField) {
+    return isValidField ? 'error' : 'success';
+  }
+
+  _isValuePresent(value) {
+    return value.trim() ? true : false;
+  }
+
+  _updateValidationStatus(key, status, message) {
+    this.validation[key].status = status;
+    this.validation[key].message = message;
+  }
+
+  _updateInputsStatus() {
+    const errors = this.args.user.errors;
+    errors.forEach(({ attribute, message }) => {
+      this._updateValidationStatus(attribute, 'error', message);
+    });
+  }
+
+  _executeFieldValidation(key, isValid) {
+    const modelAttrValue = this.args.user[key];
+    const isValidInput = !isValid(modelAttrValue);
+    const status = this._getValidationStatus(isValidInput);
+    const message = this._getErrorMessage(status, key);
+    this._updateValidationStatus(key, status, message);
+  }
+
+  _trimNamesAndEmailOfUser() {
+    const { firstName, lastName, email } = this.args.user;
+    this.args.user.firstName = firstName.trim();
+    this.args.user.lastName = lastName.trim();
+    this.args.user.email = email.trim();
   }
 }

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -45,6 +45,16 @@ class SignupFormValidation {
   email = new Email();
   password = new Password();
   cgu = new Cgu();
+
+  get isValid() {
+    return [
+      this.lastName.status,
+      this.firstName.status,
+      this.email.status,
+      this.password.status,
+      this.cgu.status,
+    ].every((status) => status !== 'error');
+  }
 }
 
 export default class SignupForm extends Component {
@@ -109,6 +119,9 @@ export default class SignupForm extends Component {
   @action
   async signup(event) {
     event && event.preventDefault();
+
+    if (!this.validation.isValid) return;
+
     this.isLoading = true;
 
     this._trimNamesAndEmailOfUser();

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -46,7 +46,7 @@ module('Integration | Component | SignupForm', function (hooks) {
   });
 
   module('Rendering', function () {
-    test('should display form elements', async function (assert) {
+    test('displays form elements', async function (assert) {
       // given
       this.set('user', userEmpty);
 
@@ -81,7 +81,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.dom(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') })).exists();
     });
 
-    test("should have links to Pix's CGU and data protection policy ", async function (assert) {
+    test("links to Pix's CGU and data protection policy are available", async function (assert) {
       // given
       this.set('user', userEmpty);
 
@@ -93,7 +93,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.ok(screen.getByRole('link', { name: this.intl.t('common.cgu.data-protection-policy') }));
     });
 
-    test('should render a submit button', async function (assert) {
+    test('renders a submit button', async function (assert) {
       // given
       this.set('user', userEmpty);
 
@@ -104,7 +104,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.ok(screen.getByRole('button', { name: this.intl.t('pages.sign-up.actions.submit') }));
     });
 
-    test('[a11y] it should display a message that all inputs are required', async function (assert) {
+    test('[a11y] displays a message that all inputs are required', async function (assert) {
       // given & when
       const screen = await render(hbs`<SignupForm />`);
 
@@ -136,7 +136,7 @@ module('Integration | Component | SignupForm', function (hooks) {
   });
 
   module('When API returns errors', function () {
-    test('should display an error if api cannot be reached', async function (assert) {
+    test('displays an error if api cannot be reached', async function (assert) {
       // given
       const stubCatchedApiErrorInternetDisconnected = undefined;
 
@@ -158,7 +158,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
 
-    test('should display related error message if internal server error', async function (assert) {
+    test('displays related error message if internal server error', async function (assert) {
       // given
       const apiReturn = {
         errors: [
@@ -187,7 +187,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
 
-    test('should display related error message if bad gateway error', async function (assert) {
+    test('displays related error message if bad gateway error', async function (assert) {
       // given
       const apiReturn = {
         errors: [
@@ -215,7 +215,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.BAD_GATEWAY.I18N_KEY))).exists();
     });
 
-    test('should display related error message if gateway timeout error', async function (assert) {
+    test('displays related error message if gateway timeout error', async function (assert) {
       // given
       const apiReturn = {
         errors: [
@@ -243,7 +243,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.GATEWAY_TIMEOUT.I18N_KEY))).exists();
     });
 
-    test('should display related error message if not implemented error', async function (assert) {
+    test('displays related error message if not implemented error', async function (assert) {
       // given
       const apiReturn = {
         errors: [
@@ -283,8 +283,9 @@ module('Integration | Component | SignupForm', function (hooks) {
       this.owner.register('service:session', sessionService);
       session = this.owner.lookup('service:session', sessionService);
     });
-    module('behavior when signup successful (test external calls)', function () {
-      test('should return true if action <Signup> is handled', async function (assert) {
+
+    module('when signup is successful (test external calls)', function () {
+      test('returns true if action <Signup> is handled', async function (assert) {
         // given
         let isFormSubmitted = false;
         const user = EmberObject.create({
@@ -308,7 +309,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.true(isFormSubmitted);
       });
 
-      test('should authenticate the user and empty the password', async function (assert) {
+      test('authenticates the user and empty the password', async function (assert) {
         // given
         const authenticateUserStub = sinon.stub();
 
@@ -336,7 +337,7 @@ module('Integration | Component | SignupForm', function (hooks) {
     });
 
     module('Errors management', function () {
-      test('should display an error message on first name field, when field is empty and focus-out', async function (assert) {
+      test('displays an error message on first name field, when field is empty and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -353,7 +354,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.firstname.error'))).exists();
       });
 
-      test('should display an error message on last name field, when field is empty and focus-out', async function (assert) {
+      test('displays an error message on last name field, when field is empty and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -370,7 +371,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.lastname.error'))).exists();
       });
 
-      test('should display an error message on email field, when field is empty and focus-out', async function (assert) {
+      test('displays an error message on email field, when field is empty and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -387,7 +388,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.email.error'))).exists();
       });
 
-      test('should display an error message on password field, when field is empty and focus-out', async function (assert) {
+      test('displays an error message on password field, when field is empty and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -404,7 +405,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.password.error'))).exists();
       });
 
-      test("should display an error message on cgu field, when cgu isn't accepted and form is submitted", async function (assert) {
+      test("displays an error message on cgu field, when cgu isn't accepted and form is submitted", async function (assert) {
         // given
         const uncheckedCheckboxCguErrorMessage = this.intl.t('common.cgu.error');
         const userWithCguNotAccepted = EmberObject.create({
@@ -438,7 +439,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.getByText(uncheckedCheckboxCguErrorMessage)).exists();
       });
 
-      test('should display an error message on email field, when email above a maximum length of 255 and focus-out', async function (assert) {
+      test('displays an error message on email field, when email above a maximum length of 255 and focus-out', async function (assert) {
         // given
         const expectedMaxLengthEmailError = 'Votre adresse e-mail ne doit pas dépasser les 255 caractères.';
         const errors = [
@@ -479,7 +480,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.getByText(expectedMaxLengthEmailError)).exists();
       });
 
-      test('should not display success notification message when an error occurred during the form submission', async function (assert) {
+      test('does not display success notification message when an error occurred during the form submission', async function (assert) {
         const userThatThrowAnErrorDuringSaving = EmberObject.create({
           errors: ArrayProxy.create({
             content: [
@@ -568,7 +569,7 @@ module('Integration | Component | SignupForm', function (hooks) {
     });
 
     module('Successfull cases', function () {
-      test('should display first name field as validated without error message, when field is filled and focus-out', async function (assert) {
+      test('displays first name field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -585,7 +586,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.firstname.error'))).doesNotExist();
       });
 
-      test('should display last name field as validated without error message, when field is filled and focus-out', async function (assert) {
+      test('displays last name field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -602,7 +603,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.lastname.error'))).doesNotExist();
       });
 
-      test('should display email field as validated without error message, when field is filled and focus-out', async function (assert) {
+      test('displays email field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -619,7 +620,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.email.error'))).doesNotExist();
       });
 
-      test('should display password field as validated without error message, when field is filled and focus-out', async function (assert) {
+      test('displays password field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
@@ -636,7 +637,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.password.error'))).doesNotExist();
       });
 
-      test('should not display an error message on cgu field, when cgu is accepted and form is submitted', async function (assert) {
+      test('does not display an error message on cgu field, when cgu is accepted and form is submitted', async function (assert) {
         // given
         const userWithCguAccepted = EmberObject.create({
           cgu: true,
@@ -656,7 +657,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.queryByText(this.intl.t('common.cgu.error'))).doesNotExist();
       });
 
-      test('should reset validation property, when all informations are validated and form is submitted', async function (assert) {
+      test('resets validation property, when all informations are validated and form is submitted', async function (assert) {
         // given
         const validUser = EmberObject.create({
           email: 'toto@pix.fr',

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -45,41 +45,41 @@ module('Unit | Component | signup-form', function (hooks) {
   });
 
   module('#signup', function () {
-    test('should save user with spaces', function (assert) {
-      // given
-      const userWithSpaces = EmberObject.create({
-        firstName: '  Chris  ',
-        lastName: '  MylastName  ',
-        email: '    user@example.net  ',
-        password: 'Pix12345',
-        save: sinon.stub().resolves(),
+    module('when user information contains spaces', function () {
+      test('trims spaces before saving the user information', function (assert) {
+        // given
+        const userWithSpaces = EmberObject.create({
+          firstName: '  Chris  ',
+          lastName: '  MylastName  ',
+          email: '    user@example.net  ',
+          password: 'Pix12345',
+          save: sinon.stub().resolves(),
+        });
+        component.args.user = userWithSpaces;
+
+        // when
+        component.signup();
+
+        // then
+        const expectedUser = {
+          firstName: userWithSpaces.firstName.trim(),
+          lastName: userWithSpaces.lastName.trim(),
+          email: userWithSpaces.email.trim(),
+          lang: 'fr',
+        };
+        assert.deepEqual(pick(component.args.user, ['firstName', 'lastName', 'email', 'lang']), expectedUser);
       });
-      component.args.user = userWithSpaces;
-
-      const expectedUser = {
-        firstName: userWithSpaces.firstName.trim(),
-        lastName: userWithSpaces.lastName.trim(),
-        email: userWithSpaces.email.trim(),
-        lang: 'fr',
-      };
-
-      // when
-      component.signup();
-
-      // then
-      const user = component.args.user;
-      assert.deepEqual(pick(user, ['firstName', 'lastName', 'email', 'lang']), expectedUser);
     });
 
-    test('should authenticate user after sign up', async function (assert) {
-      const userWithSpaces = EmberObject.create({
-        firstName: '  Chris  ',
-        lastName: '  MylastName  ',
-        email: '    user@example.net  ',
+    test('authenticates the user after sign up', async function (assert) {
+      const user = EmberObject.create({
+        firstName: 'Chris',
+        lastName: 'MylastName',
+        email: 'user@example.net',
         password: 'Pix12345',
         save: sinon.stub().resolves(),
       });
-      component.args.user = userWithSpaces;
+      component.args.user = user;
 
       // when
       await component.signup();
@@ -90,26 +90,28 @@ module('Unit | Component | signup-form', function (hooks) {
       assert.ok(true);
     });
 
-    test('should send campaignCode when is defined', function (assert) {
-      // given
-      const userWithSpaces = EmberObject.create({
-        firstName: '  Chris  ',
-        lastName: '  MylastName  ',
-        email: '    user@example.net  ',
-        password: 'Pix12345',
-        save: sinon.stub().resolves(),
+    module('when campaign code is available', function () {
+      test('sends the campaign code', function (assert) {
+        // given
+        const user = EmberObject.create({
+          firstName: 'Chris',
+          lastName: 'MylastName',
+          email: 'user@example.net',
+          password: 'Pix12345',
+          save: sinon.stub().resolves(),
+        });
+        component.args.user = user;
+
+        const campaignCode = 'AZERTY123';
+        component.session.attemptedTransition.from.parent.params.code = campaignCode;
+
+        // when
+        component.signup();
+
+        // then
+        sinon.assert.calledWith(user.save, { adapterOptions: { campaignCode } });
+        assert.ok(true);
       });
-      component.args.user = userWithSpaces;
-
-      const campaignCode = 'AZERTY123';
-      component.session.attemptedTransition.from.parent.params.code = campaignCode;
-
-      // when
-      component.signup();
-
-      // then
-      sinon.assert.calledWith(userWithSpaces.save, { adapterOptions: { campaignCode } });
-      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -41,58 +41,42 @@ module('Unit | Component | signup-form', function (hooks) {
     this.owner.register('service:currentDomain', CurrentDomainStub);
     this.owner.register('service:cookies', CookiesStub);
     this.owner.register('service:intl', IntlStub);
+
     component = createGlimmerComponent('signup-form');
   });
 
   module('#signup', function () {
-    module('when user information contains spaces', function () {
-      test('trims spaces before saving the user information', function (assert) {
-        // given
-        const userWithSpaces = EmberObject.create({
-          firstName: '  Chris  ',
-          lastName: '  MylastName  ',
-          email: '    user@example.net  ',
-          password: 'Pix12345',
-          save: sinon.stub().resolves(),
+    module('error cases', function () {
+      module('when the form is invalid', function () {
+        test('does not save the user', async function (assert) {
+          // given
+          const user = EmberObject.create({
+            firstName: 'Chris',
+            lastName: 'MylastName',
+            email: 'invalid-user-email.com',
+            password: 'Pix12345',
+            save: sinon.stub().resolves(),
+          });
+          component.validation.firstName.status = 'success';
+          component.validation.lastName.status = 'success';
+          component.validation.email.status = 'error';
+          component.validation.password.status = 'success';
+          component.validation.cgu.status = 'success';
+          component.args.user = user;
+
+          // when
+          await component.signup();
+
+          // then
+          sinon.assert.notCalled(component.args.user.save);
+          sinon.assert.notCalled(component.session.authenticateUser);
+          assert.ok(true);
         });
-        component.args.user = userWithSpaces;
-
-        // when
-        component.signup();
-
-        // then
-        const expectedUser = {
-          firstName: userWithSpaces.firstName.trim(),
-          lastName: userWithSpaces.lastName.trim(),
-          email: userWithSpaces.email.trim(),
-          lang: 'fr',
-        };
-        assert.deepEqual(pick(component.args.user, ['firstName', 'lastName', 'email', 'lang']), expectedUser);
       });
     });
 
-    test('authenticates the user after sign up', async function (assert) {
-      const user = EmberObject.create({
-        firstName: 'Chris',
-        lastName: 'MylastName',
-        email: 'user@example.net',
-        password: 'Pix12345',
-        save: sinon.stub().resolves(),
-      });
-      component.args.user = user;
-
-      // when
-      await component.signup();
-
-      // then
-      sinon.assert.calledOnce(component.args.user.save);
-      sinon.assert.calledWith(component.session.authenticateUser, 'user@example.net', 'Pix12345');
-      assert.ok(true);
-    });
-
-    module('when campaign code is available', function () {
-      test('sends the campaign code', function (assert) {
-        // given
+    module('success cases', function () {
+      test('authenticates the user after sign up', async function (assert) {
         const user = EmberObject.create({
           firstName: 'Chris',
           lastName: 'MylastName',
@@ -102,15 +86,63 @@ module('Unit | Component | signup-form', function (hooks) {
         });
         component.args.user = user;
 
-        const campaignCode = 'AZERTY123';
-        component.session.attemptedTransition.from.parent.params.code = campaignCode;
-
         // when
-        component.signup();
+        await component.signup();
 
         // then
-        sinon.assert.calledWith(user.save, { adapterOptions: { campaignCode } });
+        sinon.assert.calledOnce(component.args.user.save);
+        sinon.assert.calledWith(component.session.authenticateUser, 'user@example.net', 'Pix12345');
         assert.ok(true);
+      });
+
+      module('when user information contains spaces', function () {
+        test('trims spaces before saving the user information', function (assert) {
+          // given
+          const userWithSpaces = EmberObject.create({
+            firstName: '  Chris  ',
+            lastName: '  MylastName  ',
+            email: '    user@example.net  ',
+            password: 'Pix12345',
+            save: sinon.stub().resolves(),
+          });
+          component.args.user = userWithSpaces;
+
+          // when
+          component.signup();
+
+          // then
+          const expectedUser = {
+            firstName: userWithSpaces.firstName.trim(),
+            lastName: userWithSpaces.lastName.trim(),
+            email: userWithSpaces.email.trim(),
+            lang: 'fr',
+          };
+          assert.deepEqual(pick(component.args.user, ['firstName', 'lastName', 'email', 'lang']), expectedUser);
+        });
+      });
+
+      module('when campaign code is available', function () {
+        test('sends the campaign code', function (assert) {
+          // given
+          const user = EmberObject.create({
+            firstName: 'Chris',
+            lastName: 'MylastName',
+            email: 'user@example.net',
+            password: 'Pix12345',
+            save: sinon.stub().resolves(),
+          });
+          component.args.user = user;
+
+          const campaignCode = 'AZERTY123';
+          component.session.attemptedTransition.from.parent.params.code = campaignCode;
+
+          // when
+          component.signup();
+
+          // then
+          sinon.assert.calledWith(user.save, { adapterOptions: { campaignCode } });
+          assert.ok(true);
+        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Le bouton de soumission du formulaire d'inscription est toujours cliquable lorsqu'il y a eu une une erreur suite à un premier envoi.

## :robot: Proposition

Ne pas initier de requête vers l'API dans les 2 cas suivants :
- Le formulaire est complet avec une ou plusieurs erreurs, donc invalide
- Le formulaire a été soumis mais une erreur est survenue, et on tente de soumettre de nouveau le même formulaire

## :rainbow: Remarques

RAS

## :100: Pour tester

### Erreur formulaire avant envoie

- Ouvrir la page d'inscription de Pix App : https://app-pr6243.review.pix.fr/ ou https://app-pr6243.review.pix.org/
- Ouvrir la console développeur, l'onglet Network en particulier
- Remplir le formulaire complètement en y ajoutant une erreur (l'email étant le plus simple)
- Soumettre le formulaire
- Vérifier dans l'onglet Network, qu'aucune requête n'a été initié

### Erreur formulaire après envoie

- Ouvrir la page d'inscription de Pix App : https://app-pr6243.review.pix.fr/ ou https://app-pr6243.review.pix.org/
- Ouvrir la console développeur, l'onglet Network en particulier
- Remplir le formulaire complètement en y ajoutant un email existant (ex: userpix1@example.net)
- Soumettre le formulaire
- Vérifier dans l'onglet Network que la requête est bien exécutée et que cette dernière est en erreur
- Vérifier dans le formulaire que l'erreur s'affiche bien en dessous du champ email
- Soumettre de nouveau le formulaire sans modification
- Vérifier dans l'onglet Network, qu'aucune nouvelle requête n'a été initié