### PR TITLE
[TECH] Ignorer le fichier codemods dans le linter de l'API

### DIFF
--- a/api/.eslintignore
+++ b/api/.eslintignore
@@ -1,4 +1,5 @@
 # https://eslint.org/docs/user-guide/configuring#eslintignore
 # .file are implicitly ignored, unless explicitly specified here
 node_modules/
+codemods/
 nyc.config.js


### PR DESCRIPTION
## :unicorn: Problème
Le linter est très lent

## :robot: Proposition
Ignorer le linting du dossier codemods qui ne contient que des node_modules

## :100: Pour tester
Valider que le lint dans la CI est plus rapide
