### PR TITLE
[FEATURE] Génération d'un scénario aléatoire (PIX-8121).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -23,7 +23,7 @@ const register = async (server) => {
             simulationAnswers: Joi.array().items(Joi.string().allow('ok', 'ko', 'aband')).required(),
           }).required(),
         },
-        handler: scenarioSimulatorController.simulateFlashDeterministicAssessmentScenario,
+        handler: scenarioSimulatorController.simulateFlashAssessmentScenario,
         tags: ['api'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',

--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -18,10 +18,23 @@ const register = async (server) => {
           options: {
             allowUnknown: true,
           },
-          payload: Joi.object({
-            assessmentId: Joi.string().required(),
-            simulationAnswers: Joi.array().items(Joi.string().allow('ok', 'ko', 'aband')).required(),
-          }).required(),
+          payload: Joi.alternatives([
+            Joi.object({
+              assessmentId: Joi.string().required(),
+              type: Joi.string().valid('deterministic').required(),
+              simulationAnswers: Joi.array().items(Joi.string().allow('ok', 'ko', 'aband')).required(),
+            }),
+            Joi.object({
+              assessmentId: Joi.string().required(),
+              type: Joi.string().valid('random').required(),
+              probabilities: Joi.object({
+                ok: Joi.number(),
+                ko: Joi.number(),
+                aband: Joi.number(),
+              }),
+              length: Joi.number().integer().min(0).required(),
+            }),
+          ]).required(),
         },
         handler: scenarioSimulatorController.simulateFlashAssessmentScenario,
         tags: ['api'],

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -52,4 +52,4 @@ function _isValidSimulationAnswers(simulationAnswers) {
   return simulationAnswers.every((row) => row.every((cell) => ['ok', 'ko', 'aband'].includes(cell)));
 }
 
-export const scenarioSimulatorController = { simulateFlashDeterministicAssessmentScenario, importScenarios };
+export const scenarioSimulatorController = { simulateFlashAssessmentScenario, importScenarios };

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -1,15 +1,17 @@
 import { usecases } from '../../domain/usecases/index.js';
 import { extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
 import { scenarioSimulatorSerializer } from '../../infrastructure/serializers/jsonapi/scenario-simulator-serializer.js';
+import { random } from '../../infrastructure/utils/random.js';
 import { scenarioSimulatorBatchSerializer } from '../../infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js';
 import { parseCsv } from '../../../scripts/helpers/csvHelpers.js';
 
-async function simulateFlashDeterministicAssessmentScenario(
-  request,
-  h,
-  dependencies = { scenarioSimulatorSerializer }
-) {
-  const { assessmentId, simulationAnswers } = request.payload;
+async function simulateFlashAssessmentScenario(request, h, dependencies = { scenarioSimulatorSerializer, random }) {
+  const { assessmentId, type, probabilities, length } = request.payload;
+  const simulationAnswers =
+    type === 'deterministic'
+      ? request.payload.simulationAnswers
+      : _generateSimulationAnswers(random, probabilities, length);
+
   const locale = extractLocaleFromRequest(request);
 
   const result = await usecases.simulateFlashDeterministicAssessmentScenario({
@@ -50,6 +52,10 @@ async function importScenarios(request, h, dependencies = { parseCsv, scenarioSi
 
 function _isValidSimulationAnswers(simulationAnswers) {
   return simulationAnswers.every((row) => row.every((cell) => ['ok', 'ko', 'aband'].includes(cell)));
+}
+
+function _generateSimulationAnswers(random, probabilities, length) {
+  return random.randomsInEnum(probabilities, length);
 }
 
 export const scenarioSimulatorController = { simulateFlashAssessmentScenario, importScenarios };

--- a/api/lib/infrastructure/utils/random.js
+++ b/api/lib/infrastructure/utils/random.js
@@ -1,0 +1,14 @@
+const randomInEnum = (values) => {
+  let probabilitiesSum = 0;
+  const randomFloat = Math.random();
+  for (const key in values) {
+    if (probabilitiesSum + values[key] > randomFloat) {
+      return key;
+    }
+    probabilitiesSum += values[key];
+  }
+};
+
+const randomsInEnum = (values, length) => [...new Array(length)].map(() => randomInEnum(values));
+
+export const random = { randomsInEnum };

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -10,7 +10,8 @@ const {
 describe('Acceptance | Controller | scenario-simulator-controller', function () {
   let server;
   let adminAuthorization;
-  let validPayload;
+  let validDeterministicPayload;
+  let validRandomPayload;
   let validPayloadForBatch;
   const assessmentId = '1234';
   const simulationAnswers = ['ok', 'ko', 'aband'];
@@ -24,9 +25,20 @@ describe('Acceptance | Controller | scenario-simulator-controller', function () 
     adminAuthorization = generateValidRequestAuthorizationHeader(adminId);
     await databaseBuilder.commit();
 
-    validPayload = {
+    validDeterministicPayload = {
       assessmentId,
       simulationAnswers,
+      type: 'deterministic',
+    };
+    validRandomPayload = {
+      assessmentId,
+      type: 'random',
+      probabilities: {
+        ok: 0.3,
+        ko: 0.5,
+        aband: 0.2,
+      },
+      length: 5,
     };
     validPayloadForBatch = `ok,ko,aband
 ko,aband,ok`;
@@ -140,17 +152,34 @@ ko,aband,ok`;
       };
     });
 
-    it('should return a payload with simulation deterministic scenario results', async function () {
-      // given
-      options.headers.authorization = adminAuthorization;
-      options.payload = validPayload;
+    describe('when the scenario is deterministic', function () {
+      it('should return a payload with simulation deterministic scenario results', async function () {
+        // given
+        options.headers.authorization = adminAuthorization;
+        options.payload = validDeterministicPayload;
 
-      // when
-      const response = await server.inject(options);
+        // when
+        const response = await server.inject(options);
 
-      // then
-      expect(response).to.have.property('statusCode', 200);
-      expect(response.result.data).to.have.lengthOf(3);
+        // then
+        expect(response).to.have.property('statusCode', 200);
+        expect(response.result.data).to.have.lengthOf(3);
+      });
+    });
+
+    describe('when the scenario is random', function () {
+      it('should return a payload with simulation deterministic scenario results', async function () {
+        // given
+        options.headers.authorization = adminAuthorization;
+        options.payload = validRandomPayload;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 200);
+        expect(response.result.data).to.have.lengthOf(5);
+      });
     });
 
     describe('when there is no connected user', function () {
@@ -172,7 +201,7 @@ ko,aband,ok`;
         const { id: userId } = databaseBuilder.factory.buildUser();
         options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
         await databaseBuilder.commit();
-        options.payload = validPayload;
+        options.payload = validDeterministicPayload;
 
         // when
         const response = await server.inject(options);

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -128,7 +128,7 @@ ko,aband,ok`;
     mockLearningContent(learningContent);
   });
 
-  describe('#simulateFlashDeterministicAssessmentScenario', function () {
+  describe('#simulateFlashAssessmentScenario', function () {
     let options;
 
     beforeEach(async function () {

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -1,6 +1,7 @@
 import { expect, sinon, HttpTestServer, domainBuilder } from '../../../test-helper.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import * as moduleUnderTest from '../../../../lib/application/scenarios-simulator/index.js';
+import { random } from '../../../../lib/infrastructure/utils/random.js';
 import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
 
 describe('Integration | Application | Scoring-simulator | scenario-simulator-controller', function () {
@@ -14,6 +15,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
   beforeEach(async function () {
     sinon.stub(usecases, 'simulateFlashDeterministicAssessmentScenario');
     sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+    sinon.stub(random, 'randomsInEnum');
 
     challenge1 = domainBuilder.buildChallenge({ id: 'chall1', successProbabilityThreshold: 0.65 });
     reward1 = 0.2;
@@ -50,48 +52,104 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
         ];
       });
 
-      context('When the route is called with correct arguments', function () {
-        it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
-          // given
-          const simulationAnswers = ['ok'];
-          const assessmentId = '13802DK';
-          usecases.simulateFlashDeterministicAssessmentScenario
-            .withArgs({
-              simulationAnswers,
-              assessmentId,
-              locale: 'en',
-            })
-            .resolves(simulationResults);
-          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+      context('When the scenario is deterministic', function () {
+        context('When the route is called with correct arguments', function () {
+          it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+            // given
+            const simulationAnswers = ['ok'];
+            const assessmentId = '13802DK';
+            usecases.simulateFlashDeterministicAssessmentScenario
+              .withArgs({
+                simulationAnswers,
+                assessmentId,
+                locale: 'en',
+              })
+              .resolves(simulationResults);
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
 
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/scenario-simulator',
-            {
-              assessmentId,
-              simulationAnswers,
-            },
-            null,
-            { 'accept-language': 'en' }
-          );
-
-          // then
-          expect(response.statusCode).to.equal(200);
-          expect(response.result).to.deep.equal({
-            data: [
+            // when
+            const response = await httpTestServer.request(
+              'POST',
+              '/api/scenario-simulator',
               {
-                attributes: {
-                  'error-rate': errorRate1,
-                  'estimated-level': estimatedLevel1,
-                  'minimum-capability': 0.6190392084062237,
-                  answer: 'ok',
-                  reward: reward1,
-                },
-                id: 'chall1',
-                type: 'scenario-simulator-challenges',
+                assessmentId,
+                simulationAnswers,
+                type: 'deterministic',
               },
-            ],
+              null,
+              { 'accept-language': 'en' }
+            );
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.deep.equal({
+              data: [
+                {
+                  attributes: {
+                    'error-rate': errorRate1,
+                    'estimated-level': estimatedLevel1,
+                    'minimum-capability': 0.6190392084062237,
+                    answer: 'ok',
+                    reward: reward1,
+                  },
+                  id: 'chall1',
+                  type: 'scenario-simulator-challenges',
+                },
+              ],
+            });
+          });
+        });
+      });
+
+      context('When the scenario is random', function () {
+        context('When the route is called with correct arguments', function () {
+          it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+            // given
+            const length = 1;
+            const probabilities = { ok: 0.3, ko: 0.4, aband: 0.3 };
+            random.randomsInEnum.withArgs(probabilities, length).returns(['ok']);
+            const simulationAnswers = ['ok'];
+            const assessmentId = '13802DK';
+            usecases.simulateFlashDeterministicAssessmentScenario
+              .withArgs({
+                simulationAnswers,
+                assessmentId,
+                locale: 'en',
+              })
+              .resolves(simulationResults);
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+            // when
+            const response = await httpTestServer.request(
+              'POST',
+              '/api/scenario-simulator',
+              {
+                assessmentId,
+                type: 'random',
+                probabilities,
+                length,
+              },
+              null,
+              { 'accept-language': 'en' }
+            );
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result).to.deep.equal({
+              data: [
+                {
+                  attributes: {
+                    'error-rate': errorRate1,
+                    'estimated-level': estimatedLevel1,
+                    'minimum-capability': 0.6190392084062237,
+                    answer: 'ok',
+                    reward: reward1,
+                  },
+                  id: 'chall1',
+                  type: 'scenario-simulator-challenges',
+                },
+              ],
+            });
           });
         });
       });

--- a/api/tests/unit/infrastructure/utils/pseudo-random_test.js
+++ b/api/tests/unit/infrastructure/utils/pseudo-random_test.js
@@ -1,0 +1,35 @@
+import { expect } from '../../../test-helper.js';
+import lodash from 'lodash';
+
+const { range, countBy } = lodash;
+
+import * as pseudoRandom from '../../../../lib/infrastructure/utils/pseudo-random.js';
+
+describe('Unit | Infrastructure | Utils | PseudoRandom', function () {
+  describe('#binaryTreeRandom', function () {
+    context('randomDistributionTest', function () {
+      it('should have a decent distribution', function () {
+        const sampleSize = 100000;
+        const treeSize = 5;
+        const seeds = range(0, sampleSize);
+
+        const results = seeds.map((seed) => {
+          const randomContext = pseudoRandom.create(seed);
+          return randomContext.binaryTreeRandom(50, treeSize);
+        });
+
+        const resultDistribution = countBy(results);
+
+        const computeDistance = (value, expected) => Math.abs(value / sampleSize - expected / 100);
+
+        const RESULTS_AVERAGE_DISTRIBUTION = [50, 25, 12.5, 6.25, 6.25];
+
+        expect(computeDistance(resultDistribution[0], RESULTS_AVERAGE_DISTRIBUTION[0])).to.be.lessThan(0.01);
+        expect(computeDistance(resultDistribution[1], RESULTS_AVERAGE_DISTRIBUTION[1])).to.be.lessThan(0.01);
+        expect(computeDistance(resultDistribution[2], RESULTS_AVERAGE_DISTRIBUTION[2])).to.be.lessThan(0.01);
+        expect(computeDistance(resultDistribution[3], RESULTS_AVERAGE_DISTRIBUTION[3])).to.be.lessThan(0.01);
+        expect(computeDistance(resultDistribution[4], RESULTS_AVERAGE_DISTRIBUTION[4])).to.be.lessThan(0.01);
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/utils/random_test.js
+++ b/api/tests/unit/infrastructure/utils/random_test.js
@@ -1,34 +1,26 @@
 import { expect } from '../../../test-helper.js';
-import lodash from 'lodash';
-
-const { range, countBy } = lodash;
-
-import * as pseudoRandom from '../../../../lib/infrastructure/utils/pseudo-random.js';
+import { random } from '../../../../lib/infrastructure/utils/random.js';
+import _ from 'lodash';
 
 describe('Unit | Infrastructure | Utils | Random', function () {
   describe('#binaryTreeRandom', function () {
     context('randomDistributionTest', function () {
       it('should have a decent distribution', function () {
-        const sampleSize = 100000;
-        const treeSize = 5;
-        const seeds = range(0, sampleSize);
+        const length = 100000;
+        const values = {
+          ok: 0.1,
+          ko: 0.3,
+          aband: 0.6,
+        };
 
-        const results = seeds.map((seed) => {
-          const randomContext = pseudoRandom.create(seed);
-          return randomContext.binaryTreeRandom(50, treeSize);
-        });
+        const results = random.randomsInEnum(values, length);
 
-        const resultDistribution = countBy(results);
+        const resultDistribution = _.countBy(results);
 
-        const computeDistance = (value, expected) => Math.abs(value / sampleSize - expected / 100);
-
-        const RESULTS_AVERAGE_DISTRIBUTION = [50, 25, 12.5, 6.25, 6.25];
-
-        expect(computeDistance(resultDistribution[0], RESULTS_AVERAGE_DISTRIBUTION[0])).to.be.lessThan(0.01);
-        expect(computeDistance(resultDistribution[1], RESULTS_AVERAGE_DISTRIBUTION[1])).to.be.lessThan(0.01);
-        expect(computeDistance(resultDistribution[2], RESULTS_AVERAGE_DISTRIBUTION[2])).to.be.lessThan(0.01);
-        expect(computeDistance(resultDistribution[3], RESULTS_AVERAGE_DISTRIBUTION[3])).to.be.lessThan(0.01);
-        expect(computeDistance(resultDistribution[4], RESULTS_AVERAGE_DISTRIBUTION[4])).to.be.lessThan(0.01);
+        const computeDistance = (value, expected) => Math.abs(value / length - expected);
+        expect(computeDistance(resultDistribution.ok, values.ok)).to.be.lessThan(0.01);
+        expect(computeDistance(resultDistribution.ko, values.ko)).to.be.lessThan(0.01);
+        expect(computeDistance(resultDistribution.aband, values.aband)).to.be.lessThan(0.01);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

A la place d’un scénario précis le statut pour chaque épreuve, on peut envisager une version aléatoire

## :robot: Proposition

Ajout de paramètres en entrée de la route de génération d'un scénario:
- probabilities: probabilités de succès, d'échec et d'abandon à chacune des questions (la somme doit être égale à 1)
- length: longueur du scénario à créer
- type: détermine le type de scénario à créer (`random` ou `deterministic`)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

```
TOKEN=$(curl 'https://api-pr6256.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6256.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "assessmentId": "1234", "length": 4, "probabilities": { "ok": 0.3, "ko": 0.5, "aband": 0.2}, "type": "random" }' | jq '.'
```