### PR TITLE
[TECH] Active l'option staticHelpers d'embroider sur mon-pix

### DIFF
--- a/mon-pix/app/components/form-textfield-date.hbs
+++ b/mon-pix/app/components/form-textfield-date.hbs
@@ -20,7 +20,7 @@
         name={{@dayTextfieldName}}
         {{on "focusout" (fn @onValidateDay @dayTextfieldName @dayInputBindingValue)}}
         class="form-textfield__input {{this.dayInputValidationStatus}}"
-        aria-describedby={{@aria-describedby @dayValidationMessage}}
+        aria-describedby={{@aria-describedby}}
         required={{@require}}
         disabled={{@disabled}}
         aria-label={{t "pages.login-or-register.register-form.fields.birthdate.day.label"}}
@@ -58,7 +58,7 @@
         name={{@monthTextfieldName}}
         {{on "focusout" (fn @onValidateMonth @monthTextfieldName @monthInputBindingValue)}}
         class="form-textfield__input {{this.monthInputValidationStatus}}"
-        aria-describedby={{@aria-describedby @monthValidationMessage}}
+        aria-describedby={{@aria-describedby}}
         required={{@require}}
         disabled={{@disabled}}
         aria-label={{t "pages.login-or-register.register-form.fields.birthdate.month.label"}}
@@ -95,7 +95,7 @@
         name={{@yearTextfieldName}}
         {{on "focusout" (fn @onValidateYear @yearTextfieldName @yearInputBindingValue)}}
         class="form-textfield__input {{this.yearInputValidationStatus}}"
-        aria-describedby={{@aria-describedby @yearValidationMessage}}
+        aria-describedby={{@aria-describedby}}
         required={{@require}}
         disabled={{@disabled}}
         aria-label={{t "pages.login-or-register.register-form.fields.birthdate.year.label"}}

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -43,6 +43,7 @@ module.exports = function (defaults) {
   return require('@embroider/compat').compatBuild(app, Webpack, {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
+    staticHelpers: true,
     staticModifiers: true,
     staticComponents: true,
   });


### PR DESCRIPTION
## :unicorn: Problème
L'option `staticHelpers`  d'embroider n'est pas activé: https://github.com/embroider-build/embroider#options

## :robot: Proposition
L'activer

## :rainbow: Remarques

> The `aria-describedby` attribute lists the ids of the elements that describe the object […]
> As its value is one or a space-separated list of more than one id, **it must reference elements in the same DOM document.**

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby

## :100: Pour tester

* Tests verts + navigation dans l'application
* Tester fonctionnellement le composant `FormTextfieldDate` dans le formulaire `RegisterForm` _« Je m’inscris sur Pix »_ par exemple à l'URL https://app-pr6257.review.pix.org/campagnes/SCOBADGE1/rejoindre/identification
