### PR TITLE
[FEATURE] Ajoute le détachement d'un profil cible d'une organisation (PIX-7028)

### DIFF
--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -27,4 +27,12 @@ export default class TargetProfileAdapter extends ApplicationAdapter {
 
     return super.createRecord(...arguments);
   }
+
+  async detachOrganizations(targetProfileId, organizationIds) {
+    const url = `${this.host}/${this.namespace}/target-profiles/${targetProfileId}/detach-organizations`;
+    const result = await this.ajax(url, 'DELETE', {
+      data: { data: { attributes: { 'organization-ids': organizationIds } } },
+    });
+    return result.data.attributes['detached-organization-ids'];
+  }
 }

--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -7,6 +7,9 @@
           <th><label for="name">Nom</label></th>
           <th><label for="type">Type</label></th>
           <th><label for="externalId">Identifiant externe</label></th>
+          {{#if @showDetachColumn}}
+            <th>Actions</th>
+          {{/if}}
         </tr>
         <tr>
           <td class="table__column table__column--id">
@@ -45,6 +48,9 @@
               class="table-admin-input form-control"
             />
           </td>
+          {{#if @showDetachColumn}}
+            <td></td>
+          {{/if}}
         </tr>
       </thead>
 
@@ -60,6 +66,18 @@
               <td>{{organization.name}}</td>
               <td>{{organization.type}}</td>
               <td>{{organization.externalId}}</td>
+              {{#if @showDetachColumn}}
+                <td>
+                  <PixButton
+                    @backgroundColor="red"
+                    @size="small"
+                    aria-label="Détacher l'organisation"
+                    @triggerAction={{fn @detachOrganizations organization.id}}
+                  >
+                    Détacher
+                  </PixButton>
+                </td>
+              {{/if}}
             </tr>
           {{/each}}
         </tbody>

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -59,5 +59,7 @@
     @externalId={{@externalId}}
     @triggerFiltering={{@triggerFiltering}}
     @goToOrganizationPage={{@goToOrganizationPage}}
+    @detachOrganizations={{@detachOrganizations}}
+    @showDetachColumn={{true}}
   />
 </section>

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -43,12 +43,11 @@ export default class TargetProfileOrganizationsController extends Controller {
     const adapter = this.store.adapterFor('target-profile');
 
     try {
-      const response = await adapter.detachOrganizations(this.model.targetProfile.id, [organizationId]);
-      const { 'detached-ids': detachedIds } = response.data.attributes;
-      const hasDetachedOrganizations = detachedIds.length > 0;
+      const detachedOrganizationIds = await adapter.detachOrganizations(this.model.targetProfile.id, [organizationId]);
+      const hasDetachedOrganizations = detachedOrganizationIds.length > 0;
 
       if (hasDetachedOrganizations) {
-        const message = 'Organisation(s) détachée(s) avec succès : ' + detachedIds.join(', ');
+        const message = 'Organisation(s) détachée(s) avec succès : ' + detachedOrganizationIds.join(', ');
         await this.notifications.success(message, { htmlContent: true });
         this.router.transitionTo('authenticated.target-profiles.target-profile.organizations');
       }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
@@ -9,4 +9,5 @@
   @externalId={{this.externalId}}
   @triggerFiltering={{this.triggerFiltering}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
+  @detachOrganizations={{this.detachOrganizations}}
 />

--- a/admin/tests/integration/components/target-profiles/organizations_test.js
+++ b/admin/tests/integration/components/target-profiles/organizations_test.js
@@ -10,6 +10,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   hooks.beforeEach(function () {
     this.triggerFiltering = () => {};
     this.goToOrganizationPage = () => {};
+    this.detachOrganizations = () => {};
   });
 
   test('it should display the organizations', async function (assert) {
@@ -26,6 +27,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   @organizations={{this.organizations}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
 />`
     );
 
@@ -47,6 +49,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   @organizations={{this.organizations}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
 />`
     );
 
@@ -68,6 +71,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   @organizations={{this.organizations}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
 />`
     );
 
@@ -84,6 +88,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   @organizations={{this.organizations}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
 />`
     );
     await fillByLabel('Rattacher une ou plusieurs organisation(s)', '1, 2');
@@ -102,6 +107,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   @organizations={{this.organizations}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
 />`
     );
     await fillByLabel("Rattacher les organisations d'un profil cible existant", 1);
@@ -122,6 +128,7 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   @organizations={{this.organizations}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
 />`
     );
 

--- a/admin/tests/integration/controllers/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/integration/controllers/authenticated/target-profiles/target-profile/organizations_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Intregration | Controller | authenticated/target-profiles/target-profile/organizations', function (hooks) {
+module('Integration | Controller | authenticated/target-profiles/target-profile/organizations', function (hooks) {
   setupTest(hooks);
   const organizationId = 1;
   let controller;
@@ -29,15 +29,7 @@ module('Intregration | Controller | authenticated/target-profiles/target-profile
   module('#detachOrganizations', function () {
     test('it should display a confirmation message after detaching an organization from a target profile', async function (assert) {
       // given
-      controller.store.adapterFor('target-profile').detachOrganizations.resolves({
-        data: {
-          type: 'target-profile-detach-organizations',
-          id: controller.model.targetProfile.id,
-          attributes: {
-            'detached-ids': [organizationId],
-          },
-        },
-      });
+      controller.store.adapterFor('target-profile').detachOrganizations.resolves([organizationId]);
 
       // when
       await controller.detachOrganizations(organizationId);
@@ -52,15 +44,7 @@ module('Intregration | Controller | authenticated/target-profiles/target-profile
 
     test('it should reload the page after detaching an organization from a target profile', async function (assert) {
       // given
-      controller.store.adapterFor('target-profile').detachOrganizations.resolves({
-        data: {
-          type: 'target-profile-detach-organizations',
-          id: controller.model.targetProfile.id,
-          attributes: {
-            'detached-ids': [organizationId],
-          },
-        },
-      });
+      controller.store.adapterFor('target-profile').detachOrganizations.resolves([organizationId]);
 
       // when
       await controller.detachOrganizations(organizationId);

--- a/admin/tests/integration/controllers/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/integration/controllers/authenticated/target-profiles/target-profile/organizations_test.js
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Intregration | Controller | authenticated/target-profiles/target-profile/organizations', function (hooks) {
+  setupTest(hooks);
+  const organizationId = 1;
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated.target-profiles.target-profile.organizations');
+    controller.router = { transitionTo: sinon.stub() };
+    controller.model = {
+      targetProfile: {
+        id: 3,
+      },
+    };
+    controller.notifications = {
+      success: sinon.stub(),
+      error: sinon.stub(),
+    };
+    controller.store = {
+      adapterFor: sinon.stub().returns({
+        detachOrganizations: sinon.stub(),
+      }),
+    };
+  });
+
+  module('#detachOrganizations', function () {
+    test('it should display a confirmation message after detaching an organization from a target profile', async function (assert) {
+      // given
+      controller.store.adapterFor('target-profile').detachOrganizations.resolves({
+        data: {
+          type: 'target-profile-detach-organizations',
+          id: controller.model.targetProfile.id,
+          attributes: {
+            'detached-ids': [organizationId],
+          },
+        },
+      });
+
+      // when
+      await controller.detachOrganizations(organizationId);
+
+      // then
+      assert.true(
+        controller.notifications.success.calledWith(`Organisation(s) détachée(s) avec succès : ${organizationId}`, {
+          htmlContent: true,
+        })
+      );
+    });
+
+    test('it should reload the page after detaching an organization from a target profile', async function (assert) {
+      // given
+      controller.store.adapterFor('target-profile').detachOrganizations.resolves({
+        data: {
+          type: 'target-profile-detach-organizations',
+          id: controller.model.targetProfile.id,
+          attributes: {
+            'detached-ids': [organizationId],
+          },
+        },
+      });
+
+      // when
+      await controller.detachOrganizations(organizationId);
+
+      // then
+      assert.true(
+        controller.router.transitionTo.calledWith('authenticated.target-profiles.target-profile.organizations')
+      );
+    });
+
+    test('it should display a generic message for any error', async function (assert) {
+      // given
+      //no mock for the api call
+
+      // when
+      await controller.detachOrganizations(organizationId);
+
+      // then
+      assert.true(controller.notifications.error.calledWith('Une erreur est survenue.'));
+    });
+  });
+});

--- a/admin/tests/unit/adapters/target-profile_test.js
+++ b/admin/tests/unit/adapters/target-profile_test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | Target-profile ', function (hooks) {
+  setupTest(hooks);
+  let adapter;
+  const organizationToDetachId = 2;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:target-profile');
+    sinon
+      .stub(adapter, 'ajax')
+      .resolves({ data: { attributes: { 'detached-organization-ids': [organizationToDetachId] } } });
+  });
+
+  module('#detachOrganizations', function () {
+    test('should trigger an ajax call with the right url, method and payload', async function (assert) {
+      // given
+      const targetProfileId = 1;
+
+      const expectedPayload = {
+        data: { data: { attributes: { 'organization-ids': organizationToDetachId } } },
+      };
+      const expectedUrl = `http://localhost:3000/api/admin/target-profiles/${targetProfileId}/detach-organizations`;
+
+      // when
+      const result = await adapter.detachOrganizations(targetProfileId, organizationToDetachId);
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, 'DELETE', expectedPayload);
+      assert.deepEqual(result, [organizationToDetachId]);
+    });
+  });
+});

--- a/admin/tests/unit/components/organizations/list-items_test.js
+++ b/admin/tests/unit/components/organizations/list-items_test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Unit | Component | Organizations::ListItems', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.triggerFiltering = () => {};
+    this.goToOrganizationPage = () => {};
+    this.detachOrganizations = sinon.stub();
+
+    const organization1 = { id: 123, name: 'Orga1', externalId: 'O1' };
+    const organization2 = { id: 456, name: 'Orga2', externalId: 'O2' };
+    const organizations = [organization1, organization2];
+    organizations.meta = { page: 1, pageSize: 1 };
+    this.organizations = organizations;
+  });
+
+  test('it should not display an Actions column to detach organizations', async function (assert) {
+    // given
+    const screen = await render(
+      hbs`<Organizations::ListItems
+  @organizations={{this.organizations}}
+  @externalId='{{@externalId}}'
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+/>`
+    );
+
+    // then
+    assert.dom(screen.queryByText('Actions')).doesNotExist();
+    assert.strictEqual(screen.queryAllByRole('button', { name: "Détacher l'organisation" }).length, 0);
+  });
+
+  module('when detaching organizations from a target profiles', () => {
+    test('it should display an Actions column to detach organizations', async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<Organizations::ListItems
+  @organizations={{this.organizations}}
+  @externalId='{{@externalId}}'
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+  @showDetachColumn={{true}}
+/>`
+      );
+
+      // then
+      assert.strictEqual(
+        screen.queryAllByRole('button', { name: "Détacher l'organisation" }).length,
+        this.organizations.length
+      );
+      screen.queryByText('Actions');
+      assert.dom(screen.queryByText('Actions')).exists();
+    });
+
+    test('it should detach an organization when the user cliks on "Désactiver" button', async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<Organizations::ListItems
+  @organizations={{this.organizations}}
+  @externalId='{{@externalId}}'
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+  @showDetachColumn={{true}}
+/>`
+      );
+      const detachButton = screen.queryAllByRole('button', { name: "Détacher l'organisation" })[0];
+
+      //when
+      await click(detachButton);
+
+      // then
+      assert.true(this.detachOrganizations.calledWith(this.organizations[0].id));
+    });
+  });
+});

--- a/api/lib/application/target-profiles-management/index.js
+++ b/api/lib/application/target-profiles-management/index.js
@@ -1,0 +1,46 @@
+import Joi from 'joi';
+import { securityPreHandlers } from '../security-pre-handlers.js';
+import { targetProfilesManagementController } from './target-profile-management-controller.js';
+import { identifiersType } from '../../domain/types/identifiers-type.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'DELETE',
+      path: '/api/admin/target-profiles/{id}/detach-organizations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'organization-ids': Joi.array().items(Joi.number().integer()).required(),
+              },
+            },
+          }),
+          params: Joi.object({
+            id: identifiersType.targetProfileId,
+          }),
+        },
+        handler: targetProfilesManagementController.detachOrganizations,
+        tags: ['api', 'admin', 'target-profiles'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet de détacher des organisations d'un profil cible",
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'target-profile-management-api';
+export { register, name };

--- a/api/lib/application/target-profiles-management/target-profile-management-controller.js
+++ b/api/lib/application/target-profiles-management/target-profile-management-controller.js
@@ -1,0 +1,31 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as targetProfileRepository from '../../infrastructure/repositories/target-profile-management/target-profile-repository.js';
+import * as targetProfileDetachOrganizationsSerializer from '../../infrastructure/serializers/jsonapi/target-profiles-management/target-profile-detach-organizations-serializer.js';
+import { deserializer } from '../../infrastructure/serializers/jsonapi/deserializer.js';
+
+const detachOrganizations = async function (
+  request,
+  h,
+  dependencies = { targetProfileDetachOrganizationsSerializer, targetProfileRepository, deserializer }
+) {
+  const { organizationIds } = await dependencies.deserializer.deserialize(request.payload);
+  const targetProfileId = request.params.id;
+
+  const detachedOrganizationIds = await usecases.detachOrganizationsFromTargetProfile({
+    targetProfileId,
+    organizationIds,
+    targetProfileRepository: dependencies.targetProfileRepository,
+  });
+
+  return h
+    .response(
+      dependencies.targetProfileDetachOrganizationsSerializer.serialize({ detachedOrganizationIds, targetProfileId })
+    )
+    .code(200);
+};
+
+const targetProfilesManagementController = {
+  detachOrganizations,
+};
+
+export { targetProfilesManagementController };

--- a/api/lib/domain/models/target-profile-management/TargetProfile.js
+++ b/api/lib/domain/models/target-profile-management/TargetProfile.js
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+
+class TargetProfile {
+  constructor({ id }) {
+    this.id = id;
+  }
+
+  detach(organizationIds) {
+    this.organizationIdsToDetach = _.uniq(organizationIds);
+  }
+}
+
+export { TargetProfile };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -202,7 +202,6 @@ import { tokenService } from '../../domain/services/token-service.js';
 
 import { importNamedExportsFromDirectory } from '../../infrastructure/utils/import-named-exports-from-directory.js';
 import { injectDependencies } from '../../infrastructure/utils/dependency-injection.js';
-
 import { findTargetProfileOrganizations as findPaginatedFilteredTargetProfileOrganizations } from './find-paginated-filtered-target-profile-organizations.js';
 import { getCampaignManagement as getCampaignDetailsManagement } from './get-campaign-details-management.js';
 
@@ -422,6 +421,7 @@ const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './organization-learners-management') })),
   ...(await importNamedExportsFromDirectory({ path: join(path, './organizations-administration') })),
   ...(await importNamedExportsFromDirectory({ path: join(path, './sessions-mass-import') })),
+  ...(await importNamedExportsFromDirectory({ path: join(path, './target-profile-management') })),
   findPaginatedFilteredTargetProfileOrganizations,
   getCampaignDetailsManagement,
 };

--- a/api/lib/domain/usecases/target-profile-management/detach-organizations-from-target-profile.js
+++ b/api/lib/domain/usecases/target-profile-management/detach-organizations-from-target-profile.js
@@ -1,0 +1,15 @@
+import { TargetProfile } from '../../models/target-profile-management/TargetProfile.js';
+
+const detachOrganizationsFromTargetProfile = async function ({
+  targetProfileId,
+  organizationIds,
+  targetProfileRepository,
+}) {
+  const targetProfile = new TargetProfile({ id: targetProfileId });
+
+  targetProfile.detach(organizationIds);
+
+  return targetProfileRepository.update(targetProfile);
+};
+
+export { detachOrganizationsFromTargetProfile };

--- a/api/lib/infrastructure/repositories/target-profile-management/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-management/target-profile-repository.js
@@ -1,0 +1,12 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+
+const update = async function (targetProfile) {
+  const results = await knex('target-profile-shares')
+    .where('targetProfileId', targetProfile.id)
+    .whereIn('organizationId', targetProfile.organizationIdsToDetach)
+    .del()
+    .returning('organizationId');
+  return results.map(({ organizationId }) => organizationId);
+};
+
+export { update };

--- a/api/lib/infrastructure/serializers/jsonapi/target-profiles-management/target-profile-detach-organizations-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profiles-management/target-profile-detach-organizations-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (model) {
+  return new Serializer('target-profile-detach-organizations', {
+    id: 'targetProfileId',
+    attributes: ['detachedOrganizationIds'],
+  }).serialize(model);
+};
+
+export { serialize };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -51,6 +51,7 @@ import * as supOrganizationLearners from './application/sup-organization-learner
 import * as sessions from './application/sessions/index.js';
 import * as tags from './application/tags/index.js';
 import * as targetProfiles from './application/target-profiles/index.js';
+import * as targetProfilesManagement from './application/target-profiles-management/index.js';
 import * as trainings from './application/trainings/index.js';
 import * as missions from './application/missions/index.js';
 import * as frameworks from './application/frameworks/index.js';
@@ -113,6 +114,7 @@ const routes = [
   tags,
   targetProfiles,
   missions,
+  targetProfilesManagement,
   trainings,
   frameworks,
   tutorialEvaluations,

--- a/api/tests/acceptance/application/target-profiles-management/index_test.js
+++ b/api/tests/acceptance/application/target-profiles-management/index_test.js
@@ -1,0 +1,39 @@
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
+
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | Route | target-profiles-management', function () {
+  describe('DELETE /api/admin/target-profiles/{id}/detach-organizations', function () {
+    it('should return 200 after successfully detaching organizations from target profile', async function () {
+      // given
+      const server = await createServer();
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const user = databaseBuilder.factory.buildUser.withRole();
+      const organization1Id = databaseBuilder.factory.buildOrganization().id;
+      const organization2Id = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: organization1Id });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: organization2Id });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'DELETE',
+        url: `/api/admin/target-profiles/${targetProfileId}/detach-organizations`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        payload: {
+          data: {
+            attributes: {
+              'organization-ids': [organization1Id, organization2Id],
+            },
+          },
+        },
+      };
+
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/application/target-profiles-management/index_test.js
+++ b/api/tests/integration/application/target-profiles-management/index_test.js
@@ -1,0 +1,92 @@
+import {
+  expect,
+  generateValidRequestAuthorizationHeader,
+  databaseBuilder,
+  sinon,
+  HttpTestServer,
+} from '../../../test-helper.js';
+
+import { targetProfilesManagementController } from '../../../../lib/application/target-profiles-management/target-profile-management-controller.js';
+import * as moduleUnderTest from '../../../../lib/application/target-profiles-management/index.js';
+
+describe('Integration | Application | target-profiles-management | Routes ', function () {
+  describe('DELETE /api/admin/target-profiles/{id}/detach-organizations', function () {
+    const getHeaders = (userId) => ({
+      authorization: generateValidRequestAuthorizationHeader(userId),
+    });
+    let httpTestServer;
+    let targetProfileId, organizationId;
+    let method, url, payload;
+
+    beforeEach(async function () {
+      sinon.stub(targetProfilesManagementController, 'detachOrganizations').resolves('ok');
+
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      httpTestServer.setupAuthentication();
+
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      method = 'DELETE';
+      url = `/api/admin/target-profiles/${targetProfileId}/detach-organizations`;
+      payload = {
+        data: {
+          attributes: {
+            'organization-ids': [organizationId],
+          },
+        },
+      };
+    });
+
+    it('should return a 401 status code when calling route unauthenticated', async function () {
+      // given
+      const headers = {
+        authorization: null,
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('should return a 403 status code when calling route with a user with no admin role', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, getHeaders(userId));
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should reach handler when calling route with an admin user with role super admin', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: 'SUPER_ADMIN' }).id;
+      await databaseBuilder.commit();
+
+      // when
+      await httpTestServer.request(method, url, payload, null, getHeaders(userId));
+
+      // then
+      expect(targetProfilesManagementController.detachOrganizations).to.have.been.calledOnce;
+    });
+
+    it('should reach handler when calling route with an admin user with role metier', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: 'METIER' }).id;
+      await databaseBuilder.commit();
+
+      // when
+      await httpTestServer.request(method, url, payload, null, getHeaders(userId));
+
+      // then
+      expect(targetProfilesManagementController.detachOrganizations).to.have.been.calledOnce;
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/target-profile-management/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-management/target-profile-repository_test.js
@@ -1,0 +1,86 @@
+import { expect, databaseBuilder } from '../../../../test-helper.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
+import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-management/target-profile-repository.js';
+
+describe('Integration | Repository | Target Profile Management | Target Profile ', function () {
+  describe('#update', function () {
+    it('Detach a target profile from an organization', async function () {
+      // given
+      const organizationIdToDetach = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: organizationIdToDetach });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: otherOrganizationId });
+
+      await databaseBuilder.commit();
+
+      const targetProfile = {
+        id: targetProfileId,
+        organizationIdsToDetach: [organizationIdToDetach],
+      };
+
+      // when
+      await targetProfileRepository.update(targetProfile);
+
+      // then
+      const result = await knex
+        .select('organizationId')
+        .from('target-profile-shares')
+        .where('targetProfileId', targetProfile.id);
+
+      expect(result.length).to.equal(1);
+      expect(result).to.not.deep.include({ organizationId: targetProfile.organizationIdsToDetach[0] });
+    });
+
+    it('Detach a target profile from several organizations', async function () {
+      // given
+
+      const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: firstOrganizationId });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: secondOrganizationId });
+
+      await databaseBuilder.commit();
+
+      const targetProfile = {
+        id: targetProfileId,
+        organizationIdsToDetach: [firstOrganizationId, secondOrganizationId],
+      };
+
+      // when
+      await targetProfileRepository.update(targetProfile);
+
+      // then
+      const result = await knex
+        .select('organizationId')
+        .from('target-profile-shares')
+        .where('targetProfileId', targetProfile.id);
+
+      expect(result.length).to.equal(0);
+    });
+
+    it('should return detached organization ids', async function () {
+      // given
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: organizationId });
+      databaseBuilder.factory.buildTargetProfileShare({ targetProfileId, organizationId: otherOrganizationId });
+
+      await databaseBuilder.commit();
+
+      const targetProfile = {
+        id: targetProfileId,
+        organizationIdsToDetach: [organizationId, otherOrganizationId],
+      };
+
+      // when
+      const result = await targetProfileRepository.update(targetProfile);
+
+      // then
+      expect(result).to.deepEqualArray([organizationId, otherOrganizationId]);
+    });
+  });
+});

--- a/api/tests/unit/application/target-profiles-management/target-profile-management-controller_test.js
+++ b/api/tests/unit/application/target-profiles-management/target-profile-management-controller_test.js
@@ -1,0 +1,48 @@
+import { sinon, expect, hFake } from '../../../test-helper.js';
+import { targetProfilesManagementController } from '../../../../lib/application/target-profiles-management/target-profile-management-controller.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | Controller | Target Profiles Management | target-profile-management-controller', function () {
+  describe('#detachOrganizations', function () {
+    it('should call the detachOrganizationsFromTargetProfile use-case', async function () {
+      // given
+      const connectedUserId = 1;
+      const payload = { data: { 'organization-ids': [1, 2, 3] } };
+      const request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: 1 },
+        payload,
+        i18n: {
+          __: sinon.stub(),
+        },
+      };
+
+      const expectedResult = Symbol('result');
+      const organizationIds = Symbol('organizationIds');
+      const detachedOrganizationIds = Symbol('detachedOrganizationIds');
+      const targetProfileRepository = Symbol('target profile repository');
+
+      sinon.stub(usecases, 'detachOrganizationsFromTargetProfile');
+      usecases.detachOrganizationsFromTargetProfile
+        .withArgs({ targetProfileId: 1, organizationIds, targetProfileRepository })
+        .resolves(detachedOrganizationIds);
+
+      const targetProfileDetachOrganizationsSerializer = { serialize: sinon.stub() };
+      targetProfileDetachOrganizationsSerializer.serialize
+        .withArgs({ targetProfileId: 1, detachedOrganizationIds })
+        .returns(expectedResult);
+
+      const deserializer = { deserialize: sinon.stub() };
+      deserializer.deserialize.withArgs(payload).returns({ organizationIds: organizationIds });
+
+      const dependencies = { targetProfileRepository, deserializer, targetProfileDetachOrganizationsSerializer };
+
+      // when
+      const response = await targetProfilesManagementController.detachOrganizations(request, hFake, dependencies);
+
+      // then
+      expect(response.source).to.equal(expectedResult);
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/target-profile-management/TargetProfile_test.js
+++ b/api/tests/unit/domain/models/target-profile-management/TargetProfile_test.js
@@ -1,0 +1,22 @@
+import { expect } from '../../../../test-helper.js';
+import { TargetProfile } from '../../../../../lib/domain/models/target-profile-management/TargetProfile.js';
+
+describe('Unit | Domain | Models | TargetProfile', function () {
+  describe('#detach', function () {
+    it('should detach organizations', function () {
+      const targetProfile = new TargetProfile({ id: 123 });
+
+      targetProfile.detach([1, 2]);
+
+      expect(targetProfile.organizationIdsToDetach).deep.equal([1, 2]);
+    });
+
+    it('should not detach an organization twice', function () {
+      const targetProfile = new TargetProfile({ id: 123 });
+
+      targetProfile.detach([3, 3]);
+
+      expect(targetProfile.organizationIdsToDetach).deep.equal([3]);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/target-profile-management/detach-organizations-from-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/target-profile-management/detach-organizations-from-target-profile_test.js
@@ -1,0 +1,31 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { detachOrganizationsFromTargetProfile } from '../../../../../lib/domain/usecases/target-profile-management/detach-organizations-from-target-profile.js';
+
+describe('Unit | UseCase | Target Profile Management | Detach Organizations From Target Profile', function () {
+  let targetProfileRepository;
+
+  beforeEach(function () {
+    targetProfileRepository = {
+      update: sinon.stub(),
+    };
+  });
+
+  it('should detach organizations from target profile', async function () {
+    // given
+    const targetProfileId = 777;
+    const organizationIds = [123, 456, 789];
+
+    // when
+    await detachOrganizationsFromTargetProfile({
+      organizationIds,
+      targetProfileId,
+      targetProfileRepository,
+    });
+
+    // then
+    expect(targetProfileRepository.update).to.have.been.calledWithMatch({
+      id: targetProfileId,
+      organizationIdsToDetach: organizationIds,
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-management/target-profile-detach-organizations-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-management/target-profile-detach-organizations-serializer_test.js
@@ -1,0 +1,23 @@
+import { expect } from '../../../../../test-helper.js';
+import * as serializer from '../../../../../../lib/infrastructure/serializers/jsonapi/target-profiles-management/target-profile-detach-organizations-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | target-profile-detach-organizations-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert a target profile detach organizations object to JSON API data', function () {
+      const json = serializer.serialize({
+        targetProfileId: 1,
+        detachedOrganizationIds: [1, 5],
+      });
+
+      expect(json).to.deep.equal({
+        data: {
+          type: 'target-profile-detach-organizations',
+          id: '1',
+          attributes: {
+            'detached-organization-ids': [1, 5],
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, les pôles métiers peuvent rattacher des profils cibles à des orga, ou des orga à des profils cibles, afin que les orga puissent créer des parcours selon leurs besoins.

Il n’est pas possible de détacher ces profils cibles, qu’ils aient été rattachés par erreur ou qu’ils soient obsolètes pour une orga (mais pas pour les autres), cette epix a pour but de permettre aux pôles métiers d’effectuer ce détachement.

## :robot: Proposition
On ajoute une colonne sur la liste des organisations rattachées à un profil cible avec un bouton qui permet de détacher l'organisation du profil cible.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixAdmin en tant qu'admin ou métier
- Aller sur la page d'un profil cible
- Aller dans l'onglet organisations
- Constater la présence d'une nouvelle colonne
- Cliquer sur le bouton pour détacher une organisation
- Constater qu'elle n'apparaît plus dans la liste
- Vérifier sur PixOrga que le profil cible n'apparaît plus dans la liste des possibilités sur la page de création d'une campagne
