### PR TITLE
[FEATURE] Ajouter la traduction anglaise du mail d'invitation à Pix Certif (PIX-8141).

### DIFF
--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -111,17 +111,17 @@
   },
   "certification-center-invitation-email": {
     "params": {
-      "acceptInvitation": "Accepter l’invitation",
-      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
-      "here": "ici",
-      "moreAbout": "En savoir plus sur",
-      "needHelp": "Besoin d’aide, contactez-nous",
-      "oneTimeLink": "Ce lien est à usage unique",
-      "pixCertifPresentation": "L’espace Pix Certif est un outil dédié à l’organisation des sessions de certification.",
-      "title": "Invitation à rejoindre l’espace",
-      "yourCertificationCenter": "Votre centre de certification"
+      "acceptInvitation": "Accept the invitation",
+      "doNotAnswer": "This is an automated email message, please do not reply.",
+      "here": "here",
+      "moreAbout": "Find out more about",
+      "needHelp": "Need help, contact us",
+      "oneTimeLink": "This is a one-time use link",
+      "pixCertifPresentation": "The Pix Certif space is a tool dedicated to the organisation of certification sessions.",
+      "title": "Invitation to join the Pix Certif space",
+      "yourCertificationCenter": "Your certification centre"
     },
-    "subject": "Invitation à rejoindre Pix Certif"
+    "subject": "Invitation to join Pix Certif"
   },
   "certification-result-email": {
     "params": {


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Pour avoir accès à un espace Pix Certif, un utilisateur doit y avoir été invité. L’invitation est envoyée par mail depuis Pix Admin.

Toutes les informations du mail d’invitation sont en français alors qu’on a choisi la version en anglais dans Pix Admin.

## :robot: Proposition
Rajouter les traductions du mail en anglais. 

## :100: Pour tester
- Se connecter à Pix Admin avec superadmin ou nextsuperadmin
- Aller sur un centre de certification
- Envoyer un mail de destinataire et choisir la langue anglaise puis envoyer l'invitation
- Constater dans la boite mail de destination que le mail et son objet sont en anglais
