### PR TITLE
[FEATURE] Améliorer le style visuel de la recommendation des contenus formatifs (PIX-7667).

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -2,7 +2,7 @@
   <a class="training-card__content" href={{@training.link}} target="_blank" rel="noopener noreferrer">
     <h3 class="training-card-content__title">{{@training.title}}</h3>
     <div class="training-card-content__infos" title="{{this.tagTitle}}">
-      <PixTag @color={{this.tagColor}} class="training-card-content-infos__tag">
+      <PixTag @compact={{true}} @color={{this.tagColor}} class="training-card-content-infos__tag">
         <ul class="training-card-content-infos-tag__list">
           <li class="training-card-content-infos-tag-list__type">
             {{this.type}}

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -1,7 +1,6 @@
 .training-card {
   position: relative;
   min-width: 240px;
-  height: 390px;
 }
 
 .training-card__content {
@@ -11,20 +10,19 @@
 }
 
 .training-card-content__title {
+  @extend %pix-body-l;
+
   display: -webkit-box;
-  margin: 24px 16px 8px;
+  padding: $pix-spacing-s;
   overflow: hidden;
   color: $pix-neutral-90;
   font-weight: $font-medium;
-  font-size: 1.12rem;
-  font-family: $font-roboto;
-  line-height: 1.75rem;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
 
 .training-card-content__infos {
-  padding: 0 $pix-spacing-s $pix-spacing-xxl;
+  padding: 0 $pix-spacing-s;
 }
 
 .training-card-content-infos__tag {
@@ -49,11 +47,9 @@
 }
 
 .training-card-content__illustration {
-  position: absolute;
-  bottom: 80px;
-  left: 0;
-  width: 100%;
+  position: relative;
   height: 155px;
+  margin-top: $pix-spacing-m;
 
   .training-card-content-illustration {
     &__logo {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -36,9 +36,8 @@
 
   &__trainings {
     margin-top: $pix-spacing-xl;
-    padding: 2.5rem 2rem 3rem;
-    background-color: $pix-neutral-10;
-    border-radius: 10px;
+    padding: $pix-spacing-l 0;
+    border-top: 2px solid $pix-neutral-20;
   }
 
   &__share {
@@ -142,44 +141,43 @@
 
 .skill-review-trainings {
   &__title {
-    color: $pix-neutral-100;
-    font-size: 1.5rem;
-    font-family: $font-open-sans;
-    text-align: center;
+    @extend %pix-title-s;
+
+    color: $pix-neutral-90;
   }
 
   &__description {
-    margin: 0.5rem 0 2rem;
+    @extend %pix-body-s;
+
+    margin-top: $pix-spacing-xs;
     color: $pix-neutral-45;
-    font-size: 1.125rem;
-    font-family: $font-open-sans;
-    line-height: 1.8rem;
-    text-align: center;
   }
 
   &__list {
     display: grid;
     grid-template-columns: 1fr;
+    align-items: center;
+    margin-top: $pix-spacing-m;
     padding: 0;
     column-gap: 24px;
-    list-style: none;
     row-gap: 24px;
+    list-style: none;
 
     @include device-is('tablet') {
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(2, 1fr);
     }
 
     @include device-is('desktop') {
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: repeat(3, 1fr);
     }
   }
-}
 
-.skill-review-trainings-list {
-  &__item {
+  &-list__item {
     width: 100%;
     padding: 0;
     overflow: hidden;
+    border: 1px solid $pix-neutral-15;
+    border-radius: 8px;
     transition: all 0.2s ease-in-out;
 
     &:hover {
@@ -608,7 +606,7 @@
 .skill-review-share-error {
   &__message {
     padding-bottom: 10px;
-    color: #F45C00;
+    color: #f45c00;
     font-size: 0.938rem;
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Pour des raisons d'accessibilité, le texte en gris sur gris n’était pas assez lisible.

![image](https://github.com/1024pix/pix/assets/7335131/bc31d1b6-144b-4fff-86b6-a2ee954d6975)


## :robot: Proposition

Revoir le design du bloc des contenus formatifs pour correspondre à la [maquette](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?type=design&node-id=3726-107456&t=efvXRg3djBFGsAbG-4) : 
- Enlever le background-color gris
- Aligner les textes à gauche
- Revoir le style des textes (utiliser les couleurs du DS, revoir les tailles…)

## :100: Pour tester

- Aller sur la RA de Pix-App
- Se connecter avec l'utilisateur `userpix1`
- Rentrer le code de campagne `PIXEDUINI`
- Vérifier que le style du bloc de recommandation de contenu formatif correspond bien à la maquette
