### PR TITLE
[FEATURE] Reporter le texte des pages SCO de Pix Certif dans des clés de traduction (PIX-8023).

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -2,13 +2,13 @@
 
   <div class="add-student-list">
     <div class="add-student-list__filters">
-      <span>Filtrer</span>
+      <span>{{t "pages.sco.enrol-candidates-in-session.list.table.filter.title"}}</span>
       <PixMultiSelect
-        @label="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
+        @label={{t "pages.sco.enrol-candidates-in-session.list.table.filter.extra-information"}}
         @emptyMessage={{this.emptyMessage}}
         @id={{"add-student-list__multi-select"}}
         @onChange={{this.selectDivision}}
-        @placeholder={{"Chercher une classe ..."}}
+        @placeholder={{t "pages.sco.enrol-candidates-in-session.list.table.filter.placeholder"}}
         @isSearchable={{true}}
         @screenReaderOnly={{true}}
         @values={{this.selectedDivisions}}
@@ -34,10 +34,12 @@
                 <span class="screen-reader-only">{{t "pages.candidates.add.actions.select-all.label"}}</span>
               </PixCheckbox>
             </th>
-            <th>Classe</th>
-            <th>Nom</th>
-            <th>Prénom</th>
-            <th class="add-student-list__column-birthdate">Date de naissance</th>
+            <th>{{t "pages.sco.enrol-candidates-in-session.list.table.division"}}</th>
+            <th>{{t "pages.sco.enrol-candidates-in-session.list.table.last-name"}}</th>
+            <th>{{t "pages.sco.enrol-candidates-in-session.list.table.first-name"}}</th>
+            <th class="add-student-list__column-birthdate">
+              {{t "pages.sco.enrol-candidates-in-session.list.table.birthdate"}}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -93,15 +95,15 @@
           <p class="bottom-action-bar__informations--candidates-selected">
             {{#if this.numberOfStudentsSelected}}
               {{this.numberOfStudentsSelected}}
-              candidat(s) sélectionné(s)
+              {{t "pages.sco.enrol-candidates-in-session.list.action-bar.candidate-selected"}}
             {{else}}
-              Aucun candidat sélectionné
+              {{t "pages.sco.enrol-candidates-in-session.list.action-bar.no-candidate-selected"}}
             {{/if}}
           </p>
           <span class="bottom-action-bar__seperator"></span>
           <p class="bottom-action-bar__informations--candidates-already-added">
             {{this.numberOfStudentsAlreadyCandidate}}
-            candidat(s) déjà inscrit(s) à la session
+            {{t "pages.sco.enrol-candidates-in-session.list.action-bar.candidate-already-enrolled"}}
           </p>
         </div>
 

--- a/certif/app/components/certification-candidates-sco.hbs
+++ b/certif/app/components/certification-candidates-sco.hbs
@@ -1,9 +1,9 @@
 <div class="panel">
   <div class="certification-candidates-sco-actions">
     <img src="/images/adding_candidate.svg" alt="" role="none" />
-    <p>Inscrivez des élèves et c'est partix !</p>
+    <p>{{t "pages.sco.enrol-candidates-in-session.certification-candidates-sco.information"}}</p>
     <PixButtonLink @route="authenticated.sessions.add-student" @model={{@sessionId}}>
-      Inscrire des candidats
+      {{t "pages.sco.enrol-candidates-in-session.certification-candidates-sco.actions.enrol-candidates"}}
     </PixButtonLink>
   </div>
 </div>

--- a/certif/app/controllers/authenticated/sessions/add-student.js
+++ b/certif/app/controllers/authenticated/sessions/add-student.js
@@ -1,7 +1,14 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default class SessionsAddStudentController extends Controller {
+  @service url;
+
   get pageTitle() {
     return `Inscription des candidats | Session ${this.model.session.id} | Pix Certif`;
+  }
+
+  get supportUrl() {
+    return this.url.supportUrl;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/add-student.js
+++ b/certif/app/controllers/authenticated/sessions/add-student.js
@@ -3,9 +3,12 @@ import { inject as service } from '@ember/service';
 
 export default class SessionsAddStudentController extends Controller {
   @service url;
+  @service intl;
 
   get pageTitle() {
-    return `Inscription des candidats | Session ${this.model.session.id} | Pix Certif`;
+    return `${this.intl.t('pages.sco.enrol-candidates-in-session.page-title')} | Session ${
+      this.model.session.id
+    } | Pix Certif`;
   }
 
   get supportUrl() {

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -49,4 +49,11 @@ export default class Url extends Service {
       ? 'https://pix.org/fr/accessibilite-pix-certif'
       : 'https://pix.org/en-gb/accessibility-pix-certif';
   }
+
+  get supportUrl() {
+    if (this.currentDomain.isFranceDomain) return 'https://support.pix.fr';
+
+    const currentLanguage = this.intl.t('current-lang');
+    return currentLanguage === 'fr' ? 'https://support.pix.org' : 'https://support.pix.org/en/support/home';
+  }
 }

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -60,11 +60,11 @@
 
     {{#if this.showBanner}}
       <PixBanner
-        @actionLabel="documentation pour voir les nouveautés."
+        @actionLabel={{t "pages.sco.banner.url-label"}}
         @actionUrl="https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
         @canCloseBanner="true"
-      >La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin
-        2023 pour les collèges. Pensez à consulter la
+      >
+        {{t "pages.sco.banner.information"}}
       </PixBanner>
 
     {{/if}}

--- a/certif/app/templates/authenticated/restricted-access.hbs
+++ b/certif/app/templates/authenticated/restricted-access.hbs
@@ -1,6 +1,7 @@
 <div class="page restricted-access-page">
   <img class="restricted-access-content__image" src="/images/calendar_blocked_access_sco.svg" alt="" role="none" />
-  <h1 class="restricted-access-content__opening-title">Ouverture de votre espace PixCertif le
+  <h1 class="restricted-access-content__opening-title">
+    {{t "pages.sco.restricted-access.title"}}
     {{dayjs-format this.certificationOpeningDate "DD/MM/YYYY"}}
   </h1>
 </div>

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -14,7 +14,7 @@
     Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br
     />
     Si malgré tout des élèves ne sont pas visibles, merci de contacter
-    <a href="https://support.pix.fr" target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
+    <a href={{this.supportUrl}} target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
   </PixMessage>
 
   <AddStudentList

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -5,7 +5,9 @@
     @route="authenticated.sessions.details.certification-candidates"
     @model={{@model.session.id}}
     class="add-student__return-to"
-  >Retour à la session</PixReturnTo>
+  >
+    {{t "common.sessions.actions.return-to"}}
+  </PixReturnTo>
 
   <h1 class="add-student__title">Inscrire des candidats</h1>
   <PixMessage @type="info" @withIcon={{true}} class="add-student__info-message">

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -14,6 +14,7 @@
     {{t "pages.sco.enrol-candidates-in-session.information" htmlSafe=true}}
     <a href={{this.supportUrl}} target="_blank" rel="noopener noreferrer">
       {{t "pages.sco.enrol-candidates-in-session.link-label"}}
+      <span class="sr-only">{{t "navigation.external-link-title"}}</span>
     </a>
   </PixMessage>
 

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -9,12 +9,12 @@
     {{t "common.sessions.actions.return-to"}}
   </PixReturnTo>
 
-  <h1 class="add-student__title">Inscrire des candidats</h1>
+  <h1 class="add-student__title">{{t "pages.sco.enrol-candidates-in-session.title"}}</h1>
   <PixMessage @type="info" @withIcon={{true}} class="add-student__info-message">
-    Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br
-    />
-    Si malgré tout des élèves ne sont pas visibles, merci de contacter
-    <a href={{this.supportUrl}} target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
+    {{t "pages.sco.enrol-candidates-in-session.information" htmlSafe=true}}
+    <a href={{this.supportUrl}} target="_blank" rel="noopener noreferrer">
+      {{t "pages.sco.enrol-candidates-in-session.link-label"}}
+    </a>
   </PixMessage>
 
   <AddStudentList

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -2,7 +2,7 @@
 <div class="page__title finalize">
   <div class="finalize__title">
     <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}}>
-      {{t "pages.session-finalization.return-to"}}
+      {{t "common.sessions.actions.return-to"}}
     </PixReturnTo>
     <h1 class="page-title">{{t "pages.session-finalization.title" sessionId=this.session.id}}</h1>
   </div>

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -77,6 +77,15 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       assert.dom(screen.getByRole('heading', { name: 'Inscrire des candidats' })).exists();
     });
 
+    test('it should display support external link', async function (assert) {
+      // when
+      const screen = await visitScreen(`/sessions/${session.id}/candidats`);
+      await click(screen.getByRole('link', { name: 'Inscrire des candidats' }));
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'support.pix.fr Ouverture dans une nouvelle fenêtre' })).exists();
+    });
+
     test('it should be possible to return to candidates page from add student page', async function (assert) {
       // when
       const screen = await visitScreen(`/sessions/${session.id}/candidats`);

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -234,4 +234,52 @@ module('Unit | Service | url', function (hooks) {
       });
     });
   });
+
+  module('#supportUrl', function () {
+    module('when current domain is fr', function () {
+      test('should return "pix.fr" url', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
+
+        // when
+        const supportUrl = service.supportUrl;
+
+        // then
+        assert.strictEqual(supportUrl, 'https://support.pix.fr');
+      });
+    });
+
+    module('when current domain is org', function () {
+      module('when current language is en', function () {
+        test('should return "pix.org/en/support/home" url', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const supportUrl = service.supportUrl;
+
+          // then
+          assert.strictEqual(supportUrl, 'https://support.pix.org/en/support/home');
+        });
+      });
+
+      module('when current language is fr', function () {
+        test('should return "pix.org" url', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+          service.intl = { t: sinon.stub().returns('fr') };
+
+          // when
+          const supportUrl = service.supportUrl;
+
+          // then
+          assert.strictEqual(supportUrl, 'https://support.pix.org');
+        });
+      });
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -210,8 +210,14 @@
         "url-label": "documentation pour voir les nouveautés."
       },
       "enrol-candidates-in-session": {
+        "certification-candidates-sco": {
+          "actions": {
+            "enrol-candidates": "Inscrire des candidats"
+          },
+          "information": "Inscrivez des élèves et c'est partix !"
+        },
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br> Si malgré tout des élèves ne sont pas visibles, merci de contacter",
-        "link-label": "support.pix.fr",
+        "link-label": "support.pix.org",
         "list": {
           "action-bar": {
             "candidate-already-enrolled": "candidat(s) déjà inscrit(s) à la session",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -115,6 +115,9 @@
       }
     },
     "sessions": {
+      "actions": {
+        "return-to": "Return to the session"
+      },
       "candidates": "Candidates",
       "invigilator": "Invigilator"
     }
@@ -338,7 +341,6 @@
           }
         }
       },
-      "return-to": "Return to the session",
       "title": "Finalise the session {sessionId}"
     },
     "session-supervising": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -214,6 +214,9 @@
         "link-label": "support.pix.fr",
         "page-title": "Inscription des candidats",
         "title": "Inscrire des candidats"
+      },
+      "restricted-access": {
+        "title": "Ouverture de votre espace PixCertif le"
       }
     },
     "session-finalization": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -208,6 +208,12 @@
       "banner": {
         "information": "La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la",
         "url-label": "documentation pour voir les nouveautés."
+      },
+      "enrol-candidates-in-session": {
+        "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br> Si malgré tout des élèves ne sont pas visibles, merci de contacter",
+        "link-label": "support.pix.fr",
+        "page-title": "Inscription des candidats",
+        "title": "Inscrire des candidats"
       }
     },
     "session-finalization": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -201,6 +201,12 @@
       },
       "title": "You have been invited to join the certification center {certificationCenterName}"
     },
+    "sco": {
+      "banner": {
+        "information": "La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la",
+        "url-label": "documentation pour voir les nouveautés."
+      }
+    },
     "session-finalization": {
       "actions": {
         "finalise": "Finalise"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -212,6 +212,24 @@
       "enrol-candidates-in-session": {
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br> Si malgré tout des élèves ne sont pas visibles, merci de contacter",
         "link-label": "support.pix.fr",
+        "list": {
+          "action-bar": {
+            "candidate-already-enrolled": "candidat(s) déjà inscrit(s) à la session",
+            "candidate-selected": "candidat(s) sélectionné(s)",
+            "no-candidate-selected": "Aucun candidat sélectionné"
+          },
+          "table": {
+            "birthdate": "Date de naissance",
+            "division": "Classe",
+            "filter": {
+              "extra-information": "Filtrer la liste des élèves en cochant la ou les classes souhaitées",
+              "placeholder": "Chercher une classe ...",
+              "title": "Filtrer"
+            },
+            "first-name": "Prénom",
+            "last-name": "Nom"
+          }
+        },
         "page-title": "Inscription des candidats",
         "title": "Inscrire des candidats"
       },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -210,6 +210,12 @@
         "url-label": "documentation pour voir les nouveautés."
       },
       "enrol-candidates-in-session": {
+        "certification-candidates-sco": {
+          "actions": {
+            "enrol-candidates": "Inscrire des candidats"
+          },
+          "information": "Inscrivez des élèves et c'est partix !"
+        },
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br> Si malgré tout des élèves ne sont pas visibles, merci de contacter",
         "link-label": "support.pix.fr",
         "list": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -214,6 +214,9 @@
         "link-label": "support.pix.fr",
         "page-title": "Inscription des candidats",
         "title": "Inscrire des candidats"
+      },
+      "restricted-access": {
+        "title": "Ouverture de votre espace PixCertif le"
       }
     },
     "session-finalization": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -208,6 +208,12 @@
       "banner": {
         "information": "La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la",
         "url-label": "documentation pour voir les nouveautés."
+      },
+      "enrol-candidates-in-session": {
+        "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br> Si malgré tout des élèves ne sont pas visibles, merci de contacter",
+        "link-label": "support.pix.fr",
+        "page-title": "Inscription des candidats",
+        "title": "Inscrire des candidats"
       }
     },
     "session-finalization": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -201,6 +201,12 @@
       },
       "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}"
     },
+    "sco": {
+      "banner": {
+        "information": "La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la",
+        "url-label": "documentation pour voir les nouveautés."
+      }
+    },
     "session-finalization": {
       "actions": {
         "finalise": "Finaliser"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -212,6 +212,24 @@
       "enrol-candidates-in-session": {
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br> Si malgré tout des élèves ne sont pas visibles, merci de contacter",
         "link-label": "support.pix.fr",
+        "list": {
+          "action-bar": {
+            "candidate-already-enrolled": "candidat(s) déjà inscrit(s) à la session",
+            "candidate-selected": "candidat(s) sélectionné(s)",
+            "no-candidate-selected": "Aucun candidat sélectionné"
+          },
+          "table": {
+            "birthdate": "Date de naissance",
+            "division": "Classe",
+            "filter": {
+              "extra-information": "Filtrer la liste des élèves en cochant la ou les classes souhaitées",
+              "placeholder": "Chercher une classe ...",
+              "title": "Filtrer"
+            },
+            "first-name": "Prénom",
+            "last-name": "Nom"
+          }
+        },
         "page-title": "Inscription des candidats",
         "title": "Inscrire des candidats"
       },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -115,6 +115,9 @@
       }
     },
     "sessions": {
+      "actions": {
+        "return-to": "Retour à la session"
+      },
       "candidates": "Candidats",
       "invigilator": "Surveillant"
     }
@@ -338,7 +341,6 @@
           }
         }
       },
-      "return-to": "Retour à la session",
       "title": "Finaliser la session {sessionId}"
     },
     "session-supervising": {


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Aucun utilisateur SCO anglophone n’est prévu à ce stade, les pages spécifiques au SCO ne sont donc pas traduites en anglais. Mais dans un contexte d’internationalisation de Pix, il n’est pas impossible qu’on ait besoin à l’avenir de traduire ces éléments spécifiques au SCO.

## :robot: Proposition
Transformer en clés de trad les phrases en dur dans les pages sco (**mais sans traduire**)

## :rainbow: Remarques
Ajout d'un supportUrl pour accéder au site du support selon la langue de l'app

## :100: Pour tester

Scénario 1 : 

- Ajouter la variable `PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE`=2023-09-22 sur l'API
- Se connecter avec certifsco
- Constater que le texte est bien retournée

<img width="1173" alt="Capture d’écran 2023-05-24 à 18 19 28" src="https://github.com/1024pix/pix/assets/58915422/0c226ac2-58fd-489f-abe9-cf29ccf80c8a">

scénario 2:

- Retirer la variable pour avoir accès à l'espace certif
- Constater que le bandeau est bien retourné 
<img width="1549" alt="Capture d’écran 2023-05-25 à 10 26 37" src="https://github.com/1024pix/pix/assets/58915422/c47f9b13-0749-4353-ba10-4ed4679ad24d">

- Cliquer sur une session
- Constater que le texte est bien retourné pour les pages suivantes : 
<img width="1484" alt="Capture d’écran 2023-05-25 à 10 18 54" src="https://github.com/1024pix/pix/assets/58915422/130cd5f2-e5e2-4e59-b4b2-14adb877806c">
<img width="772" alt="Capture d’écran 2023-05-25 à 10 19 07" src="https://github.com/1024pix/pix/assets/58915422/77cf2fdf-37d2-4f62-bf97-426cdeab7a88">
