### PR TITLE
[FEATURE] Empêcher la double soumission des formulaires d'authentification (PIX-8153)

### DIFF
--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -29,13 +29,13 @@
       </PixCheckbox>
     </div>
 
-    {{#if this.registerError}}
+    {{#if this.registerErrorMessage}}
       <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
         {{this.registerErrorMessage}}
       </PixMessage>
     {{/if}}
 
-    <PixButton @type="submit" @triggerAction={{this.register}}>
+    <PixButton @type="submit" @triggerAction={{this.register}} @isLoading={{this.isRegisterLoading}}>
       {{t "pages.login-or-register-oidc.register-form.button"}}
     </PixButton>
   </div>
@@ -75,13 +75,13 @@
         </LinkTo>
       </div>
 
-      {{#if this.loginError}}
+      {{#if this.loginErrorMessage}}
         <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
           {{this.loginErrorMessage}}
         </PixMessage>
       {{/if}}
 
-      <PixButton @type="submit" class="login-or-register-oidc-form__submit-button">
+      <PixButton @type="submit" @isLoading={{this.isLoginLoading}} class="login-or-register-oidc-form__submit-button">
         {{t "pages.login-or-register-oidc.login-form.button"}}
       </PixButton>
     </form>

--- a/mon-pix/app/components/authentication/oidc-reconciliation.hbs
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.hbs
@@ -62,6 +62,8 @@
       @backgroundColor="transparent-light"
       @isBorderVisible={{true}}
     >{{t "pages.oidc-reconciliation.return"}}</PixButton>
-    <PixButton @triggerAction={{this.reconcile}}>{{t "pages.oidc-reconciliation.confirm"}}</PixButton>
+    <PixButton @triggerAction={{this.reconcile}} @isLoading={{this.isLoading}}>
+      {{t "pages.oidc-reconciliation.confirm"}}
+    </PixButton>
   </div>
 </div>

--- a/mon-pix/app/components/authentication/oidc-reconciliation.js
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.js
@@ -10,6 +10,7 @@ export default class OidcReconciliationComponent extends Component {
   @service session;
 
   @tracked reconcileErrorMessage = null;
+  @tracked isLoading = false;
 
   get identityProviderOrganizationName() {
     return this.oidcIdentityProviders[this.args.identityProviderSlug]?.organizationName;
@@ -40,6 +41,8 @@ export default class OidcReconciliationComponent extends Component {
 
   @action
   async reconcile() {
+    this.isLoading = true;
+
     try {
       await this.session.authenticate('authenticator:oidc', {
         authenticationKey: this.args.authenticationKey,
@@ -52,6 +55,8 @@ export default class OidcReconciliationComponent extends Component {
         401: this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key'),
       };
       this.reconcileErrorMessage = errorsMapping[status] || this.intl.t('common.error');
+    } finally {
+      this.isLoading = false;
     }
   }
 }

--- a/mon-pix/app/components/routes/campaigns/sco-form.hbs
+++ b/mon-pix/app/components/routes/campaigns/sco-form.hbs
@@ -85,7 +85,7 @@
     <div class="join-restricted-campaign__error" aria-live="polite">{{@errorMessage}}</div>
   {{/if}}
   <div class="join-restricted-campaign__actions">
-    <PixButton @type="submit">{{t "pages.join.button"}}</PixButton>
+    <PixButton @type="submit" @isLoading={{this.isLoading}}>{{t "pages.join.button"}}</PixButton>
   </div>
 
   <p class="legal-notice">

--- a/mon-pix/app/components/routes/campaigns/sco-form.js
+++ b/mon-pix/app/components/routes/campaigns/sco-form.js
@@ -28,13 +28,14 @@ class Validation {
 export default class ScoForm extends Component {
   @service intl;
 
-  validation = new Validation();
-
   @tracked firstName;
   @tracked lastName;
   @tracked dayOfBirth;
   @tracked monthOfBirth;
   @tracked yearOfBirth;
+  @tracked isLoading = false;
+
+  validation = new Validation();
 
   constructor() {
     super(...arguments);
@@ -70,8 +71,10 @@ export default class ScoForm extends Component {
     if (this.isFormNotValid) {
       return;
     }
+    this.isLoading = true;
 
     await this.args.onSubmit({ firstName: this.firstName, lastName: this.lastName, birthdate: this.birthdate });
+    this.isLoading = false;
   }
 
   @action

--- a/mon-pix/app/components/routes/login-form.hbs
+++ b/mon-pix/app/components/routes/login-form.hbs
@@ -30,13 +30,9 @@
     </div>
 
     <div class="login-button-container pix-form__actions">
-      {{#if this.isLoading}}
-        <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
-      {{else}}
-        <PixButton id="submit-connexion" @type="submit">
-          {{t "pages.login-or-register.login-form.button"}}
-        </PixButton>
-      {{/if}}
+      <PixButton id="submit-connexion" @type="submit" @isLoading={{this.isLoading}}>
+        {{t "pages.login-or-register.login-form.button"}}
+      </PixButton>
     </div>
 
   </form>

--- a/mon-pix/app/components/routes/register-form.hbs
+++ b/mon-pix/app/components/routes/register-form.hbs
@@ -63,13 +63,9 @@
 
     {{#unless this.matchingStudentFound}}
       <div class="register-button-container">
-        {{#if this.isLoading}}
-          <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
-        {{else}}
-          <PixButton id="submit-search" @type="submit">
-            {{t "pages.login-or-register.register-form.button-form"}}
-          </PixButton>
-        {{/if}}
+        <PixButton id="submit-search" @type="submit" @isLoading={{this.isLoading}}>
+          {{t "pages.login-or-register.register-form.button-form"}}
+        </PixButton>
       </div>
     {{/unless}}
 
@@ -132,13 +128,9 @@
       {{/if}}
 
       <div class="register-button-container">
-        {{#if this.isLoading}}
-          <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
-        {{else}}
-          <PixButton id="submit-registration" @type="submit">
-            {{t "pages.login-or-register.register-form.button-form"}}
-          </PixButton>
-        {{/if}}
+        <PixButton id="submit-registration" @type="submit" @isLoading={{this.isLoading}}>
+          {{t "pages.login-or-register.register-form.button-form"}}
+        </PixButton>
       </div>
 
       <PixButton

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -59,6 +59,7 @@ class YearOfBirth {
   @tracked status = 'default';
   @tracked message = null;
 }
+
 class FormValidation {
   lastName = new LastName();
   firstName = new FirstName();
@@ -191,10 +192,10 @@ export default class RegisterForm extends Component {
     if (this.isCreationFormNotValid) {
       return (this.isLoading = false);
     }
-
     try {
       this.dependentUser.password = this.password;
       this.dependentUser.withUsername = this.loginWithUsername;
+
       if (this.loginWithUsername) {
         this.dependentUser.username = this.username;
         this.dependentUser.email = undefined;
@@ -202,12 +203,12 @@ export default class RegisterForm extends Component {
         this.dependentUser.email = this.email;
         this.dependentUser.username = undefined;
       }
+
       await this.dependentUser.save();
 
       const userLogin = this.loginWithUsername ? this.dependentUser.username : this.dependentUser.email;
       await this._authenticate(userLogin, this.dependentUser.password);
     } catch (responseError) {
-      this.isLoading = false;
       responseError.errors.forEach((error) => {
         let defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
         if (error.status === '422') {
@@ -222,10 +223,10 @@ export default class RegisterForm extends Component {
         this.displayRegisterErrorMessage = true;
         this.registerErrorMessage = defaultMessage;
       });
+    } finally {
+      this.dependentUser.password = null;
+      this.isLoading = false;
     }
-
-    this.dependentUser.password = null;
-    this.isLoading = false;
   }
 
   @action

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -13,7 +13,7 @@
     </div>
   </div>
 
-  {{#if this.hasFailed}}
+  {{#if this.errorMessage}}
     <p class="sign-form__notification-message--error" role="alert" id="sign-in-error-message">
       {{this.errorMessage}}
     </p>
@@ -55,7 +55,7 @@
     </fieldset>
 
     <div class="sign-form-body__bottom-button">
-      <PixButton @type="submit" @shape="rounded">
+      <PixButton @type="submit" @shape="rounded" @isLoading={{this.isLoading}}>
         {{t "pages.sign-in.actions.submit"}}
       </PixButton>
     </div>

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -16,10 +16,10 @@ export default class SigninForm extends Component {
   @service router;
   @service oidcIdentityProviders;
 
-  @tracked hasFailed = false;
   @tracked errorMessage;
   @tracked password = null;
   @tracked login = null;
+  @tracked isLoading = false;
 
   get showcase() {
     return this.url.showcase;
@@ -36,12 +36,14 @@ export default class SigninForm extends Component {
   @action
   async signin(event) {
     event && event.preventDefault();
-    this.hasFailed = false;
+    this.isLoading = true;
+
     try {
       await this.session.authenticateUser(this.login, this.password);
     } catch (responseError) {
-      this.hasFailed = true;
       this._handleApiError(responseError);
+    } finally {
+      this.isLoading = false;
     }
   }
 

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -10,37 +10,141 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
   setupIntl(hooks);
 
   module('#register', function () {
-    test('should create session', function (assert) {
-      // given
-      const component = createGlimmerComponent('authentication/login-or-register-oidc');
-      const authenticateStub = sinon.stub();
-
-      class SessionStub extends Service {
-        authenticate = authenticateStub;
-      }
-
-      this.owner.register('service:session', SessionStub);
-      component.args.identityProviderSlug = 'super-idp';
-      component.args.authenticationKey = 'super-key';
-      component.isTermsOfServiceValidated = true;
-
-      // when
-      component.register();
-
-      // then
-      sinon.assert.calledWith(authenticateStub, 'authenticator:oidc', {
-        authenticationKey: 'super-key',
-        identityProviderSlug: 'super-idp',
-        hostSlug: 'users',
-      });
-      assert.ok(true);
-    });
-
-    module('when authentication key has expired', function () {
-      test('should display error', async function (assert) {
+    module('completes', function () {
+      test('creates session', function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        const authenticateStub = sinon.stub().rejects({ errors: [{ status: '401' }] });
+        const authenticateStub = sinon.stub();
+
+        class SessionStub extends Service {
+          authenticate = authenticateStub;
+        }
+
+        this.owner.register('service:session', SessionStub);
+        component.args.identityProviderSlug = 'super-idp';
+        component.args.authenticationKey = 'super-key';
+        component.isTermsOfServiceValidated = true;
+
+        // when
+        component.register();
+
+        // then
+        sinon.assert.calledWith(authenticateStub, 'authenticator:oidc', {
+          authenticationKey: 'super-key',
+          identityProviderSlug: 'super-idp',
+          hostSlug: 'users',
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('completes with error', function () {
+      module('when authentication key has expired', function () {
+        test('displays error', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/login-or-register-oidc');
+          const authenticateStub = sinon.stub().rejects({ errors: [{ status: '401' }] });
+
+          class SessionStub extends Service {
+            authenticate = authenticateStub;
+          }
+
+          this.owner.register('service:session', SessionStub);
+          component.args.identityProviderSlug = 'super-idp';
+          component.args.authenticationKey = 'super-key';
+          component.isTermsOfServiceValidated = true;
+
+          // when
+          await component.register();
+
+          // then
+          assert.strictEqual(
+            component.registerErrorMessage,
+            this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
+          );
+        });
+      });
+
+      module('when terms of service are not selected', function () {
+        test('displays error', function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/login-or-register-oidc');
+          component.isTermsOfServiceValidated = false;
+
+          // when
+          component.register();
+
+          // then
+
+          assert.strictEqual(
+            component.registerErrorMessage,
+            this.intl.t('pages.login-or-register-oidc.error.error-message')
+          );
+        });
+      });
+
+      module('locale errors', function () {
+        module('when invalid locale', function () {
+          test('it displays the invalid locale error message', async function (assert) {
+            // given
+            const component = createGlimmerComponent('authentication/login-or-register-oidc');
+            const authenticateStub = sinon
+              .stub()
+              .rejects({ errors: [{ status: '400', code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'zzzz' } }] });
+
+            class SessionStub extends Service {
+              authenticate = authenticateStub;
+            }
+
+            this.owner.register('service:session', SessionStub);
+            component.args.identityProviderSlug = 'super-idp';
+            component.args.authenticationKey = 'super-key';
+            component.isTermsOfServiceValidated = true;
+
+            // when
+            await component.register();
+
+            // then
+            assert.strictEqual(
+              component.registerErrorMessage,
+              `${this.intl.t('pages.sign-up.errors.invalid-locale-format', { invalidLocale: 'zzzz' })}`
+            );
+          });
+        });
+
+        module('when locale is not supported', function () {
+          test('it displays the unsupported locale error message', async function (assert) {
+            // given
+            const component = createGlimmerComponent('authentication/login-or-register-oidc');
+            const authenticateStub = sinon
+              .stub()
+              .rejects({ errors: [{ status: '400', code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'jp' } }] });
+
+            class SessionStub extends Service {
+              authenticate = authenticateStub;
+            }
+
+            this.owner.register('service:session', SessionStub);
+            component.args.identityProviderSlug = 'super-idp';
+            component.args.authenticationKey = 'super-key';
+            component.isTermsOfServiceValidated = true;
+
+            // when
+            await component.register();
+
+            // then
+            assert.strictEqual(
+              component.registerErrorMessage,
+              `${this.intl.t('pages.sign-up.errors.locale-not-supported', { localeNotSupported: 'jp' })}`
+            );
+          });
+        });
+      });
+
+      test('displays detailed error', async function (assert) {
+        // given
+        const component = createGlimmerComponent('authentication/login-or-register-oidc');
+        const authenticateStub = sinon.stub().rejects({ errors: [{ status: '500', detail: 'some detail' }] });
 
         class SessionStub extends Service {
           authenticate = authenticateStub;
@@ -55,134 +159,34 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.register();
 
         // then
-        assert.strictEqual(
-          component.registerErrorMessage,
-          this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
-        );
+        assert.strictEqual(component.registerErrorMessage, `${this.intl.t('common.error')} (some detail)`);
       });
-    });
 
-    module('when terms of service are not selected', function () {
-      test('should display error', function (assert) {
+      test('displays generic error', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        component.isTermsOfServiceValidated = false;
+        const authenticateStub = sinon.stub().rejects({ errors: [{ status: '500' }] });
+
+        class SessionStub extends Service {
+          authenticate = authenticateStub;
+        }
+
+        this.owner.register('service:session', SessionStub);
+        component.args.identityProviderSlug = 'super-idp';
+        component.args.authenticationKey = 'super-key';
+        component.isTermsOfServiceValidated = true;
 
         // when
-        component.register();
+        await component.register();
 
         // then
-
-        assert.strictEqual(
-          component.registerErrorMessage,
-          this.intl.t('pages.login-or-register-oidc.error.error-message')
-        );
+        assert.strictEqual(component.registerErrorMessage, this.intl.t('common.error'));
       });
-    });
-
-    module('locale errors', function () {
-      module('when invalid locale', function () {
-        test('it displays the invalid locale error message', async function (assert) {
-          // given
-          const component = createGlimmerComponent('authentication/login-or-register-oidc');
-          const authenticateStub = sinon
-            .stub()
-            .rejects({ errors: [{ status: '400', code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'zzzz' } }] });
-
-          class SessionStub extends Service {
-            authenticate = authenticateStub;
-          }
-
-          this.owner.register('service:session', SessionStub);
-          component.args.identityProviderSlug = 'super-idp';
-          component.args.authenticationKey = 'super-key';
-          component.isTermsOfServiceValidated = true;
-
-          // when
-          await component.register();
-
-          // then
-          assert.strictEqual(
-            component.registerErrorMessage,
-            `${this.intl.t('pages.sign-up.errors.invalid-locale-format', { invalidLocale: 'zzzz' })}`
-          );
-        });
-      });
-
-      module('when locale is not supported', function () {
-        test('it displays the unsupported locale error message', async function (assert) {
-          // given
-          const component = createGlimmerComponent('authentication/login-or-register-oidc');
-          const authenticateStub = sinon
-            .stub()
-            .rejects({ errors: [{ status: '400', code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'jp' } }] });
-
-          class SessionStub extends Service {
-            authenticate = authenticateStub;
-          }
-
-          this.owner.register('service:session', SessionStub);
-          component.args.identityProviderSlug = 'super-idp';
-          component.args.authenticationKey = 'super-key';
-          component.isTermsOfServiceValidated = true;
-
-          // when
-          await component.register();
-
-          // then
-          assert.strictEqual(
-            component.registerErrorMessage,
-            `${this.intl.t('pages.sign-up.errors.locale-not-supported', { localeNotSupported: 'jp' })}`
-          );
-        });
-      });
-    });
-
-    test('it should display detailed error', async function (assert) {
-      // given
-      const component = createGlimmerComponent('authentication/login-or-register-oidc');
-      const authenticateStub = sinon.stub().rejects({ errors: [{ status: '500', detail: 'some detail' }] });
-
-      class SessionStub extends Service {
-        authenticate = authenticateStub;
-      }
-
-      this.owner.register('service:session', SessionStub);
-      component.args.identityProviderSlug = 'super-idp';
-      component.args.authenticationKey = 'super-key';
-      component.isTermsOfServiceValidated = true;
-
-      // when
-      await component.register();
-
-      // then
-      assert.strictEqual(component.registerErrorMessage, `${this.intl.t('common.error')} (some detail)`);
-    });
-
-    test('it should display generic error', async function (assert) {
-      // given
-      const component = createGlimmerComponent('authentication/login-or-register-oidc');
-      const authenticateStub = sinon.stub().rejects({ errors: [{ status: '500' }] });
-
-      class SessionStub extends Service {
-        authenticate = authenticateStub;
-      }
-
-      this.owner.register('service:session', SessionStub);
-      component.args.identityProviderSlug = 'super-idp';
-      component.args.authenticationKey = 'super-key';
-      component.isTermsOfServiceValidated = true;
-
-      // when
-      await component.register();
-
-      // then
-      assert.strictEqual(component.registerErrorMessage, this.intl.t('common.error'));
     });
   });
 
   module('#validateEmail', function () {
-    test('should trim on email validation', function (assert) {
+    test('trims on email validation', function (assert) {
       // given
       const emailWithSpaces = '   glace@aleau.net   ';
       const component = createGlimmerComponent('authentication/login-or-register-oidc');
@@ -195,7 +199,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
     });
 
     module('when email is invalid', function () {
-      test('should display error', function (assert) {
+      test('displays error', function (assert) {
         // given
         const invalidEmail = 'glace@aleau';
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
@@ -230,49 +234,111 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
     });
 
-    test('should request api for login', async function (assert) {
-      // given
-      const email = 'glace.alo@example.net';
-      const password = 'pix123';
-      const component = createGlimmerComponent('authentication/login-or-register-oidc');
-      component.email = email;
-      component.password = password;
-      component.args.onLogin = sinon.stub();
-      const eventStub = { preventDefault: sinon.stub() };
-
-      // when
-      await component.login(eventStub);
-
-      // then
-      sinon.assert.calledWith(component.args.onLogin, {
-        enteredPassword: password,
-        enteredEmail: email,
-      });
-      assert.ok(true);
-    });
-
-    module('when form is invalid', function () {
-      test('should not request api for reconciliation', async function (assert) {
+    module('completes', function () {
+      test('requests api for login', async function (assert) {
         // given
+        const email = 'glace.alo@example.net';
+        const password = 'pix123';
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        component.email = '';
-        const eventStub = { preventDefault: sinon.stub() };
+        component.email = email;
+        component.password = password;
         component.args.onLogin = sinon.stub();
+        const eventStub = { preventDefault: sinon.stub() };
 
         // when
         await component.login(eventStub);
 
         // then
-        sinon.assert.notCalled(component.args.onLogin);
+        sinon.assert.calledWith(component.args.onLogin, {
+          enteredPassword: password,
+          enteredEmail: email,
+        });
         assert.ok(true);
       });
     });
 
-    module('when authentication key has expired', function () {
-      test('should display error', async function (assert) {
+    module('completes with error', function () {
+      module('when form is invalid', function () {
+        test('does not request api for reconciliation', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/login-or-register-oidc');
+          component.email = '';
+          const eventStub = { preventDefault: sinon.stub() };
+          component.args.onLogin = sinon.stub();
+
+          // when
+          await component.login(eventStub);
+
+          // then
+          sinon.assert.notCalled(component.args.onLogin);
+          assert.ok(true);
+        });
+      });
+
+      module('when authentication key has expired', function () {
+        test('should display error', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/login-or-register-oidc');
+          component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '401' }] });
+          component.email = 'glace.alo@example.net';
+          component.password = 'pix123';
+          const eventStub = { preventDefault: sinon.stub() };
+
+          // when
+          await component.login(eventStub);
+
+          // then
+          assert.strictEqual(
+            component.loginErrorMessage,
+            this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
+          );
+        });
+      });
+
+      module('when user is not found', function () {
+        test('should display error', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/login-or-register-oidc');
+          component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '404' }] });
+          component.email = 'glace.alo@example.net';
+          component.password = 'pix123';
+          const eventStub = { preventDefault: sinon.stub() };
+
+          // when
+          await component.login(eventStub);
+
+          // then
+          assert.strictEqual(
+            component.loginErrorMessage,
+            this.intl.t('pages.login-or-register-oidc.error.login-unauthorized-error')
+          );
+        });
+      });
+
+      module('when there is an account conflict', function () {
+        test('should display error', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/login-or-register-oidc');
+          component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '409' }] });
+          component.email = 'glace.alo@example.net';
+          component.password = 'pix123';
+          const eventStub = { preventDefault: sinon.stub() };
+
+          // when
+          await component.login(eventStub);
+
+          // then
+          assert.strictEqual(
+            component.loginErrorMessage,
+            this.intl.t('pages.login-or-register-oidc.error.account-conflict')
+          );
+        });
+      });
+
+      test('displays generic error', async function (assert) {
         // given
         const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '401' }] });
+        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '500' }] });
         component.email = 'glace.alo@example.net';
         component.password = 'pix123';
         const eventStub = { preventDefault: sinon.stub() };
@@ -281,66 +347,8 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.login(eventStub);
 
         // then
-        assert.strictEqual(
-          component.loginErrorMessage,
-          this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
-        );
+        assert.strictEqual(component.loginErrorMessage, this.intl.t('common.error'));
       });
-    });
-
-    module('when user is not found', function () {
-      test('should display error', async function (assert) {
-        // given
-        const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '404' }] });
-        component.email = 'glace.alo@example.net';
-        component.password = 'pix123';
-        const eventStub = { preventDefault: sinon.stub() };
-
-        // when
-        await component.login(eventStub);
-
-        // then
-        assert.strictEqual(
-          component.loginErrorMessage,
-          this.intl.t('pages.login-or-register-oidc.error.login-unauthorized-error')
-        );
-      });
-    });
-
-    module('when there is an account conflict', function () {
-      test('should display error', async function (assert) {
-        // given
-        const component = createGlimmerComponent('authentication/login-or-register-oidc');
-        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '409' }] });
-        component.email = 'glace.alo@example.net';
-        component.password = 'pix123';
-        const eventStub = { preventDefault: sinon.stub() };
-
-        // when
-        await component.login(eventStub);
-
-        // then
-        assert.strictEqual(
-          component.loginErrorMessage,
-          this.intl.t('pages.login-or-register-oidc.error.account-conflict')
-        );
-      });
-    });
-
-    test('it should display generic error', async function (assert) {
-      // given
-      const component = createGlimmerComponent('authentication/login-or-register-oidc');
-      component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '500' }] });
-      component.email = 'glace.alo@example.net';
-      component.password = 'pix123';
-      const eventStub = { preventDefault: sinon.stub() };
-
-      // when
-      await component.login(eventStub);
-
-      // then
-      assert.strictEqual(component.loginErrorMessage, this.intl.t('common.error'));
     });
   });
 });

--- a/mon-pix/tests/unit/components/authentication/oidc-reconciliation_test.js
+++ b/mon-pix/tests/unit/components/authentication/oidc-reconciliation_test.js
@@ -137,52 +137,56 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
     });
   });
 
-  module('when authentication key has expired', function () {
-    test('should display error', async function (assert) {
-      // given
-      const component = createGlimmerComponent('authentication/oidc-reconciliation');
-      const authenticateStub = sinon.stub().rejects({ errors: [{ status: '401' }] });
+  module('#reconcile', function () {
+    module('completes with error', function () {
+      module('when authentication key has expired', function () {
+        test('should display error', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/oidc-reconciliation');
+          const authenticateStub = sinon.stub().rejects({ errors: [{ status: '401' }] });
 
-      class SessionStub extends Service {
-        authenticate = authenticateStub;
-      }
+          class SessionStub extends Service {
+            authenticate = authenticateStub;
+          }
 
-      this.owner.register('service:session', SessionStub);
-      component.args.identityProviderSlug = 'super-idp';
-      component.args.authenticationKey = 'super-key';
-      component.isTermsOfServiceValidated = true;
+          this.owner.register('service:session', SessionStub);
+          component.args.identityProviderSlug = 'super-idp';
+          component.args.authenticationKey = 'super-key';
+          component.isTermsOfServiceValidated = true;
 
-      // when
-      await component.reconcile();
+          // when
+          await component.reconcile();
 
-      // then
-      assert.strictEqual(
-        component.reconcileErrorMessage,
-        this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
-      );
-    });
-  });
+          // then
+          assert.strictEqual(
+            component.reconcileErrorMessage,
+            this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
+          );
+        });
+      });
 
-  module('when an error happens', function () {
-    test('should display generic error message', async function (assert) {
-      // given
-      const component = createGlimmerComponent('authentication/oidc-reconciliation');
-      const authenticateStub = sinon.stub().rejects({ errors: [{ status: '400' }] });
+      module('when an error happens', function () {
+        test('should display generic error message', async function (assert) {
+          // given
+          const component = createGlimmerComponent('authentication/oidc-reconciliation');
+          const authenticateStub = sinon.stub().rejects({ errors: [{ status: '400' }] });
 
-      class SessionStub extends Service {
-        authenticate = authenticateStub;
-      }
+          class SessionStub extends Service {
+            authenticate = authenticateStub;
+          }
 
-      this.owner.register('service:session', SessionStub);
-      component.args.identityProviderSlug = 'super-idp';
-      component.args.authenticationKey = 'super-key';
-      component.isTermsOfServiceValidated = true;
+          this.owner.register('service:session', SessionStub);
+          component.args.identityProviderSlug = 'super-idp';
+          component.args.authenticationKey = 'super-key';
+          component.isTermsOfServiceValidated = true;
 
-      // when
-      await component.reconcile();
+          // when
+          await component.reconcile();
 
-      // then
-      assert.strictEqual(component.reconcileErrorMessage, this.intl.t('common.error'));
+          // then
+          assert.strictEqual(component.reconcileErrorMessage, this.intl.t('common.error'));
+        });
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/components/register-form_test.js
+++ b/mon-pix/tests/unit/components/register-form_test.js
@@ -1,10 +1,256 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Unit | Component | register-form', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
+
+  module('#searchForMatchingStudent', function () {
+    module('completes successfully', function () {
+      test('retrieves matching sco organization learner', async function (assert) {
+        // given
+        const eventStub = { preventDefault: sinon.stub() };
+        const campaignCode = 'SCO789';
+        const component = createGlimmerComponent('routes/register-form', { campaignCode });
+
+        component.firstName = 'Lili';
+        component.lastName = 'Coptère';
+        component.monthOfBirth = '05';
+        component.yearOfBirth = '2002';
+        component.dayOfBirth = '02';
+
+        const scoOrganizationLearnerSaveStub = sinon.stub();
+        const dependentUserSaveStub = sinon.stub();
+        const createdScoOrganizationLearner = { username: 'lilicoptere0205' };
+        scoOrganizationLearnerSaveStub.resolves(createdScoOrganizationLearner);
+        dependentUserSaveStub.resolves();
+
+        class storeStub extends Service {
+          createRecord = sinon
+            .stub()
+            .onFirstCall()
+            .returns({
+              username: 'lilicoptere0205',
+              save: scoOrganizationLearnerSaveStub,
+              unloadRecord: sinon.stub().resolves(),
+            })
+            .onSecondCall()
+            .returns({
+              save: dependentUserSaveStub,
+            });
+        }
+
+        this.owner.register('service:store', storeStub);
+
+        component.scoOrganizationLearner = scoOrganizationLearnerSaveStub;
+        component.dependentUser = dependentUserSaveStub;
+
+        // when
+        await component.searchForMatchingStudent(eventStub);
+
+        // then
+        sinon.assert.called(scoOrganizationLearnerSaveStub);
+        assert.strictEqual(component.username, 'lilicoptere0205');
+        assert.true(component.matchingStudentFound);
+        assert.false(component.isSearchFormNotValid);
+        assert.false(component.isLoading);
+        assert.strictEqual(component.scoOrganizationLearner.username, component.username);
+        assert.strictEqual(component.errorMessage, null);
+      });
+    });
+
+    module('completes with error', function () {
+      test('displays error message', async function (assert) {
+        // given
+        const eventStub = { preventDefault: sinon.stub() };
+        const campaignCode = 'SCO789';
+        const unloadRecordStub = sinon.stub();
+        const component = createGlimmerComponent('routes/register-form', { campaignCode });
+        component.firstName = 'Lili';
+        component.lastName = 'Coptère';
+        component.monthOfBirth = '05';
+        component.yearOfBirth = '2002';
+        component.dayOfBirth = '02';
+
+        const scoOrganizationLearnerSaveStub = sinon.stub().returns({
+          save: sinon.stub().rejects({
+            errors: [{ status: '409', meta: { shortCode: 'S50', message: 'api-error-messages.register-error.s50' } }],
+          }),
+          unloadRecord: unloadRecordStub,
+        });
+
+        const createRecordStub = scoOrganizationLearnerSaveStub;
+        component.store = {
+          createRecord: createRecordStub,
+        };
+
+        component.scoOrganizationLearner = scoOrganizationLearnerSaveStub;
+
+        // when
+        await component.searchForMatchingStudent(eventStub);
+
+        // then
+        sinon.assert.called(unloadRecordStub);
+        assert.false(component.matchingStudentFound);
+        assert.false(component.isLoading);
+        assert.strictEqual(component.errorMessage, this.intl.t('api-error-messages.register-error.s50'));
+      });
+    });
+
+    module('while waiting for submission completion', function () {
+      test('isLoading true', async function (assert) {
+        // given
+        let inflightLoading;
+        const campaignCode = 'SCO789';
+        const eventStub = { preventDefault: sinon.stub() };
+
+        const component = createGlimmerComponent('routes/register-form', { campaignCode });
+        component.firstName = 'Lili';
+        component.lastName = 'Coptère';
+        component.monthOfBirth = '05';
+        component.yearOfBirth = '2002';
+        component.dayOfBirth = '02';
+
+        const saveStub = function () {
+          inflightLoading = component.isLoading;
+          return Promise.resolve({ username: 'lilicoptere0205' });
+        };
+
+        const scoOrganizationLearnerSaveStub = sinon.stub().returns({ save: saveStub });
+
+        const createRecordStub = scoOrganizationLearnerSaveStub;
+        component.store = {
+          createRecord: createRecordStub,
+        };
+
+        component.scoOrganizationLearner = scoOrganizationLearnerSaveStub;
+
+        // when
+        await component.searchForMatchingStudent(eventStub);
+
+        // then
+        assert.true(inflightLoading);
+      });
+    });
+  });
+
+  module('#register', function () {
+    module('completes successfully', function () {
+      test('registers and authenticates user with username', async function (assert) {
+        // given
+        const eventStub = { preventDefault: sinon.stub() };
+        const store = this.owner.lookup('service:store');
+        const createdDependentUser = store.createRecord('dependent-user', {
+          save: sinon.stub(),
+        });
+
+        const component = createGlimmerComponent('routes/register-form');
+
+        component.dependentUser = createdDependentUser;
+        component.password = 'Password12345!';
+        component.username = 'lilicoptere0205';
+
+        const authenticateStub = sinon.stub();
+
+        class SessionStub extends Service {
+          authenticate = authenticateStub;
+        }
+        this.owner.register('service:session', SessionStub);
+
+        // when
+        await component.register(eventStub);
+
+        // then
+        sinon.assert.calledWith(authenticateStub, 'authenticator:oauth2', {
+          login: component.username,
+          password: component.password,
+          scope: 'mon-pix',
+        });
+        sinon.assert.called(createdDependentUser.save);
+
+        assert.true(component.loginWithUsername);
+        assert.false(component.isCreationFormNotValid);
+        assert.false(component.isLoading);
+        assert.strictEqual(component.dependentUser.password, null);
+        assert.strictEqual(component.dependentUser.username, component.username);
+      });
+    });
+
+    module('completes with error', function () {
+      test('displays error message', async function (assert) {
+        // given
+        const eventStub = { preventDefault: sinon.stub() };
+        const store = this.owner.lookup('service:store');
+        const createdDependentUser = store.createRecord('dependent-user', {
+          save: sinon.stub().rejects({
+            errors: [{ status: '409', meta: { shortCode: 'S50', message: 'api-error-messages.register-error.s50' } }],
+          }),
+        });
+
+        const component = createGlimmerComponent('routes/register-form');
+
+        component.dependentUser = createdDependentUser;
+        component.password = 'Password12345!';
+        component.username = 'lilicoptere0205';
+
+        const authenticateStub = sinon.stub();
+
+        class SessionStub extends Service {
+          authenticate = authenticateStub;
+        }
+        this.owner.register('service:session', SessionStub);
+
+        // when
+        await component.register(eventStub);
+
+        // then
+        sinon.assert.notCalled(authenticateStub);
+
+        assert.false(component.isCreationFormNotValid);
+        assert.false(component.isLoading);
+        assert.ok(component.displayRegisterErrorMessage);
+        assert.strictEqual(component.registerErrorMessage, this.intl.t('api-error-messages.register-error.s50'));
+      });
+    });
+
+    module('while waiting for submission completion', function () {
+      test('isloading true', async function (assert) {
+        // given
+        let inflightLoading;
+        const eventStub = { preventDefault: sinon.stub() };
+        const store = this.owner.lookup('service:store');
+        const createdDependentUser = store.createRecord('dependent-user', {
+          save: sinon.stub(),
+        });
+
+        const component = createGlimmerComponent('routes/register-form');
+
+        component.dependentUser = createdDependentUser;
+        component.password = 'Password12345!';
+        component.username = 'lilicoptere0205';
+
+        const authenticateStub = function () {
+          inflightLoading = component.isLoading;
+          return Promise.resolve();
+        };
+
+        class SessionStub extends Service {
+          authenticate = authenticateStub;
+        }
+        this.owner.register('service:session', SessionStub);
+
+        // when
+        await component.register(eventStub);
+
+        // then
+        assert.true(inflightLoading);
+      });
+    });
+  });
 
   module('#resetForm', function () {
     module('when click on "It\'s not me"', function () {
@@ -14,6 +260,7 @@ module('Unit | Component | register-form', function (hooks) {
         const unloadRecordStub = sinon.stub();
         store.createRecord('sco-organization-learner', { unloadRecord: unloadRecordStub });
         store.createRecord('dependent-user', { unloadRecord: unloadRecordStub });
+
         const component = createGlimmerComponent('routes/register-form');
         component.firstName = 'Lili';
         component.lastName = 'Coptère';

--- a/mon-pix/tests/unit/components/signin-form_test.js
+++ b/mon-pix/tests/unit/components/signin-form_test.js
@@ -9,44 +9,8 @@ module('Unit | Component | signin-form', function (hooks) {
   setupTest(hooks);
 
   module('#signin', function () {
-    module('when user should change password', function () {
-      test('should save reset password token and redirect to update-expired-password', async function (assert) {
-        // given
-        const eventStub = { preventDefault: sinon.stub() };
-        const createRecordStub = sinon.stub();
-        const storeStub = { createRecord: createRecordStub };
-        const sessionStub = {
-          authenticateUser: sinon.stub().rejects({
-            responseJSON: {
-              errors: [
-                {
-                  title: 'PasswordShouldChange',
-                  code: 'SHOULD_CHANGE_PASSWORD',
-                  meta: 'PASSWORD_RESET_TOKEN',
-                },
-              ],
-            },
-          }),
-        };
-        const component = createGlimmerComponent('signin-form');
-        component.session = sessionStub;
-        component.args.updateExpiredPassword = sinon.stub();
-        component.store = storeStub;
-        component.router = { replaceWith: sinon.stub() };
-
-        // when
-        await component.signin(eventStub);
-
-        // then
-        sinon.assert.calledWith(createRecordStub, 'reset-expired-password-demand', {
-          passwordResetToken: 'PASSWORD_RESET_TOKEN',
-        });
-        assert.ok(true);
-      });
-    });
-
-    module('when user sign in', function () {
-      test('should authenticate the user even if email contains spaces', async function (assert) {
+    module('completes', function () {
+      test('authenticates the user even if email contains spaces', async function (assert) {
         // given
         const foundUser = EmberObject.create({ id: 12 });
         const eventStub = { preventDefault: sinon.stub() };
@@ -77,6 +41,44 @@ module('Unit | Component | signin-form', function (hooks) {
         // then
         sinon.assert.calledWith(authenticateStub, trimedEmail, password);
         assert.ok(true);
+      });
+    });
+
+    module('completes with error', function () {
+      module('when user should change password', function () {
+        test('saves reset password token and redirect to update-expired-password', async function (assert) {
+          // given
+          const eventStub = { preventDefault: sinon.stub() };
+          const createRecordStub = sinon.stub();
+          const storeStub = { createRecord: createRecordStub };
+          const sessionStub = {
+            authenticateUser: sinon.stub().rejects({
+              responseJSON: {
+                errors: [
+                  {
+                    title: 'PasswordShouldChange',
+                    code: 'SHOULD_CHANGE_PASSWORD',
+                    meta: 'PASSWORD_RESET_TOKEN',
+                  },
+                ],
+              },
+            }),
+          };
+          const component = createGlimmerComponent('signin-form');
+          component.session = sessionStub;
+          component.args.updateExpiredPassword = sinon.stub();
+          component.store = storeStub;
+          component.router = { replaceWith: sinon.stub() };
+
+          // when
+          await component.signin(eventStub);
+
+          // then
+          sinon.assert.calledWith(createRecordStub, 'reset-expired-password-demand', {
+            passwordResetToken: 'PASSWORD_RESET_TOKEN',
+          });
+          assert.ok(true);
+        });
       });
     });
   });

--- a/mon-pix/tests/unit/components/signin-form_test.js
+++ b/mon-pix/tests/unit/components/signin-form_test.js
@@ -9,7 +9,7 @@ module('Unit | Component | signin-form', function (hooks) {
   setupTest(hooks);
 
   module('#signin', function () {
-    module('completes', function () {
+    module('completes successfully', function () {
       test('authenticates the user even if email contains spaces', async function (assert) {
         // given
         const foundUser = EmberObject.create({ id: 12 });
@@ -40,7 +40,7 @@ module('Unit | Component | signin-form', function (hooks) {
 
         // then
         sinon.assert.calledWith(authenticateStub, trimedEmail, password);
-        assert.ok(true);
+        assert.false(component.isLoading);
       });
     });
 
@@ -77,8 +77,31 @@ module('Unit | Component | signin-form', function (hooks) {
           sinon.assert.calledWith(createRecordStub, 'reset-expired-password-demand', {
             passwordResetToken: 'PASSWORD_RESET_TOKEN',
           });
-          assert.ok(true);
+          assert.false(component.isLoading);
         });
+      });
+    });
+
+    module('while waiting for submission completion', function () {
+      test('isLoading is true', async function (assert) {
+        // given
+        let inflightLoading;
+        const eventStub = { preventDefault: sinon.stub() };
+        const component = createGlimmerComponent('signin-form');
+        const authenticateStub = function () {
+          inflightLoading = component.isLoading;
+          return Promise.resolve();
+        };
+        const sessionStub = Service.create({
+          authenticateUser: authenticateStub,
+        });
+        component.session = sessionStub;
+
+        // when
+        await component.signin(eventStub);
+
+        // then
+        assert.true(inflightLoading);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible de soumettre plusieurs fois les formulaires d’inscription et de connexion, même si la requête du premier envoi n’est pas terminé.

## :robot: Proposition
Empêcher la re-soumission des formulaires tant que la réponse du premier envoi (succès ou échec) n’a pas été reçu, en tirant partie de la fonctionnalité `isLoading` du PixButton. L'utilisateur verra un bouton avec trois petits points indiquant le chargement de la requête.


## :rainbow: Remarques

Pour chaque formulaire dans lequel se trouve le PixButton sur lequel la soumission est faite, nous nous sommes basés sur le `try/catch/finally` de la fonction de soumission du composant, en y plaçant l'affectation `isLoading = false` au niveau du `finally`.

Seule exception : le `sco-form`, car la soumission du formulaire est gérée dans la méthode `this.args.onSubmit()` qui provient du composant parent. De ce fait la gestion d'erreur (`try/catch`) se trouve dans le composant parent et nous n'avons donc pas pu en tirer partie et nous avons alors simplement précédé la fonction de soumission d'une affection `isLoading = true` et nous l'avons fait suivre d'une affectation `isLoading = false`.

## :100: Pour tester

1. Aller sur chaque formulaire, il y a en a 7.
2. Ralentir la connexion réseau de son navigateur (par exemple _slow 3G_).
3. Constater que lors de chaque soumission de formulaire le bouton de soumission du formulaire change pour afficher les 3 petits points du style « isLoading » et qu'il n'est plus cliquable.

### Les formulaires : 
  **1. La page de connexion à Pix :** https://app-pr6266.review.pix.fr/connexion
      - Remplissez le formulaire et cliquer sur le bouton "Je me connecte' et vérifier le chargement de la page avec les 3 petits points sur le bouton.

  **2. La double mire de connexion OIDC - inscription :** _(à tester en locale car pas disponible sur les RA)_
         - Se connecter à Pix en passant par Pole Emploi (sur le domaine .fr) ou par la FWB (sur le domaine .org) 
         - Dans la partie "Je n’ai pas de compte Pix", cliquer sur le bouton "Je crée mon compte" et vérifier le chargement de la page avec les 3 petits points sur le bouton.

  **3. La double mire de connexion OIDC - connexion :** _(à tester en locale car pas disponible sur les RA)_
       - Se connecter à Pix en passant par Pole Emploi (sur le domaine .fr) ou par la FWB (sur le domaine .org)
       - Dans la partie "Vous avez déjà un compte Pix", cliquer sur le bouton "Je me connecte" et vérifier le chargement de la page avec les 3 petits points sur le bouton.
      
  **4. La page de réconciliation OIDC :** _(à tester en locale car pas disponible sur les RA)_
       - Se connecter à Pix en passant par Pole Emploi (sur le domaine .fr) ou par la FWB (sur le domaine .org)
       - Connectez vous à un compte Pix déjà existant dans la partie "Vous avez déjà un compte Pix" 
       - Vous devez arriver sur une page avec écrit : _"Attention ! Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix. L'évaluation des compétences étant personnalisée, votre compte doit rester strictement personnel"_
       - Cliquer sur le bouton "Continuer" et vérifier le chargement de la page avec les 3 petits points sur le bouton.

  **5. La page de réconciliation SCO :**  _(à tester en locale car pas disponible sur les RA)_
     - Se connecter au faux GAR
     - Vous devez arriver sur une page avec comme URL `/campagnes/{code_campagne}/rejoindre/mediacentre`
     - Remplissez les informations manquantes et cliquez sur "C'est parti!" et vérifier le chargement de la page avec les 3 petits points sur le bouton.

  **6. La double mire de connexion SCO - connexion :**  _(disponible en local et sur la RA en .fr)_
     - Se rendre sur `/campagnes/SCOBADGE1/presentation`
     - Cliquer sur "Je commence"
     - Dans la partie "J'ai déjà un compte Pix" connectez-vous et vérifier le chargement de la page avec les 3 petits points sur le bouton.

  **7. La double mire de connexion SCO - inscription :**  _(disponible en local et sur la RA en .fr)_
     - Se rendre sur `/campagnes/SCOBADGE1/presentation`
     - Cliquer sur "Je commence"
     - Dans la partie "Je m'inscris" entrez les seeds suivants : `Prénom: First`, `Nom: Last`, `Date de naissance : 10/10/2010`.
     - Cliquer sur le bouton "Je m'inscris" et vérifier le chargement de la page avec les 3 petits points sur le bouton.
     - Vous devez à présent voir la suite du formulaire avec un identifiant pré-rempli. 
     - Ajoutez un mot de passe et cliquez sur le bouton "Je m'inscris" et vérifier le chargement de la page avec les 3 petits points sur le bouton.
