### PR TITLE
[BUGFIX] Remettre la génération de villes et de pays dans les seeds (PIX-8162)

### DIFF
--- a/api/db/seeds/data/certification/certification-cpf-city-builder.js
+++ b/api/db/seeds/data/certification/certification-cpf-city-builder.js
@@ -1,0 +1,93 @@
+const certificationCpfCityBuilder = function ({ databaseBuilder }) {
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 1',
+    postalCode: '75001',
+    INSEECode: '75101',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 12',
+    postalCode: '75012',
+    INSEECode: '75112',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 15',
+    postalCode: '75015',
+    INSEECode: '75115',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS 19',
+    postalCode: '75019',
+    INSEECode: '75119',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS',
+    postalCode: '75001',
+    INSEECode: '75101',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS',
+    postalCode: '75012',
+    INSEECode: '75112',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS',
+    postalCode: '75015',
+    INSEECode: '75115',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PARIS',
+    postalCode: '75019',
+    INSEECode: '75119',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'PERPIGNAN',
+    postalCode: '66000',
+    INSEECode: '66136',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'NANTES',
+    postalCode: '44000',
+    INSEECode: '44109',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'LES-BAUX-DE-BRETEUIL',
+    postalCode: '27160',
+    INSEECode: '27043',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'MARBOIS',
+    postalCode: '27160',
+    INSEECode: '27157',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'MESNILS-SUR-ITON',
+    postalCode: '27160',
+    INSEECode: '27240',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'BUELLAS',
+    postalCode: '01310',
+    INSEECode: '01065',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'LES ABYMES',
+    postalCode: '97139',
+    INSEECode: '97101',
+  });
+};
+
+export { certificationCpfCityBuilder };

--- a/api/db/seeds/data/certification/certification-cpf-country-builder.js
+++ b/api/db/seeds/data/certification/certification-cpf-country-builder.js
@@ -1,0 +1,33 @@
+const certificationCpfCountryBuilder = function ({ databaseBuilder }) {
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99401',
+    commonName: 'CANADA',
+    originalName: 'CANADA',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99100',
+    commonName: 'FRANCE',
+    originalName: 'FRANCE',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99345',
+    commonName: 'TOGO',
+    originalName: 'TOGO',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99243',
+    commonName: 'VIET NAM',
+    originalName: 'VIET NAM',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCountry({
+    code: '99425',
+    commonName: 'TURKS ET CAIQUES (ILES)',
+    originalName: 'TURKS ET CAÏQUES (ÎLES)',
+  });
+};
+
+export { certificationCpfCountryBuilder };

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -42,6 +42,7 @@ import { commonBuilder } from './data/common/common-builder.js';
 import { teamContenuDataBuilder } from './data/team-contenu/data-builder.js';
 import { teamCertificationDataBuilder } from './data/team-certification/data-builder.js';
 import { certificationCpfCityBuilder } from './data/certification/certification-cpf-city-builder.js';
+import { certificationCpfCountryBuilder } from './data/certification/certification-cpf-country-builder.js';
 
 const seed = async function (knex) {
   const shouldUseNewSeeds = process.env.USE_NEW_SEEDS === 'true';
@@ -58,6 +59,9 @@ const seed = async function (knex) {
 
     // cities
     certificationCpfCityBuilder({ databaseBuilder });
+
+    // countries
+    certificationCpfCountryBuilder({ databaseBuilder });
 
     // Users
     usersBuilder({ databaseBuilder });

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -41,6 +41,7 @@ import { addLastAssessmentResultCertificationCourse } from '../../scripts/certif
 import { commonBuilder } from './data/common/common-builder.js';
 import { teamContenuDataBuilder } from './data/team-contenu/data-builder.js';
 import { teamCertificationDataBuilder } from './data/team-certification/data-builder.js';
+import { certificationCpfCityBuilder } from './data/certification/certification-cpf-city-builder.js';
 
 const seed = async function (knex) {
   const shouldUseNewSeeds = process.env.USE_NEW_SEEDS === 'true';
@@ -54,6 +55,9 @@ const seed = async function (knex) {
   } else {
     // Feature list
     featuresBuilder({ databaseBuilder });
+
+    // cities
+    certificationCpfCityBuilder({ databaseBuilder });
 
     // Users
     usersBuilder({ databaseBuilder });


### PR DESCRIPTION
## :unicorn: Problème
On fait un gros coup de balai dans les seeds. Avec les "nouveaux" profil cibles, beaucoup de profil cibles crées dans les seeds (et les autres données qui en découlent style campagnes, certifs, etc...) sont cassés.
La grosse proposition du travail mené est de fournir un outillage générique pour aider les développeurs à facilement créer des seeds pour faire leur travail au quotidien, en évitant ce qui existe dans les seeds aujourd'hui et qui est très fragile, à savoir beaucoup de tartines de données copier/coller et qui deviennent vite désuètes et difficiles à maintenir.

Le nouveau procéder de génération de seed coéxiste pour l'instant avec l'ancien. Les seed de génération de villes et de pays ont été déplacés vers le nouveau process.

Lorsque l'on travaille en local ou avec les RA, plus aucunes villes ou pays n'éxistent

## :robot: Proposition
Remettre temporairement les villes et pays dans l'ancien système de seed

## :rainbow: Remarques

## :100: Pour tester
- Depuis pix certif, tenter d'inscrire un candidat avec code insee 75115 par exemple
- Constater que son inscription a bin été prise en compte