### PR TITLE
[FEATURE] Ajout d'une condition d’arrêt au scénario

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -22,6 +22,7 @@ const register = async (server) => {
             Joi.object({
               assessmentId: Joi.string().required(),
               type: Joi.string().valid('deterministic').required(),
+              stopAtChallenge: Joi.number().integer().min(0),
               simulationAnswers: Joi.array().items(Joi.string().allow('ok', 'ko', 'aband')).required(),
             }),
             Joi.object({
@@ -33,11 +34,13 @@ const register = async (server) => {
                 aband: Joi.number(),
               }),
               length: Joi.number().integer().min(0).required(),
+              stopAtChallenge: Joi.number().integer().min(0),
             }),
             Joi.object({
               assessmentId: Joi.string().required(),
               type: Joi.string().valid('capacity').required(),
               capacity: Joi.number().min(-8).max(8).required(),
+              stopAtChallenge: Joi.number().integer().min(0),
             }),
           ]).required(),
         },

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -12,7 +12,7 @@ async function simulateFlashAssessmentScenario(
   h,
   dependencies = { scenarioSimulatorSerializer, random, pickAnswersService, extractLocaleFromRequest }
 ) {
-  const { assessmentId } = request.payload;
+  const { assessmentId, stopAtChallenge } = request.payload;
 
   const pickAnswer = _getPickAnswerMethod(dependencies.pickAnswersService, request.payload);
 
@@ -22,6 +22,7 @@ async function simulateFlashAssessmentScenario(
     pickAnswer,
     assessmentId,
     locale,
+    stopAtChallenge,
   });
 
   return dependencies.scenarioSimulatorSerializer.serialize(result);

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -14,7 +14,7 @@ async function simulateFlashAssessmentScenario(
 ) {
   const { assessmentId } = request.payload;
 
-  const pickAnswer = _getPickAnswerMethod(dependencies.pickAnswerService, request.payload);
+  const pickAnswer = _getPickAnswerMethod(dependencies.pickAnswersService, request.payload);
 
   const locale = dependencies.extractLocaleFromRequest(request);
 
@@ -59,7 +59,7 @@ async function importScenarios(
   return dependencies.scenarioSimulatorBatchSerializer.serialize(results);
 }
 
-function _getPickAnswerMethod(pickAnswerService, payload) {
+function _getPickAnswerMethod(pickAnswersService, payload) {
   const { type, probabilities, length, capacity, simulationAnswers } = payload;
 
   switch (type) {

--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -1,20 +1,21 @@
 import { Answer } from './Answer.js';
 
 export class AssessmentSimulator {
-  constructor({ algorithm, challenges, pickChallenge, pickAnswer }) {
-    this.pickAnswer = pickAnswer;
+  constructor({ algorithm, challenges, pickChallenge, pickAnswer, stopAtChallenge }) {
     this.algorithm = algorithm;
     this.challenges = challenges;
+    this.pickAnswer = pickAnswer;
     this.pickChallenge = pickChallenge;
+    this.stopAtChallenge = stopAtChallenge;
   }
 
   run() {
     const challengesAnswers = [];
     const result = [];
     let estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({ allAnswers: [] }).estimatedLevel;
+    const maxChallenge = this.stopAtChallenge || Infinity;
 
-    // eslint-disable-next-line no-constant-condition
-    for (let i = 0; true; i++) {
+    for (let i = 0; i < maxChallenge; i++) {
       try {
         const possibleChallenges = this.algorithm.getPossibleNextChallenges({
           allAnswers: challengesAnswers,

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -7,6 +7,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   pickChallengeService,
   pickAnswer,
   assessmentId,
+  stopAtChallenge,
 }) {
   const challenges = await challengeRepository.findOperativeFlashCompatible({ locale });
 
@@ -24,6 +25,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     challenges,
     pickChallenge,
     pickAnswer,
+    stopAtChallenge,
   });
 
   return simulator.run();

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -158,6 +158,24 @@ ko,aband,ok`;
       };
     });
 
+    describe('when a number of challenges to pass is specified', function () {
+      it('should return a payload with the same number of simulation deterministic scenario results', async function () {
+        // given
+        const validPayload = {
+          ...validDeterministicPayload,
+          stopAtChallenge: 2,
+        };
+        options.headers.authorization = adminAuthorization;
+        options.payload = validPayload;
+
+        // when
+        const response = await server.inject(options);
+        // then
+        expect(response).to.have.property('statusCode', 200);
+        expect(response.result.data).to.have.lengthOf(2);
+      });
+    });
+
     describe('when the scenario is deterministic', function () {
       it('should return a payload with simulation deterministic scenario results', async function () {
         // given

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -70,6 +70,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 pickAnswer: pickAnswerFromArrayImplementation,
                 assessmentId,
                 locale: 'en',
+                stopAtChallenge: undefined,
               })
               .resolves(simulationResults);
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
@@ -127,6 +128,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 assessmentId,
                 locale: 'en',
                 pickAnswer: pickAnswerFromArrayImplementation,
+                stopAtChallenge: undefined,
               })
               .resolves(simulationResults);
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
@@ -183,6 +185,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 assessmentId,
                 locale: 'en',
                 pickAnswer: pickAnswerFromCapacityImplementation,
+                stopAtChallenge: undefined,
               })
               .resolves(simulationResults);
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);


### PR DESCRIPTION
## :unicorn: Problème
On ne sait pas combien d'preuves sont nécessaires pour calculer la capacité

## :robot: Proposition
Faire des points d'arrêt à X challenges pour vérifier si c'est suffisant

## :rainbow: Remarques
CF la [documentation](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/3761635329/Simulateur+d+roul#Condition-d%E2%80%99arr%C3%AAt) 

## :100: Pour tester

```
TOKEN=$(curl 'https://api-pr6269.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6269.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "assessmentId": "1234", "length": 4, "probabilities": { "ok": 0.3, "ko": 0.5, "aband": 0.2}, "type": "random", "stopAtChallenge": 2 }' | jq '.'
```