### PR TITLE
[FEATURE] Suppression du filtre du status des challenges pour les simulateurs (PIX-8173).

### DIFF
--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -9,7 +9,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   assessmentId,
   stopAtChallenge,
 }) {
-  const challenges = await challengeRepository.findOperativeFlashCompatible({ locale });
+  const challenges = await challengeRepository.findFlashCompatible({ locale });
 
   const flashAssessmentAlgorithm = new FlashAssessmentAlgorithm();
 

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -51,26 +51,23 @@ const challengeDatasource = datasource.extend({
   },
 
   async findActiveFlashCompatible(locale) {
-    const challenges = await this.list();
-    return challenges.filter(
-      (challengeData) =>
-        challengeData.status === VALIDATED_CHALLENGE &&
-        challengeData.skillId &&
-        _.includes(challengeData.locales, locale) &&
-        challengeData.alpha != null &&
-        challengeData.delta != null
-    );
+    const flashChallenges = await this.findFlashCompatible(locale);
+    return flashChallenges.filter((challengeData) => challengeData.status === VALIDATED_CHALLENGE);
   },
 
   async findOperativeFlashCompatible(locale) {
+    const flashChallenges = await this.findFlashCompatible(locale);
+    return flashChallenges.filter((challengeData) => _.includes(OPERATIVE_CHALLENGES, challengeData.status));
+  },
+
+  async findFlashCompatible(locale) {
     const challenges = await this.list();
     return challenges.filter(
       (challengeData) =>
-        _.includes(OPERATIVE_CHALLENGES, challengeData.status) &&
-        challengeData.skillId &&
         _.includes(challengeData.locales, locale) &&
         challengeData.alpha != null &&
-        challengeData.delta != null
+        challengeData.delta != null &&
+        challengeData.skillId
     );
   },
 });

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -138,6 +138,12 @@ const findOperativeFlashCompatible = async function ({
   return _toDomainCollection({ challengeDataObjects, skills, successProbabilityThreshold });
 };
 
+const findFlashCompatible = async function ({ locale }) {
+  const challengeDataObjects = await challengeDatasource.findFlashCompatible(locale);
+  const skills = await skillDatasource.list();
+  return _toDomainCollection({ challengeDataObjects, skills });
+};
+
 const findValidatedBySkillId = async function (skillId) {
   const challengeDataObjects = await challengeDatasource.findValidatedBySkillId(skillId);
   const activeSkills = await skillDatasource.findActive();
@@ -154,6 +160,7 @@ export {
   findOperativeHavingLocale,
   findValidatedByCompetenceId,
   findOperativeBySkills,
+  findFlashCompatible,
   findActiveFlashCompatible,
   findOperativeFlashCompatible,
   findValidatedBySkillId,

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -33,12 +33,12 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
       });
 
       const challengeRepository = {
-        findOperativeFlashCompatible: sinon.stub(),
+        findFlashCompatible: sinon.stub(),
       };
       const pickChallengeService = { chooseNextChallenge: sinon.stub() };
       const pickAnswer = sinon.stub();
 
-      challengeRepository.findOperativeFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
+      challengeRepository.findFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
 
       pickChallengeService.chooseNextChallenge
         .withArgs({
@@ -100,9 +100,9 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
       const challenge = domainBuilder.buildChallenge({ id: 1 });
       const challengeRepository = {
-        findOperativeFlashCompatible: sinon.stub(),
+        findFlashCompatible: sinon.stub(),
       };
-      challengeRepository.findOperativeFlashCompatible.resolves([challenge]);
+      challengeRepository.findFlashCompatible.resolves([challenge]);
 
       const pickChallengeService = { chooseNextChallenge: sinon.stub() };
       const pickAnswer = sinon.stub();

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -205,6 +205,42 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     });
   });
 
+  describe('#findFlashCompatible', function () {
+    beforeEach(function () {
+      sinon.stub(lcms, 'getLatestRelease').resolves({
+        challenges: [
+          challenge_competence1,
+          challenge_competence1_notValidated,
+          challenge_competence1_noSkills,
+          challenge_competence2,
+          challenge_web1,
+          challenge_web1_notValidated,
+          challenge_web2_en,
+          challenge_web3,
+          challenge_web3_archived,
+        ],
+      });
+    });
+
+    it('should resolve an array of matching Challenges from learning content', async function () {
+      // when
+      const locale = 'fr-fr';
+      const result = await challengeDatasource.findFlashCompatible(locale);
+
+      // then
+      expect(lcms.getLatestRelease).to.have.been.called;
+      expect(_.map(result, 'id').sort()).to.deep.equal(
+        [
+          challenge_competence1_notValidated.id,
+          challenge_competence1.id,
+          challenge_competence2.id,
+          challenge_web3.id,
+          challenge_web3_archived.id,
+        ].sort()
+      );
+    });
+  });
+
   describe('#findActiveFlashCompatible', function () {
     beforeEach(function () {
       sinon.stub(lcms, 'getLatestRelease').resolves({


### PR DESCRIPTION
## :unicorn: Problème

A l'heure actuelle, nous ne sélectionnons que les challenges ayant des statuts validés et archivés.
Nous souhaitons également récupérer les statuts périmés.

## :robot: Proposition

Suppression du filtre sur le statut dans le usecase de simulation.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
N/A