### PR TITLE
[FEATURE] Remplacement de AnswerStatus par la réponse dans les simulateurs (PIX-8179).

### DIFF
--- a/api/lib/domain/services/pick-answer-service.js
+++ b/api/lib/domain/services/pick-answer-service.js
@@ -1,5 +1,3 @@
-import { AnswerStatus } from '../models/index.js';
-
 function pickAnswersFromArray(array) {
   return function ({ answerIndex }) {
     return array[answerIndex];
@@ -9,7 +7,7 @@ function pickAnswersFromArray(array) {
 function pickAnswerForCapacity(capacity) {
   return function ({ nextChallenge }) {
     const successProbability = 1 / (1 + Math.exp(-nextChallenge.discriminant * (capacity - nextChallenge.difficulty)));
-    return successProbability > Math.random() ? AnswerStatus.OK : AnswerStatus.KO;
+    return successProbability > Math.random() ? 'ok' : 'ko';
   };
 }
 


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre d'un simulateur basé sur la capacité, nous renvoyions un `AnswerStatus` en guise de réponse dans le JSON, chose que nous ne faisons pas dans les autres types de simulateurs.

## :robot: Proposition

On aligne l'ensemble des simulateurs sur la réponse afin de ne pas charger le JSON de retour avec un nouvel objet qui n'apporte pas de valeur.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

```
TOKEN=$(curl 'https://api-pr6275.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6275.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "assessmentId": "1234", "capacity": 2.3 }' | jq '.'
```