### PR TITLE
[TECH] Mise à jour de ember-dayjs 

### DIFF
--- a/admin/ember-cli-build.js
+++ b/admin/ember-cli-build.js
@@ -20,9 +20,6 @@ module.exports = function (defaults) {
     flatpickr: {
       locales: ['fr'],
     },
-    'ember-dayjs': {
-      locales: ['fr'],
-    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -42,7 +42,7 @@
         "ember-concurrency": "^3.0.0",
         "ember-cp-validations": "^5.0.0",
         "ember-data": "~4.0.2",
-        "ember-dayjs": "^0.10.3",
+        "ember-dayjs": "^0.11.0",
         "ember-decorators": "^6.1.1",
         "ember-exam": "^8.0.0",
         "ember-export-application-global": "^2.0.1",
@@ -17420,14 +17420,14 @@
       }
     },
     "node_modules/ember-dayjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.6.tgz",
-      "integrity": "sha512-eiGUz5fTyi/gD6IKULcjmWgl9yGP7Ca5jQfXzHMjTppGlWRwZFHejvNYtZ9s9UKpJ1WDQcMVaYK6NZil7DD44w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "dependencies": {
-        "dayjs": "^1.11.7",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
@@ -50386,14 +50386,14 @@
       }
     },
     "ember-dayjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.6.tgz",
-      "integrity": "sha512-eiGUz5fTyi/gD6IKULcjmWgl9yGP7Ca5jQfXzHMjTppGlWRwZFHejvNYtZ9s9UKpJ1WDQcMVaYK6NZil7DD44w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "requires": {
-        "dayjs": "^1.11.7",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       }
     },
     "ember-decorators": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -69,7 +69,7 @@
     "ember-concurrency": "^3.0.0",
     "ember-cp-validations": "^5.0.0",
     "ember-data": "~4.0.2",
-    "ember-dayjs": "^0.10.3",
+    "ember-dayjs": "^0.11.0",
     "ember-decorators": "^6.1.1",
     "ember-exam": "^8.0.0",
     "ember-export-application-global": "^2.0.1",

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -26,10 +26,6 @@ module.exports = function (defaults) {
     'ember-cli-template-lint': {
       testGenerator: 'qunit',
     },
-    'ember-dayjs': {
-      locales: ['fr'],
-      plugins: ['customParseFormat'],
-    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -46,7 +46,7 @@
         "ember-composable-helpers": "^5.0.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
-        "ember-dayjs": "^0.10.3",
+        "ember-dayjs": "^0.11.0",
         "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^7.1.0",
@@ -13138,9 +13138,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "node_modules/debug": {
@@ -17095,17 +17095,20 @@
       }
     },
     "node_modules/ember-dayjs": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.3.tgz",
-      "integrity": "sha512-S+PIMVQH1ZC6MK8vIdOTzvezWWX4MfxoLeYw3w338+bchSY24YbpsCkkvBTILuVXA/a2ENwRIZgHZibjhHfJtQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "dependencies": {
-        "dayjs": "^1.11.6",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.1"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.28.0 || ^4.0.0"
       }
     },
     "node_modules/ember-decorators-polyfill": {
@@ -46102,9 +46105,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "debug": {
@@ -49343,14 +49346,14 @@
       }
     },
     "ember-dayjs": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.3.tgz",
-      "integrity": "sha512-S+PIMVQH1ZC6MK8vIdOTzvezWWX4MfxoLeYw3w338+bchSY24YbpsCkkvBTILuVXA/a2ENwRIZgHZibjhHfJtQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "requires": {
-        "dayjs": "^1.11.6",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.1"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       }
     },
     "ember-decorators-polyfill": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -75,7 +75,7 @@
     "ember-composable-helpers": "^5.0.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
-    "ember-dayjs": "^0.10.3",
+    "ember-dayjs": "^0.11.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^7.1.0",

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -19,10 +19,6 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
-    'ember-dayjs': {
-      locales: ['fr', 'en'],
-      plugins: ['duration', 'relativeTime'],
-    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -53,7 +53,7 @@
         "ember-cli-test-loader": "^3.0.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
-        "ember-dayjs": "^0.10.3",
+        "ember-dayjs": "^0.11.0",
         "ember-decorators": "^6.1.1",
         "ember-exam": "^8.0.0",
         "ember-export-application-global": "^2.0.1",
@@ -15611,9 +15611,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "node_modules/debug": {
@@ -21876,17 +21876,199 @@
       }
     },
     "node_modules/ember-dayjs": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.3.tgz",
-      "integrity": "sha512-S+PIMVQH1ZC6MK8vIdOTzvezWWX4MfxoLeYw3w338+bchSY24YbpsCkkvBTILuVXA/a2ENwRIZgHZibjhHfJtQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "dependencies": {
-        "dayjs": "^1.11.6",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.1"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.28.0 || ^4.0.0"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/@embroider/macros": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.11.0.tgz",
+      "integrity": "sha512-P/WSB+PqKSja5qXjYvhLyUM0ivcDoI9kkqs+R0GNujfVhS0EIIAMHfD9uHDBbhzFit39pT0QJqgcXGE2rprCPA==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/shared-internals": "2.1.0",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^1.1.0",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/@embroider/shared-internals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.1.0.tgz",
+      "integrity": "sha512-9hKbMxW7wDWt1BqdpnLZ5W6ETrmAg9HnfBwf1IDkT+8he5nOdTD0PNtruMjm7V0Tb9p9hI7O+UXSa8ZnX1BQXg==",
+      "dev": true,
+      "dependencies": {
+        "babel-import-util": "^1.1.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-dayjs/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/ember-decorators": {
@@ -52854,9 +53036,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "debug": {
@@ -57729,14 +57911,137 @@
       }
     },
     "ember-dayjs": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.3.tgz",
-      "integrity": "sha512-S+PIMVQH1ZC6MK8vIdOTzvezWWX4MfxoLeYw3w338+bchSY24YbpsCkkvBTILuVXA/a2ENwRIZgHZibjhHfJtQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "requires": {
-        "dayjs": "^1.11.6",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.1"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
+      },
+      "dependencies": {
+        "@embroider/macros": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.11.0.tgz",
+          "integrity": "sha512-P/WSB+PqKSja5qXjYvhLyUM0ivcDoI9kkqs+R0GNujfVhS0EIIAMHfD9uHDBbhzFit39pT0QJqgcXGE2rprCPA==",
+          "dev": true,
+          "requires": {
+            "@embroider/shared-internals": "2.1.0",
+            "assert-never": "^1.2.1",
+            "babel-import-util": "^1.1.0",
+            "ember-cli-babel": "^7.26.6",
+            "find-up": "^5.0.0",
+            "lodash": "^4.17.21",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "@embroider/shared-internals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.1.0.tgz",
+          "integrity": "sha512-9hKbMxW7wDWt1BqdpnLZ5W6ETrmAg9HnfBwf1IDkT+8he5nOdTD0PNtruMjm7V0Tb9p9hI7O+UXSa8ZnX1BQXg==",
+          "dev": true,
+          "requires": {
+            "babel-import-util": "^1.1.0",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-package-path": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+          "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "ember-decorators": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -81,7 +81,7 @@
     "ember-cli-test-loader": "^3.0.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
-    "ember-dayjs": "^0.10.3",
+    "ember-dayjs": "^0.11.0",
     "ember-decorators": "^6.1.1",
     "ember-exam": "^8.0.0",
     "ember-export-application-global": "^2.0.1",

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -20,10 +20,6 @@ module.exports = function (defaults) {
     'ember-cli-babel': {
       includePolyfill: true,
     },
-    'ember-dayjs': {
-      locales: ['fr', 'en'], // English is automatically included. No need to add.
-      plugins: ['duration', 'relativeTime'],
-    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -53,7 +53,7 @@
         "ember-click-outside": "^6.0.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
-        "ember-dayjs": "^0.10.4",
+        "ember-dayjs": "^0.11.0",
         "ember-fetch": "^8.1.2",
         "ember-intl": "^5.7.2",
         "ember-load-initializers": "^2.1.2",
@@ -18944,14 +18944,14 @@
       }
     },
     "node_modules/ember-dayjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.6.tgz",
-      "integrity": "sha512-eiGUz5fTyi/gD6IKULcjmWgl9yGP7Ca5jQfXzHMjTppGlWRwZFHejvNYtZ9s9UKpJ1WDQcMVaYK6NZil7DD44w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "dependencies": {
-        "dayjs": "^1.11.7",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
@@ -51507,14 +51507,14 @@
       }
     },
     "ember-dayjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.10.6.tgz",
-      "integrity": "sha512-eiGUz5fTyi/gD6IKULcjmWgl9yGP7Ca5jQfXzHMjTppGlWRwZFHejvNYtZ9s9UKpJ1WDQcMVaYK6NZil7DD44w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.11.0.tgz",
+      "integrity": "sha512-tqcoCFgnMctNa78sHk7PKyv6a0zLjfoglbI3a7GHNUuohrxWS69ZvVtY9T3N0fVorcjoEZq9pdRTlm6sTmykug==",
       "dev": true,
       "requires": {
-        "dayjs": "^1.11.7",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0"
+        "@embroider/addon-shim": "^1.8.4",
+        "@embroider/macros": "^1.10.0",
+        "dayjs": "^1.11.7"
       }
     },
     "ember-decorators-polyfill": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -78,7 +78,7 @@
     "ember-click-outside": "^6.0.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
-    "ember-dayjs": "^0.10.4",
+    "ember-dayjs": "^0.11.0",
     "ember-fetch": "^8.1.2",
     "ember-intl": "^5.7.2",
     "ember-load-initializers": "^2.1.2",


### PR DESCRIPTION
## :unicorn: Problème
ember-dayjs n'est pas a jour. Dans sa dernière version l'extension ember permet de ne plus spécifier les plugins et les locales utilisées, elles sont cherchées dynamiquement lorsqu''on les demande. Voir https://github.com/sinankeskin/ember-dayjs/blob/main/CHANGELOG.md
De plus l'addon est passé au format v2 des extensions ember.

## :robot: Proposition
Mettre à jour et supprimer la configuration devenu inutile.

## :100: Pour tester
Sur mon-pix:
1. se connecter sur le .fr et se connecter avec le compte userpix1.
2. Aller sur la page de tutoriel
3. Ouvrir la console de developpement ember -> Et cliquer sur data
4. Sélectionner tutorial, et ensuite la première entrée 
5. Dans les attributs, modifier duration a 17000
6. Constater que l'affichage change en **5 heures**.
7. Ensuite reproduire en se connectant sur le org, et mettre lang=en dans les paramètres de l'URL
8. Voir que l'affichage est **5 hours**

Dans les autres cas et les autres appli, on spécifie l'affichage souhaité, donc pas de problèmes en théorie.
