### PR TITLE
[TECH] Supprime l'orb slack de la configuration de circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.4.1
-  slack: circleci/slack@4.9.3
 
 workflows:
   version: 2


### PR DESCRIPTION
## :unicorn: Problème
L'orb slack n'est pas utilisé.

## :robot: Proposition
La supprimer.

## :rainbow: Remarques
Rajouté 5dd813aea9e0678a99a346b7d9320f0c4a25b7f6
Supprimé 7af1124965d344f894d67a1374e364b34225fd3a

## :100: Pour tester
Tests verts
