### PR TITLE
[FEATURE] Afficher des corrections claires pour les QROCM-dep (PIX-7866)

### DIFF
--- a/mon-pix/app/components/comparison-window.hbs
+++ b/mon-pix/app/components/comparison-window.hbs
@@ -71,6 +71,7 @@
               @solution={{this.solution}}
               @challenge={{@answer.challenge}}
               @solutionToDisplay={{this.solutionToDisplay}}
+              @correctionBlocks={{this.correctionBlocks}}
             />
           </div>
         {{/if}}

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -69,6 +69,10 @@ export default class ComparisonWindow extends Component {
     return this._isAutoReply ? null : this.args.answer.correction.get('solution');
   }
 
+  get correctionBlocks() {
+    return this.args.answer.correction.get('correctionBlocks');
+  }
+
   get solutionToDisplay() {
     return this.args.answer.correction.get('solutionToDisplay');
   }

--- a/mon-pix/app/models/correction.js
+++ b/mon-pix/app/models/correction.js
@@ -8,6 +8,7 @@ export default class Correction extends Model {
   @attr('string') solution;
   @attr('string') solutionToDisplay;
   @attr('string') hint;
+  @attr('array') correctionBlocks;
 
   // includes
   @hasMany('tutorial', { inverse: null }) tutorials;

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -200,6 +200,16 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         hint: 'Sortir de paris !',
         tutorials: [tutorial],
         learningMoreTutorials: [learningMoreTutorial],
+        correctionBlocks: [
+          {
+            validated: false,
+            alternativeSolutions: ['Versailles-Chantiers', 'Poissy'],
+          },
+          {
+            validated: false,
+            alternativeSolutions: ['Versailles-Chantiers', 'Poissy'],
+          },
+        ],
       });
       server.create('answer', {
         value: "station1: 'Republique'\nstation2: 'Chatelet'\n",
@@ -213,6 +223,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         hint: 'Sortir de paris !',
         tutorials: [tutorial],
         learningMoreTutorials: [learningMoreTutorial],
+        correctionBlocks: [],
       });
       server.create('answer', {
         value: "titre: 'Le rouge et le noir'\nauteur: 'Stendhal'\n",
@@ -227,6 +238,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         hint: 'Sortir de paris !',
         tutorials: [tutorial],
         learningMoreTutorials: [learningMoreTutorial],
+        correctionBlocks: [],
       });
       server.create('answer', {
         value: "banana: 'potato'\n",

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -137,26 +137,24 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             // given
             const answer = EmberObject.create({
               id: 'answer_id',
-              value: "key1: 'wrongAnswer1' key2: 'wrongAnswer2'",
+              value: "key1: 'rightAnswer1' key2: 'wrongAnswer2'",
               result: classByResultKey.ko,
               assessment,
               challenge,
             });
             this.set('answer', answer);
-          });
 
-          test('should display one solution in bold green', async function (assert) {
-            // when
-            await render(
-              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
-            );
-
-            // then
-            const wrongSolutionBlock = find(SOLUTION_BLOCK);
-            const wrongSolutionText = find(SOLUTION_TEXT);
-
-            assert.ok(wrongSolutionBlock);
-            assert.ok(wrongSolutionText);
+            const correctionBlocks = [
+              {
+                validated: true,
+                alternativeSolutions: [],
+              },
+              {
+                validated: false,
+                alternativeSolutions: [],
+              },
+            ];
+            this.set('correctionBlocks', correctionBlocks);
           });
 
           test('should display the solutionToDisplay if exist', async function (assert) {
@@ -164,7 +162,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             const solutionToDisplay = 'Ceci est la solution !';
             this.set('solutionToDisplay', solutionToDisplay);
             await render(
-              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @solutionToDisplay={{this.solutionToDisplay}}/>`
+              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @solutionToDisplay={{this.solutionToDisplay}} @correctionBlocks={{this.correctionBlocks}}/>`
             );
 
             // then
@@ -172,17 +170,30 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             assert.ok(find(SOLUTION_TEXT).textContent.includes(solutionToDisplay));
           });
 
-          test('should display the wrong answer in standard style since we do not handle single wrong answer yet', async function (assert) {
+          test('should display the first answer input in bold green', async function (assert) {
             // when
             await render(
-              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
+              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @correctionBlocks={{this.correctionBlocks}} />`
             );
 
             // then
             const firstAnswerInput = findAll(ANSWER)[0];
 
             assert.ok(firstAnswerInput);
-            assert.false(firstAnswerInput.classList.contains('correction-qroc-box-answer--wrong'));
+            assert.true(firstAnswerInput.classList.contains('correction-qroc-box-answer--correct'));
+          });
+
+          test('should strike the second answer input', async function (assert) {
+            // when
+            await render(
+              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @correctionBlocks={{this.correctionBlocks}} />`
+            );
+
+            // then
+            const secondAnswerInput = findAll(ANSWER)[1];
+
+            assert.ok(secondAnswerInput);
+            assert.true(secondAnswerInput.classList.contains('correction-qroc-box-answer--wrong'));
           });
         });
       });

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -52,9 +52,21 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             });
             this.set('answer', answer);
 
+            const correctionBlocks = [
+              {
+                validated: true,
+                alternativeSolutions: [],
+              },
+              {
+                validated: false,
+                alternativeSolutions: [],
+              },
+            ];
+            this.set('correctionBlocks', correctionBlocks);
+
             // when
             await render(
-              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
+              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @correctionBlocks={{this.correctionBlocks}} />`
             );
           });
 
@@ -86,9 +98,21 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             });
             this.set('answer', answer);
 
+            const correctionBlocks = [
+              EmberObject.create({
+                validated: false,
+                alternativeSolutions: [],
+              }),
+              EmberObject.create({
+                validated: false,
+                alternativeSolutions: [],
+              }),
+            ];
+            this.set('correctionBlocks', correctionBlocks);
+
             // when
             await render(
-              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
+              hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @correctionBlocks={{this.correctionBlocks}} />`
             );
           });
 
@@ -174,6 +198,17 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
         assessment,
         challenge,
       });
+      const correctionBlocks = [
+        {
+          validated: true,
+          alternativeSolutions: [],
+        },
+        {
+          validated: false,
+          alternativeSolutions: [],
+        },
+      ];
+      this.set('correctionBlocks', correctionBlocks);
       this.set('answer', answer);
       this.set('solution', solution);
       this.set('challenge', challenge);
@@ -182,9 +217,10 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
     test(`should display a disabled input with expected size`, async function (assert) {
       //given
       const answerSize = 'rightAnswer1'.length;
+
       //when
       await render(
-        hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
+        hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @solutionToDisplay={{this.solutionToDisplay}} @correctionBlocks={{this.correctionBlocks}} />`
       );
 
       //then
@@ -205,6 +241,17 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
         assessment,
         challenge,
       });
+      const correctionBlocks = [
+        {
+          validated: true,
+          alternativeSolutions: [],
+        },
+        {
+          validated: false,
+          alternativeSolutions: [],
+        },
+      ];
+      this.set('correctionBlocks', correctionBlocks);
       this.set('answer', answer);
       this.set('solution', solution);
       this.set('challenge', challenge);
@@ -214,7 +261,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
     test('should display a disabled textarea', async function (assert) {
       // when
       await render(
-        hbs`<QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.solution}} @challenge={{this.challenge}} />`
+        hbs`<QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.solution}} @challenge={{this.challenge}} @correctionBlocks={{this.correctionBlocks}} />`
       );
 
       // then
@@ -243,7 +290,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
     test('should display a disabled input', async function (assert) {
       // when
       await render(
-        hbs`<QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.solution}} @challenge={{this.challenge}} />`
+        hbs`<QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.solution}} @challenge={{this.challenge}} @correctionBlocks={{this.correctionBlocks}} />`
       );
 
       // then

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -99,15 +99,16 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
             this.set('answer', answer);
 
             const correctionBlocks = [
-              EmberObject.create({
+              {
                 validated: false,
                 alternativeSolutions: [],
-              }),
-              EmberObject.create({
+              },
+              {
                 validated: false,
                 alternativeSolutions: [],
-              }),
+              },
             ];
+
             this.set('correctionBlocks', correctionBlocks);
 
             // when

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
@@ -12,9 +12,13 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
     test('should return an array with data to display', function (assert) {
       //Given
       const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
-      const answer = { value: "smiley1: ':)' smiley2: ''", result: 'ko' };
+      const answer = {
+        value: "smiley1: ':)' smiley2: ''",
+        result: 'ko',
+      };
+      const correctionBlocks = [{ validated: true }, { validated: false }];
 
-      const component = createGlimmerComponent('qrocm-dep-solution-panel', { challenge, answer });
+      const component = createGlimmerComponent('qrocm-dep-solution-panel', { challenge, answer, correctionBlocks });
 
       const expectedBlocksData = [
         {
@@ -22,7 +26,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
           text: 'content : ',
           ariaLabel: null,
           autoAriaLabel: false,
-          inputClass: '',
+          inputClass: 'correction-qroc-box-answer--correct',
           answer: ':)',
           placeholder: null,
           type: 'input',
@@ -46,6 +50,41 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
 
       //Then
       assert.deepEqual(blocks, expectedBlocksData);
+    });
+  });
+
+  module('#getInputClass', function () {
+    test('should return "aband" css class when isAnswerEmpty param is true', function (assert) {
+      //Given
+      const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
+
+      //when
+      const inputClass = component.getInputClass(true);
+
+      //Then
+      assert.deepEqual(inputClass, 'correction-qroc-box-answer--aband');
+    });
+
+    test('should return "correct" css class when isAnswerEmpty param is false and isCorrectAnswer is true', function (assert) {
+      //Given
+      const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
+
+      //when
+      const inputClass = component.getInputClass(false, true);
+
+      //Then
+      assert.deepEqual(inputClass, 'correction-qroc-box-answer--correct');
+    });
+
+    test('should return "wrong" css class when isAnswerEmpty param is false and isCorrectAnswer is false', function (assert) {
+      //Given
+      const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
+
+      //when
+      const inputClass = component.getInputClass(false, false);
+
+      //Then
+      assert.deepEqual(inputClass, 'correction-qroc-box-answer--wrong');
     });
   });
 

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
@@ -56,7 +56,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
   module('#getInputClass', function () {
     test('should return "aband" css class when isAnswerEmpty param is true', function (assert) {
       //Given
-      const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
+      const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
       //when
       const inputClass = component.getInputClass(true);
@@ -67,7 +67,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
 
     test('should return "correct" css class when isAnswerEmpty param is false and isCorrectAnswer is true', function (assert) {
       //Given
-      const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
+      const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
       //when
       const inputClass = component.getInputClass(false, true);
@@ -78,7 +78,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
 
     test('should return "wrong" css class when isAnswerEmpty param is false and isCorrectAnswer is false', function (assert) {
       //Given
-      const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
+      const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
       //when
       const inputClass = component.getInputClass(false, false);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'affichage des correction des QROCM-dep n'est pas parlant pour l'utilisateur. On souhaite afficher plus précisément quelle réponse est bonne ou fasse.

## :robot: Proposition
Dans un premier temps, nous avons modifié l'API pour qu'elle renvoie une correction par block de réponse du QROCM-dep. Il faut maintenant l'utiliser dans le front de l'application pix app.

## :rainbow: Remarques


## :100: Pour tester
- Se connecter  à la RA de pix app 
- ouvrir ce qrocm-dep en preview : challenges/challenge28kwuFJjZlaJs8/preview
- répondre un vrai et un faux
- vérifier que l'affichage est conforme à ce qui est demandé dans le ticket [jira 542](https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/94?modal=detail&selectedIssue=PIX-542)