### PR TITLE
[BUGFIX] Ajouter le i18n à la méthode publishInBatch (PIX-8187).

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -339,8 +339,11 @@ const publish = async function (request, h, dependencies = { sessionSerializer }
 
 const publishInBatch = async function (request, h) {
   const sessionIds = request.payload.data.attributes.ids;
+  const i18n = request.i18n;
+
   const result = await usecases.publishSessionsInBatch({
     sessionIds,
+    i18n,
   });
   if (result.hasPublicationErrors()) {
     _logSessionBatchPublicationErrors(result);

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { SessionPublicationBatchResult } from '../models/SessionPublicationBatchResult.js';
 
 const publishSessionsInBatch = async function ({
+  i18n,
   sessionIds,
   certificationCenterRepository,
   certificationRepository,
@@ -16,6 +17,7 @@ const publishSessionsInBatch = async function ({
   for (const sessionId of sessionIds) {
     try {
       await sessionPublicationService.publishSession({
+        i18n,
         sessionId,
         certificationRepository,
         certificationCenterRepository,

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -737,7 +737,10 @@ describe('Unit | Controller | sessionController', function () {
   describe('#publishInBatch', function () {
     it('returns 204 when no error occurred', async function () {
       // given
+      const i18n = getI18n();
+
       const request = {
+        i18n,
         payload: {
           data: {
             attributes: {
@@ -750,22 +753,26 @@ describe('Unit | Controller | sessionController', function () {
         .stub(usecases, 'publishSessionsInBatch')
         .withArgs({
           sessionIds: ['sessionId1', 'sessionId2'],
+          i18n,
         })
         .resolves(new SessionPublicationBatchResult('batchId'));
 
       // when
       const response = await sessionController.publishInBatch(request, hFake);
+
       // then
       expect(response.statusCode).to.equal(204);
     });
 
     it('logs errors when errors occur', async function () {
       // given
+      const i18n = getI18n();
       const result = new SessionPublicationBatchResult('batchId');
       result.addPublicationError('sessionId1', new Error('an error'));
       result.addPublicationError('sessionId2', new Error('another error'));
 
       const request = {
+        i18n,
         payload: {
           data: {
             attributes: {
@@ -774,12 +781,7 @@ describe('Unit | Controller | sessionController', function () {
           },
         },
       };
-      sinon
-        .stub(usecases, 'publishSessionsInBatch')
-        .withArgs({
-          sessionIds: ['sessionId1', 'sessionId2'],
-        })
-        .resolves(result);
+      sinon.stub(usecases, 'publishSessionsInBatch').resolves(result);
       sinon.stub(logger, 'warn');
 
       // when
@@ -809,10 +811,12 @@ describe('Unit | Controller | sessionController', function () {
 
     it('returns the serialized batch id', async function () {
       // given
+      const i18n = getI18n();
       const result = new SessionPublicationBatchResult('batchId');
       result.addPublicationError('sessionId1', new Error('an error'));
 
       const request = {
+        i18n,
         payload: {
           data: {
             attributes: {
@@ -821,12 +825,7 @@ describe('Unit | Controller | sessionController', function () {
           },
         },
       };
-      sinon
-        .stub(usecases, 'publishSessionsInBatch')
-        .withArgs({
-          sessionIds: ['sessionId1', 'sessionId2'],
-        })
-        .resolves(result);
+      sinon.stub(usecases, 'publishSessionsInBatch').resolves(result);
       sinon.stub(logger, 'warn');
 
       // when

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -24,6 +24,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     const sessionId1 = Symbol('first session id');
     const sessionId2 = Symbol('second session id');
     const publishedAt = Symbol('a publication date');
+    const i18n = Symbol('i18n');
 
     // when
     await publishSessionsInBatch({
@@ -35,6 +36,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       sessionRepository,
       publishedAt,
       batchId: 'batch id',
+      i18n,
     });
 
     // then
@@ -45,6 +47,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       finalizedSessionRepository,
       sessionRepository,
       publishedAt,
+      i18n,
     });
     expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
       sessionId: sessionId2,
@@ -53,12 +56,14 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       finalizedSessionRepository,
       sessionRepository,
       publishedAt,
+      i18n,
     });
   });
 
   context('when one or many session publication fail', function () {
     it('should continue', async function () {
       // given
+      const i18n = Symbol('i18n');
       const sessionId1 = Symbol('first session id');
       const sessionId2 = Symbol('second session id');
       const publishedAt = Symbol('a publication date');
@@ -84,6 +89,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         sessionRepository,
         publishedAt,
         batchId: 'batch id',
+        i18n,
       });
 
       expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
@@ -93,6 +99,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         finalizedSessionRepository,
         sessionRepository,
         publishedAt,
+        i18n,
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Des logs d'erreurs sur la publication en masse de 9h13 ont été détecté par les captains avec le message suivant : `Cannot read properties of undefined (reading '__')`
L'erreur provient de i18n, qui n'a pas été set sur la méthode de publication en masse des sessions de certification.

## :robot: Proposition
Ajouter i18n dans la méthode publishInBatch


## :100: Pour tester

- Se connecter sur Pix Admin
- entrer dans l'url `/sessions/list/to-be-published`
- Cliquer sur le bouton pour publier toutes les sessions
- S'assurer que les mails ont été envoyés