### PR TITLE
[FEATURE] Ajout d'une capacité initiale dans les simulateurs d'évaluation (PIX-8159).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -22,7 +22,8 @@ const register = async (server) => {
             Joi.object({
               assessmentId: Joi.string().required(),
               type: Joi.string().valid('deterministic').required(),
-              stopAtChallenge: Joi.number().integer().min(0),
+              stopAtChallenge: Joi.number().integer().min(0).optional(),
+              initialCapacity: Joi.number().integer().min(-8).max(8).optional(),
               simulationAnswers: Joi.array().items(Joi.string().allow('ok', 'ko', 'aband')).required(),
             }),
             Joi.object({
@@ -34,12 +35,14 @@ const register = async (server) => {
                 aband: Joi.number(),
               }),
               length: Joi.number().integer().min(0).required(),
+              initialCapacity: Joi.number().integer().min(-8).max(8),
               stopAtChallenge: Joi.number().integer().min(0),
             }),
             Joi.object({
               assessmentId: Joi.string().required(),
               type: Joi.string().valid('capacity').required(),
               capacity: Joi.number().min(-8).max(8).required(),
+              initialCapacity: Joi.number().integer().min(-8).max(8),
               stopAtChallenge: Joi.number().integer().min(0),
             }),
           ]).required(),

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -12,7 +12,7 @@ async function simulateFlashAssessmentScenario(
   h,
   dependencies = { scenarioSimulatorSerializer, random, pickAnswersService, extractLocaleFromRequest }
 ) {
-  const { assessmentId, stopAtChallenge } = request.payload;
+  const { assessmentId, stopAtChallenge, initialCapacity } = request.payload;
 
   const pickAnswer = _getPickAnswerMethod(dependencies.pickAnswersService, request.payload);
 
@@ -23,6 +23,7 @@ async function simulateFlashAssessmentScenario(
     assessmentId,
     locale,
     stopAtChallenge,
+    initialCapacity,
   });
 
   return dependencies.scenarioSimulatorSerializer.serialize(result);

--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -20,6 +20,7 @@ export class AssessmentSimulator {
         const possibleChallenges = this.algorithm.getPossibleNextChallenges({
           allAnswers: challengesAnswers,
           challenges: this.challenges,
+          estimatedLevel,
         });
         const nextChallenge = this.pickChallenge({ possibleChallenges });
 

--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -1,18 +1,20 @@
 import { Answer } from './Answer.js';
 
 export class AssessmentSimulator {
-  constructor({ algorithm, challenges, pickChallenge, pickAnswer, stopAtChallenge }) {
+  constructor({ algorithm, challenges, pickChallenge, pickAnswer, stopAtChallenge, initialCapacity }) {
     this.algorithm = algorithm;
     this.challenges = challenges;
     this.pickAnswer = pickAnswer;
     this.pickChallenge = pickChallenge;
     this.stopAtChallenge = stopAtChallenge;
+    this.initialCapacity = initialCapacity;
   }
 
   run() {
     const challengesAnswers = [];
     const result = [];
-    let estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({ allAnswers: [] }).estimatedLevel;
+    let estimatedLevel =
+      this.initialCapacity ?? this.algorithm.getEstimatedLevelAndErrorRate({ allAnswers: [] }).estimatedLevel;
     const maxChallenge = this.stopAtChallenge || Infinity;
 
     for (let i = 0; i < maxChallenge; i++) {

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -8,6 +8,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   pickAnswer,
   assessmentId,
   stopAtChallenge,
+  initialCapacity,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale });
 
@@ -24,6 +25,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     algorithm: flashAssessmentAlgorithm,
     challenges,
     pickChallenge,
+    initialCapacity,
     pickAnswer,
     stopAtChallenge,
   });

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -12,6 +12,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
   let errorRate1;
   let challenge1;
   let estimatedLevel1;
+  const initialCapacity = 2;
 
   beforeEach(async function () {
     sinon.stub(usecases, 'simulateFlashDeterministicAssessmentScenario');
@@ -57,55 +58,114 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
 
       context('When the scenario is deterministic', function () {
         context('When the route is called with correct arguments', function () {
-          it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
-            // given
-            const simulationAnswers = ['ok'];
-            const assessmentId = '13802DK';
+          context('When the route is called with an initial capacity', function () {
+            it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+              // given
+              const simulationAnswers = ['ok'];
+              const assessmentId = '13802DK';
 
-            const pickAnswerFromArrayImplementation = sinon.stub();
-            pickAnswersService.pickAnswersFromArray.withArgs(['ok']).returns(pickAnswerFromArrayImplementation);
+              const pickAnswerFromArrayImplementation = sinon.stub();
+              pickAnswersService.pickAnswersFromArray.withArgs(['ok']).returns(pickAnswerFromArrayImplementation);
 
-            usecases.simulateFlashDeterministicAssessmentScenario
-              .withArgs({
-                pickAnswer: pickAnswerFromArrayImplementation,
-                assessmentId,
-                locale: 'en',
-                stopAtChallenge: undefined,
-              })
-              .resolves(simulationResults);
-            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+              usecases.simulateFlashDeterministicAssessmentScenario
+                .withArgs({
+                  pickAnswer: pickAnswerFromArrayImplementation,
+                  assessmentId,
+                  locale: 'en',
+                  initialCapacity,
+                  stopAtChallenge: undefined,
+                })
+                .resolves(simulationResults);
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
 
-            // when
-            const response = await httpTestServer.request(
-              'POST',
-              '/api/scenario-simulator',
-              {
-                assessmentId,
-                simulationAnswers,
-                type: 'deterministic',
-              },
-              null,
-              { 'accept-language': 'en' }
-            );
-
-            // then
-            expect(response.statusCode).to.equal(200);
-            expect(response.result).to.deep.equal({
-              data: [
+              // when
+              const response = await httpTestServer.request(
+                'POST',
+                '/api/scenario-simulator',
                 {
-                  attributes: {
-                    'error-rate': errorRate1,
-                    'estimated-level': estimatedLevel1,
-                    'minimum-capability': 0.6190392084062237,
-                    answer: 'ok',
-                    reward: reward1,
-                    difficulty: challenge1.difficulty,
-                    discriminant: challenge1.discriminant,
-                  },
-                  id: 'chall1',
-                  type: 'scenario-simulator-challenges',
+                  assessmentId,
+                  initialCapacity,
+                  simulationAnswers,
+                  type: 'deterministic',
                 },
-              ],
+                null,
+                { 'accept-language': 'en' }
+              );
+
+              // then
+              expect(response.statusCode).to.equal(200);
+              expect(response.result).to.deep.equal({
+                data: [
+                  {
+                    attributes: {
+                      'error-rate': errorRate1,
+                      'estimated-level': estimatedLevel1,
+                      'minimum-capability': 0.6190392084062237,
+                      answer: 'ok',
+                      reward: reward1,
+                      difficulty: challenge1.difficulty,
+                      discriminant: challenge1.discriminant,
+                    },
+                    id: 'chall1',
+                    type: 'scenario-simulator-challenges',
+                  },
+                ],
+              });
+            });
+          });
+
+          context('When the route is called without an initial capacity', function () {
+            it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+              // given
+              const simulationAnswers = ['ok'];
+              const assessmentId = '13802DK';
+
+              const pickAnswerFromArrayImplementation = sinon.stub();
+              pickAnswersService.pickAnswersFromArray.withArgs(['ok']).returns(pickAnswerFromArrayImplementation);
+
+              usecases.simulateFlashDeterministicAssessmentScenario
+                .withArgs({
+                  pickAnswer: pickAnswerFromArrayImplementation,
+                  assessmentId,
+                  locale: 'en',
+                  stopAtChallenge: undefined,
+                  initialCapacity: undefined,
+                })
+                .resolves(simulationResults);
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+              // when
+              const response = await httpTestServer.request(
+                'POST',
+                '/api/scenario-simulator',
+                {
+                  assessmentId,
+                  simulationAnswers,
+                  type: 'deterministic',
+                },
+                null,
+                { 'accept-language': 'en' }
+              );
+
+              // then
+              expect(response.statusCode).to.equal(200);
+              expect(response.result).to.deep.equal({
+                data: [
+                  {
+                    attributes: {
+                      'error-rate': errorRate1,
+                      'estimated-level': estimatedLevel1,
+                      'minimum-capability': 0.6190392084062237,
+                      answer: 'ok',
+                      reward: reward1,
+                      difficulty: challenge1.difficulty,
+                      discriminant: challenge1.discriminant,
+                    },
+                    id: 'chall1',
+                    type: 'scenario-simulator-challenges',
+                  },
+                ],
+              });
             });
           });
         });
@@ -113,58 +173,120 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
 
       context('When the scenario is random', function () {
         context('When the route is called with correct arguments', function () {
-          it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
-            // given
-            const length = 1;
-            const probabilities = { ok: 0.3, ko: 0.4, aband: 0.3 };
-            random.weightedRandoms.withArgs(probabilities, length).returns(['ok']);
-            const assessmentId = '13802DK';
+          context('When the route is called without an initial capacity', function () {
+            it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+              // given
+              const length = 1;
+              const probabilities = { ok: 0.3, ko: 0.4, aband: 0.3 };
+              random.weightedRandoms.withArgs(probabilities, length).returns(['ok']);
+              const assessmentId = '13802DK';
 
-            const pickAnswerFromArrayImplementation = sinon.stub();
-            pickAnswersService.pickAnswersFromArray.withArgs(['ok']).returns(pickAnswerFromArrayImplementation);
+              const pickAnswerFromArrayImplementation = sinon.stub();
+              pickAnswersService.pickAnswersFromArray.withArgs(['ok']).returns(pickAnswerFromArrayImplementation);
 
-            usecases.simulateFlashDeterministicAssessmentScenario
-              .withArgs({
-                assessmentId,
-                locale: 'en',
-                pickAnswer: pickAnswerFromArrayImplementation,
-                stopAtChallenge: undefined,
-              })
-              .resolves(simulationResults);
-            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+              usecases.simulateFlashDeterministicAssessmentScenario
+                .withArgs({
+                  assessmentId,
+                  locale: 'en',
+                  pickAnswer: pickAnswerFromArrayImplementation,
+                  stopAtChallenge: undefined,
+                  initialCapacity: undefined,
+                })
+                .resolves(simulationResults);
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
 
-            // when
-            const response = await httpTestServer.request(
-              'POST',
-              '/api/scenario-simulator',
-              {
-                assessmentId,
-                type: 'random',
-                probabilities,
-                length,
-              },
-              null,
-              { 'accept-language': 'en' }
-            );
-
-            // then
-            expect(response.statusCode).to.equal(200);
-            expect(response.result).to.deep.equal({
-              data: [
+              // when
+              const response = await httpTestServer.request(
+                'POST',
+                '/api/scenario-simulator',
                 {
-                  attributes: {
-                    'error-rate': errorRate1,
-                    'estimated-level': estimatedLevel1,
-                    'minimum-capability': 0.6190392084062237,
-                    answer: 'ok',
-                    reward: reward1,
-                    difficulty: challenge1.difficulty,
-                    discriminant: challenge1.discriminant,
-                  },
-                  id: 'chall1',
-                  type: 'scenario-simulator-challenges',
+                  assessmentId,
+                  type: 'random',
+                  probabilities,
+                  length,
                 },
-              ],
+                null,
+                { 'accept-language': 'en' }
+              );
+
+              // then
+              expect(response.statusCode).to.equal(200);
+              expect(response.result).to.deep.equal({
+                data: [
+                  {
+                    attributes: {
+                      'error-rate': errorRate1,
+                      'estimated-level': estimatedLevel1,
+                      'minimum-capability': 0.6190392084062237,
+                      answer: 'ok',
+                      reward: reward1,
+                      difficulty: challenge1.difficulty,
+                      discriminant: challenge1.discriminant,
+                    },
+                    id: 'chall1',
+                    type: 'scenario-simulator-challenges',
+                  },
+                ],
+              });
+            });
+          });
+
+          context('When the route is called with an initial capacity', function () {
+            it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+              // given
+              const length = 1;
+              const probabilities = { ok: 0.3, ko: 0.4, aband: 0.3 };
+              random.weightedRandoms.withArgs(probabilities, length).returns(['ok']);
+              const assessmentId = '13802DK';
+
+              const pickAnswerFromArrayImplementation = sinon.stub();
+              pickAnswersService.pickAnswersFromArray.withArgs(['ok']).returns(pickAnswerFromArrayImplementation);
+
+              usecases.simulateFlashDeterministicAssessmentScenario
+                .withArgs({
+                  assessmentId,
+                  locale: 'en',
+                  pickAnswer: pickAnswerFromArrayImplementation,
+                  stopAtChallenge: undefined,
+                  initialCapacity,
+                })
+                .resolves(simulationResults);
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+              // when
+              const response = await httpTestServer.request(
+                'POST',
+                '/api/scenario-simulator',
+                {
+                  assessmentId,
+                  type: 'random',
+                  probabilities,
+                  initialCapacity,
+                  length,
+                },
+                null,
+                { 'accept-language': 'en' }
+              );
+
+              // then
+              expect(response.statusCode).to.equal(200);
+              expect(response.result).to.deep.equal({
+                data: [
+                  {
+                    attributes: {
+                      'error-rate': errorRate1,
+                      'estimated-level': estimatedLevel1,
+                      'minimum-capability': 0.6190392084062237,
+                      answer: 'ok',
+                      reward: reward1,
+                      difficulty: challenge1.difficulty,
+                      discriminant: challenge1.discriminant,
+                    },
+                    id: 'chall1',
+                    type: 'scenario-simulator-challenges',
+                  },
+                ],
+              });
             });
           });
         });
@@ -172,55 +294,114 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
 
       context('When the scenario is capacity', function () {
         context('When the route is called with correct arguments', function () {
-          it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
-            // given
-            const capacity = -3.1;
-            const assessmentId = '13802DK';
+          context('When the route is called without an initial capacity', function () {
+            it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+              // given
+              const capacity = -3.1;
+              const assessmentId = '13802DK';
 
-            const pickAnswerFromCapacityImplementation = sinon.stub();
-            pickAnswersService.pickAnswerForCapacity.withArgs(capacity).returns(pickAnswerFromCapacityImplementation);
+              const pickAnswerFromCapacityImplementation = sinon.stub();
+              pickAnswersService.pickAnswerForCapacity.withArgs(capacity).returns(pickAnswerFromCapacityImplementation);
 
-            usecases.simulateFlashDeterministicAssessmentScenario
-              .withArgs({
-                assessmentId,
-                locale: 'en',
-                pickAnswer: pickAnswerFromCapacityImplementation,
-                stopAtChallenge: undefined,
-              })
-              .resolves(simulationResults);
-            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+              usecases.simulateFlashDeterministicAssessmentScenario
+                .withArgs({
+                  assessmentId,
+                  locale: 'en',
+                  pickAnswer: pickAnswerFromCapacityImplementation,
+                  stopAtChallenge: undefined,
+                  initialCapacity: undefined,
+                })
+                .resolves(simulationResults);
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
 
-            // when
-            const response = await httpTestServer.request(
-              'POST',
-              '/api/scenario-simulator',
-              {
-                assessmentId,
-                type: 'capacity',
-                capacity,
-              },
-              null,
-              { 'accept-language': 'en' }
-            );
-
-            // then
-            expect(response.statusCode).to.equal(200);
-            expect(response.result).to.deep.equal({
-              data: [
+              // when
+              const response = await httpTestServer.request(
+                'POST',
+                '/api/scenario-simulator',
                 {
-                  attributes: {
-                    'error-rate': errorRate1,
-                    'estimated-level': estimatedLevel1,
-                    'minimum-capability': 0.6190392084062237,
-                    answer: 'ok',
-                    reward: reward1,
-                    difficulty: challenge1.difficulty,
-                    discriminant: challenge1.discriminant,
-                  },
-                  id: 'chall1',
-                  type: 'scenario-simulator-challenges',
+                  assessmentId,
+                  type: 'capacity',
+                  capacity,
                 },
-              ],
+                null,
+                { 'accept-language': 'en' }
+              );
+
+              // then
+              expect(response.statusCode).to.equal(200);
+              expect(response.result).to.deep.equal({
+                data: [
+                  {
+                    attributes: {
+                      'error-rate': errorRate1,
+                      'estimated-level': estimatedLevel1,
+                      'minimum-capability': 0.6190392084062237,
+                      answer: 'ok',
+                      reward: reward1,
+                      difficulty: challenge1.difficulty,
+                      discriminant: challenge1.discriminant,
+                    },
+                    id: 'chall1',
+                    type: 'scenario-simulator-challenges',
+                  },
+                ],
+              });
+            });
+          });
+
+          context('When the route is called with an initial capacity', function () {
+            it('should call simulateFlashDeterministicAssessmentScenario usecase with correct arguments', async function () {
+              // given
+              const capacity = -3.1;
+              const assessmentId = '13802DK';
+
+              const pickAnswerFromCapacityImplementation = sinon.stub();
+              pickAnswersService.pickAnswerForCapacity.withArgs(capacity).returns(pickAnswerFromCapacityImplementation);
+
+              usecases.simulateFlashDeterministicAssessmentScenario
+                .withArgs({
+                  assessmentId,
+                  locale: 'en',
+                  pickAnswer: pickAnswerFromCapacityImplementation,
+                  stopAtChallenge: undefined,
+                  initialCapacity,
+                })
+                .resolves(simulationResults);
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => true);
+
+              // when
+              const response = await httpTestServer.request(
+                'POST',
+                '/api/scenario-simulator',
+                {
+                  assessmentId,
+                  type: 'capacity',
+                  capacity,
+                  initialCapacity,
+                },
+                null,
+                { 'accept-language': 'en' }
+              );
+
+              // then
+              expect(response.statusCode).to.equal(200);
+              expect(response.result).to.deep.equal({
+                data: [
+                  {
+                    attributes: {
+                      'error-rate': errorRate1,
+                      'estimated-level': estimatedLevel1,
+                      'minimum-capability': 0.6190392084062237,
+                      answer: 'ok',
+                      reward: reward1,
+                      difficulty: challenge1.difficulty,
+                      discriminant: challenge1.discriminant,
+                    },
+                    id: 'chall1',
+                    type: 'scenario-simulator-challenges',
+                  },
+                ],
+              });
             });
           });
         });

--- a/api/tests/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/unit/domain/models/AssessmentSimulator_test.js
@@ -31,16 +31,12 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             })
             .returns({
               estimatedLevel: initialEstimatedLevel,
-            });
-
-          algorithm.getEstimatedLevelAndErrorRate
+            })
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
             })
-            .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] });
-
-          algorithm.getEstimatedLevelAndErrorRate
+            .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
             .withArgs({
               allAnswers: [sinon.match(answer1), sinon.match(answer2)],
               challenges: allChallenges,
@@ -54,17 +50,21 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             .withArgs({
               allAnswers: [],
               challenges: allChallenges,
+              estimatedLevel: initialEstimatedLevel,
             })
-            .returns([challenge2, challenge1]);
-          algorithm.getPossibleNextChallenges
+            .returns([challenge2, challenge1])
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
+              estimatedLevel: expectedEstimatedLevels[0],
             })
             .returns([challenge1]);
 
-          pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
-          pickChallenge.withArgs({ possibleChallenges: [challenge1] }).returns(challenge1);
+          pickChallenge
+            .withArgs({ possibleChallenges: [challenge2, challenge1] })
+            .returns(challenge2)
+            .withArgs({ possibleChallenges: [challenge1] })
+            .returns(challenge1);
 
           pickAnswer
             .withArgs({ nextChallenge: challenge2, answerIndex: 0 })
@@ -78,9 +78,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
               difficulty: challenge1.difficulty,
               discriminant: challenge1.discriminant,
             })
-            .returns(expectedRewards[0]);
-
-          algorithm.getReward
+            .returns(expectedRewards[0])
             .withArgs({
               estimatedLevel: expectedEstimatedLevels[0],
               difficulty: challenge2.difficulty,
@@ -144,9 +142,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             })
             .returns({
               estimatedLevel: initialEstimatedLevel,
-            });
-
-          algorithm.getEstimatedLevelAndErrorRate
+            })
             .withArgs({
               allAnswers: [sinon.match(answer)],
               challenges: allChallenges,
@@ -157,17 +153,21 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             .withArgs({
               allAnswers: [],
               challenges: allChallenges,
+              estimatedLevel: initialEstimatedLevel,
             })
-            .returns([challenge2, challenge1]);
-          algorithm.getPossibleNextChallenges
+            .returns([challenge2, challenge1])
             .withArgs({
               allAnswers: [sinon.match(answer)],
               challenges: allChallenges,
+              estimatedLevel: expectedEstimatedLevels[0],
             })
             .returns([challenge1]);
 
-          pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
-          pickChallenge.withArgs({ possibleChallenges: [challenge1] }).returns(challenge1);
+          pickChallenge
+            .withArgs({ possibleChallenges: [challenge2, challenge1] })
+            .returns(challenge2)
+            .withArgs({ possibleChallenges: [challenge1] })
+            .returns(challenge1);
 
           pickAnswer.withArgs({ nextChallenge: challenge2, answerIndex: 0 }).returns(answersForSimulator[0]);
 
@@ -231,16 +231,12 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             })
             .returns({
               estimatedLevel: initialEstimatedLevel,
-            });
-
-          algorithm.getEstimatedLevelAndErrorRate
+            })
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
             })
-            .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] });
-
-          algorithm.getEstimatedLevelAndErrorRate
+            .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
             .withArgs({
               allAnswers: [sinon.match(answer1), sinon.match(answer2)],
               challenges: allChallenges,
@@ -254,17 +250,21 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             .withArgs({
               allAnswers: [],
               challenges: allChallenges,
+              estimatedLevel: initialEstimatedLevel,
             })
-            .returns([challenge2, challenge1]);
-          algorithm.getPossibleNextChallenges
+            .returns([challenge2, challenge1])
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
+              estimatedLevel: expectedEstimatedLevels[0],
             })
             .returns([challenge1]);
 
-          pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
-          pickChallenge.withArgs({ possibleChallenges: [challenge1] }).returns(challenge1);
+          pickChallenge
+            .withArgs({ possibleChallenges: [challenge2, challenge1] })
+            .returns(challenge2)
+            .withArgs({ possibleChallenges: [challenge1] })
+            .returns(challenge1);
 
           pickAnswer
             .withArgs({ nextChallenge: challenge2, answerIndex: 0 })
@@ -278,9 +278,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
               difficulty: challenge1.difficulty,
               discriminant: challenge1.discriminant,
             })
-            .returns(expectedRewards[0]);
-
-          algorithm.getReward
+            .returns(expectedRewards[0])
             .withArgs({
               estimatedLevel: expectedEstimatedLevels[0],
               difficulty: challenge2.difficulty,

--- a/api/tests/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/unit/domain/models/AssessmentSimulator_test.js
@@ -310,5 +310,119 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
         });
       });
     });
+
+    context('when an initial capacity is provided', function () {
+      it('should return the list of all the challenges', function () {
+        // given
+        const answersForSimulator = [AnswerStatus.OK, AnswerStatus.KO];
+        const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+        const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+        const answer1 = { challengeId: challenge2.id, result: answersForSimulator[0] };
+        const answer2 = { challengeId: challenge1.id, result: answersForSimulator[1] };
+        const allChallenges = [challenge1, challenge2];
+        const initialEstimatedLevel = 0;
+        const expectedEstimatedLevels = [0.4, 0.1];
+        const expectedErrorRates = [0.2, 0.5];
+        const expectedRewards = [5, 6];
+        const initialCapacity = 2;
+        const algorithm = {
+          getPossibleNextChallenges: sinon.stub(),
+          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getReward: sinon.stub(),
+        };
+        const pickChallenge = sinon.stub();
+        const pickAnswer = sinon.stub();
+
+        algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            allAnswers: [],
+          })
+          .returns({
+            estimatedLevel: initialEstimatedLevel,
+          })
+          .withArgs({
+            allAnswers: [sinon.match(answer1)],
+            challenges: allChallenges,
+          })
+          .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
+          .withArgs({
+            allAnswers: [sinon.match(answer1), sinon.match(answer2)],
+            challenges: allChallenges,
+          })
+          .returns({
+            estimatedLevel: expectedEstimatedLevels[1],
+            errorRate: expectedErrorRates[1],
+          });
+
+        algorithm.getPossibleNextChallenges
+          .withArgs({
+            allAnswers: [],
+            challenges: allChallenges,
+            estimatedLevel: initialCapacity,
+          })
+          .returns([challenge2, challenge1])
+          .withArgs({
+            allAnswers: [sinon.match(answer1)],
+            challenges: allChallenges,
+            estimatedLevel: expectedEstimatedLevels[0],
+          })
+          .returns([challenge1]);
+
+        pickChallenge
+          .withArgs({ possibleChallenges: [challenge2, challenge1] })
+          .returns(challenge2)
+          .withArgs({ possibleChallenges: [challenge1] })
+          .returns(challenge1);
+
+        pickAnswer
+          .withArgs({ nextChallenge: challenge2, answerIndex: 0 })
+          .returns(answersForSimulator[0])
+          .withArgs({ nextChallenge: challenge1, answerIndex: 1 })
+          .returns(answersForSimulator[1]);
+
+        algorithm.getReward
+          .withArgs({
+            estimatedLevel: initialCapacity,
+            difficulty: challenge1.difficulty,
+            discriminant: challenge1.discriminant,
+          })
+          .returns(expectedRewards[0])
+          .withArgs({
+            estimatedLevel: expectedEstimatedLevels[0],
+            difficulty: challenge2.difficulty,
+            discriminant: challenge2.discriminant,
+          })
+          .returns(expectedRewards[1]);
+
+        // when
+        const expectedResult = [
+          {
+            challenge: challenge2,
+            estimatedLevel: expectedEstimatedLevels[0],
+            errorRate: expectedErrorRates[0],
+            reward: expectedRewards[0],
+            answer: answersForSimulator[0],
+          },
+          {
+            challenge: challenge1,
+            estimatedLevel: expectedEstimatedLevels[1],
+            errorRate: expectedErrorRates[1],
+            reward: expectedRewards[1],
+            answer: answersForSimulator[1],
+          },
+        ];
+
+        const result = new AssessmentSimulator({
+          algorithm,
+          challenges: allChallenges,
+          pickChallenge,
+          pickAnswer,
+          initialCapacity,
+        }).run();
+
+        // then
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -65,17 +65,10 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
       pickAnswer.withArgs(sinon.match({ nextChallenge: secondChallenge })).returns(AnswerStatus.OK);
       pickAnswer.withArgs(sinon.match({ nextChallenge: thirdChallenge })).returns(AnswerStatus.OK);
 
-      const pseudoRandom = {
-        create: () => ({
-          binaryTreeRandom: () => 0,
-        }),
-      };
-
       // when
       const result = await simulateFlashDeterministicAssessmentScenario({
         challengeRepository,
         locale,
-        pseudoRandom,
         assessmentId,
         pickChallengeService,
         pickAnswer,
@@ -116,17 +109,10 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
       pickAnswer.withArgs(sinon.match({ nextChallenge: challenge })).returns(AnswerStatus.OK);
 
-      const pseudoRandom = {
-        create: () => ({
-          binaryTreeRandom: () => 0,
-        }),
-      };
-
       // when
       const result = await simulateFlashDeterministicAssessmentScenario({
         challengeRepository,
         locale,
-        pseudoRandom,
         assessmentId,
         pickChallengeService,
         pickAnswer,


### PR DESCRIPTION
## :unicorn: Problème
A terme le positionnement et autres parcours libres peuvent apporter une information pour avoir une capacité initiale avant la certification. Plus la capacité initiale est proche de la capacité de la personne plus l’algorithme convergera vite.

## :rainbow: Remarques
Corrige également la non prise en charge de la capacité de l'utilisateur lors du choix de la question suivante dans les simulateurs.

## :100: Pour tester
```
TOKEN=$(curl 'https://api-pr6287.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6287.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "assessmentId": "1234", "capacity": 2.3 }' | jq '.'
```
