### PR TITLE
[FEATURE] Améliorer l'a11y de la page de lancement d'une épreuve chronométrée (PIX-7670).

### DIFF
--- a/mon-pix/.template-lintrc.js
+++ b/mon-pix/.template-lintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'no-redundant-role': false,
     'no-html-comments': false,
     'no-bare-strings': ['Pix', '&nbsp;', '&#8226;', '.', '*', '1024', '/', '•', '-', '%'],
+    'require-valid-alt-text': false,
   },
 
   ignore: ['blueprints/component-test/files/tests/integration/components/*'],

--- a/mon-pix/app/components/timed-challenge-instructions.hbs
+++ b/mon-pix/app/components/timed-challenge-instructions.hbs
@@ -9,12 +9,7 @@
 
   <div class="timed-challenge-instructions__allocated-time">
     <div class="timed-challenge-instructions-allocated-time__gauge">
-      <img
-        class="timed-challenge-instructions-gauge__icon"
-        src="/images/icons/icon-timed-challenge.svg"
-        alt=""
-        role="presentation"
-      />
+      <img class="timed-challenge-instructions-gauge__icon" src="/images/icons/icon-timed-challenge.svg" alt="" />
       <span class="timed-challenge-instructions-gauge__value">{{this.allocatedTime}}</span>
     </div>
   </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1435,7 +1435,7 @@
       "message": "We have updated our terms and conditions of use. Please agree to them in order to continue your experience on Pix."
     },
     "timed-challenge-instructions": {
-      "action": "Start",
+      "action": "Start the challenge",
       "primary": "You have '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' to complete the next question.",
       "secondary": "You can continue answering after this, but the question will not be marked as correct."
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1435,7 +1435,7 @@
       "message": "Nous avons mis à jour nos conditions d'utilisation. Veuillez les accepter afin de pouvoir continuer votre expérience sur Pix."
     },
     "timed-challenge-instructions": {
-      "action": "Commencer",
+      "action": "Commencer l'épreuve",
       "primary": "Vous disposerez de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' pour réussir la question suivante.",
       "secondary": "Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie."
     },


### PR DESCRIPTION
## :unicorn: Problème

D’après l’audit : le label du bouton "Commencer" est trop générique.

De plus, il faudrait enlever le rôle présentation de l’icône horloge car l'image est déjà correctement ignorée par les technologies d'assistance en tant que tel, mais le role="presentation" vient casser la sémantique naturelle de l'élément img et peut engendrer des soucis de restitution.

## :robot: Proposition

- Changer le label du bouton pour "Commencer l'épreuve" 
- Enlever l'attribut HTML `role="presentation"` car inutile

## :rainbow: Remarques

Une règles Eslint a été désactivée car elle nous empêche d'enlever cet attribut HTML inutile.
PR de proposition en cours côté lib utilisée : https://github.com/ember-template-lint/ember-template-lint/pull/2828

## :100: Pour tester

- Visiter l'écran de lancement d'épreuve chronométrée : [/challenges/challenge18RL3n5OTUFbnd/preview](https://app-pr6291.review.pix.fr/challenges/challenge18RL3n5OTUFbnd/preview)
- Constater des changements
