### PR TITLE
[ADMIN] Permettre de déplacer une méthode de connexion via SSO vers un autre utilisateur (PIX-7738)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -140,20 +140,20 @@
       </td>
     </tr>
 
-    {{#each this.oidcAuthenticationMethods as |oidcAuthenticationMethod|}}
+    {{#each this.userOidcAuthenticationMethods as |userOidcAuthenticationMethod|}}
       <tr>
-        <td class="authentication-method-table__name-column">{{oidcAuthenticationMethod.name}}</td>
+        <td class="authentication-method-table__name-column">{{userOidcAuthenticationMethod.name}}</td>
         <td>
-          {{#if oidcAuthenticationMethod.hasAuthenticationMethod}}
+          {{#if userOidcAuthenticationMethod.userHasThisOidcAuthenticationMethod}}
             <FaIcon
               @icon="circle-check"
-              aria-label="L'utilisateur a une méthode de connexion {{oidcAuthenticationMethod.name}}"
+              aria-label="L'utilisateur a une méthode de connexion {{userOidcAuthenticationMethod.name}}"
               class="authentication-method-table__check"
             />
           {{else}}
             <FaIcon
               @icon="circle-xmark"
-              aria-label="L'utilisateur n'a pas de méthode de connexion {{oidcAuthenticationMethod.name}}"
+              aria-label="L'utilisateur n'a pas de méthode de connexion {{userOidcAuthenticationMethod.name}}"
               class="authentication-method-table__uncheck"
             />
           {{/if}}
@@ -161,17 +161,17 @@
         <td class="authentication-method-table__actions-column">
           {{#if this.accessControl.hasAccessToUsersActionsScope}}
             <div>
-              {{#if oidcAuthenticationMethod.canBeRemoved}}
+              {{#if userOidcAuthenticationMethod.canBeRemovedFromUserAuthenticationMethods}}
                 <PixButton
                   class="user-authentication-method__remove-button"
                   @size="small"
                   @backgroundColor="red"
-                  @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal oidcAuthenticationMethod.code}}
+                  @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal userOidcAuthenticationMethod.code}}
                 >Supprimer</PixButton>
               {{/if}}
-              {{#if oidcAuthenticationMethod.canBeReassigned}}
+              {{#if userOidcAuthenticationMethod.canBeReassignedToAnotherUser}}
                 <PixButton
-                  @triggerAction={{fn this.toggleReassignOidcAuthenticationMethodModal oidcAuthenticationMethod}}
+                  @triggerAction={{fn this.toggleReassignOidcAuthenticationMethodModal userOidcAuthenticationMethod}}
                   @size="small"
                 >
                   Déplacer cette méthode de connexion

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -24,9 +24,7 @@
   <ul>
     <li class="authentication-method__connexions-information">
       {{t "components.users.user-detail-personal-information.authentication-method.should-change-password-status"}}
-      {{#if this.pixAuthenticationMethod.authenticationComplement.shouldChangePassword}}{{t
-          "common.words.yes"
-        }}{{else}}{{t "common.words.no"}}{{/if}}
+      {{#if this.shouldChangePassword}}{{t "common.words.yes"}}{{else}}{{t "common.words.no"}}{{/if}}
     </li>
   </ul>
 {{/if}}

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -76,18 +76,19 @@ export default class AuthenticationMethod extends Component {
     return userAuthenticationMethods.length > 1 || (userAuthenticationMethods.length === 1 && hasUsername && hasEmail);
   }
 
-  get oidcAuthenticationMethods() {
+  get userOidcAuthenticationMethods() {
     return this.oidcIdentityProviders.list.map((oidcIdentityProvider) => {
-      const hasAuthenticationMethod = this.args.user.authenticationMethods.any(
+      const userHasThisOidcAuthenticationMethod = this.args.user.authenticationMethods.any(
         (authenticationMethod) => authenticationMethod.identityProvider === oidcIdentityProvider.code
       );
 
       return {
         code: oidcIdentityProvider.code,
         name: oidcIdentityProvider.organizationName,
-        hasAuthenticationMethod,
-        canBeRemoved: hasAuthenticationMethod && this._hasMultipleAuthenticationMethods(),
-        canBeReassigned: hasAuthenticationMethod,
+        userHasThisOidcAuthenticationMethod,
+        canBeRemovedFromUserAuthenticationMethods:
+          userHasThisOidcAuthenticationMethod && this._hasMultipleAuthenticationMethods(),
+        canBeReassignedToAnotherUser: userHasThisOidcAuthenticationMethod,
       };
     });
   }

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -22,10 +22,10 @@ export default class AuthenticationMethod extends Component {
     );
   }
 
-  get pixAuthenticationMethod() {
-    return this.args.user.authenticationMethods.find(
+  get shouldChangePassword() {
+    return !!this.args.user.authenticationMethods.find(
       (authenticationMethod) => authenticationMethod.identityProvider === 'PIX'
-    );
+    )?.authenticationComplement?.shouldChangePassword;
   }
 
   get hasEmailAuthenticationMethod() {
@@ -141,8 +141,7 @@ export default class AuthenticationMethod extends Component {
       targetUserId: this.targetUserId,
       identityProvider: oidcAuthenticationMethodCode,
     });
-
-    this.showReassignOidcAuthenticationMethodModal = false;
+    this.showReassignOidcAuthenticationMethodModal = !this.showReassignOidcAuthenticationMethodModal;
   }
 
   @action

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -160,7 +160,6 @@ export default class AuthenticationMethod extends Component {
 
   @action
   toggleReassignOidcAuthenticationMethodModal(oidcAuthenticationMethod) {
-    this.targetUserId = '';
     this.selectedOidcAuthenticationMethod = oidcAuthenticationMethod ? { ...oidcAuthenticationMethod } : null;
     this.showReassignOidcAuthenticationMethodModal = !this.showReassignOidcAuthenticationMethodModal;
   }

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -93,16 +93,13 @@ export default class AuthenticationMethod extends Component {
   }
 
   @action
-  toggleAddAuthenticationMethodModal() {
-    this.showAddAuthenticationMethodModal = !this.showAddAuthenticationMethodModal;
-    this.showAlreadyExistingEmailError = false;
-    this.newEmail = '';
+  onChangeNewEmail(event) {
+    this.newEmail = event.target.value;
   }
 
   @action
-  toggleReassignGarAuthenticationMethodModal() {
-    this.showReassignGarAuthenticationMethodModal = !this.showReassignGarAuthenticationMethodModal;
-    this.targetUserId = '';
+  onChangeTargetUserId(event) {
+    this.targetUserId = event.target.value;
   }
 
   @action
@@ -139,23 +136,6 @@ export default class AuthenticationMethod extends Component {
   }
 
   @action
-  onChangeNewEmail(event) {
-    this.newEmail = event.target.value;
-  }
-
-  @action
-  onChangeTargetUserId(event) {
-    this.targetUserId = event.target.value;
-  }
-
-  @action
-  toggleReassignOidcAuthenticationMethodModal(oidcAuthenticationMethod) {
-    this.targetUserId = '';
-    this.selectedOidcAuthenticationMethod = oidcAuthenticationMethod ? { ...oidcAuthenticationMethod } : null;
-    this.showReassignOidcAuthenticationMethodModal = !this.showReassignOidcAuthenticationMethodModal;
-  }
-
-  @action
   async submitReassignOidcAuthenticationMethod(oidcAuthenticationMethodCode) {
     await this.args.reassignAuthenticationMethod({
       targetUserId: this.targetUserId,
@@ -163,5 +143,25 @@ export default class AuthenticationMethod extends Component {
     });
 
     this.showReassignOidcAuthenticationMethodModal = false;
+  }
+
+  @action
+  toggleAddAuthenticationMethodModal() {
+    this.showAddAuthenticationMethodModal = !this.showAddAuthenticationMethodModal;
+    this.showAlreadyExistingEmailError = false;
+    this.newEmail = '';
+  }
+
+  @action
+  toggleReassignGarAuthenticationMethodModal() {
+    this.showReassignGarAuthenticationMethodModal = !this.showReassignGarAuthenticationMethodModal;
+    this.targetUserId = '';
+  }
+
+  @action
+  toggleReassignOidcAuthenticationMethodModal(oidcAuthenticationMethod) {
+    this.targetUserId = '';
+    this.selectedOidcAuthenticationMethod = oidcAuthenticationMethod ? { ...oidcAuthenticationMethod } : null;
+    this.showReassignOidcAuthenticationMethodModal = !this.showReassignOidcAuthenticationMethodModal;
   }
 }

--- a/admin/app/controllers/authenticated/users/get/information.js
+++ b/admin/app/controllers/authenticated/users/get/information.js
@@ -11,6 +11,7 @@ export default class UserInformationController extends Controller {
     STATUS_422: {
       POLE_EMPLOI: "L'utilisateur a déjà une méthode de connexion Pôle Emploi.",
       GAR: "L'utilisateur a déjà une méthode de connexion Médiacentre.",
+      CNAV: "L'utilisateur a déjà une méthode de connexion CNAV.",
     },
     STATUS_400: 'Cette requête est impossible',
     STATUS_404: "Cet utilisateur n'existe pas.",

--- a/admin/tests/acceptance/authenticated/users/authentication-method_test.js
+++ b/admin/tests/acceptance/authenticated/users/authentication-method_test.js
@@ -33,7 +33,6 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
       await clickByName("Enregistrer l'adresse e-mail");
 
       // then
-      //assert.throws(screen.getByRole('textbox', { name: 'Nouvelle adresse e-mail' }));
       assert.dom(
         screen.getByText(`nouvel-email@example.net a bien été rajouté aux méthodes de connexion de l'utilisateur`)
       );
@@ -96,7 +95,6 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
       assert.dom(screen.getByText("La méthode de connexion a bien été déplacé vers l'utilisateur 1")).exists();
       assert.dom(screen.getByText("L'utilisateur n'a plus de méthode de connexion Médiacentre")).exists();
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion Médiacentre")).exists();
-      //assert.throws(screen.getByRole('button', { name: 'Valider le déplacement' }));
     });
   });
 
@@ -130,35 +128,6 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
       // then
       assert.dom(screen.getByText("La méthode de connexion a bien été déplacé vers l'utilisateur 1")).exists();
       assert.dom(screen.getByText("L'utilisateur n'a plus de méthode de connexion Partenaire OIDC")).exists();
-      assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion Partenaire OIDC")).exists();
-      //assert.throws(screen.getByRole('button', { name: 'Valider le déplacement' }));
-    });
-  });
-
-  module('when a user has multiple authentication methods', function () {
-    test('it should be able to delete one of the authentication methods', async function (assert) {
-      // given
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-
-      const firstName = 'Ayotunde';
-      const lastName = 'Efemena';
-      const pixAuthenticationMethod = server.create('authentication-method', { identityProvider: 'PIX' });
-      const oidcAuthenticationMethod = server.create('authentication-method', { identityProvider: 'OIDC_PARTNER' });
-      const user = server.create('user', {
-        firstName,
-        lastName,
-        authenticationMethods: [pixAuthenticationMethod, oidcAuthenticationMethod],
-      });
-
-      // when
-      const screen = await visit(`/users/${user.id}`);
-      await click(screen.getAllByRole('button', { name: 'Supprimer' })[1]);
-
-      await screen.findByRole('dialog');
-
-      await click(screen.getByRole('button', { name: 'Oui, je supprime' }));
-
-      // then
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion Partenaire OIDC")).exists();
     });
   });

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -262,25 +262,6 @@ module('Integration | Component | users | user-detail-personal-information/authe
           }
         }
 
-        module('when user has "Sunlight Navigations" authentication method', function () {
-          test('should display information', async function (assert) {
-            // given
-            this.set('user', {
-              authenticationMethods: [{ identityProvider: 'SUNLIGHT_NAVIGATIONS' }],
-            });
-            this.owner.register('service:access-control', AccessControlStub);
-            this.owner.register('service:oidc-identity-providers', OidcIdentityProvidersStub);
-
-            // when
-            const screen = await render(
-              hbs`<Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`
-            );
-
-            // then
-            assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Sunlight Navigations")).exists();
-          });
-        });
-
         module('when user does not have "Sunlight Navigations" authentication method', function () {
           test('should display information', async function (assert) {
             // given
@@ -300,7 +281,7 @@ module('Integration | Component | users | user-detail-personal-information/authe
           });
         });
 
-        module('when user has more authentication methods', function () {
+        module('when user has one or more authentication methods', function () {
           test('should display information, delete and reassign buttons', async function (assert) {
             // given
             const toggleDisplayRemoveAuthenticationMethodModalStub = sinon.stub();

--- a/admin/tests/integration/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information_test.js
@@ -113,7 +113,6 @@ module('Integration | Component | users | user-detail-personal-information', fun
 
       // then
       assert.ok(destroyRecordStub.called);
-      // assert.dom(screen.queryByRole('heading', { name: 'Merci de confirmer' })).doesNotExist();
     });
   });
 
@@ -201,7 +200,6 @@ module('Integration | Component | users | user-detail-personal-information', fun
 
         // then
         assert.ok(removeAuthenticationMethodStub.called);
-        //assert.dom(screen.queryByRole('heading', { name: 'Merci de confirmer' })).doesNotExist();
       });
     });
   });

--- a/admin/tests/unit/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information/authentication-method_test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
-import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
 import sinon from 'sinon';
+import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
 
-module('Unit | Component | users | user-overview', function (hooks) {
+module('Unit | Component | users | user-detail-personal-information/authentication-method', function (hooks) {
   setupTest(hooks);
   module('#toggleReassignOidcAuthenticationMethodModal', function () {
     test('do not reinitialize userdId value', function (assert) {
@@ -24,9 +25,9 @@ module('Unit | Component | users | user-overview', function (hooks) {
       const oidcAuthenticationMethod = {
         code: 'CNAV',
         name: 'CNAV',
-        hasAuthenticationMethod: true,
-        canBeRemoved: true,
-        canBeReassigned: true,
+        userHasThisOidcAuthenticationMethod: true,
+        canBeRemovedFromUserAuthenticationMethods: true,
+        canBeReassignedToAnotherUser: true,
       };
 
       // when
@@ -94,6 +95,195 @@ module('Unit | Component | users | user-overview', function (hooks) {
 
         // when && then
         assert.false(component.shouldChangePassword);
+      });
+    });
+  });
+
+  module('#userOidcAuthenticationMethods', function () {
+    module('when user has many authentication methods but no oidc', function () {
+      test('returns oidc methods with actions that can be done on it all disabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const oidcIdentityProvider1 = store.createRecord('oidc-identity-provider', {
+          code: 'OIDC-1',
+          organizationName: 'organization 1',
+          hasLogoutUrl: false,
+          source: 'source1',
+        });
+        const oidcIdentityProvider2 = store.createRecord('oidc-identity-provider', {
+          code: 'OIDC-2',
+          organizationName: 'organization 2',
+          hasLogoutUrl: false,
+          source: 'source2',
+        });
+        class OidcIdentittyProvidersStub extends Service {
+          list = [oidcIdentityProvider1, oidcIdentityProvider2];
+        }
+        this.owner.register('service:oidcIdentityProviders', OidcIdentittyProvidersStub);
+
+        const reassignAuthenticationMethod = sinon.spy();
+        const addPixAuthenticationMethod = sinon.spy();
+
+        // user
+        const pixAuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'PIX' });
+        const garAuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'GAR' });
+
+        const user = store.createRecord('user', {
+          email: 'email@example.net',
+          id: 5,
+          authenticationMethods: [pixAuthenticationMethod, garAuthenticationMethod],
+        });
+        const component = createGlimmerComponent(
+          'component:users/user-detail-personal-information/authentication-method',
+          {
+            user,
+            reassignAuthenticationMethod,
+            addPixAuthenticationMethod,
+          }
+        );
+
+        // when && then
+        const expected = [
+          {
+            canBeReassignedToAnotherUser: false,
+            canBeRemovedFromUserAuthenticationMethods: false,
+            code: 'OIDC-1',
+            name: 'organization 1',
+            userHasThisOidcAuthenticationMethod: false,
+          },
+          {
+            canBeReassignedToAnotherUser: false,
+            canBeRemovedFromUserAuthenticationMethods: false,
+            code: 'OIDC-2',
+            name: 'organization 2',
+            userHasThisOidcAuthenticationMethod: false,
+          },
+        ];
+        assert.deepEqual(component.userOidcAuthenticationMethods, expected);
+      });
+    });
+    module('when user has many authentication methods including oidc', function () {
+      test('returns oidc methods with actions that can be done on it', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const oidcIdentityProvider1 = store.createRecord('oidc-identity-provider', {
+          code: 'OIDC-1',
+          organizationName: 'organization 1',
+          hasLogoutUrl: false,
+          source: 'source1',
+        });
+        const oidcIdentityProvider2 = store.createRecord('oidc-identity-provider', {
+          code: 'OIDC-2',
+          organizationName: 'organization 2',
+          hasLogoutUrl: false,
+          source: 'source2',
+        });
+        class OidcIdentittyProvidersStub extends Service {
+          list = [oidcIdentityProvider1, oidcIdentityProvider2];
+        }
+        this.owner.register('service:oidcIdentityProviders', OidcIdentittyProvidersStub);
+
+        const reassignAuthenticationMethod = sinon.spy();
+        const addPixAuthenticationMethod = sinon.spy();
+
+        // user
+        const pixAuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'PIX' });
+        const garAuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'GAR' });
+        const Oidc2AuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'OIDC-2' });
+
+        const user = store.createRecord('user', {
+          email: 'email@example.net',
+          id: 5,
+          authenticationMethods: [pixAuthenticationMethod, garAuthenticationMethod, Oidc2AuthenticationMethod],
+        });
+        const component = createGlimmerComponent(
+          'component:users/user-detail-personal-information/authentication-method',
+          {
+            user,
+            reassignAuthenticationMethod,
+            addPixAuthenticationMethod,
+          }
+        );
+
+        // when && then
+        const expected = [
+          {
+            canBeReassignedToAnotherUser: false,
+            canBeRemovedFromUserAuthenticationMethods: false,
+            code: 'OIDC-1',
+            name: 'organization 1',
+            userHasThisOidcAuthenticationMethod: false,
+          },
+          {
+            canBeReassignedToAnotherUser: true,
+            canBeRemovedFromUserAuthenticationMethods: true,
+            code: 'OIDC-2',
+            name: 'organization 2',
+            userHasThisOidcAuthenticationMethod: true,
+          },
+        ];
+        assert.deepEqual(component.userOidcAuthenticationMethods, expected);
+      });
+    });
+    module('When user has only one oidc authentication method left and no other method', function () {
+      test('oidc authentication method can be reassigned', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const oidcIdentityProvider1 = store.createRecord('oidc-identity-provider', {
+          code: 'OIDC-1',
+          organizationName: 'organization 1',
+          hasLogoutUrl: false,
+          source: 'source1',
+        });
+        const oidcIdentityProvider2 = store.createRecord('oidc-identity-provider', {
+          code: 'OIDC-2',
+          organizationName: 'organization 2',
+          hasLogoutUrl: false,
+          source: 'source2',
+        });
+        class OidcIdentittyProvidersStub extends Service {
+          list = [oidcIdentityProvider1, oidcIdentityProvider2];
+        }
+        this.owner.register('service:oidcIdentityProviders', OidcIdentittyProvidersStub);
+
+        const reassignAuthenticationMethod = sinon.spy();
+        const addPixAuthenticationMethod = sinon.spy();
+
+        // user
+        const Oidc2AuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'OIDC-2' });
+
+        const user = store.createRecord('user', {
+          email: 'email@example.net',
+          id: 5,
+          authenticationMethods: [Oidc2AuthenticationMethod],
+        });
+        const component = createGlimmerComponent(
+          'component:users/user-detail-personal-information/authentication-method',
+          {
+            user,
+            reassignAuthenticationMethod,
+            addPixAuthenticationMethod,
+          }
+        );
+
+        // when && then
+        const expected = [
+          {
+            canBeReassignedToAnotherUser: false,
+            canBeRemovedFromUserAuthenticationMethods: false,
+            code: 'OIDC-1',
+            name: 'organization 1',
+            userHasThisOidcAuthenticationMethod: false,
+          },
+          {
+            canBeReassignedToAnotherUser: true,
+            canBeRemovedFromUserAuthenticationMethods: false,
+            code: 'OIDC-2',
+            name: 'organization 2',
+            userHasThisOidcAuthenticationMethod: true,
+          },
+        ];
+        assert.deepEqual(component.userOidcAuthenticationMethods, expected);
       });
     });
   });

--- a/admin/tests/unit/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information/authentication-method_test.js
@@ -3,35 +3,98 @@ import createGlimmerComponent from '../../../../helpers/create-glimmer-component
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 
-module('#toggleReassignOidcAuthenticationMethodModal', function (hooks) {
+module('Unit | Component | users | user-overview', function (hooks) {
   setupTest(hooks);
+  module('#toggleReassignOidcAuthenticationMethodModal', function () {
+    test('do not reinitialize userdId value', function (assert) {
+      // given
+      const reassignAuthenticationMethod = sinon.spy();
+      const addPixAuthenticationMethod = sinon.spy();
+      const user = {};
+      const component = createGlimmerComponent(
+        'component:users/user-detail-personal-information/authentication-method',
+        {
+          user,
+          reassignAuthenticationMethod,
+          addPixAuthenticationMethod,
+        }
+      );
+      component.targetUserId = '12';
+      component.showReassignOidcAuthenticationMethodModal = true;
+      const oidcAuthenticationMethod = {
+        code: 'CNAV',
+        name: 'CNAV',
+        hasAuthenticationMethod: true,
+        canBeRemoved: true,
+        canBeReassigned: true,
+      };
 
-  test('do not reinitialize userdId value', function (assert) {
-    // given
-    const reassignAuthenticationMethod = sinon.spy();
-    const addPixAuthenticationMethod = sinon.spy();
-    const user = {};
-    const component = createGlimmerComponent('component:users/user-detail-personal-information/authentication-method', {
-      user,
-      reassignAuthenticationMethod,
-      addPixAuthenticationMethod,
+      // when
+      component.toggleReassignOidcAuthenticationMethodModal(oidcAuthenticationMethod);
+
+      // then
+      assert.deepEqual(component.selectedOidcAuthenticationMethod, oidcAuthenticationMethod);
+      assert.false(component.showReassignOidcAuthenticationMethodModal);
+      assert.strictEqual(component.targetUserId, '12');
     });
-    component.targetUserId = '12';
-    component.showReassignOidcAuthenticationMethodModal = true;
-    const oidcAuthenticationMethod = {
-      code: 'CNAV',
-      name: 'CNAV',
-      hasAuthenticationMethod: true,
-      canBeRemoved: true,
-      canBeReassigned: true,
-    };
+  });
 
-    // when
-    component.toggleReassignOidcAuthenticationMethodModal(oidcAuthenticationMethod);
+  module('#shouldChangePassword', function () {
+    module('when user has a PIX authentication method', function () {
+      test('returns value provided', function (assert) {
+        // given
+        const reassignAuthenticationMethod = sinon.spy();
+        const addPixAuthenticationMethod = sinon.spy();
+        const user = {
+          authenticationMethods: [
+            {
+              identityProvider: 'PIX',
+              authenticationComplement: {
+                shouldChangePassword: true,
+              },
+            },
+          ],
+        };
+        const component = createGlimmerComponent(
+          'component:users/user-detail-personal-information/authentication-method',
+          {
+            user,
+            reassignAuthenticationMethod,
+            addPixAuthenticationMethod,
+          }
+        );
+        component.targetUserId = '12';
 
-    // then
-    assert.deepEqual(component.selectedOidcAuthenticationMethod, oidcAuthenticationMethod);
-    assert.false(component.showReassignOidcAuthenticationMethodModal);
-    assert.strictEqual(component.targetUserId, '12');
+        // when && then
+        assert.true(component.shouldChangePassword);
+      });
+    });
+    module('when user has not a PIX authentication method', function () {
+      test('returns false', function (assert) {
+        // given
+        const reassignAuthenticationMethod = sinon.spy();
+        const addPixAuthenticationMethod = sinon.spy();
+        const user = {
+          authenticationMethods: [
+            {
+              identityProvider: 'CNAV',
+              authenticationComplement: {},
+            },
+          ],
+        };
+        const component = createGlimmerComponent(
+          'component:users/user-detail-personal-information/authentication-method',
+          {
+            user,
+            reassignAuthenticationMethod,
+            addPixAuthenticationMethod,
+          }
+        );
+        component.targetUserId = '12';
+
+        // when && then
+        assert.false(component.shouldChangePassword);
+      });
+    });
   });
 });

--- a/admin/tests/unit/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information/authentication-method_test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+import { setupTest } from 'ember-qunit';
+
+module('#toggleReassignOidcAuthenticationMethodModal', function (hooks) {
+  setupTest(hooks);
+
+  test('do not reinitialize userdId value', function (assert) {
+    // given
+    const reassignAuthenticationMethod = sinon.spy();
+    const addPixAuthenticationMethod = sinon.spy();
+    const user = {};
+    const component = createGlimmerComponent('component:users/user-detail-personal-information/authentication-method', {
+      user,
+      reassignAuthenticationMethod,
+      addPixAuthenticationMethod,
+    });
+    component.targetUserId = '12';
+    component.showReassignOidcAuthenticationMethodModal = true;
+    const oidcAuthenticationMethod = {
+      code: 'CNAV',
+      name: 'CNAV',
+      hasAuthenticationMethod: true,
+      canBeRemoved: true,
+      canBeReassigned: true,
+    };
+
+    // when
+    component.toggleReassignOidcAuthenticationMethodModal(oidcAuthenticationMethod);
+
+    // then
+    assert.deepEqual(component.selectedOidcAuthenticationMethod, oidcAuthenticationMethod);
+    assert.false(component.showReassignOidcAuthenticationMethodModal);
+    assert.strictEqual(component.targetUserId, '12');
+  });
+});

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -5,12 +5,13 @@ import { buildUser } from './build-user.js';
 import { AuthenticationMethod } from '../../../lib/domain/models/AuthenticationMethod.js';
 import * as OidcIdentityProviders from '../../../lib/domain/constants/oidc-identity-providers.js';
 import * as encrypt from '../../../lib/domain/services/encryption-service.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
 
 const buildAuthenticationMethod = {};
 
 buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   id = databaseBuffer.getNextId(),
-  identityProvider = AuthenticationMethod.identityProviders.GAR,
+  identityProvider = NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
   externalIdentifier = 'externalId',
   userId,
   userFirstName = 'Margotte',
@@ -50,7 +51,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function 
 
   const values = {
     id,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
       password: hashedPassword,
       shouldChangePassword,
@@ -80,7 +81,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndPassword = function ({
 
   const values = {
     id,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
       password: hashedPassword,
       shouldChangePassword,

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -3,6 +3,7 @@ const { isUndefined, isNil } = lodash;
 
 import { databaseBuffer } from '../database-buffer.js';
 import { AuthenticationMethod } from '../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
 import { Membership } from '../../../lib/domain/models/Membership.js';
 
 import * as encrypt from '../../../lib/domain/services/encryption-service.js';
@@ -31,7 +32,7 @@ function _buildPixAuthenticationMethod({
   const values = {
     id,
     userId,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
       password: hashedPassword,
       shouldChangePassword,

--- a/api/db/migrations/20201125103011_migrate-samlid-to-authentication-methods.js
+++ b/api/db/migrations/20201125103011_migrate-samlid-to-authentication-methods.js
@@ -1,5 +1,4 @@
-import { AuthenticationMethod } from '../../lib/domain/models/AuthenticationMethod.js';
-
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../lib/domain/constants/identity-providers.js';
 const up = function (knex) {
   // eslint-disable-next-line knex/avoid-injections
   return knex.raw(
@@ -16,7 +15,7 @@ const down = async function (knex) {
   );
 
   return await knex('authentication-methods')
-    .where({ identityProvider: AuthenticationMethod.identityProviders.GAR })
+    .where({ identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code })
     .delete();
 };
 

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,6 +1,6 @@
 import { Membership } from '../../../lib/domain/models/index.js';
 import { DEFAULT_PASSWORD, PIX_ALL_ORGA_ID } from './users-builder.js';
-import { IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
 import { PIX_ADMIN } from '../../../lib/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -74,7 +74,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: SCO_COLLEGE_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+    identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
   databaseBuilder.factory.buildOrganization({
@@ -86,7 +86,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+    identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
 
@@ -339,7 +339,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+    identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
   const greatOakSchoolAdmin = databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,6 +1,6 @@
-import { Membership } from '../../../lib/domain/models/Membership.js';
+import { Membership } from '../../../lib/domain/models/index.js';
 import { DEFAULT_PASSWORD, PIX_ALL_ORGA_ID } from './users-builder.js';
-import { SamlIdentityProviders } from '../../../lib/domain/constants/saml-identity-providers.js';
+import { IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
 import { PIX_ADMIN } from '../../../lib/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -74,7 +74,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: SCO_COLLEGE_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+    identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
   databaseBuilder.factory.buildOrganization({
@@ -86,7 +86,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+    identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
 
@@ -339,7 +339,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+    identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
   const greatOakSchoolAdmin = databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -70,14 +70,117 @@ const register = async function (server) {
       },
     },
     {
-      method: 'POST',
-      path: '/api/admin/users/{id}/anonymize',
+      method: 'GET',
+      path: '/api/admin/users/{id}/profile',
       config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
         validate: {
           params: Joi.object({
             id: identifiersType.userId,
           }),
         },
+        handler: userController.getProfileForAdmin,
+        notes: [
+          "- Permet à un administrateur de récupérer le nombre total de Pix d'un utilisateur\n et de ses scorecards",
+        ],
+        tags: ['api', 'user', 'profile'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/users/{id}/participations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.findCampaignParticipationsForUserManagement,
+        notes: ["- Permet à un administrateur de lister les participations d'un utilisateur à une campagne"],
+        tags: ['api', 'user', 'campaign-participations'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/users/{id}/organizations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.findUserOrganizationsForAdmin,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet à un administrateur de lister les organisations auxquelles appartient l´utilisateur',
+        ],
+        tags: ['api', 'admin', 'user', 'organizations'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/users/{id}/certification-center-memberships',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.findCertificationCenterMembershipsByUser,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet à un administrateur de lister les centres de certification auxquels appartient l´utilisateur',
+        ],
+        tags: ['api', 'admin', 'user', 'certification-centers'],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/admin/users/{id}',
+      config: {
         pre: [
           {
             method: (request, h) =>
@@ -87,8 +190,35 @@ const register = async function (server) {
               ])(request, h),
           },
         ],
-        handler: userController.anonymizeUser,
-        notes: ["- Permet à un administrateur d'anonymiser un utilisateur"],
+        plugins: {
+          'hapi-swagger': {
+            payloadType: 'form',
+          },
+        },
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                email: Joi.string().email().allow(null).optional(),
+                username: Joi.string().allow(null).optional(),
+                lang: Joi.string().valid('fr', 'en'),
+                locale: Joi.string().allow(null).optional().valid('en', 'fr', 'fr-BE', 'fr-FR'),
+              },
+            },
+          }),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: userController.updateUserDetailsForAdministration,
+        notes: [
+          "- Permet à un administrateur de mettre à jour certains attributs d'un utilisateur identifié par son identifiant",
+        ],
         tags: ['api', 'admin', 'user'],
       },
     },
@@ -113,6 +243,29 @@ const register = async function (server) {
         handler: userController.unblockUserAccount,
         notes: ["- Permet à un administrateur de débloquer le compte d'un utilisateur"],
         tags: ['api', 'admin', 'user', 'unblock'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/users/{id}/anonymize',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+          },
+        ],
+        handler: userController.anonymizeUser,
+        notes: ["- Permet à un administrateur d'anonymiser un utilisateur"],
+        tags: ['api', 'admin', 'user'],
       },
     },
     {
@@ -221,186 +374,10 @@ const register = async function (server) {
         tags: ['api', 'admin', 'user'],
       },
     },
-
-    {
-      method: 'PATCH',
-      path: '/api/admin/users/{id}',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-              ])(request, h),
-          },
-        ],
-        plugins: {
-          'hapi-swagger': {
-            payloadType: 'form',
-          },
-        },
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-                'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
-                email: Joi.string().email().allow(null).optional(),
-                username: Joi.string().allow(null).optional(),
-                lang: Joi.string().valid('fr', 'en'),
-                locale: Joi.string().allow(null).optional().valid('en', 'fr', 'fr-BE', 'fr-FR'),
-              },
-            },
-          }),
-          options: {
-            allowUnknown: true,
-          },
-        },
-        handler: userController.updateUserDetailsForAdministration,
-        notes: [
-          "- Permet à un administrateur de mettre à jour certains attributs d'un utilisateur identifié par son identifiant",
-        ],
-        tags: ['api', 'admin', 'user'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/admin/users/{id}/profile',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        handler: userController.getProfileForAdmin,
-        notes: [
-          "- Permet à un administrateur de récupérer le nombre total de Pix d'un utilisateur\n et de ses scorecards",
-        ],
-        tags: ['api', 'user', 'profile'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/admin/users/{id}/participations',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        handler: userController.findCampaignParticipationsForUserManagement,
-        notes: ["- Permet à un administrateur de lister les participations d'un utilisateur à une campagne"],
-        tags: ['api', 'user', 'campaign-participations'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/admin/users/{id}/organizations',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        handler: userController.findUserOrganizationsForAdmin,
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet à un administrateur de lister les organisations auxquelles appartient l´utilisateur',
-        ],
-        tags: ['api', 'admin', 'user', 'organizations'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/admin/users/{id}/certification-center-memberships',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        handler: userController.findCertificationCenterMembershipsByUser,
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet à un administrateur de lister les centres de certification auxquels appartient l´utilisateur',
-        ],
-        tags: ['api', 'admin', 'user', 'certification-centers'],
-      },
-    },
   ];
 
   server.route([
     ...adminRoutes,
-    {
-      method: 'POST',
-      path: '/api/users',
-      config: {
-        auth: false,
-        validate: {
-          payload: Joi.object({
-            data: Joi.object({
-              type: Joi.string(),
-              attributes: Joi.object().required(),
-              relationships: Joi.object(),
-            }).required(),
-            meta: Joi.object(),
-          }).required(),
-          options: {
-            allowUnknown: true,
-          },
-        },
-        handler: userController.save,
-        tags: ['api'],
-      },
-    },
     {
       method: 'GET',
       path: '/api/users/me',
@@ -467,8 +444,8 @@ const register = async function (server) {
       },
     },
     {
-      method: 'POST',
-      path: '/api/users/{id}/update-email',
+      method: 'GET',
+      path: '/api/users/{id}/is-certifiable',
       config: {
         pre: [
           {
@@ -476,34 +453,166 @@ const register = async function (server) {
             assign: 'requestedUserIsAuthenticatedUser',
           },
         ],
-        handler: userController.updateUserEmailWithValidation,
         validate: {
           params: Joi.object({
             id: identifiersType.userId,
           }),
-          options: {
-            allowUnknown: true,
-          },
-          payload: Joi.object({
-            data: {
-              type: Joi.string().valid('email-verification-codes').required(),
-              attributes: {
-                code: Joi.string()
-                  .regex(/^[1-9]{6}$/)
-                  .required(),
-              },
-            },
-          }),
-          failAction: (request, h, error) => {
-            return EntityValidationError.fromJoiErrors(error.details);
-          },
         },
+        handler: userController.isCertifiable,
         notes: [
-          "- Suite à une demande de changement d'adresse e-mail, met à jour cette dernière pour l'utilisateur identifié par son id.",
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Récupération du nombre total de Pix de l'utilisateur\n" +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
         ],
-        tags: ['api', 'user', 'update-email'],
+        tags: ['api', 'user'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/profile',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.getProfile,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Récupération du nombre total de Pix de l'utilisateur\n et de ses scorecards" +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'profile'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/users/{userId}/campaigns/{campaignId}/profile',
+      config: {
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.getUserProfileSharedForCampaign,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération du profil d’un utilisateur partagé (**userId**) pour la campagne donnée (**campaignId**)\n' +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'campaign'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/users/{userId}/campaigns/{campaignId}/assessment-result',
+      config: {
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.getUserCampaignAssessmentResult,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération des résultats d’un parcours pour un utilisateur (**userId**) et pour la campagne d’évaluation donnée (**campaignId**)\n' +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'campaign'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/users/{userId}/campaigns/{campaignId}/campaign-participations',
+      config: {
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+            campaignId: identifiersType.campaignId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.getUserCampaignParticipationToCampaign,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération de la dernière participation d’un utilisateur (**userId**) à une campagne donnée (**campaignId**)\n' +
+            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'campaign', 'campaign-participations'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/authentication-methods',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.getUserAuthenticationMethods,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Elle permet la récupération des noms des méthodes de connexion de l'utilisateur.",
+        ],
+        tags: ['api', 'user', 'authentication-methods'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/trainings',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.findPaginatedUserRecommendedTrainings,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Elle permet la récupération des contenus formatifs de l'utilisateur courant.",
+        ],
+        tags: ['api', 'user', 'trainings'],
+      },
+    },
+
     {
       method: 'PATCH',
       path: '/api/users/{id}/password-update',
@@ -716,8 +825,8 @@ const register = async function (server) {
       },
     },
     {
-      method: 'GET',
-      path: '/api/users/{id}/is-certifiable',
+      method: 'PATCH',
+      path: '/api/users/{id}/has-seen-last-data-protection-policy-information',
       config: {
         pre: [
           {
@@ -730,18 +839,41 @@ const register = async function (server) {
             id: identifiersType.userId,
           }),
         },
-        handler: userController.isCertifiable,
+        handler: userController.rememberUserHasSeenLastDataProtectionPolicyInformation,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Récupération du nombre total de Pix de l'utilisateur\n" +
+            "- Sauvegarde le fait que l'utilisateur ait vu la nouvelle politique de confidentialité Pix" +
             '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
         ],
         tags: ['api', 'user'],
       },
     },
+
     {
-      method: 'GET',
-      path: '/api/users/{id}/profile',
+      method: 'POST',
+      path: '/api/users',
+      config: {
+        auth: false,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              type: Joi.string(),
+              attributes: Joi.object().required(),
+              relationships: Joi.object(),
+            }).required(),
+            meta: Joi.object(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: userController.save,
+        tags: ['api'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/users/{id}/update-email',
       config: {
         pre: [
           {
@@ -749,18 +881,32 @@ const register = async function (server) {
             assign: 'requestedUserIsAuthenticatedUser',
           },
         ],
+        handler: userController.updateUserEmailWithValidation,
         validate: {
           params: Joi.object({
             id: identifiersType.userId,
           }),
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: {
+              type: Joi.string().valid('email-verification-codes').required(),
+              attributes: {
+                code: Joi.string()
+                  .regex(/^[1-9]{6}$/)
+                  .required(),
+              },
+            },
+          }),
+          failAction: (request, h, error) => {
+            return EntityValidationError.fromJoiErrors(error.details);
+          },
         },
-        handler: userController.getProfile,
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Récupération du nombre total de Pix de l'utilisateur\n et de ses scorecards" +
-            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+          "- Suite à une demande de changement d'adresse e-mail, met à jour cette dernière pour l'utilisateur identifié par son id.",
         ],
-        tags: ['api', 'user', 'profile'],
+        tags: ['api', 'user', 'update-email'],
       },
     },
     {
@@ -789,81 +935,7 @@ const register = async function (server) {
         tags: ['api', 'user', 'scorecard'],
       },
     },
-    {
-      method: 'GET',
-      path: '/api/users/{userId}/campaigns/{campaignId}/profile',
-      config: {
-        validate: {
-          params: Joi.object({
-            userId: identifiersType.userId,
-            campaignId: identifiersType.campaignId,
-          }),
-        },
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        handler: userController.getUserProfileSharedForCampaign,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Récupération du profil d’un utilisateur partagé (**userId**) pour la campagne donnée (**campaignId**)\n' +
-            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
-        ],
-        tags: ['api', 'user', 'campaign'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/users/{userId}/campaigns/{campaignId}/assessment-result',
-      config: {
-        validate: {
-          params: Joi.object({
-            userId: identifiersType.userId,
-            campaignId: identifiersType.campaignId,
-          }),
-        },
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        handler: userController.getUserCampaignAssessmentResult,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Récupération des résultats d’un parcours pour un utilisateur (**userId**) et pour la campagne d’évaluation donnée (**campaignId**)\n' +
-            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
-        ],
-        tags: ['api', 'user', 'campaign'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/users/{userId}/campaigns/{campaignId}/campaign-participations',
-      config: {
-        validate: {
-          params: Joi.object({
-            userId: identifiersType.userId,
-            campaignId: identifiersType.campaignId,
-          }),
-        },
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        handler: userController.getUserCampaignParticipationToCampaign,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Récupération de la dernière participation d’un utilisateur (**userId**) à une campagne donnée (**campaignId**)\n' +
-            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
-        ],
-        tags: ['api', 'user', 'campaign', 'campaign-participations'],
-      },
-    },
+
     {
       method: 'PUT',
       path: '/api/users/{id}/email/verification-code',
@@ -896,76 +968,6 @@ const register = async function (server) {
           '- Permet à un utilisateur de recevoir un code de vérification pour la validation de son adresse mail.',
         ],
         tags: ['api', 'user', 'verification-code'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/users/{id}/authentication-methods',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        handler: userController.getUserAuthenticationMethods,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Elle permet la récupération des noms des méthodes de connexion de l'utilisateur.",
-        ],
-        tags: ['api', 'user', 'authentication-methods'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/users/{id}/trainings',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        handler: userController.findPaginatedUserRecommendedTrainings,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Elle permet la récupération des contenus formatifs de l'utilisateur courant.",
-        ],
-        tags: ['api', 'user', 'trainings'],
-      },
-    },
-    {
-      method: 'PATCH',
-      path: '/api/users/{id}/has-seen-last-data-protection-policy-information',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-            assign: 'requestedUserIsAuthenticatedUser',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
-        handler: userController.rememberUserHasSeenLastDataProtectionPolicyInformation,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Sauvegarde le fait que l'utilisateur ait vu la nouvelle politique de confidentialité Pix" +
-            '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
-        ],
-        tags: ['api', 'user'],
       },
     },
   ]);

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -9,14 +9,18 @@ import { config } from '../../config.js';
 import { EntityValidationError } from '../../domain/errors.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
-import { IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 
 const reassignAuthenticationMethodJoiSchema = Joi.object({
   data: {
     attributes: {
       'user-id': identifiersType.userId,
       'identity-provider': Joi.string()
-        .valid(IDENTITY_PROVIDERS.GAR.code, OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.CNAV.code)
+        .valid(
+          NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+          OidcIdentityProviders.POLE_EMPLOI.code,
+          OidcIdentityProviders.CNAV.code
+        )
         .required(),
     },
   },
@@ -363,7 +367,7 @@ const register = async function (server) {
               attributes: {
                 type: Joi.string()
                   .valid(
-                    IDENTITY_PROVIDERS.GAR.code,
+                    NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
                     'EMAIL',
                     'USERNAME',
                     OidcIdentityProviders.POLE_EMPLOI.code,

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -9,6 +9,18 @@ import { config } from '../../config.js';
 import { EntityValidationError } from '../../domain/errors.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
+import { IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
+
+const reassignAuthenticationMethodJoiSchema = Joi.object({
+  data: {
+    attributes: {
+      'user-id': identifiersType.userId,
+      'identity-provider': Joi.string()
+        .valid(IDENTITY_PROVIDERS.GAR.code, OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.CNAV.code)
+        .required(),
+    },
+  },
+});
 
 const { passwordValidationPattern } = config.account;
 
@@ -310,14 +322,10 @@ const register = async function (server) {
             userId: identifiersType.userId,
             authenticationMethodId: identifiersType.authenticationMethodId,
           }),
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'user-id': identifiersType.userId,
-                'identity-provider': Joi.string().valid('GAR', OidcIdentityProviders.POLE_EMPLOI.code).required(),
-              },
-            },
-          }),
+          payload: reassignAuthenticationMethodJoiSchema,
+          options: {
+            abortEarly: false,
+          },
         },
         pre: [
           {
@@ -355,7 +363,7 @@ const register = async function (server) {
               attributes: {
                 type: Joi.string()
                   .valid(
-                    'GAR',
+                    IDENTITY_PROVIDERS.GAR.code,
                     'EMAIL',
                     'USERNAME',
                     OidcIdentityProviders.POLE_EMPLOI.code,

--- a/api/lib/domain/constants/identity-providers.js
+++ b/api/lib/domain/constants/identity-providers.js
@@ -1,7 +1,10 @@
-const IDENTITY_PROVIDERS = {
+const NON_OIDC_IDENTITY_PROVIDERS = {
+  PIX: {
+    code: 'PIX',
+  },
   GAR: {
     code: 'GAR',
   },
 };
 
-export { IDENTITY_PROVIDERS };
+export { NON_OIDC_IDENTITY_PROVIDERS };

--- a/api/lib/domain/constants/identity-providers.js
+++ b/api/lib/domain/constants/identity-providers.js
@@ -1,0 +1,7 @@
+const IDENTITY_PROVIDERS = {
+  GAR: {
+    code: 'GAR',
+  },
+};
+
+export { IDENTITY_PROVIDERS };

--- a/api/lib/domain/constants/saml-identity-providers.js
+++ b/api/lib/domain/constants/saml-identity-providers.js
@@ -1,7 +1,0 @@
-const SamlIdentityProviders = {
-  GAR: {
-    code: 'GAR',
-  },
-};
-
-export { SamlIdentityProviders };

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -111,10 +111,6 @@ class AuthenticationMethod {
   }
 }
 
-const legacyIdentityProviderCodeMapping = Object.fromEntries(
-  Object.entries(NON_OIDC_IDENTITY_PROVIDERS).map(([_, val]) => [val.code, val.code])
-);
-AuthenticationMethod.identityProviders = legacyIdentityProviderCodeMapping;
 AuthenticationMethod.PixAuthenticationComplement = PixAuthenticationComplement;
 AuthenticationMethod.OidcAuthenticationComplement = OidcAuthenticationComplement;
 AuthenticationMethod.GARAuthenticationComplement = GARAuthenticationComplement;

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -2,11 +2,8 @@ import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 import { validateEntity } from '../validators/entity-validator.js';
-
-const identityProviders = {
-  PIX: 'PIX',
-  GAR: 'GAR',
-};
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
+import { getValidOidcProviderCodes, POLE_EMPLOI, CNAV, FWB } from '../constants/oidc-identity-providers.js';
 
 class PixAuthenticationComplement {
   constructor({ password, shouldChangePassword } = {}) {
@@ -58,21 +55,21 @@ class GARAuthenticationComplement {
 const validationSchema = Joi.object({
   id: Joi.number().optional(),
   identityProvider: Joi.string()
-    .valid(...Object.values(identityProviders), 'POLE_EMPLOI', 'CNAV', 'FWB')
+    .valid(NON_OIDC_IDENTITY_PROVIDERS.PIX.code, NON_OIDC_IDENTITY_PROVIDERS.GAR.code, ...getValidOidcProviderCodes())
     .required(),
   authenticationComplement: Joi.when('identityProvider', [
-    { is: identityProviders.PIX, then: Joi.object().instance(PixAuthenticationComplement).required() },
-    { is: 'POLE_EMPLOI', then: Joi.object().instance(OidcAuthenticationComplement).required() },
-    { is: identityProviders.GAR, then: Joi.any().empty() },
-    { is: 'CNAV', then: Joi.any().empty() },
-    { is: 'FWB', then: Joi.any().empty() },
+    { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.object().instance(PixAuthenticationComplement).required() },
+    { is: POLE_EMPLOI.code, then: Joi.object().instance(OidcAuthenticationComplement).required() },
+    { is: NON_OIDC_IDENTITY_PROVIDERS.GAR.code, then: Joi.any().empty() },
+    { is: CNAV.code, then: Joi.any().empty() },
+    { is: FWB.code, then: Joi.any().empty() },
   ]),
   externalIdentifier: Joi.when('identityProvider', [
-    { is: identityProviders.GAR, then: Joi.string().required() },
-    { is: 'POLE_EMPLOI', then: Joi.string().required() },
-    { is: identityProviders.PIX, then: Joi.any().forbidden() },
-    { is: 'CNAV', then: Joi.string().required() },
-    { is: 'FWB', then: Joi.string().required() },
+    { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.any().forbidden() },
+    { is: NON_OIDC_IDENTITY_PROVIDERS.GAR.code, then: Joi.string().required() },
+    { is: POLE_EMPLOI.code, then: Joi.string().required() },
+    { is: CNAV.code, then: Joi.string().required() },
+    { is: FWB.code, then: Joi.string().required() },
   ]),
   userId: Joi.number().integer().required(),
   createdAt: Joi.date().optional(),
@@ -104,7 +101,7 @@ class AuthenticationMethod {
     const authenticationComplement = new PixAuthenticationComplement({ password, shouldChangePassword });
     return new AuthenticationMethod({
       id,
-      identityProvider: identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       authenticationComplement,
       externalIdentifier: undefined,
       createdAt,
@@ -114,7 +111,10 @@ class AuthenticationMethod {
   }
 }
 
-AuthenticationMethod.identityProviders = identityProviders;
+const legacyIdentityProviderCodeMapping = Object.fromEntries(
+  Object.entries(NON_OIDC_IDENTITY_PROVIDERS).map(([_, val]) => [val.code, val.code])
+);
+AuthenticationMethod.identityProviders = legacyIdentityProviderCodeMapping;
 AuthenticationMethod.PixAuthenticationComplement = PixAuthenticationComplement;
 AuthenticationMethod.OidcAuthenticationComplement = OidcAuthenticationComplement;
 AuthenticationMethod.GARAuthenticationComplement = GARAuthenticationComplement;

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 
 import { config } from '../../config.js';
 import * as localeService from '../services/locale-service.js';
-import { AuthenticationMethod } from './AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 class User {
   constructor(
@@ -83,7 +83,7 @@ class User {
 
   get shouldChangePassword() {
     const pixAuthenticationMethod = this.authenticationMethods.find(
-      (authenticationMethod) => authenticationMethod.identityProvider === AuthenticationMethod.identityProviders.PIX
+      (authenticationMethod) => authenticationMethod.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code
     );
 
     return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement.shouldChangePassword : null;

--- a/api/lib/domain/services/obfuscation-service.js
+++ b/api/lib/domain/services/obfuscation-service.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method-repository.js';
-import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { NotFoundError } from '../errors.js';
 
 const CONNEXION_TYPES = {
@@ -17,7 +17,7 @@ const TWO_PARTS = 2;
 async function getUserAuthenticationMethodWithObfuscation(user, dependencies = { authenticationMethodRepository }) {
   const garAuthenticationMethod = await dependencies.authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
     userId: user.id,
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
   });
   if (garAuthenticationMethod) return { authenticatedBy: CONNEXION_TYPES.samlId, value: null };
 

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -1,11 +1,12 @@
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { UserToCreate } from '../models/UserToCreate.js';
 
 function _buildPasswordAuthenticationMethod({ userId, hashedPassword }) {
   return new AuthenticationMethod({
     userId,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
       password: hashedPassword,
       shouldChangePassword: false,
@@ -16,7 +17,7 @@ function _buildPasswordAuthenticationMethod({ userId, hashedPassword }) {
 function _buildGARAuthenticationMethod({ externalIdentifier, user }) {
   return new AuthenticationMethod({
     externalIdentifier,
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
     userId: user.id,
     authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
       firstName: user.firstName,

--- a/api/lib/domain/usecases/account-recovery/update-user-for-account-recovery.js
+++ b/api/lib/domain/usecases/account-recovery/update-user-for-account-recovery.js
@@ -1,4 +1,5 @@
 import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../constants/identity-providers.js';
 
 const updateUserForAccountRecovery = async function ({
   password,
@@ -30,7 +31,7 @@ const updateUserForAccountRecovery = async function ({
   } else {
     const authenticationMethodFromPix = new AuthenticationMethod({
       userId,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
         password: hashedPassword,
         shouldChangePassword: false,

--- a/api/lib/domain/usecases/add-pix-authentication-method-by-email.js
+++ b/api/lib/domain/usecases/add-pix-authentication-method-by-email.js
@@ -1,5 +1,6 @@
 import { AuthenticationMethodAlreadyExistsError } from '../errors.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 const addPixAuthenticationMethodByEmail = async function ({
   userId,
@@ -21,7 +22,7 @@ const addPixAuthenticationMethodByEmail = async function ({
 
     const authenticationMethodFromPix = new AuthenticationMethod({
       userId,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
         password: hashedPassword,
         shouldChangePassword: false,

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -8,6 +8,7 @@ import {
 } from '../errors.js';
 
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 async function authenticateExternalUser({
   username,
@@ -73,7 +74,7 @@ async function _addGarAuthenticationMethod({
   await _checkIfSamlIdIsNotReconciledWithAnotherUser({ samlId, userId, userRepository });
 
   const garAuthenticationMethod = new AuthenticationMethod({
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
     externalIdentifier: samlId,
     userId,
     authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -1,6 +1,6 @@
 import { CampaignCodeError, ObjectValidationError } from '../errors.js';
 import { User } from '../models/User.js';
-import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../constants.js';
 
 const createUserAndReconcileToOrganizationLearnerFromExternalUser = async function ({
@@ -80,7 +80,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
       await authenticationMethodRepository.updateExternalIdentifierByUserIdAndIdentityProvider({
         externalIdentifier: externalUser.samlId,
         userId: error.meta.userId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
       const organizationLearner = await organizationLearnerRepository.reconcileUserToOrganizationLearner({
         userId: error.meta.userId,

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -1,4 +1,5 @@
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 const getExternalAuthenticationRedirectionUrl = async function ({
   userAttributes,
@@ -47,7 +48,7 @@ async function _getUrlWithAccessToken({
 async function _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser }) {
   const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
     userId: user.id,
-    identityProvider: AuthenticationMethod.identityProviders.GAR,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
   });
 
   if (

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -1,4 +1,4 @@
-import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { UserNotAuthorizedToRemoveAuthenticationMethod } from '../errors.js';
 import * as OidcIdentityProviders from '../constants/oidc-identity-providers.js';
 
@@ -8,30 +8,18 @@ const removeAuthenticationMethod = async function ({ userId, type, userRepositor
   switch (type) {
     case 'EMAIL':
       if (!user.username) {
-        await _removeAuthenticationMethod(
-          userId,
-          AuthenticationMethod.identityProviders.PIX,
-          authenticationMethodRepository
-        );
+        await _removeAuthenticationMethod(userId, NON_OIDC_IDENTITY_PROVIDERS.PIX.code, authenticationMethodRepository);
       }
       await userRepository.updateEmail({ id: userId, email: null });
       break;
     case 'USERNAME':
       if (!user.email) {
-        await _removeAuthenticationMethod(
-          userId,
-          AuthenticationMethod.identityProviders.PIX,
-          authenticationMethodRepository
-        );
+        await _removeAuthenticationMethod(userId, NON_OIDC_IDENTITY_PROVIDERS.PIX.code, authenticationMethodRepository);
       }
       await userRepository.updateUsername({ id: userId, username: null });
       break;
     case 'GAR':
-      await _removeAuthenticationMethod(
-        userId,
-        AuthenticationMethod.identityProviders.GAR,
-        authenticationMethodRepository
-      );
+      await _removeAuthenticationMethod(userId, NON_OIDC_IDENTITY_PROVIDERS.GAR.code, authenticationMethodRepository);
       break;
     case OidcIdentityProviders.POLE_EMPLOI.code:
       await _removeAuthenticationMethod(userId, OidcIdentityProviders.POLE_EMPLOI.code, authenticationMethodRepository);

--- a/api/lib/domain/usecases/send-verification-code.js
+++ b/api/lib/domain/usecases/send-verification-code.js
@@ -1,4 +1,4 @@
-import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { InvalidPasswordForUpdateEmailError, UserNotAuthorizedToUpdateEmailError } from '../errors.js';
 import lodash from 'lodash';
 
@@ -26,7 +26,7 @@ const sendVerificationCode = async function ({
 
   const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
     userId,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
   });
 
   try {

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 
 const { get } = lodash;
 
-import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { ForbiddenAccess, UserNotFoundError } from '../../domain/errors.js';
 import { logger } from '../../../lib/infrastructure/logger.js';
 
@@ -28,7 +28,7 @@ const updateExpiredPassword = async function ({
 
   const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
     userId: foundUser.id,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
   });
 
   const shouldChangePassword = get(authenticationMethod, 'authenticationComplement.shouldChangePassword');

--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -3,6 +3,7 @@ import { EntityValidationError } from '../errors.js';
 import { Organization } from '../models/Organization.js';
 import { Membership } from '../models/Membership.js';
 import { getValidOidcProviderCodes } from '../constants/oidc-identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 const schema = Joi.object({
   type: Joi.string()
@@ -27,7 +28,7 @@ const schema = Joi.object({
   }),
   identityProviderForCampaigns: Joi.string()
     .allow(null)
-    .valid('GAR', ...getValidOidcProviderCodes())
+    .valid(NON_OIDC_IDENTITY_PROVIDERS.GAR.code, ...getValidOidcProviderCodes())
     .messages({
       'any.only': `L'organisme fourni doit avoir l'une des valeurs suivantes : GAR,${getValidOidcProviderCodes()}`,
     }),

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -4,10 +4,11 @@ import * as knexUtils from '../utils/knex-utils.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 import { AlreadyExistingEntityError, AuthenticationMethodNotFoundError } from '../../domain/errors.js';
 import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
 
 function _toDomain(authenticationMethodDTO) {
-  if (authenticationMethodDTO.identityProvider === AuthenticationMethod.identityProviders.PIX) {
+  if (authenticationMethodDTO.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
     authenticationMethodDTO.externalIdentifier = undefined;
   }
   const authenticationComplement = _toAuthenticationComplement(
@@ -22,7 +23,7 @@ function _toDomain(authenticationMethodDTO) {
 }
 
 function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationComplement) {
-  if (identityProvider === AuthenticationMethod.identityProviders.PIX) {
+  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
     return new AuthenticationMethod.PixAuthenticationComplement(bookshelfAuthenticationComplement);
   }
 
@@ -30,7 +31,7 @@ function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationCo
     return new AuthenticationMethod.OidcAuthenticationComplement(bookshelfAuthenticationComplement);
   }
 
-  if (identityProvider === AuthenticationMethod.identityProviders.GAR) {
+  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.GAR.code) {
     const methodWasCreatedWithoutUserFirstAndLastName = bookshelfAuthenticationComplement === null;
     if (methodWasCreatedWithoutUserFirstAndLastName) {
       return undefined;
@@ -89,7 +90,7 @@ const createPasswordThatShouldBeChanged = async function ({
     });
     const authenticationMethod = new AuthenticationMethod({
       authenticationComplement,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       userId,
     });
     const authenticationMethodForDB = _.pick(authenticationMethod, [
@@ -154,7 +155,7 @@ const hasIdentityProviderPIX = async function ({ userId }) {
     .from(AUTHENTICATION_METHODS_TABLE)
     .where({
       userId,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     })
     .first();
 
@@ -186,7 +187,7 @@ const updateChangedPassword = async function (
   const [authenticationMethodDTO] = await knexConn(AUTHENTICATION_METHODS_TABLE)
     .where({
       userId,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     })
     .update({ authenticationComplement, updatedAt: new Date() })
     .returning(COLUMNS);
@@ -211,7 +212,7 @@ const updatePasswordThatShouldBeChanged = async function ({
   const [authenticationMethodDTO] = await knexConn(AUTHENTICATION_METHODS_TABLE)
     .where({
       userId,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     })
     .update({ authenticationComplement, updatedAt: new Date() })
     .returning(COLUMNS);
@@ -231,7 +232,7 @@ const updateExpiredPassword = async function ({ userId, hashedPassword }) {
   const [authenticationMethodDTO] = await knex(AUTHENTICATION_METHODS_TABLE)
     .where({
       userId,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     })
     .update({ authenticationComplement, updatedAt: new Date() })
     .returning(COLUMNS);

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { filterByFullName } from '../utils/filter-utils.js';
-import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import { fetchPage } from '../utils/knex-utils.js';
 import { ScoOrganizationParticipant } from '../../domain/read-models/ScoOrganizationParticipant.js';
@@ -147,7 +147,7 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
     .leftJoin('authentication-methods', function () {
       this.on('users.id', 'authentication-methods.userId').andOnVal(
         'authentication-methods.identityProvider',
-        AuthenticationMethod.identityProviders.GAR
+        NON_OIDC_IDENTITY_PROVIDERS.GAR.code
       );
     })
     .leftJoin('campaigns', function () {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -21,6 +21,7 @@ import { CertificationCenterMembership } from '../../domain/models/Certification
 import { Organization } from '../../domain/models/Organization.js';
 import { OrganizationLearnerForAdmin } from '../../domain/read-models/OrganizationLearnerForAdmin.js';
 import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
 import { UserLogin } from '../../domain/models/UserLogin.js';
 
@@ -196,7 +197,7 @@ const getBySamlId = async function (samlId) {
   const bookshelfUser = await BookshelfUser.query((qb) => {
     qb.innerJoin('authentication-methods', function () {
       this.on('users.id', 'authentication-methods.userId')
-        .andOnVal('authentication-methods.identityProvider', AuthenticationMethod.identityProviders.GAR)
+        .andOnVal('authentication-methods.identityProvider', NON_OIDC_IDENTITY_PROVIDERS.GAR.code)
         .andOnVal('authentication-methods.externalIdentifier', samlId);
     });
   }).fetch({ require: false, withRelated: 'authenticationMethods' });
@@ -485,7 +486,7 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
 
   const authenticationMethods = authenticationMethodsDTO.map((authenticationMethod) => {
     const isPixAuthenticationMethodWithAuthenticationComplement =
-      authenticationMethod.identityProvider === AuthenticationMethod.identityProviders.PIX &&
+      authenticationMethod.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code &&
       authenticationMethod.authenticationComplement;
     if (isPixAuthenticationMethodWithAuthenticationComplement) {
       // eslint-disable-next-line no-unused-vars
@@ -561,7 +562,7 @@ function _getAuthenticationComplementAndExternalIdentifier(authenticationMethodB
   let authenticationComplement = authenticationMethodBookshelf.get('authenticationComplement');
   let externalIdentifier = authenticationMethodBookshelf.get('externalIdentifier');
 
-  if (identityProvider === AuthenticationMethod.identityProviders.PIX) {
+  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
     authenticationComplement = new AuthenticationMethod.PixAuthenticationComplement({
       password: authenticationComplement.password,
       shouldChangePassword: Boolean(authenticationComplement.shouldChangePassword),

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -1,7 +1,7 @@
 import querystring from 'querystring';
 import { expect, databaseBuilder, knex } from '../../../test-helper.js';
 import { tokenService } from '../../../../lib/domain/services/token-service.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -441,7 +441,7 @@ describe('Acceptance | Controller | authentication-controller', function () {
 
         // then
         const authenticationMethods = await knex('authentication-methods').where({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           userId: user.id,
           externalIdentifier: 'SAMLJACKSONID',
         });

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Acceptance | Controller | sco-organization-learners', function () {
   let server;
@@ -408,7 +408,7 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
           expect(response.payload).to.contains('access-token');
           const result = await knex('authentication-methods').where({
             userId: user.id,
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           });
           const garAuthenticationMethod = result[0];
           expect(garAuthenticationMethod.externalIdentifier).to.equal(externalUser.samlId);
@@ -455,7 +455,7 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
           expect(response.payload).to.contains('access-token');
           const result = await knex('authentication-methods').where({
             userId: userWithSamlIdOnly.id,
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           });
           const garAuthenticationMethod = result[0];
           expect(garAuthenticationMethod.externalIdentifier).to.equal(externalUser.samlId);

--- a/api/tests/acceptance/application/users/get-user-authentication-methods-route-get_test.js
+++ b/api/tests/acceptance/application/users/get-user-authentication-methods-route-get_test.js
@@ -1,5 +1,5 @@
 import { databaseBuilder, expect, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Route | Users', function () {
@@ -33,7 +33,7 @@ describe('Acceptance | Route | Users', function () {
             type: 'authentication-methods',
             id: garAuthenticationMethod.id.toString(),
             attributes: {
-              'identity-provider': AuthenticationMethod.identityProviders.GAR,
+              'identity-provider': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             },
           },
         ],

--- a/api/tests/acceptance/application/users/reassign-authentication-methods-route-put_test.js
+++ b/api/tests/acceptance/application/users/reassign-authentication-methods-route-put_test.js
@@ -6,7 +6,7 @@ import {
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Acceptance | Route | Users', function () {
   describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
@@ -38,7 +38,7 @@ describe('Acceptance | Route | Users', function () {
           data: {
             attributes: {
               'user-id': targetUserId,
-              'identity-provider': AuthenticationMethod.identityProviders.GAR,
+              'identity-provider': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             },
           },
         },
@@ -74,7 +74,7 @@ describe('Acceptance | Route | Users', function () {
           data: {
             attributes: {
               'user-id': targetUserId,
-              'identity-provider': AuthenticationMethod.identityProviders.GAR,
+              'identity-provider': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             },
           },
         },

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Acceptance | Controller | users-controller-remove-authentication-method', function () {
   let server;
@@ -62,7 +62,7 @@ describe('Acceptance | Controller | users-controller-remove-authentication-metho
 
       // then
       const pixAuthenticationMethod = await knex('authentication-methods')
-        .where({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.PIX })
+        .where({ userId: user.id, identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code })
         .first();
       expect(pixAuthenticationMethod).to.be.undefined;
     });

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -8,7 +8,7 @@ import * as organizationLearnerRepository from '../../../../lib/infrastructure/r
 import * as userRepository from '../../../../lib/infrastructure/repositories/user-repository.js';
 import * as userToCreateRepository from '../../../../lib/infrastructure/repositories/user-to-create-repository.js';
 
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { OrganizationLearnerNotFound } from '../../../../lib/domain/errors.js';
 
 import * as userService from '../../../../lib/domain/services/user-service.js';
@@ -55,7 +55,7 @@ describe('Integration | Domain | Services | user-service', function () {
 
       const foundAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
         userId: foundUser.id,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       });
       expect(pick(foundAuthenticationMethod, authenticationMethodPickedAttributes)).to.deep.equal(
         expectedAuthenticationMethod
@@ -116,7 +116,7 @@ describe('Integration | Domain | Services | user-service', function () {
           password: hashedPassword,
           shouldChangePassword: true,
         },
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       };
 
       // when
@@ -225,7 +225,7 @@ describe('Integration | Domain | Services | user-service', function () {
 
           // then
           const foundAuthenticationMethod = await knex('authentication-methods').where({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             externalIdentifier: samlId,
           });
           expect(foundAuthenticationMethod).to.have.lengthOf(1);

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -11,7 +11,7 @@ import { tokenService } from '../../../../lib/domain/services/token-service.js';
 import * as userReconciliationService from '../../../../lib/domain/services/user-reconciliation-service.js';
 import * as userService from '../../../../lib/domain/services/user-service.js';
 
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 import {
   CampaignCodeError,
@@ -299,7 +299,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             expect(organizationLearnerInDB[0].userId).to.equal(otherAccount.id);
 
             const authenticationMethodInDB = await knex('authentication-methods').where({
-              identityProvider: AuthenticationMethod.identityProviders.GAR,
+              identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
               userId: otherAccount.id,
             });
             expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);
@@ -352,7 +352,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             expect(organizationLearnerInDB[0].userId).to.equal(otherAccount.id);
 
             const authenticationMethodInDB = await knex('authentication-methods').where({
-              identityProvider: AuthenticationMethod.identityProviders.GAR,
+              identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
               userId: otherAccount.id,
             });
             expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -1,6 +1,7 @@
 import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../test-helper.js';
 import { AlreadyExistingEntityError, AuthenticationMethodNotFoundError } from '../../../../lib/domain/errors.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 import * as authenticationMethodRepository from '../../../../lib/infrastructure/repositories/authentication-method-repository.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
@@ -286,7 +287,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const authenticationMethodsByUserIdAndIdentityProvider =
         await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
           userId,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         });
 
       // then
@@ -303,7 +304,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const authenticationMethodsByUserIdAndIdentityProvider =
         await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
           userId,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         });
 
       // then
@@ -324,7 +325,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // when
         const pixAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.PIX,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         });
 
         // then
@@ -380,7 +381,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // when
         const garAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         });
 
         // then
@@ -414,7 +415,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const authenticationMethodsByTypeAndValue =
         await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
           externalIdentifier,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         });
 
       // then
@@ -426,7 +427,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const authenticationMethodsByTypeAndValue =
         await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
           externalIdentifier: 'samlId',
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         });
 
       // then
@@ -459,7 +460,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // when
         await authenticationMethodRepository.updateExternalIdentifierByUserIdAndIdentityProvider({
           userId,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           externalIdentifier: 'new_value',
         });
 
@@ -484,7 +485,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         const updatedAuthenticationMethod =
           await authenticationMethodRepository.updateExternalIdentifierByUserIdAndIdentityProvider({
             userId,
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             externalIdentifier: 'new_value',
           });
 
@@ -499,7 +500,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       it('should throw an AuthenticationMethodNotFoundError', async function () {
         // given
         const userId = 12345;
-        const identityProvider = AuthenticationMethod.identityProviders.GAR;
+        const identityProvider = NON_OIDC_IDENTITY_PROVIDERS.GAR.code;
         const externalIdentifier = 'new_saml_id';
 
         // when
@@ -648,7 +649,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // then
       const expectedAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       });
       expect(createdAuthenticationMethod).to.deepEqualInstance(expectedAuthenticationMethod);
     });
@@ -665,11 +666,11 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // when
       const foundAuthenticationMethodPIX = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       });
       const foundAuthenticationMethodGAR = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
 
       // then
@@ -934,7 +935,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // when
       await authenticationMethodRepository.removeByUserIdAndIdentityProvider({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
 
       // then
@@ -1037,7 +1038,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       expect(result).to.be.instanceOf(AuthenticationMethod);
       expect(result.id).to.be.equal(garAuthenticationMethodId);
       expect(result.userId).to.be.equal(userId);
-      expect(result.identityProvider).to.be.equal(AuthenticationMethod.identityProviders.GAR);
+      expect(result.identityProvider).to.be.equal(NON_OIDC_IDENTITY_PROVIDERS.GAR.code);
     });
 
     describe('when authentication method belongs to another user', function () {
@@ -1130,7 +1131,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // when
       await authenticationMethodRepository.updateAuthenticationMethodUserId({
         originUserId,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         targetUserId,
       });
 

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -3,7 +3,7 @@ import { NotFoundError, MissingAttributesError } from '../../../../lib/domain/er
 import { OrganizationForAdmin } from '../../../../lib/domain/models/organizations-administration/Organization.js';
 import { OrganizationInvitation } from '../../../../lib/domain/models/index.js';
 import * as organizationForAdminRepository from '../../../../lib/infrastructure/repositories/organization-for-admin-repository.js';
-import { IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 
 describe('Integration | Repository | Organization-for-admin', function () {
@@ -221,7 +221,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         credit: 50,
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
-        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
       const organizationSaved = await organizationForAdminRepository.update(organizationToUpdate);
 
@@ -251,7 +251,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         dataProtectionOfficerEmail: undefined,
         creatorFirstName: undefined,
         creatorLastName: undefined,
-        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         enableMultipleSendingAssessment: undefined,
         tags: [{ id: tagId, name: 'orga tag' }],
       });

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -1,9 +1,9 @@
 import { catchErr, expect, domainBuilder, databaseBuilder, sinon, knex } from '../../../test-helper.js';
 import { NotFoundError, MissingAttributesError } from '../../../../lib/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../lib/domain/models/organizations-administration/Organization.js';
-import { OrganizationInvitation } from '../../../../lib/domain/models/OrganizationInvitation.js';
+import { OrganizationInvitation } from '../../../../lib/domain/models/index.js';
 import * as organizationForAdminRepository from '../../../../lib/infrastructure/repositories/organization-for-admin-repository.js';
-import { SamlIdentityProviders } from '../../../../lib/domain/constants/saml-identity-providers.js';
+import { IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 
 describe('Integration | Repository | Organization-for-admin', function () {
@@ -221,7 +221,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         credit: 50,
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
-        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
       });
       const organizationSaved = await organizationForAdminRepository.update(organizationToUpdate);
 
@@ -251,7 +251,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         dataProtectionOfficerEmail: undefined,
         creatorFirstName: undefined,
         creatorLastName: undefined,
-        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
         enableMultipleSendingAssessment: undefined,
         tags: [{ id: tagId, name: 'orga tag' }],
       });

--- a/api/tests/integration/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository_test.js
@@ -1,7 +1,7 @@
 import { expect, databaseBuilder, catchErr } from '../../../../test-helper.js';
 import * as organizationLearnerFollowUpRepository from '../../../../../lib/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
-import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
 
 describe('Integration | Infrastructure | Repository | Organization Learner Follow Up | Organization Learner', function () {
   describe('#get', function () {
@@ -132,8 +132,8 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
 
             expect(organizationLearner.authenticationMethods).to.deep.equal([
-              AuthenticationMethod.identityProviders.PIX,
-              AuthenticationMethod.identityProviders.GAR,
+              NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+              NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             ]);
           });
         });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import { catchErr, expect, knex, domainBuilder, databaseBuilder } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
-import { Organization } from '../../../../lib/domain/models/Organization.js';
+import { Organization } from '../../../../lib/domain/models/index.js';
 import * as organizationRepository from '../../../../lib/infrastructure/repositories/organization-repository.js';
-import { SamlIdentityProviders } from '../../../../lib/domain/constants/saml-identity-providers.js';
+import { IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Integration | Repository | Organization', function () {
   describe('#create', function () {
@@ -82,7 +82,7 @@ describe('Integration | Repository | Organization', function () {
         logoUrl: 'http://new.logo.url',
         externalId: '999Z527F',
         provinceCode: '999',
-        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
         isManagingStudents: true,
         credit: 50,
         email: 'email@example.net',
@@ -109,7 +109,7 @@ describe('Integration | Repository | Organization', function () {
         externalId: '999Z527F',
         provinceCode: '999',
         isManagingStudents: true,
-        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
         credit: 50,
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
@@ -153,7 +153,7 @@ describe('Integration | Repository | Organization', function () {
           credit: 154,
           externalId: '100',
           provinceCode: '75',
-          identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+          identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
           isManagingStudents: 'true',
           email: 'sco.generic.account@example.net',
           documentationUrl: 'https://pix.fr/',
@@ -185,7 +185,7 @@ describe('Integration | Repository | Organization', function () {
           email: 'sco.generic.account@example.net',
           targetProfileShares: [],
           organizationInvitations: [],
-          identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+          identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
           tags: [{ id: tag.id, name: 'SUPER-TAG' }],
           documentationUrl: 'https://pix.fr/',
           createdBy: insertedOrganization.createdBy,

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -3,7 +3,7 @@ import { catchErr, expect, knex, domainBuilder, databaseBuilder } from '../../..
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { Organization } from '../../../../lib/domain/models/index.js';
 import * as organizationRepository from '../../../../lib/infrastructure/repositories/organization-repository.js';
-import { IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Integration | Repository | Organization', function () {
   describe('#create', function () {
@@ -82,7 +82,7 @@ describe('Integration | Repository | Organization', function () {
         logoUrl: 'http://new.logo.url',
         externalId: '999Z527F',
         provinceCode: '999',
-        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         isManagingStudents: true,
         credit: 50,
         email: 'email@example.net',
@@ -109,7 +109,7 @@ describe('Integration | Repository | Organization', function () {
         externalId: '999Z527F',
         provinceCode: '999',
         isManagingStudents: true,
-        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         credit: 50,
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
@@ -153,7 +153,7 @@ describe('Integration | Repository | Organization', function () {
           credit: 154,
           externalId: '100',
           provinceCode: '75',
-          identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+          identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           isManagingStudents: 'true',
           email: 'sco.generic.account@example.net',
           documentationUrl: 'https://pix.fr/',
@@ -185,7 +185,7 @@ describe('Integration | Repository | Organization', function () {
           email: 'sco.generic.account@example.net',
           targetProfileShares: [],
           organizationInvitations: [],
-          identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+          identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           tags: [{ id: tag.id, name: 'SUPER-TAG' }],
           documentationUrl: 'https://pix.fr/',
           createdBy: insertedOrganization.createdBy,

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -11,7 +11,7 @@ import {
 } from '../../../../lib/domain/errors.js';
 
 import { User } from '../../../../lib/domain/models/User.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { UserDetailsForAdmin } from '../../../../lib/domain/models/UserDetailsForAdmin.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { CertificationCenter } from '../../../../lib/domain/models/CertificationCenter.js';
@@ -134,7 +134,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         // when
         const foundUser = await userRepository.findByExternalIdentifier({
           externalIdentityId,
-          identityProvider: AuthenticationMethod.identityProviders.PIX,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         });
 
         // then
@@ -1178,7 +1178,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
           // then
           const pixAuthenticationMethod = userDetailsForAdmin.authenticationMethods.find(
-            ({ identityProvider }) => identityProvider === AuthenticationMethod.identityProviders.PIX
+            ({ identityProvider }) => identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code
           );
           expect(userDetailsForAdmin.authenticationMethods.length).to.equal(2);
           expect(pixAuthenticationMethod).to.deep.equal({
@@ -1186,7 +1186,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
               shouldChangePassword: false,
             },
             id: expectedPixAuthenticationMethod.id,
-            identityProvider: AuthenticationMethod.identityProviders.PIX,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
           });
         });
       });

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -4,6 +4,7 @@ const { isUndefined } = lodash;
 import * as encrypt from '../../../../lib/domain/services/encryption-service.js';
 import { User } from '../../../../lib/domain/models/User.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 
 function _buildUser() {
@@ -19,7 +20,7 @@ const buildAuthenticationMethod = {};
 
 buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   id = 123,
-  identityProvider = AuthenticationMethod.identityProviders.GAR,
+  identityProvider = NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
   externalIdentifier = `externalId${id}`,
   userId = 456,
   userFirstName = 'Margotte',
@@ -57,7 +58,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword = function ({
 
   return new AuthenticationMethod({
     id,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
       password,
       shouldChangePassword,
@@ -82,7 +83,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword = function 
 
   return new AuthenticationMethod({
     id,
-    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
       password,
       shouldChangePassword,

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -4,7 +4,7 @@ import { userVerification } from '../../../../lib/application/preHandlers/user-e
 import { userController } from '../../../../lib/application/users/user-controller.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 import * as moduleUnderTest from '../../../../lib/application/users/index.js';
-import { IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Router | user-router', function () {
   describe('POST /api/users', function () {
@@ -934,7 +934,7 @@ describe('Unit | Router | user-router', function () {
     describe('POST /api/admin/users/{id}/remove-authentication', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
-        IDENTITY_PROVIDERS.GAR.code,
+        NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         'EMAIL',
         'USERNAME',
         // eslint-disable-next-line mocha/no-setup-in-describe
@@ -1064,81 +1064,81 @@ describe('Unit | Router | user-router', function () {
 
     describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
-      [IDENTITY_PROVIDERS.GAR.code, OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.CNAV.code].forEach(
-        (identityProvider) => {
-          it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
-            // given
-            sinon
-              .stub(userController, 'reassignAuthenticationMethods')
-              .callsFake((request, h) => h.response({}).code(204));
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-              .callsFake((request, h) => h.response(true));
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-            const httpTestServer = new HttpTestServer();
-            await httpTestServer.register(moduleUnderTest);
-            const payload = {
-              data: {
-                attributes: {
-                  'user-id': 2,
-                  'identity-provider': identityProvider,
-                },
+      [
+        NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        OidcIdentityProviders.POLE_EMPLOI.code,
+        OidcIdentityProviders.CNAV.code,
+      ].forEach((identityProvider) => {
+        it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
+          // given
+          sinon
+            .stub(userController, 'reassignAuthenticationMethods')
+            .callsFake((request, h) => h.response({}).code(204));
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response(true));
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+          const payload = {
+            data: {
+              attributes: {
+                'user-id': 2,
+                'identity-provider': identityProvider,
               },
-            };
+            },
+          };
 
-            // when
-            const { statusCode } = await httpTestServer.request(
-              'POST',
-              '/api/admin/users/1/authentication-methods/1',
-              payload
-            );
+          // when
+          const { statusCode } = await httpTestServer.request(
+            'POST',
+            '/api/admin/users/1/authentication-methods/1',
+            payload
+          );
 
-            // then
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-            sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
-            expect(statusCode).to.equal(204);
-          });
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+          expect(statusCode).to.equal(204);
+        });
 
-          it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
-            // given
-            sinon
-              .stub(userController, 'reassignAuthenticationMethods')
-              .callsFake((request, h) => h.response({}).code(204));
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-              .callsFake((request, h) => h.response(true));
-            const httpTestServer = new HttpTestServer();
-            await httpTestServer.register(moduleUnderTest);
-            const payload = {
-              data: {
-                attributes: {
-                  'user-id': 3,
-                  'identity-provider': identityProvider,
-                },
+        it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
+          // given
+          sinon
+            .stub(userController, 'reassignAuthenticationMethods')
+            .callsFake((request, h) => h.response({}).code(204));
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(true));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+          const payload = {
+            data: {
+              attributes: {
+                'user-id': 3,
+                'identity-provider': identityProvider,
               },
-            };
+            },
+          };
 
-            // when
-            const { statusCode } = await httpTestServer.request(
-              'POST',
-              '/api/admin/users/1/authentication-methods/1',
-              payload
-            );
+          // when
+          const { statusCode } = await httpTestServer.request(
+            'POST',
+            '/api/admin/users/1/authentication-methods/1',
+            payload
+          );
 
-            // then
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-            sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
-            expect(statusCode).to.equal(204);
-          });
-        }
-      );
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+          expect(statusCode).to.equal(204);
+        });
+      });
 
       it('returns 400 when "userId" is not a number', async function () {
         // given
@@ -1206,7 +1206,7 @@ describe('Unit | Router | user-router', function () {
           data: {
             attributes: {
               'user-id': 'invalid-user-id',
-              'identity-provider': IDENTITY_PROVIDERS.GAR.code,
+              'identity-provider': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             },
           },
         };
@@ -1238,7 +1238,7 @@ describe('Unit | Router | user-router', function () {
           data: {
             attributes: {
               'user-id': 2,
-              'identity-provider': IDENTITY_PROVIDERS.GAR.code,
+              'identity-provider': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             },
           },
         };

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -4,6 +4,7 @@ import { userVerification } from '../../../../lib/application/preHandlers/user-e
 import { userController } from '../../../../lib/application/users/user-controller.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 import * as moduleUnderTest from '../../../../lib/application/users/index.js';
+import { IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Router | user-router', function () {
   describe('POST /api/users', function () {
@@ -933,7 +934,7 @@ describe('Unit | Router | user-router', function () {
     describe('POST /api/admin/users/{id}/remove-authentication', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
-        'GAR',
+        IDENTITY_PROVIDERS.GAR.code,
         'EMAIL',
         'USERNAME',
         // eslint-disable-next-line mocha/no-setup-in-describe
@@ -1063,79 +1064,83 @@ describe('Unit | Router | user-router', function () {
 
     describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
-      ['GAR', OidcIdentityProviders.POLE_EMPLOI.code].forEach((identityProvider) => {
-        it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
-          // given
-          sinon
-            .stub(userController, 'reassignAuthenticationMethods')
-            .callsFake((request, h) => h.response({}).code(204));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response(true));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-          const payload = {
-            data: {
-              attributes: {
-                'user-id': 2,
-                'identity-provider': identityProvider,
+      [IDENTITY_PROVIDERS.GAR.code, OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.CNAV.code].forEach(
+        (identityProvider) => {
+          it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
+            // given
+            sinon
+              .stub(userController, 'reassignAuthenticationMethods')
+              .callsFake((request, h) => h.response({}).code(204));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+              .callsFake((request, h) => h.response(true));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
+            const payload = {
+              data: {
+                attributes: {
+                  'user-id': 2,
+                  'identity-provider': identityProvider,
+                },
               },
-            },
-          };
+            };
 
-          // when
-          const { statusCode } = await httpTestServer.request(
-            'POST',
-            '/api/admin/users/1/authentication-methods/1',
-            payload
-          );
+            // when
+            const { statusCode } = await httpTestServer.request(
+              'POST',
+              '/api/admin/users/1/authentication-methods/1',
+              payload
+            );
 
-          // then
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
-          expect(statusCode).to.equal(204);
-        });
+            // then
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+            sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+            expect(statusCode).to.equal(204);
+          });
 
-        it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
-          // given
-          sinon
-            .stub(userController, 'reassignAuthenticationMethods')
-            .callsFake((request, h) => h.response({}).code(204));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(true));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-          const payload = {
-            data: {
-              attributes: {
-                'user-id': 3,
-                'identity-provider': identityProvider,
+          it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
+            // given
+            sinon
+              .stub(userController, 'reassignAuthenticationMethods')
+              .callsFake((request, h) => h.response({}).code(204));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+              .callsFake((request, h) => h.response(true));
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
+            const payload = {
+              data: {
+                attributes: {
+                  'user-id': 3,
+                  'identity-provider': identityProvider,
+                },
               },
-            },
-          };
+            };
 
-          // when
-          const { statusCode } = await httpTestServer.request(
-            'POST',
-            '/api/admin/users/1/authentication-methods/1',
-            payload
-          );
+            // when
+            const { statusCode } = await httpTestServer.request(
+              'POST',
+              '/api/admin/users/1/authentication-methods/1',
+              payload
+            );
 
-          // then
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
-          expect(statusCode).to.equal(204);
-        });
-      });
+            // then
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+            sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+            expect(statusCode).to.equal(204);
+          });
+        }
+      );
 
-      it('should return 400 when "userId" is not a number', async function () {
+      it('returns 400 when "userId" is not a number', async function () {
         // given
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -1151,7 +1156,7 @@ describe('Unit | Router | user-router', function () {
         expect(JSON.parse(payload).errors[0].detail).to.equal('"userId" must be a number');
       });
 
-      it('should return 400 when "authenticationMethodId" is not a number', async function () {
+      it('returns 400 when "authenticationMethodId" is not a number', async function () {
         // given
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -1167,21 +1172,21 @@ describe('Unit | Router | user-router', function () {
         expect(JSON.parse(payload).errors[0].detail).to.equal('"authenticationMethodId" must be a number');
       });
 
-      it('should return 400 when the payload is invalid', async function () {
+      it('returns 400 when the payload contains an invalid identity provider', async function () {
         // given
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
         const payload = {
           data: {
             attributes: {
-              'user-id': 'invalid-user-id',
+              'user-id': 1,
               'identity-provider': 'invalid-identity-provider',
             },
           },
         };
 
         // when
-        const { statusCode } = await httpTestServer.request(
+        const { statusCode, result } = await httpTestServer.request(
           'POST',
           '/api/admin/users/1/authentication-methods/1',
           payload
@@ -1189,9 +1194,36 @@ describe('Unit | Router | user-router', function () {
 
         // then
         expect(statusCode).to.equal(400);
+        expect(result.errors[0].detail).to.equal(
+          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV]'
+        );
+      });
+      it('returns 400 when the payload contains an invalid user id', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = {
+          data: {
+            attributes: {
+              'user-id': 'invalid-user-id',
+              'identity-provider': IDENTITY_PROVIDERS.GAR.code,
+            },
+          },
+        };
+
+        // when
+        const { statusCode, result } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/1/authentication-methods/1',
+          payload
+        );
+
+        // then
+        expect(statusCode).to.equal(400);
+        expect(result.errors[0].detail).to.equal('"data.attributes.user-id" must be a number');
       });
 
-      it(`should return 403 when user don't have access (CERTIF | METIER)`, async function () {
+      it(`returns 403 when user don't have access (CERTIF | METIER)`, async function () {
         // given
         sinon.stub(userController, 'reassignAuthenticationMethods').returns('ok');
         sinon
@@ -1206,7 +1238,7 @@ describe('Unit | Router | user-router', function () {
           data: {
             attributes: {
               'user-id': 2,
-              'identity-provider': 'GAR',
+              'identity-provider': IDENTITY_PROVIDERS.GAR.code,
             },
           },
         };

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -1,6 +1,6 @@
 import { sinon, expect, domainBuilder, hFake } from '../../../test-helper.js';
 import { User } from '../../../../lib/domain/models/User.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as queryParamsUtils from '../../../../lib/infrastructure/utils/query-params-utils.js';
 import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
@@ -1166,7 +1166,7 @@ describe('Unit | Controller | user-controller', function () {
             data: {
               attributes: {
                 'user-id': targetUserId,
-                'identity-provider': AuthenticationMethod.identityProviders.GAR,
+                'identity-provider': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
               },
             },
           },

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -1,6 +1,7 @@
 import { expect } from '../../../test-helper.js';
 import { ObjectValidationError } from '../../../../lib/domain/errors.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 
 describe('Unit | Domain | Models | AuthenticationMethod', function () {
@@ -32,7 +33,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
 
       const expectedResult = {
         id,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         authenticationComplement,
         externalIdentifier: undefined,
         userId,
@@ -49,7 +50,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             externalIdentifier: 'externalIdentifier',
             userId: 1,
           })
@@ -108,7 +109,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             externalIdentifier: undefined,
             userId: 1,
           })
@@ -136,7 +137,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: AuthenticationMethod.identityProviders.PIX,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
             authenticationComplement: undefined,
             userId: 1,
           })
@@ -148,7 +149,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             externalIdentifier: 'externalIdentifier',
             userId: 'not_valid',
           })
@@ -156,7 +157,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: AuthenticationMethod.identityProviders.GAR,
+            identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
             externalIdentifier: 'externalIdentifier',
             userId: undefined,
           })

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import * as obfuscationService from '../../../../lib/domain/services/obfuscation-service.js';
 import { User } from '../../../../lib/domain/models/User.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Service | user-authentication-method-obfuscation-service', function () {
@@ -66,7 +66,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', func
       const user = new User({ username });
       const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
@@ -1,6 +1,7 @@
 import { expect, domainBuilder, sinon } from '../../../../test-helper.js';
 import { updateUserForAccountRecovery } from '../../../../../lib/domain/usecases/account-recovery/update-user-for-account-recovery.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import { User } from '../../../../../lib/domain/models/User.js';
 
@@ -71,7 +72,7 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
 
       // then
       const expectedAuthenticationMethodFromPix = new AuthenticationMethod({
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
           password: hashedPassword,
           shouldChangePassword: false,

--- a/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
+++ b/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
@@ -1,6 +1,7 @@
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { addPixAuthenticationMethodByEmail } from '../../../../lib/domain/usecases/add-pix-authentication-method-by-email.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | UseCase | add-pix-authentication-method-by-email', function () {
   let userRepository, authenticationMethodRepository;
@@ -75,7 +76,7 @@ describe('Unit | UseCase | add-pix-authentication-method-by-email', function () 
       // then
       const authenticationMethodFromPix = new AuthenticationMethod({
         userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
           password: hashedPassword,
           shouldChangePassword: false,

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -11,6 +11,7 @@ import {
 } from '../../../../lib/domain/errors.js';
 
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Application | UseCase | authenticate-external-user', function () {
   let tokenService;
@@ -227,7 +228,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
 
         // then
         const expectedAuthenticationMethod = new AuthenticationMethod({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           externalIdentifier: samlId,
           userId: user.id,
           authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
@@ -278,7 +279,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
 
         // then
         const expectedAuthenticationMethod = new AuthenticationMethod({
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           externalIdentifier,
           userId: user.id,
           authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -1,6 +1,7 @@
 import { expect, sinon, domainBuilder } from '../../../test-helper.js';
 import { User } from '../../../../lib/domain/models/User.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { getExternalAuthenticationRedirectionUrl } from '../../../../lib/domain/usecases/get-external-authentication-redirection-url.js';
 
 describe('Unit | UseCase | get-external-authentication-redirection-url', function () {
@@ -142,7 +143,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         const authenticationMethodWithoutFirstAndLastName = new AuthenticationMethod({
           id: 1234,
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           authenticationComplement: null,
           externalIdentifier: 'saml-id',
           createdAt: new Date('2020-01-01'),
@@ -150,7 +151,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         });
         userRepository.getBySamlId.withArgs('saml-id').resolves(user);
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .withArgs({ userId: user.id, identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code })
           .resolves(authenticationMethodWithoutFirstAndLastName);
 
         // when
@@ -166,7 +167,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           id: authenticationMethodWithoutFirstAndLastName.id,
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           userFirstName: 'Vassili',
           userLastName: 'Lisitsa',
           externalIdentifier: 'saml-id',
@@ -185,7 +186,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         });
         userRepository.getBySamlId.withArgs('saml-id').resolves(user);
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .withArgs({ userId: user.id, identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code })
           .resolves(authenticationMethod);
 
         // when
@@ -201,7 +202,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           id: authenticationMethod.id,
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           userFirstName: 'Valentina',
           userLastName: 'Lisitsa',
           externalIdentifier: 'saml-id',
@@ -220,7 +221,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         });
         userRepository.getBySamlId.withArgs('saml-id').resolves(user);
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .withArgs({ userId: user.id, identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code })
           .resolves(authenticationMethod);
 
         // when
@@ -236,7 +237,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
           id: authenticationMethod.id,
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           userFirstName: 'Valentina',
           userLastName: 'Volk',
           externalIdentifier: 'saml-id',
@@ -255,7 +256,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         });
         userRepository.getBySamlId.withArgs('saml-id').resolves(user);
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .withArgs({ userId: user.id, identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code })
           .resolves(authenticationMethod);
 
         // when

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import { removeAuthenticationMethod } from '../../../../lib/domain/usecases/remove-authentication-method.js';
 import { UserNotAuthorizedToRemoveAuthenticationMethod } from '../../../../lib/domain/errors.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 
 describe('Unit | UseCase | remove-authentication-method', function () {
@@ -77,7 +77,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         // then
         expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.PIX,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         });
       });
     });
@@ -130,7 +130,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         // then
         expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
           userId: user.id,
-          identityProvider: AuthenticationMethod.identityProviders.PIX,
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         });
       });
     });
@@ -168,7 +168,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // then
       expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
         userId: user.id,
-        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
     });
   });

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -6,7 +6,7 @@ import {
   UserNotAuthorizedToUpdateEmailError,
 } from '../../../../lib/domain/errors.js';
 
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 
@@ -56,7 +56,7 @@ describe('Unit | UseCase | send-verification-code', function () {
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider
       .withArgs({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       })
       .resolves(
         domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
@@ -101,7 +101,7 @@ describe('Unit | UseCase | send-verification-code', function () {
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider
       .withArgs({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       })
       .resolves(
         domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
@@ -176,7 +176,7 @@ describe('Unit | UseCase | send-verification-code', function () {
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider
       .withArgs({
         userId,
-        identityProvider: AuthenticationMethod.identityProviders.PIX,
+        identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
       })
       .resolves(
         domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -1,6 +1,6 @@
 import { sinon, expect, domainBuilder, catchErr } from '../../../test-helper.js';
 import { ForbiddenAccess, UserNotFoundError } from '../../../../lib/domain/errors.js';
-import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { updateExpiredPassword } from '../../../../lib/domain/usecases/update-expired-password.js';
 import { logger } from '../../../../lib/infrastructure/logger.js';
 
@@ -60,7 +60,7 @@ describe('Unit | UseCase | update-expired-password', function () {
     expect(encryptionService.hashPassword).to.have.been.calledOnceWith(newPassword);
     expect(authenticationMethodRepository.findOneByUserIdAndIdentityProvider).to.have.been.calledOnceWith({
       userId: user.id,
-      identityProvider: AuthenticationMethod.identityProviders.PIX,
+      identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
     });
     expect(authenticationMethodRepository.updateExpiredPassword).to.have.been.calledOnceWith({
       userId: user.id,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -1,9 +1,7 @@
 import { expect, domainBuilder } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js';
-import { Organization } from '../../../../../lib/domain/models/Organization.js';
-import { OrganizationForAdmin } from '../../../../../lib/domain/models/organizations-administration/Organization.js';
-import { Tag } from '../../../../../lib/domain/models/Tag.js';
-import { SamlIdentityProviders } from '../../../../../lib/domain/constants/saml-identity-providers.js';
+import { Organization, OrganizationForAdmin, Tag } from '../../../../../lib/domain/models/index.js';
+import { IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Serializer | organization-for-admin-serializer', function () {
   describe('#serialize', function () {
@@ -23,7 +21,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerFirstName: 'Justin',
         dataProtectionOfficerLastName: 'Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
-        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
       });
       const meta = { some: 'meta' };
 
@@ -56,7 +54,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'data-protection-officer-last-name': organization.dataProtectionOfficerLastName,
             'data-protection-officer-email': organization.dataProtectionOfficerEmail,
             'creator-full-name': organization.creatorFullName,
-            'identity-provider-for-campaigns': SamlIdentityProviders.GAR.code,
+            'identity-provider-for-campaigns': IDENTITY_PROVIDERS.GAR.code,
           },
           relationships: {
             'organization-memberships': {
@@ -123,7 +121,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         createdBy: 10,
         documentationUrl: 'https://pix.fr/',
         showSkills: false,
-        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
         dataProtectionOfficerFirstName: 'Justin',
         dataProtectionOfficerLastName: 'Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -1,7 +1,7 @@
 import { expect, domainBuilder } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js';
 import { Organization, OrganizationForAdmin, Tag } from '../../../../../lib/domain/models/index.js';
-import { IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Serializer | organization-for-admin-serializer', function () {
   describe('#serialize', function () {
@@ -21,7 +21,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerFirstName: 'Justin',
         dataProtectionOfficerLastName: 'Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
-        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
       const meta = { some: 'meta' };
 
@@ -54,7 +54,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'data-protection-officer-last-name': organization.dataProtectionOfficerLastName,
             'data-protection-officer-email': organization.dataProtectionOfficerEmail,
             'creator-full-name': organization.creatorFullName,
-            'identity-provider-for-campaigns': IDENTITY_PROVIDERS.GAR.code,
+            'identity-provider-for-campaigns': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           },
           relationships: {
             'organization-memberships': {
@@ -121,7 +121,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         createdBy: 10,
         documentationUrl: 'https://pix.fr/',
         showSkills: false,
-        identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         dataProtectionOfficerFirstName: 'Justin',
         dataProtectionOfficerLastName: 'Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -2,7 +2,7 @@ import { expect, domainBuilder } from '../../../../test-helper.js';
 
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/prescriber-serializer.js';
 import { Membership } from '../../../../../lib/domain/models/index.js';
-import { IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
   describe('#serialize', function () {
@@ -106,7 +106,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
       it('should serialize prescriber with identityProviderForCampaigns', function () {
         // given
         const organization = domainBuilder.buildOrganization({
-          identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
+          identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
         });
         const membership = domainBuilder.buildMembership({ organization });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -1,8 +1,8 @@
 import { expect, domainBuilder } from '../../../../test-helper.js';
 
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/prescriber-serializer.js';
-import { Membership } from '../../../../../lib/domain/models/Membership.js';
-import { SamlIdentityProviders } from '../../../../../lib/domain/constants/saml-identity-providers.js';
+import { Membership } from '../../../../../lib/domain/models/index.js';
+import { IDENTITY_PROVIDERS } from '../../../../../lib/domain/constants/identity-providers.js';
 
 describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
   describe('#serialize', function () {
@@ -106,7 +106,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
       it('should serialize prescriber with identityProviderForCampaigns', function () {
         // given
         const organization = domainBuilder.buildOrganization({
-          identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+          identityProviderForCampaigns: IDENTITY_PROVIDERS.GAR.code,
         });
         const membership = domainBuilder.buildMembership({ organization });
 


### PR DESCRIPTION
## :unicorn: Problème
Un membre de Pix peut via l'interface d'administration attribuer une méthode de connexion à un autre utilisateur. C'est notamment le cas lorsqu'un utilisateur a lié cette méthode de connexion à un compte utilisateur qu'il ne voulait pas utiliser par exemple.
Or, dans la route api qui est appelé, on ne permettait pas de transférer la méthode CNAV.
A noter que celle de la FWB non plus.
Nous ajoutons actuellement en dur, les méthodes permises, 'GAR', 'POLE-EMPLOI', etc.
Or cela est source d'erreur car nous pouvons oublier d'ajouter un identity provider à cette liste lors de l'ajout d'un SSO et surtout de son activation.
Le code actuel ne permet pas une automatisation.

Bugfix : le userId était rénitialisé lors de l'ouverture de la modale, ce qui fait qu'un appel après une api en erreur, renvoyait une 422 car la valeur de userId était null

## :robot: Proposition

- Ajouter l'identity provider manquant
- Commencer un refacto en utilisante des constantes au lieu de termes en dur pour nos idp
- Objectifs : avoir une liste fiable des idp (oidc ou non) installés et actifs
- Piste : créer un objet du domaine (en read model) et une méthode `getIdentityProvidersEnabled()` par exemple
- A suivre

## :rainbow: Remarques
- pour activer le SSO CNAV, il faut que toutes les variables d'env soit présentes. Sinon l'appel api http://localhost:4202/api/oidc/identity-providers ne renverra pas la CNAV  cela pourrait être améliorer par des tests automatisés et un refacto du code mais cela n'a pas été pris en compte dans ce ticket, on a ce ticket qui est lié https://1024pix.atlassian.net/browse/PIX-7126 (le fichier de récupération des constantes instancie des classe.)
- Le ticket https://1024pix.atlassian.net/browse/PIX-7569 est toujours d'actualité 

Le bugfix a été corrigé


## :100: Pour tester

Attention : pour activer le SSO CNAV, il faut que toutes les variables d'env soit présentes. Sinon l'appel api http://localhost:4202/api/oidc/identity-providers ne renverra pas la CNAV

- Sélectionner en base un utilisateur qui a comme méthode de connexion CNAV 
`select email from users inner join "authentication-methods" "a-m" on users.id = "a-m"."userId" and "a-m"."identityProvider"='CNAV';`
- se connecter à admin avec superadmin@example.net
- rechercher l'utilisateur
- cliquer sur transférer la méthode
- Ecrire -- sur chrome ou firefox et observer l'erreur 400 qui est dans le ticket
- Mettre l'id d'un utilisateur valide
- Observer que la méthode a bien été transférée (en BDD ou via l'interface d'admin)

Pour voir le bug **avant le fix :**
- aller sur dev ou autre
- mettre tout d'abord un chiffre très grand par exemple `56545264243245325` comme userId pour avoir une erreur
```
{
    "errors": [
        {
            "status": "400",
            "title": "Bad Request",
            "detail": "\"data.attributes.user-id\" must be a safe number"
        }
    ]
}
```

La payload de la requête contient bien 56545264243245325` 
- mettre un id valide et observer l'erreur


Refaire cette manip sur la branche et observer que vous pouvez déplacer la méthode de connexion !


Tests de non régression :
- supprimer toutes les méthodes (Ex de l'utilisateur Charity Noble), etc

Lien utile : la PR de refacto effectuée avant https://github.com/1024pix/pix/pull/4954/files#diff-0499f681d0a3edd77f2dcef757e1bec6a3626e542f2e75effbccbdeeef755027




