### PR TITLE
[FEATURE] Traduire les erreurs lors de l'import de candidats sur Pix Certif (PIX-7967).

### DIFF
--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -1,6 +1,6 @@
 import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
 import { badges } from '../../../constants.js';
-const ROLES = { PIX_ADMIN };
+const { ROLES } = PIX_ADMIN;
 
 // IDS
 /// USERS
@@ -188,7 +188,7 @@ function _createClea(databaseBuilder) {
     message:
       'Bravo ! Vous maîtrisez les compétences indispensables pour utiliser le numérique en milieu professionnel. Pour valoriser vos compétences avec une double certification Pix-CléA numérique, renseignez-vous auprès de votre conseiller ou de votre formateur.',
     altMessage: 'Prêt pour le CléA numérique',
-    key: badges.keys.PIX_EMPLOI_CLEA_V4,
+    key: badges.keys.PIX_EMPLOI_CLEA_V3,
     imageUrl: 'https://images.pix.fr/badges/Logos_badge_Prêt-CléA_Num NEW 2020.svg',
     title: 'Prêt pour le CléA numérique',
     isCertifiable: true,

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -505,7 +505,7 @@ async function _registerCandidatesToSession({
       }
 
       const { billingMode: randomBillingMode, prepaymentCode: randomPrepaymentCode } =
-        billingModes[i % extraTimePercentages.length];
+        billingModes[i % billingModes.length];
 
       const randomExtraTimePercentage = extraTimePercentages[i % extraTimePercentages.length];
 

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -190,7 +190,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
   if (error instanceof DomainErrors.CertificationCandidatesImportError) {
-    return new HttpErrors.UnprocessableEntityError(error.message, error.code);
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
   if (error instanceof DomainErrors.CertificationCandidateForbiddenDeletionError) {
     return new HttpErrors.ForbiddenError(error.message);

--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -124,6 +124,18 @@ const CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_SEX_REQUIRED',
     getMessage: () => '',
   },
+  CANDIDATE_INFORMATION_MUST_BE_A_STRING: {
+    code: 'CANDIDATE_INFORMATION_MUST_BE_A_STRING',
+    getMessage: () => '',
+  },
+  CANDIDATE_INFORMATION_MUST_BE_A_NUMBER: {
+    code: 'CANDIDATE_INFORMATION_MUST_BE_A_NUMBER',
+    getMessage: () => '',
+  },
+  CANDIDATE_INFORMATION_REQUIRED: {
+    code: 'CANDIDATE_INFORMATION_REQUIRED',
+    getMessage: () => '',
+  },
 };
 
 export { CERTIFICATION_CANDIDATES_ERRORS };

--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -39,10 +39,6 @@ const CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED',
     getMessage: () => "Candidat né à l'étranger, champ obligatoire nom de commune de naissance manquant",
   },
-  CANDIDATE_BIRTH_CITY_MUST_BE_EMPTY: {
-    code: 'CANDIDATE_BIRTH_CITY_MUST_BE_EMPTY',
-    getMessage: () => 'Le champ "nom de la commune" doit rester vide (dans le cas d\'un code INSEE\')',
-  },
   CANDIDATE_BIRTH_COUNTRY_NOT_FOUND: {
     code: 'CANDIDATE_BIRTH_COUNTRY_NOT_FOUND',
     getMessage: ({ birthCountry }) => `Le pays "${birthCountry}" n'a pas été trouvé.`,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1,4 +1,5 @@
 import { SESSION_SUPERVISING } from './constants/session-supervising.js';
+import { CERTIFICATION_CANDIDATES_ERRORS } from './constants/certification-candidates-errors.js';
 
 class DomainError extends Error {
   constructor(message, code, meta) {
@@ -579,36 +580,35 @@ class CertificationCandidateAddError extends DomainError {
 }
 
 class CertificationCandidatesImportError extends DomainError {
-  constructor({ message = "Quelque chose s'est mal passé. Veuillez réessayer", code = null } = {}) {
-    super(message, code);
+  constructor({ message = "Quelque chose s'est mal passé. Veuillez réessayer", code = null, meta = null } = {}) {
+    super(message, code, meta);
   }
 
   static fromInvalidCertificationCandidateError(error, keyLabelMap, lineNumber) {
     const label = error.key in keyLabelMap ? keyLabelMap[error.key].replace(/\* /, '') : 'none';
-    const linePortion = `Ligne ${lineNumber} :`;
-    let contentPortion = "Quelque chose s'est mal passé. Veuillez réessayer";
+    let code;
 
     if (error.why === 'not_a_date' || error.why === 'date_format') {
-      contentPortion = `Le champ “${label}” doit être au format jj/mm/aaaa.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID.code;
     } else if (error.why === 'email_format') {
-      contentPortion = `Le champ “${label}” doit être au format email.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code;
     } else if (error.why === 'not_a_string') {
-      contentPortion = `Le champ “${label}” doit être une chaîne de caractères.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_INFORMATION_MUST_BE_A_STRING.code;
     } else if (error.why === 'not_a_number') {
-      contentPortion = `Le champ “${label}” doit être un nombre.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_INFORMATION_MUST_BE_A_NUMBER.code;
     } else if (error.why === 'required') {
-      contentPortion = `Le champ “${label}” est obligatoire.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_INFORMATION_REQUIRED.code;
     } else if (error.why === 'not_a_sex_code') {
-      contentPortion = `Le champ “${label}” accepte les valeurs "M" pour un homme ou "F" pour une femme.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code;
     } else if (error.why === 'not_a_billing_mode') {
-      contentPortion = `Le champ “${label}” ne peut contenir qu'une des valeurs suivantes: Gratuite, Payante ou Prépayée.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code;
     } else if (error.why === 'prepayment_code_null') {
-      contentPortion = `Le champ “${label}” est obligatoire puisque l’option “Prépayée” a été sélectionnée pour ce candidat.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code;
     } else if (error.why === 'prepayment_code_not_null') {
-      contentPortion = `Le champ “${label}” doit rester vide puisque l’option “Prépayée” n'a pas été sélectionnée pour ce candidat.`;
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code;
     }
 
-    return new CertificationCandidatesImportError({ message: `${linePortion} ${contentPortion}` });
+    return new CertificationCandidatesImportError({ code, meta: { line: lineNumber, label } });
   }
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -360,6 +360,9 @@ class InvalidCertificationCandidate extends DomainError {
     if (type === 'any.required' && error.key === 'prepaymentCode') {
       error.why = 'prepayment_code_null';
     }
+    if (type === 'number.less' || type === 'number.min') {
+      error.why = 'extra_time_percentage_out_of_range';
+    }
 
     return new InvalidCertificationCandidate({ error });
   }
@@ -606,6 +609,8 @@ class CertificationCandidatesImportError extends DomainError {
       code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code;
     } else if (error.why === 'prepayment_code_not_null') {
       code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code;
+    } else if (error.why === 'extra_time_percentage_out_of_range') {
+      code = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_OUT_OF_RANGE.code;
     }
 
     return new CertificationCandidatesImportError({ code, meta: { line: lineNumber, label } });

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -10,6 +10,7 @@ import {
 import { CertificationCandidatesImportError } from '../errors.js';
 import _ from 'lodash';
 import bluebird from 'bluebird';
+import { CERTIFICATION_CANDIDATES_ERRORS } from '../constants/certification-candidates-errors.js';
 
 export { extractCertificationCandidatesFromCandidatesImportSheet };
 
@@ -82,8 +83,11 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
         })
       ) {
         line = parseInt(line) + 1;
+
         throw new CertificationCandidatesImportError({
-          message: `Ligne ${line} : Vous ne pouvez pas inscrire un candidat à plus d'une certification complémentaire.`,
+          code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION,
+          message: 'A candidate cannot have more than one complementary certification',
+          meta: { line },
         });
       }
 

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -178,7 +178,7 @@ function _handleBirthInformationValidationError(cpfBirthInformation, line) {
 function _handleVersionError() {
   throw new CertificationCandidatesImportError({
     code: 'INVALID_DOCUMENT',
-    message: 'La version du document est inconnue.',
+    message: 'This version of the document is unknown.',
   });
 }
 

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -85,7 +85,7 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
         line = parseInt(line) + 1;
 
         throw new CertificationCandidatesImportError({
-          code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION,
+          code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
           message: 'A candidate cannot have more than one complementary certification',
           meta: { line },
         });
@@ -174,8 +174,10 @@ function _handleFieldValidationError(err, tableHeaderTargetPropertyMap, line) {
 
 function _handleBirthInformationValidationError(cpfBirthInformation, line) {
   line = parseInt(line) + 1;
+  const { birthCountry, birthINSEECode, birthPostalCode, birthCity, firstErrorCode } = cpfBirthInformation;
   throw new CertificationCandidatesImportError({
-    message: `Ligne ${line} : ${cpfBirthInformation.firstErrorMessage}`,
+    code: firstErrorCode,
+    meta: { line, birthCountry, birthINSEECode, birthPostalCode, birthCity },
   });
 }
 

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -42,6 +42,10 @@ class CpfBirthInformationValidation {
   get firstErrorMessage() {
     return this.errors?.[0]?.message;
   }
+
+  get firstErrorCode() {
+    return this.errors?.[0]?.code;
+  }
 }
 
 function _getForeignCountryBirthInformation({
@@ -148,7 +152,12 @@ async function getBirthInformation({
   certificationCpfCountryRepository,
   certificationCpfCityRepository,
 }) {
-  const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+  const cpfBirthInformationValidation = new CpfBirthInformationValidation({
+    birthCountry,
+    birthCity,
+    birthPostalCode,
+    birthINSEECode,
+  });
 
   if (!birthCountry && !birthINSEECode && !birthPostalCode && !birthCity) {
     cpfBirthInformationValidation.failure({

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -300,8 +300,15 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
         });
 
         // then
-        expect(error).to.be.instanceOf(CertificationCandidatesImportError);
-        expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code);
+        expect(error).to.deepEqualInstance(
+          new CertificationCandidatesImportError({
+            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+            message: 'A candidate cannot have more than one complementary certification',
+            meta: {
+              line: 13,
+            },
+          })
+        );
       });
     });
 

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -24,6 +24,7 @@ import { getI18n } from '../../../../tooling/i18n/i18n.js';
 const i18n = getI18n();
 
 import * as url from 'url';
+import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../lib/domain/constants/certification-candidates-errors.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 describe('Integration | Services | extractCertificationCandidatesFromCandidatesImportSheet', function () {
@@ -87,8 +88,8 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     // then
     expect(error).to.be.instanceOf(CertificationCandidatesImportError);
-    expect(error.message).to.equal('Ligne 13 : Le champ “Prénom” est obligatoire.');
-    expect(error.code).to.be.null;
+    expect(error.code).to.equal('CANDIDATE_INFORMATION_REQUIRED');
+    expect(error.meta).to.deep.equal({ line: 13, label: 'Prénom' });
   });
 
   it('should throw a CertificationCandidatesImportError if there is an error in the birth information', async function () {
@@ -113,8 +114,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     // then
     expect(error).to.be.instanceOf(CertificationCandidatesImportError);
-    expect(error.message).to.equal('Ligne 13 : La valeur du code INSEE doit être "99" pour un pays étranger.');
-    expect(error.code).to.be.null;
+    expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID.code);
   });
 
   it('should return extracted and validated certification candidates', async function () {
@@ -301,10 +301,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
         // then
         expect(error).to.be.instanceOf(CertificationCandidatesImportError);
-
-        expect(error.message).to.equal(
-          "Ligne 13 : Vous ne pouvez pas inscrire un candidat à plus d'une certification complémentaire."
-        );
+        expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION);
       });
     });
 

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -301,7 +301,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
         // then
         expect(error).to.be.instanceOf(CertificationCandidatesImportError);
-        expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION);
+        expect(error.code).to.equal(CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code);
       });
     });
 

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -1,5 +1,6 @@
 import { expect } from '../../test-helper.js';
 import * as errors from '../../../lib/domain/errors.js';
+import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../lib/domain/constants/certification-candidates-errors.js';
 
 describe('Unit | Domain | Errors', function () {
   it('should export a AdminMemberError', function () {
@@ -395,25 +396,6 @@ describe('Unit | Domain | Errors', function () {
         expect(error).to.be.instanceOf(errors.CertificationCandidatesImportError);
       });
 
-      it('should start the error message with line number', function () {
-        // given
-        const lineNumber = 20;
-        const invalidCertificationCandidateError = {
-          key: 'someKey',
-          why: 'someWhy',
-        };
-
-        // when
-        const error = errors.CertificationCandidatesImportError.fromInvalidCertificationCandidateError(
-          invalidCertificationCandidateError,
-          {},
-          lineNumber
-        );
-
-        // then
-        expect(error.message.startsWith(`Ligne ${lineNumber} :`)).to.be.true;
-      });
-
       context('when err.why is known', function () {
         it('should include the right label when found in the keyLabelMap', function () {
           // given
@@ -435,19 +417,29 @@ describe('Unit | Domain | Errors', function () {
           );
 
           // then
-          expect(error.message).to.contain('Le champ “someLabel”');
+          expect(error.meta).to.deep.equal({ line: lineNumber, label: 'someLabel' });
         });
 
         // eslint-disable-next-line mocha/no-setup-in-describe
         [
-          { why: 'not_a_date', content: 'doit être au format jj/mm/aaaa.' },
-          { why: 'date_format', content: 'doit être au format jj/mm/aaaa.' },
-          { why: 'email_format', content: 'doit être au format email.' },
-          { why: 'not_a_string', content: 'doit être une chaîne de caractères.' },
-          { why: 'not_a_number', content: 'doit être un nombre.' },
-          { why: 'required', content: 'est obligatoire.' },
-        ].forEach(({ why, content }) => {
-          it(`message should contain "${content}" when why is "${why}"`, async function () {
+          { why: 'not_a_date', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID.code },
+          { why: 'date_format', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID.code },
+          { why: 'email_format', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code },
+          { why: 'not_a_string', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_INFORMATION_MUST_BE_A_STRING.code },
+          { why: 'not_a_number', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_INFORMATION_MUST_BE_A_NUMBER.code },
+          { why: 'required', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_INFORMATION_REQUIRED.code },
+          { why: 'not_a_sex_code', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code },
+          { why: 'not_a_billing_mode', code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code },
+          {
+            why: 'prepayment_code_null',
+            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code,
+          },
+          {
+            why: 'prepayment_code_not_null',
+            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,
+          },
+        ].forEach(({ why, code }) => {
+          it(`code should equal "${code}" when why is "${why}"`, async function () {
             // given
             const invalidCertificationCandidateError = {
               key: 'someKey',
@@ -465,7 +457,7 @@ describe('Unit | Domain | Errors', function () {
             );
 
             // then
-            expect(error.message.endsWith(content)).to.be.true;
+            expect(error.code).to.equal(code);
           });
         });
       });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -438,6 +438,10 @@ describe('Unit | Domain | Errors', function () {
             why: 'prepayment_code_not_null',
             code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,
           },
+          {
+            why: 'extra_time_percentage_out_of_range',
+            code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_OUT_OF_RANGE.code,
+          },
         ].forEach(({ why, code }) => {
           it(`code should equal "${code}" when why is "${why}"`, async function () {
             // given

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -23,17 +23,20 @@ describe('Unit | Service | Certification CPF service', function () {
     context('when country name is not defined', function () {
       it('should return a validation failure', async function () {
         // when
-        const cpfBirthInformationValidationResult = new CpfBirthInformationValidation();
-        cpfBirthInformationValidationResult.failure({
-          certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED,
-        });
-        const result = await getBirthInformation({
+        const birthInformation = {
           birthCountry: null,
           birthCity: 'GOTHAM CITY',
           birthPostalCode: '12345',
           birthINSEECode: '12345',
-          certificationCpfCountryRepository,
+        };
+        const cpfBirthInformationValidationResult = new CpfBirthInformationValidation({ ...birthInformation });
+        cpfBirthInformationValidationResult.failure({
+          certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED,
+        });
+        const result = await getBirthInformation({
+          ...birthInformation,
           certificationCpfCityRepository,
+          certificationCpfCountryRepository,
         });
 
         // then
@@ -44,24 +47,23 @@ describe('Unit | Service | Certification CPF service', function () {
     context('when country does not exist', function () {
       it('should return a validation failure', async function () {
         // given
-        const birthCountry = 'ABCD';
-        const birthCity = 'GOTHAM CITY';
-        const birthPostalCode = null;
-        const birthINSEECode = '12345';
-        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        const birthInformation = {
+          birthCountry: 'ABCD',
+          birthCity: 'GOTHAM CITY',
+          birthPostalCode: null,
+          birthINSEECode: '12345',
+        };
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
         cpfBirthInformationValidation.failure({
           certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_NOT_FOUND,
-          data: { birthCountry },
+          data: { birthCountry: birthInformation.birthCountry },
         });
 
         certificationCpfCountryRepository.getByMatcher.resolves(null);
 
         // when
         const result = await getBirthInformation({
-          birthCountry,
-          birthCity,
-          birthPostalCode,
-          birthINSEECode,
+          ...birthInformation,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
         });
@@ -75,11 +77,13 @@ describe('Unit | Service | Certification CPF service', function () {
       context('when country is not FRANCE', function () {
         it('should return a validation failure when city name is not defined', async function () {
           // given
-          const birthCountry = 'PORTUGAL';
-          const birthCity = null;
-          const birthPostalCode = null;
-          const birthINSEECode = '99';
-          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          const birthInformation = {
+            birthCountry: 'PORTUGAL',
+            birthCity: null,
+            birthPostalCode: null,
+            birthINSEECode: '99',
+          };
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
           cpfBirthInformationValidation.failure({
             certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED,
           });
@@ -95,10 +99,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // when
           const result = await getBirthInformation({
-            birthCountry,
-            birthCity,
-            birthPostalCode,
-            birthINSEECode,
+            ...birthInformation,
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           });
@@ -109,11 +110,13 @@ describe('Unit | Service | Certification CPF service', function () {
 
         it('should return a validation failure when postal code is defined', async function () {
           // given
-          const birthCountry = 'PORTUGAL';
-          const birthCity = 'Porto';
-          const birthPostalCode = '1234';
-          const birthINSEECode = '99';
-          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          const birthInformation = {
+            birthCountry: 'PORTUGAL',
+            birthCity: 'Porto',
+            birthPostalCode: '1234',
+            birthINSEECode: '99',
+          };
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
           cpfBirthInformationValidation.failure({
             certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY,
           });
@@ -129,10 +132,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // when
           const result = await getBirthInformation({
-            birthCountry,
-            birthCity,
-            birthPostalCode,
-            birthINSEECode,
+            ...birthInformation,
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           });
@@ -143,11 +143,13 @@ describe('Unit | Service | Certification CPF service', function () {
 
         it('should return a validation failure when INSEE code is not defined', async function () {
           // given
-          const birthCountry = 'PORTUGAL';
-          const birthCity = 'Porto';
-          const birthPostalCode = null;
-          const birthINSEECode = null;
-          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          const birthInformation = {
+            birthCountry: 'PORTUGAL',
+            birthCity: 'Porto',
+            birthPostalCode: null,
+            birthINSEECode: null,
+          };
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
           cpfBirthInformationValidation.failure({
             certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
           });
@@ -163,10 +165,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // when
           const result = await getBirthInformation({
-            birthCountry,
-            birthCity,
-            birthPostalCode,
-            birthINSEECode,
+            ...birthInformation,
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           });
@@ -177,11 +176,13 @@ describe('Unit | Service | Certification CPF service', function () {
 
         it('should return a validation failure when INSEE code is not 99', async function () {
           // given
-          const birthCountry = 'PORTUGAL';
-          const birthCity = 'Porto';
-          const birthPostalCode = null;
-          const birthINSEECode = '1234';
-          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          const birthInformation = {
+            birthCountry: 'PORTUGAL',
+            birthCity: 'Porto',
+            birthPostalCode: null,
+            birthINSEECode: '1234',
+          };
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
           cpfBirthInformationValidation.failure({
             certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
           });
@@ -197,10 +198,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // when
           const result = await getBirthInformation({
-            birthCountry,
-            birthCity,
-            birthPostalCode,
-            birthINSEECode,
+            ...birthInformation,
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           });
@@ -211,10 +209,12 @@ describe('Unit | Service | Certification CPF service', function () {
 
         it('should return birth information when city name is defined', async function () {
           // given
-          const birthCountry = 'PORTUGAL';
-          const birthCity = 'Porto';
-          const birthPostalCode = null;
-          const birthINSEECode = '99';
+          const birthInformation = {
+            birthCountry: 'PORTUGAL',
+            birthCity: 'Porto',
+            birthPostalCode: null,
+            birthINSEECode: '99',
+          };
 
           const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({
             code: '1234',
@@ -227,10 +227,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // when
           const result = await getBirthInformation({
-            birthCountry,
-            birthCity,
-            birthPostalCode,
-            birthINSEECode,
+            ...birthInformation,
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           });
@@ -238,10 +235,8 @@ describe('Unit | Service | Certification CPF service', function () {
           // then
           expect(result).to.deep.equal(
             new CpfBirthInformationValidation({
-              birthCountry: 'PORTUGAL',
+              ...birthInformation,
               birthINSEECode: '1234',
-              birthPostalCode: null,
-              birthCity: 'Porto',
             })
           );
         });
@@ -252,11 +247,13 @@ describe('Unit | Service | Certification CPF service', function () {
           context('when birthcity is defined', function () {
             it('should return a validation failure', async function () {
               // given
-              const birthCountry = 'FRANCE';
-              const birthCity = 'Tours';
-              const birthPostalCode = null;
-              const birthINSEECode = null;
-              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              const birthInformation = {
+                birthCountry: 'FRANCE',
+                birthCity: 'Tours',
+                birthPostalCode: null,
+                birthINSEECode: null,
+              };
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
               cpfBirthInformationValidation.failure({
                 certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
               });
@@ -268,10 +265,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
               // when
               const result = await getBirthInformation({
-                birthCountry,
-                birthCity,
-                birthPostalCode,
-                birthINSEECode,
+                ...birthInformation,
                 certificationCpfCountryRepository,
                 certificationCpfCityRepository,
               });
@@ -283,11 +277,13 @@ describe('Unit | Service | Certification CPF service', function () {
           context('when birthcity is not defined', function () {
             it('should return a validation failure', async function () {
               // given
-              const birthCountry = 'FRANCE';
-              const birthCity = null;
-              const birthPostalCode = null;
-              const birthINSEECode = null;
-              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              const birthInformation = {
+                birthCountry: 'FRANCE',
+                birthCity: null,
+                birthPostalCode: null,
+                birthINSEECode: null,
+              };
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
               cpfBirthInformationValidation.failure({
                 certificationCandidateError:
                   CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
@@ -300,10 +296,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
               // when
               const result = await getBirthInformation({
-                birthCountry,
-                birthCity,
-                birthPostalCode,
-                birthINSEECode,
+                ...birthInformation,
                 certificationCpfCountryRepository,
                 certificationCpfCityRepository,
               });
@@ -318,11 +311,13 @@ describe('Unit | Service | Certification CPF service', function () {
           context('when birthcity is defined', function () {
             it('should return a validation failure', async function () {
               // given
-              const birthCountry = 'FRANCE';
-              const birthCity = 'MARSEILLE';
-              const birthPostalCode = '1234';
-              const birthINSEECode = '1234';
-              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              const birthInformation = {
+                birthCountry: 'FRANCE',
+                birthCity: 'MARSEILLE',
+                birthPostalCode: '1234',
+                birthINSEECode: '1234',
+              };
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
               cpfBirthInformationValidation.failure({
                 certificationCandidateError:
                   CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
@@ -343,10 +338,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
               // when
               const result = await getBirthInformation({
-                birthCountry,
-                birthCity,
-                birthPostalCode,
-                birthINSEECode,
+                ...birthInformation,
                 certificationCpfCountryRepository,
                 certificationCpfCityRepository,
               });
@@ -358,11 +350,13 @@ describe('Unit | Service | Certification CPF service', function () {
           context('when birthcity is not defined', function () {
             it('should return a validation failure', async function () {
               // given
-              const birthCountry = 'FRANCE';
-              const birthCity = null;
-              const birthPostalCode = '1234';
-              const birthINSEECode = '1234';
-              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              const birthInformation = {
+                birthCountry: 'FRANCE',
+                birthCity: null,
+                birthPostalCode: '1234',
+                birthINSEECode: '1234',
+              };
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
               cpfBirthInformationValidation.failure({
                 certificationCandidateError:
                   CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
@@ -375,10 +369,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
               // when
               const result = await getBirthInformation({
-                birthCountry,
-                birthCity,
-                birthPostalCode,
-                birthINSEECode,
+                ...birthInformation,
                 certificationCpfCountryRepository,
                 certificationCpfCityRepository,
               });
@@ -392,11 +383,13 @@ describe('Unit | Service | Certification CPF service', function () {
         context('when INSEE code is provided', function () {
           it('should return birth information when INSEE code is valid', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = null;
-            const birthPostalCode = null;
-            const birthINSEECode = '12345';
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: null,
+              birthPostalCode: null,
+              birthINSEECode: '12345',
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.success({
               birthCountry: 'FRANCE',
               birthINSEECode: '12345',
@@ -410,7 +403,7 @@ describe('Unit | Service | Certification CPF service', function () {
               .resolves(certificationCPFCountry);
 
             const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
-              INSEECode: birthINSEECode,
+              INSEECode: birthInformation.birthINSEECode,
               name: 'GOTHAM CITY',
             });
             certificationCpfCityRepository.findByINSEECode.resolves([certificationCPFCity]);
@@ -422,10 +415,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });
@@ -433,20 +423,22 @@ describe('Unit | Service | Certification CPF service', function () {
             // then
             expect(result).to.deep.equal(cpfBirthInformationValidation);
             expect(certificationCpfCityRepository.findByINSEECode).to.have.been.calledWith({
-              INSEECode: birthINSEECode,
+              INSEECode: birthInformation.birthINSEECode,
             });
           });
 
           it('should return a validation failure when INSEE code is not valid', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = null;
-            const birthPostalCode = null;
-            const birthINSEECode = '12345';
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: null,
+              birthPostalCode: null,
+              birthINSEECode: '12345',
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.failure({
               certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID,
-              data: { birthINSEECode },
+              data: { birthINSEECode: birthInformation.birthINSEECode },
             });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
@@ -459,10 +451,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });
@@ -473,11 +462,13 @@ describe('Unit | Service | Certification CPF service', function () {
 
           it('should return a validation failure when birth city is provided along with INSEE code', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = 'GOTHAM CITY';
-            const birthPostalCode = null;
-            const birthINSEECode = '12345';
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: 'GOTHAM CITY',
+              birthPostalCode: null,
+              birthINSEECode: '12345',
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.failure({
               certificationCandidateError:
                 CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
@@ -496,10 +487,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });
@@ -512,11 +500,13 @@ describe('Unit | Service | Certification CPF service', function () {
         context('when postal code is provided', function () {
           it('should return birth information when postal code is valid', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = 'GOTHAM CITY';
-            const birthPostalCode = '12345';
-            const birthINSEECode = null;
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: 'GOTHAM CITY',
+              birthPostalCode: '12345',
+              birthINSEECode: null,
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.success({
               birthCountry: 'FRANCE',
               birthINSEECode: null,
@@ -526,7 +516,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
             const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
-              birthPostalCode,
+              birthPostalCode: birthInformation.birthPostalCode,
               name: 'GOTHAM CITY',
             });
 
@@ -537,10 +527,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });
@@ -548,18 +535,20 @@ describe('Unit | Service | Certification CPF service', function () {
             // then
             expect(result).to.deep.equal(cpfBirthInformationValidation);
             expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({
-              postalCode: birthPostalCode,
+              postalCode: birthInformation.birthPostalCode,
             });
           });
 
           context('when there is multiple cities for the same postal code', function () {
             it('should return birth information with the normalized provided city name', async function () {
               // given
-              const birthCountry = 'FRANCE';
-              const birthCity = 'Losse-en-Gelaisse';
-              const birthPostalCode = '12345';
-              const birthINSEECode = null;
-              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              const birthInformation = {
+                birthCountry: 'FRANCE',
+                birthCity: 'Losse-en-Gelaisse',
+                birthPostalCode: '12345',
+                birthINSEECode: null,
+              };
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
               cpfBirthInformationValidation.success({
                 birthCountry: 'FRANCE',
                 birthINSEECode: null,
@@ -573,12 +562,12 @@ describe('Unit | Service | Certification CPF service', function () {
                 .resolves(certificationCPFCountry);
               certificationCpfCityRepository.findByPostalCode.resolves([
                 domainBuilder.buildCertificationCpfCity({
-                  birthPostalCode,
+                  birthPostalCode: birthInformation.birthPostalCode,
                   name: 'NOUILLORC',
                   isActualName: true,
                 }),
                 domainBuilder.buildCertificationCpfCity({
-                  birthPostalCode,
+                  birthPostalCode: birthInformation.birthPostalCode,
                   name: 'LOSSE EN GELAISSE',
                   isActualName: true,
                 }),
@@ -586,10 +575,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
               // when
               const result = await getBirthInformation({
-                birthCountry,
-                birthCity,
-                birthPostalCode,
-                birthINSEECode,
+                ...birthInformation,
                 certificationCpfCountryRepository,
                 certificationCpfCityRepository,
               });
@@ -597,21 +583,23 @@ describe('Unit | Service | Certification CPF service', function () {
               // then
               expect(result).to.deep.equal(cpfBirthInformationValidation);
               expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({
-                postalCode: birthPostalCode,
+                postalCode: birthInformation.birthPostalCode,
               });
             });
           });
 
           it('should return a validation failure when postal code is not valid', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = 'GOTHAM CITY';
-            const birthPostalCode = '12345';
-            const birthINSEECode = null;
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: 'GOTHAM CITY',
+              birthPostalCode: '12345',
+              birthINSEECode: null,
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.failure({
               certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND,
-              data: { birthPostalCode },
+              data: { birthPostalCode: birthInformation.birthPostalCode },
             });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
@@ -623,10 +611,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });
@@ -637,11 +622,13 @@ describe('Unit | Service | Certification CPF service', function () {
 
           it('should return a validation failure when birth city is not defined', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = null;
-            const birthPostalCode = '12345';
-            const birthINSEECode = null;
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: null,
+              birthPostalCode: '12345',
+              birthINSEECode: null,
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.failure({
               certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
             });
@@ -653,10 +640,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });
@@ -667,20 +651,22 @@ describe('Unit | Service | Certification CPF service', function () {
 
           it('should return a validation failure when postal code does not match city name', async function () {
             // given
-            const birthCountry = 'FRANCE';
-            const birthCity = 'METROPOLIS';
-            const birthPostalCode = '12345';
-            const birthINSEECode = null;
-            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            const birthInformation = {
+              birthCountry: 'FRANCE',
+              birthCity: 'METROPOLIS',
+              birthPostalCode: '12345',
+              birthINSEECode: null,
+            };
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation({ ...birthInformation });
             cpfBirthInformationValidation.failure({
               certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID,
-              data: { birthPostalCode, birthCity },
+              data: { birthPostalCode: birthInformation.birthPostalCode, birthCity: birthInformation.birthCity },
             });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
 
             const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
-              birthPostalCode,
+              birthPostalCode: birthInformation.birthPostalCode,
               name: 'GOTHAM CITY',
             });
 
@@ -691,10 +677,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // when
             const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
+              ...birthInformation,
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             });

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -18,7 +18,7 @@ export default class ImportCandidates extends Component {
     this.notifications.clearAll();
     try {
       await adapter.addCertificationCandidatesFromOds(sessionId, files);
-      this.notifications.success('La liste des candidats a été importée avec succès.');
+      this.notifications.success(this.intl.t('pages.sessions.import.candidates-list.import-success'));
       this.args.reloadCertificationCandidate();
     } catch (errorResponse) {
       const errorMessage = this._handleErrorMessage(errorResponse);

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -30,11 +30,19 @@ export default class ImportCandidates extends Component {
 
   _handleErrorMessage(errorResponse) {
     const error = errorResponse?.errors?.[0];
+    const errorPrefix = this.intl.t('pages.sessions.import.candidates-list.import-fail-prefix', { htmlSafe: true });
+
     if (error?.code) {
-      return this.intl.t(`common.api-error-messages.${error.code}`);
+      if (error.meta?.line) {
+        return `${errorPrefix} ${this.intl.t(`common.labels.line`, { line: error.meta.line })}
+        ${this.intl.t(`common.api-error-messages.certification-candidates-import.${error.code}`, {
+          ...error.meta,
+        })}`;
+      }
+
+      return `${errorPrefix} ${this.intl.t(`common.api-error-messages.${error.code}`)}`;
     }
 
-    const errorPrefix = this.intl.t('pages.sessions.import.candidates-list.import-fail-prefix', { htmlSafe: true });
     let errorMessage = `${errorPrefix} ${this.intl.t('pages.sessions.import.candidates-list.try-again-or-contact')}`;
 
     if (errorResponse?.errors) {

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -42,21 +42,6 @@ export default class ImportCandidates extends Component {
 
       return `${errorPrefix} ${this.intl.t(`common.api-error-messages.${error.code}`)}`;
     }
-
-    let errorMessage = `${errorPrefix} ${this.intl.t('pages.sessions.import.candidates-list.try-again-or-contact')}`;
-
-    if (errorResponse?.errors) {
-      errorResponse.errors.forEach((error) => {
-        if (error.status === '422') {
-          errorMessage = htmlSafe(`
-              <p>
-                ${errorPrefix}<b>${error.detail}</b>
-              </p>`);
-        }
-      });
-      return errorMessage;
-    }
-
-    return this.intl.t(`common.api-error-messages.internal-server-error`);
+    return `${errorPrefix} ${this.intl.t('pages.sessions.import.candidates-list.try-again-or-contact')}`;
   }
 }

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -35,7 +35,7 @@ export default class ImportCandidates extends Component {
     }
 
     const errorPrefix = this.intl.t('pages.sessions.import.candidates-list.import-fail-prefix', { htmlSafe: true });
-    let errorMessage = `${errorPrefix} Veuillez réessayer ou nous contacter via le formulaire du centre d'aide`;
+    let errorMessage = `${errorPrefix} ${this.intl.t('pages.sessions.import.candidates-list.try-again-or-contact')}`;
 
     if (errorResponse?.errors) {
       errorResponse.errors.forEach((error) => {

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -34,7 +34,7 @@ export default class ImportCandidates extends Component {
       return this.intl.t(`common.api-error-messages.${error.code}`);
     }
 
-    const errorPrefix = 'Aucun candidat n’a été importé. <br>';
+    const errorPrefix = this.intl.t('pages.sessions.import.candidates-list.import-fail-prefix', { htmlSafe: true });
     let errorMessage = `${errorPrefix} Veuillez réessayer ou nous contacter via le formulaire du centre d'aide`;
 
     if (errorResponse?.errors) {

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -125,6 +125,19 @@ export default function () {
         }
       );
     }
+    if (type === 'internal-error') {
+      return new Response(
+        500,
+        { some: 'header' },
+        {
+          errors: [
+            {
+              status: '500',
+            },
+          ],
+        }
+      );
+    }
     if (type === 'candidate-birth-postal-code-city-not-valid') {
       return new Response(
         422,

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -125,7 +125,7 @@ export default function () {
         }
       );
     }
-    if (type === 'validation-error') {
+    if (type === 'candidate-birth-postal-code-city-not-valid') {
       return new Response(
         422,
         { some: 'header' },
@@ -133,8 +133,12 @@ export default function () {
           errors: [
             {
               status: '422',
-              title: 'Unprocessable Entity',
-              detail: 'Une erreur personnalisée.',
+              code: 'CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID',
+              meta: {
+                line: 2,
+                birthPostalCode: 88000,
+                birthCity: 'Gotham City',
+              },
             },
           ],
         }

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -184,77 +184,87 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             .hasText('La liste des candidats a été importée avec succès.');
         });
 
-        test('it should display the error message when uploading an invalid file', async function (assert) {
-          // given
-          const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
-          const file = new Blob(['foo'], { type: 'invalid-file' });
+        module('error cases', function () {
+          module('when uploading an invalid file', function () {
+            test('it should display the error message', async function (assert) {
+              // given
+              const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+              const file = new Blob(['foo'], { type: 'invalid-file' });
 
-          // when
-          const input = find('#upload-attendance-sheet');
-          await triggerEvent(input, 'change', { files: [file] });
+              // when
+              const input = find('#upload-attendance-sheet');
+              await triggerEvent(input, 'change', { files: [file] });
 
-          // then
-          assert
-            .dom(
-              screen.getByText(
-                "Aucun candidat n’a été importé.La version du document est inconnue.Veuillez télécharger à nouveau le modèle de liste des candidats et l'importer à nouveau.",
-                { exact: false }
-              )
-            )
-            .exists();
-        });
-
-        test('it should display the error message when uploading a file with validation error', async function (assert) {
-          // given
-          await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
-          const file = new Blob(['foo'], { type: 'validation-error' });
-
-          // when
-          const input = find('#upload-attendance-sheet');
-          await triggerEvent(input, 'change', { files: [file] });
-
-          // then
-          assert
-            .dom('[data-test-notification-message="error"]')
-            .hasText('Aucun candidat n’a été importé. Une erreur personnalisée.');
-        });
-
-        test('it should display a specific error message when importing is forbidden', async function (assert) {
-          // given
-          const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
-          const file = new Blob(['foo'], { type: 'forbidden-import' });
-
-          // when
-          const input = find('#upload-attendance-sheet');
-          await triggerEvent(input, 'change', { files: [file] });
-
-          // then
-          assert
-            .dom(
-              screen.getByText(
-                (errorMessage) =>
-                  errorMessage.startsWith('Aucun candidat n’a été importé.') &&
-                  errorMessage.endsWith(
-                    'Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    "Aucun candidat n’a été importé.La version du document est inconnue.Veuillez télécharger à nouveau le modèle de liste des candidats et l'importer à nouveau.",
+                    { exact: false }
                   )
-              )
-            )
-            .exists();
-        });
+                )
+                .exists();
+            });
+          });
 
-        test('it should display a warning when the import is not allowed', async function (assert) {
-          // given
-          server.create('certification-candidate', { sessionId: sessionWithCandidates.id, isLinked: true });
+          module('when uploading a file with validation error', function () {
+            test('it should display the error message', async function (assert) {
+              // given
+              await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+              const file = new Blob(['foo'], { type: 'validation-error' });
 
-          // when
-          await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+              // when
+              const input = find('#upload-attendance-sheet');
+              await triggerEvent(input, 'change', { files: [file] });
 
-          // then
-          assert
-            .dom('.panel-actions__warning')
-            .hasText(
-              'La session a débuté, vous ne pouvez plus importer une liste de candidats. Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
-            );
+              // then
+              assert
+                .dom('[data-test-notification-message="error"]')
+                .hasText('Aucun candidat n’a été importé. Une erreur personnalisée.');
+            });
+          });
+
+          module('when importing is forbidden', function () {
+            test('it should display a specific error message', async function (assert) {
+              // given
+              const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+              const file = new Blob(['foo'], { type: 'forbidden-import' });
+
+              // when
+              const input = find('#upload-attendance-sheet');
+              await triggerEvent(input, 'change', { files: [file] });
+
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    (errorMessage) =>
+                      errorMessage.startsWith('Aucun candidat n’a été importé.') &&
+                      errorMessage.endsWith(
+                        'Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
+                      )
+                  )
+                )
+                .exists();
+            });
+          });
+
+          module('when the import is not allowed', function () {
+            test('it should display a warning', async function (assert) {
+              // given
+              server.create('certification-candidate', { sessionId: sessionWithCandidates.id, isLinked: true });
+
+              // when
+              await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+
+              // then
+              assert
+                .dom('.panel-actions__warning')
+                .hasText(
+                  'La session a débuté, vous ne pouvez plus importer une liste de candidats. Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
+                );
+            });
+          });
         });
       });
     });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -226,6 +226,27 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             });
           });
 
+          module('when uploading a file with generic error', function () {
+            test('it should display the default message', async function (assert) {
+              // given
+              const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+              const file = new Blob(['foo'], { type: 'internal-error' });
+
+              // when
+              const input = find('#upload-attendance-sheet');
+              await triggerEvent(input, 'change', { files: [file] });
+
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    "Aucun candidat n’a été importé. Veuillez réessayer ou nous contacter via le formulaire du centre d'aide."
+                  )
+                )
+                .exists();
+            });
+          });
+
           module('when importing is forbidden', function () {
             test('it should display a specific error message', async function (assert) {
               // given

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -211,7 +211,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             test('it should display the error message', async function (assert) {
               // given
               await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
-              const file = new Blob(['foo'], { type: 'validation-error' });
+              const file = new Blob(['foo'], { type: 'candidate-birth-postal-code-city-not-valid' });
 
               // when
               const input = find('#upload-attendance-sheet');
@@ -220,7 +220,9 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               // then
               assert
                 .dom('[data-test-notification-message="error"]')
-                .hasText('Aucun candidat n’a été importé. Une erreur personnalisée.');
+                .hasText(
+                  'Aucun candidat n’a été importé. Ligne 2 : Le code postal "88000" ne correspond pas à la ville "Gotham City"'
+                );
             });
           });
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -171,7 +171,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
         test('it should display a success message when uploading a valid file', async function (assert) {
           // given
-          await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+          const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
           const file = new Blob(['foo'], { type: 'valid-file' });
 
           // when
@@ -179,9 +179,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           await triggerEvent(input, 'change', { files: [file] });
 
           // then
-          assert
-            .dom('[data-test-notification-message="success"]')
-            .hasText('La liste des candidats a été importée avec succès.');
+          assert.dom(screen.getByText('La liste des candidats a été importée avec succès.')).exists();
         });
 
         module('error cases', function () {
@@ -210,7 +208,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           module('when uploading a file with validation error', function () {
             test('it should display the error message', async function (assert) {
               // given
-              await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
+              const screen = await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
               const file = new Blob(['foo'], { type: 'candidate-birth-postal-code-city-not-valid' });
 
               // when
@@ -219,10 +217,12 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
               // then
               assert
-                .dom('[data-test-notification-message="error"]')
-                .hasText(
-                  'Aucun candidat n’a été importé. Ligne 2 : Le code postal "88000" ne correspond pas à la ville "Gotham City"'
-                );
+                .dom(
+                  screen.getByText(
+                    'Aucun candidat n’a été importé. Ligne 2 : Le code postal "88000" ne correspond pas à la ville "Gotham City"'
+                  )
+                )
+                .exists();
             });
           });
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -232,7 +232,11 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           assert
             .dom(
               screen.getByText(
-                'La session a débuté, vous ne pouvez plus importer une liste de candidats.Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
+                (errorMessage) =>
+                  errorMessage.startsWith('Aucun candidat n’a été importé.') &&
+                  errorMessage.endsWith(
+                    'Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
+                  )
               )
             )
             .exists();
@@ -249,7 +253,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           assert
             .dom('.panel-actions__warning')
             .hasText(
-              'La session a débuté, vous ne pouvez plus importer une liste de candidats.Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
+              'La session a débuté, vous ne pouvez plus importer une liste de candidats. Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
             );
         });
       });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -592,6 +592,7 @@
         "candidates-list": {
           "import-fail-prefix": "No candidate has been uploaded.<br/>",
           "import-success": "The candidate list has been successfully uploaded.",
+          "try-again-or-contact": "Please try again or contact us through the help centre’s form.",
           "unknown-document-version": "This version of the document is unknown."
         },
         "step-one": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -589,6 +589,9 @@
           "import": "Import du modèle",
           "summary": "Récapitulatif"
         },
+        "candidates-list": {
+          "import-success": "The candidate list has been successfully uploaded."
+        },
         "step-one": {
           "actions": {
             "cancel": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -482,7 +482,7 @@
               "error-remove-already-in": "This candidate has already joined the session, you can’t delete them.",
               "error-remove-unknown": "An error occurred while deleting the candidate.",
               "success-add": "The candidate has been successfully enrolled.",
-              "success-remove": "The candidate has been successfully deleted.Ï"
+              "success-remove": "The candidate has been successfully deleted."
             },
             "prepayment-information": "Prepayment code information",
             "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -590,7 +590,9 @@
           "summary": "Récapitulatif"
         },
         "candidates-list": {
-          "import-success": "The candidate list has been successfully uploaded."
+          "import-fail-prefix": "No candidate has been uploaded.<br/>",
+          "import-success": "The candidate list has been successfully uploaded.",
+          "unknown-document-version": "This version of the document is unknown."
         },
         "step-one": {
           "actions": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -26,6 +26,31 @@
       "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "The field \"Reason for abandonment\" has been filled in for a candidate who has finished their certification exam in between. The session therefore can't be finalised. Please refresh the page before finalising.",
       "authorize-resume-error": "An error has occurred, {firstName} {lastName} couldn't be allowed to resume his/her Pix certification exam.",
       "bad-request-error": "The data entered was not in the correct format.",
+      "certification-candidates-import": {
+        "CANDIDATE_BILLING_MODE_NOT_VALID": "The field \"Pricing of Pix’s share\" can only contain one of the following values : Free, Payable, Prepaid.",
+        "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "The field \"Date of birth\" must be in DD/MM/YYYY format.",
+        "CANDIDATE_BIRTH_CITY_REQUIRED": "The field \"Name of birth city\" is required",
+        "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "The country \"{birthCountry}\" hasn’t been found",
+        "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "The field \"Country\" is required",
+        "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Fill in the candidate’s birth information",
+        "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "The INSEE code \"{birthINSEECode}\" is invalid",
+        "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Fill in either an INSEE code or a postcode and the name of the birth city",
+        "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "The postcode \"{birthPostalCode}\" doesn’t match with the city \"{birthCity}\"",
+        "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "The postcode \"{birthPostalCode}\" is invalid",
+        "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "The field \"Postcode\" is required",
+        "CANDIDATE_EMAIL_NOT_VALID": "The field \"{label}\" must be in email format",
+        "CANDIDATE_EXTRA_TIME_OUT_OF_RANGE": "The field \"Extra time\" is invalid (format accepted example: 30%)",
+        "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidate born abroad, required field \"Name of birth city\" is missing",
+        "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "The value of the INSEE code must be \"99\" for any birth country other than France",
+        "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidate born abroad, the field \"Postcode\" must stay blank",
+        "CANDIDATE_INFORMATION_MUST_BE_A_NUMBER": "The field \"{label}\" must be a number",
+        "CANDIDATE_INFORMATION_MUST_BE_A_STRING": "The field \"{label}\" must be a string of characters",
+        "CANDIDATE_INFORMATION_REQUIRED": "The field \"{label}\" is required",
+        "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "You cannot register a candidate for more than one complementary certification",
+        "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "The field \"Prepayment code\" must remain blank since the \"Prepaid\" option hasn't been selected for this candidate",
+        "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "The field \"Prepayment code\" is required since the \"Prepaid\" option has been selected for this candidate",
+        "CANDIDATE_SEX_NOT_VALID": "The field \"Gender\" accepts the values \"M\" for a man or \"F\" for a woman"
+      },
       "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
       "login-unauthorized-error": "There was an error in the email address or password entered.",
@@ -113,7 +138,8 @@
         "lastname": "Last name",
         "none": "None",
         "postcode": "City postcode"
-      }
+      },
+      "line": "Line {line}: "
     },
     "sessions": {
       "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -26,6 +26,31 @@
       "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.",
       "authorize-resume-error": "Une erreur est survenue, {firstName} {lastName} n'a pas pu être autorisé à reprendre son test.",
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+      "certification-candidates-import": {
+        "CANDIDATE_BILLING_MODE_NOT_VALID": "Le champ \"Tarification part Pix\" ne peut contenir qu'une des valeurs suivantes: Gratuite, Payante ou Prépayée",
+        "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Le champ \"Date de naissance\" doit être au format jj/mm/aaaa",
+        "CANDIDATE_BIRTH_CITY_REQUIRED": "Le champ \"Nom de la commune\" est obligatoire",
+        "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Le pays \"{birthCountry}\" n'a pas été trouvé",
+        "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Le champ \"Pays\" est obligatoire",
+        "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
+        "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Le code INSEE \"{birthINSEECode}\" est invalide",
+        "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE soit un code postal et un nom de commune de naissance",
+        "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal \"{birthPostalCode}\" ne correspond pas à la ville \"{birthCity}\"",
+        "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Le code postal \"{birthPostalCode}\" est invalide",
+        "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Le champ \"Code postal\" est obligatoire",
+        "CANDIDATE_EMAIL_NOT_VALID": "Le champ \"{label}\" doit être au format e-mail",
+        "CANDIDATE_EXTRA_TIME_OUT_OF_RANGE": "Le champ \"Temps majoré\" est invalide (exemple de format accepté: 30%)",
+        "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire nom de commune de naissance manquant",
+        "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "La valeur du code INSEE doit être \"99\" pour un pays étranger",
+        "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
+        "CANDIDATE_INFORMATION_MUST_BE_A_NUMBER": "Le champ \"{label}\" doit être un nombre",
+        "CANDIDATE_INFORMATION_MUST_BE_A_STRING": "Le champ \"{label}\" doit être une chaîne de caractères",
+        "CANDIDATE_INFORMATION_REQUIRED": "Le champ \"{label}\" est obligatoire",
+        "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Vous ne pouvez pas inscrire un candidat à plus d'une certification complémentaire",
+        "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Le champ \"Code de prépaiement\" doit rester vide puisque l’option \"Prépayée\" n'a pas été sélectionnée pour ce candidat",
+        "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Le champ \"Code de prépaiement\" est obligatoire puisque l’option \"Prépayée\" a été sélectionnée pour ce candidat",
+        "CANDIDATE_SEX_NOT_VALID": "Le champ \"Sexe\" accepte les valeurs \"M\" pour un homme ou \"F\" pour une femme"
+      },
       "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
       "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
       "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
@@ -113,7 +138,8 @@
         "lastname": "Nom",
         "none": "Aucune",
         "postcode": "Code postal"
-      }
+      },
+      "line": "Ligne {line} : "
     },
     "sessions": {
       "actions": {
@@ -532,7 +558,7 @@
               }
             },
             "title": "Inscrire des candidats",
-            "warning": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous."
+            "warning": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br /> Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous."
           }
         },
         "downloads": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -592,6 +592,7 @@
         "candidates-list": {
           "import-fail-prefix": "Aucun candidat n’a été importé. <br/>",
           "import-success": "La liste des candidats a été importée avec succès.",
+          "try-again-or-contact": "Veuillez réessayer ou nous contacter via le formulaire du centre d'aide.",
           "unknown-document-version": "La version du document est inconnue."
         },
         "step-one": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -589,6 +589,9 @@
           "import": "Import du modèle",
           "summary": "Récapitulatif"
         },
+        "candidates-list": {
+          "import-success": "La liste des candidats a été importée avec succès."
+        },
         "step-one": {
           "actions": {
             "cancel": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -28,7 +28,7 @@
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
       "certification-candidates-import": {
         "CANDIDATE_BILLING_MODE_NOT_VALID": "Le champ \"Tarification part Pix\" ne peut contenir qu'une des valeurs suivantes: Gratuite, Payante ou Prépayée",
-        "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Le champ \"Date de naissance\" doit être au format jj/mm/aaaa",
+        "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Le champ \"Date de naissance\" doit être au format JJ/MM/AAAA",
         "CANDIDATE_BIRTH_CITY_REQUIRED": "Le champ \"Nom de la commune\" est obligatoire",
         "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Le pays \"{birthCountry}\" n'a pas été trouvé",
         "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Le champ \"Pays\" est obligatoire",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -590,7 +590,9 @@
           "summary": "Récapitulatif"
         },
         "candidates-list": {
-          "import-success": "La liste des candidats a été importée avec succès."
+          "import-fail-prefix": "Aucun candidat n’a été importé. <br/>",
+          "import-success": "La liste des candidats a été importée avec succès.",
+          "unknown-document-version": "La version du document est inconnue."
         },
         "step-one": {
           "actions": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, lors de l'import d'un candidat via le template, les erreurs retournées sont en français en dur. Elles ne sont donc pas traduites.

## :robot: Proposition
Traduire les erreurs lors de l'import.

## :rainbow: Remarques
Suite à l'ADR, nous retournons des codes d'erreurs coté API et c'est le front qui se charge des traductions.

## :100: Pour tester

- Se connecter avec certifsup@example.net sur Pix Certif
- Passer en anglais (changer la langue de l'utilisateur sur Pix App (en org))
- Créer une nouvelle session (ou trouver une session qui puisse encore importer des candidats via template)
- Dans le détail d'une session, cliquer dans l'onglet candidat et télécharger le template.
- Dans ce dernier essayer plusieurs erreurs : 

ex : 
- Ne pas mettre les infos obligatoires (ceux avec les *)
- Se tromper sur le format attendu (ex : Mettre un A pour le Sexe, mettre une adresse e-mail incomplète)
- Mettre le code postal 75015 / Nom de la commune : Paris / Pays : Tutu

- Constater que les messages d'erreurs sont correctement traduits (avec l'indication de la ligne impactée)


<img width="649" alt="Capture d’écran 2023-06-14 à 11 06 04" src="https://github.com/1024pix/pix/assets/58915422/ea475e2c-ef1f-4ad3-ba14-80a41682e1dc">
<img width="453" alt="Capture d’écran 2023-06-14 à 11 06 15" src="https://github.com/1024pix/pix/assets/58915422/dd36dfe9-538d-4915-a21d-efd6bf77bfed">


