### PR TITLE
[FEATURE] Script de migration des paliers seuils en niveaux (PIX-8098)

### DIFF
--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -1,0 +1,175 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { readFile, writeFile } from 'fs/promises';
+import { dirname, resolve } from 'path';
+import { performance } from 'perf_hooks';
+import { fileURLToPath } from 'url';
+import { utils as xlsxUtils, writeXLSX } from 'xlsx';
+import fp from 'lodash/fp.js';
+
+import { logger } from '../../../lib/infrastructure/logger.js';
+import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
+import { disconnect } from '../../../db/knex-database-connection.js';
+
+import * as targetProfileForAdminRepository from '../../../lib/infrastructure/repositories/target-profile-for-admin-repository.js';
+import * as skillRepository from '../../../lib/infrastructure/repositories/skill-repository.js';
+
+const modulePath = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+export async function migrateStagesToLevel(inputFile) {
+  const buf = await readFile(inputFile);
+  const targetProfileIds = JSON.parse(buf.toString());
+
+  const migrations = await Promise.all(
+    targetProfileIds.map(async (targetProfileId) => {
+      const targetProfile = await targetProfileForAdminRepository.get({ id: targetProfileId });
+
+      const levels = await _computeLevels(targetProfile.cappedTubes);
+
+      const stagesWOLevel = _getStagesWOLevel(targetProfile.stageCollection.stages);
+
+      const stagesMigrations = _computeStagesMigrations(stagesWOLevel, levels);
+
+      return {
+        targetProfileId,
+        stagesMigrations,
+        ok: _checkAllStagesHaveLevels(stagesMigrations) && _checkStagesHaveDifferentLevels(stagesMigrations),
+        levels,
+      };
+    })
+  );
+
+  await _writeReport(migrations);
+}
+
+async function _computeLevels(cappedTubes) {
+  const cappedTubesSkills = await Promise.all(
+    cappedTubes.map(async (cappedTube) => {
+      const skills = await skillRepository.findActiveByTubeId(cappedTube.id);
+      return skills.filter((skill) => skill.difficulty <= cappedTube.level);
+    })
+  );
+
+  const skills = cappedTubesSkills.flat();
+  const nbSkills = skills.length;
+
+  return fp.flow([
+    fp.countBy('difficulty'),
+    fp.entries,
+    fp.map(([sLevel, count]) => ({ level: +sLevel, count })),
+    fp.sortBy('level'),
+    fp.transform(
+      (levels, level) => {
+        const prevLevel = levels.at(-1);
+        const count = prevLevel.count + level.count;
+
+        if (count === nbSkills) {
+          prevLevel.maxThreshold = 100;
+          levels.push({
+            ...level,
+            count,
+            threshold: 100,
+            minThreshold: 100,
+            maxThreshold: 100.00000000000001,
+          });
+          return;
+        }
+
+        const threshold = (count / nbSkills) * 100;
+        const minThreshold =
+          prevLevel.level === 0 ? Number.MIN_VALUE : (threshold - prevLevel.threshold) / 2 + prevLevel.threshold;
+        prevLevel.maxThreshold = minThreshold;
+
+        levels.push({
+          ...level,
+          count,
+          threshold,
+          minThreshold,
+        });
+      },
+      [{ level: 0, threshold: 0, minThreshold: 0, maxThreshold: Number.MIN_VALUE, count: 0 }]
+    ),
+  ])(skills);
+}
+
+function _getStagesWOLevel(stages) {
+  return stages
+    .filter(({ isFirstSkill, level }) => !isFirstSkill && level == null)
+    .sort(({ threshold: t1 }, { threshold: t2 }) => t1 - t2);
+}
+
+function _computeStagesMigrations(stages, levels) {
+  return stages.map((stage) => {
+    const level = levels.find(
+      ({ minThreshold, maxThreshold }) => stage.threshold >= minThreshold && stage.threshold <= maxThreshold
+    );
+    return {
+      stageId: stage.id,
+      threshold: stage.threshold,
+      level: level?.level,
+    };
+  });
+}
+
+function _checkAllStagesHaveLevels(stagesMigrations) {
+  return stagesMigrations.every(({ level }) => level != null) ?? true;
+}
+
+function _checkStagesHaveDifferentLevels(stagesMigrations) {
+  return fp.flow([fp.countBy('level'), fp.every((count) => count === 1)])(stagesMigrations);
+}
+
+async function _writeReport(migrations) {
+  const wb = xlsxUtils.book_new();
+
+  const mainWS = xlsxUtils.aoa_to_sheet([
+    ['ID profil cible', 'Statut'],
+    ...migrations.map(({ targetProfileId, ok }) => [targetProfileId, ok ? 'OK' : 'KO']),
+  ]);
+  xlsxUtils.book_append_sheet(wb, mainWS, 'Résumé');
+
+  for (const { targetProfileId, stagesMigrations, levels } of migrations) {
+    const ws = xlsxUtils.aoa_to_sheet([
+      ['ID palier', 'Seuil', 'Niveau'],
+      ...stagesMigrations.map(({ stageId, threshold, level }) => [stageId, threshold, level]),
+      [],
+      ['Seuil théorique', 'Seuil min.', 'Seuil max.', 'Niveau'],
+      ...levels.map(({ threshold, minThreshold, maxThreshold, level }) => [
+        threshold,
+        minThreshold,
+        maxThreshold,
+        level,
+      ]),
+    ]);
+    xlsxUtils.book_append_sheet(wb, ws, `${targetProfileId}`);
+  }
+
+  const buf = writeXLSX(wb, { compression: true, type: 'buffer' });
+  await writeFile(resolve(dirname(modulePath), 'stages-migration.xlsx'), buf);
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${modulePath} has started`);
+  const inputFile = resolve(process.cwd(), process.argv[2]);
+  await migrateStagesToLevel(inputFile);
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -82,7 +82,7 @@ async function _computeLevels(cappedTubes) {
             count,
             threshold: 100,
             minThreshold: 100,
-            maxThreshold: 100.00000000000001,
+            maxThreshold: 100.1,
           });
           return;
         }
@@ -99,7 +99,7 @@ async function _computeLevels(cappedTubes) {
           minThreshold,
         });
       },
-      [{ level: 0, threshold: 0, minThreshold: 0, maxThreshold: Number.MIN_VALUE, count: 0 }]
+      [{ level: 0, threshold: 0, minThreshold: 0, maxThreshold: 0.1, count: 0 }]
     ),
   ])(skills);
 }
@@ -113,7 +113,7 @@ function _getStagesWOLevel(stages) {
 function _computeStagesMigrations(stages, levels) {
   return stages.map((stage) => {
     const level = levels.find(
-      ({ minThreshold, maxThreshold }) => stage.threshold >= minThreshold && stage.threshold <= maxThreshold
+      ({ minThreshold, maxThreshold }) => stage.threshold >= minThreshold && stage.threshold < maxThreshold
     );
     return {
       stageId: stage.id,


### PR DESCRIPTION
## :unicorn: Problème
Il existe des paliers seuils qu'il faut migrer en niveaux.

## :robot: Proposition
Prend en entrée une liste de PC.
Migre les paliers de ces PC en niveaux en calculant le niveau correspondant au seuil pour chaque palier (on prend le niveau le plus "proche").

## :rainbow: Remarques
Le script est en dry run par défaut.
Pour désactiver le dry run il faut mettre `DRY_RUN=false`.

## :100: Pour tester
Pour lancer le script :
```
cd api
node scripts/prod/target-profile-migrations/migrate-stages-to-level.js scripts/prod/target-profile-migrations/need-stages-migration.json
```

Pour générer le fichier `need-stages-migration.json` :
```
node scripts/prod/target-profile-migrations/extract-need-stages-migration.js scripts/prod/target-profile-migrations/xlsx/*.xlsx
```