### PR TITLE
[FEATURE] Avoir toujours la liste des badges et des logos des éditeurs de CF à jour (PIX-8218).

### DIFF
--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -10,7 +10,7 @@
       <p class="badge-form__information">
         <a
           class="badge-form__information--link"
-          href="https://images.pix.fr/badges.html"
+          href="https://1024pix.github.io/pix-images-list/badges.html"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/admin/app/components/trainings/create-or-update-training-form.hbs
+++ b/admin/app/components/trainings/create-or-update-training-form.hbs
@@ -81,7 +81,7 @@
         <label for="trainingEditorLogoUrl-name">Nom du fichier du logo éditeur (.svg)
           <span class="training-editor-logo-url-input__information">
             <a
-              href="https://images.pix.fr/contenu-formatif/editeurs.html"
+              href="https://1024pix.github.io/pix-images-list/editeurs-cf.html"
               target="_blank"
               rel="noopener noreferrer"
             >Voir la liste des logos éditeur</a>


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il faut mettre à jour manuellement la liste des badges et celles des logos des éditeurs de contenus formatifs.

## :robot: Proposition
Nous avons créé un repo, qui contient des pages html qui récupère les bonnes images et les affiche.
Dans cette PR nous changeons les liens pour pointer vers ces nouveaux liens.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Admin 
- Aller sur un profil cible puis clés de lecture 
- Cliquer sur "Nouveau résultat thématique"
- Ouvrir le lien de la documentation et constater le bon fonctionnement

- Aller ensuite dans l'onglet contenus formatifs
- Puis créer un profil cible
- Ouvrir le lien de la documentation et constater le bon fonctionnement