### PR TITLE
[FEATURE] Amélioration et ajout d'une barre de défilement au menu utilisateur sur Pix Certif (PIX-8154).

### DIFF
--- a/certif/app/components/dropdown/item.hbs
+++ b/certif/app/components/dropdown/item.hbs
@@ -1,3 +1,5 @@
-<li class="dropdown__item" ...attributes>
-  <div role="button" class="dropdown__item__button" {{on "click" @onClick}}>{{yield}}</div>
+<li class="dropdown__item dropdown__item--link" ...attributes>
+  <button type="button" {{on "click" @onClick}}>
+    {{yield}}
+  </button>
 </li>

--- a/certif/app/components/user-logged-menu.hbs
+++ b/certif/app/components/user-logged-menu.hbs
@@ -1,29 +1,24 @@
-<div class="dropdown logged-user-summary content-text content-text--small" aria-label="Résumé utilisateur">
-  <a
-    href="#"
-    class="logged-user-summary__link"
-    {{on "click" (toggle "isMenuOpen" this)}}
-    aria-haspopup="listbox"
-    aria-expanded="{{this.isMenuOpen}}"
-  >
-    <div>
-      <div class="logged-user-summary__name">{{this.userFullName}}</div>
-      <div class="logged-user-summary__certification-center">{{this.certificationCenterNameAndExternalId}}</div>
-    </div>
-    {{#if this.isMenuOpen}}
-      <FaIcon @icon="chevron-up" class="logged-user-summary__chevron logged-user-summary__chevron-up" />
-    {{else}}
-      <FaIcon @icon="chevron-down" class="logged-user-summary__chevron" />
-    {{/if}}
-  </a>
-</div>
-
-<Dropdown::Content
-  @display={{this.isMenuOpen}}
-  @close={{this.closeMenu}}
-  class="logged-user-menu"
-  aria-label="Menu utilisateur"
+<button
+  type="button"
+  {{on "click" (toggle "isMenuOpen" this)}}
+  aria-haspopup="listbox"
+  aria-expanded="{{this.isMenuOpen}}"
+  class="logged-user-summary"
+  ...attributes
 >
+  <span class="logged-user-summary__text">
+    <span>{{this.userFullName}}</span>
+    <span>{{this.certificationCenterNameAndExternalId}}</span>
+  </span>
+  <span class="screen-reader-only">{{t "navigation.user-logged-menu.button-extra-information"}}</span>
+  {{#if this.isMenuOpen}}
+    <FaIcon @icon="chevron-up" @class="logged-user-summary__chevron logged-user-summary__chevron--up" />
+  {{else}}
+    <FaIcon @icon="chevron-down" @class="logged-user-summary__chevron" />
+  {{/if}}
+</button>
+
+<Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} class="logged-user-menu">
   {{#each this.eligibleCertificationCenterAccesses as |certificationCenterAccess|}}
     <Dropdown::Item
       @onClick={{fn this.onCertificationCenterAccessChanged certificationCenterAccess}}
@@ -32,13 +27,11 @@
     >
       <span class="logged-user-menu-item__certification-center-name">{{certificationCenterAccess.name}}</span>
       {{#if certificationCenterAccess.externalId}}
-        <span
-          class="logged-user-menu-item__certification-center-externalId"
-        >({{certificationCenterAccess.externalId}})</span>
+        <span>({{certificationCenterAccess.externalId}})</span>
       {{/if}}
     </Dropdown::Item>
   {{/each}}
-  <Dropdown::ItemLink @linkTo="logout" class="logged-user-menu-item logged-user-menu-item__last">
+  <Dropdown::ItemLink @linkTo="logout" class="logged-user-menu-item">
     <FaIcon @icon="power-off" @class="logged-user-menu-item__icon" />
     {{t "navigation.user-logged-menu.logout"}}
   </Dropdown::ItemLink>

--- a/certif/app/styles/components/dropdown.scss
+++ b/certif/app/styles/components/dropdown.scss
@@ -4,7 +4,7 @@
 
   &__content {
     background-color: $pix-neutral-0;
-    border-radius: 4px;
+    border-radius: $pix-spacing-xxs;
     box-shadow: 1px 1px 3px 1px rgba($pix-neutral-110, 0.13), 0 1px 1px 0 rgba($pix-neutral-110, 0.08);
     overflow: hidden;
     position: absolute;
@@ -14,27 +14,48 @@
   }
 
   &__item {
-    align-items: center;
-    border-radius: 4px;
-    color: $pix-neutral-60;
-    cursor: pointer;
     display: flex;
-    font-size: 0.875rem;
-    transition: background-color 0.1s linear;
-
-    &__button {
-      padding: 12px 16px;
-      display: flex;
-    }
 
     &--link {
       padding: 0;
 
-      > a {
+      > button {
+        border: none;
+        background-color: transparent;
+        font-family: $font-roboto;
+        text-align: start;
+      }
+
+      > a,
+      > button {
+        color: $pix-neutral-60;
         padding: 12px 16px;
         width: 100%;
         height: 100%;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: background-color 0.1s linear;
+
+        &:hover,
+        &:active,
+        &:focus {
+          background-color: $pix-neutral-10;
+          color: $pix-neutral-60;
+          text-decoration: none;
+        }
+
+        &:focus,
+        &:focus-visible {
+          border-radius: $pix-spacing-xxs;
+          box-shadow: inset 0 0 0 1.6px $pix-primary;
+          outline: none;
+        }
       }
+    }
+
+    &__button {
+      padding: 12px 16px;
+      display: flex;
     }
 
     &:hover,

--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -54,6 +54,8 @@
   right: 0;
   top: 60px;
   min-width: 400px;
+  overflow: scroll;
+  max-height: 600px;
 
   &-item {
     text-decoration: none;

--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -1,29 +1,42 @@
 .logged-user-summary {
-  letter-spacing: 0.0313rem;
-  text-align: right;
+  color: $pix-neutral-60;
+  cursor: pointer;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 30px;
+  background-color: transparent;
+  border-width: 0;
+  border-left: 1px solid $pix-neutral-20;
 
-  &__link {
-    color: $pix-neutral-60;
-    cursor: pointer;
-    display: flex;
+  &:hover,
+  &:active,
+  &:focus {
+    color: $pix-neutral-70;
     text-decoration: none;
-
-    &:hover,
-    &:active,
-    &:focus {
-      color: $pix-neutral-70;
-    }
   }
 
-  &__name {
+  &:focus {
+    border-radius: $pix-spacing-xxs;
+    box-shadow: inset 0 0 0 1.6px $pix-primary;
+    outline: none;
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: right;
     font-size: 0.875rem;
-    font-weight: bold;
-    height: 19px;
-    text-transform: capitalize;
+    font-weight: 700;
+    letter-spacing: .0313rem;
+    height: 100%;
+    line-height: 1.1rem;
+    padding-right: $pix-spacing-xs;
   }
 
-  &__certification-center {
-    height: 18px;
+  &__text > *:last-child {
+    font-weight: normal;
   }
 
   &__chevron {
@@ -31,7 +44,7 @@
     margin-left: 18px;
     vertical-align: middle;
 
-    &-up {
+    &--up {
       color: $pix-primary;
     }
   }
@@ -39,12 +52,10 @@
 
 .logged-user-menu {
   right: 0;
-  margin-right: 10px;
-  top: 50px;
+  top: 60px;
   min-width: 400px;
 
   &-item {
-    color: $pix-neutral-60;
     text-decoration: none;
 
     &:hover,
@@ -67,10 +78,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-
-    &__certification-center-externalId {
-      flex: 0;
     }
   }
 }

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -79,10 +79,4 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-
-  &__user-logged-menu {
-    position: relative;
-    padding: 0 30px;
-    border-left: 1px solid $pix-neutral-20;
-  }
 }

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -53,9 +53,7 @@
   <div class="app__main-content main-content">
 
     <div class="main-content__topbar topbar">
-      <div class="topbar__user-logged-menu"><UserLoggedMenu
-          @onCertificationCenterAccessChanged={{this.changeCurrentCertificationCenterAccess}}
-        /></div>
+      <UserLoggedMenu @onCertificationCenterAccessChanged={{this.changeCurrentCertificationCenterAccess}} />
     </div>
 
     {{#if this.showBanner}}

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -153,11 +153,13 @@ module('Acceptance | authenticated', function (hooks) {
 
       // when
       const screen = await visitScreen('/');
-      await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Bibiche (ABC123) Ouvrir le menu utilisateur' }));
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Buffy Summers Poupoune (DEF456)' })).exists();
+      assert
+        .dom(screen.getByRole('button', { name: 'Buffy Summers Poupoune (DEF456) Ouvrir le menu utilisateur' }))
+        .exists();
     });
 
     test('should redirect to sessions/liste URL when changing the current certification center', async function (assert) {
@@ -189,7 +191,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // when
       const screen = await visitScreen('/sessions/555');
-      await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Bibiche (ABC123) Ouvrir le menu utilisateur' }));
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
@@ -226,7 +228,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // when
       const screen = await visitScreen('/sessions/555');
-      await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Bibiche (ABC123) Ouvrir le menu utilisateur' }));
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
@@ -263,7 +265,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // when
       const screen = await visitScreen('/');
-      await click(screen.getByRole('link', { name: 'Buffy Summers Bibiche (ABC123)' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Bibiche (ABC123) Ouvrir le menu utilisateur' }));
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
-import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { currentURL, click, fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession, invalidateSession } from 'ember-simple-auth/test-support';
 import {
@@ -100,26 +100,6 @@ module('Acceptance | authentication', function (hooks) {
           'The certificationPointOfContact is authenticated'
         );
       });
-
-      test('it should show certificationPointOfContact name', async function (assert) {
-        // given
-        await invalidateSession();
-        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-
-        await visit('/connexion');
-        await fillIn('#login-email', certificationPointOfContact.email);
-        await fillIn('#login-password', 'secret');
-
-        // when
-        await click('button[type=submit]');
-
-        // then
-        assert.ok(
-          currentSession(this.application).get('isAuthenticated'),
-          'The certificationPointOfContact is authenticated'
-        );
-        assert.dom('.logged-user-summary__name').hasText('Harry Cover');
-      });
     });
   });
 
@@ -141,16 +121,22 @@ module('Acceptance | authentication', function (hooks) {
         );
       });
 
-      test('it should show the name and externalId of certification center', async function (assert) {
+      test('it should show the user name, the name and externalId of certification center', async function (assert) {
         // given
-        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted('SUP', 'Centre');
         await authenticateSession(certificationPointOfContact.id);
 
         // when
-        await visit('/sessions/liste');
+        const screen = await visit('/sessions/liste');
 
         // then
-        assert.dom('.logged-user-summary__certification-center').hasText('Centre de certification du pix (ABC123)');
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: 'Harry Cover Centre (ABC123) Ouvrir le menu utilisateur',
+            })
+          )
+          .exists();
       });
 
       test('it should redirect certificationPointOfContact to the session list on root url', async function (assert) {
@@ -172,9 +158,9 @@ module('Acceptance | authentication', function (hooks) {
         certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
 
         // when
-        await visitScreen('/?lang=en');
+        await visit('/?lang=en');
         await authenticateSession(certificationPointOfContact.id);
-        const screen = await visitScreen('/');
+        const screen = await visit('/');
 
         // then
         assert.dom(screen.getByRole('link', { name: 'Invigilator’s Portal' })).exists();

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -158,12 +158,35 @@ module('Acceptance | Session List', function (hooks) {
         server.create('session-summary', { certificationCenterId: centerManagingStudents.id });
 
         // when
-        await visit('/sessions/liste');
-        await click('.logged-user-summary__link');
-        await click('.logged-user-menu-item');
+        const screen = await visit('/sessions/liste');
+
+        assert
+          .dom(
+            screen.queryByText(
+              'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
+            )
+          )
+          .doesNotExist();
+
+        await click(
+          screen.getByRole('button', {
+            name: 'Harry Cover Centre SCO isNotM (ABC123) Ouvrir le menu utilisateur',
+          })
+        );
+        await click(
+          screen.getByRole('button', {
+            name: 'Centre SCO isM (ABC123)',
+          })
+        );
 
         // then
-        assert.dom('.pix-message').doesNotExist();
+        assert
+          .dom(
+            screen.getByText(
+              'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
+            )
+          )
+          .exists();
       });
 
       test('it should delete the session of clicked session-summary', async function (assert) {

--- a/certif/tests/integration/components/user-logged-menu_test.js
+++ b/certif/tests/integration/components/user-logged-menu_test.js
@@ -70,20 +70,26 @@ module('Integration | Component | user-logged-menu', function (hooks) {
 
   module('when menu is closed', function () {
     test('([a11y] should indicate that the menu is not displayed', async function (assert) {
+      // given
+      const userMenuInformation = 'Buffy Summers Sunnydale Ouvrir le menu utilisateur';
+
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: userMenuInformation }));
+      await click(screen.getByRole('button', { name: userMenuInformation }));
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' })).hasAria('expanded', 'false');
+      assert.dom(screen.getByRole('button', { name: userMenuInformation })).hasAria('expanded', 'false');
     });
 
     test('should hide the disconnect link', async function (assert) {
+      // given
+      const userMenuInformation = 'Buffy Summers Sunnydale Ouvrir le menu utilisateur';
+
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: userMenuInformation }));
+      await click(screen.getByRole('button', { name: userMenuInformation }));
 
       // then
       assert.dom(screen.queryByRole('link', { name: 'Se déconnecter' })).doesNotExist();
@@ -92,18 +98,21 @@ module('Integration | Component | user-logged-menu', function (hooks) {
 
   module('when menu is open', function () {
     test('([a11y] should indicate that the menu is displayed', async function (assert) {
+      // given
+      const userMenuInformation = 'Buffy Summers Sunnydale Ouvrir le menu utilisateur';
+
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: userMenuInformation }));
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' })).hasAria('expanded', 'true');
+      assert.dom(screen.getByRole('button', { name: userMenuInformation })).hasAria('expanded', 'true');
     });
 
     test('should display the disconnect link', async function (assert) {
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Sunnydale Ouvrir le menu utilisateur' }));
 
       // then
       assert.dom(screen.getByRole('link', { name: 'Se déconnecter' })).exists();
@@ -133,7 +142,7 @@ module('Integration | Component | user-logged-menu', function (hooks) {
 
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Sunnydale Ouvrir le menu utilisateur' }));
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Torreilles (externalId1)' })).exists();
@@ -161,12 +170,12 @@ module('Integration | Component | user-logged-menu', function (hooks) {
       const screen = await renderScreen(
         hbs`<UserLoggedMenu @onCertificationCenterAccessChanged={{this.onCertificationAccessChangedStub}}/>`
       );
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Sunnydale Ouvrir le menu utilisateur' }));
       await click(screen.getByRole('button', { name: 'Torreilles (externalId1)' }));
 
       // then
       assert.dom(screen.queryByRole('button', { name: 'Torreilles (externalId1)' })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: 'Se déconnecter' })).doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: 'Se déconnecter' })).doesNotExist();
     });
 
     test('should call the "onCertificationCenterAccessChanged" function', async function (assert) {
@@ -188,7 +197,7 @@ module('Integration | Component | user-logged-menu', function (hooks) {
       const screen = await renderScreen(
         hbs`<UserLoggedMenu @onCertificationCenterAccessChanged={{this.onCertificationAccessChangedStub}}/>`
       );
-      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('button', { name: 'Buffy Summers Sunnydale Ouvrir le menu utilisateur' }));
       await click(screen.getByRole('button', { name: 'Torreilles (externalId1)' }));
 
       // then

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -139,6 +139,7 @@
       "team": "Team"
     },
     "user-logged-menu": {
+      "button-extra-information": "Open user menu",
       "logout": "Log out",
       "page-title": "Logout"
     }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -73,7 +73,7 @@
         "forgot-password": "Mot de passe oublié ?",
         "password": "Mot de passe"
       },
-      "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
+      "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
       "required": "Obligatoire",
       "session-labels": {
         "center-name": "Nom du site",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -139,6 +139,7 @@
       "team": "Équipe"
     },
     "user-logged-menu": {
+      "button-extra-information": "Ouvrir le menu utilisateur",
       "logout": "Se déconnecter",
       "page-title": "Déconnexion"
     }


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un utilisateur Pix Certif se connecte sur Pix Certif, celui-ci peut cliquer sur la flèche à côté de son nom et prénom en haut à droite de la page pour dérouler la liste des centres de certification dans lesquels il est membre.

Seulement, lorsqu'un utilisateur est membre de plusieurs centres (utilisateur existant membre de 80 centres de certification) il lui est impossible scroller jusqu’en bas de la liste des centres passé la hauteur totale de la page sur laquelle l’utilisateur se trouve lors du dépliage du menu déroulant. Sa seule solution pour voir tout le menu déroulant est de dézoomer l'écran jusqu'à voir le bas du menu déroulant.

## :robot: Proposition
Ajouter un scrollbar dans le menu

## :rainbow: Remarques
Une amélioration de ce menu à été apportée dans cette PR, elle permet désormais la navigation clavier sur ce dernier. 

## :100: Pour tester
Des centres ont été ajouté en RA pour reproduire cas de figure.

- Se connecter sur certifsco@example.net
- Cliquer dans le menu en haut à droite et constater que l'on peut scroller pour accéder à toute la liste des centres
- Naviguer au clavier et constater que l'on passe bien dans la liste (comparer avec une autre RA ou un autre environnement)
- Testé sur Chrome, à tester sur Firefox