### PR TITLE
[FEATURE] Améliorer l'accessibilité de la modale de solution des QROC/m (PIX-8189).

### DIFF
--- a/mon-pix/app/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/components/qroc-solution-panel.hbs
@@ -3,15 +3,13 @@
     {{#if @solution}}
       <div class="correction-qroc-box__answer">
         {{#if (eq @answer.challenge.format "paragraphe")}}
-          <label class="screen-reader-only" for="correction-qroc-box-answer__paragraphe">
-            {{t "pages.comparison-window.results.a11y.given-answer"}}
-          </label>
           <div class="correction-qroc-box-answer {{this.inputClass}}">
             <PixTextarea
               class="correction-qroc-box-answer--paragraph"
               @id="correction-qroc-box-answer__paragraphe"
               rows="5"
               @value={{this.answerToDisplay}}
+              aria-label={{this.inputAriaLabel}}
               disabled
             />
           </div>
@@ -21,7 +19,7 @@
               class="correction-qroc-box-answer--sentence"
               @id="correction-qroc-box-answer--sentence"
               @value="{{this.answerToDisplay}}"
-              @ariaLabel={{t "pages.comparison-window.results.a11y.given-answer"}}
+              @ariaLabel={{this.inputAriaLabel}}
               disabled
             />
           </div>
@@ -32,8 +30,8 @@
               @id="correction-qroc-box-answer"
               size="{{this.answerToDisplay.length}}"
               @value="{{this.answerToDisplay}}"
+              @ariaLabel={{this.inputAriaLabel}}
               disabled
-              @ariaLabel={{t "pages.comparison-window.results.a11y.given-answer"}}
             />
           </div>
         {{/if}}
@@ -41,10 +39,10 @@
     {{/if}}
     {{#if this.isNotCorrectlyAnswered}}
       {{#if this.understandableSolution}}
-        <div class="comparison-window-solution">
+        <p class="comparison-window-solution">
           <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-          <div class="comparison-window-solution__text">{{this.understandableSolution}}</div>
-        </div>
+          <span class="comparison-window-solution__text">{{this.understandableSolution}}</span>
+        </p>
       {{/if}}
     {{/if}}
   </div>

--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -18,6 +18,17 @@ export default class QrocSolutionPanel extends Component {
     return this.args.answer.result !== 'ok';
   }
 
+  get inputAriaLabel() {
+    switch (this.args.answer.result) {
+      case 'ok':
+        return this.intl.t('pages.comparison-window.results.a11y.good-answer');
+      case 'ko':
+        return this.intl.t('pages.comparison-window.results.a11y.wrong-answer');
+      default:
+        return this.intl.t('pages.comparison-window.results.a11y.skipped-answer');
+    }
+  }
+
   get hasCorrection() {
     return this.args.solution || this.args.solutionToDisplay;
   }

--- a/mon-pix/app/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.hbs
@@ -17,6 +17,7 @@
               rows="5"
               @value="{{block.answer}}"
               @id="{{block.input}}"
+              aria-label={{block.ariaLabel}}
               disabled
             />
           </div>
@@ -26,6 +27,7 @@
               class="correction-qrocm-answer__input-sentence"
               @value="{{block.answer}}"
               @id="{{block.input}}"
+              @ariaLabel={{block.ariaLabel}}
               disabled
             />
           </div>
@@ -36,6 +38,7 @@
               @value="{{block.answer}}"
               size="{{block.answer.length}}"
               @id="{{block.input}}"
+              @ariaLabel={{block.ariaLabel}}
               disabled
             />
           </div>
@@ -47,10 +50,10 @@
       {{/if}}
     {{/each}}
     {{#unless this.answerIsCorrect}}
-      <div class="comparison-window-solution">
+      <p class="comparison-window-solution">
         <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-        <div class="correction-qrocm__solution-text">{{this.understandableSolution}}</div>
-      </div>
+        <span class="correction-qrocm__solution-text">{{this.understandableSolution}}</span>
+      </p>
     {{/unless}}
   </div>
 </div>

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -24,6 +24,7 @@ export default class QrocmDepSolutionPanel extends Component {
       const isAnswerEmpty = answers[block.input] === '';
       block.answer = isAnswerEmpty ? this.intl.t('pages.result-item.aband') : answers[block.input];
       block.inputClass = this.getInputClass(isAnswerEmpty, correctionBlock?.validated);
+      block.ariaLabel = this.getAriaLabel(isAnswerEmpty, correctionBlock?.validated);
       return block;
     });
   }
@@ -63,5 +64,15 @@ export default class QrocmDepSolutionPanel extends Component {
       default:
         return `${CSS_PREPEND}wrong`;
     }
+  }
+
+  getAriaLabel(isEmptyAnswer, isAnswerCorrect) {
+    if (isEmptyAnswer) {
+      return this.intl.t('pages.comparison-window.results.a11y.skipped-answer');
+    }
+
+    return isAnswerCorrect
+      ? this.intl.t('pages.comparison-window.results.a11y.good-answer')
+      : this.intl.t('pages.comparison-window.results.a11y.wrong-answer');
   }
 }

--- a/mon-pix/app/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.hbs
@@ -27,13 +27,15 @@
               rows="5"
               @value="{{block.answer}}"
               @id="{{block.input}}"
+              aria-label={{block.ariaLabel}}
               disabled
             />
           </div>
           {{#if block.emptyOrWrongAnswer}}
-            <div class="correction-qrocm__solution">
-              <div class="correction-qrocm__solution-text">{{block.solution}}</div>
-            </div>
+            <p class="correction-qrocm__solution">
+              <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+              <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+            </p>
           {{/if}}
         {{else if (eq @challenge.format "phrase")}}
           <div class="correction-qrocm__answer {{block.inputClass}}">
@@ -42,13 +44,15 @@
               @value="{{block.answer}}"
               size="{{get-qroc-input-size @challenge.format}}"
               @id="{{block.input}}"
+              @ariaLabel={{block.ariaLabel}}
               disabled
             />
           </div>
           {{#if block.emptyOrWrongAnswer}}
-            <div class="correction-qrocm__solution">
-              <div class="correction-qrocm__solution-text">{{block.solution}}</div>
-            </div>
+            <p class="correction-qrocm__solution">
+              <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+              <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+            </p>
           {{/if}}
         {{else}}
           <div class="correction-qrocm__answer-wrapper correction-qrocm__answer {{block.inputClass}}">
@@ -57,12 +61,14 @@
               @value="{{block.answer}}"
               size="{{block.answer.length}}"
               @id="{{block.input}}"
+              @ariaLabel={{block.ariaLabel}}
               disabled
             />
             {{#if block.emptyOrWrongAnswer}}
-              <div class="correction-qrocm__solution">
-                <div class="correction-qrocm__solution-text">{{block.solution}}</div>
-              </div>
+              <p class="correction-qrocm__solution">
+                <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+                <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+              </p>
             {{/if}}
           </div>
         {{/if}}

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -30,11 +30,13 @@ export default class QrocmIndSolutionPanel extends Component {
       const blockIsInputOrTextarea = !block.showText && !block.breakline;
 
       if (blockIsInputOrTextarea) {
-        const answerOutcome = _computeAnswerOutcome(answers[block.input], resultDetails[block.input]);
-        const inputClass = _computeInputClass(answerOutcome);
+        const answerOutcome = this._computeAnswerOutcome(answers[block.input], resultDetails[block.input]);
+        const inputClass = this._computeInputClass(answerOutcome);
+        const ariaLabel = this._computeAriaLabel(answerOutcome);
         if (answers[block.input] === '') {
           answers[block.input] = this.intl.t('pages.result-item.aband');
         }
+        block.ariaLabel = ariaLabel;
         block.inputClass = inputClass;
         block.answer = answers[block.input];
         block.solution = solutions[block.input][0];
@@ -43,21 +45,32 @@ export default class QrocmIndSolutionPanel extends Component {
       return block;
     });
   }
-}
 
-function _computeAnswerOutcome(inputFieldValue, resultDetail) {
-  if (inputFieldValue === '') {
-    return 'empty';
+  _computeAnswerOutcome(inputFieldValue, resultDetail) {
+    if (inputFieldValue === '') {
+      return 'empty';
+    }
+    return resultDetail === true ? 'ok' : 'ko';
   }
-  return resultDetail === true ? 'ok' : 'ko';
-}
 
-function _computeInputClass(answerOutcome) {
-  if (answerOutcome === 'empty') {
-    return 'correction-qroc-box-answer--aband';
+  _computeInputClass(answerOutcome) {
+    if (answerOutcome === 'empty') {
+      return 'correction-qroc-box-answer--aband';
+    }
+    if (answerOutcome === 'ok') {
+      return 'correction-qroc-box-answer--correct';
+    }
+    return 'correction-qroc-box-answer--wrong';
   }
-  if (answerOutcome === 'ok') {
-    return 'correction-qroc-box-answer--correct';
+
+  _computeAriaLabel(answerOutcome) {
+    switch (answerOutcome) {
+      case 'ok':
+        return this.intl.t('pages.comparison-window.results.a11y.good-answer');
+      case 'ko':
+        return this.intl.t('pages.comparison-window.results.a11y.wrong-answer');
+      default:
+        return this.intl.t('pages.comparison-window.results.a11y.skipped-answer');
+    }
   }
-  return 'correction-qroc-box-answer--wrong';
 }

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -60,17 +60,13 @@
 .comparison-window-solution {
   display: flex;
   align-items: stretch;
+  margin-top: $pix-spacing-xs;
 
   &__text {
-    position: relative;
-    bottom: 3px;
-    display: flex;
-    margin-top: 10px;
-    margin-left: 10px;
+    @extend %pix-body-m;
+
     color: $pix-success-70;
     font-weight: $font-bold;
-    font-size: 1rem;
-    overflow-wrap: break-word;
   }
 
   &__img {

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -1,5 +1,4 @@
 .correction-qrocm {
-
   &__text {
     display: inline-block;
     width: 100%;
@@ -35,18 +34,16 @@
     align-items: center;
 
     &-text {
-      margin-top: 3px;
-      margin-left: 10px;
-      padding-bottom: 1px;
+      @extend %pix-body-m;
+
+      margin: $pix-spacing-xxs 0 $pix-spacing-xs;
       color: $pix-success-70;
       font-weight: $font-bold;
-      font-size: 1rem;
     }
   }
 }
 
 .correction-qrocm-text {
-
   &__label {
     display: block;
   }

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -25,6 +25,10 @@ module('Integration | Component | QROC solution panel', function (hooks) {
       assert.dom('input').doesNotExist();
       assert.dom('textarea.correction-qroc-box-answer--paragraph').hasAttribute('disabled');
       assert.strictEqual(find('textarea.correction-qroc-box-answer--paragraph').getAttribute('rows'), '5');
+      assert.strictEqual(
+        find('textarea.correction-qroc-box-answer--paragraph').getAttribute('aria-label'),
+        'Question passée'
+      );
     });
   });
 

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -245,6 +245,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       assert.dom(SENTENCE).doesNotExist();
       assert.strictEqual(find(INPUT).tagName, 'INPUT');
       assert.strictEqual(find(INPUT).getAttribute('size'), answerSize.toString());
+      assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'La réponse donnée est valide');
       assert.true(find(INPUT).hasAttribute('disabled'));
     });
   });
@@ -285,6 +286,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       assert.dom(INPUT).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
       assert.strictEqual(find(PARAGRAPH).tagName, 'TEXTAREA');
+      assert.strictEqual(find(PARAGRAPH).getAttribute('aria-label'), 'La réponse donnée est valide');
       assert.true(find(PARAGRAPH).hasAttribute('disabled'));
     });
   });
@@ -298,6 +300,17 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
         assessment,
         challenge,
       });
+      const correctionBlocks = [
+        {
+          validated: true,
+          alternativeSolutions: [],
+        },
+        {
+          validated: true,
+          alternativeSolutions: [],
+        },
+      ];
+      this.set('correctionBlocks', correctionBlocks);
       this.set('answer', answer);
       this.set('solution', solution);
       this.set('challenge', challenge);
@@ -314,6 +327,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       assert.dom(INPUT).doesNotExist();
       assert.dom(PARAGRAPH).doesNotExist();
       assert.strictEqual(find(SENTENCE).tagName, 'INPUT');
+      assert.strictEqual(find(SENTENCE).getAttribute('aria-label'), 'La réponse donnée est valide');
       assert.true(find(SENTENCE).hasAttribute('disabled'));
     });
   });

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -156,6 +156,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       assert.strictEqual(find(INPUT).tagName, 'INPUT');
       assert.strictEqual(find(INPUT).value, EMPTY_DEFAULT_MESSAGE);
       assert.strictEqual(find(INPUT).getAttribute('size'), EMPTY_DEFAULT_MESSAGE.length.toString());
+      assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'Question passée');
       assert.true(find(INPUT).hasAttribute('disabled'));
     });
   });
@@ -178,6 +179,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       assert.dom(INPUT).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
       assert.strictEqual(find(PARAGRAPH).tagName, 'TEXTAREA');
+      assert.strictEqual(find(PARAGRAPH).getAttribute('aria-label'), 'Question passée');
       assert.true(find(PARAGRAPH).hasAttribute('disabled'));
     });
   });
@@ -200,6 +202,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       assert.dom(INPUT).doesNotExist();
       assert.dom(PARAGRAPH).doesNotExist();
       assert.strictEqual(find(SENTENCE).tagName, 'INPUT');
+      assert.strictEqual(find(SENTENCE).getAttribute('aria-label'), 'Question passée');
       assert.true(find(SENTENCE).hasAttribute('disabled'));
     });
   });

--- a/mon-pix/tests/unit/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qroc-solution-panel_test.js
@@ -8,6 +8,7 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
   setupIntl(hooks);
   const rightAnswer = { result: 'ok' };
   const wrongAnswer = { result: 'ko' };
+  const skippedAnswer = { result: 'aband' };
 
   module('#isNotCorrectlyAnswered', function () {
     test('should return false when result is ok', function (assert) {
@@ -100,6 +101,35 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
 
       // then
       assert.strictEqual(solutionToDisplay, '');
+    });
+  });
+
+  module('#inputAriaLabel', function () {
+    test('should return specific aria label if answer is  ok', function (assert) {
+      // given
+      const component = createGlimmerComponent('qroc-solution-panel', { answer: rightAnswer });
+      // when
+      const inputAriaLabel = component.inputAriaLabel;
+      // then
+      assert.strictEqual(inputAriaLabel, 'La réponse donnée est valide');
+    });
+
+    test('should return specific aria label if answer is ko', function (assert) {
+      // given
+      const component = createGlimmerComponent('qroc-solution-panel', { answer: wrongAnswer });
+      // when
+      const inputAriaLabel = component.inputAriaLabel;
+      // then
+      assert.strictEqual(inputAriaLabel, 'La réponse donnée est fausse');
+    });
+
+    test('should return specific aria label if answer is skipped', function (assert) {
+      // given
+      const component = createGlimmerComponent('qroc-solution-panel', { answer: skippedAnswer });
+      // when
+      const inputAriaLabel = component.inputAriaLabel;
+      // then
+      assert.strictEqual(inputAriaLabel, 'Question passée');
     });
   });
 });

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
@@ -24,7 +24,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
         {
           input: 'smiley1',
           text: 'content : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est valide',
           autoAriaLabel: false,
           inputClass: 'correction-qroc-box-answer--correct',
           answer: ':)',
@@ -35,7 +35,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
         {
           input: 'smiley2',
           text: '<br/><br/>triste : ',
-          ariaLabel: null,
+          ariaLabel: 'Question passée',
           autoAriaLabel: false,
           inputClass: 'correction-qroc-box-answer--aband',
           answer: 'Pas de réponse',
@@ -85,6 +85,41 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
 
       //Then
       assert.deepEqual(inputClass, 'correction-qroc-box-answer--wrong');
+    });
+  });
+
+  module('#getAriaLabel', function () {
+    test('should return specific aria-label when question is skipped', function (assert) {
+      //Given
+      const component = createGlimmerComponent('qrocm-dep-solution-panel');
+
+      //when
+      const ariaLabel = component.getAriaLabel(true);
+
+      //Then
+      assert.deepEqual(ariaLabel, 'Question passée');
+    });
+
+    test('should return specific aria-label when question answer is ok', function (assert) {
+      //Given
+      const component = createGlimmerComponent('qrocm-dep-solution-panel');
+
+      //when
+      const inputClass = component.getAriaLabel(false, true);
+
+      //Then
+      assert.deepEqual(inputClass, 'La réponse donnée est valide');
+    });
+
+    test('should return specific aria-label when question answer is ko', function (assert) {
+      //Given
+      const component = createGlimmerComponent('qrocm-dep-solution-panel');
+
+      //when
+      const inputClass = component.getAriaLabel(false, false);
+
+      //Then
+      assert.deepEqual(inputClass, 'La réponse donnée est fausse');
     });
   });
 

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel_test.js
@@ -29,7 +29,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'smiley1',
           text: 'content : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est valide',
           showText: false,
           inputClass: 'correction-qroc-box-answer--correct',
           answer: ':)',
@@ -43,7 +43,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'smiley2',
           text: '<br/><br/>triste : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est valide',
           showText: false,
           inputClass: 'correction-qroc-box-answer--correct',
           answer: ':(',
@@ -76,7 +76,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num1',
           text: 'Clé USB : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '1',
@@ -90,7 +90,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num2',
           text: '<br/><br/>Carte mémoire (SD) : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '2',
@@ -124,7 +124,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num1',
           text: 'Clé USB : ',
-          ariaLabel: null,
+          ariaLabel: 'Question passée',
           showText: false,
           inputClass: 'correction-qroc-box-answer--aband',
           answer: 'Pas de réponse',
@@ -138,7 +138,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num2',
           text: '<br/><br/>Carte mémoire (SD) : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '2',
@@ -175,7 +175,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num1',
           text: '<br/>- alain@pix.fr : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '1',
@@ -189,7 +189,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num2',
           text: '<br/><br/>- leonie@pix.fr : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '2',
@@ -226,7 +226,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'Num1',
           text: '<br/>- Combien le dossier "projet PIX" contient-il de dossiers ? ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '2',
@@ -240,7 +240,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'Num2',
           text: '<br/><br/>- Combien le dossier "images" contient-il de fichiers ? ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est fausse',
           showText: false,
           inputClass: 'correction-qroc-box-answer--wrong',
           answer: '3',
@@ -264,7 +264,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
       assert.deepEqual(component.blocks, result);
     });
 
-    test('it should return "Pas de réponse" in each answer if the question was passed', function (assert) {
+    test('it should return "Pas de réponse" in each answer if the question was skipped', function (assert) {
       // given
       challenge = EmberObject.create({ proposals: 'Clé USB : ${num1}\n\nCarte mémoire (SD) : ${num2}' });
       answer = { value: '#ABAND#', resultDetails: 'num1: false\nnum2: false' };
@@ -274,7 +274,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num1',
           text: 'Clé USB : ',
-          ariaLabel: null,
+          ariaLabel: 'Question passée',
           showText: false,
           inputClass: 'correction-qroc-box-answer--aband',
           answer: 'Pas de réponse',
@@ -288,7 +288,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num2',
           text: '<br/><br/>Carte mémoire (SD) : ',
-          ariaLabel: null,
+          ariaLabel: 'Question passée',
           showText: false,
           inputClass: 'correction-qroc-box-answer--aband',
           answer: 'Pas de réponse',
@@ -326,7 +326,7 @@ module('Unit | Component | qrocm-ind-solution-panel', function (hooks) {
         {
           input: 'num1',
           text: 'Clé USB : ',
-          ariaLabel: null,
+          ariaLabel: 'La réponse donnée est valide',
           type: 'input',
           defaultValue: null,
           showText: false,

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -632,8 +632,10 @@
     "comparison-window": {
       "results": {
         "a11y": {
-          "given-answer": "given answer",
-          "the-answer-was": "The answer was"
+          "good-answer": "Given answer is correct",
+          "wrong-answer": "Given answer is not correct",
+          "skipped-answer": "Question skipped",
+          "the-answer-was": "The good answer is"
         },
         "aband": {
           "title": "You did not answer",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -632,8 +632,10 @@
     "comparison-window": {
       "results": {
         "a11y": {
-          "given-answer": "réponse donnée",
-          "the-answer-was": "La bonne réponse était"
+          "good-answer": "La réponse donnée est valide",
+          "wrong-answer": "La réponse donnée est fausse",
+          "skipped-answer": "Question passée",
+          "the-answer-was": "La bonne réponse est"
         },
         "aband": {
           "title": "Vous n’avez pas donné de réponse",


### PR DESCRIPTION
## :unicorn: Problème

Dans les épreuves QROC et QROCm (ind et dep), on indique visuellement à l’utilisateur si sa réponse est **bonne**, **mauvaise** ou **passée** mais n’est pas accessible à tous. 

## :robot: Proposition

Ajouter ou compléter l’aria-label de l’input / textarea en ajoutant une indication de l'état de la réponse (correct, faux ou passé).

## :100: Pour tester

Répondre aux épreuves et attester de la présence d'un aria-label indiquant sur l'input de correction indiquent si la réponse est bonne, fausse ou passée :

- **QROC** : [/challenges/rec0gm0GFue3PQB3k/preview](https://app-pr6309.review.pix.fr/challenges/rec0gm0GFue3PQB3k/preview)<br/>(bonne réponse : `https://www.assemblee-nationale.fr/`)
- **QROCm ind** : [/challenges/rec1bBSshto0bcR2L/preview](https://app-pr6309.review.pix.fr/challenges/rec1bBSshto0bcR2L/preview)<br/>(bonnes réponses : `coucou` puis `hello`)
- **QROCm dep** : [/challenges/rec2jQSdF8spj4lVr/preview](https://app-pr6309.review.pix.fr/challenges/rec2jQSdF8spj4lVr/preview)<br/>(ex de bonne réponse : `Metallinos / Communication Commerce Électronique / 2017 / 4 / 41`)

