### PR TITLE
[BUGFIX] Corriger la création de campagne à envoi multiple (PIX-8238)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1267,7 +1267,7 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         expect(participations[0]).to.be.instanceOf(CampaignParticipation);
         expect(participations[1]).to.be.instanceOf(CampaignParticipation);
-        expect(participations.map((participation) => participation.id)).to.deep.equal([
+        expect(participations.map((participation) => participation.id)).to.have.members([
           campaignParticipationImproved.id,
           campaignParticipationToDelete.id,
         ]);

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -144,7 +144,7 @@
         <PixRadioButton
           name="multiple-sendings-label"
           @value="false"
-          {{on "change" this.selectMultipleSendingsStatus}}
+          {{on "change" (fn this.selectMultipleSendingsStatus false)}}
           aria-describedby="multiple-sendings-info"
         >
           {{t "pages.campaign-creation.no"}}
@@ -153,7 +153,7 @@
         <PixRadioButton
           name="multiple-sendings-label"
           @value="true"
-          {{on "change" this.selectMultipleSendingsStatus}}
+          {{on "change" (fn this.selectMultipleSendingsStatus true)}}
           aria-describedby="multiple-sendings-info"
         >
           {{t "pages.campaign-creation.yes"}}

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -84,10 +84,9 @@ export default class CreateForm extends Component {
   }
 
   @action
-  selectMultipleSendingsStatus(event) {
-    const status = Boolean(event.target.value);
-    this.multipleSendingsEnabled = status;
-    this.campaign.multipleSendings = status;
+  selectMultipleSendingsStatus(value) {
+    this.multipleSendingsEnabled = value;
+    this.campaign.multipleSendings = value;
   }
 
   @action

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -32,4 +32,42 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       assert.deepEqual(component.ownerId, 7);
     });
   });
+
+  module('#selectMultipleSendingsStatus', function () {
+    test('set to true', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        prescriber = { id: 1 };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const component = await createGlimmerComponent('component:campaign/create-form', {
+        targetProfiles: [],
+        membersSortedByFullName: [{ id: 1, fullName: 'Just me' }],
+      });
+
+      //when
+      await component.selectMultipleSendingsStatus(true);
+
+      //then
+      assert.true(component.campaign.multipleSendings);
+    });
+
+    test('set to false', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        prescriber = { id: 1 };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const component = await createGlimmerComponent('component:campaign/create-form', {
+        targetProfiles: [],
+        membersSortedByFullName: [{ id: 1, fullName: 'Just me' }],
+      });
+
+      //when
+      await component.selectMultipleSendingsStatus(false);
+
+      //then
+      assert.false(component.campaign.multipleSendings);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'envoi multiple est toujours activé même si nous le définissions à NON dans la création de campagne sur Pix Orga

## :robot: Proposition
Corriger ce "petit" problème

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur Pix Orga et faire deux créations campagnes à envoi multiple. une activé, l'autre non, vérifier que dans le premier cas il est actif et dans le second inactif.