### PR TITLE
[TECH] Gestion de langue manquante sur le kit superviseur (PIX-8243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pix Changelog
 
+## v4.1.2 (05/06/2023)
+
+
+### :bug: Correction
+- [#6314](https://github.com/1024pix/pix/pull/6314) [TECH] Gestion de langue manquante sur le kit superviseur (PIX-8243)
+
 ## v4.1.1 (01/06/2023)
 
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-admin",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-admin",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": false,
   "description": "Interface d'administration pour les membres de Pix.",
   "license": "AGPL-3.0",

--- a/api/lib/infrastructure/utils/pdf/supervisor-kit-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/supervisor-kit-pdf.js
@@ -19,7 +19,7 @@ async function getSupervisorKitPdfBuffer({
   dirname = __dirname,
   fontkit = pdfLibFontkit,
   creationDate = new Date(),
-  lang,
+  lang = FRENCH_SPOKEN,
 } = {}) {
   let templatePath;
   let fileName;
@@ -73,17 +73,14 @@ function _drawSessionDate({ lang, sessionForSupervisorKit, page, font }) {
   const day = date.getDate();
   const year = date.getFullYear();
   const options = { month: 'short' };
-  const month = new Intl.DateTimeFormat(lang, options).format(date);
+  let month, fullDate;
 
-  let fullDate;
-
-  switch (lang) {
-    case ENGLISH_SPOKEN:
-      fullDate = `${year} ${month} ${day}`;
-      break;
-    case FRENCH_SPOKEN:
-      fullDate = `${day} ${month} ${year}`;
-      break;
+  if (lang === ENGLISH_SPOKEN) {
+    month = new Intl.DateTimeFormat(lang, options).format(date);
+    fullDate = `${year} ${month} ${day}`;
+  } else {
+    month = new Intl.DateTimeFormat(FRENCH_SPOKEN, options).format(date);
+    fullDate = `${day} ${month} ${year}`;
   }
 
   page.drawText(fullDate, {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-api",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/api/tests/integration/infrastructure/utils/pdf/supervisor-kit-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/supervisor-kit-pdf_test.js
@@ -108,6 +108,70 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification supervisor 
       expect(fileName).to.equal(`invigilator-kit-${sessionForSupervisorKit.id}.pdf`);
     });
   });
+
+  context('when lang is not supported', function () {
+    context('when lang is not given', function () {
+      it('should return full french supervisor kit as a buffer', async function () {
+        // given
+        const lang = undefined;
+        const sessionForSupervisorKit = domainBuilder.buildSessionForSupervisorKit({
+          id: 12345678,
+          supervisorPassword: 12344,
+          accessCode: 'WB64K2',
+          date: '2022-09-21',
+          examiner: 'Ariete Bordeauxchesnel',
+        });
+        const expectedPdfPath = __dirname + '/kit-surveillant_expected.pdf';
+
+        // when
+        const { buffer: actualSupervisorKitBuffer, fileName } = await getSupervisorKitPdfBuffer({
+          sessionForSupervisorKit,
+          lang,
+          creationDate: new Date('2021-01-01'),
+        });
+
+        // Note: to update the reference pdf, you can run the test with the following lines.
+        //
+        // import { writeFile } from 'fs/promises';
+        // await writeFile(expectedPdfPath, actualSupervisorKitBuffer);
+
+        // then
+        expect(await isSameBinary(expectedPdfPath, actualSupervisorKitBuffer)).to.be.true;
+        expect(fileName).to.equal(`kit-surveillant-${sessionForSupervisorKit.id}.pdf`);
+      });
+    });
+
+    context('when lang is given', function () {
+      it('should return full french supervisor kit as a buffer', async function () {
+        // given
+        const lang = 'pt';
+        const sessionForSupervisorKit = domainBuilder.buildSessionForSupervisorKit({
+          id: 12345678,
+          supervisorPassword: 12344,
+          accessCode: 'WB64K2',
+          date: '2022-09-21',
+          examiner: 'Ariete Bordeauxchesnel',
+        });
+        const expectedPdfPath = __dirname + '/kit-surveillant_expected.pdf';
+
+        // when
+        const { buffer: actualSupervisorKitBuffer, fileName } = await getSupervisorKitPdfBuffer({
+          sessionForSupervisorKit,
+          lang,
+          creationDate: new Date('2021-01-01'),
+        });
+
+        // Note: to update the reference pdf, you can run the test with the following lines.
+        //
+        // import { writeFile } from 'fs/promises';
+        // await writeFile(expectedPdfPath, actualSupervisorKitBuffer);
+
+        // then
+        expect(await isSameBinary(expectedPdfPath, actualSupervisorKitBuffer)).to.be.true;
+        expect(fileName).to.equal(`kit-surveillant-${sessionForSupervisorKit.id}.pdf`);
+      });
+    });
+  });
 });
 
 // Warning: call _restorePdfLib() when finished /!\

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-certif",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-certif",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": false,
   "description": "Plateforme en ligne de gestion des sessions de certification",
   "license": "AGPL-3.0",

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-e2e",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-e2e",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Permet d'exécuter des tests de bout en bout sur la plateforme Pix",
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-load-testing",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-load-testing",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Permet d'exécuter des tests de charge sur l'API de la plateforme Pix.",
   "homepage": "https://github.com/1024pix/pix/tree/dev/high-level-tests/load-testing#readme",
   "author": "GIP Pix",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mon-pix",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-orga",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-orga",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": false,
   "description": "Plateforme en ligne de gestion de campagne d'évaluation",
   "license": "AGPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## :unicorn: Problème

Suite à la mise en production de la version 4.1.1 de Pix, il manque une gestion de l'absence de langue pour le kit superviseur.

## :robot: Proposition

EN cas de manquement de la langue, on de langue non supportée, on passe en cas par défaut (FR)

## :rainbow: Remarques

Traité par le process de hotfix

## :100: Pour tester

* Récupérer le lien d'un kit superviseur sur l'application Pix Certif (clic droit, copier le lien)
* Editer le lien en supprimant le paramètre `lang=` ou bien le mettre à une valeur non supportée (exemple à date: `ru`)
* Vérifier que le lien fonctionne après édiition
