### PR TITLE
[FEATURE] Ajout de la colonne isNextGenPilot dans la table certification-centers

### DIFF
--- a/api/db/migrations/20230605135419_add-is-v3-pilot-column-to-certification-center-table.js
+++ b/api/db/migrations/20230605135419_add-is-v3-pilot-column-to-certification-center-table.js
@@ -1,0 +1,23 @@
+const TABLE_CERTIFICATION_CENTERS = 'certification-centers';
+const COLUMN_IS_V3_PILOT = 'isV3Pilot';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_CERTIFICATION_CENTERS, function (table) {
+    table.boolean(COLUMN_IS_V3_PILOT).defaultTo(false);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_CERTIFICATION_CENTERS, function (table) {
+    table.dropColumn(COLUMN_IS_V3_PILOT);
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
Afin d'identifier les centres pilotes pour la certification next gen, nous devons ajouter une colonne dans la table.

## :100: Pour tester
Vérifier qu'il y a la colonne dans la base avec la valeur `false` par défaut.
