### PR TITLE
[FEATURE] Retravailler l'accessibilité des signalements de problème en épreuve (PIX-7668).

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -78,7 +78,12 @@
                     {{on "change" this.setContent}}
                   />
                 </div>
-                <PixButton @type="submit" @backgroundColor="grey" @isDisabled={{this.isSendButtonDisabled}}>
+                <PixButton
+                  @type="submit"
+                  @backgroundColor="grey"
+                  aria-label={{t "pages.challenge.feedback-panel.form.actions.submit-aria-label"}}
+                  @isDisabled={{this.isSendButtonDisabled}}
+                >
                   {{t "pages.challenge.feedback-panel.form.actions.submit"}}
                 </PixButton>
               {{/if}}

--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -72,7 +72,9 @@
                     @id="feedback-panel__field"
                     @maxlength="10000"
                     rows="5"
-                    placeholder={{t "pages.challenge.feedback-panel.form.fields.detail-selection.label"}}
+                    placeholder={{t
+                      "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
+                    }}
                     @errorMessage={{this.emptyTextBoxMessageError}}
                     required
                     {{on "change" this.setContent}}

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -41,12 +41,12 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
       test('should open the feedback form', function (assert) {
         // then
         assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).hasAttribute('aria-expanded', 'true');
-        assert.dom(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' })).exists();
+        assert.dom(screen.getByRole('button', { name: "J'ai un problème avec" })).exists();
       });
 
       module('and the form is filled but not sent', function (hooks) {
         hooks.beforeEach(async function () {
-          await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+          await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
           await screen.findByRole('listbox');
           await click(
             screen.getByRole('option', {
@@ -65,19 +65,17 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
             await click(screen.getByRole('button', { name: 'Je passe et je vais à la prochaine question' }));
           });
 
-          test('should not display the feedback form', function (assert) {
+          test('should not display the feedback form', async function (assert) {
             // then
             assert
               .dom(screen.getByRole('button', { name: 'Signaler un problème' }))
               .hasAttribute('aria-expanded', 'false');
-            assert
-              .dom(screen.queryByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }))
-              .doesNotExist();
+            assert.dom(screen.queryByRole('button', { name: "J'ai un problème avec" })).doesNotExist();
           });
 
           test('should always reset the feedback form between two consecutive challenges', async function (assert) {
             await click(screen.getByRole('button', { name: 'Signaler un problème' }));
-            await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+            await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
             await screen.findByRole('listbox');
             await click(
               screen.getByRole('option', {
@@ -124,7 +122,7 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).hasAttribute('aria-expanded', 'true');
-      assert.dom(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' })).exists();
+      assert.dom(screen.getByRole('button', { name: "J'ai un problème avec" })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -47,7 +47,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
       await screen.findByRole('listbox');
       await click(
         screen.getByRole('option', {
@@ -59,7 +59,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), contentValue);
 
       // when
-      await click(screen.getByRole('button', { name: 'Envoyer' }));
+      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
       // then
       assert
@@ -79,7 +79,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
@@ -89,7 +89,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
         // then
         const textareaLabel = screen.queryByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
-        const submitButtonLabel = screen.queryByRole('button', { name: 'Envoyer' });
+        const submitButtonLabel = screen.queryByRole('button', { name: 'Envoyer mon message de signalement' });
         assert.dom(textareaLabel).doesNotExist();
         assert.dom(submitButtonLabel).doesNotExist();
 
@@ -106,7 +106,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
@@ -116,7 +116,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
         // then
         const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
-        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer mon message de signalement' });
         assert.dom(textareaLabel).exists();
         assert.dom(submitButtonLabel).exists();
       });
@@ -130,7 +130,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         // when
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
@@ -140,7 +140,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
         // then
         const textareaLabel = screen.queryByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
-        const submitButtonLabel = screen.queryByRole('button', { name: 'Envoyer' });
+        const submitButtonLabel = screen.queryByRole('button', { name: 'Envoyer mon message de signalement' });
         assert.dom(textareaLabel).doesNotExist();
         assert.dom(submitButtonLabel).doesNotExist();
 
@@ -156,7 +156,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
         // when
-        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
@@ -173,7 +173,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
 
         const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
-        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer mon message de signalement' });
         assert.dom(textareaLabel).exists();
         assert.dom(submitButtonLabel).exists();
       });
@@ -186,7 +186,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
         // when
-        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
@@ -203,7 +203,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
 
         const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
-        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer mon message de signalement' });
         assert.dom(textareaLabel).exists();
         assert.dom(submitButtonLabel).exists();
       });
@@ -216,7 +216,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
         // when
-        await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
@@ -242,7 +242,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
           )
           .exists();
         const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
-        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer mon message de signalement' });
         assert.dom(textareaLabel).exists();
         assert.dom(submitButtonLabel).exists();
       });
@@ -321,7 +321,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       // then
       const selectInputLabel = screen.getByRole('button', {
-        name: 'Sélectionner la catégorie du problème rencontré',
+        name: "J'ai un problème avec",
       });
       assert.dom(selectInputLabel).exists();
     });
@@ -389,7 +389,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
       await screen.findByRole('listbox');
       await click(
         screen.getByRole('option', {
@@ -398,7 +398,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Envoyer' }));
+      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
       // then
       assert.dom(screen.getByText('Vous devez saisir un message.')).exists();
@@ -409,7 +409,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
       await screen.findByRole('listbox');
       await click(
         screen.getByRole('option', {
@@ -419,7 +419,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '');
 
       // when
-      await click(screen.getByRole('button', { name: 'Envoyer' }));
+      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
       // then
       assert.dom(screen.getByText('Vous devez saisir un message.')).exists();
@@ -430,7 +430,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      await click(screen.getByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }));
+      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
       await screen.findByRole('listbox');
       await click(
         screen.getByRole('option', {
@@ -440,7 +440,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '    ');
 
-      await click(screen.getByRole('button', { name: 'Envoyer' }));
+      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
       // when
       await click(screen.getByRole('button', { name: 'Signaler un problème' }));

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -468,7 +468,7 @@
             "detail-selection": {
               "aria-first": "Select the category of the problem encountered",
               "aria-secondary": "Select an option to specify your problem",
-              "label": "Please specify",
+              "label": "Select an option to specify your problem",
               "options": {
                 "answer-not-accepted": "My answer is correct but has not been approved",
                 "answer-not-agreed": "I disagree with the answer",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -447,7 +447,8 @@
         "description": "Pix wants to hear from you so we can improve our tests!*",
         "form": {
           "actions": {
-            "submit": "Send"
+            "submit": "Send",
+            "submit-aria-label": "Send my feedback"
           },
           "fields": {
             "category-selection": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -447,7 +447,8 @@
         "description": "Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*",
         "form": {
           "actions": {
-            "submit": "Envoyer"
+            "submit": "Envoyer",
+            "submit-aria-label": "Envoyer mon message de signalement"
           },
           "fields": {
             "category-selection": {
@@ -465,7 +466,7 @@
               }
             },
             "detail-selection": {
-              "aria-first": "Sélectionner la catégorie du problème rencontré",
+              "aria-first": "J'ai un problème avec",
               "aria-secondary": "Sélectionner une option pour préciser votre problème",
               "label": "Précisez",
               "options": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -468,7 +468,7 @@
             "detail-selection": {
               "aria-first": "J'ai un problème avec",
               "aria-secondary": "Sélectionner une option pour préciser votre problème",
-              "label": "Précisez",
+              "label": "Sélectionner une option pour préciser votre problème",
               "options": {
                 "answer-not-accepted": "Ma réponse est correcte mais n’a pas été validée",
                 "answer-not-agreed": "Je ne suis pas d’accord avec la réponse",


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'audit d'accessibilité, des problèmes ont été constatés sur la partie signalement dans les épreuves. Il a été recommandé d'apporter quelques modifications au libellés et aux libellés destinés aux lecteurs d'écran afin de les faire correspondre.

## :robot: Proposition
- Modifier le texte du champ screen-reader-only lié au select "J'ai un problème avec" de "" en "J'ai un problème avec".
- Modifier le text du second Select "Précisez" en "Sélectionner une option pour préciser votre problème"
- Modifier le texte placeholder du champ texte libre pour mettre le même que celui présent dans le screen-reader-only ('Décrivez votre problème ou votre suggestion')

## :100: Pour tester
- Accéder à [Pix App](https://app-pr6320.review.pix.fr/accueil) et se connecter (par exemple avec userpix1@example.net:pix123)
- Cliquer sur une des cartes présentes dans la rubrique "Compétences" pour accéder à une épreuve
- Commencer une épreuve en cliquant sur "Commencer" ou "Reprendre"
- Une fois sur la page d'épreuve, cliquer sur "Signaler un problème" en bas de page
- Ouvrir l'inspecteur d'écran pour vérifier qu'une div "screen-reader-only" liée au Select "J'ai un problème" contient bien elle-même un label "J'ai un problème" (extrait de l'inspecteur d'écran ci-dessous)
- Sélectionner l'option "La question" afin de faire apparaitre le second select
- Vérifier que le libellé de ce second Select est "Sélectionner une option pour préciser votre problème"
- Sélectionner l'option "Je ne comprends pas la question" pour faire apparaitre le champ texte libre
- Vérifier que le texte du placeholder est "Décrivez votre problème ou votre suggestion"

<img width="542" alt="image" src="https://github.com/1024pix/pix/assets/35962680/1cf0830e-fbff-437f-877c-b9c90d659b1b">
