### PR TITLE
[BUGFIX] Permettre à un candidat éligible mais non inscrit à une certif complémentaire de passer la certification (PIX-8257).

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -252,7 +252,7 @@ class CertificationCandidate {
   }
 
   isGranted(key) {
-    return this.complementaryCertification.key === key;
+    return this.complementaryCertification?.key === key;
   }
 
   isBillingModePrepaid() {

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -909,12 +909,17 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       // given
                       const complementaryCertification = domainBuilder.buildComplementaryCertification({
                         key: 'PIX+TEST',
+                        label: 'PIX+TEST',
                       });
 
+                      const badge = domainBuilder.buildBadge({ isCertifiable: true });
+
                       const badgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-                        complementaryCertification,
-                        userid: 2,
-                        badge: domainBuilder.buildBadge({ isCertifiable: true }),
+                        complementaryCertificationId: complementaryCertification.id,
+                        complementaryCertificationKey: complementaryCertification.key,
+                        complementaryCertificationBadgeId: 3456789,
+                        badgeId: badge.id,
+                        badgeKey: badge.key,
                       });
 
                       const domainTransaction = Symbol('someDomainTransaction');


### PR DESCRIPTION
## :unicorn: Problème
Des candidats ont reçu plusieurs 500 lorsqu’ils ont tenté d’accéder à leur certification sur Pix App. 

Dans leurs cas de figure, ils ont des badges certifiant (et donc éligible à la certification complémentaire) et leur centre de certif est bien habilité à cette certification complémentaire MAIS ils ne sont pas inscrit à la certif complémentaie.

Et dans cette route, on s'assure que le candidat est bien inscrit à la certification complémentaire grâce à la méthode isGranted mais celui des candidats s'est retrouvé vide, ce qui a crash l'API et retourné une 500.

![Capture d’écran 2023-06-06 à 11 29 11](https://github.com/1024pix/pix/assets/103997660/4ee2ebfe-62e4-4081-96ac-29540b63bc18)

## :robot: Proposition
Corriger la méthode isGranted qui tombe en erreur.

## :rainbow: Remarques
Cas de figure avec table associé : 
- centre habilité (complementary-certification-habilitations)
- un badge certifiant (éligible - badge-acquisitions)
- non inscrit à la certification complémentaire (complementary-certification-subscriptions).

L'erreur provient du refacto des certifications complémentaire ( [PR](https://github.com/1024pix/pix/pull/6102) )

## :100: Pour tester

- Se connecter sur Pix App avec certif-success@pix.fr
- Aller dans certifications et renseigner les données d'un élèves non inscrit à une certification complémentaire mais ayant un badge certifiant
- Renseigner le code candidat (code donné sur Pix Certif dans le détail de la session)
- Coté Pix Certif, se connecter et aller dans l'espace surveillant pour donner l'accès à l'élève
- Constater que l'on accède bien à la certification
