### PR TITLE
[BUGFIX] Retourner une erreur dans la méthode getWithComplementaryCertification lorsque le candidat n'existe pas (PIX-8266).

### DIFF
--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -217,6 +217,11 @@ const getWithComplementaryCertification = async function (id) {
     )
     .where('certification-candidates.id', id)
     .first();
+
+  if (!candidateData) {
+    throw new NotFoundError('Candidate not found');
+  }
+
   return _toDomain(candidateData);
 };
 

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -786,6 +786,23 @@ describe('Integration | Repository | CertificationCandidate', function () {
   });
 
   describe('#getWithComplementaryCertification', function () {
+    context('when certification candidate is not found', function () {
+      it('should throw NotFound error', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCandidate({ id: 1 });
+        const wrongCandidateId = 99;
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(certificationCandidateRepository.getWithComplementaryCertification)(
+          wrongCandidateId
+        );
+
+        // then
+        expect(error).to.be.an.instanceOf(NotFoundError);
+      });
+    });
+
     context('when the candidate has no complementary certification subscription', function () {
       it('should return the candidate with empty complementary certification', async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
2 erreurs en production concernant la route `/subscriptions` retournent le message suivant : 
```
Cannot read properties of undefined (reading 'complementaryCertificationId')
at _toDomain (file:///app/lib/infrastructure/repositories/certification-candidate-repository.js:273:47)
at Module.getWithComplementaryCertification
```

La méthode getWithComplementaryCertification ne retourne pas d'erreur lorsque que le candidat n'est pas trouvé en BDD.

## :robot: Proposition
Retourner l'erreur NotFound lorsque le candidat n'existe pas.

## :100: Pour tester

- Se connecter sur Pix App avec certif-failure@example.net
- Dans certifications, renseigner les infos = 11 Herbie Hancock 04012000
- changer l'id dans l'url pour un id de candidat inéxistant en base
- Constater une erreur 404 au lieu d'une 500