### PR TITLE
[TECH] Référencer les composants avec un chemin absolu dans l'API

### DIFF
--- a/api/.depcheckrc
+++ b/api/.depcheckrc
@@ -1,3 +1,4 @@
+skip-missing: true
 ignores:
   [
     '@babel/plugin-syntax-import-assertions',

--- a/api/lib/application/account-recovery/account-recovery-controller.js
+++ b/api/lib/application/account-recovery/account-recovery-controller.js
@@ -1,4 +1,5 @@
-import { usecases } from '../../domain/usecases/index.js';
+// eslint-disable-next-line import/no-unresolved,node/no-missing-import
+import { usecases } from '#lib/domain/usecases/index.js';
 import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 

--- a/api/lib/application/healthcheck/healthcheck-controller.js
+++ b/api/lib/application/healthcheck/healthcheck-controller.js
@@ -2,7 +2,8 @@ import Boom from '@hapi/boom';
 import packageJSON from '../../../package.json' assert { type: 'json' };
 import { config } from '../../config.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
-import { knex } from '../../../db/knex-database-connection.js';
+// eslint-disable-next-line import/no-unresolved,node/no-missing-import
+import { knex } from '#db/knex-database-connection.js';
 
 const get = function (request) {
   return {

--- a/api/package.json
+++ b/api/package.json
@@ -170,5 +170,10 @@
   },
   "optionalDependencies": {
     "nyc": "^15.1.0"
+  },
+
+  "imports": {
+    "#lib/*.js": "./lib/*.js",
+    "#db/*.js": "./db/*.js"
   }
 }

--- a/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
@@ -1,5 +1,6 @@
 import { expect, sinon, hFake, domainBuilder } from '../../../test-helper.js';
-import { accountRecoveryController } from '../../../../lib/application/account-recovery/account-recovery-controller.js';
+// eslint-disable-next-line import/no-unresolved,node/no-missing-import
+import { accountRecoveryController } from '#lib/application/account-recovery/account-recovery-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 


### PR DESCRIPTION
## :unicorn: Problème
Le chemin complet du fichier doit être mentionné à l'import.
Dans le cas de tests, l'import du code à tester peut comprendre plus de 5 niveaux.

```
import { accountRecoveryController } from '../../../../lib/application/account-recovery/account-recovery-controller.js';
```

## :robot: Proposition
Utiliser [la fonctionnalité d'import native ](https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#subpath-imports)NodeJS depuis le package.
L'import devient alors un import "absolu"
```
import { accountRecoveryController } from '#lib/application/account-recovery/account-recovery-controller.js';
```

## :rainbow: Remarques
Reste à faire:
- configurer le lint pour pouvoir conserver la règle de vérification d'import: peut-on écrire un plugin babel qui remplace les alias #lib par le chemin relatif ?
- reprendre le code existant
- modifier la doc NodeJS

## :100: Pour tester
Vérifier la CI
