### PR TITLE
[TECH] Ajoute une règle ESLint pour éviter les `sinon.stub().withArgs` en une ligne

### DIFF
--- a/api/.depcheckrc
+++ b/api/.depcheckrc
@@ -1,34 +1,17 @@
 ignores:
   [
     '@babel/plugin-syntax-import-assertions',
-    '@1024pix/eslint-config',
     'bookshelf-validate',
-    'eslint-plugin-mocha',
     'hapi-swagger',
     'hapi-sentry',
-    'jscodeshift',
     'mocha-junit-reporter',
-    'pg-connection-string',
-    'pino-pretty',
   ]
 #  @babel/plugin-syntax-import-assertions is used by eslint
 # see https://github.com/babel/babel/blob/main/packages/babel-plugin-syntax-import-assertions/README.md
 
-# "@1024pix/eslint-plugin" is used in ../.eslintrc.cjs
-# code =>  plugins: - @1024pix
-# see https://github.com/1024pix/eslint-plugin
-
 # "bookshelf-validate" is used in ./lib/infrastructure/bookshelf.js
 # code => bookshelf.plugin('bookshelf-validate',
 # see https://github.com/kripod/bookshelf-validate#configuration
-
-# "mocha-junit-reporter" is used in ../.circleci/config.yml
-# code =>  MOCHA_REPORTER: mocha-junit-reporter
-# see https://github.com/michaelleeallen/mocha-junit-reporter#usage
-
-# "eslint-plugin-mocha" is used in ../.eslintrc.cjs
-# code =>  plugins: - mocha
-# see https://github.com/lo1tuma/eslint-plugin-mocha#install-and-configure
 
 # "hapi-sentry" is used in ./lib/infrastructure/plugins/sentry.js
 # see https://github.com/hydra-newmedia/hapi-sentry
@@ -36,11 +19,6 @@ ignores:
 # "hapi-swagger" is used in ./lib/application/authentication/index.js
 # see https://github.com/hapi-swagger/hapi-swagger
 
-#  @babel/plugin-syntax-import-assertions is used by eslint
-# see https://github.com/babel/babel/blob/main/packages/babel-plugin-syntax-import-assertions/README.md
-
-# "pino-pretty" is used in ../lib/infrastructure/logger.js
-# code =>  target: 'pino-pretty'
-# see https://github.com/pinojs/pino-pretty#programmatic-integration
-
-# "pg-connection-string" is used in api/tests/acceptance/database/configuration.cjs
+# "mocha-junit-reporter" is used in ../.circleci/config.yml
+# code =>  MOCHA_REPORTER: mocha-junit-reporter
+# see https://github.com/michaelleeallen/mocha-junit-reporter#usage

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
   globals: {
     include: true,
   },
-  plugins: ['knex', 'unicorn'],
+  plugins: ['knex', 'unicorn', 'local-rules'],
   rules: {
     'no-console': 'error',
     'mocha/no-hooks-for-single-case': 'off',
@@ -52,6 +52,21 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain/usecases', from: 'lib/infrastructure/repositories', except: [], message : "Repositories are automatically injected in use-case, you don't need to import them. Check for further details: https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md" },{ "target": "tests/unit", "from": "db" }] }],
+    'import/no-restricted-paths': [
+      'error',
+      {
+        zones: [
+          {
+            target: 'lib/domain/usecases',
+            from: 'lib/infrastructure/repositories',
+            except: [],
+            message:
+              "Repositories are automatically injected in use-case, you don't need to import them. Check for further details: https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md",
+          },
+          { target: 'tests/unit', from: 'db' },
+        ],
+      },
+    ],
+    'local-rules/no-sinon-stub-with-args-oneliner': 'error',
   },
 };

--- a/api/eslint-local-rules.cjs
+++ b/api/eslint-local-rules.cjs
@@ -1,0 +1,7 @@
+"use strict";
+
+const noSinonStubWithArgsOneliner = require("@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner");
+
+module.exports = {
+  "no-sinon-stub-with-args-oneliner": noSinonStubWithArgsOneliner,
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,6 +79,7 @@
       },
       "devDependencies": {
         "@1024pix/eslint-config": "^1.0.3",
+        "@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner": "^0.2.0",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@ls-lint/ls-lint": "^2.0.0",
@@ -91,6 +92,7 @@
         "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
+        "eslint-plugin-local-rules": "^2.0.0",
         "eslint-plugin-mocha": "^10.0.5",
         "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -126,6 +128,12 @@
       "peerDependencies": {
         "eslint": ">=8.0.0"
       }
+    },
+    "node_modules/@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner/-/eslint-plugin-no-sinon-stub-with-args-oneliner-0.2.0.tgz",
+      "integrity": "sha512-cPmR+jhMEU0g4ROrjqmT5bjcA0HAvDHFSqoOta32G+mT8j4eRG3X8bA5lVS++mjCrqfX2L2BZXIsgVwLV4OCJA==",
+      "dev": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -5182,6 +5190,12 @@
       "resolved": "git+ssh://git@github.com/1024pix/eslint-plugin-knex.git#48af579a29b194c7e061acc22548652dd32951ef",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.0.tgz",
+      "integrity": "sha512-sWueme0kUcP0JC1+6OBDQ9edBDVFJR92WJHSRbhiRExlenMEuUisdaVBPR+ItFBFXo2Pdw6FD2UfGZWkz8e93g==",
+      "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -85,6 +85,7 @@
   },
   "devDependencies": {
     "@1024pix/eslint-config": "^1.0.3",
+    "@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner": "^0.2.0",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@ls-lint/ls-lint": "^2.0.0",
@@ -97,6 +98,7 @@
     "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
+    "eslint-plugin-local-rules": "^2.0.0",
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
+++ b/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
@@ -43,6 +43,9 @@ describe('Unit | Scripts | organizations-by-external-id-helper.js', function () 
         { externalId: 'A100', targetProfileIdList: ['1', '2', '999'] },
         { externalId: 'B200', targetProfileIdList: ['1', '3', '6'] },
       ];
+
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line local-rules/no-sinon-stub-with-args-oneliner
       const findByExternalIdsFetchingIdsOnlyStub = sinon.stub().withArgs(['A100', 'B200']).resolves([]);
       const organizationRepository = { findByExternalIdsFetchingIdsOnly: findByExternalIdsFetchingIdsOnlyStub };
 


### PR DESCRIPTION
## :unicorn: Problème
Voir https://nikas.praninskas.com/javascript/2015/07/28/quickie-sinon-withargs-not-working/.

## :robot: Proposition
Avec @emeric-martineau nous avons développé une règle ESLint qui s'assure de ne pas chainer l'appel de la méthode `stub()` avec `withArgs()`. Elle est  disponible sur https://github.com/1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner. Cette règle est inclue ici à la racine du projet et donc appliquée dans tous les sous-dossiers.

Certaines erreurs ont directement été corrigées.

Pour celles qui n'étaient pas évidentes (toute l'API en particulier), j'ai ajouté des commentaires là où un correctif était nécessaire ainsi qu'un `eslint-disable` temporaire. Il est possible de les retrouver en faisant cette recherche : `// eslint-disable-next-line local-rules/no-sinon-stub-with-args-oneliner`. Cela représente 213 erreurs que l'on pourra traiter petit à petit.

Attention, un `npm ci` à la racine du monorepo est nécessaire pour installer les dépendances nécessaire au lint des sous projets.

## :rainbow: Remarques
Je n'ai découvert que trop tard qu'il n'est pas possible de mettre à disposition des règles ESLint via npm. D'où l'utilisation de `eslint-plugin-local-rules`.

## :100: Pour tester
Vérifier que la CI passe, que certaines erreurs ont été corrigées et d'autres ont été ignorées temporairement avec l'ajout d'un commentaire incitant à corriger.