### PR TITLE
[TECH] Proposer l'injection de dépendances pour les répositories

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,4 +1,7 @@
 import { config } from '../../config.js';
+
+import { repositories } from '../../infrastructure/repositories/index.js';
+
 import * as accountRecoveryDemandRepository from '../../infrastructure/repositories/account-recovery-demand-repository.js';
 import * as adminMemberRepository from '../../infrastructure/repositories/admin-member-repository.js';
 
@@ -73,7 +76,6 @@ import * as complementaryCertificationHabilitationRepository from '../../infrast
 import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
 import * as complementaryCertificationSubscriptionRepository from '../../infrastructure/repositories/complementary-certification-subscription-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
-import * as correctionRepository from '../../infrastructure/repositories/correction-repository.js';
 import * as countryRepository from '../../infrastructure/repositories/country-repository.js';
 import * as courseRepository from '../../infrastructure/repositories/course-repository.js';
 import * as cpfCertificationResultRepository from '../../infrastructure/repositories/cpf-certification-result-repository.js';
@@ -572,7 +574,7 @@ const dependencies = {
   complementaryCertificationRepository,
   complementaryCertificationSubscriptionRepository,
   complementaryCertificationCourseResultRepository,
-  correctionRepository,
+  correctionRepository: repositories.correctionRepository,
   countryRepository,
   courseRepository,
   cpfCertificationResultRepository,

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -4,12 +4,10 @@ import { Correction } from '../../domain/models/Correction.js';
 import { Hint } from '../../domain/models/Hint.js';
 import { challengeDatasource } from '../datasources/learning-content/challenge-datasource.js';
 import { skillDatasource } from '../datasources/learning-content/skill-datasource.js';
-import * as tutorialRepository from './tutorial-repository.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
-import { getCorrection } from '../../domain/services/solution-service-qrocm-dep.js';
 import { Challenge } from '../../domain/models/Challenge.js';
-import { fromDatasourceObject } from '../adapters/solution-adapter.js';
 import { Answer } from '../../domain/models/Answer.js';
+
 const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
 
 const getByChallengeId = async function ({
@@ -17,12 +15,14 @@ const getByChallengeId = async function ({
   answerValue,
   userId,
   locale,
-  dependencies = { tutorialRepository, fromDatasourceObject, getCorrection },
+  tutorialRepository,
+  fromDatasourceObject,
+  getCorrection,
 } = {}) {
   const challenge = await challengeDatasource.get(challengeId);
   const skill = await _getSkill(challenge);
   const hint = await _getHint({ skill, locale });
-  const solution = dependencies.fromDatasourceObject(challenge);
+  const solution = fromDatasourceObject(challenge);
   let correctionDetails;
 
   const tutorials = await _getTutorials({
@@ -30,18 +30,18 @@ const getByChallengeId = async function ({
     skill,
     tutorialIdsProperty: 'tutorialIds',
     locale,
-    tutorialRepository: dependencies.tutorialRepository,
+    tutorialRepository,
   });
   const learningMoreTutorials = await _getTutorials({
     userId,
     skill,
     tutorialIdsProperty: 'learningMoreTutorialIds',
     locale,
-    tutorialRepository: dependencies.tutorialRepository,
+    tutorialRepository,
   });
 
   if (challenge.type === Challenge.Type.QROCM_DEP && answerValue !== Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
-    correctionDetails = dependencies.getCorrection({ solution, answerValue });
+    correctionDetails = getCorrection({ solution, answerValue });
   }
 
   return new Correction({

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -1,0 +1,21 @@
+import { injectDependencies } from '../utils/dependency-injection.js';
+
+import * as correctionRepository from './correction-repository.js';
+
+import { fromDatasourceObject } from '../adapters/solution-adapter.js';
+import { getCorrection } from '../../domain/services/solution-service-qrocm-dep.js';
+import * as tutorialRepository from './tutorial-repository.js';
+
+const repositoriesWithoutInjectedDependencies = {
+  correctionRepository,
+};
+
+const dependencies = {
+  fromDatasourceObject,
+  getCorrection,
+  tutorialRepository,
+};
+
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+
+export { repositories };

--- a/api/lib/infrastructure/utils/dependency-injection.js
+++ b/api/lib/infrastructure/utils/dependency-injection.js
@@ -5,7 +5,13 @@ function injectDefaults(defaults, targetFn) {
 }
 
 function injectDependencies(toBeInjected, dependencies) {
-  return _.mapValues(toBeInjected, _.partial(injectDefaults, dependencies));
+  return _.mapValues(toBeInjected, (value) => {
+    if (_.isFunction(value)) {
+      return _.partial(injectDefaults, dependencies, value)();
+    } else {
+      return injectDependencies(value, dependencies);
+    }
+  });
 }
 
 export { injectDependencies, injectDefaults };

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -115,7 +115,9 @@ describe('Unit | Repository | correction-repository', function () {
           challengeId: recordId,
           userId,
           locale,
-          dependencies: { tutorialRepository, fromDatasourceObject, getCorrection: getCorrectionStub },
+          tutorialRepository,
+          fromDatasourceObject,
+          getCorrection: getCorrectionStub,
         });
 
         // then
@@ -142,7 +144,9 @@ describe('Unit | Repository | correction-repository', function () {
           challengeId: recordId,
           userId,
           locale,
-          dependencies: { tutorialRepository, fromDatasourceObject, getCorrection: getCorrectionStub },
+          tutorialRepository,
+          fromDatasourceObject,
+          getCorrection: getCorrectionStub,
         });
 
         // then
@@ -171,7 +175,9 @@ describe('Unit | Repository | correction-repository', function () {
               answerValue,
               userId,
               locale,
-              dependencies: { tutorialRepository, fromDatasourceObject, getCorrection: getCorrectionStub },
+              tutorialRepository,
+              fromDatasourceObject,
+              getCorrection: getCorrectionStub,
             });
 
             // then
@@ -205,7 +211,9 @@ describe('Unit | Repository | correction-repository', function () {
             answerValue,
             userId,
             locale,
-            dependencies: { tutorialRepository, fromDatasourceObject, getCorrection: getCorrectionStub },
+            tutorialRepository,
+            fromDatasourceObject,
+            getCorrection: getCorrectionStub,
           });
 
           // then

--- a/api/tests/unit/infrastructure/utils/dependency-injection_test.js
+++ b/api/tests/unit/infrastructure/utils/dependency-injection_test.js
@@ -2,20 +2,149 @@ import { expect } from '../../../test-helper.js';
 import { injectDependencies } from '../../../../lib/infrastructure/utils/dependency-injection.js';
 
 describe('Unit | Utils | #injectDependencies', function () {
-  it('should inject dependencies by name', function () {
+  context('when the object value to be injected is a function', function () {
+    it('should inject dependencies by name', function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      const toBeInjected = {
+        functionToBeInjected: function ({ dependency }) {
+          return dependency;
+        },
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(injected.functionToBeInjected({})).to.equal(dependency);
+    });
+  });
+
+  context('when the object value to be injected is an arrow function', function () {
+    it('should inject dependencies by name', function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      const toBeInjected = {
+        functionToBeInjected: ({ dependency }) => {
+          return dependency;
+        },
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(injected.functionToBeInjected({})).to.equal(dependency);
+    });
+  });
+
+  context('when the object value to be injected is an async arrow function', function () {
+    it('should inject dependencies by name', async function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      const toBeInjected = {
+        functionToBeInjected: async ({ dependency }) => {
+          return dependency;
+        },
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(await injected.functionToBeInjected({})).to.equal(dependency);
+    });
+  });
+
+  context('when the object value to be injected is an async function', function () {
+    it('should inject dependencies by name', async function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      const toBeInjected = {
+        functionToBeInjected: async function ({ dependency }) {
+          return dependency;
+        },
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(await injected.functionToBeInjected({})).to.equal(dependency);
+    });
+  });
+
+  context('when the object value to be injected is an object containing function', function () {
+    it('should inject dependencies by name', function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      const toBeInjected = {
+        functions: {
+          functionToBeInjected: function ({ dependency }) {
+            return dependency;
+          },
+          functionToBeInjected2: function ({ dependency }) {
+            return dependency;
+          },
+        },
+        functions2: {
+          functionToBeInjected3: function ({ dependency }) {
+            return dependency;
+          },
+        },
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(injected.functions.functionToBeInjected({})).to.equal(dependency);
+      expect(injected.functions.functionToBeInjected2({})).to.equal(dependency);
+      expect(injected.functions2.functionToBeInjected3({})).to.equal(dependency);
+    });
+  });
+
+  it('should be possible to pass args to the injected function', function () {
     // given
     const dependency = Symbol('a dependency');
+    const arg = Symbol('an arg');
     const dependencies = { dependency };
     const toBeInjected = {
-      functionToBeInjected: function ({ dependency }) {
-        return dependency;
+      functionToBeInjected: function ({ dependency, arg }) {
+        return { dependency, arg };
       },
     };
 
-    // when
     const injected = injectDependencies(toBeInjected, dependencies);
 
+    // when
+    const result = injected.functionToBeInjected({ arg });
+
     // then
-    expect(injected.functionToBeInjected({})).to.equal(dependency);
+    expect(result).to.deep.equal({ dependency, arg });
+  });
+
+  context('when the function arg is not an object', function () {
+    it('should not inject dependencies', function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      const toBeInjected = {
+        functionToBeInjected: function (dependency) {
+          return dependency;
+        },
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(injected.functionToBeInjected({})).to.be.empty;
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'injection de dépendances se fait automatiquement uniquement dans le cadre des usecases. Cependant, il serait bénéfique de pouvoir en bénéficier dans d'autres cas : controllers, repositories, services, … 

Cette injection de dépendance se fait dans le fichier `usecases/index.js` grâce à la fonction `injectDependencies`. 
Cette fonction prends en paramètre 2 objets : 
- le premier, un objet contenant des fonctions pour lequel on souhaite avoir de l'injection de dépendances
- le second, un objet contenant les dépendances qui doivent être injectées (objets de fonctions, fonction, …) 

## :robot: Proposition
A l'instar des use-cases les repositories, controllers, etc peuvent exporter plusieurs méthodes. Cependant, notre injecteur de dépendances fonctionne uniquement dans le cadre d'une unique fonction. Je l'ai donc modifié pour qu'il fasse l'injection aussi pour un objet de fonctions. 

Grâce à ça les repositories peuvent bénéficier de l'injection de dépendances.

## :rainbow: Remarques
- Il faut que toutes les méthodes d'un repository prennent en argument un objet => Pour un prochain point tech, je propose de faire des refactos de signature de fonction grâce à de l'AST
- Il faut que toutes les méthodes du répo appellent les autres fonctions du repo sans utiliser `this.<nom-de-fonction>`

**Explication de ce que fait la méthode `injectDependencies`**: 

Voici l'implémentation : 
```javascript
function injectDependencies(toBeInjected, dependencies) {
  return _.mapValues(toBeInjected, _.partial(injectDefaults, dependencies));
}

function injectDefaults(defaults, targetFn) {
  return (args) => targetFn(Object.assign(Object.create(defaults), args));
}
```

[Le `_.mapValues` ](https://lodash.com/docs/4.17.15#mapValues) permet de changer les valeurs contenues dans un objet sans en changer les clés. 

[La méthode `_.partial(func, [partials])` de lodash](https://lodash.com/docs/4.17.15#partial), permet de retourner une nouvelle fonction qui appelle celle passée en paramètre avec les arguments déjà passés par la méthode `partial`. 
Elle permet donc de définir une nouvelle méthode qui utilise une méthode existante avec des arguments prédéfinis.  
Voici l'exemple de lodash pour cette méthode : 
```jaavscript
function greet(greeting, name) {
  return greeting + ' ' + name;
}
 
var sayHelloTo = _.partial(greet, 'hello');
sayHelloTo('fred');
// => 'hello fred'
```

Pour `injectDefaults` :

Cette fonction retourne une fonction qui accepte des arguments. Cette nouvelle fonction invoque la fonction passée en paramètre (notre usecase) auquel nous passons toutes les dépendances ainsi que les arguments passés lors de l'invocation de celle-ci.

Si nous remontons sur le `mapValues` et que nous n'utilisons pas la simplification syntaxique nous avons en réalité : 
```javascript
function injectDependencies(toBeInjected, dependencies) {
  return _.mapValues(toBeInjected, (value) => _.partial(injectDefaults, dependencies,value) );
}
```
`value` correspond à la fonction de notre usecase.  

En résumé, la méthode `injectDependencies` effectue une injection de dépendances en utilisant `_.mapValues` pour transformer les valeurs de l'objet `toBeInjected` et `_.partial` pour créer de nouvelles fonctions avec des dépendances prédéfinies. 

En fin, avec l'amélioration proposée, nous vérifions que la valeur de la clé de l'objet `toBeInjected` est bien une fonction pour faire l'injection sinon (c'est qu'il s'agit d'un objet) on invoque `injectDependencies` de manière récursive. 

## Check-list pour faire de l'injection de dépendance dans un repository

- [ ] Les fonctions prennent en paramètre un objet 
- [ ] Il n'y a plus de `dependencies` dans l'objet en paramètre
- [ ] Ajouter le repo dans `/repositories/index.js` et ses dépendances
- [ ] Importer mon repo dans `usecases/index.js` : dans l'objet `dépendancies` en faisant `repositories.<nom-du-repo>`

## :100: Pour tester
- CI OK 