### PR TITLE
[BUGFIX] Corriger les urls de la documentation des Organisations en fonction de certains TAGS (PIX-8271)

### DIFF
--- a/api/scripts/prod/update-documentation-url.js
+++ b/api/scripts/prod/update-documentation-url.js
@@ -2,13 +2,29 @@ import { knex, disconnect } from '../../db/knex-database-connection.js';
 import * as url from 'url';
 
 async function updateDocumentationUrl() {
+  // common cases
   await _updateProOrganizations();
-
-  await _updateMedNumOrganizations();
 
   await _updateSUPOrganizations();
 
   await _updateSCOOrganizations();
+
+  // specific cases
+  await _updateAufOrganizations();
+
+  await _updateEfenhOrganizations();
+
+  await _updateDiputacioDeBarcelonaOrganizations();
+
+  await _updatePriveHorsContratOrganizations();
+
+  await _updatePromSocOrganizations();
+
+  await _updateInternationalOrganizations();
+
+  await _updateDocEnglishOrganizations();
+
+  await _updateMedNumOrganizations();
 
   await _updateAEFEOrganizations();
 
@@ -36,13 +52,17 @@ async function updateDocumentationUrl() {
 }
 
 const URL = {
-  PRO: 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4',
-  SUP: 'https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo',
   AEFE: 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8',
   MLF: 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8',
   MEDNUM: 'https://view.genial.ly/6048a0d3757f980dc010d6d4',
   SCO: 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f',
   AGRI: 'https://view.genial.ly/5f85a0b87812e90d12b7b593',
+  PRIVE_HORS_CONTRAT: 'https://view.genial.ly/602e3786dd02300d9c14ac3f',
+  EFENH: 'https://view.genial.ly/63b2a4ae12e4fc0018c73fbf',
+
+  PROMSOC: 'https://crp.education/documentation-pix-orga-eps/',
+
+  //LIEN COOL
   CPAM: 'https://cloud.pix.fr/s/deploiement_cnam',
   CNAF: 'https://cloud.pix.fr/s/deploiement_cnaf',
   CNAV: 'https://cloud.pix.fr/s/deploiement_cnav',
@@ -52,12 +72,103 @@ const URL = {
   SECTEUR_CHIMIE: 'https://cloud.pix.fr/s/deploiement_branchechimie',
   EDUSERVICES: 'https://cloud.pix.fr/s/deploiement_eduservices',
   PIXTERRITOIRES: 'https://cloud.pix.fr/s/deploiement_pixterritoires',
+
+  //LIEN PAS COOL
+  PRO: 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4',
+  SUP: 'https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo',
+  INTERNATIONAL: 'https://cloud.pix.fr/s/sR2FPjfq9krTmJY',
+  DOC_ENGLISH: 'https://cloud.pix.fr/s/nftApJjLct8mki8',
+  AUF: 'https://cloud.pix.fr/s/F8aek7qjA2d6A4T',
+  DIPUTACIO_DE_BARCELONA: 'https://cloud.pix.fr/s/AdTPdGMbKWYqfKR',
 };
 
 export { updateDocumentationUrl, URL };
 
 async function _updateProOrganizations() {
   await knex('organizations').where('type', 'PRO').update({ documentationUrl: URL.PRO });
+}
+
+async function _updateAufOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ type: 'PRO', 'tags.name': 'AUF' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AUF });
+}
+async function _updateEfenhOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ type: 'SCO', 'tags.name': 'EFENH' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.EFENH });
+}
+async function _updateDiputacioDeBarcelonaOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ type: 'PRO', 'tags.name': 'DIPUTACIO DE BARCELONA' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.DIPUTACIO_DE_BARCELONA });
+}
+async function _updatePriveHorsContratOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': 'PRIVE HORS CONTRAT' })
+    .whereIn('type', ['PRO', 'SUP'])
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.PRIVE_HORS_CONTRAT });
+}
+
+async function _updatePromSocOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': 'PROMSOC' })
+    .whereIn('type', ['PRO', 'SUP'])
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.PROMSOC });
+}
+
+async function _updateInternationalOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': 'INTERNATIONAL' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.INTERNATIONAL });
+}
+
+async function _updateDocEnglishOrganizations() {
+  const ids = await knex
+    .select('organizations.id')
+    .from('organizations')
+    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
+    .leftJoin('tags', 'tagId', 'tags.id')
+    .where({ type: 'PRO', 'tags.name': 'DOC ENGLISH' })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.DOC_ENGLISH });
 }
 
 async function _updateCPAMOrganizations() {

--- a/api/tests/integration/scripts/prod/update-documentation-url_test.js
+++ b/api/tests/integration/scripts/prod/update-documentation-url_test.js
@@ -16,6 +16,448 @@ describe('updateDocumentationUrl', function () {
     });
   });
 
+  context('when the organization is SUP', function () {
+    it('uses the SUP documentation', async function () {
+      databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.SUP);
+    });
+  });
+
+  context('when the organization is SCO', function () {
+    it('uses the SCO documentation', async function () {
+      databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.SCO);
+    });
+
+    context('when the organization does not manage students', function () {
+      it('does not update documentation', async function () {
+        databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          isManagingStudents: false,
+          documentationUrl: 'toto',
+        });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal('toto');
+      });
+    });
+
+    context('when the organization is AEFE', function () {
+      it('uses the AEFE documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AEFE' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.AEFE);
+      });
+    });
+
+    context('when the organization is MLF', function () {
+      it('uses the MLF documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MLF' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.MLF);
+      });
+    });
+
+    context('when the organization is AGRI', function () {
+      it('uses the AGRI documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          isManagingStudents: true,
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.AGRI);
+      });
+
+      context('when the organization is not managing students', function () {
+        it('does not update documentation', async function () {
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+            type: 'SCO',
+            isManagingStudents: false,
+            documentationUrl: 'toto',
+          });
+          const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
+          databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+          await databaseBuilder.commit();
+
+          await updateDocumentationUrl();
+
+          const { documentationUrl } = await knex('organizations').first();
+
+          expect(documentationUrl).equal('toto');
+        });
+      });
+    });
+  });
+
+  context('when the organization is INTERNATIONAL', function () {
+    context('when the organization is PRO', function () {
+      it('uses the INTERNATIONAL documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.INTERNATIONAL);
+      });
+    });
+
+    context('when the organization is SCO', function () {
+      it('uses the INTERNATIONAL documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.equal(URL.INTERNATIONAL);
+      });
+    });
+
+    context('when the organization is SUP', function () {
+      it('uses the INTERNATIONAL documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SUP',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.equal(URL.INTERNATIONAL);
+      });
+    });
+  });
+
+  context('when the organization is PRIVE HORS CONTRAT', function () {
+    context('when the organization is PRO', function () {
+      it('uses the PRIVE HORS CONTRAT documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.PRIVE_HORS_CONTRAT);
+      });
+    });
+
+    context('when the organization is SUP', function () {
+      it('uses the PRIVE HORS CONTRAT documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.PRIVE_HORS_CONTRAT);
+      });
+    });
+
+    context('when the organization is SCO', function () {
+      it('does not the PRIVE HORS CONTRAT documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.PRIVE_HORS_CONTRAT);
+      });
+    });
+  });
+
+  context('when the organization is DOC ENGLISH', function () {
+    it('uses the DOC ENGLISH documentation', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DOC ENGLISH' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.DOC_ENGLISH);
+    });
+
+    context('when the organization is not PRO', function () {
+      it('does not the DOC ENGLISH documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DOC ENGLISH' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.DOC_ENGLISH);
+      });
+    });
+  });
+
+  context('when the organization is PROMSOC', function () {
+    context('when the organization is PRO', function () {
+      it('uses the PROMSOC documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.PROMSOC);
+      });
+    });
+
+    context('when the organization is SUP', function () {
+      it('uses the PROMSOC documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.PROMSOC);
+      });
+    });
+
+    context('when the organization is SCO', function () {
+      it('does not the PROMSOC documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.PROMSOC);
+      });
+    });
+  });
+
+  context('when the organization is AUF', function () {
+    it('uses the AUF documentation', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AUF' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.AUF);
+    });
+
+    context('when the organization is not PRO', function () {
+      it('does not the AUF documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AUF' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.AUF);
+      });
+    });
+  });
+
+  context('when the organization is EFENH', function () {
+    context('when the organization is SCO', function () {
+      it('uses the EFENH documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.EFENH);
+      });
+    });
+
+    context('when the organization is SUP', function () {
+      it('does not the EFENH documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SUP',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.EFENH);
+      });
+    });
+
+    context('when the organization is PRO', function () {
+      it('does not the EFENH documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'PRO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.EFENH);
+      });
+    });
+  });
+
+  context('when the organization is DIPUTACIO DE BARCELONA', function () {
+    context('when the organization is PRO', function () {
+      it('uses the DIPUTACIO DE BARCELONA documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DIPUTACIO DE BARCELONA' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).equal(URL.DIPUTACIO_DE_BARCELONA);
+      });
+    });
+
+    context('when the organization is not PRO', function () {
+      it('does not the DIPUTACIO DE BARCELONA documentation', async function () {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          documentationUrl: 'toto',
+        });
+        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DIPUTACIO DE BARCELONA' });
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        await databaseBuilder.commit();
+
+        await updateDocumentationUrl();
+
+        const { documentationUrl } = await knex('organizations').first();
+
+        expect(documentationUrl).to.not.equal(URL.DIPUTACIO_DE_BARCELONA);
+      });
+    });
+  });
+
   context('when the organization is MEDNUM', function () {
     it('uses the MEDNUM documentation', async function () {
       const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
@@ -362,123 +804,6 @@ describe('updateDocumentationUrl', function () {
         const { documentationUrl } = await knex('organizations').first();
 
         expect(documentationUrl).to.not.equal(URL.PIXTERRITOIRES);
-      });
-    });
-  });
-
-  context('when the organization is SUP', function () {
-    it('uses the SUP documentation', async function () {
-      databaseBuilder.factory.buildOrganization({ type: 'SUP' });
-
-      await databaseBuilder.commit();
-
-      await updateDocumentationUrl();
-
-      const { documentationUrl } = await knex('organizations').first();
-
-      expect(documentationUrl).equal(URL.SUP);
-    });
-  });
-
-  context('when the organization is SCO', function () {
-    it('uses the SCO documentation', async function () {
-      databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
-
-      await databaseBuilder.commit();
-
-      await updateDocumentationUrl();
-
-      const { documentationUrl } = await knex('organizations').first();
-
-      expect(documentationUrl).equal(URL.SCO);
-    });
-
-    context('when the organization does not manage students', function () {
-      it('does not update documentation', async function () {
-        databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          isManagingStudents: false,
-          documentationUrl: 'toto',
-        });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal('toto');
-      });
-    });
-
-    context('when the organization is AEFE', function () {
-      it('uses the AEFE documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AEFE' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.AEFE);
-      });
-    });
-
-    context('when the organization is MLF', function () {
-      it('uses the MLF documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MLF' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.MLF);
-      });
-    });
-
-    context('when the organization is AGRI', function () {
-      it('uses the AGRI documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          isManagingStudents: true,
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.AGRI);
-      });
-
-      context('when the organization is not managing students', function () {
-        it('does not update documentation', async function () {
-          const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-            type: 'SCO',
-            isManagingStudents: false,
-            documentationUrl: 'toto',
-          });
-          const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
-          databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-          await databaseBuilder.commit();
-
-          await updateDocumentationUrl();
-
-          const { documentationUrl } = await knex('organizations').first();
-
-          expect(documentationUrl).equal('toto');
-        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La précedente mise à niveau de lien en masse à engendré une régression sur certaines organisations du fait de la meconnaissance de tout les liens possible en fonction des orga

## :robot: Proposition
Rajouter les urls / tags des type d'organisations manquantes

## :rainbow: Remarques
Trouver une solution plus pérenne pour ne plus avoir à utiliser un script comme cela

## :100: Pour tester
RAS