### PR TITLE
[BUGFIX] La bonne réponse affichée pour un QCM mélangé n'est pas bonne (PIX-8250)

### DIFF
--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -8,7 +8,7 @@ import isEmpty from 'lodash/isEmpty';
 export default class QcmSolutionPanel extends Component {
   get solutionArray() {
     const solution = this.args.solution;
-    const solutionArray = !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
+    const solutionArray = !isEmpty(solution) ? valueAsArrayOfBoolean(solution, this._proposalsArray.length) : [];
     if (this.args.challenge.get('shuffled')) {
       pshuffle(solutionArray, this.args.answer.assessment.get('id'));
     }
@@ -23,14 +23,17 @@ export default class QcmSolutionPanel extends Component {
     const answer = this.args.answer.value;
     let checkboxes = [];
     if (!isEmpty(answer)) {
-      const proposals = this.args.challenge.get('proposals');
-      const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
-      checkboxes = labeledCheckboxes(proposalsArray, answerArray);
+      checkboxes = labeledCheckboxes(this._proposalsArray, answerArray);
       if (this.args.challenge.get('shuffled')) {
         pshuffle(checkboxes, this.args.answer.assessment.get('id'));
       }
     }
     return checkboxes;
+  }
+
+  get _proposalsArray() {
+    const proposals = this.args.challenge.get('proposals');
+    return proposalsAsArray(proposals);
   }
 }

--- a/mon-pix/app/utils/value-as-array-of-boolean.js
+++ b/mon-pix/app/utils/value-as-array-of-boolean.js
@@ -1,29 +1,26 @@
 import flow from 'lodash/fp/flow';
-import thru from 'lodash/fp/thru';
 import split from 'lodash/fp/split';
 import map from 'lodash/fp/map';
-import reject from 'lodash/fp/reject';
 import filter from 'lodash/fp/filter';
 import sortBy from 'lodash/fp/sortBy';
-import uniqBy from 'lodash/fp/uniqBy';
-import times from 'lodash/times';
-import max from 'lodash/max';
-import includes from 'lodash/includes';
 import isString from 'lodash/isString';
 import trim from 'lodash/trim';
-import identity from 'lodash/identity';
-import isEmpty from 'lodash/isEmpty';
+import compact from 'lodash/fp/compact';
+import sortedUniq from 'lodash/fp/sortedUniq';
+import last from 'lodash/last';
 
-export default flow(
-  // in the worst case : ',4, 2 , 2,1,  ,-1'
-  thru((e) => (isString(e) ? e : '')), // check if string
-  split(','), // now ['', '4', ' 2 ', ' 2', '1', '  ', '','-1']
-  map(trim), // now ['', '4', '2', '2', '1', '', '','-1']
-  reject(isEmpty), // now ['4', '2', '2', '1','-1']
-  map(parseInt), // now [4, 2, 2, 1,-1]
-  filter((e) => e >= 1), // check if int >= 1
-  sortBy(identity), // now [1, 2, 2, 4]
-  uniqBy(identity), // now [1, 2, 4]
-  map((e) => e - 1), // now [0, 1, 3]
-  thru((e) => times(max(e) + 1, (o) => includes(e, o))) // now [true, true, false, true]
-);
+export default function valueAsArrayOfBoolean(value, length) {
+  return flow(
+    // in the worst case : ',4, 2 , 2,1,  ,-1'
+    (e) => (isString(e) ? e : ''), // check if string
+    split(','), // now ['', '4', ' 2 ', ' 2', '1', '  ', '','-1']
+    map(trim), // now ['', '4', '2', '2', '1', '', '','-1']
+    compact, // now ['4', '2', '2', '1','-1']
+    map(parseInt), // now [4, 2, 2, 1,-1]
+    filter((e) => e >= 1), // check if int >= 1
+    sortBy((_) => _), // now [1, 2, 2, 4]
+    sortedUniq, // now [1, 2, 4]
+    map((e) => e - 1), // now [0, 1, 3]
+    (e) => Array.from({ length: length ?? last(e) + 1 }, (_, i) => e.includes(i)) // now [true, true, false, true]
+  )(value);
+}

--- a/mon-pix/tests/unit/utils/value-as-array-of-boolean_test.js
+++ b/mon-pix/tests/unit/utils/value-as-array-of-boolean_test.js
@@ -20,11 +20,12 @@ module('Unit | Utility | value as array of boolean', function () {
       input: ',4, 2 , 2,1,  ,',
       expected: [true, true, false, true],
     },
+    { when: 'With specified length', input: '2,3', length: 5, expected: [false, true, true, false, false] },
   ];
 
-  testData.forEach(({ when, input, expected }) => {
-    test(`"${when}", example : "${JSON.stringify(input)}" retourne [${expected}]`, function (assert) {
-      assert.deepEqual(valueAsArrayOfBoolean(input), expected);
+  testData.forEach(({ when, input, length, expected }) => {
+    test(`"${when}", example : "${JSON.stringify(input, length)}" retourne [${expected}]`, function (assert) {
+      assert.deepEqual(valueAsArrayOfBoolean(input, length), expected);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Je réponds à une épreuve QCM avec l’option “Afficher aléatoirement l'ordre des propositions” cochée

J’affiche l'écran de réponse. Les propositions qui sont notées comme étant correctes ne sont pas les bonnes…

## :robot: Proposition

Corriger le mélange des bonnes réponses qui n'était pas le même que celui des propositions.

## :rainbow: Remarques

Les QCUs utilisent également `valueAsArrayOfBoolean` mais ne sont pas concernés car ils ne shufflent pas le résultat.

## :100: Pour tester

challenge2INQCB5nGmr8no