### PR TITLE
[TECH] Utiliser toString() au lieu de .string sur les instances SafeString

### DIFF
--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -12,7 +12,7 @@ export default class QrocmDepSolutionPanel extends Component {
 
   get blocks() {
     const escapedProposals = this.args.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
-    const labels = labelsAsObject(htmlSafe(escapedProposals).string);
+    const labels = labelsAsObject(htmlSafe(escapedProposals).toString());
     const answers = answersAsObject(this.args.answer.value, keys(labels));
     const correctionBlocks = this.args.correctionBlocks ? [...this.args.correctionBlocks] : null;
 

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -20,7 +20,7 @@ export default class QrocmIndSolutionPanel extends Component {
       return undefined;
     }
     const escapedProposals = this.args.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
-    const labels = labelsAsObject(htmlSafe(escapedProposals).string);
+    const labels = labelsAsObject(htmlSafe(escapedProposals).toString());
     const answers = answersAsObject(this.args.answer.value, keys(labels));
     const solutions = solutionsAsObject(this.args.solution);
     const resultDetails = resultDetailsAsObject(this.args.answer.resultDetails);

--- a/mon-pix/tests/unit/components/markdown-to-html-unsafe_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html-unsafe_test.js
@@ -19,7 +19,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
         component = createGlimmerComponent('markdown-to-html-unsafe', { markdown });
 
         // then
-        assert.strictEqual(component.html.string, expectedValue);
+        assert.strictEqual(component.html.toString(), expectedValue);
       });
     });
   });
@@ -40,7 +40,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
         component = createGlimmerComponent('markdown-to-html-unsafe', { markdown });
 
         // then
-        assert.strictEqual(component.html.string, expectedValue);
+        assert.strictEqual(component.html.toString(), expectedValue);
       });
     });
   });
@@ -54,7 +54,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
 
     // then
     const expectedHtml = `<p>${html}</p>`;
-    assert.strictEqual(component.html.string, expectedHtml);
+    assert.strictEqual(component.html.toString(), expectedHtml);
   });
 
   module('when extensions are passed in arguments', function () {
@@ -68,7 +68,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
 
       // then
       const expectedHtml = '<h1 id="title1">Title 1</h1>\nCeci est un paragraphe.\n<img src="/images.png" alt="img" />';
-      assert.strictEqual(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.toString(), expectedHtml);
     });
   });
 });

--- a/mon-pix/tests/unit/components/markdown-to-html_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html_test.js
@@ -19,7 +19,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
         component = createGlimmerComponent('markdown-to-html', { markdown });
 
         // then
-        assert.strictEqual(component.html.string, expectedValue);
+        assert.strictEqual(component.html.toString(), expectedValue);
       });
     });
   });
@@ -41,7 +41,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
         component = createGlimmerComponent('markdown-to-html', { markdown });
 
         // then
-        assert.strictEqual(component.html.string, expectedValue);
+        assert.strictEqual(component.html.toString(), expectedValue);
       });
     });
   });
@@ -55,7 +55,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
     // then
     const expectedHtml = `<p>${html}</p>`;
-    assert.strictEqual(component.html.string, expectedHtml);
+    assert.strictEqual(component.html.toString(), expectedHtml);
   });
 
   module('when extensions are passed in arguments', function () {
@@ -69,7 +69,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
       // then
       const expectedHtml = '<h1>Title 1</h1>\nCeci est un paragraphe.\n<img src="/images.png" alt="img" />';
-      assert.strictEqual(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.toString(), expectedHtml);
     });
   });
 
@@ -83,7 +83,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
       // then
       const expectedHtml = '<h1>Test</h1>';
-      assert.strictEqual(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.toString(), expectedHtml);
     });
   });
 
@@ -97,7 +97,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
       // then
       const expectedHtml = '<h1 class="sr-only">Test</h1>';
-      assert.strictEqual(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.toString(), expectedHtml);
     });
   });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
@@ -158,7 +158,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
+        assert.strictEqual(component.errorMessage.toString(), expectedErrorMessage);
         assert.ok(true);
       });
 
@@ -237,7 +237,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
           await component.actions.submit.call(component, attributes);
 
           // then
-          assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
+          assert.strictEqual(component.errorMessage.toString(), expectedErrorMessage);
         });
       });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form_test.js
@@ -103,7 +103,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
+        assert.strictEqual(component.errorMessage.toString(), expectedErrorMessage);
         assert.ok(true);
       });
 
@@ -182,7 +182,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
           await component.actions.submit.call(component, attributes);
 
           // then
-          assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
+          assert.strictEqual(component.errorMessage.toString(), expectedErrorMessage);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans les tests de mon-pix, on utiliser l'API privé de `SafeString` pour récupérer la chaine plutot que la méthode `toString`. SafeString ayant changé son implémentation dans ember 4.12, on prépare la mise à jour avant.

## :robot: Proposition
Utiliser l'API publique.

## :100: Pour tester
Tests verts
