### PR TITLE
[TECH] POC pour la suppression des prescrits utilisant le helper in-element

### DIFF
--- a/orga/app/components/counter.hbs
+++ b/orga/app/components/counter.hbs
@@ -1,0 +1,2 @@
+{{yield this.counter this.show to="display"}}
+{{yield this.increment to="trigger"}}

--- a/orga/app/components/counter.js
+++ b/orga/app/components/counter.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class OrganizationParticipantList extends Component {
+  @tracked counter = 0;
+
+  @action
+  increment() {
+    this.counter = this.counter + 1;
+  }
+
+  get show() {
+    return this.counter > 0;
+  }
+}

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -6,6 +6,24 @@
   @onResetFilter={{@onResetFilter}}
 />
 
+<section class="organization-participant-list-page__counter">
+  <span>Mon compteur :</span>
+  <Counter>
+    <:trigger as |onClick|>
+      <PixButton @triggerAction={{onClick}}>+1</PixButton>
+    </:trigger>
+    <:display as |count show|>
+      {{#if show}}
+        {{#in-element this.footerBanner}}
+          <PixBanner @type="communication">
+            {{count}}
+          </PixBanner>
+        {{/in-element}}
+      {{/if}}
+    </:display>
+  </Counter>
+</section>
+
 <div class="panel">
   <table class="table content-text content-text--small">
     <caption class="screen-reader-only">{{t "pages.organization-participants.table.description"}}</caption>
@@ -104,3 +122,5 @@
 </div>
 
 <Table::PaginationControl @pagination={{@participants.meta}} />
+
+<div class="organization-participant-list-page__footer" id={{this.footerId}}></div>

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+
+export default class OrganizationParticipantList extends Component {
+  get footerId() {
+    return guidFor(this);
+  }
+
+  get footerBanner() {
+    return document.getElementById(this.footerId);
+  }
+}

--- a/orga/app/styles/pages/authenticated/organization-participants.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants.scss
@@ -6,6 +6,23 @@ $margin-right: 32px;
   flex-grow: 1;
   width: 100%;
 
+  &__footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+  }
+
+  &__counter {
+    display: flex;
+    align-items: center;
+    padding-bottom: $pix-spacing-xs;
+
+    span {
+      margin-right: $pix-spacing-xs;
+    }
+  }
+
   &__last-participation {
     display: flex;
     gap: $pix-spacing-xs;


### PR DESCRIPTION
## Contexte
Dans le cadre du développement de l'Epix sur la suppression des prescrits nous allons devoir réaliser une liste d'éléments sélectionnable avec la possibilté d'appliquer une suppression sur ces éléments.

Ce mécanisme est déjà présent sur PixCertif et va être ajouté sur PixOrga lors de cet Epix. De plus la team Accès va en avoir besoin dans le cadre son Epix qui vise à réinitialiser le mot de passe de plusieurs prescrits d'un coup. 

Dans un soucis de mutualisation du code pour rendre ce mécanisme réutilisable nous avons à coeur de trouver une solution réutilisable par tous. Pour ça la solution devra répondre à plusieurs critères : 
- Permettre de rendre une liste d'éléments
- Mettre un disposition un mécanisme de sélection des éléments
- Ne pas préjugé du rendu des éléments ni du mécanisme de sélection (checkbox, toggle, button, etc...)
- Mettre à disposition l'état des éléments sélectionné et permettre son utilisation en dehors de l'affichage de la liste des éléments

Les trois premiers points peuvent être adressé via le mécanisme de yiedable named blocks de Ember qui permettent de faire de la composition. Ici la RFC qui décrit ce mécanisme : https://rfcs.emberjs.com/id/0460-yieldable-named-blocks/. Il existe aussi une MEJ sur le sujet. Les yieldable name blocks permettent aussi de mettre à disposition aussi bien des données que des fonctions dans le hbs appelant le composant. 

## Problématique

Cependant ce mécanisme ne permet pas l'utilisation de ces données en dehors du cadre du composant. 

![Participants -- Liste](https://github.com/1024pix/pix/assets/13099512/655ef134-f77f-4a6e-a99a-2ff5c79a1372)

Cela pose problème dans l'exemple de la suppression du prescrit puisqu'on voit les deux éléments en vert qui se situe en dehors de la liste mais ont besoin soit d'impacter l'état des éléments sélectionné dans le cadre de la checkbox de l'entête du tableau ou d'utiliser la liste des éléments sélectionnés dans le cadre bandeau statique en bas de la page. 

## Piste de solution

Il existe un mécanisme en React qui permet de gérer ce cas de figure qui s'appelle Portals (cf: https://react.dev/reference/react-dom/createPortal). J'ai donc cherché si un équivalent existe avec Ember. J'ai découvert l'addon https://github.com/ef4/ember-elsewhere qui fait l'équivalent. En lisant la documentation j'ai vu la mention du helper natif in-element présent dans Ember depuis la 3.21 (cf: https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element). Le but de mon après-midi a été de déterminé si en utilisant ce helper on pourrait faire un système générique et flexible répondant aux critères listé plus haut. 

## POC

Pour ce faire j'ai pris un exemple simple d'un bouton qui incrémente un compteur présent quelque part dans la page et d'un bandeau qui affiche l'état de ce compteur à un autre endroit de la page. Voici une petite démo en fonctionnement :
 
![Kapture 2023-06-08 at 16 22 13](https://github.com/1024pix/pix/assets/13099512/4131e003-2b97-4e19-9d72-d92741e7f56a)

Le code du composant gère l'état du compteur et met à disposition des moyens de l'influencer

```js
import Component from '@glimmer/component';
import { tracked } from '@glimmer/tracking';
import { action } from '@ember/object';

export default class OrganizationParticipantList extends Component {
  @tracked counter = 0;

  @action
  increment() {
    this.counter = this.counter + 1;
  }

  get show() {
    return this.counter > 0;
  }
}
```

La partie rendu du composant ne préjuge pas de l'élément qui va incrémenter le compteur ni de l'élément qui affichera l'état du compteur : 

```hbs
{{yield this.counter this.show to="display"}}
{{yield this.increment to="trigger"}}
```

On voit ici l'utilisation du mécanisme de yieldable named block avec passage de variables et de fonctions.

Le compteur s'utilise comme suit pour la partie incrémentation : 

```hbs
<section class="organization-participant-list-page__counter">
  <span>Mon compteur :</span>
  <Counter>
    <:trigger as |onClick|>
      <PixButton @triggerAction={{onClick}}>+1</PixButton>
    </:trigger>
  </Counter>
</section>
```

On voit qu'on peut brancher la fonction qui permet d'incrémenter le compteur sur la propriété triggerAction du bouton.

Pour la partie affichage de l'état du compteur, nous allons faire entrée en jeu le helper in-element. Ce dernier a besoin deux pré-requis : 
- un élément HTML dans lequel injecter le rendu du code hbs qu'on va écrire
- cet élément HTML doit être déjà présent dans le DOM au moment du rendu

Il s'utilise de cette façon : 

```hbs
{{#in-element this.destinationElement}}
  Hello
{{/in-element}}
```

```js
import Component from '@glimmer/component';
import { guidFor } from '@ember/object/internals';

export default class MyComponent extends Component {
  get destinationElement() {
    return document.getElementById('mon-id');
  }
}
```

Voici comment on l'utilise dans notre exemple avec le compteur : 
```hbs
<section class="organization-participant-list-page__counter">
  <span>Mon compteur :</span>
  <Counter>
    <:trigger as |onClick|>
      <PixButton @triggerAction={{onClick}}>+1</PixButton>
    </:trigger>
    <:display as |count show|>
      {{#if show}}
        {{#in-element this.footerBanner}}
          <PixBanner @type="communication">
            {{count}}
          </PixBanner>
        {{/in-element}}
      {{/if}}
    </:display>
  </Counter>
</section>

<!-- Plus bas dans le code HTML -->

<div class="organization-participant-list-page__footer" id={{this.footerId}}></div>
```

On voit que puisque l'élément de footer est rendu plus bas que notre composant Counter il n'existe pas au moment du premier rendu du compteur. On est donc obligé d'ajouter une condition pour n'afficher le compteur que si il est supérieur à 0. Cette contrainte ne nous pose pas problème puisque ça sera le comportement voulu dans le cadre de la suppression des prescrits et de la réinitialisation de leur mot de passe.

```js
import Component from '@glimmer/component';
import { guidFor } from '@ember/object/internals';

export default class OrganizationParticipantList extends Component {
  get footerId() {
    return guidFor(this);
  }

  get footerBanner() {
    return document.getElementById(this.footerId);
  }
}
```

## Conclusion

Cela fonctionne correctement et n'ajoute pas de nouvelle dépendance et la seule contrainte qui pourrait être problématique ne l'est pas pour le moment dans nos cas d'usage. On voit que cette solution répond aux besoins évoqués plus haut à savoir : 
- Rendre des éléments sans préjugé de leur aspect
- Mettre à disposition un état et les moyens de l'impacter
- Permettre un rendu en dehors du composant