### PR TITLE
[FEATURE] Améliorer l'accessibilité des images décoratives sur Pix-App (PIX-6815)

### DIFF
--- a/mon-pix/app/components/certification-banner.hbs
+++ b/mon-pix/app/components/certification-banner.hbs
@@ -1,6 +1,6 @@
 <div class="assessment-banner--certification {{if @shouldBlurBanner 'blur-banner'}}" role="banner">
   <div class="assessment-banner-container">
-    <img class="assessment-banner__pix-logo" src="/images/pix-logo-blanc.svg" role="none" alt="" />
+    <img class="assessment-banner__pix-logo" src="/images/pix-logo-blanc.svg" alt="" />
     <div class="assessment-banner__splitter"></div>
     <h1 class="assessment-banner__title">{{this.candidateFullName}}</h1>
 

--- a/mon-pix/app/components/certifications-list-item.hbs
+++ b/mon-pix/app/components/certifications-list-item.hbs
@@ -12,12 +12,7 @@
       </div>
 
       <div class="certifications-list-item__cell-double-width">
-        <img
-          src="/images/icons/sablier.svg"
-          alt=""
-          role="presentation"
-          data-test-id="certifications-list-item__hourglass-img"
-        />
+        <img src="/images/icons/sablier.svg" alt="" data-test-id="certifications-list-item__hourglass-img" />
         {{t "pages.certifications-list.statuses.not-published.title"}}
       </div>
       <div class="certifications-list-item__cell-pix-score"></div>
@@ -38,12 +33,7 @@
       </div>
 
       <div class="certifications-list-item__cell-double-width">
-        <img
-          src="/images/icons/icon-croix.svg"
-          alt=""
-          role="presentation"
-          data-test-id="certifications-list-item__cross-img"
-        />
+        <img src="/images/icons/icon-croix.svg" alt="" data-test-id="certifications-list-item__cross-img" />
         {{t "pages.certifications-list.statuses.fail.title"}}
       </div>
       <div class="certifications-list-item__cell-pix-score"></div>
@@ -85,12 +75,7 @@
       </div>
 
       <div class="certifications-list-item__cell-double-width">
-        <img
-          src="/images/icons/icon-check-vert.svg"
-          alt=""
-          role="presentation"
-          data-test-id="certifications-list-item__green-check-img"
-        />
+        <img src="/images/icons/icon-check-vert.svg" alt="" data-test-id="certifications-list-item__green-check-img" />
         {{t "pages.certifications-list.statuses.success.title"}}
       </div>
       <div class="certifications-list-item__cell-pix-score">
@@ -115,12 +100,7 @@
       </div>
 
       <div class="certifications-list-item__cell-double-width">
-        <img
-          src="/images/icons/icon-croix.svg"
-          alt=""
-          role="presentation"
-          data-test-id="certifications-list-item__cross-img"
-        />
+        <img src="/images/icons/icon-croix.svg" alt="" data-test-id="certifications-list-item__cross-img" />
         {{t "pages.certifications-list.statuses.cancelled.title"}}
       </div>
       <div class="certifications-list-item__cell-pix-score"></div>

--- a/mon-pix/app/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/components/certifications/certification-ender.hbs
@@ -3,12 +3,7 @@
 <div class="certification-ender rounded-panel result-content">
 
   <div class="certification-ender__finished-test">
-    <img
-      src="/images/illustrations/certification-ender/test-completed.svg"
-      alt=""
-      role="presentation"
-      class="certification-ender__image"
-    />
+    <img src="/images/illustrations/certification-ender/test-completed.svg" alt="" class="certification-ender__image" />
     <div class="certification-ender__candidate">
       <div class="certification-ender__candidate-name">
         <span><FaIcon @icon="circle-user" /></span>
@@ -40,7 +35,6 @@
     <img
       src="/images/illustrations/certification-ender/results-example.svg"
       alt=""
-      role="presentation"
       class="certification-ender__results-example"
     />
     <div class="certification-ender__results-instructions">

--- a/mon-pix/app/components/levelup-notif.hbs
+++ b/mon-pix/app/components/levelup-notif.hbs
@@ -7,15 +7,9 @@
         <div class="levelup-competence__level">{{t "pages.levelup-notif.obtained-level" level=@level}}</div>
         <div class="levelup-competence__name">{{@competenceName}}</div>
       </div>
-      <button
-        role="button"
-        class="levelup__close"
-        aria-labelledby="button-label"
-        {{on "click" this.close}}
-        type="button"
-      >
+      <button class="levelup__close" aria-labelledby="button-label" type="button" {{on "click" this.close}}>
         <span id="button-label" hidden>{{t "common.actions.close"}}</span>
-        <FaIcon @icon="xmark" role="presentation" />
+        <FaIcon @icon="xmark" alt="" />
       </button>
     </div>
   {{/unless}}

--- a/mon-pix/app/components/levelup-notif.hbs
+++ b/mon-pix/app/components/levelup-notif.hbs
@@ -1,7 +1,7 @@
 <div {{did-update this.resetLevelUp}}>
   {{#unless this.closeLevelup}}
     <div class="levelup">
-      <img src="/images/levelup.svg" alt="" role="none" />
+      <img src="/images/levelup.svg" alt="" />
       <div class="levelup__icon-card-level">{{@level}}</div>
       <div class="levelup__competence">
         <div class="levelup-competence__level">{{t "pages.levelup-notif.obtained-level" level=@level}}</div>

--- a/mon-pix/app/components/loader.hbs
+++ b/mon-pix/app/components/loader.hbs
@@ -1,6 +1,6 @@
 <div class="app-loader">
   <p class="app-loader__image">
-    <img src="/images/interwind.gif" alt="" role="presentation" />
+    <img src="/images/interwind.gif" alt="" />
   </p>
   <p class="app-loader__text">{{@loaderText}}</p>
 </div>

--- a/mon-pix/app/components/new-information.hbs
+++ b/mon-pix/app/components/new-information.hbs
@@ -2,7 +2,7 @@
 <div class="new-information {{@backgroundColorClass}}">
   <div class="new-information__content">
     {{#if (media "isDesktop")}}
-      <img class="new-information-content__img" src="{{@image}}" alt="" role="presentation" />
+      <img class="new-information-content__img" src="{{@image}}" alt="" />
     {{/if}}
     <div class="new-information-content__text {{@textAlignment}} {{@textColorClass}}">
       {{{@information}}}

--- a/mon-pix/app/components/profile-content.hbs
+++ b/mon-pix/app/components/profile-content.hbs
@@ -30,7 +30,7 @@
       />
     {{else}}
       <p class="app-loader__image">
-        <img src="/images/interwind.gif" alt="" role="presentation" />
+        <img src="/images/interwind.gif" alt="" />
         <br />{{t "common.loading.default"}}
       </p>
     {{/if}}

--- a/mon-pix/app/components/reached-stage.hbs
+++ b/mon-pix/app/components/reached-stage.hbs
@@ -13,6 +13,6 @@
     </div>
   </div>
   {{#if @imageUrl}}
-    <img class="reached-stage__image" src={{@imageUrl}} alt="" role="none" />
+    <img class="reached-stage__image" src={{@imageUrl}} alt="" />
   {{/if}}
 </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -5,7 +5,7 @@
   {{#if this.showDisabledBlock}}
     <PixBlock class="skill-review__result-abstract-container">
       <div class="skill-review__disabled-share">
-        <img class="skill-review-disabled-share__image" src="/images/illustrations/fat-bee.svg" alt="" role="none" />
+        <img class="skill-review-disabled-share__image" src="/images/illustrations/fat-bee.svg" alt="" />
         <p class="skill-review-disabled-share__text">
           {{t "pages.skill-review.disabled-share" htmlSafe=true}}
         </p>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -184,7 +184,7 @@
     <PixBlock class="skill-review__organization-message">
       {{#if @model.campaign.organizationLogoUrl}}
         <div class="skill-review-organization-message__logo">
-          <img class="logo" src={{@model.campaign.organizationLogoUrl}} alt="" role="presentation" />
+          <img class="logo" src={{@model.campaign.organizationLogoUrl}} alt="" />
         </div>
       {{/if}}
       <div class="skill-review-organization-message__content">
@@ -212,7 +212,7 @@
   {{#if this.showNPS}}
     <PixBlock class="skill-review__net-promoter-score">
       <div class="skill-review-net-promoter-score__logo">
-        <img src="/images/illustrations/skill-review/net-promoter-score.svg" role="presentation" alt="" />
+        <img src="/images/illustrations/skill-review/net-promoter-score.svg" alt="" />
       </div>
       <div class="skill-review-net-promoter-score__content">
         <h2>{{t "pages.skill-review.net-promoter-score.title"}}</h2>

--- a/mon-pix/app/components/timeout-gauge.hbs
+++ b/mon-pix/app/components/timeout-gauge.hbs
@@ -1,7 +1,7 @@
 <div class="timeout-gauge">
   <div class="timeout-gauge-container">
     <div class="timeout-gauge-clock">
-      <img src={{this.imageSource}} alt="" role="none" />
+      <img src={{this.imageSource}} alt="" />
       <div>&nbsp;</div>
       <div data-test="timeout-gauge-remaining" data-spent="{{this.remainingSeconds}}">
         {{this.formattedRemainingTime}}

--- a/mon-pix/app/components/tutorial-panel.hbs
+++ b/mon-pix/app/components/tutorial-panel.hbs
@@ -7,12 +7,7 @@
       {{#if this.shouldDisplayHint}}
         <div class="tutorial-panel__hint-container-body">
           <div class="tutorial-panel__hint-picto-container">
-            <img
-              src="/images/icons/comparison-window/icon-lampe.svg"
-              alt=""
-              role="presentation"
-              class="tutorial-panel__hint-picto"
-            />
+            <img src="/images/icons/comparison-window/icon-lampe.svg" alt="" class="tutorial-panel__hint-picto" />
           </div>
           <MarkdownToHtml @class="tutorial-panel__hint-content" @markdown={{@hint}} />
         </div>

--- a/mon-pix/app/components/tutorials/recommended-empty.hbs
+++ b/mon-pix/app/components/tutorials/recommended-empty.hbs
@@ -1,5 +1,5 @@
 <div class="user-tutorials-content__recommended-empty">
-  <img src="/images/illustrations/user-tutorials/recommended-empty.svg" role="presentation" alt="" />
+  <img src="/images/illustrations/user-tutorials/recommended-empty.svg" alt="" />
   <div>
     <h2 class="user-tutorials-recommended-empty__title">
       {{t "pages.user-tutorials.recommended-empty.title" firstName=this.currentUser.user.firstName}}

--- a/mon-pix/app/components/tutorials/saved-empty.hbs
+++ b/mon-pix/app/components/tutorials/saved-empty.hbs
@@ -1,5 +1,5 @@
 <div class="user-tutorials-content__saved-empty">
-  <img src="/images/illustrations/user-tutorials/saved-empty.png" alt="" role="presentation" />
+  <img src="/images/illustrations/user-tutorials/saved-empty.png" alt="" />
   <div>
     <h2 class="user-tutorials-saved-empty__title">
       {{t "pages.user-tutorials.saved-empty.title"}}

--- a/mon-pix/app/templates/account-recovery/find-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/find-sco-record.hbs
@@ -4,7 +4,7 @@
   <div class="account-recovery__content">
     <PixLogo />
     <div class="account-recovery__content--image">
-      <img alt="" role="none" src="/images/illustrations/account-recovery/{{this.templateImg}}.svg" />
+      <img alt="" src="/images/illustrations/account-recovery/{{this.templateImg}}.svg" />
     </div>
 
     <div class="account-recovery__content--step">

--- a/mon-pix/app/templates/account-recovery/update-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/update-sco-record.hbs
@@ -4,7 +4,7 @@
   <div class="account-recovery__content">
     <PixLogo />
     <div class="account-recovery__content--image">
-      <img alt="" role="none" src="/images/illustrations/account-recovery/illustration.svg" />
+      <img alt="" src="/images/illustrations/account-recovery/illustration.svg" />
     </div>
 
     <div class="account-recovery__content--step">

--- a/mon-pix/app/templates/authenticated/user-tests.hbs
+++ b/mon-pix/app/templates/authenticated/user-tests.hbs
@@ -7,7 +7,7 @@
 <main id="main" role="main">
   <PixBackgroundHeader class="user-tests__header">
     <div class="user-tests-banner">
-      <img src="/images/background/user-test-banner.svg" class="user-tests-banner__icon" role="none" alt="" />
+      <img src="/images/background/user-test-banner.svg" class="user-tests-banner__icon" alt="" />
       <h1 class="user-tests-banner__title">{{t "pages.user-tests.title"}}</h1>
     </div>
   </PixBackgroundHeader>

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -11,7 +11,7 @@
     </div>
 
     <div class="campaign-tutorial__explanation-icon">
-      <img alt="" role="none" src="/images/illustrations/tutorial-campaign/{{@model.icon}}" />
+      <img alt="" src="/images/illustrations/tutorial-campaign/{{@model.icon}}" />
     </div>
 
     <div class="campaign-tutorial__explanation-text"><p>{{@model.explanation}}</p></div>

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -16,7 +16,6 @@
             <img
               class="campaign-landing-page__details__article-image measure"
               src="/images/illustrations/landing-page/icon-mesurer.svg"
-              role="none"
               alt=""
             />
             <div class="campaign-landing-page__details__article-side">
@@ -30,7 +29,7 @@
           <div
             class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline"
           >
-            <img src="/images/illustrations/landing-page/icon-conseil.svg" role="none" alt="" />
+            <img src="/images/illustrations/landing-page/icon-conseil.svg" alt="" />
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title">
                 {{t "pages.campaign-landing.assessment.develop.title"}}
@@ -45,7 +44,7 @@
           <div
             class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline"
           >
-            <img src="/images/illustrations/landing-page/icon-certif.svg" role="none" alt="" />
+            <img src="/images/illustrations/landing-page/icon-certif.svg" alt="" />
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title">
                 {{t "pages.campaign-landing.assessment.certify.title"}}

--- a/mon-pix/app/templates/components/focused-certification-challenge-instructions.hbs
+++ b/mon-pix/app/templates/components/focused-certification-challenge-instructions.hbs
@@ -1,6 +1,6 @@
 <div class="focused-certification-challenge-instructions">
   <div class="focused-certification-challenge-instructions__image">
-    <img src="/images/icone-pix-focus-rounded.svg" role="none" alt="" />
+    <img src="/images/icone-pix-focus-rounded.svg" alt="" />
   </div>
   <div class="focused-certification-challenge-instructions__title">
     {{t "pages.focused-certification-challenge-instructions.title"}}


### PR DESCRIPTION
## :unicorn: Problème
Suite à un retour sur l'audit, les images décoratives utilisait le rôle `presentation` ou `none` associé ou non avec un `alt` vide. Ajouté un `alt=""` permet déjà d'être ignoré par les technologies d'assistance. L'ajout du `role="presentation"` ou `role="none"` revient à casser cette sémantique et peut donc causer des soucis de détection. (cf https://www.w3.org/WAI/tutorials/images/decorative/)

## :robot: Proposition
Enlever le rôle `presentation` et `none` sur les images décoratives.
Ajouter un alt vide.

## :100: Pour tester
Vérifier que les images décoratives ne possède plus de rôle `presentation` ou `none` et comporte un alt vide. 
