### PR TITLE
[TECH] Supprimer les warnings sinon.stub

### DIFF
--- a/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
+++ b/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
@@ -1,6 +1,5 @@
-import { expect, knex } from '../../test-helper.js';
+import { expect, knex, sinon } from '../../test-helper.js';
 import { createUsers } from '../../../scripts/create-users-accounts-for-contest.js';
-import sinon from 'sinon';
 
 describe('Acceptance | Scripts | create-users-accounts-for-contest', function () {
   describe('#createUsers', function () {

--- a/api/tests/integration/domain/usecases/cancel-certification-center-invitation_test.js
+++ b/api/tests/integration/domain/usecases/cancel-certification-center-invitation_test.js
@@ -1,5 +1,4 @@
-import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
-import sinon from 'sinon';
+import { catchErr, databaseBuilder, expect, sinon } from '../../../test-helper.js';
 
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { CertificationCenterInvitation } from '../../../../lib/domain/models/CertificationCenterInvitation.js';

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -1,5 +1,4 @@
-import sinon from 'sinon';
-import { expect, databaseBuilder, knex, catchErr } from '../../../test-helper.js';
+import { expect, databaseBuilder, knex, catchErr, sinon } from '../../../test-helper.js';
 import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;

--- a/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
@@ -1,5 +1,4 @@
-import sinon from 'sinon';
-import { expect, databaseBuilder } from '../../../test-helper.js';
+import { expect, databaseBuilder, sinon } from '../../../test-helper.js';
 import * as organizationPlacesCapacityRepository from '../../../../lib/infrastructure/repositories/organization-places-capacity-repository.js';
 import * as categories from '../../../../lib/domain/constants/organization-places-categories.js';
 

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
@@ -1,5 +1,4 @@
-import sinon from 'sinon';
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { expect, domainBuilder, sinon } from '../../../../test-helper.js';
 import { updateUserForAccountRecovery } from '../../../../../lib/domain/usecases/account-recovery/update-user-for-account-recovery.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';

--- a/api/tests/unit/domain/usecases/update-campaign-details-management_test.js
+++ b/api/tests/unit/domain/usecases/update-campaign-details-management_test.js
@@ -1,7 +1,6 @@
-import { expect, catchErr, domainBuilder } from '../../../test-helper.js';
+import { expect, catchErr, domainBuilder, sinon } from '../../../test-helper.js';
 import { updateCampaignDetailsManagement } from '../../../../lib/domain/usecases/update-campaign-details-management.js';
 import { EntityValidationError } from '../../../../lib/domain/errors.js';
-import sinon from 'sinon';
 
 describe('Unit | UseCase | update-campaign-details-management', function () {
   let campaignManagementRepository;


### PR DESCRIPTION
## :unicorn: Problème
Le linter remonte des warnings avec nos usages de sinon
<img width="897" alt="Screenshot 2023-06-12 at 14 56 01" src="https://github.com/1024pix/pix/assets/26384707/236efb36-a954-4171-a19c-4dd580a063e2">

## :robot: Proposition
Remplacer les imports de sinon, par les imports de sinon depuis le fichier test-helpers

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier qu'il reste moins de warnings de lint [dans la CI](https://app.circleci.com/pipelines/github/1024pix/pix/58366/workflows/a4e140dc-d50d-46db-ac18-dcf0d39b9243/jobs/469972)
