### PR TITLE
[TECH] Harmoniser les imports de `data-fetcher`

### DIFF
--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -8,13 +8,13 @@ const getNextChallengeForCampaignAssessment = async function ({
   assessment,
   pickChallengeService,
   locale,
-  dataFetcher,
+  algorithmDataFetcherService,
   smartRandom,
 }) {
   let algoResult;
 
   if (assessment.isFlash()) {
-    const { allAnswers, challenges, estimatedLevel } = await dataFetcher.fetchForFlashCampaigns({
+    const { allAnswers, challenges, estimatedLevel } = await algorithmDataFetcherService.fetchForFlashCampaigns({
       assessmentId: assessment.id,
       answerRepository,
       challengeRepository,
@@ -32,7 +32,7 @@ const getNextChallengeForCampaignAssessment = async function ({
 
     return pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
   } else {
-    const inputValues = await dataFetcher.fetchForCampaigns(...arguments);
+    const inputValues = await algorithmDataFetcherService.fetchForCampaigns(...arguments);
     algoResult = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, locale });
 
     if (algoResult.hasAssessmentEnded) {

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -1,5 +1,5 @@
 import { AssessmentEndedError, UserNotAuthorizedToAccessEntityError } from '../errors.js';
-import * as dataFetcher from '../services/algorithm-methods/data-fetcher.js';
+import * as algorithmDataFetcherService from '../services/algorithm-methods/data-fetcher.js';
 
 const getNextChallengeForCompetenceEvaluation = async function ({
   pickChallengeService,
@@ -9,7 +9,7 @@ const getNextChallengeForCompetenceEvaluation = async function ({
   smartRandom,
 }) {
   _checkIfAssessmentBelongsToUser(assessment, userId);
-  const inputValues = await dataFetcher.fetchForCompetenceEvaluations(...arguments);
+  const inputValues = await algorithmDataFetcherService.fetchForCompetenceEvaluations(...arguments);
 
   const { possibleSkillsForNextChallenge, hasAssessmentEnded } = smartRandom.getPossibleSkillsForNextChallenge({
     ...inputValues,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -2,8 +2,6 @@ import { config } from '../../config.js';
 import * as accountRecoveryDemandRepository from '../../infrastructure/repositories/account-recovery-demand-repository.js';
 import * as adminMemberRepository from '../../infrastructure/repositories/admin-member-repository.js';
 
-// eslint-disable-next-line import/no-duplicates
-import * as dataFetcher from '../../domain/services/algorithm-methods/data-fetcher.js';
 import * as algorithmDataFetcherService from '../../domain/services/algorithm-methods/data-fetcher.js';
 import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../infrastructure/repositories/area-repository.js';
@@ -580,7 +578,6 @@ const dependencies = {
   cpfCertificationResultRepository,
   dataProtectionOfficerRepository,
   dateUtils,
-  dataFetcher,
   divisionRepository,
   encryptionService,
   flashAssessmentResultRepository,

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, domainBuilder } from '../../../test-helper.js';
 import { getNextChallengeForCampaignAssessment } from '../../../../lib/domain/usecases/get-next-challenge-for-campaign-assessment.js';
-import * as dataFetcher from '../../../../lib/domain/services/algorithm-methods/data-fetcher.js';
+import * as algorithmDataFetcherService from '../../../../lib/domain/services/algorithm-methods/data-fetcher.js';
 
 import { LOCALE } from '../../../../lib/domain/constants.js';
 
@@ -97,7 +97,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
         pickChallengeService,
         locale,
         smartRandom,
-        dataFetcher,
+        algorithmDataFetcherService,
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -40,7 +40,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             .stub()
             .returns({ possibleSkillsForNextChallenge, hasAssessmentEnded: false }),
         };
-        const dataFetcherStub = {
+        const algorithmDataFetcherServiceStub = {
           fetchForCampaigns: sinon.stub().resolves({}),
         };
 
@@ -60,7 +60,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           pickChallengeService,
           assessment,
           smartRandom: smartRandomStub,
-          dataFetcher: dataFetcherStub,
+          algorithmDataFetcherService: algorithmDataFetcherServiceStub,
           flash,
           locale,
         });
@@ -112,7 +112,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           // given
           const challenges = [firstChallenge, secondChallenge];
 
-          const dataFetcherStub = {
+          const algorithmDataFetcherServiceStub = {
             fetchForFlashCampaigns: sinon.stub(),
           };
 
@@ -126,7 +126,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
 
           pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallenge);
 
-          dataFetcherStub.fetchForFlashCampaigns
+          algorithmDataFetcherServiceStub.fetchForFlashCampaigns
             .withArgs({
               assessmentId: assessment.id,
               answerRepository,
@@ -147,7 +147,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             pickChallengeService,
             assessment,
             locale,
-            dataFetcher: dataFetcherStub,
+            algorithmDataFetcherService: algorithmDataFetcherServiceStub,
           });
 
           // then
@@ -158,11 +158,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
       describe('when there are multiple remaining challenges', function () {
         it('should return the best next challenges', async function () {
           // given
-          const dataFetcherStub = {
+          const algorithmDataFetcherServiceStub = {
             fetchForFlashCampaigns: sinon.stub(),
           };
 
-          dataFetcherStub.fetchForFlashCampaigns
+          algorithmDataFetcherServiceStub.fetchForFlashCampaigns
             .withArgs({
               assessmentId: assessment.id,
               answerRepository,
@@ -193,7 +193,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             pickChallengeService,
             assessment,
             locale,
-            dataFetcher: dataFetcherStub,
+            algorithmDataFetcherService: algorithmDataFetcherServiceStub,
           });
 
           // then
@@ -204,11 +204,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
       describe('when there is no challenge left', function () {
         it('should throw an AssessmentEndedError()', async function () {
           // given
-          const dataFetcherStub = {
+          const algorithmDataFetcherServiceStub = {
             fetchForFlashCampaigns: sinon.stub(),
           };
 
-          dataFetcherStub.fetchForFlashCampaigns
+          algorithmDataFetcherServiceStub.fetchForFlashCampaigns
             .withArgs({
               assessmentId: assessment.id,
               answerRepository,
@@ -229,7 +229,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             pickChallengeService,
             assessment,
             locale,
-            dataFetcher: dataFetcherStub,
+            algorithmDataFetcherService: algorithmDataFetcherServiceStub,
             pseudoRandom: {
               create: () => ({
                 binaryTreeRandom: () => {
@@ -258,11 +258,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
 
         it('should throw an AssessmentEndedError()', async function () {
           // given
-          const dataFetcherStub = {
+          const algorithmDataFetcherServiceStub = {
             fetchForFlashCampaigns: sinon.stub(),
           };
 
-          dataFetcherStub.fetchForFlashCampaigns
+          algorithmDataFetcherServiceStub.fetchForFlashCampaigns
             .withArgs({
               assessmentId: assessment.id,
               answerRepository,
@@ -283,7 +283,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             pickChallengeService,
             assessment,
             locale,
-            dataFetcher: dataFetcherStub,
+            algorithmDataFetcherService: algorithmDataFetcherServiceStub,
             pseudoRandom: {
               create: () => ({
                 binaryTreeRandom: () => {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le linter remonte un warning sur le fait que nous importons deux fois le même fichiers 
<img width="897" alt="Screenshot 2023-06-12 at 15 50 10" src="https://github.com/1024pix/pix/assets/26384707/d7882ba7-426c-4990-8fe5-197019d6c21a">

## :robot: Proposition
Faire en sorte d'importer une unique fois ce fichier en harmonisant le nom de la dépendance en `algorithmDataFetcherService`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Regarder dans la CI dans l'API regarder que le linter ne remonte plus l'erreur
- CI OK
- Passer des épreuves d'une campagne
- Passer des épreuves d'une compétence