### PR TITLE
[BUGFIX] Corrige les jobs pgboss 

### DIFF
--- a/api/lib/infrastructure/jobs/JobQueue.js
+++ b/api/lib/infrastructure/jobs/JobQueue.js
@@ -13,10 +13,7 @@ class JobQueue {
     this.pgBoss.work(name, { teamSize, teamConcurrency }, async (job) => {
       const jobHandler = new handlerClass();
       const monitoredJobHandler = new MonitoredJobHandler(jobHandler, logger);
-      return monitoredJobHandler
-        .handle(job.data)
-        .then(() => job.done())
-        .catch((error) => job.done(error));
+      return monitoredJobHandler.handle(job.data);
     });
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Les jobs pgboss de calcul de campagne et d'envoi a pole emploi sont cassé. Cassé depuis #6214. 

## :robot: Proposition
Supprimer les appels a job.done qui ne sont plus nécessaire dans pgboss 9.

## :100: Pour tester
1. Faire une campagne
2. Regarder les logs de pgboss
3. Voir qu'aucun job n'est en erreur et que les jobs sont bien dépilés.
