### PR TITLE
[FEATURE] Amélioration du wording lors de la création d'une campagne d'évaluation (PIX-8293)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -360,7 +360,7 @@
         },
         "assessments": {
           "question-label": "Do you want to allow participants to submit their results more than once?",
-          "info": "If you choose to allow multiple submissions, the participants will be able to take the test and submit their results several times by re-entering the campaign code. Within Pix Orga you will find the latest participation."
+          "info": "If you choose to allow multiple submissions, the participants will be able to take the test again 4 days after and submit their results several times by re-entering the campaign code. Within Pix Orga you will find the latest participation."
         }
       },
       "name": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -363,7 +363,7 @@
         },
         "assessments": {
           "question-label": "Souhaitez-vous permettre aux participants d’envoyer plusieurs fois leurs résultats ?",
-          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne et envoyer ses résultats plusieurs fois, en saisissant à nouveau le code. Au sein de Pix Orga, vous verrez sa dernière participation."
+          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne 4 jours après et envoyer ses résultats plusieurs fois, en saisissant à nouveau le code. Au sein de Pix Orga, vous verrez sa dernière participation."
         }
       },
       "name": {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons permis d’activer la fonctionnalité d’envoi multiple pour une campagne d'évaluation pour chaque orga dans Pix Admin, rendant possible pour l’orga la création de campagne d'évaluation à envoi multiple dans Pix Orga. Actuellement aucune information explique aux prescripteurs qu’il y a un délai de 4 jours avant de pouvoir réenvoyer le résultat.

## :robot: Proposition
Ajouter lors de la création de campagne d'évaluation, un complément d’information dans le message d’information ci-dessous

## :rainbow: Remarques
-> Seulement disponible pour les orga ayant l'envoi multiple sur les campagnes d'évaluation activé

## :100: Pour tester

- Se connecter à Pix Orga avec une orga ayant l'envoi multiple actif pour les campagnes d'évaluation
- Aller sur la page de création d'une campagne
- Vérifier qu'en selectionnant "Evaluer les participants", l'encart d'information à droite comporte bien l'info des 4 jours de délai
- (Possible d'essayer également en version EN)
- 🐱 
