### PR TITLE
[FEATURE] Ajout de checkboxs à la liste de participants d'une organisation (PIX-7949)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -11,6 +11,7 @@
     <caption class="screen-reader-only">{{t "pages.organization-participants.table.description"}}</caption>
     <thead>
       <tr>
+        <Table::Header class="table__column--small" />
         <Table::HeaderSort
           @display="left"
           @size="medium"
@@ -53,12 +54,19 @@
 
     {{#if @participants}}
       <tbody>
-        {{#each @participants as |participant index|}}
+        <SelectableList @items={{@participants}} as |participant toggleParticipant isParticipantSelected index|>
           <tr
             aria-label={{t "pages.organization-participants.table.row-title"}}
             {{on "click" (fn @onClickLearner participant.id)}}
             class="tr--clickable"
           >
+            <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
+              <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>{{t
+                  "pages.organization-participants.table.column.checkbox"
+                  firstname=participant.firstName
+                  lastname=participant.lastName
+                }}</PixCheckbox>
+            </td>
             <td class="table__column">
               <LinkTo
                 @route="authenticated.organization-participants.organization-participant"
@@ -68,7 +76,9 @@
               </LinkTo>
             </td>
             <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
-            <td class="table__column--center">{{participant.participationCount}}</td>
+            <td class="table__column--center">
+              {{participant.participationCount}}
+            </td>
             <td>
               <div class="organization-participant-list-page__last-participation">
                 <span>{{dayjs-format participant.lastParticipationDate "DD/MM/YYYY"}}</span>
@@ -91,7 +101,7 @@
               {{/if}}
             </td>
           </tr>
-        {{/each}}
+        </SelectableList>
       </tbody>
     {{/if}}
   </table>

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class List extends Component {
+  @action
+  onClick(toggleParticipant, event) {
+    event.stopPropagation();
+    toggleParticipant();
+  }
+}

--- a/orga/app/components/selectable-list.hbs
+++ b/orga/app/components/selectable-list.hbs
@@ -1,0 +1,3 @@
+{{#each @items as |item index|}}
+  {{yield item (fn this.toggle item) (this.isSelected item) index}}
+{{/each}}

--- a/orga/app/components/selectable-list.js
+++ b/orga/app/components/selectable-list.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class SelectableList extends Component {
+  @tracked selectedItems = [];
+
+  @action
+  toggle(item) {
+    if (this.isSelected(item)) {
+      this.selectedItems = this.selectedItems.filter((selectedItem) => {
+        return selectedItem !== item;
+      });
+    } else {
+      this.selectedItems = [...this.selectedItems, item];
+    }
+  }
+
+  @action
+  isSelected(item) {
+    return this.selectedItems.includes(item);
+  }
+}

--- a/orga/tests/unit/components/selectable-list_test.js
+++ b/orga/tests/unit/components/selectable-list_test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Component | Selectable List', function (hooks) {
+  setupTest(hooks);
+
+  module('#toggle', function () {
+    test('should add an element in selected list', async function (assert) {
+      // given
+      const selectedItem = {};
+      const notSelectedItem = {};
+      const items = [selectedItem, notSelectedItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+
+      // when
+      component.toggle(selectedItem);
+
+      // then
+      assert.true(component.selectedItems.includes(selectedItem));
+      assert.false(component.selectedItems.includes(notSelectedItem));
+    });
+
+    test('should remove a selected element from the selected list', async function (assert) {
+      // given
+      const selectedItem = {};
+      const notSelectedItem = {};
+      const items = [selectedItem, notSelectedItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+      component.selectedItems.push(selectedItem);
+      component.selectedItems.push(notSelectedItem);
+
+      // when
+      component.toggle(notSelectedItem);
+
+      // then
+      assert.false(component.selectedItems.includes(notSelectedItem));
+      assert.true(component.selectedItems.includes(selectedItem));
+    });
+  });
+
+  module('#isSelected', function () {
+    test('should return true if item is in selected list', async function (assert) {
+      // given
+      const item = {};
+      const component = await createGlimmerComponent('component:selectable-list', { items: [item] });
+      component.selectedItems.push(item);
+
+      // when
+      const isMyItemSelected = component.isSelected(item);
+
+      // then
+      assert.true(isMyItemSelected);
+    });
+
+    test('should return false if item is not in selected list', async function (assert) {
+      // given
+      const item = {};
+      const component = await createGlimmerComponent('component:selectable-list', { items: [item] });
+
+      // when
+      const isMyItemSelected = component.isSelected(item);
+
+      // then
+      assert.false(isMyItemSelected);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -740,6 +740,7 @@
       "table": {
         "description": "Table of participants, sorted by name.",
         "column": {
+          "checkbox": "Select/Unselect {firstname} {lastname}",
           "first-name": "First name",
           "last-name": {
             "label": "Last name",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -743,6 +743,7 @@
       "table": {
         "description": "Tableau des participants trié par nom.",
         "column": {
+          "checkbox": "Sélectionner/Déselectionner {firstname} {lastname}",
           "first-name": "Prénom",
           "last-name": {
             "label": "Nom",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons réalisé les tickets back nécessaire pour rendre possible de supprimer des prescrits. Nous pouvons maintenant passer à l’API et au front, sachant que cet ensemble de tickets doivent être réalisés dans une même branche et partir en prod en simultané.

## :robot: Proposition
Pour permettre aux admins des orga concernées par la feature (toutes sauf SCO IsManagingStudents=true) de sélectionner des participants/étudiants, nous allons ajouter une colonne de coches sur la liste des prescrits (cf maquette).

La coche principale, en haut de la colonne, permet soit de sélectionner tous les prescrits de la liste sur la page affichée si aucun n’a été sélectionné, soit de désélectionner le ou les prescrits dès qu’il y en a au moins un de sélectionné.
Pour les autres coches, elles permettent de dé/sélectionner chaque prescrit individuellement.

## :rainbow: Remarques
Ici ne sont créées que les coche par participants. La coche principale sera faites dans le prochain ticket

## :100: Pour tester
- se rendre sur la page de participants (PRO)
- vérifier qu'il y a bien des checkboxes cochables pour chaque ligne