### PR TITLE
[BUGFIX] Un test d'acceptance pix-admin échoue aléatoirement (PIX-8341)

### DIFF
--- a/admin/testem.js
+++ b/admin/testem.js
@@ -17,4 +17,5 @@ module.exports = {
       ].filter(Boolean),
     },
   },
+  timeout: 20000,
 };


### PR DESCRIPTION
## :unicorn: Problème
Le test d'acceptance de création de badge échoue de temps en temps
```
178) [Chrome] error
     Error: Browser timeout exceeded: 10s
Error while executing test: Acceptance | Target Profile Insights > Insights > Stages > Stage level: it should add new stages
Stderr: 
 [0613/135438.063814:ERROR:bus.cc(399)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```

## :robot: Proposition
On se demande si c'est dû au fait que l'application est de moins en moins performante, et que ce test étant le plus gourmand, seul celui-ci échoue. Le message d'erreur `dbus` est peut-être déjà présent dans les workflow OK.

Etendre le timeout de 10 secondes à 20 secondes.
https://github.com/testem/testem/blob/master/docs/config_file.md#config-level-options

Voir si après le merge sur dev, la CI sort encore en erreur. 

## :rainbow: Remarques
Cette PR est une PR de diagnostic, pas de résolution.
Ce timeout devra être enlevé dans une PR suivante.

On a découvert que la version de Chrome utilisée est la dernière stable, et est téléchargée par la commande `install-browser` de l'orb.
https://circleci.com/developer/orbs/orb/circleci/browser-tools#orb-source

## :100: Pour tester
Vérifier la CI

Je remarque qu'il y a un test flaky sur `mon-pix`

```
[duration - 52497 ms]
1..795
# tests 795
# pass  790
# skip  0
# todo  0
# fail  5

101) [Chrome 114.0] Exam Partition 3 - Acceptance | Campaigns | Start Campaigns with type Assessment > Start a campaign > When user is not logged in > When campaign has external id > When participant external id is not set in the url: should redirect to assessment after completion of external id
     Promise rejected during "should redirect to assessment after completion of external id": Unable to find an accessible element with the role "textbox" and name "email"
```
