### PR TITLE
[TECH] Augmenter le temps d'inactivité du browser sur pix-admin

### DIFF
--- a/admin/testem.js
+++ b/admin/testem.js
@@ -17,5 +17,6 @@ module.exports = {
       ].filter(Boolean),
     },
   },
+  browser_disconnect_timeout: 20000,
   timeout: 20000,
 };


### PR DESCRIPTION
## :unicorn: Problème
#6365 ne regle pas le problème. La ci échoue au bout de 10s.

## :robot: Proposition
Utiliser l'option browser_disconnect_timeout https://github.com/testem/testem/blob/master/docs/config_file.md#config-level-option

## :100: Pour tester
Vérifier la CI
