### PR TITLE
[CHORE] Remettre le resource_class de circle ci à small pour l'app mon-pix(PIX-8347)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2
-    resource_class: medium
+    resource_class: small
     working_directory: ~/pix/mon-pix
     parallelism: 3
     steps:


### PR DESCRIPTION
## :unicorn: Problème
Il y avait des tests de l'appli mon-pix qui cassaient de manière aléatoire et qui empêchaient le déploiement des applis
Une des solutions envisagée pour palier à ce problème était de mettre l’attribut resource_class: medium
Cette solution n'a pas résolue le problème.
Mais elle a quand même été mergée. 

## :robot: Proposition
Remettre comme c'était avant.

## :rainbow: Remarques


## :100: Pour tester
Check si tout va bien 
