### PR TITLE
[FEATURE] Ajout de la checkbox principale sur la liste des participants

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -11,7 +11,7 @@
     <caption class="screen-reader-only">{{t "pages.organization-participants.table.description"}}</caption>
     <thead>
       <tr>
-        <Table::Header class="table__column--small" />
+        <Table::Header class="table__column--small" id={{this.mainCheckboxId}} />
         <Table::HeaderSort
           @display="left"
           @size="medium"
@@ -54,53 +54,65 @@
 
     {{#if @participants}}
       <tbody>
-        <SelectableList @items={{@participants}} as |participant toggleParticipant isParticipantSelected index|>
-          <tr
-            aria-label={{t "pages.organization-participants.table.row-title"}}
-            {{on "click" (fn @onClickLearner participant.id)}}
-            class="tr--clickable"
-          >
-            <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
-              <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>{{t
-                  "pages.organization-participants.table.column.checkbox"
-                  firstname=participant.firstName
-                  lastname=participant.lastName
-                }}</PixCheckbox>
-            </td>
-            <td class="table__column">
-              <LinkTo
-                @route="authenticated.organization-participants.organization-participant"
-                @model={{participant.id}}
-              >
-                {{participant.lastName}}
-              </LinkTo>
-            </td>
-            <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
-            <td class="table__column--center">
-              {{participant.participationCount}}
-            </td>
-            <td>
-              <div class="organization-participant-list-page__last-participation">
-                <span>{{dayjs-format participant.lastParticipationDate "DD/MM/YYYY"}}</span>
-                <Ui::LastParticipationDateTooltip
-                  @id={{index}}
-                  @campaignName={{participant.campaignName}}
-                  @campaignType={{participant.campaignType}}
-                  @participationStatus={{participant.participationStatus}}
-                />
-              </div>
-            </td>
-            <td class="table__column--center">
-              <Ui::IsCertifiable @isCertifiable={{participant.isCertifiable}} />
-              {{#if participant.certifiableAt}}
-                <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
-                    participant.certifiableAt
-                    "DD/MM/YYYY"
-                    allow-empty=true
-                  }}</span>
-              {{/if}}
-            </td>
-          </tr>
+        <SelectableList @items={{@participants}}>
+          <:manager as |allSelected someSelected toggleAll|>
+            {{#in-element this.mainCheckbox}}
+              <PixCheckbox
+                @screenReaderOnly={{true}}
+                @checked={{someSelected}}
+                @isIndeterminate={{(not allSelected)}}
+                {{on "click" toggleAll}}
+              >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
+            {{/in-element}}
+          </:manager>
+          <:item as |participant toggleParticipant isParticipantSelected index|>
+            <tr
+              aria-label={{t "pages.organization-participants.table.row-title"}}
+              {{on "click" (fn @onClickLearner participant.id)}}
+              class="tr--clickable"
+            >
+              <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
+                <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>{{t
+                    "pages.organization-participants.table.column.checkbox"
+                    firstname=participant.firstName
+                    lastname=participant.lastName
+                  }}</PixCheckbox>
+              </td>
+              <td class="table__column">
+                <LinkTo
+                  @route="authenticated.organization-participants.organization-participant"
+                  @model={{participant.id}}
+                >
+                  {{participant.lastName}}
+                </LinkTo>
+              </td>
+              <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
+              <td class="table__column--center">
+                {{participant.participationCount}}
+              </td>
+              <td>
+                <div class="organization-participant-list-page__last-participation">
+                  <span>{{dayjs-format participant.lastParticipationDate "DD/MM/YYYY"}}</span>
+                  <Ui::LastParticipationDateTooltip
+                    @id={{index}}
+                    @campaignName={{participant.campaignName}}
+                    @campaignType={{participant.campaignType}}
+                    @participationStatus={{participant.participationStatus}}
+                  />
+                </div>
+              </td>
+              <td class="table__column--center">
+                <Ui::IsCertifiable @isCertifiable={{participant.isCertifiable}} />
+                {{#if participant.certifiableAt}}
+                  <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
+                      participant.certifiableAt
+                      "DD/MM/YYYY"
+                      allow-empty=true
+                    }}</span>
+                {{/if}}
+              </td>
+            </tr>
+          </:item>
         </SelectableList>
       </tbody>
     {{/if}}

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -1,10 +1,19 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 
 export default class List extends Component {
   @action
   onClick(toggleParticipant, event) {
     event.stopPropagation();
     toggleParticipant();
+  }
+
+  get mainCheckboxId() {
+    return guidFor(this);
+  }
+
+  get mainCheckbox() {
+    return document.getElementById(this.mainCheckboxId);
   }
 }

--- a/orga/app/components/selectable-list.hbs
+++ b/orga/app/components/selectable-list.hbs
@@ -1,3 +1,4 @@
 {{#each @items as |item index|}}
-  {{yield item (fn this.toggle item) (this.isSelected item) index}}
+  {{yield item (fn this.toggle item) (this.isSelected item) index to="item"}}
 {{/each}}
+{{yield this.allSelected this.someSelected this.toggleAll to="manager"}}

--- a/orga/app/components/selectable-list.js
+++ b/orga/app/components/selectable-list.js
@@ -5,6 +5,23 @@ import { action } from '@ember/object';
 export default class SelectableList extends Component {
   @tracked selectedItems = [];
 
+  get allSelected() {
+    return this.selectedItems.length === this.args.items.length;
+  }
+
+  get someSelected() {
+    return this.selectedItems.length >= 1;
+  }
+
+  @action
+  toggleAll() {
+    if (this.someSelected || this.allSelected) {
+      this.selectedItems = [];
+    } else {
+      this.selectedItems = [...this.args.items.toArray()];
+    }
+  }
+
   @action
   toggle(item) {
     if (this.isSelected(item)) {

--- a/orga/tests/integration/components/selectable-list_test.js
+++ b/orga/tests/integration/components/selectable-list_test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { click } from '@ember/test-helpers';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Selectable List', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('When user toggle one of the checkbox', function () {
+    test('should toggle the main checkbox', async function (assert) {
+      // given
+      const items = [
+        { id: 1, label: 'Item 1' },
+        { id: 2, label: 'Item 2' },
+      ];
+      this.set('items', items);
+
+      const screen = await render(hbs`<SelectableList @items={{this.items}}>
+  <:manager as |allSelected someSelected|>
+    <PixCheckbox @checked={{someSelected}} @isIndeterminate={{(not allSelected)}}>
+      Main checkbox
+    </PixCheckbox>
+  </:manager>
+  <:item as |checkboxItem toggleCheckboxItem isSelected|>
+    <PixCheckbox @id={{checkboxItem.id}} @checked={{isSelected}} {{on 'click' toggleCheckboxItem}}>
+      {{checkboxItem.label}}
+    </PixCheckbox>
+  </:item>
+</SelectableList>`);
+
+      // when
+      await click(screen.getByLabelText('Item 2'));
+
+      // then
+      const mainCheckbox = screen.getByLabelText('Main checkbox');
+      assert.true(mainCheckbox.checked);
+      assert.ok(mainCheckbox.className.includes('pix-checkbox__input--indeterminate'));
+    });
+  });
+});

--- a/orga/tests/unit/components/selectable-list_test.js
+++ b/orga/tests/unit/components/selectable-list_test.js
@@ -5,6 +5,76 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Component | Selectable List', function (hooks) {
   setupTest(hooks);
 
+  module('#allSelected', function () {
+    test('should return false if not all element have been selected', async function (assert) {
+      // given
+      const firstItem = { id: 1 };
+      const secondItem = { id: 2 };
+      const items = [firstItem, secondItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+
+      // when
+      const result = component.allSelected;
+
+      // then
+      assert.false(result);
+    });
+
+    test('should return true if all element have been selected', async function (assert) {
+      // given
+      const firstItem = { id: 1 };
+      const secondItem = { id: 2 };
+      const items = [firstItem, secondItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+
+      // when
+      component.selectedItems = items;
+      const result = component.allSelected;
+
+      // then
+      assert.true(result);
+    });
+  });
+
+  module('#someSelected', function () {
+    test('should return true when selected elements count is greater than 1', async function (assert) {
+      // given
+      const firstItem = { id: 1 };
+      const secondItem = { id: 2 };
+      const items = [firstItem, secondItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+
+      // when
+      component.selectedItems.push(firstItem);
+      const result = component.someSelected;
+
+      // then
+      assert.true(result);
+    });
+
+    test('should return false when selected elements count is lesser than 1', async function (assert) {
+      // given
+      const firstItem = { id: 1 };
+      const secondItem = { id: 2 };
+      const items = [firstItem, secondItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+
+      // when
+      const result = component.someSelected;
+
+      // then
+      assert.false(result);
+    });
+  });
+
   module('#toggle', function () {
     test('should add an element in selected list', async function (assert) {
       // given
@@ -40,6 +110,62 @@ module('Unit | Component | Selectable List', function (hooks) {
       // then
       assert.false(component.selectedItems.includes(notSelectedItem));
       assert.true(component.selectedItems.includes(selectedItem));
+    });
+  });
+
+  module('#toggleAll', function () {
+    module('when selected list is empty', function () {
+      test('should add all elements in selected list', async function (assert) {
+        const firstItem = { id: 1 };
+        const lastItem = { id: 2 };
+
+        const items = [firstItem, lastItem];
+        const component = await createGlimmerComponent('component:selectable-list', { items });
+
+        // when
+        component.toggleAll();
+
+        // then
+        assert.deepEqual(component.selectedItems, items);
+      });
+    });
+
+    module('when all elements are in selected list', function () {
+      test('should unselect all elements when all are already selected', async function (assert) {
+        const firstItem = { id: 1 };
+        const lastItem = { id: 2 };
+
+        const items = [firstItem, lastItem];
+        const component = await createGlimmerComponent('component:selectable-list', { items });
+        component.selectedItems.push(firstItem);
+        component.selectedItems.push(lastItem);
+
+        // when
+        component.toggleAll();
+
+        // then
+        assert.deepEqual(component.selectedItems, []);
+      });
+    });
+
+    module('when some elements are in selected list', function () {
+      test('should unselect all elements when all are already selected', async function (assert) {
+        const firstItem = { id: 1 };
+        const secondItem = { id: 2 };
+        const lastItem = { id: 3 };
+        const items = [firstItem, secondItem, lastItem];
+
+        const component = await createGlimmerComponent('component:selectable-list', { items });
+
+        component.selectedItems.push(firstItem);
+        component.selectedItems.push(secondItem);
+
+        // when
+        component.toggleAll();
+
+        // then
+        assert.deepEqual(component.selectedItems, []);
+      });
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -740,6 +740,7 @@
       "table": {
         "description": "Table of participants, sorted by name.",
         "column": {
+          "mainCheckbox": "Select/Unselect whole column",
           "checkbox": "Select/Unselect {firstname} {lastname}",
           "first-name": "First name",
           "last-name": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -743,6 +743,7 @@
       "table": {
         "description": "Tableau des participants trié par nom.",
         "column": {
+          "mainCheckbox":"Selectionner/Deselectionner toute la colonne",
           "checkbox": "Sélectionner/Déselectionner {firstname} {lastname}",
           "first-name": "Prénom",
           "last-name": {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons réalisé les tickets back nécessaire pour rendre possible de supprimer des prescrits. Nous pouvons maintenant passer à l’API et au front, sachant que cet ensemble de tickets doivent être réalisés dans une même branche et partir en prod en simultané.

## :robot: Proposition
La coche principale, en haut de la colonne, permet soit de sélectionner tous les prescrits de la liste sur la page affichée si aucun n’a été sélectionné, soit de désélectionner le ou les prescrits dès qu’il y en a au moins un de sélectionné.


## :rainbow: Remarques
Suite de cette [PR](https://github.com/1024pix/pix/pull/6364)
La série de ticket Front de cette Epix sera mergée en même temps sur dev via la [feature branche](https://github.com/1024pix/pix/tree/pix-6616-organization-learner-deletion)

## :100: Pour tester

- Se connecter à Pix Orga avec une Orga Pro
- Aller sur la liste des participants
- Verifier que la checkbox principale est présente 
- Vérifier son fonctionnement : 

 - Si aucune ligne cochée -> Elle est décochée, et en cliquant dessus, toutes les lignes deviennent cochée
 - Si au moins une ligne cochée (mais pas toutes) -> Elle passe en état indeterminée, et au clic, toutes les lignes se décochent
 - Si toutes les lignes sont cochées -> Elle est cochée également, et un clic dessus décoche toutes les lignes
- 🐱 