### PR TITLE
[FEATURE] Filtrer les épreuves périmées dans les simulateurs (PIX-8328). 

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -9,6 +9,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   numberOfIterations: Joi.number().integer().min(0),
   warmpUpLength: Joi.number().integer().min(0),
   forcedCompetencies: Joi.array().items(Joi.string()),
+  useObsoleteChallenges: Joi.boolean(),
 });
 
 const register = async (server) => {

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -26,6 +26,7 @@ async function simulateFlashAssessmentScenario(
     numberOfIterations = 1,
     warmUpLength,
     forcedCompetences,
+    useObsoleteChallenges,
   } = request.payload;
 
   const pickAnswerStatus = _getPickAnswerStatusMethod(dependencies.pickAnswerStatusService, request.payload);
@@ -43,6 +44,7 @@ async function simulateFlashAssessmentScenario(
           initialCapacity,
           warmUpLength,
           forcedCompetences,
+          useObsoleteChallenges,
         },
         _.isUndefined
       );

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -9,8 +9,9 @@ export async function simulateFlashDeterministicAssessmentScenario({
   initialCapacity,
   warmUpLength,
   forcedCompetences,
+  useObsoleteChallenges,
 }) {
-  const challenges = await challengeRepository.findFlashCompatible({ locale });
+  const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
   const flashAssessmentAlgorithm = new FlashAssessmentAlgorithm({
     warmUpLength,

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -3,6 +3,7 @@ import * as datasource from './datasource.js';
 import { LearningContentResourceNotFound } from './LearningContentResourceNotFound.js';
 
 const VALIDATED_CHALLENGE = 'validé';
+const OBSOLETE_CHALLENGE = 'périmé';
 const OPERATIVE_CHALLENGES = [VALIDATED_CHALLENGE, 'archivé'];
 
 const challengeDatasource = datasource.extend({
@@ -51,23 +52,29 @@ const challengeDatasource = datasource.extend({
   },
 
   async findActiveFlashCompatible(locale) {
-    const flashChallenges = await this.findFlashCompatible(locale);
+    const flashChallenges = await this.findFlashCompatible({ locale });
     return flashChallenges.filter((challengeData) => challengeData.status === VALIDATED_CHALLENGE);
   },
 
   async findOperativeFlashCompatible(locale) {
-    const flashChallenges = await this.findFlashCompatible(locale);
+    const flashChallenges = await this.findFlashCompatible({ locale });
     return flashChallenges.filter((challengeData) => _.includes(OPERATIVE_CHALLENGES, challengeData.status));
   },
 
-  async findFlashCompatible(locale) {
+  async findFlashCompatible({ locale, useObsoleteChallenges }) {
     const challenges = await this.list();
+
+    const acceptedStatuses = useObsoleteChallenges
+      ? [OBSOLETE_CHALLENGE, ...OPERATIVE_CHALLENGES]
+      : OPERATIVE_CHALLENGES;
+
     return challenges.filter(
       (challengeData) =>
         _.includes(challengeData.locales, locale) &&
         challengeData.alpha != null &&
         challengeData.delta != null &&
-        challengeData.skillId
+        challengeData.skillId &&
+        acceptedStatuses.includes(challengeData.status)
     );
   },
 });

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -169,8 +169,8 @@ const findOperativeFlashCompatible = async function ({
   return _toDomainCollection({ challengeDataObjects, skills, successProbabilityThreshold });
 };
 
-const findFlashCompatible = async function ({ locale }) {
-  const challengeDataObjects = await challengeDatasource.findFlashCompatible(locale);
+const findFlashCompatible = async function ({ locale, useObsoleteChallenges }) {
+  const challengeDataObjects = await challengeDatasource.findFlashCompatible({ locale, useObsoleteChallenges });
   const skills = await skillDatasource.list();
   return _toDomainCollection({ challengeDataObjects, skills });
 };

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -687,43 +687,69 @@ describe('Integration | Repository | challenge-repository', function () {
       mockLearningContent(learningContent);
     });
 
-    it('should return all flash compatible challenges with skills', async function () {
-      // given
-      const locale = 'fr-fr';
+    context('without requesting obsolete challenges', function () {
+      it('should return all flash compatible challenges with skills', async function () {
+        // given
+        const locale = 'fr-fr';
 
-      // when
-      const actualChallenges = await challengeRepository.findFlashCompatible({
-        locale,
+        // when
+        const actualChallenges = await challengeRepository.findFlashCompatible({
+          locale,
+        });
+
+        // then
+        expect(actualChallenges).to.have.lengthOf(2);
+        expect(actualChallenges[0]).to.be.instanceOf(Challenge);
+        expect(actualChallenges[0]).to.deep.contain({
+          status: 'validé',
+        });
+        expect(actualChallenges[1]).to.deep.contain({
+          status: 'archivé',
+        });
       });
 
-      // then
-      expect(actualChallenges).to.have.lengthOf(3);
-      expect(actualChallenges[0]).to.be.instanceOf(Challenge);
-      expect(actualChallenges[0]).to.deep.contain({
-        status: 'validé',
-      });
-      expect(actualChallenges[1]).to.deep.contain({
-        status: 'archivé',
-      });
-      expect(actualChallenges[2]).to.deep.contain({
-        status: 'périmé',
+      it('should allow overriding success probability threshold default value', async function () {
+        // given
+        const successProbabilityThreshold = 0.75;
+
+        // when
+        const actualChallenges = await challengeRepository.findActiveFlashCompatible({
+          locale: 'fr-fr',
+          successProbabilityThreshold,
+        });
+
+        // then
+        expect(actualChallenges).to.have.lengthOf(1);
+        expect(actualChallenges[0]).to.be.instanceOf(Challenge);
+        expect(actualChallenges[0].minimumCapability).to.equal(-8.682265465359073);
       });
     });
 
-    it('should allow overriding success probability threshold default value', async function () {
-      // given
-      const successProbabilityThreshold = 0.75;
+    context('when requesting obsolete challenges', function () {
+      it('should return all flash compatible challenges with skills', async function () {
+        // given
+        const locale = 'fr-fr';
 
-      // when
-      const actualChallenges = await challengeRepository.findActiveFlashCompatible({
-        locale: 'fr-fr',
-        successProbabilityThreshold,
+        // when
+        const actualChallenges = await challengeRepository.findFlashCompatible({
+          locale,
+          useObsoleteChallenges: true,
+        });
+
+        // then
+        expect(actualChallenges).to.have.lengthOf(3);
+        expect(actualChallenges[0]).to.be.instanceOf(Challenge);
+        expect(actualChallenges[0]).to.deep.contain({
+          status: 'validé',
+        });
+        expect(actualChallenges[1]).to.deep.contain({
+          status: 'archivé',
+        });
+
+        expect(actualChallenges[2]).to.deep.contain({
+          status: 'périmé',
+        });
       });
-
-      // then
-      expect(actualChallenges).to.have.lengthOf(1);
-      expect(actualChallenges[0]).to.be.instanceOf(Challenge);
-      expect(actualChallenges[0].minimumCapability).to.equal(-8.682265465359073);
     });
   });
 

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -14,6 +14,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     challenge_competence1,
     challenge_competence1_noSkills,
     challenge_competence1_notValidated,
+    challenge_competence1_obsolete,
     challenge_competence2,
     challenge_web1,
     challenge_web1_notValidated,
@@ -55,6 +56,17 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       alpha: -0,
       delta: 0,
     };
+
+    challenge_competence1_obsolete = {
+      id: 'challenge-competence1-obsolete',
+      competenceId: competence1.id,
+      skillId: web1.id,
+      locales: ['fr', 'fr-fr'],
+      status: 'périmé',
+      alpha: -0,
+      delta: 0,
+    };
+
     challenge_competence2 = {
       id: 'challenge-competence2',
       competenceId: competence2.id,
@@ -212,6 +224,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
           challenge_competence1,
           challenge_competence1_notValidated,
           challenge_competence1_noSkills,
+          challenge_competence1_obsolete,
           challenge_competence2,
           challenge_web1,
           challenge_web1_notValidated,
@@ -222,22 +235,38 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       });
     });
 
-    it('should resolve an array of matching Challenges from learning content', async function () {
-      // when
-      const locale = 'fr-fr';
-      const result = await challengeDatasource.findFlashCompatible(locale);
+    context('when not requesting obsolete challenges', function () {
+      it('should resolve an array of matching Challenges from learning content', async function () {
+        // when
+        const locale = 'fr-fr';
+        const result = await challengeDatasource.findFlashCompatible({ locale });
 
-      // then
-      expect(lcms.getLatestRelease).to.have.been.called;
-      expect(_.map(result, 'id').sort()).to.deep.equal(
-        [
-          challenge_competence1_notValidated.id,
-          challenge_competence1.id,
-          challenge_competence2.id,
-          challenge_web3.id,
-          challenge_web3_archived.id,
-        ].sort()
-      );
+        // then
+        expect(lcms.getLatestRelease).to.have.been.called;
+        expect(_.map(result, 'id').sort()).to.deep.equal(
+          [challenge_competence1.id, challenge_competence2.id, challenge_web3.id, challenge_web3_archived.id].sort()
+        );
+      });
+    });
+
+    context('when requesting obsolete challenges', function () {
+      it('should resolve an array of matching Challenges from learning content', async function () {
+        // when
+        const locale = 'fr-fr';
+        const result = await challengeDatasource.findFlashCompatible({ locale, useObsoleteChallenges: true });
+
+        // then
+        expect(lcms.getLatestRelease).to.have.been.called;
+        expect(_.map(result, 'id').sort()).to.deep.equal(
+          [
+            challenge_competence1.id,
+            challenge_competence1_obsolete.id,
+            challenge_competence2.id,
+            challenge_web3.id,
+            challenge_web3_archived.id,
+          ].sort()
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

L'équipe data souhaite pouvoir filtrer les épreuves périmées dans les simulateurs du nouvel algo.

## :robot: Proposition

Ajout d'un paramètre `useObsoleteChallenges` pour filtrer les épreuves périmées.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
```
TOKEN=$(curl 'https://api-pr6373.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6373.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "assessmentId": "1234", "capacity": 1.5, "useObsoleteChallenges": true }' | jq '.'
    
    -d '{ "type": "capacity", "assessmentId": "1234", "capacity": 1.5, "useObsoleteChallenges": false }' | jq '.'
```