### PR TITLE
[BUGFIX] Utilise un mot de passe statique dans les tests

### DIFF
--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -248,18 +248,18 @@ export default Factory.extend({
   }),
   withEmail: trait({
     email: faker.internet.exampleEmail(),
-    password: faker.internet.password(),
+    password: 'Azerty123*',
   }),
   withUsername: trait({
     username: faker.internet.userName(),
-    password: faker.internet.password(),
+    password: 'Azerty123*',
   }),
   external: trait({
     lastName: 'Last',
     firstName: 'First',
     email: null,
     username: null,
-    password: faker.internet.password(),
+    password: 'Azerty123*',
   }),
   hasNotValidatedCgu: trait({
     cgu: false,


### PR DESCRIPTION
## :unicorn: Problème
Nous avons certains tests sur mon-pix qui sont flaky. 

## :robot: Proposition
Ces tests flaky sont dûs à un pattern de mot de passe qui ne correspond à notre standard généré par faker.

## :rainbow: Remarques
@jonathanperret l'avait prédit. 
Utiliser des valeurs aléatoires dans les tests peut les faire péter, mais on ne sait pas quelle valeur est fautive.

## :100: Pour tester
1. Lancer plein de fois la CI
