### PR TITLE
[FEATURE] Afficher les corrections QROCM-dep sous les champs en erreur (PIX-8263)

### DIFF
--- a/mon-pix/app/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.hbs
@@ -68,10 +68,12 @@
       {{/if}}
     {{/each}}
     {{#unless this.isCorrectAnswer}}
-      <p class="comparison-window-solution">
-        <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-        <span class="correction-qrocm__solution-text">{{this.formattedSolution}}</span>
-      </p>
+      {{#unless this.shouldDisplayAnswersUnderInputs}}
+        <p class="comparison-window-solution">
+          <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+          <span class="correction-qrocm__solution-text">{{this.formattedSolution}}</span>
+        </p>
+      {{/unless}}
     {{/unless}}
   </div>
 </div>

--- a/mon-pix/app/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.hbs
@@ -20,6 +20,12 @@
               aria-label={{block.ariaLabel}}
               disabled
             />
+            {{#if block.solution}}
+              <p class="correction-qrocm__solution">
+                <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+                <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+              </p>
+            {{/if}}
           </div>
         {{else if (eq @challenge.format "phrase")}}
           <div class="correction-qrocm__answer {{block.inputClass}}">
@@ -30,6 +36,12 @@
               @ariaLabel={{block.ariaLabel}}
               disabled
             />
+            {{#if block.solution}}
+              <p class="correction-qrocm__solution">
+                <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+                <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+              </p>
+            {{/if}}
           </div>
         {{else}}
           <div class="correction-qrocm__answer-wrapper correction-qrocm__answer {{block.inputClass}}">
@@ -41,6 +53,12 @@
               @ariaLabel={{block.ariaLabel}}
               disabled
             />
+            {{#if block.solution}}
+              <p class="correction-qrocm__solution">
+                <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
+                <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+              </p>
+            {{/if}}
           </div>
         {{/if}}
       {{/if}}
@@ -49,10 +67,10 @@
         <br />
       {{/if}}
     {{/each}}
-    {{#unless this.answerIsCorrect}}
+    {{#unless this.isCorrectAnswer}}
       <p class="comparison-window-solution">
         <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-        <span class="correction-qrocm__solution-text">{{this.understandableSolution}}</span>
+        <span class="correction-qrocm__solution-text">{{this.formattedSolution}}</span>
       </p>
     {{/unless}}
   </div>

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -2,38 +2,65 @@ import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
-import keys from 'lodash/keys';
 import { inject as service } from '@ember/service';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 import jsyaml from 'js-yaml';
+
+const SKIPPED_FLAG = '#ABAND#';
+const CHALLENGE_OK_FLAG = 'ok';
 
 export default class QrocmDepSolutionPanel extends Component {
   @service intl;
 
   get blocks() {
     const answersEvaluations = this.args.answersEvaluation ? [...this.args.answersEvaluation] : null;
+    const expectedAnswers = [...this.expectedAnswers];
 
     return proposalsAsBlocks(this.args.challenge.get('proposals')).map((block) => {
       if (!block.input || !answersEvaluations) {
         return block;
       }
       const answerEvaluation = answersEvaluations.shift();
-      const isAnswerEmpty = this.answersAsObject[block.input] === '';
-      block.answer = isAnswerEmpty ? this.intl.t('pages.result-item.aband') : this.answersAsObject[block.input];
-      block.inputClass = this.getInputClass(isAnswerEmpty, answerEvaluation);
-      block.ariaLabel = this.getAriaLabel(isAnswerEmpty, answerEvaluation);
+      block.answer = this.isSkipped ? this.intl.t('pages.result-item.aband') : this.answersAsObject[block.input];
+      block.inputClass = this.getInputClass(this.isSkipped, answerEvaluation);
+      block.ariaLabel = this.getAriaLabel(this.isSkipped, answerEvaluation);
+      if (this.shouldDisplayAnswersUnderInputs && !answerEvaluation) {
+        block.solution = expectedAnswers.shift();
+      }
       return block;
     });
+  }
+
+  get isCorrectAnswer() {
+    return this.args.answer.result === CHALLENGE_OK_FLAG;
+  }
+
+  get formattedSolution() {
+    if (this.args.solutionToDisplay) {
+      return this.args.solutionToDisplay;
+    }
+    if (this.shouldDisplayAnswersUnderInputs) {
+      return null;
+    }
+    const expectedAnswers = this.expectedAnswers;
+    const formattedExpectedAnswers = expectedAnswers.join(
+      ` ${this.intl.t('pages.comparison-window.results.solutions.or')} `
+    );
+    return `${formattedExpectedAnswers} ${this.intl.t('pages.comparison-window.results.solutions.end')}`;
+  }
+
+  get isSkipped() {
+    return this.args.answer.value === SKIPPED_FLAG;
+  }
+
+  get isIncorrectOrSkipped() {
+    return this.isSkipped || !this.isCorrectAnswer;
   }
 
   get answersAsObject() {
     const escapedProposals = this.args.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    return answersAsObject(this.args.answer.value, keys(labels));
-  }
-
-  get answerIsCorrect() {
-    return this.args.answer.result === 'ok';
+    return answersAsObject(this.args.answer.value, Object.keys(labels));
   }
 
   get solutions() {
@@ -44,25 +71,25 @@ export default class QrocmDepSolutionPanel extends Component {
     return Object.keys(this.answersAsObject).length;
   }
 
+  get solutionsCount() {
+    return Object.keys(this.solutions).length;
+  }
+
   get expectedAnswers() {
     if (!this.args.solutionsWithoutGoodAnswers) return [];
     return this.args.solutionsWithoutGoodAnswers.length
       ? this.args.solutionsWithoutGoodAnswers.slice(0, this.inputCount)
-      : Object.keys(this.solutions)
-          .slice(0, this.inputCount)
-          .map((key) => this.solutions[key][0]);
+      : this.extractSolutionsFromSolutionObject(this.solutions, this.inputCount);
   }
 
-  get understandableSolution() {
-    if (this.args.solutionToDisplay) {
-      return this.args.solutionToDisplay;
-    }
-    if (!this.args.solutionsWithoutGoodAnswers) {
-      return '';
-    }
-    return this.intl.t('pages.comparison-window.results.otherSolutions', {
-      expectedAnswers: this.expectedAnswers.join(', '),
-    });
+  get shouldDisplayAnswersUnderInputs() {
+    return this.isIncorrectOrSkipped && this.solutionsCount === this.inputCount;
+  }
+
+  extractSolutionsFromSolutionObject(solutions, sliceEndIndex) {
+    return Object.values(solutions)
+      .slice(0, sliceEndIndex)
+      .map((solutionVariants) => solutionVariants[0]);
   }
 
   getInputClass(isEmptyAnswer, isCorrectAnswer) {
@@ -77,13 +104,14 @@ export default class QrocmDepSolutionPanel extends Component {
     }
   }
 
-  getAriaLabel(isEmptyAnswer, isAnswerCorrect) {
-    if (isEmptyAnswer) {
-      return this.intl.t('pages.comparison-window.results.a11y.skipped-answer');
+  getAriaLabel(isEmptyAnswer, isCorrectAnswer) {
+    switch (true) {
+      case isEmptyAnswer:
+        return this.intl.t('pages.comparison-window.results.a11y.skipped-answer');
+      case isCorrectAnswer:
+        return this.intl.t('pages.comparison-window.results.a11y.good-answer');
+      default:
+        return this.intl.t('pages.comparison-window.results.a11y.wrong-answer');
     }
-
-    return isAnswerCorrect
-      ? this.intl.t('pages.comparison-window.results.a11y.good-answer')
-      : this.intl.t('pages.comparison-window.results.a11y.wrong-answer');
   }
 }

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -276,7 +276,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       const goodAnswers = find('.correction-qrocm__solution-text');
       const badAnswersFromUserResult = findAll('.correction-qrocm-answer__input');
 
-      assert.strictEqual(goodAnswers.textContent.trim(), 'Vous auriez pu répondre Versailles-Chantiers, Poissy');
+      assert.strictEqual(goodAnswers.textContent.trim(), 'Versailles-Chantiers');
       assert.strictEqual(badAnswersFromUserResult[0].value, 'Republique');
       assert.strictEqual(badAnswersFromUserResult[1].value, 'Chatelet');
 

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -12,236 +12,195 @@ const PARAGRAPH = 'textarea.correction-qrocm-answer__input-paragraph';
 const SENTENCE = 'input.correction-qrocm-answer__input-sentence';
 const SOLUTION_BLOCK = '.comparison-window-solution';
 const SOLUTION_TEXT = '.correction-qrocm__solution-text';
+const CORRECTION_UNDER_INPUT_BLOCK = '.correction-qrocm__solution';
 
-const classByResultKey = {
-  ok: 'ok',
-  ko: 'ko',
-  partially: 'partially',
-  aband: 'aband',
+const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
+const SOLUTION_TO_DISPLAY = 'La solution à afficher';
+
+const FORMATS = [
+  { format: 'petit', input: INPUT },
+  { format: 'phrase', input: SENTENCE },
+  { format: 'paragraphe', input: PARAGRAPH },
+  { format: 'unreferenced_format', input: INPUT },
+];
+
+const SKIPPED_VALUE = '#ABAND#';
+const CHALLENGE_OK_FLAG = 'ok';
+const CHALLENGE_KO_FLAG = 'ko';
+const CHALLENGE_SKIPPED_FLAG = 'aband';
+
+const buildComponentArguments = (
+  format = FORMATS[0].format,
+  challengeStatus = CHALLENGE_OK_FLAG,
+  moreSolutionsThanProposals = true,
+  hasSolutionToDisplay = false
+) => {
+  return {
+    solution: moreSolutionsThanProposals
+      ? 'p1:\n- solution1\np2:\n- solution2\np3:\n- solution3\np4:\n- solution1\np5:\n- solution2\np6:\n- solution3'
+      : 'p1:\n- solution1\np2:\n- solution2',
+    answer: EmberObject.create({
+      id: 'answer_id',
+      value: challengeStatus === CHALLENGE_SKIPPED_FLAG ? SKIPPED_VALUE : "key1: 'rightAnswer1' key2: 'rightAnswer2'",
+      result: challengeStatus,
+      assessment: EmberObject.create({ id: 'assessment_id' }),
+    }),
+    answersEvaluation: challengeStatus === CHALLENGE_OK_FLAG ? [true, true] : [true, false],
+    solutionsWithoutGoodAnswers: challengeStatus === CHALLENGE_OK_FLAG ? [] : ['solution1', 'solution2'],
+    solutionToDisplay: hasSolutionToDisplay ? SOLUTION_TO_DISPLAY : null,
+    challenge: EmberObject.create({
+      id: 'challenge_id',
+      proposals: '${key1}\n${key2}',
+      format,
+    }),
+  };
 };
+
+const renderComponent = () =>
+  render(
+    hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @answersEvaluation={{this.answersEvaluation}} @solutionsWithoutGoodAnswers={{this.solutionsWithoutGoodAnswers}} @solutionToDisplay={{this.solutionToDisplay}} />`
+  );
 
 module('Integration | Component | QROCm dep solution panel', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  const assessment = EmberObject.create({ id: 'assessment_id' });
-  const challenge = EmberObject.create({
-    id: 'challenge_id',
-    proposals: '${key1}\n${key2}',
-    format: 'petit',
-  });
-
-  const solution =
-    'p1:\n- solution1\np2:\n- solution2\np3:\n- solution3\np4:\n- solution1\np5:\n- solution2\np6:\n- solution3';
-
-  [
-    { format: 'petit', input: INPUT },
-    { format: 'phrase', input: SENTENCE },
-    { format: 'paragraphe', input: PARAGRAPH },
-    { format: 'unreferenced_format', input: INPUT },
-  ].forEach((data) => {
-    module(`Whatever the format (testing ${data.format} format)`, function (hooks) {
-      hooks.beforeEach(function () {
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-        this.challenge.set('format', data.format);
-      });
-
-      module('When the answer is correct', function (hooks) {
+  FORMATS.forEach(({ format, input }) => {
+    module(`When challenge is "${format}" format`, function () {
+      module('When challenge is successful', function (hooks) {
         hooks.beforeEach(async function () {
-          // given
-          const answer = EmberObject.create({
-            id: 'answer_id',
-            value: "key1: 'rightAnswer1' key2: 'rightAnswer2'",
-            result: classByResultKey.ok,
-            assessment,
-            challenge,
-          });
-          this.set('answer', answer);
-
-          const answersEvaluation = [true, false];
-          const solutionsWithoutGoodAnswers = [];
-          this.set('answersEvaluation', answersEvaluation);
-          this.set('solutionsWithoutGoodAnswers', solutionsWithoutGoodAnswers);
-
-          // when
-          await render(
-            hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @answersEvaluation={{this.answersEvaluation}} @solutionsWithoutGoodAnswers={{this.solutionsWithoutGoodAnswers}} />`
-          );
+          // Given
+          this.setProperties(buildComponentArguments(format, CHALLENGE_OK_FLAG));
+          // When
+          await renderComponent();
         });
-
-        test('should display the correct answer in green bold', function (assert) {
-          // then
+        test('should display the correct answer in green bold', async function (assert) {
+          // Then
           const firstAnswerInput = findAll(ANSWER)[0];
           assert.true(firstAnswerInput.classList.contains('correction-qroc-box-answer--correct'));
+
+          const secondAnswerInput = findAll(ANSWER)[1];
+          assert.true(secondAnswerInput.classList.contains('correction-qroc-box-answer--correct'));
         });
-
         test('should not have solution block', function (assert) {
-          // then
+          // Then
           const solutionBlockList = findAll(SOLUTION_BLOCK);
-
           assert.strictEqual(solutionBlockList.length, 0);
         });
       });
-
-      module('When there is no answer', function (hooks) {
-        const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
-
-        hooks.beforeEach(async function () {
-          // given
-          const answer = EmberObject.create({
-            id: 'answer_id',
-            value: '#ABAND#',
-            result: classByResultKey.aband,
-            assessment,
-            challenge,
-          });
-          this.set('answer', answer);
-
-          const answersEvaluation = [false, false];
-
-          this.set('answersEvaluation', answersEvaluation);
-
-          // when
-          await render(
-            hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @answersEvaluation={{this.answersEvaluation}} />`
-          );
-        });
-
-        test('should display one solution in bold green', async function (assert) {
-          // then
-          const noAnswerSolutionBlockList = findAll(SOLUTION_BLOCK);
-
-          assert.strictEqual(noAnswerSolutionBlockList.length, 1);
-        });
-
-        test('should display the empty answer with the default message "Pas de réponse" in italic', async function (assert) {
-          // then
-          const firstAnswerInputContainer = findAll(ANSWER)[0];
-          const firstAnswerInput = findAll(data.input)[0];
-
-          assert.ok(firstAnswerInput);
-          assert.strictEqual(firstAnswerInput.value, EMPTY_DEFAULT_MESSAGE);
-          assert.true(firstAnswerInputContainer.classList.contains('correction-qroc-box-answer--aband'));
-        });
-      });
-
-      module('When the answer is wrong', function (hooks) {
-        hooks.beforeEach(async function () {
-          // given
-          const answer = EmberObject.create({
-            id: 'answer_id',
-            value: "key1: 'rightAnswer1' key2: 'wrongAnswer2'",
-            result: classByResultKey.ko,
-            assessment,
-            challenge,
-          });
-          this.set('answer', answer);
-
-          const answersEvaluation = [true, false];
-          this.set('answersEvaluation', answersEvaluation);
-        });
-
+      module('When challenge is skipped', function () {
         test('should display the solutionToDisplay if exist', async function (assert) {
-          // when
-          const solutionToDisplay = 'Ceci est la solution !';
-          this.set('solutionToDisplay', solutionToDisplay);
-          await render(
-            hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @solutionToDisplay={{this.solutionToDisplay}} @answersEvaluation={{this.answersEvaluation}}/>`
-          );
-
-          // then
+          // Given
+          this.setProperties(buildComponentArguments(format, CHALLENGE_SKIPPED_FLAG, true, true));
+          // When
+          await renderComponent();
+          // Then
           assert.dom(SOLUTION_BLOCK).exists();
-          assert.ok(find(SOLUTION_TEXT).textContent.includes(solutionToDisplay));
+          assert.ok(find(SOLUTION_TEXT).textContent.includes(SOLUTION_TO_DISPLAY));
         });
-
-        test('should display the first answer input in bold green', async function (assert) {
-          // when
-          await render(
-            hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @answersEvaluation={{this.answersEvaluation}} />`
-          );
-
-          // then
-          const firstAnswerInput = findAll(ANSWER)[0];
-
-          assert.ok(firstAnswerInput);
-          assert.true(firstAnswerInput.classList.contains('correction-qroc-box-answer--correct'));
+        module('When there are more solution than proposals', function (hooks) {
+          hooks.beforeEach(async function () {
+            // Given
+            this.setProperties(buildComponentArguments(format, CHALLENGE_SKIPPED_FLAG, true));
+            // When
+            await renderComponent();
+          });
+          test('should display message at the bottom', async function (assert) {
+            // Then
+            const noAnswerSolutionBlockList = findAll(SOLUTION_BLOCK);
+            assert.strictEqual(noAnswerSolutionBlockList.length, 1);
+          });
+          test('should display the empty answer with the default message "Pas de réponse" in italic', async function (assert) {
+            // Then
+            const firstAnswerInputContainer = findAll(ANSWER)[0];
+            const firstAnswerInput = findAll(input)[0];
+            assert.ok(firstAnswerInput);
+            assert.strictEqual(firstAnswerInput.value, EMPTY_DEFAULT_MESSAGE);
+            assert.true(firstAnswerInputContainer.classList.contains('correction-qroc-box-answer--aband'));
+          });
         });
-
-        test('should strike the second answer input', async function (assert) {
-          // when
-          await render(
-            hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @answersEvaluation={{this.answersEvaluation}} />`
-          );
-
-          // then
-          const secondAnswerInput = findAll(ANSWER)[1];
-
-          assert.ok(secondAnswerInput);
-          assert.true(secondAnswerInput.classList.contains('correction-qroc-box-answer--wrong'));
+        module('When there are as many solutions as proposals', function (hooks) {
+          hooks.beforeEach(async function () {
+            // Given
+            this.setProperties(buildComponentArguments(format, CHALLENGE_SKIPPED_FLAG, false));
+            // When
+            await renderComponent();
+          });
+          test('should display corrections under inputs', async function (assert) {
+            // Then
+            const correctionUnderInputBlock = findAll(CORRECTION_UNDER_INPUT_BLOCK);
+            assert.strictEqual(correctionUnderInputBlock.length, 1);
+          });
+          test('should not display correction at the bottom', async function (assert) {
+            // Then
+            const solutionBlocks = findAll(SOLUTION_BLOCK);
+            assert.strictEqual(solutionBlocks.length, 0);
+          });
+        });
+      });
+      module('When challenge is failed', function () {
+        test('should display the solutionToDisplay if exist', async function (assert) {
+          // Given
+          this.setProperties(buildComponentArguments(format, CHALLENGE_KO_FLAG, true, true));
+          // When
+          await renderComponent();
+          // Then
+          assert.dom(SOLUTION_BLOCK).exists();
+          assert.ok(find(SOLUTION_TEXT).textContent.includes(SOLUTION_TO_DISPLAY));
+        });
+        module('When there are more solution than proposals', function (hooks) {
+          hooks.beforeEach(async function () {
+            // Given
+            this.setProperties(buildComponentArguments(format, CHALLENGE_KO_FLAG, true));
+            // When
+            await renderComponent();
+          });
+          test('should display the good answer input in bold green', async function (assert) {
+            // Then
+            const firstAnswerInput = findAll(ANSWER)[0];
+            assert.ok(firstAnswerInput);
+            assert.true(firstAnswerInput.classList.contains('correction-qroc-box-answer--correct'));
+          });
+          test('should strike the second answer input', async function (assert) {
+            // Then
+            const secondAnswerInput = findAll(ANSWER)[1];
+            assert.ok(secondAnswerInput);
+            assert.true(secondAnswerInput.classList.contains('correction-qroc-box-answer--wrong'));
+          });
+          test('should display correction at the bottom', async function (assert) {
+            // Then
+            const secondAnswerInput = findAll(ANSWER)[1];
+            assert.ok(secondAnswerInput);
+            assert.true(secondAnswerInput.classList.contains('correction-qroc-box-answer--wrong'));
+          });
+        });
+        module('When there are as many solutions as proposals', function (hooks) {
+          hooks.beforeEach(async function () {
+            // Given
+            this.setProperties(buildComponentArguments(format, CHALLENGE_KO_FLAG, false));
+            // When
+            await renderComponent();
+          });
+          test('should display corrections under inputs', async function (assert) {
+            // Then
+            const correctionUnderInputBlock = findAll(CORRECTION_UNDER_INPUT_BLOCK);
+            assert.strictEqual(correctionUnderInputBlock.length, 1);
+          });
+          test('should not display correction at the bottom', async function (assert) {
+            // Then
+            const solutionBlocks = findAll(SOLUTION_BLOCK);
+            assert.strictEqual(solutionBlocks.length, 0);
+          });
         });
       });
     });
   });
-
-  module('When format is neither a paragraph nor a sentence', function (hooks) {
-    hooks.beforeEach(function () {
-      const answer = EmberObject.create({
-        id: 'answer_id',
-        value: "key1: 'rightAnswer1' key2: 'rightAnswer2'",
-        result: classByResultKey.ok,
-        assessment,
-        challenge,
-      });
-      const answersEvaluation = [true, false];
-      this.set('answersEvaluation', answersEvaluation);
-      this.set('answer', answer);
-      this.set('solution', solution);
-      this.set('challenge', challenge);
-    });
-
-    test(`should display a disabled input with expected size`, async function (assert) {
-      //given
-      const answerSize = 'rightAnswer1'.length;
-
-      //when
-      await render(
-        hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} @solutionToDisplay={{this.solutionToDisplay}} @answersEvaluation={{this.answersEvaluation}} />`
-      );
-
-      //then
-      assert.dom(PARAGRAPH).doesNotExist();
-      assert.dom(SENTENCE).doesNotExist();
-      assert.strictEqual(find(INPUT).tagName, 'INPUT');
-      assert.strictEqual(find(INPUT).getAttribute('size'), answerSize.toString());
-      assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'La réponse donnée est valide');
-      assert.true(find(INPUT).hasAttribute('disabled'));
-    });
-  });
-
-  module('When format is a paragraph', function (hooks) {
-    hooks.beforeEach(function () {
-      const answer = EmberObject.create({
-        id: 'answer_id',
-        value: "key1: 'rightAnswer1' key2: 'rightAnswer2'",
-        result: classByResultKey.ok,
-        assessment,
-        challenge,
-      });
-      const answersEvaluation = [true, false];
-      this.set('answersEvaluation', answersEvaluation);
-      this.set('answer', answer);
-      this.set('solution', solution);
-      this.set('challenge', challenge);
-      this.challenge.set('format', 'paragraphe');
-    });
-
+  module('When format is a paragraph', function () {
     test('should display a disabled textarea', async function (assert) {
-      // when
-      await render(
-        hbs`<QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.solution}} @challenge={{this.challenge}} @answersEvaluation={{this.answersEvaluation}} />`
-      );
-
-      // then
+      // Given
+      this.setProperties(buildComponentArguments(FORMATS[2].format));
+      // When
+      await renderComponent();
+      // Then
       assert.dom(INPUT).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
       assert.strictEqual(find(PARAGRAPH).tagName, 'TEXTAREA');
@@ -250,37 +209,34 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
     });
   });
 
-  module('When format is a sentence', function (hooks) {
-    hooks.beforeEach(function () {
-      const answer = EmberObject.create({
-        id: 'answer_id',
-        value: "key1: 'rightAnswer1' key2: 'rightAnswer2'",
-        result: classByResultKey.ok,
-        assessment,
-        challenge,
-      });
-      const answersEvaluation = [true, false];
-      const solutionsWithoutGoodAnswers = [];
-      this.set('answersEvaluation', answersEvaluation);
-      this.set('solutionsWithoutGoodAnswers', solutionsWithoutGoodAnswers);
-      this.set('answer', answer);
-      this.set('solution', solution);
-      this.set('challenge', challenge);
-      this.challenge.set('format', 'phrase');
-    });
-
+  module('When format is a sentence', function () {
     test('should display a disabled input', async function (assert) {
-      // when
-      await render(
-        hbs`<QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.solution}} @challenge={{this.challenge}} @answersEvaluation={{this.answersEvaluation}} @solutionsWithoutGoodAnswers={{this.solutionsWithoutGoodAnswers}} />`
-      );
-
-      // then
+      // Given
+      this.setProperties(buildComponentArguments(FORMATS[1].format));
+      // When
+      await renderComponent();
+      // Then
       assert.dom(INPUT).doesNotExist();
       assert.dom(PARAGRAPH).doesNotExist();
       assert.strictEqual(find(SENTENCE).tagName, 'INPUT');
       assert.strictEqual(find(SENTENCE).getAttribute('aria-label'), 'La réponse donnée est valide');
       assert.true(find(SENTENCE).hasAttribute('disabled'));
+    });
+  });
+
+  module('When format is neither a paragraph nor a sentence', function () {
+    test(`should display a disabled input with expected size`, async function (assert) {
+      // Given
+      this.setProperties(buildComponentArguments(FORMATS[3].format));
+      // When
+      await renderComponent();
+      // Then
+      assert.dom(PARAGRAPH).doesNotExist();
+      assert.dom(SENTENCE).doesNotExist();
+      assert.strictEqual(find(INPUT).tagName, 'INPUT');
+      assert.strictEqual(find(INPUT).getAttribute('size'), '12');
+      assert.strictEqual(find(INPUT).getAttribute('aria-label'), 'La réponse donnée est valide');
+      assert.true(find(INPUT).hasAttribute('disabled'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -29,7 +29,9 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
     proposals: '${key1}\n${key2}',
     format: 'petit',
   });
-  const solution = 'rightAnswer:\n' + '- rightAnswer1\n' + '- rightAnswer2';
+
+  const solution =
+    'p1:\n- solution1\np2:\n- solution2\np3:\n- solution3\np4:\n- solution1\np5:\n- solution2\np6:\n- solution3';
 
   [
     { format: 'petit', input: INPUT },
@@ -88,7 +90,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
           // given
           const answer = EmberObject.create({
             id: 'answer_id',
-            value: "key1: '' key2: ''",
+            value: '#ABAND#',
             result: classByResultKey.aband,
             assessment,
             challenge,

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
@@ -9,43 +9,136 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
   setupIntl(hooks);
 
   module('#blocks', function () {
-    test('should return an array with data to display', function (assert) {
+    test('should return expected array when the challenge is successful', function (assert) {
       //Given
-      const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
+      const challenge = EmberObject.create({
+        proposals: 'content : ${challengeInput1}\n\ntriste : ${challengeInput2}',
+      });
       const answer = {
-        value: "smiley1: ':)' smiley2: ''",
+        value: "challengeInput1: 'good answer value 1' challengeInput2: 'good answer value 2'",
         result: 'ko',
       };
-      const answersEvaluation = [true, false];
-
+      const answersEvaluation = [true, true];
       const component = createGlimmerComponent('qrocm-dep-solution-panel', { challenge, answer, answersEvaluation });
-
       const expectedBlocksData = [
         {
-          input: 'smiley1',
+          input: 'challengeInput1',
           text: 'content : ',
           ariaLabel: 'La réponse donnée est valide',
           autoAriaLabel: false,
           inputClass: 'correction-qroc-box-answer--correct',
-          answer: ':)',
+          answer: 'good answer value 1',
           placeholder: null,
           type: 'input',
           defaultValue: null,
         },
         {
-          input: 'smiley2',
+          input: 'challengeInput2',
           text: '<br/><br/>triste : ',
-          ariaLabel: 'Question passée',
+          answer: 'good answer value 2',
+          ariaLabel: 'La réponse donnée est valide',
           autoAriaLabel: false,
-          inputClass: 'correction-qroc-box-answer--aband',
-          answer: 'Pas de réponse',
+          inputClass: 'correction-qroc-box-answer--correct',
           placeholder: null,
           type: 'input',
           defaultValue: null,
         },
       ];
 
-      //when
+      //When
+      const blocks = component.blocks;
+
+      //Then
+      assert.deepEqual(blocks, expectedBlocksData);
+    });
+
+    test('should return expected array when the challenge is skipped', function (assert) {
+      //Given
+      const challenge = EmberObject.create({
+        proposals: 'content : ${skippedChallengeInput1}\n\ntriste : ${skippedChallengeInput2}',
+      });
+      const answer = {
+        value: '#ABAND#',
+        result: 'ko',
+      };
+      const answersEvaluation = [];
+      const solutionsWithoutGoodAnswers = [];
+      const component = createGlimmerComponent('qrocm-dep-solution-panel', {
+        challenge,
+        answer,
+        answersEvaluation,
+        solutionsWithoutGoodAnswers,
+      });
+
+      const expectedBlocksData = [
+        {
+          answer: 'Pas de réponse',
+          ariaLabel: 'Question passée',
+          autoAriaLabel: false,
+          defaultValue: null,
+          input: 'skippedChallengeInput1',
+          inputClass: 'correction-qroc-box-answer--aband',
+          placeholder: null,
+          text: 'content : ',
+          type: 'input',
+        },
+        {
+          answer: 'Pas de réponse',
+          ariaLabel: 'Question passée',
+          autoAriaLabel: false,
+          defaultValue: null,
+          input: 'skippedChallengeInput2',
+          inputClass: 'correction-qroc-box-answer--aband',
+          placeholder: null,
+          text: '<br/><br/>triste : ',
+          type: 'input',
+        },
+      ];
+
+      //When
+      const blocks = component.blocks;
+
+      //Then
+      assert.deepEqual(blocks, expectedBlocksData);
+    });
+
+    test('should return expected array when the challenge is failed', function (assert) {
+      //Given
+      const challenge = EmberObject.create({
+        proposals: 'content : ${challengeInput1}\n\ntriste : ${challengeInput2}',
+      });
+      const answer = {
+        value: "challengeInput1: 'good answer' challengeInput2: 'wrong answer'",
+        result: 'ko',
+      };
+      const answersEvaluation = [true, false];
+      const component = createGlimmerComponent('qrocm-dep-solution-panel', { challenge, answer, answersEvaluation });
+      const expectedBlocksData = [
+        {
+          input: 'challengeInput1',
+          text: 'content : ',
+          ariaLabel: 'La réponse donnée est valide',
+          autoAriaLabel: false,
+          inputClass: 'correction-qroc-box-answer--correct',
+          answer: 'good answer',
+          placeholder: null,
+          type: 'input',
+          defaultValue: null,
+        },
+        {
+          input: 'challengeInput2',
+          text: '<br/><br/>triste : ',
+          answer: 'wrong answer',
+          ariaLabel: 'La réponse donnée est fausse',
+          autoAriaLabel: false,
+          inputClass: 'correction-qroc-box-answer--wrong',
+          placeholder: null,
+          type: 'input',
+          defaultValue: null,
+        },
+      ];
+
+      //When
       const blocks = component.blocks;
 
       //Then
@@ -58,7 +151,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
-      //when
+      //When
       const inputClass = component.getInputClass(true);
 
       //Then
@@ -69,7 +162,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
-      //when
+      //When
       const inputClass = component.getInputClass(false, true);
 
       //Then
@@ -80,7 +173,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
-      //when
+      //When
       const inputClass = component.getInputClass(false, false);
 
       //Then
@@ -93,7 +186,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
-      //when
+      //When
       const ariaLabel = component.getAriaLabel(true);
 
       //Then
@@ -104,7 +197,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
-      //when
+      //When
       const inputClass = component.getAriaLabel(false, true);
 
       //Then
@@ -115,7 +208,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel');
 
-      //when
+      //When
       const inputClass = component.getAriaLabel(false, false);
 
       //Then
@@ -123,61 +216,71 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
     });
   });
 
-  module('#answerIsCorrect', function () {
+  module('#isCorrectAnswer', function () {
     test('should return true', function (assert) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ok' } });
 
-      //when
-      const answerIsCorrect = component.answerIsCorrect;
+      //When
+      const isCorrectAnswer = component.isCorrectAnswer;
 
       //Then
-      assert.true(answerIsCorrect);
+      assert.true(isCorrectAnswer);
     });
 
     test('should return false', function (assert) {
       //Given
       const component = createGlimmerComponent('qrocm-dep-solution-panel', { answer: { result: 'ko' } });
 
-      //when
-      const answerIsCorrect = component.answerIsCorrect;
+      //When
+      const isCorrectAnswer = component.isCorrectAnswer;
 
       //Then
-      assert.false(answerIsCorrect);
+      assert.false(isCorrectAnswer);
     });
   });
 
-  module('#understandableSolution', function () {
-    test('should return the expected answers', function (assert) {
-      //Given
-      const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
-      const component = createGlimmerComponent('qrocm-dep-solution-panel', {
-        challenge,
-        answer: { result: 'ko' },
-        solutionsWithoutGoodAnswers: ['horizontalité', 'cadre'],
+  module('#formattedSolution', function () {
+    module('when there are more solutions than inputs', function () {
+      test('should return examples of good answers', function (assert) {
+        //Given
+        const challenge = EmberObject.create({
+          proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}',
+        });
+        const component = createGlimmerComponent('qrocm-dep-solution-panel', {
+          challenge,
+          answer: { result: 'ko', value: "key1: 'rightAnswer1' key2: 'rightAnswer2'" },
+          solutionsWithoutGoodAnswers: ['tag', 'marche', 'masque'],
+          solution: 'p1:\n- solution1\np2:\n- solution2\np3:\n- solution3',
+        });
+
+        //When
+        const formattedSolution = component.formattedSolution;
+
+        //Then
+        assert.strictEqual(formattedSolution, 'tag ou marche ou...');
       });
-
-      //when
-      const understandableSolution = component.understandableSolution;
-
-      //Then
-      assert.strictEqual(understandableSolution, 'Vous auriez pu répondre horizontalité, cadre');
     });
 
-    test('should return examples of good answers', function (assert) {
-      //Given
-      const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
-      const component = createGlimmerComponent('qrocm-dep-solution-panel', {
-        challenge,
-        answer: { result: 'ko', value: "titre: 'Le rouge et le noir'\nauteur: 'Stendhal'\n" },
-        solutionsWithoutGoodAnswers: ['tag', 'marche', 'masque'],
+    module('when there are as many text fields as there are solutions', function () {
+      test('should return null', function (assert) {
+        //Given
+        const challenge = EmberObject.create({
+          proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}',
+        });
+        const component = createGlimmerComponent('qrocm-dep-solution-panel', {
+          challenge,
+          answer: { result: 'ko', value: "key1: 'wrongAnswer1' key2: 'wrongAnswer2'" },
+          solutionsWithoutGoodAnswers: ['tag', 'marche'],
+          solution: 'p1:\n- solution1\np2:\n- solution2',
+        });
+
+        //When
+        const formattedSolution = component.formattedSolution;
+
+        //Then
+        assert.strictEqual(formattedSolution, null);
       });
-
-      //when
-      const understandableSolution = component.understandableSolution;
-
-      //Then
-      assert.strictEqual(understandableSolution, 'Vous auriez pu répondre tag, marche');
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -685,7 +685,10 @@
           "other-proposition": "Other proposition",
           "your-answer": "Your answer"
         },
-        "otherSolutions": "You could have answered {expectedAnswers}"
+        "solutions": {
+          "or": "or",
+          "end": "or..."
+        }
       },
       "upcoming-tutorials": "You will soon find tutorials here to help you answer correctly to this type of question."
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -685,7 +685,10 @@
           "other-proposition": "Autre proposition",
           "your-answer": "Votre réponse"
         },
-        "otherSolutions": "Vous auriez pu répondre {expectedAnswers}"
+        "solutions": {
+          "or": "ou",
+          "end": "ou..."
+        }
       },
       "upcoming-tutorials": "Bientôt ici des tutoriels pour vous aider à réussir ce type d'épreuves."
     },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans le cas d'un QROCM-dep en erreur, on affiche la correction en dessous:
![11](https://github.com/1024pix/pix/assets/6728051/a23f1095-beb4-47c4-bbf0-e4e117e78108)
Cela donne l'impression qu'il y a un nombre indéterminé de solutions pour ce challenge.
Hors ce n'est pas toujours le cas, parfois il y a autant de solutions que de champs et dans ce cas cette phrase peut prêter à confusion.

## :robot: Proposition
Dans le cas où il y a autant de solutions que de champs, afficher les solutions directement en dessous des champs en erreur.
![22](https://github.com/1024pix/pix/assets/6728051/24078411-da27-4d37-b23b-d29b3361aef2)

## :100: Pour tester
Tester différentes saveurs de QROCM-dep:

- Avec plus de solutions que de réponses:

https://app-pr6384.review.pix.fr/challenges/challenge28kwuFJjZlaJs8/preview
https://app-pr6384.review.pix.fr/challenges/receXMEiCSGX5YgaD/preview

- Avec autant de solutions que de réponses:

https://app-pr6384.review.pix.fr/challenges/challenge1aqs0e1n6x9leF/preview