### PR TITLE
[FEATURE] Renvoyer le pourcentage d'acquisition d'un Résultat Thématique à la fin d'une campagne (PIX-8058).

### DIFF
--- a/api/lib/domain/models/BadgeCriterionForCalculation.js
+++ b/api/lib/domain/models/BadgeCriterionForCalculation.js
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+
+export class BadgeCriterionForCalculation {
+  constructor({ threshold, skillIds }) {
+    this.threshold = threshold;
+    this.skillIds = skillIds;
+  }
+
+  isFulfilled(knowledgeElements) {
+    const knowledgeElementsInSkills = _removeKnowledgeElementsNotInSkills(knowledgeElements, this.skillIds);
+    const validatedSkillsCount = knowledgeElementsInSkills.filter(
+      (knowledgeElement) => knowledgeElement.isValidated
+    ).length;
+    const totalSkillsCount = this.skillIds.length;
+    const masteryPercentage = _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount);
+    return masteryPercentage >= this.threshold;
+  }
+}
+
+function _removeKnowledgeElementsNotInSkills(knowledgeElements, skillIds) {
+  return _.filter(knowledgeElements, (knowledgeElement) => skillIds.some((id) => id === knowledgeElement.skillId));
+}
+
+function _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount) {
+  if (totalSkillsCount === 0) return 0;
+  return Math.round((validatedSkillsCount * 100) / totalSkillsCount);
+}

--- a/api/lib/domain/models/BadgeCriterionForCalculation.js
+++ b/api/lib/domain/models/BadgeCriterionForCalculation.js
@@ -15,6 +15,19 @@ export class BadgeCriterionForCalculation {
     const masteryPercentage = _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount);
     return masteryPercentage >= this.threshold;
   }
+
+  getAcquisitionPercentage(knowledgeElements) {
+    const knowledgeElementsInSkills = _removeKnowledgeElementsNotInSkills(knowledgeElements, this.skillIds);
+    const validatedSkillsCount = knowledgeElementsInSkills.filter(
+      (knowledgeElement) => knowledgeElement.isValidated
+    ).length;
+    const totalSkillsCount = this.skillIds.length;
+    const masteryPercentage = _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount);
+
+    const acquisitionPercentage = Math.round((masteryPercentage / this.threshold) * 100);
+
+    return acquisitionPercentage > 100 ? 100 : acquisitionPercentage;
+  }
 }
 
 function _removeKnowledgeElementsNotInSkills(knowledgeElements, skillIds) {

--- a/api/lib/domain/models/BadgeCriterionForCalculation.js
+++ b/api/lib/domain/models/BadgeCriterionForCalculation.js
@@ -6,16 +6,6 @@ export class BadgeCriterionForCalculation {
     this.skillIds = skillIds;
   }
 
-  isFulfilled(knowledgeElements) {
-    const knowledgeElementsInSkills = _removeKnowledgeElementsNotInSkills(knowledgeElements, this.skillIds);
-    const validatedSkillsCount = knowledgeElementsInSkills.filter(
-      (knowledgeElement) => knowledgeElement.isValidated
-    ).length;
-    const totalSkillsCount = this.skillIds.length;
-    const masteryPercentage = _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount);
-    return masteryPercentage >= this.threshold;
-  }
-
   getAcquisitionPercentage(knowledgeElements) {
     const knowledgeElementsInSkills = _removeKnowledgeElementsNotInSkills(knowledgeElements, this.skillIds);
     const validatedSkillsCount = knowledgeElementsInSkills.filter(
@@ -27,6 +17,10 @@ export class BadgeCriterionForCalculation {
     const acquisitionPercentage = Math.round((masteryPercentage / this.threshold) * 100);
 
     return acquisitionPercentage > 100 ? 100 : acquisitionPercentage;
+  }
+
+  isFulfilled(knowledgeElements) {
+    return this.getAcquisitionPercentage(knowledgeElements) === 100;
   }
 }
 

--- a/api/lib/domain/models/BadgeForCalculation.js
+++ b/api/lib/domain/models/BadgeForCalculation.js
@@ -1,6 +1,4 @@
-import _ from 'lodash';
-
-class BadgeForCalculation {
+export class BadgeForCalculation {
   constructor({ id, badgeCriteria }) {
     this.id = id;
     this.badgeCriteria = badgeCriteria;
@@ -10,31 +8,3 @@ class BadgeForCalculation {
     return this.badgeCriteria.every((badgeCriterion) => badgeCriterion.isFulfilled(knowledgeElements));
   }
 }
-
-class BadgeCriterion {
-  constructor({ threshold, skillIds }) {
-    this.threshold = threshold;
-    this.skillIds = skillIds;
-  }
-
-  isFulfilled(knowledgeElements) {
-    const knowledgeElementsInSkills = _removeKnowledgeElementsNotInSkills(knowledgeElements, this.skillIds);
-    const validatedSkillsCount = knowledgeElementsInSkills.filter(
-      (knowledgeElement) => knowledgeElement.isValidated
-    ).length;
-    const totalSkillsCount = this.skillIds.length;
-    const masteryPercentage = _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount);
-    return masteryPercentage >= this.threshold;
-  }
-}
-
-function _removeKnowledgeElementsNotInSkills(knowledgeElements, skillIds) {
-  return _.filter(knowledgeElements, (knowledgeElement) => skillIds.some((id) => id === knowledgeElement.skillId));
-}
-
-function _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount) {
-  if (totalSkillsCount === 0) return 0;
-  return Math.round((validatedSkillsCount * 100) / totalSkillsCount);
-}
-
-export { BadgeForCalculation, BadgeCriterion };

--- a/api/lib/domain/models/BadgeForCalculation.js
+++ b/api/lib/domain/models/BadgeForCalculation.js
@@ -7,4 +7,12 @@ export class BadgeForCalculation {
   shouldBeObtained(knowledgeElements) {
     return this.badgeCriteria.every((badgeCriterion) => badgeCriterion.isFulfilled(knowledgeElements));
   }
+
+  getAcquisitionPercentage(knowledgeElements) {
+    const summary = this.badgeCriteria.reduce((accumulator, badgeCriterion) => {
+      return accumulator + badgeCriterion.getAcquisitionPercentage(knowledgeElements);
+    }, 0);
+
+    return Math.round(summary / this.badgeCriteria.length);
+  }
 }

--- a/api/lib/domain/read-models/participant-results/BadgeResult.js
+++ b/api/lib/domain/read-models/participant-results/BadgeResult.js
@@ -13,6 +13,7 @@ class BadgeResult {
     this.isAlwaysVisible = badge.isAlwaysVisible;
     this.isCertifiable = badge.isCertifiable;
     this.isValid = badge.isValid;
+    this.acquisitionPercentage = badge.acquisitionPercentage;
 
     this.skillSetResults = badge.badgeCompetences.map((badgeCompetence) =>
       _buildSkillSetResult(badgeCompetence, knowledgeElements)

--- a/api/lib/infrastructure/repositories/badge-for-calculation-repository.js
+++ b/api/lib/infrastructure/repositories/badge-for-calculation-repository.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { knex } from '../../../db/knex-database-connection.js';
-import { BadgeForCalculation, BadgeCriterion } from '../../domain/models/BadgeForCalculation.js';
+import { BadgeForCalculation } from '../../domain/models/BadgeForCalculation.js';
+import { BadgeCriterionForCalculation } from '../../domain/models/BadgeCriterionForCalculation.js';
 import { SCOPES } from '../../domain/models/BadgeCriterion.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import * as campaignRepository from './campaign-repository.js';
@@ -121,7 +122,7 @@ async function _buildBadge(knex, campaignSkillsByTube, campaignSkillIds, badgeCr
   for (const badgeCriterionDTO of badgeCriteriaDTO) {
     if (badgeCriterionDTO.scope === SCOPES.CAMPAIGN_PARTICIPATION) {
       badgeCriteria.push(
-        new BadgeCriterion({
+        new BadgeCriterionForCalculation({
           threshold: badgeCriterionDTO.threshold,
           skillIds: campaignSkillIds,
         })
@@ -131,7 +132,7 @@ async function _buildBadge(knex, campaignSkillsByTube, campaignSkillIds, badgeCr
       const arrayOfSkillIds = await knex('skill-sets').pluck('skillIds').whereIn('id', badgeCriterionDTO.skillSetIds);
       for (const skillIds of arrayOfSkillIds) {
         badgeCriteria.push(
-          new BadgeCriterion({
+          new BadgeCriterionForCalculation({
             threshold: badgeCriterionDTO.threshold,
             skillIds,
           })
@@ -149,7 +150,7 @@ async function _buildBadge(knex, campaignSkillsByTube, campaignSkillIds, badgeCr
       }
       if (skillIds.length > 0) {
         badgeCriteria.push(
-          new BadgeCriterion({
+          new BadgeCriterionForCalculation({
             threshold: badgeCriterionDTO.threshold,
             skillIds,
           })

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -37,6 +37,7 @@ const serialize = function (results) {
         'isAlwaysVisible',
         'isCertifiable',
         'isValid',
+        'acquisitionPercentage',
       ],
       skillSetResults: {
         ref: 'id',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -18,7 +18,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
 
   let user, campaign, assessment, campaignParticipation, targetProfile, campaignSkills;
 
-  let server, badge, skillSet, stage;
+  let server, badge1, badge2, skillSet, stage;
 
   beforeEach(async function () {
     server = await createServer();
@@ -54,6 +54,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       sharedAt: recentDate,
       masteryRate: 0.38,
     });
+
     assessment = databaseBuilder.factory.buildAssessment({
       campaignParticipationId: campaignParticipation.id,
       userId: user.id,
@@ -61,19 +62,44 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       state: 'completed',
     });
 
-    badge = databaseBuilder.factory.buildBadge({
+    badge1 = databaseBuilder.factory.buildBadge({
       id: 1,
-      altMessage: 'Banana',
+      altMessage: 'Low threshold badge',
       imageUrl: '/img/banana.svg',
-      message: 'You won a Banana Badge',
-      title: 'Banana',
-      key: 'PIX_BANANA',
+      message: 'You won a badge that had a criterion threshold set at 0',
+      title: 'Badge 1',
+      key: 'PIX_BADGE_1',
       targetProfileId: targetProfile.id,
+      isAlwaysVisible: true,
     });
+
+    badge2 = databaseBuilder.factory.buildBadge({
+      id: 2,
+      altMessage: 'High threshold badge',
+      imageUrl: '/img/banana.svg',
+      message: 'You won a badge that had a criterion threshold set at 90',
+      title: 'Badge 2',
+      key: 'PIX_BADGE_2',
+      targetProfileId: targetProfile.id,
+      isAlwaysVisible: true,
+    });
+
     databaseBuilder.factory.buildBadgeCriterion({
       badgeId: 1,
       scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
       threshold: 0,
+    });
+
+    databaseBuilder.factory.buildBadgeCriterion({
+      badgeId: 2,
+      scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+      threshold: 90,
+    });
+
+    databaseBuilder.factory.buildBadgeAcquisition({
+      userId: user.id,
+      campaignParticipationId: campaignParticipation.id,
+      badgeId: badge1.id,
     });
 
     skillSet = databaseBuilder.factory.buildSkillSet({
@@ -81,6 +107,14 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       badgeId: 1,
       name: 'Pix Emploi',
       color: 'emerald',
+      skillIds,
+    });
+
+    databaseBuilder.factory.buildSkillSet({
+      id: 2,
+      badgeId: 2,
+      name: 'Pix Emploi',
+      color: 'pink',
       skillIds,
     });
 
@@ -212,7 +246,11 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
             'campaign-participation-badges': {
               data: [
                 {
-                  id: `${badge.id}`,
+                  id: `${badge1.id}`,
+                  type: 'campaignParticipationBadges',
+                },
+                {
+                  id: `${badge2.id}`,
                   type: 'campaignParticipationBadges',
                 },
               ],
@@ -268,15 +306,16 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
           },
           {
             attributes: {
-              'alt-message': 'Banana',
+              'acquisition-percentage': 100,
+              'alt-message': 'Low threshold badge',
               'image-url': '/img/banana.svg',
-              'is-acquired': false,
-              'is-always-visible': false,
+              'is-acquired': true,
+              'is-always-visible': true,
               'is-certifiable': false,
               'is-valid': true,
-              key: 'PIX_BANANA',
-              title: 'Banana',
-              message: 'You won a Banana Badge',
+              key: 'PIX_BADGE_1',
+              title: 'Badge 1',
+              message: 'You won a badge that had a criterion threshold set at 0',
             },
             id: '1',
             type: 'campaignParticipationBadges',
@@ -293,6 +332,64 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
                 data: [
                   {
                     id: '1',
+                    type: 'partnerCompetenceResults',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            attributes: {
+              'area-color': undefined,
+              'mastery-percentage': 38,
+              name: 'Pix Emploi',
+              'tested-skills-count': 5,
+              'total-skills-count': 8,
+              'validated-skills-count': 3,
+            },
+            id: '2',
+            type: 'skillSetResults',
+          },
+          {
+            attributes: {
+              'area-color': undefined,
+              'mastery-percentage': 38,
+              name: 'Pix Emploi',
+              'tested-skills-count': 5,
+              'total-skills-count': 8,
+              'validated-skills-count': 3,
+            },
+            id: '2',
+            type: 'partnerCompetenceResults',
+          },
+          {
+            attributes: {
+              'acquisition-percentage': 42,
+              'alt-message': 'High threshold badge',
+              'image-url': '/img/banana.svg',
+              'is-acquired': false,
+              'is-always-visible': true,
+              'is-certifiable': false,
+              'is-valid': false,
+              key: 'PIX_BADGE_2',
+              title: 'Badge 2',
+              message: 'You won a badge that had a criterion threshold set at 90',
+            },
+            id: '2',
+            type: 'campaignParticipationBadges',
+            relationships: {
+              'skill-set-results': {
+                data: [
+                  {
+                    id: '2',
+                    type: 'skillSetResults',
+                  },
+                ],
+              },
+              'partner-competence-results': {
+                data: [
+                  {
+                    id: '2',
                     type: 'partnerCompetenceResults',
                   },
                 ],

--- a/api/tests/tooling/domain-builder/factory/build-badge-criterion-for-calculation.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-criterion-for-calculation.js
@@ -1,10 +1,10 @@
-import { BadgeCriterion } from '../../../../lib/domain/models/BadgeForCalculation.js';
+import { BadgeCriterionForCalculation } from '../../../../lib/domain/models/BadgeCriterionForCalculation.js';
 
 const buildBadgeCriterionForCalculation = function buildBadgeCriterionForCalculation({
   threshold = 80,
   skillIds = ['recCoucou'],
 } = {}) {
-  return new BadgeCriterion({
+  return new BadgeCriterionForCalculation({
     threshold,
     skillIds,
   });

--- a/api/tests/tooling/domain-builder/factory/build-badge-for-calculation.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-for-calculation.js
@@ -14,12 +14,14 @@ const buildBadgeForCalculation = function buildBadgeForCalculation({
 buildBadgeForCalculation.mockObtainable = function buildObtainable({ id, badgeCriteriaForCalculation }) {
   const badgeForCalculation = buildBadgeForCalculation({ id, badgeCriteria: badgeCriteriaForCalculation });
   badgeForCalculation.shouldBeObtained = () => true;
+  badgeForCalculation.getAcquisitionPercentage = () => 100;
   return badgeForCalculation;
 };
 
 buildBadgeForCalculation.mockNotObtainable = function buildObtainable({ id, badgeCriteriaForCalculation }) {
   const badgeForCalculation = buildBadgeForCalculation({ id, badgeCriteria: badgeCriteriaForCalculation });
   badgeForCalculation.shouldBeObtained = () => false;
+  badgeForCalculation.getAcquisitionPercentage = () => 20;
   return badgeForCalculation;
 };
 

--- a/api/tests/unit/domain/models/BadgeCriterionForCalculation_test.js
+++ b/api/tests/unit/domain/models/BadgeCriterionForCalculation_test.js
@@ -63,4 +63,66 @@ describe('Unit | Domain | Models | BadgeCriterionForCalculation', function () {
       });
     });
   });
+
+  describe('#isFulfilled', function () {
+    context('when enough knowledge elements are valid to fulfill the criterion', function () {
+      it('should return true', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: true },
+          { skillId: 2, isValidated: true },
+          { skillId: 3, isValidated: false },
+          { skillId: 4 },
+        ];
+        const skillIds = [1, 2, 3];
+        const badgeCriterion = new BadgeCriterionForCalculation({ skillIds, threshold: 60 });
+
+        // when
+        const isFulfilled = badgeCriterion.isFulfilled(knowledgeElements);
+
+        // then
+        expect(isFulfilled).to.be.true;
+      });
+    });
+
+    context('when not enough knowledge elements are valid to fulfill the criterion', function () {
+      it('should return false', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: true },
+          { skillId: 2, isValidated: true },
+          { skillId: 3, isValidated: false },
+          { skillId: 4 },
+        ];
+        const skillIds = [1, 2, 3];
+        const badgeCriterion = new BadgeCriterionForCalculation({ skillIds, threshold: 80 });
+
+        // when
+        const isFulfilled = badgeCriterion.isFulfilled(knowledgeElements);
+
+        // then
+        expect(isFulfilled).to.be.false;
+      });
+    });
+
+    context('when no knowledge elements are valid to fulfill the criterion', function () {
+      it('should return false', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: false },
+          { skillId: 2, isValidated: false },
+          { skillId: 3, isValidated: false },
+          { skillId: 4 },
+        ];
+        const skillIds = [1, 2, 3];
+        const badgeCriterion = new BadgeCriterionForCalculation({ skillIds, threshold: 80 });
+
+        // when
+        const isFulfilled = badgeCriterion.isFulfilled(knowledgeElements);
+
+        // then
+        expect(isFulfilled).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/BadgeCriterionForCalculation_test.js
+++ b/api/tests/unit/domain/models/BadgeCriterionForCalculation_test.js
@@ -1,0 +1,66 @@
+import { expect } from '../../../test-helper.js';
+import { BadgeCriterionForCalculation } from '../../../../lib/domain/models/BadgeCriterionForCalculation.js';
+
+describe('Unit | Domain | Models | BadgeCriterionForCalculation', function () {
+  describe('#getAcquisitionPercentage', function () {
+    context('when enough knowledge elements are valid to fulfill the criterion', function () {
+      it('should return 100', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: true },
+          { skillId: 2, isValidated: true },
+          { skillId: 3, isValidated: false },
+          { skillId: 4 },
+        ];
+        const skillIds = [1, 2, 3];
+        const badgeCriterion = new BadgeCriterionForCalculation({ skillIds, threshold: 60 });
+
+        // when
+        const acquisitionPercentage = badgeCriterion.getAcquisitionPercentage(knowledgeElements);
+
+        // then
+        expect(acquisitionPercentage).to.equal(100);
+      });
+    });
+
+    context('when not enough knowledge elements are valid to fulfill the criterion', function () {
+      it('should return badge criterion acquisition percentage', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: true },
+          { skillId: 2, isValidated: true },
+          { skillId: 3, isValidated: false },
+          { skillId: 4 },
+        ];
+        const skillIds = [1, 2, 3];
+        const badgeCriterion = new BadgeCriterionForCalculation({ skillIds, threshold: 80 });
+
+        // when
+        const acquisitionPercentage = badgeCriterion.getAcquisitionPercentage(knowledgeElements);
+
+        // then
+        expect(acquisitionPercentage).to.equal(84);
+      });
+    });
+
+    context('when no knowledge elements are valid to fulfill the criterion', function () {
+      it('should return 0', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: false },
+          { skillId: 2, isValidated: false },
+          { skillId: 3, isValidated: false },
+          { skillId: 4 },
+        ];
+        const skillIds = [1, 2, 3];
+        const badgeCriterion = new BadgeCriterionForCalculation({ skillIds, threshold: 80 });
+
+        // when
+        const acquisitionPercentage = badgeCriterion.getAcquisitionPercentage(knowledgeElements);
+
+        // then
+        expect(acquisitionPercentage).to.equal(0);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/BadgeForCalculation_test.js
+++ b/api/tests/unit/domain/models/BadgeForCalculation_test.js
@@ -59,4 +59,94 @@ describe('Unit | Domain | Models | BadgeForCalculation', function () {
       });
     });
   });
+
+  describe('#getAcquisitionPercentage', function () {
+    context('when badge criteria are all fulfilled', function () {
+      it('should return 100', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: true },
+          { skillId: 2, isValidated: false },
+          { skillId: 3, isValidated: true },
+          { skillId: 4, isValidated: false },
+        ];
+
+        const criteria1 = domainBuilder.buildBadgeCriterionForCalculation({
+          threshold: 50,
+          skillIds: [1, 2],
+        });
+        const criteria2 = domainBuilder.buildBadgeCriterionForCalculation({
+          threshold: 30,
+          skillIds: [3, 4],
+        });
+        const badgeForCalculation = domainBuilder.buildBadgeForCalculation({
+          badgeCriteria: [criteria1, criteria2],
+        });
+
+        // when
+        const acquisitionPercentage = badgeForCalculation.getAcquisitionPercentage(knowledgeElements);
+
+        // then
+        expect(acquisitionPercentage).to.equal(100);
+      });
+    });
+
+    context('when badge criteria are not all fulfilled', function () {
+      it('should return the right acquisition percentage', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: true },
+          { skillId: 2, isValidated: false },
+          { skillId: 3, isValidated: true },
+          { skillId: 4, isValidated: false },
+        ];
+
+        const criteria1 = domainBuilder.buildBadgeCriterionForCalculation({
+          threshold: 60,
+          skillIds: [1, 2],
+        });
+        const criteria2 = domainBuilder.buildBadgeCriterionForCalculation({
+          threshold: 30,
+          skillIds: [3, 4],
+        });
+        const badgeForCalculation = domainBuilder.buildBadgeForCalculation({
+          badgeCriteria: [criteria1, criteria2],
+        });
+
+        // when
+        const acquisitionPercentage = badgeForCalculation.getAcquisitionPercentage(knowledgeElements);
+
+        // then
+        expect(acquisitionPercentage).to.equal(92);
+      });
+    });
+
+    context('when no badge criteria are fulfilled', function () {
+      it('should return 0', function () {
+        // given
+        const knowledgeElements = [
+          { skillId: 1, isValidated: false },
+          { skillId: 2, isValidated: false },
+        ];
+
+        const criteria1 = domainBuilder.buildBadgeCriterionForCalculation({
+          threshold: 60,
+          skillIds: [1],
+        });
+        const criteria2 = domainBuilder.buildBadgeCriterionForCalculation({
+          threshold: 30,
+          skillIds: [2],
+        });
+        const badgeForCalculation = domainBuilder.buildBadgeForCalculation({
+          badgeCriteria: [criteria1, criteria2],
+        });
+
+        // when
+        const acquisitionPercentage = badgeForCalculation.getAcquisitionPercentage(knowledgeElements);
+
+        // then
+        expect(acquisitionPercentage).to.equal(0);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
@@ -23,6 +23,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       isAlwaysVisible: false,
       isValid: true,
       badgeCompetences: [],
+      acquisitionPercentage: null,
     };
 
     const badgeResult = new BadgeResult(badge, participationResults);
@@ -39,6 +40,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       isAlwaysVisible: false,
       isValid: true,
       skillSetResults: [],
+      acquisitionPercentage: null,
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/unit/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -67,9 +67,21 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
           campaignId,
           locale,
           badges: [
-            { ...badge1, isValid: true },
-            { ...badge2, isValid: false },
-            { ...badge3, isValid: true },
+            {
+              ...badge1,
+              isValid: true,
+              acquisitionPercentage: badgeForCalculationObtained1.getAcquisitionPercentage(),
+            },
+            {
+              ...badge2,
+              isValid: false,
+              acquisitionPercentage: badgeForCalculationNotObtained2.getAcquisitionPercentage(),
+            },
+            {
+              ...badge3,
+              isValid: true,
+              acquisitionPercentage: badgeForCalculationObtained3.getAcquisitionPercentage(),
+            },
           ],
         })
         .resolves(expectedCampaignAssessmentResult);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -75,6 +75,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           isAlwaysVisible: true,
           isCertifiable: false,
           isValid: true,
+          acquisitionPercentage: null,
         },
       ];
     });
@@ -168,6 +169,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               'is-always-visible': true,
               'is-certifiable': false,
               'is-valid': true,
+              'acquisition-percentage': null,
             },
             id: '3',
             type: 'campaignParticipationBadges',


### PR DESCRIPTION
## :unicorn: Problème

À la fin d'une campagne, on ne donnait pas d'information à l'utilisateur sur son taux de réussite d'un Résultat Thématique non acquis.

## :robot: Proposition

Faire en sorte que le use-case `get-user-campaign-assessment-result` renvoie maintenant le pourcentage de taux de complétion d'un RT non complété et visible pour l'utilisateur.

## :rainbow: Remarques
![image](https://github.com/1024pix/pix/assets/7335131/e8f2f47e-6fa3-4e09-9e8b-291bee231008)

## :100: Pour tester

- Aller sur [PixApp en RA](https://app-pr6388.review.pix.fr/)
- Se connecter avec `userpix1`
- Visiter la page https://app-pr6388.review.pix.fr/campagnes/PROCOMP51/evaluation/resultats
- Regarder dans les devtools, onglet "Réseau", ligne `assesment-result` :
  - 2 `campaignParticipationBadges ` sont présents dans les `included`
  - Attester qu'il y a bien la ligne `acquisition-percentage` dans les `attributes`
