### PR TITLE
[FEATURE] Accepter les liens absolus pour nos images (badges, CFs)

### DIFF
--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -7,7 +7,7 @@ export default class BadgeForm extends Component {
   @service store;
   @service router;
 
-  BASE_URL = 'https://images.pix.fr/badges/';
+  BADGE_BASE_URL = 'https://images.pix.fr/badges/';
 
   badge = {
     key: '',
@@ -32,11 +32,21 @@ export default class BadgeForm extends Component {
     }
   }
 
+  getBadgeLogoUrl() {
+    if (!this.imageName.endsWith('.svg')) {
+      this.imageName += '.svg';
+    }
+    if (this.imageName.startsWith(this.BADGE_BASE_URL)) {
+      return this.imageName;
+    }
+    return `${this.BADGE_BASE_URL}${this.imageName}`;
+  }
+
   async _createBadge() {
     try {
       const badgeWithFormattedImageUrl = {
         ...this.badge,
-        imageUrl: this.BASE_URL + this.imageName,
+        imageUrl: this.BADGE_BASE_URL + this.imageName,
       };
       const badge = this.store.createRecord('badge', badgeWithFormattedImageUrl);
 

--- a/admin/app/components/trainings/create-or-update-training-form.js
+++ b/admin/app/components/trainings/create-or-update-training-form.js
@@ -18,14 +18,26 @@ class Form {
   @tracked editorLogoUrl;
   @tracked editorName;
 
+  EDITOR_LOGO_BASE_URL = 'https://images.pix.fr/contenu-formatif/editeur/';
+
   constructor({ title, link, type, duration, locale, editorLogoUrl, editorName } = {}) {
     this.title = title || null;
     this.link = link || null;
     this.type = type || null;
     this.duration = duration || { days: 0, hours: 0, minutes: 0 };
     this.locale = locale || null;
-    this.editorLogoUrl = editorLogoUrl?.split('/').at(-1) || null;
+    this.editorLogoUrl = editorLogoUrl?.split('/').at(-1) || '';
     this.editorName = editorName || null;
+  }
+
+  getEditorLogoUrl() {
+    if (!this.editorLogoUrl.endsWith('.svg')) {
+      this.editorLogoUrl += '.svg';
+    }
+    if (this.editorLogoUrl.startsWith(this.EDITOR_LOGO_BASE_URL)) {
+      return this.editorLogoUrl;
+    }
+    return `${this.EDITOR_LOGO_BASE_URL}${this.editorLogoUrl}`;
   }
 }
 
@@ -63,7 +75,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
       locale: this.form.locale,
       editorName: this.form.editorName,
     };
-    training.editorLogoUrl = `https://images.pix.fr/contenu-formatif/editeur/${this.form.editorLogoUrl}`;
+    training.editorLogoUrl = this.form.getEditorLogoUrl();
 
     try {
       this.submitting = true;

--- a/admin/tests/unit/components/target-profiles/badge-form_test.js
+++ b/admin/tests/unit/components/target-profiles/badge-form_test.js
@@ -1,0 +1,45 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import createComponent from "../../../helpers/create-glimmer-component";
+
+module("Unit | Component | Badges | badgeForm", function(hooks) {
+  setupTest(hooks);
+  let component;
+
+  hooks.beforeEach(function() {
+    component = createComponent("component:target-profiles/badge-form", {});
+  });
+
+  test("it should update BadgeLogoUrl form attribute with appropriate base URL if not provided", async function(assert) {
+    // given
+    const baseURL = "https://images.pix.fr/badges/";
+    component.imageName = "new-logo.svg"
+    // when
+    const result = component.getBadgeLogoUrl();
+
+    // then
+    assert.deepEqual(result, `${baseURL}new-logo.svg`);
+  });
+
+  test('it should accept the BadgeLogoUrl form attribute with a complete URL', async function(assert) {
+    // given
+    const baseURL = "https://images.pix.fr/badges/";
+    component.imageName = `${baseURL}new-logo.svg`
+    // when
+    const result = component.getBadgeLogoUrl();
+
+    // then
+    assert.deepEqual(result, `${baseURL}new-logo.svg`);
+  });
+
+  test("it should add missing extension files in editorLogoUrl", async function(assert) {
+    // given
+    const baseURL = "https://images.pix.fr/badges/";
+    component.imageName = `${baseURL}new-logo`
+    // when
+    const result = component.getBadgeLogoUrl();
+
+    // then
+    assert.deepEqual(result, `${baseURL}new-logo.svg`);
+  });
+});

--- a/admin/tests/unit/components/trainings/create-or-update-training-form_test.js
+++ b/admin/tests/unit/components/trainings/create-or-update-training-form_test.js
@@ -59,5 +59,31 @@ module('Unit | Component | Trainings | CreateOrUpdateTrainingForm', function (ho
       // then
       assert.deepEqual(component.args.onSubmit.getCall(0).firstArg.editorLogoUrl, `${baseURL}new-logo.svg`);
     });
+
+    test('it should accept the EditorLogoUrl form attribute with a complete URL', async function (assert) {
+      // given
+      const baseURL = 'https://images.pix.fr/contenu-formatif/editeur/';
+      const formEvent = { target: { value: `${baseURL}new-logo.svg` } };
+      component.updateForm('editorLogoUrl', formEvent);
+
+      // when
+      await component.onSubmit(submitEvent);
+
+      // then
+      assert.deepEqual(component.args.onSubmit.getCall(0).firstArg.editorLogoUrl, `${baseURL}new-logo.svg`);
+    });
+
+    test('it should add missing extension files in editorLogoUrl', async function (assert) {
+      // given
+      const baseURL = 'https://images.pix.fr/contenu-formatif/editeur/';
+      const formEvent = { target: { value: `${baseURL}new-logo` } };
+      component.updateForm('editorLogoUrl', formEvent);
+
+      // when
+      await component.onSubmit(submitEvent);
+
+      // then
+      assert.deepEqual(component.args.onSubmit.getCall(0).firstArg.editorLogoUrl, `${baseURL}new-logo.svg`);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, quand on crée un nouveau contenu formatif, le champ `Nom du fichier du logo éditeur` accepte que le nom d'image et pas le lien absolus.

## :robot: Proposition
On ajoute des regles pour que les utilisateurs oublie d'ajouter le `.svg` on le rajoute. Et on accepte que ce soit le lien complet.

## :rainbow: Remarques
Pas de remarques

## :100: Pour tester
Allez à PIX Admin
creer un nouveau contenu formatif et ajouter un logo avec un lien complet : `https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg`
verifier que ca marche aussi avec `logo-ministere-education-nationale-et-jeunesse.svg`
et `logo-ministere-education-nationale-et-jeunesse`

Pour tester les badges:
- aller à les profils cibles 
- cliquer sur un profil cible
- ajouter un nouveau resultat formatique avec:
   - le lien complete pour un badge
   - le lien complete sans extension
  
