### PR TITLE
[FEATURE] Ajout du champ challengeId dans la réponse du simulateur d'évaluation

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js
@@ -11,6 +11,7 @@ const SERIALIZER_CONFIGURATION = {
   },
   simulationReport: {
     attributes: [
+      'challengeId',
       'minimumCapability',
       'reward',
       'errorRate',
@@ -30,7 +31,7 @@ export const scenarioSimulatorBatchSerializer = { serialize };
 
 const _transformSimulationReport = (answer) => ({
   ...answer,
-  id: answer.challenge.id,
+  challengeId: answer.challenge.id,
   minimumCapability: answer.challenge.minimumCapability,
   difficulty: answer.challenge.difficulty,
   discriminant: answer.challenge.discriminant,

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -105,6 +105,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
               _generateScenarioSimulatorBatch([
                 [
                   {
+                    challengeId: challenge1.id,
                     errorRate: errorRate1,
                     estimatedLevel: estimatedLevel1,
                     minimumCapability: 0.6190392084062237,
@@ -167,6 +168,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 _generateScenarioSimulatorBatch([
                   [
                     {
+                      challengeId: challenge1.id,
                       errorRate: errorRate1,
                       estimatedLevel: estimatedLevel1,
                       minimumCapability: 0.6190392084062237,
@@ -224,6 +226,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 _generateScenarioSimulatorBatch([
                   [
                     {
+                      challengeId: challenge1.id,
                       errorRate: errorRate1,
                       estimatedLevel: estimatedLevel1,
                       minimumCapability: 0.6190392084062237,
@@ -280,6 +283,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
               );
 
               const result = {
+                challengeId: challenge1.id,
                 errorRate: errorRate1,
                 estimatedLevel: estimatedLevel1,
                 minimumCapability: 0.6190392084062237,
@@ -345,6 +349,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 _generateScenarioSimulatorBatch([
                   [
                     {
+                      challengeId: challenge1.id,
                       errorRate: errorRate1,
                       estimatedLevel: estimatedLevel1,
                       minimumCapability: 0.6190392084062237,
@@ -407,6 +412,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 _generateScenarioSimulatorBatch([
                   [
                     {
+                      challengeId: challenge1.id,
                       errorRate: errorRate1,
                       estimatedLevel: estimatedLevel1,
                       minimumCapability: 0.6190392084062237,
@@ -468,6 +474,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 _generateScenarioSimulatorBatch([
                   [
                     {
+                      challengeId: challenge1.id,
                       errorRate: errorRate1,
                       estimatedLevel: estimatedLevel1,
                       minimumCapability: 0.6190392084062237,
@@ -527,6 +534,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 _generateScenarioSimulatorBatch([
                   [
                     {
+                      challengeId: challenge1.id,
                       errorRate: errorRate1,
                       estimatedLevel: estimatedLevel1,
                       minimumCapability: 0.6190392084062237,
@@ -644,6 +652,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 attributes: {
                   'simulation-report': [
                     {
+                      'challenge-id': challenge1.id,
                       'minimum-capability': 0.6190392084062237,
                       reward: reward1,
                       'error-rate': errorRate1,
@@ -653,6 +662,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                       discriminant: challenge1.discriminant,
                     },
                     {
+                      'challenge-id': challenge2.id,
                       'minimum-capability': 0,
                       reward: reward2,
                       'error-rate': errorRate2,
@@ -670,6 +680,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                 attributes: {
                   'simulation-report': [
                     {
+                      'challenge-id': challenge1.id,
                       'minimum-capability': 0.6190392084062237,
                       reward: reward1,
                       'error-rate': errorRate1,
@@ -679,6 +690,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                       discriminant: challenge1.discriminant,
                     },
                     {
+                      'challenge-id': challenge2.id,
                       'minimum-capability': 0,
                       reward: reward2,
                       'error-rate': errorRate2,
@@ -726,6 +738,7 @@ function _generateScenarioSimulatorBatch(data) {
       id: `${index}`,
       attributes: {
         'simulation-report': scenario.map((scenarioSimulatorChallenge) => ({
+          'challenge-id': scenarioSimulatorChallenge.challengeId,
           'error-rate': scenarioSimulatorChallenge.errorRate,
           'estimated-level': scenarioSimulatorChallenge.estimatedLevel,
           'minimum-capability': scenarioSimulatorChallenge.minimumCapability,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer_test.js
@@ -38,6 +38,7 @@ describe('Unit | Serializer | JSONAPI | scenario-simulator-batch-serializer', fu
             attributes: {
               'simulation-report': [
                 {
+                  'challenge-id': challenge.id,
                   'answer-status': 'ok',
                   'error-rate': 1.5,
                   'estimated-level': 1,


### PR DESCRIPTION
## :unicorn: Problème
L'équipe data souhaite savoir quelles épreuves ont été choisies par l'algorithme.

## :robot: Proposition
Ajouter le challengeId dans la réponse du simulateur.

## :100: Pour tester
```
TOKEN=$(curl 'https://api-pr6396.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6396.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity","assessmentId": "1234", "capacity": 1.5, "numberOfIterations": 3, "stopAtChallenge": 30}' | jq '.'
```