### PR TITLE
[TECH] Utiliser l'attribut embedHeight pour setter la hauteur d'un embed (PIX-8370)

### DIFF
--- a/pix1d/app/pods/components/challenge/challenge-embed-simulator/component.js
+++ b/pix1d/app/pods/components/challenge/challenge-embed-simulator/component.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+export default class ChallengeEmbedSimulator extends Component {
+  get embedDocumentHeightStyle() {
+    const height = this.args.height ?? '600';
+    return htmlSafe(`height: ${height}px`);
+  }
+}

--- a/pix1d/app/pods/components/challenge/challenge-embed-simulator/template.hbs
+++ b/pix1d/app/pods/components/challenge/challenge-embed-simulator/template.hbs
@@ -1,3 +1,10 @@
+{{! template-lint-disable style-concatenation no-inline-styles }}
 <div class="challenge-embed-simulator">
-  <iframe class="challenge-embed-simulator__iframe" src="{{@url}}" title="{{@title}}"></iframe>
+  <iframe
+    class="challenge-embed-simulator__iframe"
+    src="{{@url}}"
+    title="{{@title}}"
+    style="{{this.embedDocumentHeightStyle}}"
+  >
+  </iframe>
 </div>

--- a/pix1d/app/pods/components/challenge/item/template.hbs
+++ b/pix1d/app/pods/components/challenge/item/template.hbs
@@ -4,7 +4,11 @@
       <Challenge::ChallengeInstruction @instruction={{@challenge.instruction}} />
       <div class="challenge-item__playground">
         {{#if @challenge.hasValidEmbedDocument}}
-          <Challenge::ChallengeEmbedSimulator @url={{@challenge.embedUrl}} @title={{@challenge.embedTitle}} />
+          <Challenge::ChallengeEmbedSimulator
+            @url={{@challenge.embedUrl}}
+            @title={{@challenge.embedTitle}}
+            @height={{@challenge.embedHeight}}
+          />
         {{/if}}
         <Challenge::ChallengeItemAutoReply @setAnswerValue={{this.setAnswerValue}} />
       </div>

--- a/pix1d/app/styles/components/challenge-embed-simulator.scss
+++ b/pix1d/app/styles/components/challenge-embed-simulator.scss
@@ -1,6 +1,4 @@
 .challenge-embed-simulator {
-  height: 600px;
-
   &__iframe {
     position: relative;
     width: 100%;


### PR DESCRIPTION
## :unicorn: Problème
Pour être affichés correctement, les embed ont besoin de taille en hauteur différentes. Cette hauteur est donnée par l'attribut `embedHeight`. Cependant on utilise pas cet attribut. La hauteur est définie dans le css en dur.

## :robot: Proposition
Utiliser cet attribut pour avoir une hauteur adaptée à chaque embed

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

