### PR TITLE
[BUGFIX] Harmoniser la taille des cartes des contenus formatifs (PIX-8349).

### DIFF
--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -13,11 +13,12 @@
   @extend %pix-body-l;
 
   display: -webkit-box;
-  padding: $pix-spacing-s;
+  height: 54px;
+  margin: 16px 16px 8px;
   overflow: hidden;
   color: $pix-neutral-90;
   font-weight: $font-medium;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Depuis la PR #6262, les cartes des contenus formatifs s'affichent de différentes tailles : 
![image](https://github.com/1024pix/pix/assets/26384707/a47353b2-847a-4844-b3ec-aba8c2e112b7)


## :robot: Proposition
Rétablir l'affichage des cartes pour que ces dernières fassent toujours la même taille. 
Le padding a été remplacé par du margin car sinon le `line-clamp` ne fonctionnait pas. De plus, ce dernier a été modifié pour la valeur 2, pour l'affichage de l'ellipsis pour refléter la maquette. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix app en .fr
- Passer la compétence `PIXEDUINI`
- Constater que les cartes font la même taille même avec des titres différents et que le titre est tronqué au bout de 2 lignes.