### PR TITLE
[TECH] Refacto de la méthode privée "#" en "_"

### DIFF
--- a/api/lib/infrastructure/utils/pseudo-random.js
+++ b/api/lib/infrastructure/utils/pseudo-random.js
@@ -5,12 +5,12 @@ class PseudoRandom {
     this.seed = initialSeed;
   }
 
-  #generateInt(min, max, seed) {
+  _generateInt(min, max, seed) {
     const newSeed = hashInt(seed);
     return min + (newSeed % (max - min));
   }
 
-  #run(method, ...args) {
+  _run(method, ...args) {
     this.seed = hashInt(this.seed);
 
     return method(...args, this.seed);
@@ -21,7 +21,7 @@ class PseudoRandom {
       return 0;
     }
 
-    const randomValue = this.#run(this.#generateInt.bind(this), 0, 100);
+    const randomValue = this._run(this._generateInt.bind(this), 0, 100);
 
     if (randomValue < probability) {
       return 0;


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une précédente PR, le standard `#myMethod` a été utilisé pour une méthode privée.
Problème : ce n'est pas utilisé ailleurs chez Pix, et entre en conflit avec l'écriture des describe de certains tests.

## :robot: Proposition
En attendant que ça devienne un standard, revenir à `_myMethod`

