### PR TITLE
[TECH] Mettre à jour les seeds de la Team Accès (PIX-8208)

### DIFF
--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -78,7 +78,7 @@ function _createSuperAdmin(databaseBuilder) {
     id: REAL_PIX_SUPER_ADMIN,
     firstName: 'NextSuper',
     lastName: 'NextAdmin',
-    email: 'nextsuperadmin@example.net',
+    email: 'superadmin@example.net',
     rawPassword: 'pix123',
   });
   databaseBuilder.factory.buildPixAdminRole({ userId: REAL_PIX_SUPER_ADMIN, role: ROLES.SUPER_ADMIN });

--- a/api/db/seeds/data/team-acces/build-blocked-users.js
+++ b/api/db/seeds/data/team-acces/build-blocked-users.js
@@ -1,0 +1,21 @@
+import { DEFAULT_PASSWORD } from './constants.js';
+
+function _buildUserBeforeBeingBlocked(databaseBuilder) {
+  const blockedUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Goldi',
+    lastName: 'Locks',
+    email: 'blocked@example.net',
+    username: 'goldi.locks0101',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildUserLogin({
+    userId: blockedUser.id,
+    failureCount: 49,
+  });
+}
+
+export function buildBlockedUsers(databaseBuilder) {
+  _buildUserBeforeBeingBlocked(databaseBuilder);
+}

--- a/api/db/seeds/data/team-acces/build-pix-admin-roles.js
+++ b/api/db/seeds/data/team-acces/build-pix-admin-roles.js
@@ -1,0 +1,40 @@
+import { DEFAULT_PASSWORD } from './constants.js';
+import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
+
+const { ROLES } = PIX_ADMIN;
+
+function _buildCertifRole(databaseBuilder) {
+  databaseBuilder.factory.buildUser.withRole({
+    firstName: 'Pix',
+    lastName: 'Certif',
+    email: 'pixcertif@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    role: ROLES.CERTIF,
+  });
+}
+
+function _buildMetierRole(databaseBuilder) {
+  databaseBuilder.factory.buildUser.withRole({
+    firstName: 'Pix',
+    lastName: 'Metier',
+    email: 'pixmetier@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    role: ROLES.METIER,
+  });
+}
+
+function _buildSupportRole(databaseBuilder) {
+  databaseBuilder.factory.buildUser.withRole({
+    firstName: 'Pix',
+    lastName: 'Support',
+    email: 'pixsupport@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    role: ROLES.SUPPORT,
+  });
+}
+
+export function buildPixAdminRoles(databaseBuilder) {
+  _buildSupportRole(databaseBuilder);
+  _buildCertifRole(databaseBuilder);
+  _buildMetierRole(databaseBuilder);
+}

--- a/api/db/seeds/data/team-acces/build-temporary-blocked-user.js
+++ b/api/db/seeds/data/team-acces/build-temporary-blocked-user.js
@@ -1,0 +1,21 @@
+import { DEFAULT_PASSWORD } from './constants.js';
+
+function _buildUserBeforeBeingTemporarilyBlocked(databaseBuilder) {
+  const temporaryBlockedUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Little',
+    lastName: 'Bear',
+    email: 'temporary-blocked@example.net',
+    username: 'little.bear0101',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildUserLogin({
+    userId: temporaryBlockedUser.id,
+    failureCount: 9,
+  });
+}
+
+export function buildTemporaryBlockedUsers(databaseBuilder) {
+  _buildUserBeforeBeingTemporarilyBlocked(databaseBuilder);
+}

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -1,0 +1,43 @@
+import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
+
+function _buildUserWithCnavAuthenticationMethod(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
+    firstName: 'David',
+    lastName: 'Cnav',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+    identityProvider: OidcIdentityProviders.CNAV.service.code,
+    userId: user.id,
+  });
+}
+
+function _buildUserWithFwbAuthenticationMethod(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
+    firstName: 'Henry',
+    lastName: 'Fwb',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+    identityProvider: OidcIdentityProviders.FWB.service.code,
+    userId: user.id,
+  });
+}
+
+function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
+    firstName: 'Paul',
+    lastName: 'Emploi',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
+    userId: user.id,
+  });
+}
+
+export function buildUsers(databaseBuilder) {
+  _buildUserWithCnavAuthenticationMethod(databaseBuilder);
+  _buildUserWithFwbAuthenticationMethod(databaseBuilder);
+  _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder);
+}

--- a/api/db/seeds/data/team-acces/constants.js
+++ b/api/db/seeds/data/team-acces/constants.js
@@ -1,0 +1,3 @@
+const DEFAULT_PASSWORD = 'pix123';
+
+export { DEFAULT_PASSWORD };

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -1,12 +1,13 @@
 import { buildBlockedUsers } from './build-blocked-users.js';
+import { buildPixAdminRoles } from './build-pix-admin-roles.js';
 import { buildTemporaryBlockedUsers } from './build-temporary-blocked-user.js';
 
 async function teamAccesDataBuilder(databaseBuilder) {
   /**
    * TODO:
-   * - pix admin roles (superadmin - différent du common?, metier, certif, support)
-   * - ... à continuer
    */
+  buildPixAdminRoles(databaseBuilder);
+
   buildBlockedUsers(databaseBuilder);
   buildTemporaryBlockedUsers(databaseBuilder);
 }

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -1,0 +1,14 @@
+import { buildBlockedUsers } from './build-blocked-users.js';
+import { buildTemporaryBlockedUsers } from './build-temporary-blocked-user.js';
+
+async function teamAccesDataBuilder(databaseBuilder) {
+  /**
+   * TODO:
+   * - pix admin roles (superadmin - différent du common?, metier, certif, support)
+   * - ... à continuer
+   */
+  buildBlockedUsers(databaseBuilder);
+  buildTemporaryBlockedUsers(databaseBuilder);
+}
+
+export { teamAccesDataBuilder };

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -1,12 +1,12 @@
 import { buildBlockedUsers } from './build-blocked-users.js';
 import { buildPixAdminRoles } from './build-pix-admin-roles.js';
 import { buildTemporaryBlockedUsers } from './build-temporary-blocked-user.js';
+import { buildUsers } from './build-users.js';
 
 async function teamAccesDataBuilder(databaseBuilder) {
-  /**
-   * TODO:
-   */
   buildPixAdminRoles(databaseBuilder);
+
+  buildUsers(databaseBuilder);
 
   buildBlockedUsers(databaseBuilder);
   buildTemporaryBlockedUsers(databaseBuilder);

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -43,12 +43,14 @@ import { teamContenuDataBuilder } from './data/team-contenu/data-builder.js';
 import { teamCertificationDataBuilder } from './data/team-certification/data-builder.js';
 import { certificationCpfCityBuilder } from './data/certification/certification-cpf-city-builder.js';
 import { certificationCpfCountryBuilder } from './data/certification/certification-cpf-country-builder.js';
+import { teamAccesDataBuilder } from './data/team-acces/data-builder.js';
 
 const seed = async function (knex) {
   const shouldUseNewSeeds = process.env.USE_NEW_SEEDS === 'true';
   const databaseBuilder = new DatabaseBuilder({ knex });
   if (shouldUseNewSeeds) {
     await commonBuilder({ databaseBuilder });
+    await teamAccesDataBuilder(databaseBuilder);
     await teamContenuDataBuilder({ databaseBuilder });
     await teamCertificationDataBuilder({ databaseBuilder });
     await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème

Une migration vers un nouveau processus de génération de seed est en cours. Nous devons créer de nouvelles versions des seeds que nous avons besoin lors de nos tests.

## :robot: Proposition

Créer des seeds en suivant le nouveau processus de création de seeds.

## :rainbow: Remarques

- Cette PR modifie également les common seeds pour que l'adresse email du superadmin utilisé par tous dans les seeds soit `superadmin@example.net`.
- Les seeds précédents qui n'ont pas été pris en compte par cette PR, seront ajoutés en fonction des besoins.

## :100: Pour tester en local

- Modifier le package.json pour ajouter `USE_NEW_SEEDS=true` sur la commande npm suivante : `db:seed`
- Exécuter la commande `npm run db:reset`
- Vérifier en base de données que l'on retrouve bien les utilisateurs des seeds

