### PR TITLE
[BUGFIX] Le select des QROC n'affiche pas sa valeur courante (PIX-8371)

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -20,7 +20,7 @@
                   @label={{block.ariaLabel}}
                   @screenReaderOnly={{true}}
                   @placeholder={{block.placeholder}}
-                  @value={{this.qcrocProposalAnswerValue}}
+                  @value={{this.qrocProposalAnswerValue}}
                   @hideDefaultOption={{true}}
                   @options={{block.options}}
                   @onChange={{this.onChangeSelect}}

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -398,6 +398,20 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
+      test('should allow selecting a value', async function (assert) {
+        // given
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
+        await click('.challenge-actions__action-validate');
+
+        // when
+        await clickByName('saladAriaLabel');
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'mango' }));
+
+        // then
+        assert.dom('.pix-select-button').hasText('mango');
+      });
+
       test('should hide the alert error after the user interact with input text', async function (assert) {
         // given
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);


### PR DESCRIPTION
## :unicorn: Problème
Quand on sélectionne une valeur elle est bien enregistrée et on peut valider, mais on a pas le retour visuel, le select n'affiche pas la valeur sélectionnée et reste sur le placeholder.

## :robot: Proposition
Réparer l'affichage de la valeur courante.

## :rainbow: Remarques
N/A

## :100: Pour tester
Preview ce challenge sur la RA : challenge1UXNAJs9pNoEtl