### PR TITLE
[FEATURE] Identification des sessions NextGen en base de données (pix-8374)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center.js
+++ b/api/db/database-builder/factory/build-certification-center.js
@@ -7,6 +7,7 @@ const buildCertificationCenter = function ({
   externalId = 'EX123',
   createdAt = new Date('2020-01-01'),
   updatedAt,
+  isV3Pilot = false,
 } = {}) {
   const values = {
     id,
@@ -15,6 +16,7 @@ const buildCertificationCenter = function ({
     externalId,
     createdAt,
     updatedAt,
+    isV3Pilot,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-centers',

--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -25,6 +25,7 @@ const buildSession = function ({
   juryCommentAuthorId = null,
   juryCommentedAt = null,
   supervisorPassword = 'PIX12',
+  version = 2,
 } = {}) {
   if (_.isUndefined(certificationCenterId)) {
     const builtCertificationCenter = buildCertificationCenter();
@@ -54,6 +55,7 @@ const buildSession = function ({
     juryCommentAuthorId,
     juryCommentedAt,
     supervisorPassword,
+    version,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/db/migrations/20230616082943_add-version-field-in-session.js
+++ b/api/db/migrations/20230616082943_add-version-field-in-session.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'version';
+const CERTIFICATION_COURSE_TABLE = 'certification-courses';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME);
+  });
+
+  await knex.raw(
+    `
+      UPDATE :tableName:
+      SET version = :certificationCourseTable:.:columnName:
+      FROM :certificationCourseTable: WHERE :certificationCourseTable:."sessionId" = :tableName:.id
+    `,
+    {
+      tableName: TABLE_NAME,
+      certificationCourseTable: CERTIFICATION_COURSE_TABLE,
+      columnName: COLUMN_NAME,
+    }
+  );
+
+  await knex(TABLE_NAME)
+    .update({ [COLUMN_NAME]: 2 })
+    .where({ [COLUMN_NAME]: null });
+
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -1,7 +1,7 @@
 import { CERTIFICATION_CENTER_TYPES } from '../constants.js';
 
 class CertificationCenter {
-  constructor({ id, name, externalId, type, createdAt, updatedAt, habilitations = [] } = {}) {
+  constructor({ id, name, externalId, type, createdAt, updatedAt, habilitations = [], isV3Pilot = false } = {}) {
     this.id = id;
     this.name = name;
     this.externalId = externalId;
@@ -9,6 +9,7 @@ class CertificationCenter {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.habilitations = habilitations;
+    this.isV3Pilot = isV3Pilot;
   }
 
   get isSco() {

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -40,6 +40,7 @@ class Session {
     certificationCenterId,
     assignedCertificationOfficerId,
     supervisorPassword = Session.generateSupervisorPassword(),
+    version,
   } = {}) {
     this.id = id;
     this.accessCode = accessCode;
@@ -60,6 +61,7 @@ class Session {
     this.certificationCenterId = certificationCenterId;
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
     this.supervisorPassword = supervisorPassword;
+    this.version = version;
   }
 
   areResultsFlaggedAsSent() {

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -2,6 +2,7 @@ import { ForbiddenAccess } from '../errors.js';
 import * as sessionValidator from '../validators/session-validator.js';
 import * as sessionCodeService from '../services/session-code-service.js';
 import { Session } from '../models/Session.js';
+import { CertificationVersion } from '../models/CertificationVersion.js';
 
 const createSession = async function ({
   userId,
@@ -22,11 +23,14 @@ const createSession = async function ({
   }
 
   const accessCode = dependencies.sessionCodeService.getNewSessionCode();
-  const { name: certificationCenter } = await certificationCenterRepository.get(certificationCenterId);
+  const { isV3Pilot, name: certificationCenterName } = await certificationCenterRepository.get(certificationCenterId);
+  const version = isV3Pilot ? CertificationVersion.V3 : CertificationVersion.V2;
+
   const domainSession = new Session({
     ...session,
     accessCode,
-    certificationCenter,
+    certificationCenter: certificationCenterName,
+    version,
   });
 
   return sessionRepository.save(domainSession);

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -15,7 +15,7 @@ function _toDomain(bookshelfCertificationCenter) {
     });
   });
   return new CertificationCenter({
-    ..._.pick(dbCertificationCenter, ['id', 'name', 'type', 'externalId', 'createdAt', 'updatedAt']),
+    ..._.pick(dbCertificationCenter, ['id', 'name', 'type', 'externalId', 'createdAt', 'updatedAt', 'isV3Pilot']),
     habilitations,
   });
 }

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
@@ -37,6 +37,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-create
           accessCode: 'accessCode',
           supervisorPassword: 'KV2CP',
           certificationCandidates: [],
+          version: 2,
         };
         const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
           sessions: [sessionToSave],

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -28,6 +28,7 @@ describe('Integration | Repository | Session', function () {
         assignedCertificationOfficerId: null,
         accessCode: 'XXXX',
         supervisorPassword: 'AB2C7',
+        version: 2,
       });
 
       await databaseBuilder.commit();
@@ -145,6 +146,7 @@ describe('Integration | Repository | Session', function () {
         time: '12:00:00',
         description: 'CertificationPix pour les jeunes',
         accessCode: 'NJR10',
+        version: 2,
       });
       await databaseBuilder.commit();
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-center.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center.js
@@ -8,6 +8,7 @@ const buildCertificationCenter = function ({
   createdAt = new Date('2020-01-01'),
   updatedAt,
   habilitations = [],
+  isV3Pilot = false,
 } = {}) {
   return new CertificationCenter({
     id,
@@ -17,6 +18,7 @@ const buildCertificationCenter = function ({
     updatedAt,
     createdAt,
     habilitations,
+    isV3Pilot,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -20,6 +20,7 @@ const buildSession = function ({
   assignedCertificationOfficerId = null,
   supervisorPassword = 'PIX12',
   certificationCandidates = [],
+  version = 2,
 } = {}) {
   return new Session({
     id,
@@ -41,6 +42,7 @@ const buildSession = function ({
     assignedCertificationOfficerId,
     supervisorPassword,
     certificationCandidates,
+    version,
   });
 };
 

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -22,6 +22,7 @@ const SESSION_PROPS = [
   'certificationCenterId',
   'assignedCertificationOfficerId',
   'supervisorPassword',
+  'version',
 ];
 
 describe('Unit | Domain | Models | Session', function () {

--- a/api/tests/unit/domain/usecases/create-session_test.js
+++ b/api/tests/unit/domain/usecases/create-session_test.js
@@ -1,33 +1,27 @@
 import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
-import _ from 'lodash';
-
-const { noop } = _;
 
 import { createSession } from '../../../../lib/domain/usecases/create-session.js';
 import { ForbiddenAccess } from '../../../../lib/domain/errors.js';
 import { Session } from '../../../../lib/domain/models/Session.js';
 
 describe('Unit | UseCase | create-session', function () {
-  let certificationCenter;
+  let certificationCenterRepository;
+  let sessionRepository;
+  let userRepository;
+  let userWithMemberships;
+  const userId = 'userId';
   const certificationCenterId = 'certificationCenterId';
   const certificationCenterName = 'certificationCenterName';
+  const sessionToSave = { certificationCenterId };
 
   beforeEach(function () {
-    certificationCenter = domainBuilder.buildCertificationCenter({
-      id: certificationCenterId,
-      name: certificationCenterName,
-    });
+    certificationCenterRepository = { get: sinon.stub() };
+    sessionRepository = { save: sinon.stub() };
+    userRepository = { getWithCertificationCenterMemberships: sinon.stub() };
+    userWithMemberships = { hasAccessToCertificationCenter: sinon.stub() };
   });
 
   describe('#save', function () {
-    const userId = 'userId';
-
-    const sessionToSave = { certificationCenterId };
-    const certificationCenterRepository = { get: noop };
-    const sessionRepository = { save: noop };
-    const userRepository = { getWithCertificationCenterMemberships: noop };
-    const userWithMemberships = { hasAccessToCertificationCenter: noop };
-
     context('when session is not valid', function () {
       it('should throw an error', function () {
         // given
@@ -50,15 +44,28 @@ describe('Unit | UseCase | create-session', function () {
     });
 
     context('when session is valid', function () {
+      let accessCode;
+      let sessionValidatorStub;
+      let sessionCodeServiceStub;
+
+      beforeEach(function () {
+        accessCode = Symbol('accessCode');
+        sessionValidatorStub = { validate: sinon.stub().returns() };
+        sessionCodeServiceStub = { getNewSessionCode: sinon.stub().returns(accessCode) };
+        userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
+        userRepository.getWithCertificationCenterMemberships = sinon.stub();
+        certificationCenterRepository.get = sinon.stub();
+        sessionRepository.save = sinon.stub();
+        userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
+        userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
+        sessionRepository.save.resolves();
+      });
+
       context('when user has no certification center membership', function () {
         it('should throw a Forbidden error', async function () {
           // given
-          userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
           userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(false);
-          userRepository.getWithCertificationCenterMemberships = sinon.stub();
-          userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
-          const sessionValidatorStub = { validate: sinon.stub().returns() };
-          const sessionCodeServiceStub = { getNewSessionCode: sinon.stub() };
+          sessionCodeServiceStub = { getNewSessionCode: sinon.stub() };
 
           // when
           const error = await catchErr(createSession)({
@@ -78,18 +85,12 @@ describe('Unit | UseCase | create-session', function () {
       context('when user has certification center membership', function () {
         it('should save the session with appropriate arguments', async function () {
           // given
-          const accessCode = Symbol('accessCode');
-          const sessionValidatorStub = { validate: sinon.stub().returns() };
-          const sessionCodeServiceStub = { getNewSessionCode: sinon.stub().returns(accessCode) };
-          userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
-          userRepository.getWithCertificationCenterMemberships = sinon.stub();
-          certificationCenterRepository.get = sinon.stub();
+          const certificationCenter = domainBuilder.buildCertificationCenter({
+            id: certificationCenterId,
+            name: certificationCenterName,
+          });
 
-          sessionRepository.save = sinon.stub();
-          userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
-          userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
           certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
-          sessionRepository.save.resolves();
 
           // when
           await createSession({
@@ -113,49 +114,39 @@ describe('Unit | UseCase | create-session', function () {
           expect(sessionRepository.save).to.have.been.calledWithExactly(expectedSession);
         });
       });
-    });
 
-    context('when session is created by a V3 pilot certification center', function () {
-      it('should save the session with appropriate arguments', async function () {
-        // given
-        const v3PilotCertificationCenter = domainBuilder.buildCertificationCenter({
-          id: certificationCenterId,
-          name: certificationCenterName,
-          isV3Pilot: true,
+      context('when session is created by a V3 pilot certification center', function () {
+        it('should save the session with appropriate arguments', async function () {
+          // given
+          const v3PilotCertificationCenter = domainBuilder.buildCertificationCenter({
+            id: certificationCenterId,
+            name: certificationCenterName,
+            isV3Pilot: true,
+          });
+
+          certificationCenterRepository.get.withArgs(certificationCenterId).resolves(v3PilotCertificationCenter);
+
+          // when
+          await createSession({
+            userId,
+            session: sessionToSave,
+            certificationCenterRepository,
+            sessionRepository,
+            userRepository,
+            dependencies: { sessionValidator: sessionValidatorStub, sessionCodeService: sessionCodeServiceStub },
+          });
+
+          // then
+          const expectedSession = new Session({
+            certificationCenterId,
+            certificationCenter: certificationCenterName,
+            accessCode,
+            supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
+            version: 3,
+          });
+
+          expect(sessionRepository.save).to.have.been.calledWithExactly(expectedSession);
         });
-        const accessCode = Symbol('accessCode');
-        const sessionValidatorStub = { validate: sinon.stub().returns() };
-        const sessionCodeServiceStub = { getNewSessionCode: sinon.stub().returns(accessCode) };
-        userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
-        userRepository.getWithCertificationCenterMemberships = sinon.stub();
-        certificationCenterRepository.get = sinon.stub();
-
-        sessionRepository.save = sinon.stub();
-        userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
-        userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
-        certificationCenterRepository.get.withArgs(certificationCenterId).resolves(v3PilotCertificationCenter);
-        sessionRepository.save.resolves();
-
-        // when
-        await createSession({
-          userId,
-          session: sessionToSave,
-          certificationCenterRepository,
-          sessionRepository,
-          userRepository,
-          dependencies: { sessionValidator: sessionValidatorStub, sessionCodeService: sessionCodeServiceStub },
-        });
-
-        // then
-        const expectedSession = new Session({
-          certificationCenterId,
-          certificationCenter: certificationCenterName,
-          accessCode,
-          supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
-          version: 3,
-        });
-
-        expect(sessionRepository.save).to.have.been.calledWithExactly(expectedSession);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas différencier les sessions utilisant les différentes versions de l'algo.

## :robot: Proposition
On ajoute une colonne `version` à la table `sessions` afin de déterminer pour chaque session la version employée.
On se base sur la `certification-courses.version` de chaque session pour déterminer la version des sessions existantes.

Par la suite, chaque session créée par un centre de certification pilote NextGen sera en v3 par défaut.

## :rainbow: Remarques

Nous ne occupons pas du refacto de bookshelf dans le `certification-center-repository` dans cette PR.

## :100: Pour tester

- Vérifier en base que les sessions ayant des `certification-courses.version = 2` aient bien une version à 2
- Tests au vert
- Pas de régression après avoir passé une certif.

