### PR TITLE
[FEATURE] Creation de la bar d'action pour supprimer des participants

### DIFF
--- a/orga/app/adapters/organization-participant.js
+++ b/orga/app/adapters/organization-participant.js
@@ -7,4 +7,9 @@ export default class OrganizationParticipantAdapter extends ApplicationAdapter {
 
     return `${this.host}/${this.namespace}/organizations/${organizationId}/participants`;
   }
+
+  deleteParticipants(organizationId, ids) {
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/organization-learners`;
+    return this.ajax(url, 'DELETE', { data: { listLearners: ids } });
+  }
 }

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -55,7 +55,7 @@
     {{#if @participants}}
       <tbody>
         <SelectableList @items={{@participants}}>
-          <:manager as |allSelected someSelected toggleAll|>
+          <:manager as |allSelected someSelected toggleAll selectedParticipants|>
             {{#in-element this.mainCheckbox}}
               <PixCheckbox
                 @screenReaderOnly={{true}}
@@ -64,6 +64,24 @@
                 {{on "click" toggleAll}}
               >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
             {{/in-element}}
+            {{#if someSelected}}
+              {{#in-element this.actionBar}}
+                <Ui::ActionBar @items={{selectedParticipants}}>
+                  <:information>
+                    {{t "pages.organization-participants.action-bar.information" count=selectedParticipants.length}}
+                  </:information>
+                  <:actions>
+                    <PixButton
+                      @triggerAction={{(fn @deleteParticipants selectedParticipants)}}
+                      type="button"
+                      @backgroundColor="red"
+                    >
+                      {{t "pages.organization-participants.action-bar.delete-button"}}
+                    </PixButton>
+                  </:actions>
+                </Ui::ActionBar>
+              {{/in-element}}
+            {{/if}}
           </:manager>
           <:item as |participant toggleParticipant isParticipantSelected index|>
             <tr
@@ -126,3 +144,5 @@
 </div>
 
 <Table::PaginationControl @pagination={{@participants.meta}} />
+
+<div id={{this.actionBarId}}></div>

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -10,10 +10,18 @@ export default class List extends Component {
   }
 
   get mainCheckboxId() {
-    return guidFor(this);
+    return guidFor(this) + 'mainCheckbox';
   }
 
   get mainCheckbox() {
     return document.getElementById(this.mainCheckboxId);
+  }
+
+  get actionBarId() {
+    return guidFor(this) + 'actionBar';
+  }
+
+  get actionBar() {
+    return document.getElementById(this.actionBarId);
   }
 }

--- a/orga/app/components/selectable-list.hbs
+++ b/orga/app/components/selectable-list.hbs
@@ -1,4 +1,4 @@
 {{#each @items as |item index|}}
   {{yield item (fn this.toggle item) (this.isSelected item) index to="item"}}
 {{/each}}
-{{yield this.allSelected this.someSelected this.toggleAll to="manager"}}
+{{yield this.allSelected this.someSelected this.toggleAll this.selectedItems to="manager"}}

--- a/orga/app/components/ui/action-bar.hbs
+++ b/orga/app/components/ui/action-bar.hbs
@@ -1,0 +1,8 @@
+<div class="action-bar">
+  <p class="action-bar__informations">
+    {{yield to="information"}}
+  </p>
+  <div class="action-bar__actions">
+    {{yield to="actions"}}
+  </div>
+</div>

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ListController extends Controller {
   @service currentUser;
   @service router;
+  @service store;
 
   @tracked pageNumber = 1;
   @tracked pageSize = 50;
@@ -45,5 +46,14 @@ export default class ListController extends Controller {
   goToLearnerPage(learnerId, event) {
     event.preventDefault();
     this.router.transitionTo('authenticated.organization-participants.organization-participant', learnerId);
+  }
+
+  @action
+  async deleteOrganizationLearners(listLearners) {
+    await this.store.adapterFor('organization-participant').deleteParticipants(
+      this.currentUser.organization.id,
+      listLearners.map(({ id }) => id)
+    );
+    this.send('refreshModel');
   }
 }

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -1,4 +1,5 @@
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default class ListRoute extends Route {
@@ -41,5 +42,10 @@ export default class ListRoute extends Route {
       controller.participationCountOrder = null;
       controller.lastnameSort = 'asc';
     }
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -21,6 +21,7 @@
 // components
 @import 'components/ui';
 @import 'components/ui/last-participation-date-tooltip.scss';
+@import 'components/ui/action-bar.scss';
 @import 'components/login-form';
 @import 'components/campaign';
 @import 'components/campaign/cards';

--- a/orga/app/styles/components/ui/action-bar.scss
+++ b/orga/app/styles/components/ui/action-bar.scss
@@ -1,0 +1,35 @@
+.action-bar {
+  @extend %pix-body-m;
+  @include shadow(-4px, 8px);
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: fixed;
+  width: calc(100% - $app-sidebar-width) ;
+  height: 68px;
+  right: 0;
+  bottom: 0;
+  background-color: $pix-neutral-0;
+  color: $pix-neutral-60;
+  font-family: $font-roboto;
+
+  .action-bar__informations {
+    margin-left: $pix-spacing-xl;
+    display: flex;
+    align-items: baseline;
+  }
+
+  .action-bar__actions {
+    display: flex;
+    padding: 0 $pix-spacing-m;
+
+    .pix-button {
+      margin: 0 $pix-spacing-xs;
+    }
+  }
+}
+
+footer {
+  padding: $pix-spacing-s $pix-spacing-m;
+}

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -14,6 +14,7 @@
       @sortByParticipationCount={{this.sortByParticipationCount}}
       @sortByLastname={{this.sortByLastname}}
       @lastnameSort={{this.lastnameSort}}
+      @deleteParticipants={{this.deleteOrganizationLearners}}
     />
   {{else}}
     <OrganizationParticipant::NoParticipantPanel />

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -600,4 +600,75 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       )
       .exists();
   });
+
+  module('action bar', function (hooks) {
+    hooks.beforeEach(function () {
+      this.triggerFiltering = sinon.stub();
+      this.set('fullNameFilter', null);
+      this.set('certificabilityFilter', []);
+    });
+
+    test('it display action bar', async function (assert) {
+      //given
+      const participants = [{ id: 1, firstName: 'Spider', lastName: 'Man' }];
+
+      this.set('participants', participants);
+      this.deleteParticipants = sinon.stub();
+
+      //when
+      const screen = await render(hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+  @deleteParticipants={{this.deleteParticipants}}
+/>`);
+
+      const firstLearnerToDelete = screen.getAllByRole('checkbox')[1];
+      await click(firstLearnerToDelete);
+
+      //then
+      assert
+        .dom(screen.getByText(this.intl.t('pages.organization-participants.action-bar.information', { count: 1 })))
+        .exists();
+    });
+
+    test('it should delete participants', async function (assert) {
+      //given
+      const spiderLearner = { id: 1, firstName: 'Spider', lastName: 'Man' };
+      const peterLearner = { id: 2, firstName: 'Peter', lastName: 'Parker' };
+      const milesLearner = { id: 3, firstName: 'Miles', lastName: 'Morales' };
+      const participants = [spiderLearner, peterLearner, milesLearner];
+
+      this.set('participants', participants);
+      this.deleteParticipants = sinon.stub();
+
+      //when
+      const screen = await render(hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+  @deleteParticipants={{this.deleteParticipants}}
+/>`);
+
+      const firstLearnerToDelete = screen.getAllByRole('checkbox')[2];
+      const secondLearnerToDelete = screen.getAllByRole('checkbox')[3];
+
+      await click(firstLearnerToDelete);
+      await click(secondLearnerToDelete);
+
+      const deleteButton = await screen.findByRole('button', {
+        name: this.intl.t('pages.organization-participants.action-bar.delete-button'),
+      });
+
+      await click(deleteButton);
+      //then
+
+      sinon.assert.calledWith(this.deleteParticipants, [peterLearner, milesLearner]);
+      assert.ok(true);
+    });
+  });
 });

--- a/orga/tests/integration/components/ui/action-bar_test.js
+++ b/orga/tests/integration/components/ui/action-bar_test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | Ui | Action Bar', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    //given
+    this.information = "Je s'appelle groot";
+    this.actions = 'Je suis une action';
+
+    //when
+    const screen = await render(
+      hbs`<Ui::ActionBar><:information>{{this.information}}</:information><:actions>{{this.actions}}</:actions></Ui::ActionBar>`
+    );
+    //then
+    assert.dom(screen.getByText("Je s'appelle groot")).exists();
+    assert.dom(screen.getByText('Je suis une action')).exists();
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -321,7 +321,7 @@
           },
           "profiles-collection-campaign-participation": {
             "to-share-participation": "The participant will no longer be able to submit their profile through this campaign.",
-            "shared-participation": "The participant will no longer be able to submit their profile through this campaign."    
+            "shared-participation": "The participant will no longer be able to submit their profile through this campaign."
           }
         }
       }
@@ -768,7 +768,11 @@
         "row-title": "Participant"
       },
       "page-title": "Participants",
-      "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
+      "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}",
+      "action-bar": {
+        "information": "{count, plural, =1 {{count} selected participant} other {{count} selected participants}}",
+        "delete-button": "Delete"
+      }
     },
     "participants-list": {
       "latest-participation-information-tooltip": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -243,7 +243,7 @@
       "breadcrumb-current-page-label": "Participation de {firstName} {lastName}",
       "badges": "Résultats Thématiques",
       "progression": "Avancement",
-      "result": "Résultat",        
+      "result": "Résultat",
       "tab": {
         "results": "Résultats",
         "review": "Analyse"
@@ -320,11 +320,11 @@
           "assessment-campaign-participation": {
             "started-participation": "Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne.",
             "to-share-participation": "Le participant ne pourra pas envoyer ses résultats et il ne pourra pas non plus participer de nouveau à cette campagne.",
-            "shared-participation": "Le participant ne pourra plus participer de nouveau à cette campagne."    
+            "shared-participation": "Le participant ne pourra plus participer de nouveau à cette campagne."
           },
           "profiles-collection-campaign-participation": {
             "to-share-participation": "Le participant ne pourra pas envoyer son profil et il ne pourra pas non plus participer de nouveau à cette collecte de profil.",
-            "shared-participation": "Le participant ne pourra plus participer de nouveau à cette collecte de profil."    
+            "shared-participation": "Le participant ne pourra plus participer de nouveau à cette collecte de profil."
           }
         }
       }
@@ -771,7 +771,11 @@
         "row-title": "Participant"
       },
       "page-title": "Participants",
-      "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
+      "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}",
+      "action-bar": {
+        "information": "{count, plural, =1 {{count} participant sélectionné} other {{count} participants sélectionnés}}",
+        "delete-button": "Supprimer"
+      }
     },
     "participants-list": {
       "latest-participation-information-tooltip": {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons réalisé les tickets back nécessaire pour rendre possible de supprimer des prescrits. Nous pouvons maintenant passer à l’API et au front, sachant que **cet ensemble de tickets doivent être réalisés dans une même branche et partir en prod en simultané.**

## :robot: Proposition
Dès qu’un admin d’une orga concernée par la feature (toutes sauf SCO IsManagingStudents=true) a sélectionné au moins un de ses prescrits, nous allons afficher un bandeau sticky en bas de page qui inclut deux éléments :
- le nombre de prescrit.s sélectionné.s (utiliser pluralize ?)
- le bouton supprimer.

## :rainbow: Remarques
Suite de ces PR : 
- [Ajout de checkboxs à la liste de participants](https://github.com/1024pix/pix/pull/6364)
- [Ajout de la checkbox principale](https://github.com/1024pix/pix/pull/6371)

La série de ticket Front de cette Epix sera mergée en même temps sur dev via la [feature branche](https://github.com/1024pix/pix/tree/pix-6616-organization-learner-deletion)
## :100: Pour tester
- se connecter à Pix Orga en tant que Pro
- se rendre sur la page des participants
- sélectionner un ou plusieurs participants
- cliquer sur le bouton "Supprimer"
- vérifier que les participants sélectionnés et bien été supprimés et que la bar de suppression disparaît bien après cette action
- 🎉 