### PR TITLE
[TECH] Utiliser les nouvelles seeds pour la team xp eval (PIX-8225).

### DIFF
--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -1,0 +1,152 @@
+import * as tooling from '../common/tooling/index.js';
+
+const TEAM_EVALUATION_OFFSET_ID = 1000000;
+/// USERS
+const SCO_ORGANIZATION_USER_ID = TEAM_EVALUATION_OFFSET_ID;
+
+/// ORGAS
+const SCO_ORGANIZATION_ID = TEAM_EVALUATION_OFFSET_ID;
+
+// TARGET PROFILES
+const TARGET_PROFILE_PIX_ID = TEAM_EVALUATION_OFFSET_ID;
+
+// CAMPAIGNS
+const ASSESSMENT_CAMPAIGN_PIX_ID = TEAM_EVALUATION_OFFSET_ID;
+
+export async function teamEvaluationDataBuilder({ databaseBuilder }) {
+  createScoOrganization(databaseBuilder);
+  await createCoreTargetProfile(databaseBuilder);
+  await createAssessmentCampaign(databaseBuilder);
+}
+
+function createScoOrganization(databaseBuilder) {
+  databaseBuilder.factory.buildOrganization({
+    id: SCO_ORGANIZATION_ID,
+    type: 'SCO',
+    name: 'Sco Orga team eval',
+    isManagingStudents: false,
+    externalId: 'EVAL',
+  });
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: SCO_ORGANIZATION_USER_ID,
+    firstName: 'Orga Sco',
+    lastName: 'Team Eval',
+    email: 'eval-sco@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: SCO_ORGANIZATION_USER_ID,
+    organizationId: SCO_ORGANIZATION_ID,
+    organizationRole: 'ADMIN',
+  });
+}
+
+async function createCoreTargetProfile(databaseBuilder) {
+  const configTargetProfile = {
+    frameworks: [
+      {
+        chooseCoreFramework: true,
+        countTubes: 30,
+        minLevel: 3,
+        maxLevel: 7,
+      },
+    ],
+  };
+  const configBadge = {
+    criteria: [
+      {
+        scope: 'CappedTubes',
+        threshold: 60,
+      },
+      {
+        scope: 'CampaignParticipation',
+        threshold: 50,
+      },
+    ],
+  };
+  const { targetProfileId, cappedTubesDTO } = await tooling.targetProfile.createTargetProfile({
+    databaseBuilder,
+    targetProfileId: TARGET_PROFILE_PIX_ID,
+    name: 'Profil cible Pur Pix (Niv3 ~ 6)',
+    isPublic: true,
+    ownerOrganizationId: SCO_ORGANIZATION_ID,
+    isSimplifiedAccess: false,
+    description:
+      'Profil cible pur pix (Niv3 ~ 6) avec 1 RT double critère (tube et participation) et des paliers NIVEAUX',
+    configTargetProfile,
+  });
+  await tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 700,
+    altMessage: '1 RT double critère Campaign & Tubes',
+    imageUrl: 'some_image.svg',
+    message: '1 RT double critère Campaign & Tubes',
+    title: '1 RT double critère Campaign & Tubes',
+    key: 'SOME_KEY_FOR_RT_700',
+    isCertifiable: false,
+    isAlwaysVisible: true,
+    configBadge,
+  });
+  await tooling.targetProfile.createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 701,
+    altMessage: '1 RT simple critère Campaign',
+    imageUrl: 'some_other_image.svg',
+    message: '1 RT simple critère Campaign',
+    title: '1 RT simple critère Campaign',
+    key: 'SOME_KEY_FOR_RT_701',
+    isCertifiable: false,
+    isAlwaysVisible: true,
+    configBadge,
+  });
+  await tooling.targetProfile.createStages({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    type: 'LEVEL',
+    countStages: 4,
+    includeFirstSkill: true,
+  });
+}
+async function createAssessmentCampaign(databaseBuilder) {
+  await tooling.campaign.createAssessmentCampaign({
+    databaseBuilder,
+    campaignId: ASSESSMENT_CAMPAIGN_PIX_ID,
+    name: 'Campagne evaluation team-eval',
+    code: 'EVAL12345',
+    title: 'Campagne evaluation team-evaluation',
+    idPixLabel: null,
+    externalIdHelpImageUrl: null,
+    alternativeTextToExternalIdHelpImage: null,
+    customLandingPageText: null,
+    isForAbsoluteNovice: false,
+    archivedAt: null,
+    archivedBy: null,
+    createdAt: undefined,
+    organizationId: SCO_ORGANIZATION_ID,
+    creatorId: SCO_ORGANIZATION_USER_ID,
+    ownerId: SCO_ORGANIZATION_USER_ID,
+    targetProfileId: TARGET_PROFILE_PIX_ID,
+    customResultPageText: 'customResultPageText',
+    customResultPageButtonText: 'customResultPageButtonText',
+    customResultPageButtonUrl: 'customResultPageButtonUrl',
+    multipleSendings: false,
+    assessmentMethod: 'SMART_RANDOM',
+    configCampaign: {
+      participantCount: 30,
+    },
+  });
+}

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -41,6 +41,7 @@ import { addLastAssessmentResultCertificationCourse } from '../../scripts/certif
 import { commonBuilder } from './data/common/common-builder.js';
 import { teamContenuDataBuilder } from './data/team-contenu/data-builder.js';
 import { teamCertificationDataBuilder } from './data/team-certification/data-builder.js';
+import { teamEvaluationDataBuilder } from './data/team-evaluation/data-builder.js';
 import { certificationCpfCityBuilder } from './data/certification/certification-cpf-city-builder.js';
 import { certificationCpfCountryBuilder } from './data/certification/certification-cpf-country-builder.js';
 import { teamAccesDataBuilder } from './data/team-acces/data-builder.js';
@@ -53,6 +54,7 @@ const seed = async function (knex) {
     await teamAccesDataBuilder(databaseBuilder);
     await teamContenuDataBuilder({ databaseBuilder });
     await teamCertificationDataBuilder({ databaseBuilder });
+    await teamEvaluationDataBuilder({ databaseBuilder });
     await databaseBuilder.commit();
     await databaseBuilder.fixSequences();
   } else {


### PR DESCRIPTION
## :unicorn: Problème
Suite à la refato proposée dans ce [ticket](https://github.com/1024pix/pix/pull/6219), on change la logique de la création des seeds.

## :robot: Proposition
Se conformer à cette nouvelle logique pour la team expérience d'évaluation en recréant depuis 0 de nouvelles seeds.

## :rainbow: Remarques
Nous avons choisit de mettre à la poubelle les anciennes seeds, et de créer au fil de l'eau les nouvelles seeds en fonction des nouveaux besoins de tests en RA. Dès qu'on se rendra compte qu'on a un nouveau besoin, on enrichiera les seeds existants afin d'obtenir le résultat souhaité en RA.

## :100: Pour tester
- checkout la branche en local
- lancer la commande `npm run db:seed`
- constater qu'il n'y a pas d'erreur
- se connecter à la RA de mon-pix avec le user `eval-sco@example.net`
- saisir le code campagne `eval12345`
- constater qu'on peut bien passer la campagne