### PR TITLE
[BUGFIX] QCU: Mention "La bonne réponse est : ..." incorrecte (PIX-8385)

### DIFF
--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -19,11 +19,7 @@ export default class QcuSolutionPanel extends Component {
       return this.args.solutionToDisplay;
     }
 
-    const answersProposedByUser = this.labeledRadios;
-    const correctAnswerIndex = this.solutionArray.indexOf(true);
-    const solutionAndStatus = answersProposedByUser[correctAnswerIndex];
-
-    return solutionAndStatus.label;
+    return this.labeledRadios.find(({ value }) => value == this.args.solution).label;
   }
 
   get labeledRadios() {


### PR DESCRIPTION
## :unicorn: Problème
La réponse affichée en vert est bien la bonne, mais en dessous la mention "La bonne réponse est : ..." n'est pas bonne.

## :robot: Proposition
Se baser sur la value pour trouver la bonne solution, c'est plus simple.

## :rainbow: Remarques
N/A

## :100: Pour tester
 - Faire une preview de challenge2cukX7ErGpSq6k sur la RA.
 - Vérifier que Etalab n'est pas en 3ème position, sinon refaire une autre preview
 - Répondre autre chose que Etalab
 - Vérifier que dans la solution on a bien la phrase "La bonne réponse est : Etalab"