### PR TITLE
[FEATURE] Identification de la version des certification-courses (PIX-8273).

### DIFF
--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -74,6 +74,7 @@ class CertificationCourse {
     verificationCode,
     maxReachableLevelOnCertificationDate,
     complementaryCertificationCourses,
+    version,
   }) {
     return new CertificationCourse({
       userId: certificationCandidate.userId,
@@ -91,6 +92,7 @@ class CertificationCourse {
       verificationCode,
       maxReachableLevelOnCertificationDate,
       complementaryCertificationCourses,
+      version,
     });
   }
 
@@ -217,6 +219,10 @@ class CertificationCourse {
 
   getSessionId() {
     return this._sessionId;
+  }
+
+  getVersion() {
+    return this._version;
   }
 
   toDTO() {

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -19,8 +19,8 @@ async function getPlacementProfile({
   locale,
 }) {
   const pixCompetences = await competenceRepository.listPixCompetencesOnly({ locale });
-  if (version === CertificationVersion.V2) {
-    return _generatePlacementProfileV2({
+  if (version !== CertificationVersion.V1) {
+    return _generatePlacementProfile({
       userId,
       profileDate: limitDate,
       competences: pixCompetences,
@@ -106,7 +106,7 @@ function _createUserCompetencesV2({
   });
 }
 
-async function _generatePlacementProfileV2({ userId, profileDate, competences, allowExcessPixAndLevels }) {
+async function _generatePlacementProfile({ userId, profileDate, competences, allowExcessPixAndLevels }) {
   const knowledgeElementsByCompetence = await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
     userId,
     limitDate: profileDate,

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -34,6 +34,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   verifyCertificateCodeService,
 }) {
   const session = await sessionRepository.get(sessionId);
+
   if (session.accessCode !== accessCode) {
     throw new NotFoundError('Session not found');
   }
@@ -75,6 +76,8 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     };
   }
 
+  const { version } = session;
+
   return _startNewCertification({
     domainTransaction,
     sessionId,
@@ -89,6 +92,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     placementProfileService,
     verifyCertificateCodeService,
     certificationBadgesService,
+    version,
   });
 };
 
@@ -107,10 +111,15 @@ async function _startNewCertification({
   placementProfileService,
   certificationBadgesService,
   verifyCertificateCodeService,
+  version,
 }) {
   const challengesForCertification = [];
 
-  const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate: new Date() });
+  const placementProfile = await placementProfileService.getPlacementProfile({
+    userId,
+    limitDate: new Date(),
+    version,
+  });
 
   if (!placementProfile.isCertifiable()) {
     throw new UserNotAuthorizedToCertifyError();
@@ -180,6 +189,7 @@ async function _startNewCertification({
     domainTransaction,
     verifyCertificateCodeService,
     complementaryCertificationCourseData,
+    version,
   });
 }
 
@@ -205,6 +215,7 @@ async function _createCertificationCourse({
   certificationChallenges,
   complementaryCertificationCourseData,
   domainTransaction,
+  version,
 }) {
   const verificationCode = await verifyCertificateCodeService.generateCertificateVerificationCode();
   const complementaryCertificationCourses = complementaryCertificationCourseData.map(
@@ -217,6 +228,7 @@ async function _createCertificationCourse({
     maxReachableLevelOnCertificationDate: features.maxReachableLevel,
     complementaryCertificationCourses,
     verificationCode,
+    version,
   });
 
   const savedCertificationCourse = await certificationCourseRepository.save({

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -13,6 +13,7 @@ import {
 
 import { config } from '../../config.js';
 import bluebird from 'bluebird';
+import { CertificationVersion } from '../models/CertificationVersion.js';
 
 const { features } = config;
 
@@ -174,11 +175,14 @@ async function _startNewCertification({
     }
   );
 
-  const challengesForPixCertification = await certificationChallengesService.pickCertificationChallenges(
-    placementProfile,
-    locale
-  );
-  challengesForCertification.push(...challengesForPixCertification);
+  let challengesForPixCertification = [];
+  if (version !== CertificationVersion.V3) {
+    challengesForPixCertification = await certificationChallengesService.pickCertificationChallenges(
+      placementProfile,
+      locale
+    );
+    challengesForCertification.push(...challengesForPixCertification);
+  }
 
   return _createCertificationCourse({
     certificationCandidate,

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -55,7 +55,10 @@ const retrieveLastOrCreateCertificationCourse = async function ({
 
   _validateCandidateIsAuthorizedToStart(certificationCandidate, existingCertificationCourse);
 
-  _blockCandidateFromRestartingWithoutExplicitValidation(certificationCandidate, certificationCandidateRepository);
+  await _blockCandidateFromRestartingWithoutExplicitValidation(
+    certificationCandidate,
+    certificationCandidateRepository
+  );
 
   if (existingCertificationCourse) {
     return {
@@ -114,12 +117,12 @@ function _validateCandidateIsAuthorizedToStart(certificationCandidate, existingC
   }
 }
 
-function _blockCandidateFromRestartingWithoutExplicitValidation(
+async function _blockCandidateFromRestartingWithoutExplicitValidation(
   certificationCandidate,
   certificationCandidateRepository
 ) {
   certificationCandidate.authorizedToStart = false;
-  certificationCandidateRepository.update(certificationCandidate);
+  await certificationCandidateRepository.update(certificationCandidate);
 }
 
 async function _startNewCertification({

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -858,6 +858,9 @@ describe('Acceptance | API | Certification Course', function () {
             // then
             const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
             expect(certificationCourse.version).to.equal(CertificationVersion.V3);
+            expect(response.result.data.attributes).to.include({
+              'nb-challenges': 0,
+            });
           });
         });
 

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -58,6 +58,7 @@ buildSession.created = function ({
   room,
   time,
   certificationCandidates,
+  version = 2,
 } = {}) {
   return buildSession({
     id,
@@ -78,6 +79,7 @@ buildSession.created = function ({
     resultsSentToPrescriberAt: null,
     publishedAt: null,
     assignedCertificationOfficerId: null,
+    version,
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème

Maintenant que nous allons mettre en place la nouvelle version de la certification, il nous faut connaitre la version du certification-course créé lors de l'entrée en session.

## :robot: Proposition

Récupérer l'information de la version à partir de la session dans le usecase `retrieve-last-or-create-certification-course`.

## :rainbow: Remarques

Le nouvel algo n'est pas encore utilisé dans la session, une erreur apparait donc au chargement de la première épreuve de session  puisque nous n'avons dorénavant plus de challenges préparés en amont de la session.

## :100: Pour tester

• Se connecter à pix-certif avec le compte : `certifv3@example.net`
• Créer une session
• Sur Pix-app, se connecter avec le compte `certifiable-contenu-user@example.net` et rejoindre la session
• Constater de l'erreur de chargement à la première question (le nouvel algo n'est pas encore "branché")
• (Vous pouvez rafraichir la page pour arriver sur la page de fin de session)
• Vérifier en base que le `certification-course` créé à l'occasion dispose de la propriété `version` à `3`
 