### PR TITLE
[TECH] Analyser la progression des migrations lors des MEP (PIX-8336)

### DIFF
--- a/api/.psqlrc
+++ b/api/.psqlrc
@@ -1,4 +1,4 @@
 \set last_autovaccum 'SELECT schemaname,relname, last_vacuum, last_autovacuum FROM pg_stat_user_tables WHERE last_autovacuum IS NOT NULL ORDER BY last_autovacuum DESC;'
-\set active_queries 'SELECT query_start, query from pg_stat_activity FROM state <> \'idle\' ORDER BY query_start;'
-\set active_queries_count 'SELECT count(*) from pg_stat_activity FROM state <> \'idle\';'
+\set active_queries 'SELECT query_start, query FROM pg_stat_activity WHERE state <> \'idle\' ORDER BY query_start;'
+\set active_queries_count 'SELECT count(*) FROM pg_stat_activity WHERE state <> \'idle\';'
 \set vacuum_in_progress 'SELECT * FROM pg_stat_progress_vacuum INNER JOIN pg_stat_user_tables USING(relid);'

--- a/api/.psqlrc
+++ b/api/.psqlrc
@@ -2,3 +2,4 @@
 \set active_queries 'SELECT query_start, query FROM pg_stat_activity WHERE state <> \'idle\' ORDER BY query_start;'
 \set active_queries_count 'SELECT count(*) FROM pg_stat_activity WHERE state <> \'idle\';'
 \set vacuum_in_progress 'SELECT * FROM pg_stat_progress_vacuum INNER JOIN pg_stat_user_tables USING(relid);'
+\set ungranted_locks 'SELECT lck.pid, lck.relation::regclass, lck.locktype, lck.mode, lck.waitstart started_from, substring(ssn.query from 1 for 30) query, ssn.wait_event_type FROM pg_locks lck INNER JOIN pg_stat_activity ssn ON ssn.pid = lck.pid WHERE NOT granted';


### PR DESCRIPTION
## :unicorn: Problème
Lors de mises en production, si une migration prend du temps, on veut voir ce qui se passe.
L'IHM Scalingo n'est pas très parlante, la requête knex est perdue au milieu des requêtes API.
Les requêtes de diagnostic de [cette PR](https://github.com/1024pix/pix/pull/5285) ne nous aident pas car elles sont invalides.

## :robot: Proposition
Corriger les requêtes existantes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

### Se connecter à la BDD

#### Local

Se connecter à la BDD
```shell
PSQLRC=./.psqlrc psql postgresql://postgres@localhost:5432/pix
```

#### Review app

``` shell
scalingo --app pix-api-review-pr6414 --region=osc-fr1 psql-console
```

### Tester les alias

#### Lister

Lister les alias
``` sql
\set
```

Les requêtes sont à la fin
```
(...)
active_queries = 'SELECT query_start, query FROM pg_stat_activity WHERE state <> 'idle' ORDER BY query_start;'
````

#### Exécuter

Exécuter
``` sql
:active_queries;
:active_queries_count;
:last_autovaccum;
:vacuum_in_progress;
:ungranted_locks;
```

#### Créer des locks

Pour créer des locks exclusifs sur une table:
- soit modifier la table dans une transaction sans commiter
```
BEGIN TRANSACTION;
ALTER TABLE users ADD COLUMN code TEXT;
```
- soit demander un lock explicite `LOCK TABLE users IN ACCESS EXCLUSIVE MODE;`



