### PR TITLE
[TECH] Afficher l'avancement des migrations de BDD

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -148,7 +148,7 @@
     "lint-fix:translations": "eslint --fix --ext .json --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint-fix:code": "eslint --fix . --ext js --cache --cache-strategy content",
     "local:test:coverage": "nyc npm test",
-    "postdeploy": "npm run db:migrate",
+    "postdeploy": "DEBUG=knex:* npm run db:migrate",
     "preinstall": "npx check-engine",
     "scalingo-postbuild": "node scripts/generate-cron > cron.json",
     "start": "node index.js",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque nous suivons une mise en production, nous ne pouvons pas suivre l'état d'avancement des migrations.
L'affichage des requêtes SQL de migration est désactivé.

## :robot: Proposition
Les activer.

## :100: Pour tester
Regarder les logs du déploiement Scalingo
Vérifier que les requêtes sont présentes, au moins `SELECT FROM knex_migrations`