### PR TITLE
[TECH] Monter Pix-UI en version 36.0.0 sur PixApp (PIX-8252).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/components/campaigns/assessment/campaign-skill-review-competence-result.hbs
@@ -20,7 +20,10 @@
             <span class="skill-review-competence__name">{{skillSet.name}}</span>
           </th>
           <td>
-            <PixProgressGauge @value={{skillSet.masteryPercentage}} @tooltipText="{{skillSet.masteryPercentage}}%" />
+            <PixProgressGauge
+              @value={{skillSet.masteryPercentage}}
+              @label={{t "pages.skill-review.details.progress-bar-label"}}
+            />
           </td>
         </tr>
       {{/each}}
@@ -40,7 +43,7 @@
             {{else}}
               <PixProgressGauge
                 @value={{competence.masteryPercentage}}
-                @tooltipText="{{competence.masteryPercentage}}%"
+                @label={{t "pages.skill-review.details.progress-bar-label"}}
               />
             {{/if}}
           </td>

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -6,16 +6,17 @@
 }
 
 .checkpoint__header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  width: 80%;
-  min-height: 50px;
-  margin: 12px 0 35px;
+  width: 100%;
+  margin: $pix-spacing-m 0 $pix-spacing-s;
+  padding-inline: $pix-spacing-xs;
 
   @include device-is('tablet') {
-    width: 800px;
-    margin-bottom: 50px;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    max-width: 832px;
+    margin: $pix-spacing-l 0 $pix-spacing-xs;
+    padding: 0 $pix-spacing-s;
   }
 }
 
@@ -30,10 +31,7 @@
   }
 }
 
-.checkpoint-progression-gauge-wrapper {
-  width: 100%;
-  height: 4px;
-
+.checkpoint__progression-gauge {
   @include device-is('tablet') {
     width: 65%;
   }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -205,13 +205,10 @@
 .skill-review-competence {
   &__table {
     width: 100%;
-
-    tr {
-      height: 76px;
-    }
   }
 
   &__column-header {
+    padding-bottom: $pix-spacing-xs;
     text-align: left;
   }
 
@@ -492,11 +489,12 @@
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 32px;
+    margin-bottom: $pix-spacing-l;
     text-align: center;
 
     @include device-is('tablet') {
       flex-direction: row;
+      margin-bottom: $pix-spacing-s;
     }
   }
 

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -9,20 +9,17 @@
   <div class="checkpoint__container rounded-panel--over-background-banner">
     <div class="checkpoint__header">
       {{#if this.shouldDisplayAnswers}}
-        <div class="checkpoint-progression-gauge-wrapper">
-          <PixProgressGauge
-            @value={{this.completionPercentage}}
-            @isArrowLeft="true"
-            @color="white"
-            @subtitle={{t "pages.checkpoint.completion-percentage.caption"}}
-            @tooltipText={{t
-              "pages.checkpoint.completion-percentage.label"
-              completionPercentage=this.completionPercentage
-              htmlSafe=true
-            }}
-          />
-
-        </div>
+        <PixProgressGauge
+          class="checkpoint__progression-gauge"
+          @value={{this.completionPercentage}}
+          @label={{t
+            "pages.checkpoint.completion-percentage.label"
+            completionPercentage=this.completionPercentage
+            htmlSafe=true
+          }}
+          @subtitle={{t "pages.checkpoint.completion-percentage.caption"}}
+          @themeMode="dark"
+        />
         <div class="checkpoint__continue-wrapper">
           <CheckpointContinue
             @assessmentId={{@model.id}}

--- a/mon-pix/mirage/factories/assessment.js
+++ b/mon-pix/mirage/factories/assessment.js
@@ -20,6 +20,11 @@ export default Factory.extend({
 
   ofCompetenceEvaluationType: trait({
     type: 'COMPETENCE_EVALUATION',
+    afterCreate(assessment, server) {
+      assessment.update({
+        progression: server.create('progression', { id: 3, completionRate: 20 }),
+      });
+    },
   }),
 
   ofCertificationType: trait({

--- a/mon-pix/mirage/routes/get-progression.js
+++ b/mon-pix/mirage/routes/get-progression.js
@@ -1,7 +1,7 @@
 export default function (schema, request) {
   const { id } = request.params;
 
-  let progression = schema.progression.find(id);
+  let progression = schema.progressions.find(id);
 
   if (!progression) {
     progression = schema.scorecards.create({});

--- a/mon-pix/mirage/serializers/assessment.js
+++ b/mon-pix/mirage/serializers/assessment.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['answers', 'certificationCourse'],
+  include: ['answers', 'certificationCourse', 'progression'],
 });

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^35.0.0",
+        "@1024pix/pix-ui": "^36.0.0",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
-      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.0.tgz",
+      "integrity": "sha512-gFXFofvHxXZ754qNx6WH5y0UwHJkKWOxpEbOz4gsi0UbDKxU7eIVN8Jc7Y2I7rstHKxWGr+dGdM1J9p9jrVeXQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -40650,9 +40650,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
-      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.0.tgz",
+      "integrity": "sha512-gFXFofvHxXZ754qNx6WH5y0UwHJkKWOxpEbOz4gsi0UbDKxU7eIVN8Jc7Y2I7rstHKxWGr+dGdM1J9p9jrVeXQ==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^35.0.0",
+    "@1024pix/pix-ui": "^36.0.0",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",

--- a/mon-pix/tests/acceptance/checkpoint_test.js
+++ b/mon-pix/tests/acceptance/checkpoint_test.js
@@ -35,10 +35,10 @@ module('Acceptance | Checkpoint', function (hooks) {
       await visit(`/assessments/${assessment.id}/checkpoint`);
 
       // then
-      assert.dom('.checkpoint-progression-gauge-wrapper').exists();
+      assert.strictEqual(find('.checkpoint__progression-gauge progress').textContent.trim(), '100%');
       assert.dom('.assessment-results__list').exists();
       assert.dom('.result-item').exists({ count: NB_ANSWERS });
-      assert.ok(find('.checkpoint__continue').textContent.includes('Continuer'));
+      assert.strictEqual(find('.checkpoint__continue').textContent.trim(), 'Continuer');
       assert.dom('.checkpoint-no-answer').doesNotExist();
     });
   });
@@ -49,7 +49,7 @@ module('Acceptance | Checkpoint', function (hooks) {
       await visit(`/assessments/${assessment.id}/checkpoint?finalCheckpoint=true`);
 
       // then
-      assert.dom('.checkpoint-progression-gauge-wrapper').doesNotExist();
+      assert.dom('.checkpoint__progression-gauge').doesNotExist();
       assert.dom('.assessment-results__list').doesNotExist();
       assert.dom('.checkpoint-no-answer').exists();
 

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -74,7 +74,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
 
         // then
         assert.ok(screen.getByText(competenceResultName));
-        assert.ok(screen.getByText(COMPETENCE_MASTERY_PERCENTAGE));
+        assert.strictEqual(screen.getByRole('progressbar').textContent.trim(), COMPETENCE_MASTERY_PERCENTAGE);
       });
 
       module('When the campaign is restricted and organization learner is disabled', function (hooks) {
@@ -124,7 +124,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
 
         // then
         assert.ok(screen.getByText(skillSetResultName));
-        assert.ok(screen.getByText(BADGE_SKILL_SET_MASTERY_PERCENTAGE));
+        assert.strictEqual(screen.getByRole('progressbar').textContent.trim(), BADGE_SKILL_SET_MASTERY_PERCENTAGE);
       });
 
       test('should display the Pix emploi badge when badge is acquired', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -436,7 +436,7 @@
         "actions": {
           "launch": "Launch the app",
           "reset": "Restart",
-          "reset-label":  "Restart simulation"
+          "reset-label": "Restart simulation"
         },
         "placeholder": "App loading"
       },
@@ -1388,7 +1388,8 @@
         "header-result": "Results",
         "header-skill": "Competences tested",
         "result": "Overall result",
-        "percentage": "{rate, number, ::percent}"
+        "percentage": "{rate, number, ::percent}",
+        "progress-bar-label": "Competence result percentage"
       },
       "disabled-share": "This customised test has been deactivated by the organiser.'<br>'It is no longer possible to submit results.",
       "error": "Oops, an error occurred!",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -436,7 +436,7 @@
         "actions": {
           "launch": "Je lance l’application",
           "reset": "Réinitialiser",
-          "reset-label":  "Réinitialiser la simulation"
+          "reset-label": "Réinitialiser la simulation"
         },
         "placeholder": "Chargement de l'application en cours"
       },
@@ -1388,7 +1388,8 @@
         "header-result": "Résultats",
         "header-skill": "Compétences testées",
         "result": "Résultat global",
-        "percentage": "{rate, number, ::percent}"
+        "percentage": "{rate, number, ::percent}",
+        "progress-bar-label": "Pourcentage de réussite de la compétence"
       },
       "disabled-share": "Ce parcours a été désactivé par l'organisateur.'<br>'L'envoi des résultats n'est plus possible.",
       "error": "Oups, une erreur est survenue !",


### PR DESCRIPTION
## :unicorn: Problème

Il faut monter la version de Pix-UI sur Pix App pour utiliser le nouveau design de PixProgressGauge.

## :robot: Proposition

Faire l'upgrade.

On passe de la v35.0.0 à le v36.0.0.

2 écrans ont été impactés par le [breaking change](https://github.com/1024pix/pix-ui/pull/417) de la nouvelle version.

## :100: Pour tester

- Aller [sur la RA](https://app-pr6416.review.pix.fr/)
- Se connecter avec l'utilisateur `jaune.attend@example.net`
- Visiter une page de checkpoint et vérifier l'aspect de la progressbar (responsive aussi) : https://app-pr6416.review.pix.fr/assessments/108800/checkpoint
- Aller sur la page de résultat et vérifier l'aspect de la progressbar (responsive aussi) : https://app-pr6416.review.pix.fr/campagnes/PROPIC123/evaluation/resultats
