### PR TITLE
[TECH] Mise à jour de Pix-UI en V36 sur pix-certif (PIX-8389).

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^34.1.0",
+        "@1024pix/pix-ui": "^35.0.0",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
@@ -148,9 +148,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "34.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.1.0.tgz",
-      "integrity": "sha512-GhVS7hE4JO0mGkS9vS/pNvRAjQCDcg5zTJwPW08tPV94O5LHXwfH6zdSAbZr2cv4VZY8eVrVZQxF8vnclhhjLQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
+      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -35355,9 +35355,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "34.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.1.0.tgz",
-      "integrity": "sha512-GhVS7hE4JO0mGkS9vS/pNvRAjQCDcg5zTJwPW08tPV94O5LHXwfH6zdSAbZr2cv4VZY8eVrVZQxF8vnclhhjLQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
+      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^35.0.0",
+        "@1024pix/pix-ui": "^36.0.0",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
@@ -148,9 +148,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
-      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.0.tgz",
+      "integrity": "sha512-gFXFofvHxXZ754qNx6WH5y0UwHJkKWOxpEbOz4gsi0UbDKxU7eIVN8Jc7Y2I7rstHKxWGr+dGdM1J9p9jrVeXQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -35355,9 +35355,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
-      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.0.tgz",
+      "integrity": "sha512-gFXFofvHxXZ754qNx6WH5y0UwHJkKWOxpEbOz4gsi0UbDKxU7eIVN8Jc7Y2I7rstHKxWGr+dGdM1J9p9jrVeXQ==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^35.0.0",
+    "@1024pix/pix-ui": "^36.0.0",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",

--- a/certif/package.json
+++ b/certif/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^34.1.0",
+    "@1024pix/pix-ui": "^35.0.0",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",


### PR DESCRIPTION
## :unicorn: Problème

Pix-UI est en retard de 2 versions majeures sur pix-certif

## :robot: Proposition

Mise à jour du package.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Pas de régression

BREAKING CHANGE:
v36 : Met à jour la PixProgressBar avec le nouveau design.

[Changelog](https://github.com/1024pix/pix-ui/blob/dev/CHANGELOG.md) Pix-UI pour référence.