### PR TITLE
[FEATURE] Ajoute la possibilité de réinitialiser la liste de participants sélectionnés (PIX-8391)

### DIFF
--- a/orga/app/components/in-element.hbs
+++ b/orga/app/components/in-element.hbs
@@ -1,0 +1,5 @@
+{{#if this.destinationElement}}
+  {{#in-element this.destinationElement}}
+    {{yield}}
+  {{/in-element}}
+{{/if}}

--- a/orga/app/components/in-element.js
+++ b/orga/app/components/in-element.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+function waitForElement(id) {
+  return new Promise((resolve) => {
+    if (document.getElementById(id)) {
+      return resolve(document.getElementById(id));
+    }
+
+    const observer = new MutationObserver(() => {
+      if (document.getElementById(id)) {
+        resolve(document.getElementById(id));
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+export default class InElement extends Component {
+  @tracked destinationElement;
+
+  constructor() {
+    super(...arguments);
+    if (this.args.waitForElement) {
+      waitForElement(this.args.destinationId).then((element) => {
+        this.destinationElement = element;
+      });
+    } else {
+      this.destinationElement = document.getElementById(this.args.destinationId);
+    }
+  }
+}

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -1,142 +1,151 @@
-<OrganizationParticipant::LearnerFilters
-  @learnersCount={{@participants.meta.rowCount}}
-  @fullName={{@fullName}}
-  @certificabilityFilter={{@certificabilityFilter}}
-  @triggerFiltering={{@triggerFiltering}}
-  @onResetFilter={{@onResetFilter}}
-/>
+<div id={{this.filtersId}} />
 
 <div class="panel">
   <table class="table content-text content-text--small">
     <caption class="screen-reader-only">{{t "pages.organization-participants.table.description"}}</caption>
-    <thead>
-      <tr>
-        <Table::Header class="table__column--small" id={{this.mainCheckboxId}} />
-        <Table::HeaderSort
-          @display="left"
-          @size="medium"
-          @onSort={{@sortByLastname}}
-          @order={{@lastnameSort}}
-          @ariaLabelDefaultSort={{t "pages.organization-participants.table.column.last-name.ariaLabelDefaultSort"}}
-          @ariaLabelSortUp={{t "pages.organization-participants.table.column.last-name.ariaLabelSortUp"}}
-          @ariaLabelSortDown={{t "pages.organization-participants.table.column.last-name.ariaLabelSortDown"}}
-        >
-          {{t "pages.organization-participants.table.column.last-name.label"}}
-        </Table::HeaderSort>
-        <Table::Header @size="wide">{{t "pages.organization-participants.table.column.first-name"}}</Table::Header>
-        <Table::HeaderSort
-          @size="medium"
-          @align="center"
-          @onSort={{@sortByParticipationCount}}
-          @order={{@participationCountOrder}}
-          @ariaLabelDefaultSort={{t
-            "pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort"
-          }}
-          @ariaLabelSortUp={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortUp"}}
-          @ariaLabelSortDown={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortDown"}}
-        >
-          {{t "pages.organization-participants.table.column.participation-count.label"}}
-        </Table::HeaderSort>
-        <Table::Header @size="medium" @align="center">
-          {{t "pages.organization-participants.table.column.latest-participation"}}
-        </Table::Header>
-        <Table::Header @size="medium" @align="center">
-          <div class="organization-participant-list-page__certificability-header">
-            {{t "pages.organization-participants.table.column.is-certifiable.label"}}
-            <Ui::CertificabilityTooltip
-              @aria-label={{t "pages.organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
-              @content={{t "pages.organization-participants.table.column.is-certifiable.tooltip.content"}}
-            />
-          </div>
-        </Table::Header>
-      </tr>
-    </thead>
+    <thead id={{this.headerId}} />
 
-    {{#if @participants}}
-      <tbody>
-        <SelectableList @items={{@participants}}>
-          <:manager as |allSelected someSelected toggleAll selectedParticipants reset|>
-            <InElement @destinationId={{this.mainCheckboxId}}>
-              <PixCheckbox
-                @screenReaderOnly={{true}}
-                @checked={{someSelected}}
-                @isIndeterminate={{(not allSelected)}}
-                {{on "click" toggleAll}}
-              >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
-            </InElement>
-            {{#if someSelected}}
-              <InElement @destinationId={{this.actionBarId}}>
-                <Ui::ActionBar @items={{selectedParticipants}}>
-                  <:information>
-                    {{t "pages.organization-participants.action-bar.information" count=selectedParticipants.length}}
-                  </:information>
-                  <:actions>
-                    <PixButton
-                      @triggerAction={{(fn this.deleteParticipants selectedParticipants reset)}}
-                      type="button"
-                      @backgroundColor="red"
-                    >
-                      {{t "pages.organization-participants.action-bar.delete-button"}}
-                    </PixButton>
-                  </:actions>
-                </Ui::ActionBar>
-              </InElement>
-            {{/if}}
-            <InElement @destinationId={{this.paginationId}} @waitForElement={{true}}>
-              <Table::PaginationControl @pagination={{@participants.meta}} @onChange={{reset}} />
-            </InElement>
-          </:manager>
-          <:item as |participant toggleParticipant isParticipantSelected index|>
-            <tr
-              aria-label={{t "pages.organization-participants.table.row-title"}}
-              {{on "click" (fn @onClickLearner participant.id)}}
-              class="tr--clickable"
-            >
-              <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
-                <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>{{t
-                    "pages.organization-participants.table.column.checkbox"
-                    firstname=participant.firstName
-                    lastname=participant.lastName
-                  }}</PixCheckbox>
-              </td>
-              <td class="table__column">
-                <LinkTo
-                  @route="authenticated.organization-participants.organization-participant"
-                  @model={{participant.id}}
-                >
-                  {{participant.lastName}}
-                </LinkTo>
-              </td>
-              <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
-              <td class="table__column--center">
-                {{participant.participationCount}}
-              </td>
-              <td>
-                <div class="organization-participant-list-page__last-participation">
-                  <span>{{dayjs-format participant.lastParticipationDate "DD/MM/YYYY"}}</span>
-                  <Ui::LastParticipationDateTooltip
-                    @id={{index}}
-                    @campaignName={{participant.campaignName}}
-                    @campaignType={{participant.campaignType}}
-                    @participationStatus={{participant.participationStatus}}
+    <tbody>
+      <SelectableList @items={{@participants}}>
+        <:manager as |allSelected someSelected toggleAll selectedParticipants reset|>
+          <InElement @destinationId={{this.headerId}}>
+            <tr>
+              <Table::Header class="table__column--small">
+                <PixCheckbox
+                  @screenReaderOnly={{true}}
+                  @checked={{someSelected}}
+                  @isIndeterminate={{(not allSelected)}}
+                  {{on "click" toggleAll}}
+                >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
+              </Table::Header>
+              <Table::HeaderSort
+                @display="left"
+                @size="medium"
+                @onSort={{(fn this.addResetOnFunction @sortByLastname reset)}}
+                @order={{@lastnameSort}}
+                @ariaLabelDefaultSort={{t
+                  "pages.organization-participants.table.column.last-name.ariaLabelDefaultSort"
+                }}
+                @ariaLabelSortUp={{t "pages.organization-participants.table.column.last-name.ariaLabelSortUp"}}
+                @ariaLabelSortDown={{t "pages.organization-participants.table.column.last-name.ariaLabelSortDown"}}
+              >
+                {{t "pages.organization-participants.table.column.last-name.label"}}
+              </Table::HeaderSort>
+              <Table::Header @size="wide">{{t
+                  "pages.organization-participants.table.column.first-name"
+                }}</Table::Header>
+              <Table::HeaderSort
+                @size="medium"
+                @align="center"
+                @onSort={{(fn this.addResetOnFunction @sortByParticipationCount reset)}}
+                @order={{@participationCountOrder}}
+                @ariaLabelDefaultSort={{t
+                  "pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort"
+                }}
+                @ariaLabelSortUp={{t
+                  "pages.organization-participants.table.column.participation-count.ariaLabelSortUp"
+                }}
+                @ariaLabelSortDown={{t
+                  "pages.organization-participants.table.column.participation-count.ariaLabelSortDown"
+                }}
+              >
+                {{t "pages.organization-participants.table.column.participation-count.label"}}
+              </Table::HeaderSort>
+              <Table::Header @size="medium" @align="center">
+                {{t "pages.organization-participants.table.column.latest-participation"}}
+              </Table::Header>
+              <Table::Header @size="medium" @align="center">
+                <div class="organization-participant-list-page__certificability-header">
+                  {{t "pages.organization-participants.table.column.is-certifiable.label"}}
+                  <Ui::CertificabilityTooltip
+                    @aria-label={{t "pages.organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
+                    @content={{t "pages.organization-participants.table.column.is-certifiable.tooltip.content"}}
                   />
                 </div>
-              </td>
-              <td class="table__column--center">
-                <Ui::IsCertifiable @isCertifiable={{participant.isCertifiable}} />
-                {{#if participant.certifiableAt}}
-                  <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
-                      participant.certifiableAt
-                      "DD/MM/YYYY"
-                      allow-empty=true
-                    }}</span>
-                {{/if}}
-              </td>
+              </Table::Header>
             </tr>
-          </:item>
-        </SelectableList>
-      </tbody>
-    {{/if}}
+          </InElement>
+          {{#if someSelected}}
+            <InElement @destinationId={{this.actionBarId}}>
+              <Ui::ActionBar @items={{selectedParticipants}}>
+                <:information>
+                  {{t "pages.organization-participants.action-bar.information" count=selectedParticipants.length}}
+                </:information>
+                <:actions>
+                  <PixButton
+                    @triggerAction={{(fn this.deleteParticipants selectedParticipants reset)}}
+                    type="button"
+                    @backgroundColor="red"
+                  >
+                    {{t "pages.organization-participants.action-bar.delete-button"}}
+                  </PixButton>
+                </:actions>
+              </Ui::ActionBar>
+            </InElement>
+          {{/if}}
+          <InElement @destinationId={{this.paginationId}} @waitForElement={{true}}>
+            <Table::PaginationControl @pagination={{@participants.meta}} @onChange={{reset}} />
+          </InElement>
+          <InElement @destinationId={{this.filtersId}} @waitForElement={{true}}>
+            <OrganizationParticipant::LearnerFilters
+              @learnersCount={{@participants.meta.rowCount}}
+              @fullName={{@fullName}}
+              @certificabilityFilter={{@certificabilityFilter}}
+              @triggerFiltering={{(fn this.addResetOnFunction @triggerFiltering reset)}}
+              @onResetFilter={{@onResetFilter}}
+            />
+          </InElement>
+        </:manager>
+        <:item as |participant toggleParticipant isParticipantSelected index|>
+          <tr
+            aria-label={{t "pages.organization-participants.table.row-title"}}
+            {{on "click" (fn @onClickLearner participant.id)}}
+            class="tr--clickable"
+          >
+            <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
+              <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>{{t
+                  "pages.organization-participants.table.column.checkbox"
+                  firstname=participant.firstName
+                  lastname=participant.lastName
+                }}</PixCheckbox>
+            </td>
+            <td class="table__column">
+              <LinkTo
+                @route="authenticated.organization-participants.organization-participant"
+                @model={{participant.id}}
+              >
+                {{participant.lastName}}
+              </LinkTo>
+            </td>
+            <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
+            <td class="table__column--center">
+              {{participant.participationCount}}
+            </td>
+            <td>
+              <div class="organization-participant-list-page__last-participation">
+                <span>{{dayjs-format participant.lastParticipationDate "DD/MM/YYYY"}}</span>
+                <Ui::LastParticipationDateTooltip
+                  @id={{index}}
+                  @campaignName={{participant.campaignName}}
+                  @campaignType={{participant.campaignType}}
+                  @participationStatus={{participant.participationStatus}}
+                />
+              </div>
+            </td>
+            <td class="table__column--center">
+              <Ui::IsCertifiable @isCertifiable={{participant.isCertifiable}} />
+              {{#if participant.certifiableAt}}
+                <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
+                    participant.certifiableAt
+                    "DD/MM/YYYY"
+                    allow-empty=true
+                  }}</span>
+              {{/if}}
+            </td>
+          </tr>
+        </:item>
+      </SelectableList>
+    </tbody>
   </table>
 
   {{#unless @participants}}

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -55,24 +55,24 @@
     {{#if @participants}}
       <tbody>
         <SelectableList @items={{@participants}}>
-          <:manager as |allSelected someSelected toggleAll selectedParticipants|>
-            {{#in-element this.mainCheckbox}}
+          <:manager as |allSelected someSelected toggleAll selectedParticipants reset|>
+            <InElement @destinationId={{this.mainCheckboxId}}>
               <PixCheckbox
                 @screenReaderOnly={{true}}
                 @checked={{someSelected}}
                 @isIndeterminate={{(not allSelected)}}
                 {{on "click" toggleAll}}
               >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
-            {{/in-element}}
+            </InElement>
             {{#if someSelected}}
-              {{#in-element this.actionBar}}
+              <InElement @destinationId={{this.actionBarId}}>
                 <Ui::ActionBar @items={{selectedParticipants}}>
                   <:information>
                     {{t "pages.organization-participants.action-bar.information" count=selectedParticipants.length}}
                   </:information>
                   <:actions>
                     <PixButton
-                      @triggerAction={{(fn @deleteParticipants selectedParticipants)}}
+                      @triggerAction={{(fn this.deleteParticipants selectedParticipants reset)}}
                       type="button"
                       @backgroundColor="red"
                     >
@@ -80,8 +80,11 @@
                     </PixButton>
                   </:actions>
                 </Ui::ActionBar>
-              {{/in-element}}
+              </InElement>
             {{/if}}
+            <InElement @destinationId={{this.paginationId}} @waitForElement={{true}}>
+              <Table::PaginationControl @pagination={{@participants.meta}} @onChange={{reset}} />
+            </InElement>
           </:manager>
           <:item as |participant toggleParticipant isParticipantSelected index|>
             <tr
@@ -143,6 +146,5 @@
   {{/unless}}
 </div>
 
-<Table::PaginationControl @pagination={{@participants.meta}} />
-
-<div id={{this.actionBarId}}></div>
+<div id={{this.actionBarId}} />
+<div id={{this.paginationId}} />

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -15,6 +15,7 @@
                   @screenReaderOnly={{true}}
                   @checked={{someSelected}}
                   @isIndeterminate={{(not allSelected)}}
+                  disabled={{(not this.hasParticipants)}}
                   {{on "click" toggleAll}}
                 >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
               </Table::Header>
@@ -86,13 +87,13 @@
           <InElement @destinationId={{this.paginationId}} @waitForElement={{true}}>
             <Table::PaginationControl @pagination={{@participants.meta}} @onChange={{reset}} />
           </InElement>
-          <InElement @destinationId={{this.filtersId}} @waitForElement={{true}}>
+          <InElement @destinationId={{this.filtersId}}>
             <OrganizationParticipant::LearnerFilters
               @learnersCount={{@participants.meta.rowCount}}
               @fullName={{@fullName}}
               @certificabilityFilter={{@certificabilityFilter}}
               @triggerFiltering={{(fn this.addResetOnFunction @triggerFiltering reset)}}
-              @onResetFilter={{@onResetFilter}}
+              @onResetFilter={{(fn this.addResetOnFunction @onResetFilter reset)}}
             />
           </InElement>
         </:manager>

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -19,16 +19,20 @@ export default class List extends Component {
     return guidFor(this) + 'filters';
   }
 
-  @action
-  async deleteParticipants(selectedParticipants, reset) {
-    await this.args.deleteParticipants(selectedParticipants);
-    reset();
+  get hasParticipants() {
+    return Boolean(this.args.participants.length);
   }
 
   @action
-  async addResetOnFunction(func, reset, ...args) {
-    await func(...args);
-    reset();
+  async deleteParticipants(selectedParticipants, resetParticipants) {
+    await this.args.deleteParticipants(selectedParticipants);
+    resetParticipants();
+  }
+
+  @action
+  async addResetOnFunction(wrappedFunction, resetParticipants, ...args) {
+    await wrappedFunction(...args);
+    resetParticipants();
   }
 
   @action

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -13,15 +13,17 @@ export default class List extends Component {
     return guidFor(this) + 'mainCheckbox';
   }
 
-  get mainCheckbox() {
-    return document.getElementById(this.mainCheckboxId);
-  }
-
   get actionBarId() {
     return guidFor(this) + 'actionBar';
   }
 
-  get actionBar() {
-    return document.getElementById(this.actionBarId);
+  get paginationId() {
+    return guidFor(this) + 'pagination';
+  }
+
+  @action
+  async deleteParticipants(selectedParticipants, reset) {
+    await this.args.deleteParticipants(selectedParticipants);
+    reset();
   }
 }

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -3,13 +3,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 
 export default class List extends Component {
-  @action
-  onClick(toggleParticipant, event) {
-    event.stopPropagation();
-    toggleParticipant();
-  }
-
-  get mainCheckboxId() {
+  get headerId() {
     return guidFor(this) + 'mainCheckbox';
   }
 
@@ -21,9 +15,25 @@ export default class List extends Component {
     return guidFor(this) + 'pagination';
   }
 
+  get filtersId() {
+    return guidFor(this) + 'filters';
+  }
+
   @action
   async deleteParticipants(selectedParticipants, reset) {
     await this.args.deleteParticipants(selectedParticipants);
     reset();
+  }
+
+  @action
+  async addResetOnFunction(func, reset, ...args) {
+    await func(...args);
+    reset();
+  }
+
+  @action
+  onClick(toggleParticipant, event) {
+    event.stopPropagation();
+    toggleParticipant();
   }
 }

--- a/orga/app/components/selectable-list.hbs
+++ b/orga/app/components/selectable-list.hbs
@@ -1,4 +1,4 @@
 {{#each @items as |item index|}}
   {{yield item (fn this.toggle item) (this.isSelected item) index to="item"}}
 {{/each}}
-{{yield this.allSelected this.someSelected this.toggleAll this.selectedItems to="manager"}}
+{{yield this.allSelected this.someSelected this.toggleAll this.selectedItems this.reset to="manager"}}

--- a/orga/app/components/selectable-list.js
+++ b/orga/app/components/selectable-list.js
@@ -23,6 +23,11 @@ export default class SelectableList extends Component {
   }
 
   @action
+  reset() {
+    this.selectedItems = [];
+  }
+
+  @action
   toggle(item) {
     if (this.isSelected(item)) {
       this.selectedItems = this.selectedItems.filter((selectedItem) => {

--- a/orga/app/components/table/pagination-control.js
+++ b/orga/app/components/table/pagination-control.js
@@ -64,15 +64,18 @@ export default class PaginationControl extends Component {
   @action
   changePageSize(value) {
     this.router.replaceWith({ queryParams: { pageSize: value, pageNumber: 1 } });
+    if (this.args.onChange) this.args.onChange();
   }
 
   @action
   goToNextPage() {
     this.router.replaceWith({ queryParams: { pageNumber: this.nextPage } });
+    if (this.args.onChange) this.args.onChange();
   }
 
   @action
   goToPreviousPage() {
     this.router.replaceWith({ queryParams: { pageNumber: this.previousPage } });
+    if (this.args.onChange) this.args.onChange();
   }
 }

--- a/orga/app/styles/components/ui/action-bar.scss
+++ b/orga/app/styles/components/ui/action-bar.scss
@@ -13,6 +13,7 @@
   background-color: $pix-neutral-0;
   color: $pix-neutral-60;
   font-family: $font-roboto;
+  z-index: 1;
 
   .action-bar__informations {
     margin-left: $pix-spacing-xl;

--- a/orga/tests/integration/components/in-element_test.js
+++ b/orga/tests/integration/components/in-element_test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+
+module('Integration | Component | In Element', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should found the id and renders', async function (assert) {
+    const screen = await render(
+      hbs`<div id='ninja'></div>
+<InElement @destinationId='ninja'>Coucou le chat</InElement>`
+    );
+
+    assert.dom(screen.getByText('Coucou le chat')).exists();
+  });
+
+  test('should wait if the element does not exists yet', async function (assert) {
+    const screen = await render(
+      hbs`<InElement @destinationId='ninja' @waitForElement={{true}}>Coucou le chat</InElement>
+<div id='ninja'></div>`
+    );
+
+    // then
+    assert.dom(screen.getByText('Coucou le chat')).exists();
+  });
+});

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -23,13 +23,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
   test('it should display the header labels', async function (assert) {
     // given
-    this.set('participants', [
-      {
-        lastName: 'La Terreur',
-        firstName: 'Gigi',
-        id: 34,
-      },
-    ]);
+    this.set('participants', []);
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
     // when
@@ -285,6 +279,26 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // then
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
     assert.contains('02/01/2022');
+  });
+
+  test('it should display the filter labels', async function (assert) {
+    // given
+    this.set('participants', []);
+    this.set('certificabilityFilter', []);
+    this.set('fullNameFilter', null);
+    // when
+    await render(
+      hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`
+    );
+
+    // then
+    assert.contains('Recherche sur le nom et prénom');
   });
 
   test('it should trigger filtering with fullName search', async function (assert) {

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -628,7 +628,6 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @certificabilityFilter={{this.certificabilityFilter}}
 />`
     );
-    await fillByLabel('Recherche sur le nom et prénom', 'Karam');
 
     // then
     assert.contains(this.intl.t('pages.organization-participants.table.empty'));

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -23,7 +23,13 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
   test('it should display the header labels', async function (assert) {
     // given
-    this.set('participants', []);
+    this.set('participants', [
+      {
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        id: 34,
+      },
+    ]);
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
     // when
@@ -46,7 +52,13 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
   test('it should have a caption to describe the table ', async function (assert) {
     // given
-    this.set('participants', []);
+    this.set('participants', [
+      {
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        id: 34,
+      },
+    ]);
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
     // when
@@ -309,7 +321,14 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // given
     const triggerFiltering = sinon.spy();
     this.set('triggerFiltering', triggerFiltering);
-    this.set('participants', []);
+    const participants = [
+      {
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+      },
+    ];
+
+    this.set('participants', participants);
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
 
@@ -343,6 +362,14 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       const sortByParticipationCount = sinon.spy();
 
+      const participants = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+        },
+      ];
+
+      this.set('participants', participants);
       this.set('sortByParticipationCount', sortByParticipationCount);
       this.set('certificabilityFilter', []);
       this.set('fullNameFilter', null);
@@ -377,6 +404,14 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       const sortByParticipationCount = sinon.spy();
 
+      const participants = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+        },
+      ];
+
+      this.set('participants', participants);
       this.set('sortByParticipationCount', sortByParticipationCount);
       this.set('certificabilityFilter', []);
       this.set('fullNameFilter', null);
@@ -411,6 +446,14 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       const sortByParticipationCount = sinon.spy();
 
+      const participants = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+        },
+      ];
+
+      this.set('participants', participants);
       this.set('sortByParticipationCount', sortByParticipationCount);
       this.set('certificabilityFilter', []);
       this.set('fullNameFilter', null);
@@ -446,13 +489,21 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       const sortByLastname = sinon.spy();
 
+      const participants = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+        },
+      ];
+
+      this.set('participants', participants);
       this.set('sortByLastname', sortByLastname);
       this.set('certificabilityFilter', []);
       this.set('fullNameFilter', null);
 
       const screen = await render(
         hbs`<OrganizationParticipant::List
-  @students={{this.students}}
+  @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onFilter={{this.noop}}
   @onClickLearner={{this.noop}}
@@ -481,13 +532,21 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       const sortByLastname = sinon.spy();
 
+      const participants = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+        },
+      ];
+
+      this.set('participants', participants);
       this.set('sortByLastname', sortByLastname);
       this.set('certificabilityFilter', []);
       this.set('fullNameFilter', null);
 
       const screen = await render(
         hbs`<OrganizationParticipant::List
-  @students={{this.students}}
+  @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onFilter={{this.noop}}
   @onClickLearner={{this.noop}}
@@ -514,13 +573,21 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       const sortByLastname = sinon.spy();
 
+      const participants = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+        },
+      ];
+
+      this.set('participants', participants);
       this.set('sortByLastname', sortByLastname);
       this.set('certificabilityFilter', []);
       this.set('fullNameFilter', null);
 
       const screen = await render(
         hbs`<OrganizationParticipant::List
-  @students={{this.students}}
+  @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onFilter={{this.noop}}
   @onClickLearner={{this.noop}}
@@ -705,6 +772,77 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       //then
       assert.false(mainCheckbox.checked);
     });
+  });
+
+  test('it should reset selected participant when using sort', async function (assert) {
+    // given
+    const routerService = this.owner.lookup('service:router');
+    sinon.stub(routerService, 'replaceWith');
+
+    const participants = [{ id: 1, firstName: 'Spider', lastName: 'Man' }];
+
+    participants.meta = { page: 1, pageSize: 10, rowCount: 50, pageCount: 5 };
+
+    this.set('participants', participants);
+    this.triggerFiltering = sinon.stub();
+    this.set('certificabilityFilter', []);
+    this.set('fullNameFilter', null);
+
+    // when
+    const screen = await render(
+      hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @sortByParticipationCount={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`
+    );
+    const firstLearnerSelected = screen.getAllByRole('checkbox')[1];
+
+    await click(firstLearnerSelected);
+
+    await click(
+      screen.getByLabelText(
+        this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort')
+      )
+    );
+
+    assert.false(firstLearnerSelected.checked);
+  });
+
+  test('it should reset selected participant when using filters', async function (assert) {
+    // given
+    const routerService = this.owner.lookup('service:router');
+    sinon.stub(routerService, 'replaceWith');
+
+    const participants = [{ id: 1, firstName: 'Spider', lastName: 'Man' }];
+
+    participants.meta = { page: 1, pageSize: 10, rowCount: 50, pageCount: 5 };
+
+    this.set('participants', participants);
+    this.triggerFiltering = sinon.stub();
+    this.set('certificabilityFilter', []);
+    this.set('fullNameFilter', null);
+
+    // when
+    const screen = await render(
+      hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+/>`
+    );
+    const firstLearnerSelected = screen.getAllByRole('checkbox')[1];
+
+    await click(firstLearnerSelected);
+
+    await fillByLabel('Recherche sur le nom et prénom', 'Something');
+
+    assert.false(firstLearnerSelected.checked);
   });
 
   test('it should reset selected participant when using pagination', async function (assert) {

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
-module('Integration | Component | OrganizationParticipant::List', function (hooks) {
+module.only('Integration | Component | OrganizationParticipant::List', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
@@ -286,8 +286,9 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('participants', []);
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
+
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
@@ -298,7 +299,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains('Recherche sur le nom et prénom');
+    assert.dom(screen.getByLabelText('Recherche sur le nom et prénom')).exists();
   });
 
   test('it should trigger filtering with fullName search', async function (assert) {
@@ -785,6 +786,29 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       //then
       assert.false(mainCheckbox.checked);
     });
+  });
+
+  test('it should disable the main checkbox when partipants list is empty', async function (assert) {
+    //given
+    const participants = [];
+
+    this.set('participants', participants);
+    this.deleteParticipants = sinon.stub();
+
+    //when
+    const screen = await render(hbs`<OrganizationParticipant::List
+@participants={{this.participants}}
+@triggerFiltering={{this.triggerFiltering}}
+@onClickLearner={{this.noop}}
+@certificabilityFilter={{this.noop}}
+@fullName={{this.fullNameFilter}}
+@certificabilityFilter={{this.certificabilityFilter}}
+@deleteParticipants={{this.deleteParticipants}}
+/>`);
+    const mainCheckbox = screen.getAllByRole('checkbox')[0];
+
+    //then
+    assert.dom(mainCheckbox).isDisabled();
   });
 
   test('it should reset selected participant when using sort', async function (assert) {

--- a/orga/tests/unit/components/selectable-list_test.js
+++ b/orga/tests/unit/components/selectable-list_test.js
@@ -5,6 +5,25 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Component | Selectable List', function (hooks) {
   setupTest(hooks);
 
+  module('#reset', function () {
+    test('should clear list of selected elements', async function (assert) {
+      // given
+      const firstItem = { id: 1 };
+      const secondItem = { id: 2 };
+      const items = [firstItem, secondItem];
+      const component = await createGlimmerComponent('component:selectable-list', {
+        items,
+      });
+      component.selectedItems = items;
+
+      // when
+      component.reset();
+
+      // then
+      assert.strictEqual(component.selectedItems.length, 0);
+    });
+  });
+
   module('#allSelected', function () {
     test('should return false if not all element have been selected', async function (assert) {
       // given

--- a/orga/tests/unit/components/table/pagination-control_test.js
+++ b/orga/tests/unit/components/table/pagination-control_test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Component | Table | Pagination Control', function (hooks) {
+  setupTest(hooks);
+
+  module('#changePageSize', function () {
+    test('should call onChange', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+
+      const component = await createGlimmerComponent('component:table/pagination-control', {
+        onChange: sinon.stub(),
+      });
+
+      // when
+      await component.changePageSize();
+
+      // then
+      sinon.assert.calledOnce(component.args.onChange);
+      assert.ok(true);
+    });
+  });
+
+  module('#goToNextPage', function () {
+    test('should call onChange', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+
+      const component = await createGlimmerComponent('component:table/pagination-control', {
+        onChange: sinon.stub(),
+      });
+
+      // when
+      await component.goToNextPage();
+
+      // then
+      sinon.assert.calledOnce(component.args.onChange);
+      assert.ok(true);
+    });
+  });
+
+  module('#goToPreviousPage', function () {
+    test('should call onChange', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+
+      const component = await createGlimmerComponent('component:table/pagination-control', {
+        onChange: sinon.stub(),
+      });
+
+      // when
+      await component.goToPreviousPage();
+
+      // then
+      sinon.assert.calledOnce(component.args.onChange);
+      assert.ok(true);
+    });
+  });
+});

--- a/orga/tests/unit/components/table/pagination-control_test.js
+++ b/orga/tests/unit/components/table/pagination-control_test.js
@@ -23,6 +23,22 @@ module('Unit | Component | Table | Pagination Control', function (hooks) {
       sinon.assert.calledOnce(component.args.onChange);
       assert.ok(true);
     });
+
+    test('should not throw an error', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+
+      const component = await createGlimmerComponent('component:table/pagination-control', {
+        onChange: null,
+      });
+
+      // when
+      await component.changePageSize();
+
+      // then
+      assert.ok(true);
+    });
   });
 
   module('#goToNextPage', function () {
@@ -42,6 +58,22 @@ module('Unit | Component | Table | Pagination Control', function (hooks) {
       sinon.assert.calledOnce(component.args.onChange);
       assert.ok(true);
     });
+
+    test('should not throw an error', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+
+      const component = await createGlimmerComponent('component:table/pagination-control', {
+        onChange: null,
+      });
+
+      // when
+      await component.goToNextPage();
+
+      // then
+      assert.ok(true);
+    });
   });
 
   module('#goToPreviousPage', function () {
@@ -59,6 +91,22 @@ module('Unit | Component | Table | Pagination Control', function (hooks) {
 
       // then
       sinon.assert.calledOnce(component.args.onChange);
+      assert.ok(true);
+    });
+
+    test('should not throw an error', async function (assert) {
+      // given
+      const routerService = this.owner.lookup('service:router');
+      sinon.stub(routerService, 'replaceWith');
+
+      const component = await createGlimmerComponent('component:table/pagination-control', {
+        onChange: null,
+      });
+
+      // when
+      await component.goToPreviousPage();
+
+      // then
       assert.ok(true);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix "Suppression des prescrits" (cf : https://1024pix.atlassian.net/browse/PIX-6616), nous réalisons un composant générique appelé SelectableList qui permet de sélectionner les éléments d'un tableau ou d'une liste et d'appliquer des actions dessus comme la suppression ou la réinitialisation de mot de passe pour la team Accès. Dans les 3 premières PRs, nous avons jeté les bases de ce composant :

- https://github.com/1024pix/pix/pull/6364
- https://github.com/1024pix/pix/pull/6371
- https://github.com/1024pix/pix/pull/6410

Cette PR vise à finaliser le développement de ce composant en adressant une dernière problématique. Dans certains cas de figure il doit être possible de réinitialiser la liste des éléments sélectionnés comme par exemple :
- lors d'un changement dans la pagination (les éléments sélectionnés ne sont plus affichés)
- lorsque la liste des éléments change suite à un changement sur les données (suppression de certaines lignes)
- Sur les filtres
- Sur les tris

## :robot: Proposition
Cette PR ajoute une méthode reset exposée au niveau du yieldable named block manager. Elle permet de vider la liste des éléments sélectionnés. Elle ajoute aussi la possibilité de passer une méthode au composant PaginationControl qui sera appelé lorsque les actions suivantes sont effectuées : 
- changement de la taille de la page
- aller à la page suivante
- aller à la page précédente

## :rainbow: Remarques
Dans cette PR https://github.com/1024pix/pix/pull/6342 on parle de la limitation du helper in-element qui a besoin que l'élément de destination existe au moment où la ligne du helper est interpretée. Ce qui peut poser problème quand l'élément est présent plus loin dans le dom. Ce cas spécifique ne se posait pas pour le bandeau d'actions puisque celui-ci est conditionnel et s'affiche quand au moins un élément est sélectionné laissant le temps à la page d'être interprétée entièrement avant l'affichage de celui-ci. 

Dans le cadre de la pagination, elle est toujours affichée nous confrontant donc à cette limitation. Pour la contourner, nous avons développé un composant InElement qui vient wrapper l'utilisation du helper et facilite deux usages : 
- il prend en paramètre un id et facilite donc l'utilisation de in-element en n'ayant plus besoin de coder deux fonctions (une pour l'id et une pour l'élément)
- il propose une option qui permet d'attendre automatiquement que l'élément de destination soit monté dans le DOM avant d'utiliser le helper in-element

Ce composant nous aide donc à brancher la pagination avec la méthode reset malgré le fait que la pagination soit plus bas dans la page et afficher en permanence.

## :100: Pour tester
- Se connecter a Pix Orga avec une Orga type PRO
- Aller sur la page des participants
- Sélectionner à l'aide des cases a cocher un ou plusieurs participants
- Utilisez la pagination (page suivante/page précédente/taille de la page)
- Vérifier que les cases sont automatiquement décochées ( y comprit la coche principale )
- Sélectionner de nouveau un ou plusieurs participants
- Supprimer le(s) à l'aide du bouton dans le bandeau
- Vérifier que la coche principale à bien été réinitialisée
