### PR TITLE
[FEATURE] Afficher les checkboxs seulement pour les admins des Orga Pro (PIX-8392)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -10,15 +10,17 @@
         <:manager as |allSelected someSelected toggleAll selectedParticipants reset|>
           <InElement @destinationId={{this.headerId}}>
             <tr>
-              <Table::Header class="table__column--small">
-                <PixCheckbox
-                  @screenReaderOnly={{true}}
-                  @checked={{someSelected}}
-                  @isIndeterminate={{(not allSelected)}}
-                  disabled={{(not this.hasParticipants)}}
-                  {{on "click" toggleAll}}
-                >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
-              </Table::Header>
+              {{#if this.isUserAdmin}}
+                <Table::Header class="table__column--small">
+                  <PixCheckbox
+                    @screenReaderOnly={{true}}
+                    @checked={{someSelected}}
+                    @isIndeterminate={{(not allSelected)}}
+                    disabled={{(not this.hasParticipants)}}
+                    {{on "click" toggleAll}}
+                  >{{t "pages.organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
+                </Table::Header>
+              {{/if}}
               <Table::HeaderSort
                 @display="left"
                 @size="medium"
@@ -103,13 +105,17 @@
             {{on "click" (fn @onClickLearner participant.id)}}
             class="tr--clickable"
           >
-            <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
-              <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>{{t
-                  "pages.organization-participants.table.column.checkbox"
-                  firstname=participant.firstName
-                  lastname=participant.lastName
-                }}</PixCheckbox>
-            </td>
+            {{#if this.isUserAdmin}}
+              <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
+                <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>
+                  {{t
+                    "pages.organization-participants.table.column.checkbox"
+                    firstname=participant.firstName
+                    lastname=participant.lastName
+                  }}
+                </PixCheckbox>
+              </td>
+            {{/if}}
             <td class="table__column">
               <LinkTo
                 @route="authenticated.organization-participants.organization-participant"

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -1,8 +1,15 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import { inject as service } from '@ember/service';
 
 export default class List extends Component {
+  @service currentUser;
+
+  get isUserAdmin() {
+    return this.currentUser.isAdminInOrganization;
+  }
+
   get headerId() {
     return guidFor(this) + 'mainCheckbox';
   }


### PR DESCRIPTION
## :unicorn: Problème
Dans les PR précédentes : https://github.com/1024pix/pix/pull/6364, https://github.com/1024pix/pix/pull/6371, https://github.com/1024pix/pix/pull/6410, https://github.com/1024pix/pix/pull/6421, nous avons crée les checkbox et la possibilité de supprimer des participants pour une organisation de type PRO, cependant nous avons laisser cette possibiltée pour tous les utilisateurs.

## :robot: Proposition
Il faut conditionner l'affichage de ces checkbox aux seuls admins de l'organisation.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga avec une orga de type PRO en tant qu'admin (pro.admin@example.net)
- Vérifier que les coches sont bien présentes et qu'on peut supprimer un participant
- Se connecter maintenant avec une orga de type PRO, mais en tant que simple membre (pro.member@example.net)
- Vérifier que cette fois aucune coche n'est affichée
- 🐱 
