### PR TITLE
[TECH] Ajouter une config pour jouer Pix1d sur safari (PIX-8403)

### DIFF
--- a/1d/ember-cli-build.js
+++ b/1d/ember-cli-build.js
@@ -15,6 +15,13 @@ module.exports = function (defaults) {
     'ember-cli-babel': {
       includePolyfill: true,
     },
+    '@embroider/macros': {
+      setConfig: {
+        '@ember-data/store': {
+          polyfillUUID: true,
+        },
+      },
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/api/lib/domain/usecases/get-next-challenge-for-pix1d.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-pix1d.js
@@ -19,7 +19,7 @@ export async function getNextChallengeForPix1d({
   try {
     return await challengeRepository.getForPix1D({
       missionId,
-      activityLevel: 'didacticiel',
+      activityLevel: 'di',
       challengeNumber,
     });
   } catch (error) {

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-pix1d_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-pix1d_test.js
@@ -7,8 +7,8 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-pix1d', func
       // given
       const missionId = 'AZERTYUIO';
       const assessmentId = 'id_assessment';
-      const DIDACTICIEL = 'didacticiel';
-      const firstChallenge = domainBuilder.buildChallenge({ id: 'first_challenge', skill: { name: '@didacticiel' } });
+      const DIDACTICIEL = 'di';
+      const firstChallenge = domainBuilder.buildChallenge({ id: 'first_challenge', skill: { name: '@recherche_di1' } });
 
       const assessmentRepository = { get: sinon.stub() };
       const answerRepository = { findByAssessment: sinon.stub() };

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-pix1d_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-pix1d_test.js
@@ -9,7 +9,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-pix1d', function ()
       it('should call the challengeRepository with an challenge number equal to 1 ', async function () {
         const missionId = 'AZERTYUIO';
         const assessmentId = 'id_assessment';
-        const DIDACTICIEL = 'didacticiel';
+        const DIDACTICIEL = 'di';
         const answers = [];
 
         const assessmentRepository = { get: sinon.stub() };
@@ -39,7 +39,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-pix1d', function ()
     context('when there is an answer for the given assessmentId', function () {
       it('should call the challengeRepository with an challenge number equal to 2 ', async function () {
         const missionId = 'AZERTYUIO';
-        const DIDACTICIEL = 'didacticiel';
+        const DIDACTICIEL = 'di';
         const assessmentId = 'id_assessment';
         const answer = domainBuilder.buildAnswer({ assessmentId });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors du panel du 19 juin, Pix1d n’a pas focntionné sur les iPad/safari. Ils ont réussi à accéder à la plateforme mais lorsqu’il fallait valider une réponse ou passer, rien ne se passait.

Après investigation, on a vu qu’il y avait cette erreur dans la console.
`Unhandled Promise Rejection: TypeError: j.randomUUID is not a function. (In 'j.randomUUID()', 'j.randomUUID' is undefined)`

les iPad qu'ils utilisaient:
<img width="1002" alt="image" src="https://github.com/1024pix/pix/assets/35958509/9b72c477-acc1-4521-9d85-d4e9646cdbec">


## :robot: Proposition
 Un ajout d’une config dans ember-cli-build.js pourrait résoudre le souci.
'@embroider/macros': {  setConfig: {    '@ember-data/store': {      polyfillUUID: true,    },  },}

## :rainbow: Remarques


## :100: Pour tester
- soit essayer d'accéder à la plateforme avec safari  mais une ancienne version
- soit passer par lambda test pour simuler une tablette
