### PR TITLE
[TECH] Corriger la v4.4.0 dans le CHANGELOG 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 - [#6374](https://github.com/1024pix/pix/pull/6374) [BUMP] Update nginx Docker tag to v1.25.1.
 - [#6372](https://github.com/1024pix/pix/pull/6372) [BUMP] Lock file maintenance (dossier racine).
 
+## v4.4.0 (13/06/2023)
+
 
 
 ### :rocket: Amélioration


### PR DESCRIPTION
## :unicorn: Problème
Le header `v4.4.0` n'est opas au bon endroit

## :robot: Proposition
Le déplacer au dessus des PR impactées

## :100: Pour tester
Relire le CHANGELOG
