### PR TITLE
[TECH] Remplacer eslint-plugin-node par son successeur eslint-plugin-n.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -22,7 +22,6 @@ globals:
 
 plugins:
   - knex
-  - node
   - unicorn
 
 rules:

--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -4,7 +4,7 @@ extends:
   - 'plugin:mocha/recommended'
   - 'plugin:prettier/recommended'
   - 'plugin:chai-expect/recommended'
-  - 'plugin:node/recommended-module'
+  - 'plugin:n/recommended'
   - 'plugin:import/recommended'
 
 parserOptions:
@@ -13,7 +13,7 @@ parserOptions:
   babelOptions:
     parserOpts:
       plugins:
-      - importAssertions
+        - importAssertions
 
 parser: '@babel/eslint-parser'
 
@@ -46,9 +46,9 @@ rules:
   mocha/no-top-level-hooks: error
   no-empty-function: error
   # Refer to scripts/_template.js for reliable alternatives to process.exit()
-  node/no-process-exit: error
+  n/no-process-exit: error
   unicorn/no-empty-file: error
-  node/no-unpublished-import:
+  n/no-unpublished-import:
     - error
     - allowModules:
         - chai

--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,8 @@
 import * as dotenv from 'dotenv';
+
 dotenv.config();
 import { validateEnvironmentVariables } from './lib/infrastructure/validate-environment-variables.js';
+
 validateEnvironmentVariables();
 
 import { createServer } from './server.js';
@@ -47,7 +49,6 @@ process.on('SIGINT', () => {
   try {
     await start();
     if (process.env.START_JOB_IN_WEB_PROCESS) {
-      // eslint-disable-next-line node/no-unsupported-features/es-syntax
       import('./worker.js');
     }
   } catch (error) {

--- a/api/lib/.eslintrc.cjs
+++ b/api/lib/.eslintrc.cjs
@@ -14,6 +14,6 @@ module.exports = {
         ],
       },
     ],
-    'node/no-process-env': 'error',
+    'n/no-process-env': 'error',
   },
 };

--- a/api/lib/application/healthcheck/healthcheck-controller.js
+++ b/api/lib/application/healthcheck/healthcheck-controller.js
@@ -10,9 +10,9 @@ const get = function (request) {
     version: packageJSON.version,
     description: packageJSON.description,
     environment: config.environment,
-    // eslint-disable-next-line node/no-process-env
+    // eslint-disable-next-line n/no-process-env
     'container-version': process.env.CONTAINER_VERSION,
-    // eslint-disable-next-line node/no-process-env
+    // eslint-disable-next-line n/no-process-env
     'container-app-name': process.env.APP,
     'current-lang': request.i18n.__('current-lang'),
   };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 // eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable node/no-process-env */
+/* eslint-disable n/no-process-env */
 import path from 'path';
 import moment from 'moment';
 import ms from 'ms';
@@ -9,6 +9,7 @@ import ms from 'ms';
 import { getArrayOfStrings } from '../lib/infrastructure/utils/string-utils.js';
 
 import * as url from 'url';
+
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 function parseJSONEnv(varName) {

--- a/api/lib/infrastructure/utils/import-named-exports-from-directory.js
+++ b/api/lib/infrastructure/utils/import-named-exports-from-directory.js
@@ -10,7 +10,6 @@ export async function importNamedExportsFromDirectory(path, ignoredFileNames = [
       continue;
     }
 
-    // eslint-disable-next-line node/no-unsupported-features/es-syntax
     const module = await import(join(path, file));
     const namedExports = Object.entries(module);
 

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -58,7 +58,7 @@ const schema = Joi.object({
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {
-  // eslint-disable-next-line node/no-process-env
+  // eslint-disable-next-line n/no-process-env
   const { error } = schema.validate(process.env);
   if (error) {
     throw new Error('Configuration is invalid: ' + error.message + ', but was: ' + error.details[0].context.value);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -95,7 +95,6 @@
         "eslint-plugin-knex": "^0.2.1",
         "eslint-plugin-mocha": "^10.0.5",
         "eslint-plugin-n": "^16.0.0",
-        "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-unicorn": "^46.0.0",
         "eslint-plugin-yml": "^1.0.0",
@@ -5053,25 +5052,6 @@
         "eslint": ">=2.0.0 <= 8.x"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
-      "dev": true,
-      "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
     "node_modules/eslint-plugin-es-x": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-6.2.1.tgz",
@@ -5089,30 +5069,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint-plugin-i18n-json": {
@@ -5273,50 +5229,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
-      "dev": true,
-      "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -10860,18 +10772,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/regjsparser": {
@@ -17070,33 +16970,6 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-es-x": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-6.2.1.tgz",
@@ -17227,37 +17100,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
@@ -21242,12 +21084,6 @@
         "define-properties": "^1.2.0",
         "functions-have-names": "^1.2.3"
       }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
     },
     "regjsparser": {
       "version": "0.9.1",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -94,6 +94,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-knex": "^0.2.1",
         "eslint-plugin-mocha": "^10.0.5",
+        "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-unicorn": "^46.0.0",
@@ -3698,6 +3699,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -5029,6 +5072,25 @@
         "eslint": ">=4.19.1"
       }
     },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-6.2.1.tgz",
+      "integrity": "sha512-uR34zUhZ9EBoiSD2DdV5kHLpydVEvwWqjteUr9sXRgJknwbKZJZhdJ7uFnaTtd+Nr/2G3ceJHnHXrFhJ67n3Tw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
     "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -5153,6 +5215,64 @@
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.0.tgz",
+      "integrity": "sha512-akkZTE3hsHBrq6CwmGuYCzQREbVUrA855kzcHqe6i0FLBkeY7Y/6tThCVkjUnjhvRBAlc+8lILcSe5QvvDpeZQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^6.1.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.12.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -15842,6 +15962,41 @@
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
     },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -16942,6 +17097,16 @@
         }
       }
     },
+    "eslint-plugin-es-x": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-6.2.1.tgz",
+      "integrity": "sha512-uR34zUhZ9EBoiSD2DdV5kHLpydVEvwWqjteUr9sXRgJknwbKZJZhdJ7uFnaTtd+Nr/2G3ceJHnHXrFhJ67n3Tw==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.5.0"
+      }
+    },
     "eslint-plugin-i18n-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-json/-/eslint-plugin-i18n-json-4.0.0.tgz",
@@ -17022,6 +17187,48 @@
       "requires": {
         "eslint-utils": "^3.0.0",
         "rambda": "^7.1.0"
+      }
+    },
+    "eslint-plugin-n": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.0.tgz",
+      "integrity": "sha512-akkZTE3hsHBrq6CwmGuYCzQREbVUrA855kzcHqe6i0FLBkeY7Y/6tThCVkjUnjhvRBAlc+8lILcSe5QvvDpeZQ==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^6.1.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.12.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-node": {

--- a/api/package.json
+++ b/api/package.json
@@ -101,6 +101,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-knex": "^0.2.1",
     "eslint-plugin-mocha": "^10.0.5",
+    "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^46.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -102,7 +102,6 @@
     "eslint-plugin-knex": "^0.2.1",
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-n": "^16.0.0",
-    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^46.0.0",
     "eslint-plugin-yml": "^1.0.0",

--- a/api/scripts/.eslintrc.yaml
+++ b/api/scripts/.eslintrc.yaml
@@ -7,4 +7,4 @@ rules:
   no-console:
     - off
   # Refer to scripts/_template.js for reliable alternatives to process.exit()
-  node/no-process-exit: error
+  n/no-process-exit: error

--- a/api/scripts/certification/verify-certificate-code-service_script.js
+++ b/api/scripts/certification/verify-certificate-code-service_script.js
@@ -2,7 +2,7 @@
 /* eslint-disable import/namespace */
 import _ from 'lodash';
 import * as verifyCertificationCodeService from '../../lib/domain/services/verify-certificate-code-service.js';
-// eslint-disable-next-line node/no-missing-import, import/no-unresolved, node/no-unpublished-import
+// eslint-disable-next-line n/no-missing-import, import/no-unresolved, n/no-unpublished-import
 import * as verifyCertificateCodeRepository from '../../../../lib/infrastructure/repositories/verify-certificate-code-repository.js';
 
 const addCertification = async () => {

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -1,7 +1,7 @@
 import * as url from 'url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
-// eslint-disable-next-line node/no-unpublished-import
+// eslint-disable-next-line n/no-unpublished-import
 import inquirer from 'inquirer';
 import * as dotenv from 'dotenv';
 
@@ -361,6 +361,7 @@ async function _getResults(sessionId) {
     )
     .where('sessions.id', sessionId);
 }
+
 async function _createUser({ firstName, lastName, birthdate, email, organizationId, maxUserId }, databaseBuilder) {
   const { id: userId } = databaseBuilder.factory.buildUser.withRawPassword({
     firstName,

--- a/api/tests/integration/infrastructure/utils/imports/import-named-exports-from-directory_test.js
+++ b/api/tests/integration/infrastructure/utils/imports/import-named-exports-from-directory_test.js
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import { catchErr, expect } from '../../../../test-helper.js';
 import { importNamedExportsFromDirectory } from '../../../../../lib/infrastructure/utils/import-named-exports-from-directory.js';
 import { fileURLToPath } from 'url';
@@ -80,5 +79,3 @@ describe('Integration | Utils | #importNamedExportsFromDirectory', function () {
     expect(dirContent.b).to.be.a('function');
   });
 });
-
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable node/no-unpublished-import */
+/* eslint-disable n/no-unpublished-import */
 import * as url from 'url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -27,6 +27,7 @@ _.each(customChaiHelpers, chai.use);
 import { learningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
 
 import { config } from '../lib/config.js';
+
 const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 import { knex, disconnect } from '../db/knex-database-connection.js';
 import { DatabaseBuilder } from '../db/database-builder/database-builder.js';

--- a/api/worker.js
+++ b/api/worker.js
@@ -1,4 +1,5 @@
 import * as dotenv from 'dotenv';
+
 dotenv.config();
 import PgBoss from 'pg-boss';
 import _ from 'lodash';
@@ -38,7 +39,7 @@ async function runJobs() {
   const monitoredJobQueue = new MonitoredJobQueue(jobQueue);
   process.on('SIGINT', async () => {
     await monitoredJobQueue.stop();
-    // eslint-disable-next-line node/no-process-exit,no-process-exit
+    // eslint-disable-next-line n/no-process-exit
     process.exit(0);
   });
 
@@ -54,6 +55,7 @@ async function runJobs() {
 
   await scheduleCpfJobs(pgBoss);
 }
+
 const startInWebProcess = process.env.START_JOB_IN_WEB_PROCESS;
 const modulePath = url.fileURLToPath(import.meta.url);
 const isEntryPointFromOtherFile = process.argv[1] !== modulePath;
@@ -64,6 +66,6 @@ if (!startInWebProcess || (startInWebProcess && isEntryPointFromOtherFile)) {
   logger.error(
     'Worker process is started in the web process. Please unset the START_JOB_IN_WEB_PROCESS environment variable to start a dedicated worker process.'
   );
-  // eslint-disable-next-line node/no-process-exit,no-process-exit
+  // eslint-disable-next-line n/no-process-exit
   process.exit(1);
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous utilisons `eslint-plugin-node` qui n'est plus maintenu et qui a des règles obsolètes.

## :robot: Proposition
Utiliser `eslint-plugin-n` qui est son successeur et qui a des règles plus à jour

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
CI OK