### PR TITLE
[TECH] Enlever Faker des applications Front (PIX-8406).

### DIFF
--- a/admin/mirage/factories/certification-center-invitation.js
+++ b/admin/mirage/factories/certification-center-invitation.js
@@ -1,9 +1,8 @@
 import { Factory, association } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   email() {
-    return faker.internet.exampleEmail();
+    return 'standard-invitation-mail@example.net';
   },
 
   certificationCenter: association(),

--- a/admin/mirage/factories/certification-center.js
+++ b/admin/mirage/factories/certification-center.js
@@ -2,7 +2,7 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name() {
-    return 'Centre des certifs';
+    return `Centre des certifs ${Math.random().toString(36).slice(2, 8)}`;
   },
 
   type() {

--- a/admin/mirage/factories/certification-center.js
+++ b/admin/mirage/factories/certification-center.js
@@ -1,9 +1,8 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   name() {
-    return faker.company.name();
+    return 'Centre des certifs';
   },
 
   type() {

--- a/admin/mirage/factories/organization-invitation.js
+++ b/admin/mirage/factories/organization-invitation.js
@@ -1,9 +1,8 @@
 import { Factory, association } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   email() {
-    return faker.internet.exampleEmail();
+    return 'a-fake-address@example.net';
   },
 
   organization: association(),

--- a/admin/mirage/factories/session.js
+++ b/admin/mirage/factories/session.js
@@ -1,5 +1,4 @@
 import { Factory, trait } from 'miragejs';
-import dayjs from 'dayjs';
 import { CREATED, FINALIZED, IN_PROCESS, PROCESSED } from 'pix-admin/models/session';
 
 export default Factory.extend({
@@ -8,7 +7,7 @@ export default Factory.extend({
   },
 
   certificationCenterExternalId() {
-    return 'center1234';
+    return `center${Math.floor(Math.random() * 100000)}`;
   },
 
   certificationCenterType() {
@@ -16,7 +15,7 @@ export default Factory.extend({
   },
 
   certificationCenterId() {
-    return 1234;
+    return Math.floor(Math.random() * 100000);
   },
 
   address() {
@@ -32,11 +31,16 @@ export default Factory.extend({
   },
 
   date() {
-    return dayjs('2023-05-17');
+    const twoDaysAgo = new Date();
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+    const tenDaysAgo = new Date();
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+    return new Date(+twoDaysAgo + Math.random() * (tenDaysAgo - twoDaysAgo)).toISOString().slice(0, 10);
   },
 
   time() {
-    return '14:15';
+    return `${Math.floor((Math.random() * 10000) % 24)}:${Math.floor((Math.random() * 10000) % 60)}`;
   },
 
   status() {

--- a/admin/mirage/factories/session.js
+++ b/admin/mirage/factories/session.js
@@ -1,15 +1,14 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 import { CREATED, FINALIZED, IN_PROCESS, PROCESSED } from 'pix-admin/models/session';
 
 export default Factory.extend({
   certificationCenterName() {
-    return faker.company.name();
+    return 'Centre des certifs';
   },
 
   certificationCenterExternalId() {
-    return faker.company.name();
+    return 'center1234';
   },
 
   certificationCenterType() {
@@ -21,27 +20,23 @@ export default Factory.extend({
   },
 
   address() {
-    return faker.location.street();
+    return '26 quai de la Marne';
   },
 
   room() {
-    return faker.string.alphanumeric(9);
+    return 987654321;
   },
 
   examiner() {
-    return faker.company.name();
+    return 'Jean-Jacques Voitou';
   },
 
   date() {
-    return dayjs(faker.date.recent()).format('YYYY-MM-DD');
+    return dayjs('2023-05-17');
   },
 
   time() {
-    return (
-      faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0') +
-      ':' +
-      faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')
-    );
+    return '14:15';
   },
 
   status() {
@@ -49,23 +44,23 @@ export default Factory.extend({
   },
 
   accessCode() {
-    return 'ABCDEF' + faker.number.int({ min: 100, max: 999 });
+    return 'ABCDEF354';
   },
 
   description() {
-    return faker.lorem.words();
+    return 'Une description, un roman, une épopée';
   },
 
   examinerGlobalComment(i) {
     if (i % 2 === 0) {
-      return faker.lorem.words();
+      return 'Tout va pour le mieux dans le meilleur des mondes possibles';
     }
 
     return '';
   },
 
   withResultsSentToPrescriber: trait({
-    resultsSentToPrescriberAt: faker.date.past(),
+    resultsSentToPrescriberAt: '2023-05-28',
   }),
 
   created: trait({
@@ -74,17 +69,17 @@ export default Factory.extend({
 
   finalized: trait({
     status: FINALIZED,
-    finalizedAt: faker.date.past(),
+    finalizedAt: '2023-05-27',
   }),
 
   inProcess: trait({
     status: IN_PROCESS,
-    finalizedAt: faker.date.past(),
+    finalizedAt: '2023-05-19',
   }),
 
   processed: trait({
     status: PROCESSED,
-    finalizedAt: faker.date.past(),
-    publishedAt: faker.date.recent(),
+    finalizedAt: '2023-05-20',
+    publishedAt: '2023-05-21',
   }),
 });

--- a/admin/mirage/factories/training.js
+++ b/admin/mirage/factories/training.js
@@ -1,10 +1,9 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 import { createLearningContent } from '../helpers/create-learning-content';
 
 export default Factory.extend({
   title() {
-    return faker.lorem.word();
+    return 'Un contenu très formatif';
   },
 
   withFramework: trait({

--- a/admin/mirage/factories/user.js
+++ b/admin/mirage/factories/user.js
@@ -1,15 +1,14 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   firstName() {
-    return faker.person.firstName();
+    return 'Michel';
   },
   lastName() {
-    return faker.person.lastName();
+    return 'Chefchef';
   },
   email() {
-    return faker.internet.exampleEmail().toLowerCase();
+    return 'chef-michou@example.net';
   },
   lang() {
     return 'FR';

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -22,7 +22,6 @@
         "@embroider/compat": "^3.2.0",
         "@embroider/core": "^3.2.0",
         "@embroider/webpack": "^3.1.4",
-        "@faker-js/faker": "^8.0.0",
         "@formatjs/intl": "^2.5.1",
         "@fortawesome/ember-fontawesome": "^2.0.0",
         "@fortawesome/fontawesome-svg-core": "6.4.2",
@@ -13526,22 +13525,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.2.0.tgz",
-      "integrity": "sha512-VacmzZqVxdWdf9y64lDOMZNDMM/FQdtM9IsaOPKOm2suYwEatb8VkdHqOzXcDnZbk7YDE2BmsJmy/2Hmkn563g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -53,7 +53,6 @@
     "@embroider/compat": "^3.2.0",
     "@embroider/core": "^3.2.0",
     "@embroider/webpack": "^3.1.4",
-    "@faker-js/faker": "^8.0.0",
     "@formatjs/intl": "^2.5.1",
     "@fortawesome/ember-fontawesome": "^2.0.0",
     "@fortawesome/fontawesome-svg-core": "6.4.2",

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -1,17 +1,21 @@
 import { Factory } from 'miragejs';
-import dayjs from 'dayjs';
 
 export default Factory.extend({
   firstName() {
-    return 'Quentin';
+    return `Quentin_${Math.floor(Math.random() * 100000)}`;
   },
 
   lastName() {
-    return 'Leboncollegue';
+    return `Leboncollègue_${Math.floor(Math.random() * 100000)}`;
   },
 
   birthdate() {
-    return dayjs('1990-01-02');
+    const twoDaysAgo = new Date();
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+    const tenDaysAgo = new Date();
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+    return new Date(+twoDaysAgo + Math.random() * (tenDaysAgo - twoDaysAgo)).toISOString().slice(0, 10);
   },
 
   birthCity() {
@@ -31,7 +35,7 @@ export default Factory.extend({
   },
 
   externalId() {
-    return '123456ABCD';
+    return Math.random().toString(36).slice(2, 12);
   },
 
   extraTimePercentage() {

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -1,65 +1,60 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 
 export default Factory.extend({
   firstName() {
-    return faker.person.firstName();
+    return 'Quentin';
   },
 
   lastName() {
-    return faker.person.lastName();
+    return 'Leboncollegue';
   },
 
   birthdate() {
-    return dayjs(faker.date.past({ years: 30 })).format('YYYY-MM-DD');
+    return dayjs('1990-01-02');
   },
 
   birthCity() {
-    return faker.location.city();
+    return 'Saint-Malo';
   },
 
   birthProvinceCode() {
-    return faker.string.alphanumeric(3);
+    return '354';
   },
 
   birthCountry() {
-    return faker.location.country();
+    return 'France';
   },
 
   email() {
-    return faker.internet.exampleEmail();
+    return 'quentin.boncollegue@example.net';
   },
 
   externalId() {
-    return faker.string.uuid();
+    return '123456ABCD';
   },
 
   extraTimePercentage() {
-    if (faker.datatype.boolean()) {
-      return 0.3;
-    }
-
-    return null;
+    return 0.3;
   },
 
   isLinked() {
-    return faker.datatype.boolean();
+    return false;
   },
 
   sessionId() {
-    return faker.number.int();
+    return 123456;
   },
 
   sex() {
-    return faker.helpers.arrayElement(['M', 'F']);
+    return 'M';
   },
 
   birthInseeCode() {
-    return faker.string.alphanumeric(5);
+    return '35288';
   },
 
   birthPostalCode() {
-    return faker.string.alphanumeric(5);
+    return '35400';
   },
 });

--- a/certif/mirage/factories/certification-report.js
+++ b/certif/mirage/factories/certification-report.js
@@ -1,32 +1,31 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   certificationCourseId() {
-    return faker.number.int();
+    return 15263748;
   },
 
   firstName() {
-    return faker.person.firstName();
+    return 'Ivan';
   },
 
   lastName() {
-    return faker.person.lastName();
+    return 'Denissovitch';
   },
 
   externalId() {
-    return faker.string.uuid();
+    return 'CH-854';
   },
 
   hasSeenEndTestScreen() {
-    return faker.datatype.boolean();
+    return false;
   },
 
   isCompleted() {
-    return faker.datatype.boolean();
+    return false;
   },
 
   abortReason() {
-    return faker.lorem.word();
+    return 'Avait froid aux mains';
   },
 });

--- a/certif/mirage/factories/country.js
+++ b/certif/mirage/factories/country.js
@@ -1,12 +1,11 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   name() {
-    return faker.lorem.word();
+    return 'Portugal';
   },
 
   code() {
-    return faker.number.int({ min: 99000, max: 99999 });
+    return 99139;
   },
 });

--- a/certif/mirage/factories/division.js
+++ b/certif/mirage/factories/division.js
@@ -1,8 +1,7 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   name() {
-    return faker.string.alphanumeric();
+    return '3emeB';
   },
 });

--- a/certif/mirage/factories/session.js
+++ b/certif/mirage/factories/session.js
@@ -24,7 +24,7 @@ export default Factory.extend({
   },
 
   room() {
-    return 375491208;
+    return Math.random().toString(36).slice(2, 12);
   },
 
   time() {

--- a/certif/mirage/factories/session.js
+++ b/certif/mirage/factories/session.js
@@ -1,39 +1,34 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 import { CREATED } from 'pix-certif/models/session';
 
 export default Factory.extend({
   address() {
-    return faker.location.street();
+    return '10 Rue des révoltés';
   },
 
   accessCode() {
-    return 'ABCDEF' + faker.number.int({ min: 100, max: 999 });
+    return 'ABCDEF313';
   },
 
   date() {
-    return dayjs(faker.date.recent()).format('YYYY-MM-DD');
+    return dayjs('2023-05-17');
   },
 
   description() {
-    return faker.lorem.words();
+    return 'Une session somme toute normale';
   },
 
   examiner() {
-    return faker.company.name();
+    return 'Argus Rusard';
   },
 
   room() {
-    return faker.string.alphanumeric(9);
+    return 375491208;
   },
 
   time() {
-    return (
-      faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0') +
-      ':' +
-      faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')
-    );
+    return '14:15';
   },
 
   status() {
@@ -42,7 +37,7 @@ export default Factory.extend({
 
   examinerGlobalComment(i) {
     if (i % 2 === 0) {
-      return faker.lorem.words();
+      return 'Un commentaire de session somme toute normal';
     }
 
     return '';

--- a/certif/mirage/factories/student.js
+++ b/certif/mirage/factories/student.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs';
 
 export default Factory.extend({
   firstName() {
-    return 'Barish';
+    return `Barish_${Math.floor(Math.random() * 100000)}`;
   },
 
   lastName() {
-    return 'Joel';
+    return `Joel_${Math.floor(Math.random() * 100000)}`;
   },
 
   birthdate() {

--- a/certif/mirage/factories/student.js
+++ b/certif/mirage/factories/student.js
@@ -1,21 +1,20 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 
 export default Factory.extend({
   firstName() {
-    return faker.person.firstName();
+    return 'Barish';
   },
 
   lastName() {
-    return faker.person.lastName();
+    return 'Joel';
   },
 
   birthdate() {
-    return dayjs(faker.date.past({ years: 30 })).format('YYYY-MM-DD');
+    return dayjs('1975-10-18');
   },
 
   division() {
-    return faker.lorem.word();
+    return '3emeB';
   },
 });

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -23,7 +23,6 @@
         "@embroider/compat": "^3.0.0",
         "@embroider/core": "^3.0.0",
         "@embroider/webpack": "^3.0.0",
-        "@faker-js/faker": "^8.0.0",
         "@formatjs/intl": "^2.9.1",
         "@fortawesome/ember-fontawesome": "^2.0.0",
         "@fortawesome/fontawesome-svg-core": "6.4.2",
@@ -12352,22 +12351,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.2.0.tgz",
-      "integrity": "sha512-VacmzZqVxdWdf9y64lDOMZNDMM/FQdtM9IsaOPKOm2suYwEatb8VkdHqOzXcDnZbk7YDE2BmsJmy/2Hmkn563g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -54,7 +54,6 @@
     "@embroider/compat": "^3.0.0",
     "@embroider/core": "^3.0.0",
     "@embroider/webpack": "^3.0.0",
-    "@faker-js/faker": "^8.0.0",
     "@formatjs/intl": "^2.9.1",
     "@fortawesome/ember-fontawesome": "^2.0.0",
     "@fortawesome/fontawesome-svg-core": "6.4.2",

--- a/certif/tests/acceptance/session-update_test.js
+++ b/certif/tests/acceptance/session-update_test.js
@@ -63,7 +63,12 @@ module('Acceptance | Session Update', function (hooks) {
 
   test('it should allow to update a session and redirect to the session details', async function (assert) {
     // given
-    const session = server.create('session', { room: 'beforeRoom', examiner: 'beforeExaminer' });
+    const session = server.create('session', {
+      room: 'beforeRoom',
+      examiner: 'beforeExaminer',
+      date: '2023-12-12',
+      time: '10:12',
+    });
     const newRoom = 'New room';
     const newExaminer = 'New examiner';
 

--- a/mon-pix/mirage/factories/assessment.js
+++ b/mon-pix/mirage/factories/assessment.js
@@ -1,9 +1,8 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   title() {
-    return faker.lorem.words();
+    return 'Assessment title';
   },
 
   type() {

--- a/mon-pix/mirage/factories/campaign.js
+++ b/mon-pix/mirage/factories/campaign.js
@@ -10,7 +10,7 @@ export default Factory.extend({
   },
 
   code() {
-    return 'B1Bli0';
+    return Math.random().toString(36).slice(2, 8);
   },
 
   idPixLabel() {

--- a/mon-pix/mirage/factories/campaign.js
+++ b/mon-pix/mirage/factories/campaign.js
@@ -1,9 +1,8 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   title() {
-    return faker.lorem.words();
+    return 'Campagne des compétences incroyables';
   },
 
   type() {
@@ -11,7 +10,7 @@ export default Factory.extend({
   },
 
   code() {
-    return faker.string.alphanumeric(6);
+    return 'B1Bli0';
   },
 
   idPixLabel() {
@@ -23,7 +22,7 @@ export default Factory.extend({
   },
 
   organizationName() {
-    return faker.company.name();
+    return 'Ligue des congres et tanches';
   },
 
   isRestricted() {

--- a/mon-pix/mirage/factories/certification-course.js
+++ b/mon-pix/mirage/factories/certification-course.js
@@ -1,17 +1,16 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   nbChallenges() {
-    return faker.number.int();
+    return 8;
   },
 
   sessionId() {
-    return faker.number.int();
+    return 314159;
   },
 
   accessCode() {
-    return faker.string.alphanumeric(9);
+    return 314159265;
   },
 
   afterCreate(certificationCourse, server) {

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -1,9 +1,8 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   id() {
-    return `rec_${faker.string.alphanumeric(5)}`;
+    return 'rec_M8fSF';
   },
 
   type() {
@@ -18,28 +17,27 @@ export default Factory.extend({
     return 'Rue de : ${Rue#}';
   },
 
-  // NOTE : ID set in the afterCreate, else faker would always generate the same ID
   forCompetenceEvaluation: trait({
     afterCreate(challenge) {
-      challenge.update({ id: `recCOMPEVAL_${faker.string.alphanumeric(5)}` });
+      challenge.update({ id: 'recCOMPEVAL_3e5V7' });
     },
   }),
 
   forCertification: trait({
     afterCreate(challenge) {
-      challenge.update({ id: `recCERTIF_${faker.string.alphanumeric(5)}` });
+      challenge.update({ id: 'recCERTIF_KWnkZ' });
     },
   }),
 
   forDemo: trait({
     afterCreate(challenge) {
-      challenge.update({ id: `recDEMO_${faker.string.alphanumeric(5)}` });
+      challenge.update({ id: 'recDEMO_6OXcE' });
     },
   }),
 
   forCampaign: trait({
     afterCreate(challenge) {
-      challenge.update({ id: `recSMARPLA_${faker.string.alphanumeric(5)}` });
+      challenge.update({ id: 'recSMARPLA_BsBEP' });
     },
   }),
 
@@ -115,7 +113,7 @@ export default Factory.extend({
   }),
 
   timed: trait({
-    timer: faker.number.int(),
+    timer: 92159,
   }),
 
   QROCwithFile1: trait({
@@ -135,12 +133,12 @@ export default Factory.extend({
   }),
 
   withAttachment: trait({
-    attachments: [faker.internet.url()],
+    attachments: ['https://pix.fr/_nuxt/image/73cc59.svg'],
   }),
 
   withEmbed: trait({
     embedUrl: 'https://example.biz',
-    embedTitle: faker.lorem.words(),
+    embedTitle: 'a title',
     embedHeight: '100',
   }),
 

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -2,7 +2,7 @@ import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   id() {
-    return 'rec_M8fSF';
+    return 'rec_' + Math.random().toString(36).slice(2, 7);
   },
 
   type() {
@@ -19,25 +19,25 @@ export default Factory.extend({
 
   forCompetenceEvaluation: trait({
     afterCreate(challenge) {
-      challenge.update({ id: 'recCOMPEVAL_3e5V7' });
+      challenge.update({ id: 'recCOMPEVAL_' + Math.random().toString(36).slice(2, 7) });
     },
   }),
 
   forCertification: trait({
     afterCreate(challenge) {
-      challenge.update({ id: 'recCERTIF_KWnkZ' });
+      challenge.update({ id: 'recCERTIF_' + Math.random().toString(36).slice(2, 7) });
     },
   }),
 
   forDemo: trait({
     afterCreate(challenge) {
-      challenge.update({ id: 'recDEMO_6OXcE' });
+      challenge.update({ id: 'recDEMO_' + Math.random().toString(36).slice(2, 7) });
     },
   }),
 
   forCampaign: trait({
     afterCreate(challenge) {
-      challenge.update({ id: 'recSMARPLA_BsBEP' });
+      challenge.update({ id: 'recSMARPLA_' + Math.random().toString(36).slice(2, 7) });
     },
   }),
 

--- a/mon-pix/mirage/factories/competence-result.js
+++ b/mon-pix/mirage/factories/competence-result.js
@@ -1,17 +1,16 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   name() {
-    return faker.lorem.words();
+    return 'Nom de competence pas inspiré';
   },
 
   index() {
-    return faker.string.alphanumeric(2);
+    return '1a';
   },
 
   totalSkillsCount() {
-    return faker.number.int() + 3;
+    return 27;
   },
 
   afterCreate(competenceResult) {

--- a/mon-pix/mirage/factories/correction.js
+++ b/mon-pix/mirage/factories/correction.js
@@ -1,12 +1,11 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   solution() {
-    return faker.lorem.word();
+    return 'a word';
   },
 
   hint() {
-    return faker.lorem.word();
+    return 'an other word';
   },
 });

--- a/mon-pix/mirage/factories/course.js
+++ b/mon-pix/mirage/factories/course.js
@@ -1,5 +1,4 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   id(i) {
@@ -7,10 +6,10 @@ export default Factory.extend({
   },
 
   name() {
-    return faker.lorem.word();
+    return 'Long cours';
   },
 
   description() {
-    return faker.lorem.paragraph();
+    return 'Une description de cours assez longue';
   },
 });

--- a/mon-pix/mirage/factories/tutorial.js
+++ b/mon-pix/mirage/factories/tutorial.js
@@ -1,5 +1,4 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   format() {
@@ -11,11 +10,11 @@ export default Factory.extend({
   },
 
   link() {
-    return faker.internet.url();
+    return 'https://pix.fr/_nuxt/image/73cc59.svg';
   },
 
   title() {
-    return faker.lorem.word();
+    return 'temporibus';
   },
 
   withUserSavedTutorial: trait({

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -1,5 +1,4 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 import sumBy from 'lodash/sumBy';
 
 function _addDefaultProfile(user, server) {
@@ -258,10 +257,10 @@ function _createTutorial(server) {
 
 export default Factory.extend({
   firstName() {
-    return faker.person.firstName();
+    return 'Victoria';
   },
   lastName() {
-    return faker.person.lastName();
+    return 'Osinski';
   },
   cgu() {
     return false;
@@ -279,11 +278,11 @@ export default Factory.extend({
     shouldChangePassword: true,
   }),
   withEmail: trait({
-    email: faker.internet.exampleEmail(),
+    email: 'Victoria4@hotmail.com',
     password: 'Azerty123*',
   }),
   withUsername: trait({
-    username: faker.internet.userName(),
+    username: 'VO4',
     password: 'Azerty123*',
   }),
   external: trait({

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -25,7 +25,6 @@
         "@embroider/core": "^3.0.0",
         "@embroider/util": "^1.11.1",
         "@embroider/webpack": "^3.0.0",
-        "@faker-js/faker": "^8.0.0",
         "@formatjs/intl": "^2.5.1",
         "@formatjs/intl-getcanonicallocales": "^2.0.4",
         "@formatjs/intl-locale": "^3.0.7",
@@ -13325,22 +13324,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.3.1.tgz",
-      "integrity": "sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -56,7 +56,6 @@
     "@embroider/core": "^3.0.0",
     "@embroider/util": "^1.11.1",
     "@embroider/webpack": "^3.0.0",
-    "@faker-js/faker": "^8.0.0",
     "@formatjs/intl": "^2.5.1",
     "@formatjs/intl-getcanonicallocales": "^2.0.4",
     "@formatjs/intl-locale": "^3.0.7",

--- a/orga/mirage/factories/campaign.js
+++ b/orga/mirage/factories/campaign.js
@@ -1,17 +1,16 @@
 import { Factory, trait } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   name() {
-    return faker.company.name();
+    return 'Campagne d’évaluation 972';
   },
 
   code() {
-    return 'ABCDEF' + faker.number.int({ min: 100, max: 999 });
+    return 'ABCDEF972';
   },
 
   createdAt() {
-    return faker.date.recent();
+    return '2023-05-17';
   },
 
   ownerLastName() {

--- a/orga/mirage/factories/division.js
+++ b/orga/mirage/factories/division.js
@@ -1,8 +1,7 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   name() {
-    return faker.string.alphanumeric();
+    return '3emeC';
   },
 });

--- a/orga/mirage/factories/organization-participant.js
+++ b/orga/mirage/factories/organization-participant.js
@@ -1,12 +1,11 @@
 import { Factory } from 'miragejs';
-import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
   firstName() {
-    return faker.person.firstName();
+    return 'Jean-prénom';
   },
 
   lastName() {
-    return faker.person.lastName();
+    return 'Lenomdefamille';
   },
 });


### PR DESCRIPTION
## :unicorn: Problème
On utilise (ou utilisait) parfois Faker dans les tests ou dans les configurations de Mirage de tests. 
On a depuis constaté que l'usage de Faker peut entraîner des tests non déterministes (flaky).

## :robot: Proposition
Supprimer les usages de Faker et les remplacer par des valeurs déterminées.

## :100: Pour tester
Pas de test fonctionnel à réaliser, car seuls les tests sont concernés.