### PR TITLE
[BUGFIX] Améliorer le design de l'input sur l'écran de réponse des QROC sur Pix-App (PIX-8316)

### DIFF
--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -17,6 +17,7 @@
 
   &--input {
     width: auto;
+    max-width: 100%;
   }
 
   &--correct {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la réponse est trop longue, l'input dépasse du bloc.
![image](https://github.com/1024pix/pix/assets/49011144/739e47ca-1dea-4e49-bf59-12ec913dedee)

## :robot: Proposition
Ajouter une `max-width` pour limiter la taille de l'input

## :100: Pour tester
Aller sur les épreuves et vérifier le visuel.
https://app-pr6435.review.pix.fr/challenges/rec2UVxbi2NTsmNUv/preview
https://app-pr6435.review.pix.fr/challenges/recwjkfQupisguP3S/preview
https://app-pr6435.review.pix.fr/challenges/recm8YzIYiQjysZrO/preview

