### PR TITLE
[TECH] Amélioration des tests en utilisant Testing Library (PIX-8412)

### DIFF
--- a/orga/tests/integration/components/campaign/cards/participants-count_test.js
+++ b/orga/tests/integration/components/campaign/cards/participants-count_test.js
@@ -1,19 +1,17 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl, t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Cards::ParticipantsCount', function (hooks) {
   setupIntlRenderingTest(hooks);
-  setupIntl(hooks);
 
   test('it should display participations count card', async function (assert) {
     this.participantsCount = 10;
 
-    await render(hbs`<Campaign::Cards::ParticipantsCount @value={{this.participantsCount}} />`);
+    const screen = await render(hbs`<Campaign::Cards::ParticipantsCount @value={{this.participantsCount}} />`);
 
-    assert.contains(t('cards.participants-count.title'));
-    assert.contains('10');
+    assert.dom(screen.getByText(this.intl.t('cards.participants-count.title'))).exists();
+    assert.dom(screen.getByText('10')).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/cards/result_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/result_average_test.js
@@ -1,19 +1,17 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl, t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Cards::ResultAverage', function (hooks) {
   setupIntlRenderingTest(hooks);
-  setupIntl(hooks);
 
   test('it should display average result card', async function (assert) {
     this.averageResult = 0.91234;
 
-    await render(hbs`<Campaign::Cards::ResultAverage @value={{this.averageResult}} />`);
+    const screen = await render(hbs`<Campaign::Cards::ResultAverage @value={{this.averageResult}} />`);
 
-    assert.contains(t('cards.participants-average-results.title'));
-    assert.contains('91 %');
+    assert.dom(screen.getByText(this.intl.t('cards.participants-average-results.title'))).exists();
+    assert.dom(screen.getByText('91 %')).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/cards/shared-count_test.js
+++ b/orga/tests/integration/components/campaign/cards/shared-count_test.js
@@ -1,21 +1,21 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl, t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Cards::SharedCount', function (hooks) {
   setupIntlRenderingTest(hooks);
-  setupIntl(hooks);
 
   module('When campaign is type assessment', () => {
     test('it should display shared participations count card', async function (assert) {
       this.sharedCount = 10;
 
-      await render(hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @isTypeAssessment={{true}} />`);
+      const screen = await render(
+        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @isTypeAssessment={{true}} />`
+      );
 
-      assert.contains(t('cards.submitted-count.title'));
-      assert.contains('10');
+      assert.dom(screen.getByText(this.intl.t('cards.submitted-count.title'))).exists();
+      assert.dom(screen.getByText('10')).exists();
     });
   });
 
@@ -23,10 +23,12 @@ module('Integration | Component | Campaign::Cards::SharedCount', function (hooks
     test('it should display shared profiles count card', async function (assert) {
       this.sharedCount = 10;
 
-      await render(hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @isTypeAssessment={{false}} />`);
+      const screen = await render(
+        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @isTypeAssessment={{false}} />`
+      );
 
-      assert.contains(t('cards.submitted-count.title-profiles'));
-      assert.contains('10');
+      assert.dom(screen.getByText(this.intl.t('cards.submitted-count.title-profiles'))).exists();
+      assert.dom(screen.getByText('10'));
     });
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-mastery-percentage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-mastery-percentage_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByMasteryPercentage', function (hooks) {
@@ -29,8 +29,11 @@ module('Integration | Component | Campaign::Charts::ParticipantsByMasteryPercent
     });
 
     // when
-    await render(hbs`<Campaign::Charts::ParticipantsByMasteryPercentage @campaignId={{this.campaignId}} />`);
+    const screen = await render(
+      hbs`<Campaign::Charts::ParticipantsByMasteryPercentage @campaignId={{this.campaignId}} />`
+    );
 
-    assert.contains('Répartition des participants par résultat');
+    // then
+    assert.dom(screen.getByText(this.intl.t('charts.participants-by-mastery-percentage.title'))).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-status_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-status_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByStatus', function (hooks) {
@@ -13,16 +13,23 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
       ['shared', 1],
     ];
 
-    await render(
+    const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
   @isTypeAssessment={{true}}
 />`
     );
-
-    assert.contains('En cours (1)');
-    assert.contains("En attente d'envoi (1)");
-    assert.contains('Résultats reçus (1)');
+    assert
+      .dom(
+        screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.completed-assessment', { count: 1 }))
+      )
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.completed-profile', { count: 1 })))
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.shared', { count: 1 })))
+      .exists();
   });
 
   test('it should contains tooltips for assessment campaign', async function (assert) {
@@ -32,18 +39,18 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
       ['shared', 1],
     ];
 
-    await render(
+    const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
   @isTypeAssessment={{true}}
 />`
     );
 
-    assert.contains('En cours : Ces participants n’ont pas encore terminé leur parcours.');
-    assert.contains(
-      'En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.'
-    );
-    assert.contains('Résultats reçus : Ces participants ont terminé leur parcours et envoyé leurs résultats.');
+    assert.dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.started-tooltip'))).exists();
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.completed-assessment-tooltip')))
+      .exists();
+    assert.dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.shared-tooltip'))).exists();
   });
 
   test('it should display status for profile collection campaign', async function (assert) {
@@ -52,16 +59,22 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
       ['shared', 1],
     ];
 
-    await render(
+    const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
   @isTypeAssessment={{false}}
 />`
     );
 
-    assert.notContains('En cours (1)');
-    assert.contains("En attente d'envoi (1)");
-    assert.contains('Profils reçus (1)');
+    assert
+      .dom(screen.queryByText(this.intl.t('charts.participants-by-status.labels-legend.started', { count: 1 })))
+      .doesNotExist();
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.completed-profile', { count: 1 })))
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.shared-profile', { count: 1 })))
+      .exists();
   });
 
   test('it should contains tooltips for profile collection campaign', async function (assert) {
@@ -70,14 +83,18 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
       ['shared', 1],
     ];
 
-    await render(
+    const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStatus
   @participantCountByStatus={{this.participantCountByStatus}}
   @isTypeAssessment={{false}}
 />`
     );
 
-    assert.contains('En attente d’envoi : Ces participants n’ont pas encore envoyé leurs profils.');
-    assert.contains('Profils reçus : Ces participants ont envoyé leurs profils.');
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.completed-profile-tooltip')))
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('charts.participants-by-status.labels-legend.shared-profile-tooltip')))
+      .exists();
   });
 });

--- a/orga/tests/integration/components/campaign/charts/result-distribution_test.js
+++ b/orga/tests/integration/components/campaign/charts/result-distribution_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ResultDistribution', function (hooks) {
@@ -27,9 +27,11 @@ module('Integration | Component | Campaign::Charts::ResultDistribution', functio
       this.campaign = { id: 12, hasStages: false };
       dataFetcher.resolves({ data: { attributes: { 'result-distribution': [] } } });
 
-      await render(hbs`<Campaign::Charts::ResultDistribution @campaign={{this.campaign}} />`);
+      const screen = await render(hbs`<Campaign::Charts::ResultDistribution @campaign={{this.campaign}} />`);
 
-      assert.contains('Répartition des participants par résultat');
+      assert
+        .dom(screen.getByRole('heading', { name: this.intl.t('charts.participants-by-mastery-percentage.title') }))
+        .exists();
     });
   });
 
@@ -43,10 +45,10 @@ module('Integration | Component | Campaign::Charts::ResultDistribution', functio
       this.onSelectStage = () => {};
       dataFetcher.resolves({ data: { attributes: { data: [{ id: 100498, value: 0 }] } } });
 
-      await render(
+      const screen = await render(
         hbs`<Campaign::Charts::ResultDistribution @campaign={{this.campaign}} @onSelectStage={{this.onSelectStage}} />`
       );
-      assert.contains('Répartition des participants par paliers');
+      assert.dom(screen.getByRole('heading', { name: this.intl.t('charts.participants-by-stage.title') })).exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il existe encore beaucoup de tests n'utilisant pas Testing Library (coté orga dans cette PR)

## :robot: Proposition
Mettre a jour ces tests en utilisant [Testing Library](https://github.com/1024pix/ember-testing-library)

## :rainbow: Remarques
Quand c'est possible selon les tests on utilise l'a11y. ( Principalement si un rôle ou un label est présent dans l'élément à tester ) 

## :100: Pour tester

- Lancer les tests de Pix Orga
- Verifier que tout passe
- 🐱 
