### PR TITLE
[BUGFIX] Les métriques systèmes ne sont plus tracées (PIX-8411)

### DIFF
--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -46,6 +46,10 @@ const plugin = {
       logger.info(server.info, 'server stopped');
     });
 
+    server.events.on('log', function (event) {
+      logger.info({ tags: event.tags, data: event.data });
+    });
+
     server.events.on('request', function (request, event) {
       if (event.error) {
         logger.error(


### PR DESCRIPTION
## :unicorn: Problème
Depuis la mise en production de la version v4.7.0, plus aucun log ops (metrics cpu...) ne remonte dans Datadog. 

La régression provient de PR #6329

## :robot: Proposition
Ajouter dans le plugin Hapi<=>Pino l'abonnement aux évènements `log`.

## :rainbow: Remarques
On a loggue du même coup les appels à `server.log`

## :100: Pour tester
Déployer un RA et regarder les logs Scalingo pour voir si les logs apparaissent.
Puis créer un log drain dans scalingo pour vérifier que les logs remontent au bon format dans Datadog.
