### PR TITLE
[BUGFIX] Les signalements ne peuvent plus être ajoutés à la finalisation de la session (PIX-8416).

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -15,12 +15,14 @@
           @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
           @toggleOnCategory={{this.toggleOnCategory}}
           @maxlength={{@maxlength}}
+          @updateCandidateInformationChangeCategoryDescription={{this.updateCandidateInformationChangeCategory}}
         />
 
         <IssueReportModal::SignatureIssueReportFields
           @signatureIssueCategory={{this.signatureIssueCategory}}
           @toggleOnCategory={{this.toggleOnCategory}}
           @maxlength={{@maxlength}}
+          @updateSignatureIssueCategoryDescription={{this.updateSignatureIssueCategory}}
         />
 
         <IssueReportModal::FraudCertificationIssueReportFields
@@ -32,12 +34,14 @@
           @nonBlockingTechnicalIssueCategory={{this.nonBlockingTechnicalIssueCategory}}
           @toggleOnCategory={{this.toggleOnCategory}}
           @maxlength={{@maxlength}}
+          @updateNonBlockingTechnicalIssueCategoryDescription={{this.updateNonBlockingTechnicalIssueCategory}}
         />
 
         <IssueReportModal::NonBlockingCandidateIssueCertificationIssueReportFields
           @nonBlockingCandidateIssueCategory={{this.nonBlockingCandidateIssueCategory}}
           @toggleOnCategory={{this.toggleOnCategory}}
           @maxlength={{@maxlength}}
+          @updateNonBlockingCandidateIssueCategoryDescription={{this.updateNonBlockingCandidateIssueCategory}}
         />
 
         <IssueReportModal::InChallengeCertificationIssueReportFields

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -155,6 +155,26 @@ export default class AddIssueReportModal extends Component {
   }
 
   @action
+  updateCandidateInformationChangeCategory(event) {
+    this.candidateInformationChangeCategory.description = event.target.value;
+  }
+
+  @action
+  updateNonBlockingCandidateIssueCategory(event) {
+    this.nonBlockingCandidateIssueCategory.description = event.target.value;
+  }
+
+  @action
+  updateNonBlockingTechnicalIssueCategory(event) {
+    this.nonBlockingTechnicalIssueCategory.description = event.target.value;
+  }
+
+  @action
+  updateSignatureIssueCategory(event) {
+    this.signatureIssueCategory.description = event.target.value;
+  }
+
+  @action
   async submitReport(event) {
     event.preventDefault();
     const categoryToAdd = this.categories.find((category) => category.isChecked);

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
@@ -27,6 +27,7 @@
         @value={{@candidateInformationChangeCategory.description}}
         @maxlength={{@maxlength}}
         required="true"
+        {{on "change" @updateCandidateInformationChangeCategoryDescription}}
       />
     </div>
   {{/if}}

--- a/certif/app/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields.hbs
@@ -36,6 +36,7 @@
         @value={{@nonBlockingCandidateIssueCategory.description}}
         @maxlength={{@maxlength}}
         required="true"
+        {{on "change" @updateNonBlockingCandidateIssueCategoryDescription}}
       />
     </div>
   {{/if}}

--- a/certif/app/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields.hbs
@@ -36,6 +36,7 @@
         @value={{@nonBlockingTechnicalIssueCategory.description}}
         @maxlength={{@maxlength}}
         required="true"
+        {{on "change" @updateNonBlockingTechnicalIssueCategoryDescription}}
       />
     </div>
   {{/if}}

--- a/certif/app/components/issue-report-modal/signature-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/signature-issue-report-fields.hbs
@@ -20,6 +20,7 @@
         @value={{@signatureIssueCategory.description}}
         @maxlength={{@maxlength}}
         required="true"
+        {{on "change" @updateSignatureIssueCategoryDescription}}
       />
     </div>
   {{/if}}

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
@@ -431,9 +431,11 @@ module('Acceptance | Session Finalization', function (hooks) {
 
             // when
             const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
+
             await click(screen.getByRole('button', { name: 'Ajouter' }));
             await screen.findByRole('dialog');
-            await click(screen.getByLabelText('C6 Suspicion de fraude'));
+            await click(screen.getByLabelText('C1-C2 Modification infos candidat'));
+            await fillIn(screen.getByLabelText('Renseignez les informations correctes'), 'erreur');
             await click(screen.getByRole('button', { name: 'Ajouter le signalement' }));
 
             // then

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
@@ -35,12 +35,14 @@ module('Integration | Component | candidate-information-change-certification-iss
   test('it should show dropdown menu with subcategories when category is checked', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const updateCandidateInformationChangeCategory = sinon.stub();
     const candidateInformationChangeCategory = {
       isChecked: true,
       subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
     };
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+    this.set('updateCandidateInformationChangeCategory', updateCandidateInformationChangeCategory);
 
     // when
     await render(hbs`
@@ -48,6 +50,7 @@ module('Integration | Component | candidate-information-change-certification-iss
         @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateCandidateInformationChangeCategoryDescription={{this.updateCandidateInformationChangeCategory}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
 
@@ -59,12 +62,14 @@ module('Integration | Component | candidate-information-change-certification-iss
   test('it should show "Renseignez les informations correctes" if subcategory NAME_OR_BIRTHDATE is selected', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const updateCandidateInformationChangeCategory = sinon.stub();
     const candidateInformationChangeCategory = {
       isChecked: true,
       subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
     };
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+    this.set('updateCandidateInformationChangeCategory', updateCandidateInformationChangeCategory);
 
     // when
     await render(hbs`
@@ -72,6 +77,7 @@ module('Integration | Component | candidate-information-change-certification-iss
         @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateCandidateInformationChangeCategoryDescription={{this.updateCandidateInformationChangeCategory}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
 
@@ -84,12 +90,14 @@ module('Integration | Component | candidate-information-change-certification-iss
   test('it should show "Précisez le temps majoré" if subcategory EXTRA_TIME_PERCENTAGE is selected', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const updateCandidateInformationChangeCategory = sinon.stub();
     const candidateInformationChangeCategory = {
       isChecked: true,
       subcategory: certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
     };
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+    this.set('updateCandidateInformationChangeCategory', updateCandidateInformationChangeCategory);
 
     // when
     await render(hbs`
@@ -97,6 +105,7 @@ module('Integration | Component | candidate-information-change-certification-iss
         @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateCandidateInformationChangeCategoryDescription={{this.updateCandidateInformationChangeCategory}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
 

--- a/certif/tests/integration/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields_test.js
@@ -34,9 +34,11 @@ module(
     test('it should show textarea if category is checked', async function (assert) {
       // given
       const toggleOnCategory = sinon.stub();
+      const updateNonBlockingCandidateIssueCategory = sinon.stub();
       const nonBlockingCandidateIssueCategory = { isChecked: true };
       this.set('toggleOnCategory', toggleOnCategory);
       this.set('nonBlockingCandidateIssueCategory', nonBlockingCandidateIssueCategory);
+      this.set('updateNonBlockingCandidateIssueCategory', updateNonBlockingCandidateIssueCategory);
 
       // when
       const screen = await renderScreen(hbs`
@@ -44,6 +46,7 @@ module(
         @nonBlockingCandidateIssueCategory={{this.nonBlockingCandidateIssueCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateNonBlockingCandidateIssueCategoryDescription={{this.updateNonBlockingCandidateIssueCategory}}
       />`);
       await click(screen.getByRole('radio'));
 
@@ -54,9 +57,11 @@ module(
     test('it should show information message if category is checked', async function (assert) {
       // given
       const toggleOnCategory = sinon.stub();
+      const updateNonBlockingCandidateIssueCategory = sinon.stub();
       const nonBlockingCandidateIssueCategory = { isChecked: true };
       this.set('toggleOnCategory', toggleOnCategory);
       this.set('nonBlockingCandidateIssueCategory', nonBlockingCandidateIssueCategory);
+      this.set('updateNonBlockingCandidateIssueCategory', updateNonBlockingCandidateIssueCategory);
 
       // when
       const screen = await renderScreen(hbs`
@@ -64,6 +69,7 @@ module(
         @nonBlockingCandidateIssueCategory={{this.nonBlockingCandidateIssueCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateNonBlockingCandidateIssueCategoryDescription={{this.updateNonBlockingCandidateIssueCategory}}
       />`);
       await click(screen.getByRole('radio'));
 

--- a/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields_test.js
@@ -33,9 +33,11 @@ module(
     test('it should show textarea if category is checked', async function (assert) {
       // given
       const toggleOnCategory = sinon.stub();
+      const updateNonBlockingTechnicalIssueCategory = sinon.stub();
       const nonBlockingTechnicalIssueCategory = { isChecked: true };
       this.set('toggleOnCategory', toggleOnCategory);
       this.set('nonBlockingTechnicalIssueCategory', nonBlockingTechnicalIssueCategory);
+      this.set('updateNonBlockingTechnicalIssueCategory', updateNonBlockingTechnicalIssueCategory);
 
       // when
       const screen = await renderScreen(hbs`
@@ -43,6 +45,7 @@ module(
         @nonBlockingTechnicalIssueCategory={{this.nonBlockingTechnicalIssueCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateNonBlockingTechnicalIssueCategoryDescription={{this.updateNonBlockingTechnicalIssueCategory}}
       />`);
       await click(screen.getByRole('radio'));
 
@@ -53,9 +56,11 @@ module(
     test('it should show information message if category is checked', async function (assert) {
       // given
       const toggleOnCategory = sinon.stub();
+      const updateNonBlockingTechnicalIssueCategory = sinon.stub();
       const nonBlockingTechnicalIssueCategory = { isChecked: true };
       this.set('toggleOnCategory', toggleOnCategory);
       this.set('nonBlockingTechnicalIssueCategory', nonBlockingTechnicalIssueCategory);
+      this.set('updateNonBlockingTechnicalIssueCategory', updateNonBlockingTechnicalIssueCategory);
 
       // when
       const screen = await renderScreen(hbs`
@@ -63,6 +68,7 @@ module(
         @nonBlockingTechnicalIssueCategory={{this.nonBlockingTechnicalIssueCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateNonBlockingTechnicalIssueCategoryDescription={{this.updateNonBlockingTechnicalIssueCategory}}
       />`);
       await click(screen.getByRole('radio'));
 

--- a/certif/tests/integration/components/issue-report-modal/signature-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/signature-issue-report-fields_test.js
@@ -34,9 +34,11 @@ module('Integration | Component | signature-issue-report-fields', function (hook
   test('it should show textarea if category is checked', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const updateSignatureIssueCategory = sinon.stub();
     const signatureIssueCategory = { isChecked: true };
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('signatureIssueCategory', signatureIssueCategory);
+    this.set('updateSignatureIssueCategory', updateSignatureIssueCategory);
 
     // when
     await render(hbs`
@@ -44,6 +46,7 @@ module('Integration | Component | signature-issue-report-fields', function (hook
         @signatureIssueCategory={{this.signatureIssueCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateSignatureIssueCategoryDescription={{this.updateSignatureIssueCategory}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
 
@@ -54,11 +57,13 @@ module('Integration | Component | signature-issue-report-fields', function (hook
   test('it should show "Précisez" if category is checked', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const updateSignatureIssueCategory = sinon.stub();
     const signatureIssueCategory = {
       isChecked: true,
     };
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('signatureIssueCategory', signatureIssueCategory);
+    this.set('updateSignatureIssueCategory', updateSignatureIssueCategory);
 
     // when
     await render(hbs`
@@ -66,6 +71,7 @@ module('Integration | Component | signature-issue-report-fields', function (hook
         @signatureIssueCategory={{this.signatureIssueCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
+        @updateSignatureIssueCategoryDescription={{this.updateSignatureIssueCategory}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
 


### PR DESCRIPTION
## :unicorn: Problème

Depuis la MAJ de Pix-UI sur Pix-Certif (PR #6419 ), nous ne pouvons plus ajouter de signalements lors de la finalisation d'une session.
Le passage d'un composant TextArea vers textarea natif HTML a supprimé le `two-way data binding` qui existait jusqu'à maintenant.

## :robot: Proposition

Passage d'une fonction du composant `add-issue-report-modal` vers les composants enfants afin de mettre à jour la valeur de la description du signalement.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Finaliser la session `toto` sur pix-certif en se connectant avec `certifsup@example.net` en ajoutant des signalements et vérifier du bon fonctionnement du tout
