### PR TITLE
[TECH] Corriger l'import des fichiers d'un dossier sur Windows. 

### DIFF
--- a/api/lib/infrastructure/utils/import-named-exports-from-directory.js
+++ b/api/lib/infrastructure/utils/import-named-exports-from-directory.js
@@ -1,5 +1,6 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 export async function importNamedExportsFromDirectory(path, ignoredFileNames = []) {
   const imports = {};
@@ -10,7 +11,8 @@ export async function importNamedExportsFromDirectory(path, ignoredFileNames = [
       continue;
     }
 
-    const module = await import(join(path, file));
+    const fileURL = pathToFileURL(join(path, file));
+    const module = await import(fileURL);
     const namedExports = Object.entries(module);
 
     for (const [exportName, exportedValue] of namedExports) {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment mis en place l'import automatique de tous les exports des fichier contenus dans un dossier. 
https://github.com/1024pix/pix/pull/6426

Cependant, celui-ci ne fonctionne pas sous windows : 
```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:387:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1017:11)
    at defaultResolve (node:internal/modules/esm/resolve:1097:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:841:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/esm/translators:110:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at importNamedExportsFromDir (file:///C:/Users/xavier-carron/OneDrive/Documents/projects/pix/api/lib/infrastructure/utils/import-named-exports-from-dir.js:14.33
```
## :robot: Proposition
Les paths que nous fournissons à la commande `import` ne sont pas de type URL `file:`. 
Ce qui fait que la class URL pense que `C:` est le protocole de l'URL, alors qu'en réalité celui-ci devrait être `file:`.

[La documentation de Node.js](https://nodejs.org/api/esm.html#file-urls) recommande d'utiliser `pathToFileURL` pour créer une URL de type `file:` 

## :rainbow: Remarques
On pourrait faire tourner la CI sous Windows pour détecter ce problème, mais cela n'arrive que très peu.

## :100: Pour tester

#### Bugfix
- Aller sur la branche en local sur un windows
- Confirmer le bon démarrage de l'API


#### Non-régression
Vérifier sur un Linux/Mac