### PR TITLE
[FEATURE] Utiliser le nouvel algorithme pour choisir les épreuves lors d'une certif v3 (PIX-8426)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -206,7 +206,7 @@ async function _getChallengeByAssessmentType({ assessment, request, dependencies
   }
 
   if (assessment.isCertification()) {
-    return dependencies.usecases.getNextChallengeForCertification({ assessment });
+    return dependencies.usecases.getNextChallengeForCertification({ assessment, locale });
   }
 
   if (assessment.isDemo()) {

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -1,13 +1,44 @@
-const getNextChallengeForCertification = function ({
-  certificationChallengeRepository,
-  challengeRepository,
+import { CertificationVersion } from '../models/CertificationVersion.js';
+import { FlashAssessmentAlgorithm } from '../models/index.js';
+
+const getNextChallengeForCertification = async function ({
+  algorithmDataFetcherService,
+  answerRepository,
   assessment,
+  certificationChallengeRepository,
+  certificationCourseRepository,
+  challengeRepository,
+  flashAssessmentResultRepository,
+  locale,
+  pickChallengeService,
 }) {
-  return certificationChallengeRepository
-    .getNextNonAnsweredChallengeByCourseId(assessment.id, assessment.certificationCourseId)
-    .then((certificationChallenge) => {
-      return challengeRepository.get(certificationChallenge.challengeId);
+  const certificationCourse = await certificationCourseRepository.get(assessment.certificationCourseId);
+
+  if (certificationCourse.getVersion() === CertificationVersion.V3) {
+    const { allAnswers, challenges, estimatedLevel } = await algorithmDataFetcherService.fetchForFlashCampaigns({
+      assessmentId: assessment.id,
+      answerRepository,
+      challengeRepository,
+      flashAssessmentResultRepository,
+      locale,
     });
+
+    const assessmentAlgorithm = new FlashAssessmentAlgorithm();
+
+    const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({
+      allAnswers,
+      challenges,
+      estimatedLevel,
+    });
+
+    return pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
+  } else {
+    return certificationChallengeRepository
+      .getNextNonAnsweredChallengeByCourseId(assessment.id, assessment.certificationCourseId)
+      .then((certificationChallenge) => {
+        return challengeRepository.get(certificationChallenge.challengeId);
+      });
+  }
 };
 
 export { getNextChallengeForCertification };

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_spec.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_spec.js
@@ -1,0 +1,146 @@
+import {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+  learningContentBuilder,
+  knex,
+  sinon,
+} from '../../../test-helper.js';
+
+import { createServer } from '../../../../server.js';
+import { Assessment } from '../../../../lib/domain/models/Assessment.js';
+import { CertificationVersion } from '../../../../lib/domain/models/CertificationVersion.js';
+
+const competenceId = 'recCompetence';
+const skillWeb1Id = 'recAcquisWeb1';
+const skillWeb2Id = 'recAcquisWeb2';
+const skillWeb3Id = 'recAcquisWeb3';
+
+const firstChallengeId = 'recFirstChallenge';
+const secondChallengeId = 'recSecondChallenge';
+const thirdChallengeId = 'recThirdChallenge';
+const otherChallengeId = 'recOtherChallenge';
+
+const learningContent = [
+  {
+    id: 'recArea1',
+    title_i18n: {
+      fr: 'area1_Title',
+    },
+    color: 'someColor',
+    competences: [
+      {
+        id: competenceId,
+        name_i18n: {
+          fr: 'Mener une recherche et une veille d’information',
+        },
+        index: '1.1',
+        tubes: [
+          {
+            id: 'recTube0_0',
+            skills: [
+              {
+                id: skillWeb2Id,
+                nom: '@web2',
+                challenges: [{ id: firstChallengeId, alpha: 2.8, delta: 1.1, langues: ['Franco Français'] }],
+              },
+              {
+                id: skillWeb3Id,
+                nom: '@web3',
+                challenges: [{ id: secondChallengeId, langues: ['Franco Français'], alpha: -1.2, delta: 3.3 }],
+              },
+              {
+                id: skillWeb1Id,
+                nom: '@web1',
+                challenges: [
+                  { id: thirdChallengeId, alpha: -0.2, delta: 2.7, langues: ['Franco Français'] },
+                  { id: otherChallengeId, alpha: -0.2, delta: -0.4, langues: ['Franco Français'] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('Acceptance | API | assessment-controller-get-next-challenge-for-certification', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+    const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+    mockLearningContent(learningContentObjects);
+  });
+
+  describe('GET /api/assessments/:assessment_id/next', function () {
+    const assessmentId = 1;
+    const userId = 1234;
+
+    context('When passing a V3 certification session', function () {
+      context('When there is still challenges to answer', function () {
+        let clock;
+
+        beforeEach(async function () {
+          databaseBuilder.factory.buildUser({ id: userId });
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot: true }).id;
+          const sessionId = databaseBuilder.factory.buildSession({
+            certificationCenterId,
+            version: CertificationVersion.V3,
+          }).id;
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            isPublished: false,
+            version: CertificationVersion.V3,
+            userId,
+            sessionId,
+          }).id;
+          databaseBuilder.factory.buildAssessment({
+            id: assessmentId,
+            type: Assessment.types.CERTIFICATION,
+            certificationCourseId,
+            userId,
+            lastQuestionDate: new Date('2020-01-20'),
+            state: 'started',
+          });
+          databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
+          await databaseBuilder.commit();
+
+          clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+          });
+        });
+
+        afterEach(async function () {
+          clock.restore();
+        });
+
+        it('should return a challenge', async function () {
+          // given
+          const options = {
+            method: 'GET',
+            url: `/api/assessments/${assessmentId}/next`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          };
+
+          const lastQuestionDate = new Date();
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          const assessmentsInDb = await knex('assessments').where('id', assessmentId).first('lastQuestionDate');
+          expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
+          expect(response.result.data.id).to.be.oneOf([
+            firstChallengeId,
+            secondChallengeId,
+            thirdChallengeId,
+            otherChallengeId,
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -162,15 +162,26 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
 
       it('should call getNextChallengeForCertificationCourse in assessmentService', async function () {
         // given
+        const locale = FRENCH_SPOKEN;
         usecases.getNextChallengeForCertification.resolves();
 
         // when
-        await assessmentController.getNextChallenge({ params: { id: 12 } }, null, dependencies);
+        await assessmentController.getNextChallenge(
+          {
+            params: { id: 12 },
+            headers: {
+              'accept-language': locale,
+            },
+          },
+          null,
+          dependencies
+        );
 
         // then
         expect(usecases.getNextChallengeForCertification).to.have.been.calledOnce;
         expect(usecases.getNextChallengeForCertification).to.have.been.calledWith({
           assessment: certificationAssessment,
+          locale,
         });
       });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -1,54 +1,131 @@
-import { expect, sinon } from '../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { getNextChallengeForCertification } from '../../../../lib/domain/usecases/get-next-challenge-for-certification.js';
 import { Assessment } from '../../../../lib/domain/models/Assessment.js';
+import { CertificationVersion } from '../../../../lib/domain/models/CertificationVersion.js';
 
-describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', function () {
+describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', function () {
   describe('#getNextChallengeForCertification', function () {
-    let certificationChallengeRepository;
-    let challengeRepository;
+    context('for a v2 certification', function () {
+      let certificationChallengeRepository;
+      let challengeRepository;
+      let certificationCourseRepository;
 
-    beforeEach(function () {
-      certificationChallengeRepository = { getNextNonAnsweredChallengeByCourseId: sinon.stub().resolves() };
-      challengeRepository = { get: sinon.stub().resolves() };
-    });
-
-    it('should use the assessmentService to select the next CertificationChallenge', async function () {
-      // given
-      const nextChallenge = Symbol('nextChallenge');
-      const assessment = new Assessment({ id: 156, certificationCourseId: 54516 });
-
-      certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextChallenge);
-
-      // when
-      await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
-
-      // then
-      expect(certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId).to.have.been.calledWith(
-        156,
-        54516
-      );
-    });
-
-    it('should return the next Challenge', async function () {
-      // given
-      const challengeId = 15167432;
-      const nextChallengeToAnswer = Symbol('nextChallengeToAnswer');
-      const nextCertificationChallenge = { challengeId };
-      const assessment = new Assessment({ id: 156, courseId: 54516 });
-
-      certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
-      challengeRepository.get.resolves(nextChallengeToAnswer);
-
-      // when
-      const challenge = await getNextChallengeForCertification({
-        assessment,
-        certificationChallengeRepository,
-        challengeRepository,
+      beforeEach(function () {
+        certificationCourseRepository = { get: sinon.stub() };
+        certificationChallengeRepository = { getNextNonAnsweredChallengeByCourseId: sinon.stub().resolves() };
+        challengeRepository = { get: sinon.stub().resolves() };
       });
 
-      // then
-      expect(challenge).to.equal(nextChallengeToAnswer);
-      expect(challengeRepository.get).to.have.been.calledWith(challengeId);
+      it('should use the assessmentService to select the next CertificationChallenge', async function () {
+        // given
+        const nextChallenge = Symbol('nextChallenge');
+        const assessment = new Assessment({ id: 156, certificationCourseId: 54516 });
+        const certificationCourse = domainBuilder.buildCertificationCourse();
+
+        certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextChallenge);
+        certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(certificationCourse);
+
+        // when
+        await getNextChallengeForCertification({
+          assessment,
+          certificationChallengeRepository,
+          certificationCourseRepository,
+          challengeRepository,
+        });
+
+        // then
+        expect(certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId).to.have.been.calledWith(
+          156,
+          54516
+        );
+      });
+
+      it('should return the next Challenge', async function () {
+        // given
+        const challengeId = 15167432;
+        const nextChallengeToAnswer = Symbol('nextChallengeToAnswer');
+        const nextCertificationChallenge = { challengeId };
+        const assessment = new Assessment({ id: 156, courseId: 54516 });
+        const certificationCourse = domainBuilder.buildCertificationCourse();
+
+        certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
+        challengeRepository.get.resolves(nextChallengeToAnswer);
+        certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(certificationCourse);
+
+        // when
+        const challenge = await getNextChallengeForCertification({
+          assessment,
+          certificationChallengeRepository,
+          certificationCourseRepository,
+          challengeRepository,
+        });
+
+        // then
+        expect(challenge).to.equal(nextChallengeToAnswer);
+        expect(challengeRepository.get).to.have.been.calledWith(challengeId);
+      });
+    });
+
+    context('for a v3 certification', function () {
+      it('should return the next Challenge', async function () {
+        // given
+        const answerRepository = Symbol('AnswerRepository');
+        const challengeRepository = Symbol('ChallengeRepository');
+        const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
+        const nextChallengeToAnswer = domainBuilder.buildChallenge();
+        const v3CertificationCourse = domainBuilder.buildCertificationCourse({
+          version: CertificationVersion.V3,
+        });
+        const assessment = domainBuilder.buildAssessment();
+        const certificationCourseRepository = {
+          get: sinon.stub(),
+        };
+        const algorithmDataFetcherService = {
+          fetchForFlashCampaigns: sinon.stub(),
+        };
+        const pickChallengeService = {
+          chooseNextChallenge: sinon.stub(),
+        };
+        const locale = 'fr-FR';
+
+        certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(v3CertificationCourse);
+        algorithmDataFetcherService.fetchForFlashCampaigns
+          .withArgs({
+            answerRepository,
+            challengeRepository,
+            flashAssessmentResultRepository,
+            assessmentId: assessment.id,
+            locale,
+          })
+          .resolves({
+            allAnswers: [],
+            challenges: [nextChallengeToAnswer],
+            estimatedLevel: 0,
+          });
+
+        const chooseNextChallengeImpl = sinon.stub();
+        chooseNextChallengeImpl
+          .withArgs({
+            possibleChallenges: [nextChallengeToAnswer],
+          })
+          .returns(nextChallengeToAnswer);
+        pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
+
+        // when
+        const challenge = await getNextChallengeForCertification({
+          algorithmDataFetcherService,
+          assessment,
+          answerRepository,
+          challengeRepository,
+          flashAssessmentResultRepository,
+          pickChallengeService,
+          certificationCourseRepository,
+          locale,
+        });
+
+        // then
+        expect(challenge).to.equal(nextChallengeToAnswer);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une certification v3, le choix des épreuves se fait au fil des réponses du candidat.

## :robot: Proposition
Utiliser le nouvel algorithme pour choisir l'épreuve suivante en fonction des réponses précédentes du candidat

## :100: Pour tester
- créer une session dans pix certif pour un centre de certification taggué pilote nextGen
- inscrire un candidat à cette session
- se connecter à app avec un utilisateur certifiable
- cliquer sur le menu “Certification”
- entrer le numéro de la session créée en étape 1, puis les info perso du candidat inscrit en étape 2
- confirmer la présence du candidat depuis l’espace surveillant
- entrer le code d’accès à la session
- cliquer sur “Commencer mon test”

résultat : 
- la 1ère question est récupérée dynamiquement
