### PR TITLE
[TECH] Suppression des scripts `dev` des applis fronts

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
-    "dev": "ember serve",
     "lint": "run-p --continue-on-error 'lint:!(fix)'",
     "lint:fix": "run-p --continue-on-error lint:*:fix",
     "lint:hbs": "ember-template-lint .",

--- a/certif/package.json
+++ b/certif/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
-    "dev": "ember serve",
     "lint": "run-p --continue-on-error 'lint:!(fix)'",
     "lint:fix": "run-p --continue-on-error lint:*:fix",
     "lint:hbs": "ember-template-lint .",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -22,7 +22,6 @@
   },
   "scripts": {
     "clean": "rm -rf tmp dist node_modules",
-    "dev": "ember serve",
     "lint": "run-p --continue-on-error 'lint:!(fix|translations)'",
     "lint:fix": "run-p --continue-on-error 'lint:!(translations):fix'",
     "lint:hbs": "ember-template-lint .",

--- a/orga/package.json
+++ b/orga/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
-    "dev": "ember serve",
     "lint": "run-p --continue-on-error 'lint:!(fix|translations)'",
     "lint:fix": "run-p --continue-on-error 'lint:!(translations):fix'",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
## :unicorn: Problème
On propose des scripts `dev` dans nos fronts qui permettent de lancer un serveur de développement sans proxy vers un back en local. En théorie cela permettrait d'utiliser nos applis front sans serveur, **si** nos configurations `mirage` étaient totalement remplis. Malheureusement ce n'est pas le cas donc on a juste une grosse erreur dans le navigateur à l'initialisation.

De plus le nom `dev` porte à confusion car il est utilisé pour d'autres frameworks comme Nuxt que l'on utilise dans d'autres projets. Ember ne met pas ce nom en avant au contraire de `start`. Voir [le package.json généré par Ember à l'initialisation d'un projet (4.12.1)](https://github.com/ember-cli/ember-new-output/blob/v4.12.1/package.json).

## :robot: Proposition
Supprimer ce script `dev` de nos applis front.

## :rainbow: Remarques
RAS

## :100: Pour tester
Rien à faire