### PR TITLE
[FEATURE] Améliorer l'affichage des solutions des QROCm (PIX-6221).

### DIFF
--- a/mon-pix/app/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.hbs
@@ -1,4 +1,4 @@
-<div class="qrocm-solution-panel rounded-panel">
+<div class="qrocm-solution-panel qrocm-solution-panel--dep rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
     {{#each this.blocks as |block|}}
       {{#if block.text}}
@@ -44,7 +44,7 @@
             {{/if}}
           </div>
         {{else}}
-          <div class="correction-qrocm__answer-wrapper correction-qrocm__answer {{block.inputClass}}">
+          <div class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}">
             <PixInput
               class="correction-qrocm-answer__input"
               @value="{{block.answer}}"

--- a/mon-pix/app/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.hbs
@@ -1,4 +1,4 @@
-<div class="qrocm-solution-panel rounded-panel">
+<div class="qrocm-solution-panel qrocm-solution-panel--ind rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
     {{#each this.blocks as |block|}}
       {{#if block.showText}}
@@ -55,7 +55,7 @@
             </p>
           {{/if}}
         {{else}}
-          <div class="correction-qrocm__answer-wrapper correction-qrocm__answer {{block.inputClass}}">
+          <div class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}">
             <PixInput
               class="correction-qrocm-answer__input"
               @value="{{block.answer}}"

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -1,51 +1,26 @@
-.correction-qrocm {
-  &__text {
-    display: inline-block;
+.correction-qrocm__answer {
+  &--paragraph {
+    display: block;
     width: 100%;
   }
 
-  &__answer {
-
-    &-wrapper {
-      display: inline-block;
-      width: 100%;
-      vertical-align: top;
-    }
-
-    &--paragraph {
-      display: block;
-      width: 100%;
-    }
-
-    &--sentence {
-      display: block;
-      width: 100%;
-    }
-
-    &--input {
-      display: inline-block;
-      width: auto;
-      max-width: 100%;
-    }
-  }
-
-  &__solution {
-    display: flex;
-    align-items: center;
-
-    &-text {
-      @extend %pix-body-m;
-
-      margin: $pix-spacing-xxs 0 $pix-spacing-xs;
-      color: $pix-success-70;
-      font-weight: $font-bold;
-    }
-  }
-}
-
-.correction-qrocm-text {
-  &__label {
+  &--sentence {
     display: block;
+    width: 100%;
+  }
+
+  &--input {
+    display: inline-block;
+    padding: $pix-spacing-xxs $pix-spacing-xxs $pix-spacing-xxs 0;
+    vertical-align: 0;
+
+    &:not(:last-child) {
+      padding-left: 0;
+    }
+  }
+
+  &.correction-qroc-box-answer--wrong {
+    vertical-align: -2.5em;
   }
 }
 
@@ -55,14 +30,42 @@
     width: 100%;
   }
 
-  &__input-sentence {
+  &-answer__input-sentence {
     display: block;
     width: 100%;
   }
 
-  &__input {
+  &-answer__input {
     display: inline-block;
     width: auto;
     max-width: 100%;
+  }
+}
+
+.correction-qrocm__text {
+  padding-inline: 12px;
+}
+
+.correction-qrocm-text {
+  &__label {
+    display: inline;
+    padding: $pix-spacing-xxs $pix-spacing-xxs $pix-spacing-xxs 0;
+
+    &:not(:last-child) {
+      padding-left: 0;
+    }
+  }
+}
+
+.correction-qrocm__solution {
+  display: flex;
+  align-items: center;
+
+  &-text {
+    @extend %pix-body-m;
+
+    margin: $pix-spacing-xxs 0 $pix-spacing-xs;
+    color: $pix-success-70;
+    font-weight: $font-bold;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Sur l'écran réponse, des passages à la ligne suite à chaque champ réponse des QROCM ce qui rend la lecture compliquée.

<img width="822" alt="image" src="https://github.com/1024pix/pix/assets/7335131/e7a733f9-471a-473f-96cb-9d1dcd9fc30c">


## :robot: Proposition

<img width="822" alt="image" src="https://github.com/1024pix/pix/assets/7335131/a5d45c82-6920-4e8a-bbca-fded8d77ae89">

- ne pas revenir à la ligne à chaque champ réponse
- espacement de la taille de la correction (ne pas coller la suite de la phrase au champ réponse. Ex : 

## :100: Pour tester

Visiter ces épreuves pour vérifier le style des solutions :

- https://app-pr6447.review.pix.fr/challenges/rec22pH8nuM16u6Is/preview
- https://app-pr6447.review.pix.fr/challenges/challenge2CMbKqOFeZvbjp/preview
- https://app-pr6447.review.pix.fr/challenges/challenge28kwuFJjZlaJs8/preview
- https://app-pr6447.review.pix.fr/challenges/challengeZVBoM4yUQAX3F/preview
