### PR TITLE
[FEATURE] Ajouter un aria-label sur les liens d'aide sur les épreuves sur Pix-App (PIX-8076)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -583,7 +583,7 @@
           },
           "description": "Pix lets you choose which format of file to download. If you do not know which option to use, select the default option. This is the file format that is the most commonly used.",
           "file-type": "file .{fileExtension}",
-          "help": "Need help to '<a href=\"https://support.pix.org/en/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\">'open, edit or find this file'</a>'?"
+          "help": "Need help to '<a href=\"https://support.pix.org/en/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, edit or find this file (opens in new window)\">'open, edit or find this file'</a>'?"
         },
         "tooltip": {
           "aria-label": "Show question's warning",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -583,7 +583,7 @@
           },
           "description": "Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.",
           "file-type": "fichier .{fileExtension}",
-          "help": "Besoin d'aide pour '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\">'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
+          "help": "Besoin d'aide pour '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"ouvrir, modifier ou retrouver ce fichier (ouverture dans une nouvelle fenêtre)\">'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
         },
         "tooltip": {
           "aria-label": "Afficher l'indication sur l'épreuve.",


### PR DESCRIPTION
## :unicorn: Problème
Sur les épreuves, seule l'icône indique que le lien va ouvrir une nouvelle fenêtre.
![image](https://github.com/1024pix/pix/assets/49011144/155e1bfc-479a-4982-9937-741da90086d6)

## :robot: Proposition
En texte masqué, rajouter "ouverture dans une nouvelle fenêtre" pour les utilisateurs de technologies d'assistance.

## :100: Pour tester
Aller sur une [épreuve avec un lien externe](https://app-pr6448.review.pix.fr/challenges/rec1hsuXNnNsB3xCx/preview) et vérifier la présence du texte masqué.
