### PR TITLE
[FEATURE] Ajout d'une modale de confirmation quand on détache une orga d'un profil cible (PIX-7030)

### DIFF
--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -66,16 +66,12 @@
               <td>{{organization.name}}</td>
               <td>{{organization.type}}</td>
               <td>{{organization.externalId}}</td>
-              {{#if @showDetachColumn}}
+              {{#if this.isSuperAdminOrMetier}}
                 <td>
-                  <PixButton
-                    @backgroundColor="red"
-                    @size="small"
-                    aria-label="Détacher l'organisation"
-                    @triggerAction={{fn @detachOrganizations organization.id}}
-                  >
+                  <PixButton @backgroundColor="red" @size="small" @triggerAction={{(fn this.openModal organization)}}>
                     Détacher
                   </PixButton>
+
                 </td>
               {{/if}}
             </tr>
@@ -93,3 +89,29 @@
 {{#if @organizations}}
   <PixPagination @pagination={{@organizations.meta}} />
 {{/if}}
+
+<PixModal
+  @title="Détacher l'organisation du profil cible"
+  @onCloseButtonClick={{this.closeModal}}
+  @showModal={{this.showModal}}
+  aria-hidden="{{(not this.showModal)}}"
+>
+  <:content>
+    <p>
+      Etes-vous sûr de vouloir détacher l'organisation
+      <strong>{{this.organizationToDetach.name}}</strong>
+      du profil cible
+      <strong>{{@targetProfileName}}</strong>
+      ?
+    </p>
+  </:content>
+  <:footer>
+    <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.closeModal}}>
+      Annuler
+    </PixButton>
+    <PixButton
+      @backgroundColor="red"
+      @triggerAction={{fn this.detachOrganizations this.organizationToDetach.id}}
+    >Confirmer</PixButton>
+  </:footer>
+</PixModal>

--- a/admin/app/components/organizations/list-items.js
+++ b/admin/app/components/organizations/list-items.js
@@ -1,0 +1,34 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+export default class ActionsOnUsersRoleInOrganization extends Component {
+  @service notifications;
+  @service currentUser;
+
+  @tracked showModal = false;
+  @tracked organizationToDetach;
+
+  get isSuperAdminOrMetier() {
+    return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
+  }
+
+  @action
+  openModal(organization) {
+    this.showModal = true;
+    this.organizationToDetach = organization;
+  }
+
+  @action
+  closeModal() {
+    this.showModal = false;
+    this.organizationToDetach = null;
+  }
+
+  @action
+  async detachOrganizations(organizationId) {
+    await this.args.detachOrganizations(organizationId);
+    this.closeModal();
+  }
+}

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -60,6 +60,6 @@
     @triggerFiltering={{@triggerFiltering}}
     @goToOrganizationPage={{@goToOrganizationPage}}
     @detachOrganizations={{@detachOrganizations}}
-    @showDetachColumn={{true}}
+    @targetProfileName={{@targetProfile.name}}
   />
 </section>

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items_test.js
@@ -7,6 +7,8 @@ module('Integration | Component | routes/authenticated/organizations | list-item
   setupRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
     const triggerFiltering = function () {};
     this.triggerFiltering = triggerFiltering;
   });

--- a/admin/tests/integration/components/target-profiles/organizations_test.js
+++ b/admin/tests/integration/components/target-profiles/organizations_test.js
@@ -8,6 +8,8 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
     this.triggerFiltering = () => {};
     this.goToOrganizationPage = () => {};
     this.detachOrganizations = () => {};


### PR DESCRIPTION
## :unicorn: Problème
Suite de cette [PR](https://github.com/1024pix/pix/pull/6260), maintenant que nous avons rendu possible le détachement une organisation d'un profil cible. Il faut ajouter une modale de confirmation reprenant les infos de l'organisation et du profil cible.

## :robot: Proposition
Ajout d'une PixModal

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Admin ( avec un compte SuperAdmin ou Métier ) 
- Aller sur la page d'un profil cible
- Aller sur l'onglet organisation
- Cliquer sur "Détacher" 
- Vérifier que la modale s'ouvre bien, que les informations de l'orga concernée ainsi que le profil cible apparaissent bien dans le texte et que tous les boutons soient fonctionnel
-  Se connecter maintenant avec un compte Support
- Vérifier que le bouton "Détacher" cette fois n'apparait plus
- 🐱 
