### PR TITLE
[FEATURE] Afficher les résultats thématiques en lacunes lorsqu'ils sont certifiantes ou non (PIX-8438)

### DIFF
--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -177,6 +177,7 @@ function _createProfessionalBasicsBadge(databaseBuilder) {
     key: 'Pro Basics',
     message: 'Bravo ! Vous maîtrisez quelques bases  du numérique pour le monde professionnel !',
     targetProfileId: TARGET_PROFILE_ONE_COMPETENCE_ID,
+    isAlwaysVisible: true,
   });
 
   _associateBadgeCriteria(databaseBuilder, basicsBadge, []);

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -127,7 +127,7 @@
                   {{/if}}
                   {{#if this.showNotCertifiableBadges}}
                     <div class="skill-review-share-badge-icons skill-review-share-badge-icons--not-certifiable">
-                      {{#each this.acquiredNotCertifiableBadges as |badge|}}
+                      {{#each this.notCertifiableBadges as |badge|}}
                         <PixTooltip @position="top" @isInline={{true}} @id="tooltip-{{badge.key}}">
                           <:triggerElement>
                             <a href="#{{badge.title}}">
@@ -247,7 +247,7 @@
         {{t "pages.skill-review.badges-title"}}
       </h2>
       <div class="badge-container">
-        {{#each this.acquiredNotCertifiableBadges as |badge|}}
+        {{#each this.notCertifiableBadges as |badge|}}
           <BadgeCard
             @title={{badge.title}}
             @message={{badge.message}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -42,16 +42,16 @@ export default class SkillReview extends Component {
   }
 
   get showNotCertifiableBadges() {
-    return this.acquiredNotCertifiableBadges.length > 0;
+    return this.notCertifiableBadges.length > 0;
   }
 
   get showCertifiableBadges() {
     return this.certifiableBadgesOrderedByValidity.length > 0;
   }
 
-  get acquiredNotCertifiableBadges() {
+  get notCertifiableBadges() {
     const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
-    return badges.filter((badge) => badge.isAcquired && !badge.isCertifiable);
+    return badges.filter((badge) => (badge.isAcquired || badge.isAlwaysVisible) && !badge.isCertifiable);
   }
 
   get certifiableBadgesOrderedByValidity() {

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -153,7 +153,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
         assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.badges-title')));
       });
 
-      test('should display acquired badges', async function (assert) {
+      test('should display acquired and isAlwaysVisible badges', async function (assert) {
         // given
         const acquiredBadge = server.create('campaign-participation-badge', {
           altMessage: 'Yon won a Yellow badge',
@@ -189,7 +189,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        assert.strictEqual(findAll('.badge-card').length, 1);
+        assert.strictEqual(findAll('.badge-card').length, 2);
       });
 
       module('when campaign has stages', function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -338,20 +338,22 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
     });
   });
 
-  module('#acquiredNotCertifiableBadges', function () {
+  module('#notCertifiableBadges', function () {
     test('should only return acquired and not certifiable badges', function (assert) {
       // given
       component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
 
       // when
-      const acquiredBadges = component.acquiredNotCertifiableBadges;
+      const notCertifiableBadges = component.notCertifiableBadges;
 
       // then
-      assert.deepEqual(acquiredBadges, [
+      assert.deepEqual(notCertifiableBadges, [
         { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
         { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
         { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
         { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+        { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+        { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
       ]);
     });
   });

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -298,20 +298,22 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     });
   });
 
-  module('#acquiredNotCertifiableBadges', function () {
+  module('#notCertifiableBadges', function () {
     test('should only return acquired and not certifiable badges', function (assert) {
       // given
       component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
 
       // when
-      const acquiredBadges = component.acquiredNotCertifiableBadges;
+      const notCertifiableBadges = component.notCertifiableBadges;
 
       // then
-      assert.deepEqual(acquiredBadges, [
+      assert.deepEqual(notCertifiableBadges, [
         { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
         { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
         { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
         { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+        { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+        { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
       ]);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Les résultats thématiques en lacunes s'affichent lorsqu'ils sont seulement certifiants.

## :robot: Proposition
Changer la condition d'affichage pour permettre de visualiser les résultats thématiques en lacunes quand ils sont certifiants ou non.

## :100: Pour tester
Se connecter avec `jaune.attend@example.net` et aller sur la campagne `PROCOMP51`.
Visualiser les résultats thématiques acquis et en lacune.
