### PR TITLE
[TECH] Ajouter des tests au prehandler assessment-authorization (PIX-8022).

### DIFF
--- a/api/tests/unit/application/preHandlers/assessment-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/assessment-authorization_test.js
@@ -1,0 +1,98 @@
+import { expect, sinon, hFake } from '../../../test-helper.js';
+import { assessmentAuthorization } from '../../../../lib/application/preHandlers/assessment-authorization.js';
+
+describe('Unit | Pre-handler | Assessment Authorization', function () {
+  let assessmentRepository;
+  let requestResponseUtils;
+  let validationErrorSerializer;
+
+  beforeEach(function () {
+    assessmentRepository = {
+      getByAssessmentIdAndUserId: sinon.stub(),
+    };
+    requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
+    validationErrorSerializer = {
+      serialize: sinon.stub(),
+    };
+  });
+
+  describe('#verify', function () {
+    describe('When user is the owner of the assessment', function () {
+      it('should return the assessment', async function () {
+        // given
+        const request = {
+          headers: { authorization: 'VALID_TOKEN' },
+          params: {
+            id: 8,
+          },
+        };
+        const fetchedAssessment = {};
+        const extractedUserId = 100;
+        requestResponseUtils.extractUserIdFromRequest.returns(extractedUserId);
+        assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
+
+        // when
+        const response = await assessmentAuthorization.verify(request, hFake, {
+          requestResponseUtils,
+          assessmentRepository,
+          validationErrorSerializer,
+        });
+
+        // then
+        sinon.assert.calledWith(assessmentRepository.getByAssessmentIdAndUserId, 8, 100);
+        expect(response).to.deep.equal({});
+      });
+    });
+
+    describe('When the assessment has no owner', function () {
+      it('should return the assessment', async function () {
+        // given
+        const request = {
+          headers: { authorization: 'VALID_TOKEN' },
+          params: {
+            id: 8,
+          },
+        };
+        const fetchedAssessment = {};
+        const extractedUserId = null;
+        requestResponseUtils.extractUserIdFromRequest.returns(extractedUserId);
+        assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
+
+        // when
+        const response = await assessmentAuthorization.verify(request, hFake, {
+          requestResponseUtils,
+          assessmentRepository,
+          validationErrorSerializer,
+        });
+
+        // then
+        sinon.assert.calledWith(assessmentRepository.getByAssessmentIdAndUserId, 8, null);
+        expect(response).to.deep.equal({});
+      });
+    });
+
+    describe('When user is not the owner of the assessment', function () {
+      it('should return a status 401', async function () {
+        // given
+        const request = {
+          params: {
+            id: 8,
+          },
+        };
+        const extractedUserId = 101;
+        requestResponseUtils.extractUserIdFromRequest.returns(extractedUserId);
+        assessmentRepository.getByAssessmentIdAndUserId.rejects();
+
+        // when
+        const response = await assessmentAuthorization.verify(request, hFake, {
+          requestResponseUtils,
+          assessmentRepository,
+          validationErrorSerializer,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite à la prigration de l'API en ESM, des tests ont été supprimés. Il n'existe pas de test sur le prehandler d'autorisation d'accès aux assessment.

## :robot: Proposition
Mettre en place des tests sur ce prehandler

## :100: Pour tester
Pas de test fonctionnel, l'ensemble des tests automatiques doit passer.