### PR TITLE
[TECH] Utiliser les nouveaux imports de services dans Ember.js

### DIFF
--- a/1d/app/pods/assessment/challenge/route.js
+++ b/1d/app/pods/assessment/challenge/route.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
   @service router;
   @service store;
+
   async model(params, transition) {
     const assessment = await this.modelFor('assessment');
     let challenge;

--- a/1d/app/pods/assessment/resume/route.js
+++ b/1d/app/pods/assessment/resume/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResumeRoute extends Route {
   @service router;

--- a/1d/app/pods/assessment/route.js
+++ b/1d/app/pods/assessment/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AssessmentsRoute extends Route {
   @service store;

--- a/1d/app/pods/challenge-preview/route.js
+++ b/1d/app/pods/challenge-preview/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengePreviewRoute extends Route {
   @service router;

--- a/1d/app/pods/components/challenge/item/component.js
+++ b/1d/app/pods/components/challenge/item/component.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/1d/app/pods/mission/resume/route.js
+++ b/1d/app/pods/mission/resume/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionRoute extends Route {
   @service router;

--- a/1d/app/pods/mission/route.js
+++ b/1d/app/pods/mission/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionRoute extends Route {
   @service store;

--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -1,5 +1,5 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-admin/config/environment';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {

--- a/admin/app/components/actions-on-users-role-in-organization.js
+++ b/admin/app/components/actions-on-users-role-in-organization.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ActionsOnUsersRoleInOrganization extends Component {
   @service notifications;

--- a/admin/app/components/administration/learning-content.js
+++ b/admin/app/components/administration/learning-content.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LearningContent extends Component {
   @service notifications;

--- a/admin/app/components/administration/organizations-import.js
+++ b/admin/app/components/administration/organizations-import.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationsImport extends Component {
   @service intl;

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Badge extends Component {
   @service notifications;

--- a/admin/app/components/campaigns/details.js
+++ b/admin/app/components/campaigns/details.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Details extends Component {
   @service accessControl;

--- a/admin/app/components/campaigns/participation-row.js
+++ b/admin/app/components/campaigns/participation-row.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ParticipationRow extends Component {
   @service notifications;

--- a/admin/app/components/campaigns/participations-section.js
+++ b/admin/app/components/campaigns/participations-section.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ParticipationsSection extends Component {
   @service accessControl;

--- a/admin/app/components/campaigns/update.js
+++ b/admin/app/components/campaigns/update.js
@@ -3,7 +3,7 @@ import Object, { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { getOwner } from '@ember/application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const Validations = buildValidations({
   name: {

--- a/admin/app/components/certifications/issue-report.js
+++ b/admin/app/components/certifications/issue-report.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationIssueReport extends Component {
   @service notifications;

--- a/admin/app/components/common/tubes-selection.js
+++ b/admin/app/components/common/tubes-selection.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { A as EmberArray } from '@ember/array';
 

--- a/admin/app/components/login-form.js
+++ b/admin/app/components/login-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'pix-admin/config/environment';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/components/menu-bar.js
+++ b/admin/app/components/menu-bar.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class MenuBar extends Component {

--- a/admin/app/components/organizations/all-tags.js
+++ b/admin/app/components/organizations/all-tags.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-admin/config/environment';
 
 export default class OrganizationAllTags extends Component {

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -1,5 +1,5 @@
 import Object, { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/admin/app/components/organizations/information-section-view.js
+++ b/admin/app/components/organizations/information-section-view.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import ENV from 'pix-admin/config/environment';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationInformationSection extends Component {
   @service oidcIdentityProviders;

--- a/admin/app/components/organizations/information-section.js
+++ b/admin/app/components/organizations/information-section.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/organizations/invitations.js
+++ b/admin/app/components/organizations/invitations.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationInvitations extends Component {
   @service accessControl;

--- a/admin/app/components/organizations/places-lot-creation-form.js
+++ b/admin/app/components/organizations/places-lot-creation-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';

--- a/admin/app/components/organizations/places.js
+++ b/admin/app/components/organizations/places.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/organizations/places/delete-modal.js
+++ b/admin/app/components/organizations/places/delete-modal.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DeleteModal extends Component {
   @service notifications;

--- a/admin/app/components/organizations/places/list.js
+++ b/admin/app/components/organizations/places/list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class List extends Component {
   @service accessControl;

--- a/admin/app/components/organizations/target-profiles-section.js
+++ b/admin/app/components/organizations/target-profiles-section.js
@@ -1,6 +1,6 @@
 import uniq from 'lodash/uniq';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 

--- a/admin/app/components/organizations/team-section.js
+++ b/admin/app/components/organizations/team-section.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationTeamSection extends Component {
   @service accessControl;

--- a/admin/app/components/sessions/jury-comment.js
+++ b/admin/app/components/sessions/jury-comment.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import noop from 'lodash/noop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class JuryComment extends Component {
   @service accessControl;

--- a/admin/app/components/stages/update-stage.js
+++ b/admin/app/components/stages/update-stage.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isInteger from 'lodash/isInteger';
 
 export default class UpdateStage extends Component {

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class BadgeForm extends Component {
   @service notifications;

--- a/admin/app/components/target-profiles/badge-form/criteria.js
+++ b/admin/app/components/target-profiles/badge-form/criteria.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Criteria extends Component {
   @service store;

--- a/admin/app/components/target-profiles/badges.js
+++ b/admin/app/components/target-profiles/badges.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/target-profiles/create-target-profile-form.js
+++ b/admin/app/components/target-profiles/create-target-profile-form.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { optionsCategoryList } from '../../models/target-profile';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/target-profiles/organizations.js
+++ b/admin/app/components/target-profiles/organizations.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import uniq from 'lodash/uniq';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -1,7 +1,7 @@
 import difference from 'lodash/difference';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const LEVEL_COLUMN_NAME = 'Niveau';

--- a/admin/app/components/target-profiles/target-profile.js
+++ b/admin/app/components/target-profiles/target-profile.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class TargetProfile extends Component {
   @service notifications;
 

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -2,7 +2,7 @@ import Object, { action } from '@ember/object';
 import { buildValidations, validator } from 'ember-cp-validations';
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { optionsCategoryList } from '../../models/target-profile';
 

--- a/admin/app/components/team/add-member.js
+++ b/admin/app/components/team/add-member.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmailValid from '../../utils/email-validator';
 
 export default class AddMember extends Component {

--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class List extends Component {

--- a/admin/app/components/to-be-published-sessions/list-items.js
+++ b/admin/app/components/to-be-published-sessions/list-items.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ToBePublishedSessionsList extends Component {
   @service accessControl;

--- a/admin/app/components/tools/new-tag.js
+++ b/admin/app/components/tools/new-tag.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class NewTag extends Component {

--- a/admin/app/components/trainings/create-or-update-training-form.js
+++ b/admin/app/components/trainings/create-or-update-training-form.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { optionsLocaleList, optionsTypeList } from '../../models/training';
 import { tracked } from '@glimmer/tracking';
 import set from 'lodash/set';

--- a/admin/app/components/trainings/trigger/details.js
+++ b/admin/app/components/trainings/trigger/details.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Details extends Component {
   @service store;

--- a/admin/app/components/users/campaign-participations.js
+++ b/admin/app/components/users/campaign-participations.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CampaignParticipation extends Component {

--- a/admin/app/components/users/certification-center-memberships.js
+++ b/admin/app/components/users/certification-center-memberships.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationCenterMemberships extends Component {
   @service notifications;

--- a/admin/app/components/users/user-detail-personal-information.js
+++ b/admin/app/components/users/user-detail-personal-information.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticationMethod extends Component {
   @service notifications;

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.js
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationLearnerInformation extends Component {
   @service accessControl;

--- a/admin/app/components/users/user-organization-memberships.js
+++ b/admin/app/components/users/user-organization-memberships.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserOrganizationMemberships extends Component {
   @service accessControl;

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -5,7 +5,7 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { getOwner } from '@ember/application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import dayjs from 'dayjs';
 
 import ENV from 'pix-admin/config/environment';

--- a/admin/app/controllers/authenticated/campaigns/campaign/participations.js
+++ b/admin/app/controllers/authenticated/campaigns/campaign/participations.js
@@ -1,7 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { types } from '../../../models/certification-center';
 

--- a/admin/app/controllers/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/invitations.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import isEmailValid from '../../../../utils/email-validator';
 

--- a/admin/app/controllers/authenticated/certification-centers/get/team.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/team.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmailValid from '../../../../utils/email-validator';
 import { tracked } from '@glimmer/tracking';
 

--- a/admin/app/controllers/authenticated/certification-centers/new.js
+++ b/admin/app/controllers/authenticated/certification-centers/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class NewController extends Controller {

--- a/admin/app/controllers/authenticated/certifications.js
+++ b/admin/app/controllers/authenticated/certifications.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import trim from 'lodash/trim';
 

--- a/admin/app/controllers/authenticated/certifications/certification/details.js
+++ b/admin/app/controllers/authenticated/certifications/certification/details.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -4,7 +4,7 @@ import Controller from '@ember/controller';
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 /* eslint-enable ember/no-computed-properties-in-native-classes */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { schedule } from '@ember/runloop';
 import cloneDeep from 'lodash/cloneDeep';
 import find from 'lodash/find';

--- a/admin/app/controllers/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/controllers/authenticated/certifications/certification/neutralization.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action, set } from '@ember/object';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NeutralizationController extends Controller {
   @alias('model') certificationDetails;

--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import get from 'lodash/get';
 

--- a/admin/app/controllers/authenticated/organizations/get/invitations.js
+++ b/admin/app/controllers/authenticated/organizations/get/invitations.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
 import isEmailValid from '../../../../utils/email-validator';

--- a/admin/app/controllers/authenticated/organizations/get/places/new.js
+++ b/admin/app/controllers/authenticated/organizations/get/places/new.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class New extends Controller {

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import debounce from 'lodash/debounce';
 import config from 'pix-admin/config/environment';
 

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class NewController extends Controller {

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';

--- a/admin/app/controllers/authenticated/sessions/session.js
+++ b/admin/app/controllers/authenticated/sessions/session.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import trim from 'lodash/trim';
 

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -1,6 +1,6 @@
 import some from 'lodash/some';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';

--- a/admin/app/controllers/authenticated/target-profiles/new.js
+++ b/admin/app/controllers/authenticated/target-profiles/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class NewController extends Controller {

--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class TargetProfileController extends Controller {

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/badges/badge.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/badges/badge.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class BadgeController extends Controller {

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
 import debounce from 'lodash/debounce';
 import config from 'pix-admin/config/environment';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 

--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ToolsController extends Controller {

--- a/admin/app/controllers/authenticated/trainings/list.js
+++ b/admin/app/controllers/authenticated/trainings/list.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import debounce from 'lodash/debounce';
 import config from 'pix-admin/config/environment';

--- a/admin/app/controllers/authenticated/trainings/new.js
+++ b/admin/app/controllers/authenticated/trainings/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class NewController extends Controller {

--- a/admin/app/controllers/authenticated/trainings/training.js
+++ b/admin/app/controllers/authenticated/trainings/training.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class Training extends Controller {

--- a/admin/app/controllers/authenticated/trainings/training/target-profiles.js
+++ b/admin/app/controllers/authenticated/trainings/training/target-profiles.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import uniq from 'lodash/uniq';
 

--- a/admin/app/controllers/authenticated/trainings/training/triggers.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class TrainingDetailsTriggersController extends Controller {

--- a/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class TrainingEditTriggersController extends Controller {

--- a/admin/app/controllers/authenticated/users/get/campaign-participations.js
+++ b/admin/app/controllers/authenticated/users/get/campaign-participations.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserCampaignParticipationsController extends Controller {
   @service notifications;

--- a/admin/app/controllers/authenticated/users/get/information.js
+++ b/admin/app/controllers/authenticated/users/get/information.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserInformationController extends Controller {
   @service notifications;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -1,7 +1,7 @@
 import { memberAction } from 'ember-api-actions';
 import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import ENV from 'pix-admin/config/environment';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import formatList from '../utils/format-select-options';
 
 export const categories = {

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 const defaultLocale = 'fr';

--- a/admin/app/routes/authenticated.js
+++ b/admin/app/routes/authenticated.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
   @service session;

--- a/admin/app/routes/authenticated/administration.js
+++ b/admin/app/routes/authenticated/administration.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AdministrationRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/campaigns/campaign.js
+++ b/admin/app/routes/authenticated/campaigns/campaign.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class GetRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/campaigns/campaign/participations.js
+++ b/admin/app/routes/authenticated/campaigns/campaign/participations.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CampaignParticipationsRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -1,7 +1,8 @@
 import RSVP from 'rsvp';
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class CertificationCentersGetRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/invitations.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetInvitationsRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/certification-centers/get/team.js
+++ b/admin/app/routes/authenticated/certification-centers/get/team.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetTeamRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/certification-centers/index.js
+++ b/admin/app/routes/authenticated/certification-centers/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/admin/app/routes/authenticated/certification-centers/list.js
+++ b/admin/app/routes/authenticated/certification-centers/list.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class ListRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/certification-centers/new.js
+++ b/admin/app/routes/authenticated/certification-centers/new.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NewRoute extends Route {
   @service store;
+
   model() {
     return RSVP.hash({
       certificationCenter: this.store.createRecord('certification-center'),

--- a/admin/app/routes/authenticated/certifications.js
+++ b/admin/app/routes/authenticated/certifications.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationsRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/certifications/certification.js
+++ b/admin/app/routes/authenticated/certifications/certification.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationRoute extends Route {
   @service errorNotifier;

--- a/admin/app/routes/authenticated/certifications/certification/details.js
+++ b/admin/app/routes/authenticated/certifications/certification/details.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class CertificationDetailsRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/certifications/certification/informations.js
+++ b/admin/app/routes/authenticated/certifications/certification/informations.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import RSVP from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class CertificationInformationsRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/routes/authenticated/certifications/certification/neutralization.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class CertificationNeutralizationRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/certifications/certification/profile.js
+++ b/admin/app/routes/authenticated/certifications/certification/profile.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class AuthenticatedCertificationsCertificationProfileRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/index.js
+++ b/admin/app/routes/authenticated/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/admin/app/routes/authenticated/organizations/get.js
+++ b/admin/app/routes/authenticated/organizations/get.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class GetRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/organizations/get/all-tags.js
+++ b/admin/app/routes/authenticated/organizations/get/all-tags.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import sortBy from 'lodash/sortBy';
 import map from 'lodash/map';
 

--- a/admin/app/routes/authenticated/organizations/get/campaigns.js
+++ b/admin/app/routes/authenticated/organizations/get/campaigns.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class OrganizationCampaignsRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/organizations/get/invitations.js
+++ b/admin/app/routes/authenticated/organizations/get/invitations.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class InvitationsRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/organizations/get/places/list.js
+++ b/admin/app/routes/authenticated/organizations/get/places/list.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
 export default class Places extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/organizations/get/places/new.js
+++ b/admin/app/routes/authenticated/organizations/get/places/new.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class New extends Route {
   @service accessControl;
   @service store;

--- a/admin/app/routes/authenticated/organizations/get/team.js
+++ b/admin/app/routes/authenticated/organizations/get/team.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationTeamRoute extends Route {
   @service router;

--- a/admin/app/routes/authenticated/organizations/index.js
+++ b/admin/app/routes/authenticated/organizations/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class IndexRoute extends Route {
   @service router;
 

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class ListRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class NewRoute extends Route {
   @service store;
   @service accessControl;

--- a/admin/app/routes/authenticated/sessions/index.js
+++ b/admin/app/routes/authenticated/sessions/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class AuthenticatedSessionsRoute extends Route {
   @service router;
 

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class AuthenticatedSessionsListRoute extends Route {
   @service store;
 

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { FINALIZED } from 'pix-admin/models/session';
 import trim from 'lodash/trim';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedSessionsAllRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/routes/authenticated/sessions/list/to-be-published.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedSessionsListToBePublishedRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/sessions/session.js
+++ b/admin/app/routes/authenticated/sessions/session.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionRoute extends Route {
   @service errorNotifier;

--- a/admin/app/routes/authenticated/target-profiles/index.js
+++ b/admin/app/routes/authenticated/target-profiles/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class IndexRoute extends Route {
   @service router;
 

--- a/admin/app/routes/authenticated/target-profiles/list.js
+++ b/admin/app/routes/authenticated/target-profiles/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmpty from 'lodash/isEmpty';
 
 export default class ListRoute extends Route {

--- a/admin/app/routes/authenticated/target-profiles/new.js
+++ b/admin/app/routes/authenticated/target-profiles/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NewRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/target-profiles/target-profile.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TargetProfileRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/badges/badge.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/badges/badge.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class BadgeRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/details.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/details.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TargetProfileDetailsRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/index.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class IndexRoute extends Route {
   @service router;
 

--- a/admin/app/routes/authenticated/target-profiles/target-profile/insights.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/insights.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TargetProfileInsightsRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TargetProfileOrganizationsRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/stages/stage.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/stages/stage.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StageRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/training-summaries.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/training-summaries.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmpty from 'lodash/isEmpty';
 
 export default class TargetProfileTrainingsRoute extends Route {

--- a/admin/app/routes/authenticated/team/list.js
+++ b/admin/app/routes/authenticated/team/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/tools.js
+++ b/admin/app/routes/authenticated/tools.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ToolsRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/trainings/index.js
+++ b/admin/app/routes/authenticated/trainings/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/admin/app/routes/authenticated/trainings/list.js
+++ b/admin/app/routes/authenticated/trainings/list.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import isEmpty from 'lodash/isEmpty';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service accessControl;

--- a/admin/app/routes/authenticated/trainings/new.js
+++ b/admin/app/routes/authenticated/trainings/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NewRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/trainings/training.js
+++ b/admin/app/routes/authenticated/trainings/training.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TrainingRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/trainings/training/index.js
+++ b/admin/app/routes/authenticated/trainings/training/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/admin/app/routes/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/routes/authenticated/trainings/training/triggers/edit.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class EditTriggerRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/users/get.js
+++ b/admin/app/routes/authenticated/users/get.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedUsersGetRoute extends Route {
   @service store;

--- a/admin/app/routes/authenticated/users/index.js
+++ b/admin/app/routes/authenticated/users/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service store;

--- a/admin/app/routes/login.js
+++ b/admin/app/routes/login.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;

--- a/admin/app/routes/logout.js
+++ b/admin/app/routes/logout.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class LogoutRoute extends Route {

--- a/admin/app/serializers/certification-details.js
+++ b/admin/app/serializers/certification-details.js
@@ -1,5 +1,5 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationDetails extends JSONAPISerializer {
   @service featureToggles;

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AccessControlService extends Service {
   @service currentUser;

--- a/admin/app/services/error-notifier.js
+++ b/admin/app/services/error-notifier.js
@@ -1,7 +1,7 @@
 import every from 'lodash/every';
 import isEmpty from 'lodash/isEmpty';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Service from '@ember/service';
 
 export default class ErrorNotifierService extends Service {

--- a/admin/app/services/error-response-handler.js
+++ b/admin/app/services/error-response-handler.js
@@ -1,7 +1,7 @@
 import every from 'lodash/every';
 import isEmpty from 'lodash/isEmpty';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Service from '@ember/service';
 
 const ERROR_MESSAGES_BY_STATUS = {

--- a/admin/app/services/session.js
+++ b/admin/app/services/session.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 
 export default class CurrentSessionService extends SessionService {

--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -1,5 +1,5 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-certif/config/environment';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {

--- a/certif/app/adapters/member.js
+++ b/certif/app/adapters/member.js
@@ -1,5 +1,5 @@
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MemberAdapter extends ApplicationAdapter {
   @service currentUser;

--- a/certif/app/adapters/session-summary.js
+++ b/certif/app/adapters/session-summary.js
@@ -1,5 +1,5 @@
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionSummary extends ApplicationAdapter {
   @service currentUser;

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -1,5 +1,5 @@
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionAdapter extends ApplicationAdapter {
   @service currentUser;

--- a/certif/app/adapters/sessions-mass-import-report.js
+++ b/certif/app/adapters/sessions-mass-import-report.js
@@ -1,5 +1,5 @@
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionsMassImportReportAdapter extends ApplicationAdapter {
   @service currentUser;

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import some from 'lodash/some';
 
 import { tracked } from '@glimmer/tracking';

--- a/certif/app/components/auth/login-or-register.js
+++ b/certif/app/components/auth/login-or-register.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginOrRegister extends Component {
   @service currentDomain;

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import isEmpty from 'lodash/isEmpty';

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import isEmpty from 'lodash/isEmpty';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import isEmailValid from '../../utils/email-validator';

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import EmberObject, { action } from '@ember/object';
 import get from 'lodash/get';

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StepTwoSectionComponent extends Component {
   @service intl;
@@ -12,6 +12,7 @@ export default class StepTwoSectionComponent extends Component {
       message: _translatedErrorCodeToMessage(this.intl, code),
     }));
   }
+
   get translatedNonBlockingErrorReport() {
     const nonBlockingErrors = this._nonBlockingErrors;
 

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import {

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import {
   certificationIssueReportSubcategories,

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -5,7 +5,7 @@ import {
   subcategoryToCode,
   subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
   @service intl;

--- a/certif/app/components/layout/footer.js
+++ b/certif/app/components/layout/footer.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Footer extends Component {
   @service intl;

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-certif/config/environment';

--- a/certif/app/components/login-session-supervisor-form.js
+++ b/certif/app/components/login-session-supervisor-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class LoginSessionSupervisorForm extends Component {

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MembersList extends Component {
   @service featureToggles;

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const FRANCE_INSEE_CODE = '99100';
 const INSEE_CODE_OPTION = 'insee';

--- a/certif/app/components/no-session-panel.js
+++ b/certif/app/components/no-session-panel.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PanelHeader extends Component {
   @service featureToggles;

--- a/certif/app/components/session-clea-results-download.js
+++ b/certif/app/components/session-clea-results-download.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionCleaResultsDownload extends Component {
   @service intl;

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UncompletedReportsInformationStep extends Component {
   @tracked reportToEdit = null;

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class SessionSummaryList extends Component {

--- a/certif/app/components/session-summary-row.js
+++ b/certif/app/components/session-summary-row.js
@@ -1,9 +1,10 @@
 import Component from '@glimmer/component';
 import { CREATED, FINALIZED, PROCESSED } from '../models/session';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionSummaryRow extends Component {
   @service intl;
+
   get statusLabel() {
     const { status } = this.args.sessionSummary;
     if (status === FINALIZED) return this.intl.t(`pages.sessions.list.status.${FINALIZED}`);

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -1,7 +1,7 @@
 import { action, set } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import dayjs from 'dayjs';
 
 export default class CandidateInList extends Component {

--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class Header extends Component {

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PanelHeader extends Component {
   @service featureToggles;

--- a/certif/app/components/user-logged-menu.js
+++ b/certif/app/components/user-logged-menu.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/certif/app/controllers/authenticated/sessions/add-student.js
+++ b/certif/app/controllers/authenticated/sessions/add-student.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionsAddStudentController extends Controller {
   @service url;

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -5,7 +5,7 @@ import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
 /* eslint-enable ember/no-computed-properties-in-native-classes*/
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationCandidatesController extends Controller {
   @service currentUser;

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -5,7 +5,7 @@ import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
 /* eslint-enable ember/no-computed-properties-in-native-classes*/
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionParametersController extends Controller {
   @alias('model.session') session;

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-certif/config/environment';

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const DEFAULT_PAGE_NUMBER = 1;

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class SessionsNewController extends Controller {

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class SessionsUpdateController extends Controller {

--- a/certif/app/controllers/authenticated/team.js
+++ b/certif/app/controllers/authenticated/team.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/certif/app/controllers/login-session-supervisor.js
+++ b/certif/app/controllers/login-session-supervisor.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginSessionSupervisorController extends Controller {
   @service store;

--- a/certif/app/controllers/login.js
+++ b/certif/app/controllers/login.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginController extends Controller {
   @service intl;

--- a/certif/app/controllers/terms-of-service.js
+++ b/certif/app/controllers/terms-of-service.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class TermsOfServiceController extends Controller {

--- a/certif/app/helpers/text-with-multiple-lang.js
+++ b/certif/app/helpers/text-with-multiple-lang.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe, isHTMLSafe } from '@ember/template';
 
 export default class textWithMultipleLang extends Helper {

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -1,5 +1,5 @@
 import Model, { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationCandidate extends Model {
   @service intl;

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -1,7 +1,7 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-certif/config/environment';
 
 export const CREATED = 'created';

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service featureToggles;

--- a/certif/app/routes/authenticated.js
+++ b/certif/app/routes/authenticated.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class AuthenticatedRoute extends Route {

--- a/certif/app/routes/authenticated/index.js
+++ b/certif/app/routes/authenticated/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/certif/app/routes/authenticated/restricted-access.js
+++ b/certif/app/routes/authenticated/restricted-access.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class RestrictedAccessRoute extends Route {
   @service router;

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
   @service currentUser;

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import EmberObject from '@ember/object';
 
 export default class SessionsDetailsRoute extends Route {

--- a/certif/app/routes/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/routes/authenticated/sessions/details/certification-candidates.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationCandidatesRoute extends Route {
   @service currentUser;

--- a/certif/app/routes/authenticated/sessions/details/parameters.js
+++ b/certif/app/routes/authenticated/sessions/details/parameters.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ParametersRoute extends Route {
   @service currentUser;

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionsFinalizeRoute extends Route {
   @service notifications;

--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ImportRoute extends Route {

--- a/certif/app/routes/authenticated/sessions/list.js
+++ b/certif/app/routes/authenticated/sessions/list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ListRoute extends Route {

--- a/certif/app/routes/authenticated/sessions/new.js
+++ b/certif/app/routes/authenticated/sessions/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionsNewRoute extends Route {
   @service currentUser;

--- a/certif/app/routes/authenticated/sessions/update.js
+++ b/certif/app/routes/authenticated/sessions/update.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionsUpdateRoute extends Route {
   @service currentUser;

--- a/certif/app/routes/authenticated/team.js
+++ b/certif/app/routes/authenticated/team.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class AuthenticatedTeamRoute extends Route {

--- a/certif/app/routes/join.js
+++ b/certif/app/routes/join.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class JoinRoute extends Route {

--- a/certif/app/routes/login-session-supervisor.js
+++ b/certif/app/routes/login-session-supervisor.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class LoginSessionSupervisorRoute extends Route {

--- a/certif/app/routes/login.js
+++ b/certif/app/routes/login.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;

--- a/certif/app/routes/logout.js
+++ b/certif/app/routes/logout.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LogoutRoute extends Route {
   @service session;

--- a/certif/app/routes/session-supervising.js
+++ b/certif/app/routes/session-supervising.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import ENV from 'pix-certif/config/environment';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionSupervisingRoute extends Route {
   @service store;

--- a/certif/app/routes/terms-of-service.js
+++ b/certif/app/routes/terms-of-service.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class TermsOfServiceRoute extends Route {

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-certif/services/locale';
 

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import ENV from 'mon-pix/config/environment';
 

--- a/mon-pix/app/adapters/authentication-method.js
+++ b/mon-pix/app/adapters/authentication-method.js
@@ -1,5 +1,5 @@
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticationMethod extends ApplicationAdapter {
   @service currentUser;

--- a/mon-pix/app/adapters/email-verification-code.js
+++ b/mon-pix/app/adapters/email-verification-code.js
@@ -1,5 +1,5 @@
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class EmailVerificationCodeAdapter extends ApplicationAdapter {
   @service currentUser;

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -4,7 +4,7 @@ import fetch from 'fetch';
 import RSVP from 'rsvp';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 import { isEmpty } from '@ember/utils';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default BaseAuthenticator.extend({
   intl: service(),

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import { isEmpty } from '@ember/utils';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 

--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmpty from 'lodash/isEmpty';
 import isEmailValid from '../../utils/email-validator';
 

--- a/mon-pix/app/components/account-recovery/student-information-form.js
+++ b/mon-pix/app/components/account-recovery/student-information-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmpty from 'lodash/isEmpty';
 import dayjs from 'dayjs';
 

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.js
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isEmpty from 'lodash/isEmpty';
 import isPasswordValid from '../../utils/password-validator';
 

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import isEmailValid from '../../utils/email-validator';

--- a/mon-pix/app/components/authentication/oidc-reconciliation.js
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 

--- a/mon-pix/app/components/campaign-start-block.js
+++ b/mon-pix/app/components/campaign-start-block.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CampaignStartBlock extends Component {
   @service currentUser;

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import _get from 'lodash/get';
 
@@ -142,10 +142,12 @@ export default class CertificationJoiner extends Component {
   setDayOfBirth(event) {
     this.dayOfBirth = event.target.value;
   }
+
   @action
   setMonthOfBirth(event) {
     this.monthOfBirth = event.target.value;
   }
+
   @action
   setYearOfBirth(event) {
     this.yearOfBirth = event.target.value;

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/mon-pix/app/components/certifications/certification-ender.js
+++ b/mon-pix/app/components/certifications/certification-ender.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CertificationEnder extends Component {
   @service currentUser;

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import isInteger from 'lodash/isInteger';

--- a/mon-pix/app/components/challenge-item-qcm.js
+++ b/mon-pix/app/components/challenge-item-qcm.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ChallengeItemGeneric from './challenge-item-generic';
 
 export default class ChallengeItemQcm extends ChallengeItemGeneric {

--- a/mon-pix/app/components/challenge-item-qcu.js
+++ b/mon-pix/app/components/challenge-item-qcu.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengeItemQcu extends ChallengeItemGeneric {
   @service intl;

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ChallengeItemGeneric from './challenge-item-generic';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 import { isEmbedAllowedOrigin } from 'mon-pix/utils/embed-allowed-origins';

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import filter from 'lodash/filter';
 import isEmpty from 'lodash/isEmpty';
 

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import sortBy from 'lodash/sortBy';
 import ENV from 'mon-pix/config/environment';
@@ -12,6 +12,7 @@ export default class ChallengeStatement extends Component {
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
+
   constructor() {
     super(...arguments);
     this._initialiseDefaultAttachment();

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
 import { ensureSafeComponent } from '@embroider/util';

--- a/mon-pix/app/components/challenge/statement/tooltip.js
+++ b/mon-pix/app/components/challenge/statement/tooltip.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class Tooltip extends Component {

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class CompetenceCardDefault extends Component {

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import orderBy from 'lodash/orderBy';
 

--- a/mon-pix/app/components/data-protection-policy-information-banner.js
+++ b/mon-pix/app/components/data-protection-policy-information-banner.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
 import isEmpty from 'lodash/isEmpty';

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -60,6 +60,7 @@ export default class FeedbackPanel extends Component {
       label: this.intl.t(question.name),
     }));
   }
+
   get isSendButtonDisabled() {
     return this._sendButtonStatus === buttonStatusTypes.pending;
   }

--- a/mon-pix/app/components/footer.js
+++ b/mon-pix/app/components/footer.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Footer extends Component {

--- a/mon-pix/app/components/inaccessible-campaign.js
+++ b/mon-pix/app/components/inaccessible-campaign.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class InaccessibleCampaign extends Component {
   @service currentDomain;

--- a/mon-pix/app/components/learning-more-panel.js
+++ b/mon-pix/app/components/learning-more-panel.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LearningMorePanel extends Component {
   @service featureToggles;

--- a/mon-pix/app/components/navbar-burger-menu.js
+++ b/mon-pix/app/components/navbar-burger-menu.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class NavbarBurgerMenu extends Component {

--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NavbarDesktopHeader extends Component {
   @service router;

--- a/mon-pix/app/components/navbar-header.js
+++ b/mon-pix/app/components/navbar-header.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class NavbarHeader extends Component {

--- a/mon-pix/app/components/navbar-mobile-header.js
+++ b/mon-pix/app/components/navbar-mobile-header.js
@@ -1,6 +1,6 @@
 /* eslint ember/no-computed-properties-in-native-classes: 0 */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';

--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import colorGradient from 'mon-pix/utils/color-gradient';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';

--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const classByResultValue = {
   ok: 'correction-qroc-box-answer--correct',

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 import jsyaml from 'js-yaml';
 

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -5,7 +5,7 @@ import answersAsObject from 'mon-pix/utils/answers-as-object';
 import solutionsAsObject from 'mon-pix/utils/solution-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
 import resultDetailsAsObject from 'mon-pix/utils/result-details-as-object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 
 export default class QrocmIndSolutionPanel extends Component {

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class QrocmProposal extends Component {
   @service intl;

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import isPasswordValid from '../utils/password-validator';
 import { tracked } from '@glimmer/tracking';

--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import resultIcon from 'mon-pix/utils/result-icon';
 
 export default class ResultItemComponent extends Component {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import isNil from 'lodash/isNil';

--- a/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.js
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 

--- a/mon-pix/app/components/routes/campaigns/invited/associate-sup-student-form.js
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sup-student-form.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';

--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 import { getJoinErrorsMessageByShortCode } from '../../../utils/errors-messages';
 

--- a/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.js
+++ b/mon-pix/app/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { decodeToken } from 'mon-pix/helpers/jwt';

--- a/mon-pix/app/components/routes/campaigns/sco-form.js
+++ b/mon-pix/app/components/routes/campaigns/sco-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import EmberObject, { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import isEmailValid from '../utils/email-validator';

--- a/mon-pix/app/components/sitemap/content.js
+++ b/mon-pix/app/components/sitemap/content.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Content extends Component {

--- a/mon-pix/app/components/training/card.js
+++ b/mon-pix/app/components/training/card.js
@@ -1,8 +1,9 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Card extends Component {
   @service intl;
+
   get durationFormatted() {
     const formattedHours = [];
     const { hours, minutes, seconds } = this.args.training.duration;
@@ -29,6 +30,7 @@ export default class Card extends Component {
   get tagTitle() {
     return `${this.type} - ${this.durationFormatted}`;
   }
+
   get tagColor() {
     if (this.args.training.isAutoformation) {
       return 'blue-light';

--- a/mon-pix/app/components/tutorial-panel.js
+++ b/mon-pix/app/components/tutorial-panel.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TutorialPanel extends Component {
   @service featureToggles;

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import buttonStatusTypes from 'mon-pix/utils/button-status-types';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Card extends Component {
   @service intl;

--- a/mon-pix/app/components/tutorials/header.js
+++ b/mon-pix/app/components/tutorials/header.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Header extends Component {
   @service featureToggles;

--- a/mon-pix/app/components/tutorials/recommended-empty.js
+++ b/mon-pix/app/components/tutorials/recommended-empty.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class RecommendedEmpty extends Component {
   @service currentUser;

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -3,7 +3,7 @@
 
 import { action } from '@ember/object';
 import Component from '@ember/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isPasswordValid from '../utils/password-validator';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';

--- a/mon-pix/app/components/user-account/email-verification-code.js
+++ b/mon-pix/app/components/user-account/email-verification-code.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'mon-pix/config/environment';

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import isEmailValid from '../../utils/email-validator';

--- a/mon-pix/app/components/user-account/update-email-with-validation.js
+++ b/mon-pix/app/components/user-account/update-email-with-validation.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import parseISODateOnly from '../utils/parse-iso-date-only';
 

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 class StudentInformationForAccountRecovery {

--- a/mon-pix/app/controllers/account-recovery/update-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/update-sco-record.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class UpdateScoRecordController extends Controller {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 import { action } from '@ember/object';
+
 const defaultPageTitle = 'pages.challenge.title.default';
 const timedOutPageTitle = 'pages.challenge.title.timed-out';
 const focusedPageTitle = 'pages.challenge.title.focused';

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class CheckpointController extends Controller {

--- a/mon-pix/app/controllers/authenticated/certifications/join.js
+++ b/mon-pix/app/controllers/authenticated/certifications/join.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/mon-pix/app/controllers/authenticated/user-account.js
+++ b/mon-pix/app/controllers/authenticated/user-account.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserAccountController extends Controller {
   @service currentDomain;

--- a/mon-pix/app/controllers/authenticated/user-account/connection-methods.js
+++ b/mon-pix/app/controllers/authenticated/user-account/connection-methods.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ConnectionMethodsController extends Controller {
   @service featureToggles;

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserAccountPersonalInformationController extends Controller {
   @service currentUser;

--- a/mon-pix/app/controllers/authenticated/user-tests.js
+++ b/mon-pix/app/controllers/authenticated/user-tests.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class UserTestsController extends Controller {

--- a/mon-pix/app/controllers/authenticated/user-tutorials/recommended.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/recommended.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class RecommendedController extends Controller {
   @service router;

--- a/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SavedController extends Controller {
   @service router;

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginOrRegisterOidcController extends Controller {
   queryParams = ['authenticationKey', 'identityProviderSlug', 'givenName', 'familyName'];

--- a/mon-pix/app/controllers/authentication/login.js
+++ b/mon-pix/app/controllers/authentication/login.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginController extends Controller {
   @service currentDomain;

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CampaignLandingPageController extends Controller {

--- a/mon-pix/app/controllers/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/controllers/campaigns/invited/fill-in-participant-external-id.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FillInParticipantExternalId extends Controller {
   @service campaignStorage;

--- a/mon-pix/app/controllers/campaigns/invited/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/invited/student-sco.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class StudentScoController extends Controller {

--- a/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/controllers/campaigns/join/sco-mediacentre.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class ScoMediacentreController extends Controller {

--- a/mon-pix/app/controllers/campaigns/join/student-sco.js
+++ b/mon-pix/app/controllers/campaigns/join/student-sco.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class SendProfileController extends Controller {

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 const IDENTITY_PROVIDER_ID_GAR = 'GAR';

--- a/mon-pix/app/controllers/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/controllers/fill-in-certificate-verification-code.js
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class FillInCertificateVerificationCode extends Controller {

--- a/mon-pix/app/controllers/inscription.js
+++ b/mon-pix/app/controllers/inscription.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class InscriptionController extends Controller {
   @service currentDomain;

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class TermsOfServiceController extends Controller {

--- a/mon-pix/app/controllers/user-tutorials.js
+++ b/mon-pix/app/controllers/user-tutorials.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class UserTutorialsController extends Controller {

--- a/mon-pix/app/helpers/scorecard-aria-label.js
+++ b/mon-pix/app/helpers/scorecard-aria-label.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScorecardAriaLabel extends Helper {
   @service intl;

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe, isHTMLSafe } from '@ember/template';
 
 export default class textWithMultipleLang extends Helper {

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -1,7 +1,7 @@
 /* eslint ember/no-computed-properties-in-native-classes: 0 */
 
 import Model, { belongsTo, attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { computed } from '@ember/object';
 
 export const ACQUIRED = 'acquired';

--- a/mon-pix/app/routes/account-recovery/update-sco-record.js
+++ b/mon-pix/app/routes/account-recovery/update-sco-record.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class UpdateScoRecordRoute extends Route {

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ApplicationRoute extends Route {

--- a/mon-pix/app/routes/assessments.js
+++ b/mon-pix/app/routes/assessments.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AssessmentsRoute extends Route {
   @service intl;

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/assessments/results.js
+++ b/mon-pix/app/routes/assessments/results.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResultsRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import ENV from 'mon-pix/config/environment';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResumeRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/authenticated.js
+++ b/mon-pix/app/routes/authenticated.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/authenticated/certifications/join.js
+++ b/mon-pix/app/routes/authenticated/certifications/join.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 

--- a/mon-pix/app/routes/authenticated/certifications/results.js
+++ b/mon-pix/app/routes/authenticated/certifications/results.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResultsRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/certifications/resume.js
+++ b/mon-pix/app/routes/authenticated/certifications/resume.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResumeRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StartRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/competences.js
+++ b/mon-pix/app/routes/authenticated/competences.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class CompetencesRoute extends Route {

--- a/mon-pix/app/routes/authenticated/competences/details.js
+++ b/mon-pix/app/routes/authenticated/competences/details.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class DetailsRoute extends Route {

--- a/mon-pix/app/routes/authenticated/competences/results.js
+++ b/mon-pix/app/routes/authenticated/competences/results.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResultsRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/competences/resume.js
+++ b/mon-pix/app/routes/authenticated/competences/resume.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ResumeRoute extends Route {

--- a/mon-pix/app/routes/authenticated/index.js
+++ b/mon-pix/app/routes/authenticated/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedIndexRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/authenticated/profile.js
+++ b/mon-pix/app/routes/authenticated/profile.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 

--- a/mon-pix/app/routes/authenticated/sitemap.js
+++ b/mon-pix/app/routes/authenticated/sitemap.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class Sitemap extends Route {

--- a/mon-pix/app/routes/authenticated/user-account.js
+++ b/mon-pix/app/routes/authenticated/user-account.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserAccountRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/authenticated/user-account/connection-methods.js
+++ b/mon-pix/app/routes/authenticated/user-account/connection-methods.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ConnectionMethodsRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/user-account/index.js
+++ b/mon-pix/app/routes/authenticated/user-account/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/authenticated/user-certifications/get.js
+++ b/mon-pix/app/routes/authenticated/user-certifications/get.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class GetRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/user-certifications/index.js
+++ b/mon-pix/app/routes/authenticated/user-certifications/index.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/user-dashboard.js
+++ b/mon-pix/app/routes/authenticated/user-dashboard.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 

--- a/mon-pix/app/routes/authenticated/user-tests.js
+++ b/mon-pix/app/routes/authenticated/user-tests.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/mon-pix/app/routes/authenticated/user-trainings.js
+++ b/mon-pix/app/routes/authenticated/user-trainings.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserTrainingsRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/authenticated/user-tutorials.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserTutorialsRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/authenticated/user-tutorials/index.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/authenticated/user-tutorials/recommended.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/recommended.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserTutorialsRecommendedRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/saved.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class UserTutorialsSavedRoute extends Route {

--- a/mon-pix/app/routes/authentication/login-gar.js
+++ b/mon-pix/app/routes/authentication/login-gar.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import PixWindow from 'mon-pix/utils/pix-window';
 
 export default class LoginGarRoute extends Route {

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';

--- a/mon-pix/app/routes/authentication/login.js
+++ b/mon-pix/app/routes/authentication/login.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class LoginRoute extends Route {

--- a/mon-pix/app/routes/campaigns.js
+++ b/mon-pix/app/routes/campaigns.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CampaignsRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -1,5 +1,5 @@
 import get from 'lodash/get';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class AccessRoute extends Route {

--- a/mon-pix/app/routes/campaigns/assessment.js
+++ b/mon-pix/app/routes/campaigns/assessment.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AssessmentRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/routes/campaigns/assessment/skill-review.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SkillReviewRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class EvaluationStartOrResumeRoute extends Route {

--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class TutorialRoute extends Route {

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CampaignLandingPageRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class Entrance extends Route {

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class EntryPoint extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/campaigns/existing-participation.js
+++ b/mon-pix/app/routes/campaigns/existing-participation.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ExistingParticipation extends Route {
   @service store;

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class InvitedRoute extends Route {
   @service campaignStorage;

--- a/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FillInParticipantExternalIdRoute extends Route {
   @service campaignStorage;

--- a/mon-pix/app/routes/campaigns/invited/student-sco.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sco.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import get from 'lodash/get';
 

--- a/mon-pix/app/routes/campaigns/invited/student-sup.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sup.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class StudentSupRoute extends Route {

--- a/mon-pix/app/routes/campaigns/join.js
+++ b/mon-pix/app/routes/campaigns/join.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class JoinRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/campaigns/join/anonymous.js
+++ b/mon-pix/app/routes/campaigns/join/anonymous.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AnonymousRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/campaigns/join/sco-mediacentre.js
+++ b/mon-pix/app/routes/campaigns/join/sco-mediacentre.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ScoMediacentreRoute extends Route {

--- a/mon-pix/app/routes/campaigns/join/student-sco.js
+++ b/mon-pix/app/routes/campaigns/join/student-sco.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StudentScoRoute extends Route {
   @service campaignStorage;

--- a/mon-pix/app/routes/campaigns/profiles-collection.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ProfilesCollectionRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/campaigns/profiles-collection/profile-already-shared.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/profile-already-shared.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ProfileAlreadySharedRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/send-profile.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SendProfileRoute extends Route {
   @service currentUser;

--- a/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/challenge-preview.js
+++ b/mon-pix/app/routes/challenge-preview.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengePreviewRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/courses/create-assessment.js
+++ b/mon-pix/app/routes/courses/create-assessment.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CreateAssessmentRoute extends Route {
   @service store;

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import get from 'lodash/get';
 import JSONApiError from 'mon-pix/errors/json-api-error';

--- a/mon-pix/app/routes/fill-in-campaign-code.js
+++ b/mon-pix/app/routes/fill-in-campaign-code.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FillInCampaignCodeRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/routes/fill-in-certificate-verification-code.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class FillInCertificateVerificationCodeRoute extends Route {

--- a/mon-pix/app/routes/inscription.js
+++ b/mon-pix/app/routes/inscription.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class InscriptionRoute extends Route {

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ENV from 'mon-pix/config/environment';
 

--- a/mon-pix/app/routes/not-connected.js
+++ b/mon-pix/app/routes/not-connected.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NotConnectedRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/not-found.js
+++ b/mon-pix/app/routes/not-found.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NotFoundRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import get from 'lodash/get';
 

--- a/mon-pix/app/routes/shared-certification.js
+++ b/mon-pix/app/routes/shared-certification.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import Model from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SharedCertificationRoute extends Route {
   @service router;

--- a/mon-pix/app/routes/terms-of-service-oidc.js
+++ b/mon-pix/app/routes/terms-of-service-oidc.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TermsOfServiceOidcRoute extends Route {
   @service session;

--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class TermsOfServiceRoute extends Route {

--- a/mon-pix/app/routes/update-expired-password.js
+++ b/mon-pix/app/routes/update-expired-password.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class UpdateExpiredPasswordRoute extends Route {

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'mon-pix/services/locale';

--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -1,5 +1,5 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 
 const FRENCH_DOMAIN_EXTENSION = 'fr';

--- a/orga/app/components/auth/join-request-form.js
+++ b/orga/app/components/auth/join-request-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import isEmpty from 'lodash/isEmpty';

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import isEmpty from 'lodash/isEmpty';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';

--- a/orga/app/components/auth/login-or-register.js
+++ b/orga/app/components/auth/login-or-register.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginOrRegister extends Component {
   @service currentDomain;

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import isEmpty from 'lodash/isEmpty';

--- a/orga/app/components/banner/information.js
+++ b/orga/app/components/banner/information.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 
 export default class InformationBanner extends Component {

--- a/orga/app/components/campaign/activity/dashboard.js
+++ b/orga/app/components/campaign/activity/dashboard.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import sumBy from 'lodash/sumBy';
 
 export default class Dashboard extends Component {

--- a/orga/app/components/campaign/activity/participants-list.js
+++ b/orga/app/components/campaign/activity/participants-list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/orga/app/components/campaign/analysis/competences.js
+++ b/orga/app/components/campaign/analysis/competences.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 
 export default class CompetencesAnalysis extends Component {

--- a/orga/app/components/campaign/analysis/recommendation-indicator.js
+++ b/orga/app/components/campaign/analysis/recommendation-indicator.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const RECOMMENDED = 75;
 const STRONGLY_RECOMMENDED = 50;

--- a/orga/app/components/campaign/analysis/recommendations.js
+++ b/orga/app/components/campaign/analysis/recommendations.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';

--- a/orga/app/components/campaign/cards/stage-average.js
+++ b/orga/app/components/campaign/cards/stage-average.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class StageAverage extends Component {

--- a/orga/app/components/campaign/charts/participants-by-day.js
+++ b/orga/app/components/campaign/charts/participants-by-day.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { TOOLTIP_CONFIG, LEGEND_CONFIG } from '../../ui/chart';
 import maxBy from 'lodash/maxBy';

--- a/orga/app/components/campaign/charts/participants-by-mastery-percentage.js
+++ b/orga/app/components/campaign/charts/participants-by-mastery-percentage.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import remove from 'lodash/remove';
 import sumBy from 'lodash/sumBy';
 

--- a/orga/app/components/campaign/charts/participants-by-stage.js
+++ b/orga/app/components/campaign/charts/participants-by-stage.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import maxBy from 'lodash/maxBy';
 import sumBy from 'lodash/sumBy';
 import { htmlSafe } from '@ember/template';

--- a/orga/app/components/campaign/charts/participants-by-status.js
+++ b/orga/app/components/campaign/charts/participants-by-status.js
@@ -1,9 +1,10 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import sumBy from 'lodash/sumBy';
 import { TOOLTIP_CONFIG } from '../../ui/chart';
 import pattern from 'patternomaly';
+
 export default class ParticipantsByStatus extends Component {
   @service store;
   @service intl;

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/campaign/empty-state.js
+++ b/orga/app/components/campaign/empty-state.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class EmptyState extends Component {
   @service url;

--- a/orga/app/components/campaign/filter/participation-filters.js
+++ b/orga/app/components/campaign/filter/participation-filters.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ParticipationFilters extends Component {
   @service intl;

--- a/orga/app/components/campaign/header/archived-banner.js
+++ b/orga/app/components/campaign/header/archived-banner.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CampaignArchivedBanner extends Component {

--- a/orga/app/components/campaign/header/tabs.js
+++ b/orga/app/components/campaign/header/tabs.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CampaignTabs extends Component {

--- a/orga/app/components/campaign/header/title.js
+++ b/orga/app/components/campaign/header/title.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Header extends Component {
   @service intl;

--- a/orga/app/components/campaign/list.js
+++ b/orga/app/components/campaign/list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class List extends Component {
   @service intl;

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CampaignView extends Component {

--- a/orga/app/components/campaign/update-form.js
+++ b/orga/app/components/campaign/update-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UpdateForm extends Component {
   @service notifications;

--- a/orga/app/components/layout/footer.js
+++ b/orga/app/components/layout/footer.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Footer extends Component {

--- a/orga/app/components/layout/organization-credit-info.js
+++ b/orga/app/components/layout/organization-credit-info.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationCreditInfoComponent extends Component {
   @service currentUser;

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class SidebarMenu extends Component {

--- a/orga/app/components/layout/user-logged-menu.js
+++ b/orga/app/components/layout/user-logged-menu.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/orga/app/components/organization-learner/activity/campaign-type.js
+++ b/orga/app/components/organization-learner/activity/campaign-type.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CampaignType extends Component {
   @service intl;

--- a/orga/app/components/organization-learner/activity/participation-row.js
+++ b/orga/app/components/organization-learner/activity/participation-row.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ParticipationRow extends Component {
   @service router;

--- a/orga/app/components/organization-participant/learner-filters.js
+++ b/orga/app/components/organization-participant/learner-filters.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LearnerFilters extends Component {
   @service intl;

--- a/orga/app/components/organization-participant/no-participant-panel.js
+++ b/orga/app/components/organization-participant/no-participant-panel.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class List extends Component {

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Header extends Component {
   @service intl;

--- a/orga/app/components/participant/link-to.js
+++ b/orga/app/components/participant/link-to.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LinkTo extends Component {
   @service currentUser;

--- a/orga/app/components/participant/profile/header.js
+++ b/orga/app/components/participant/profile/header.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Header extends Component {
   @service intl;

--- a/orga/app/components/sco-organization-participant/header-actions.js
+++ b/orga/app/components/sco-organization-participant/header-actions.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class ScoHeaderActions extends Component {

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -1,8 +1,9 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
+
 export default class ScoList extends Component {
   @service currentUser;
   @service intl;

--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.js
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import get from 'lodash/get';
 
@@ -23,10 +23,12 @@ export default class ManageAuthenticationMethodModal extends Component {
   clipboardSuccessUsername() {
     this.tooltipTextUsername = this._t('copied');
   }
+
   @action
   clipboardSuccessEmail() {
     this.tooltipTextEmail = this._t('copied');
   }
+
   @action
   clipboardSuccessGeneratedPassword() {
     this.tooltipTextGeneratedPassword = this._t('copied');
@@ -36,10 +38,12 @@ export default class ManageAuthenticationMethodModal extends Component {
   clipboardOutUsername() {
     this.tooltipTextUsername = this._t('section.username.copy');
   }
+
   @action
   clipboardOutEmail() {
     this.tooltipTextEmail = this._t('section.email.copy');
   }
+
   @action
   clipboardOutGeneratedPassword() {
     this.tooltipTextGeneratedPassword = this._t('section.password.copy');

--- a/orga/app/components/sco-organization-participant/sco-learner-filters.js
+++ b/orga/app/components/sco-organization-participant/sco-learner-filters.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScoLearnerFilters extends Component {
   @service intl;

--- a/orga/app/components/sup-organization-participant/edit-student-number-modal.js
+++ b/orga/app/components/sup-organization-participant/edit-student-number-modal.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/orga/app/components/sup-organization-participant/header-actions.js
+++ b/orga/app/components/sup-organization-participant/header-actions.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'pix-orga/config/environment';
 

--- a/orga/app/components/sup-organization-participant/list.js
+++ b/orga/app/components/sup-organization-participant/list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/sup-organization-participant/sup-learner-filters.js
+++ b/orga/app/components/sup-organization-participant/sup-learner-filters.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SupLearnerFilters extends Component {
   @service intl;

--- a/orga/app/components/table/pagination-control.js
+++ b/orga/app/components/table/pagination-control.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 const DEFAULT_PAGE_SIZE = 10;

--- a/orga/app/components/team/invitations-list-item.js
+++ b/orga/app/components/team/invitations-list-item.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/team/invitations-list.js
+++ b/orga/app/components/team/invitations-list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class TeamInvitationsListComponent extends Component {

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/orga/app/components/team/members-list.js
+++ b/orga/app/components/team/members-list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class MembersList extends Component {

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TubeList extends Component {
   @tracked selectedTubeIds = A();

--- a/orga/app/components/ui/last-participation-date-tooltip.js
+++ b/orga/app/components/ui/last-participation-date-tooltip.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class LastParticipationDateTooltip extends Component {

--- a/orga/app/components/ui/learner-header-info.js
+++ b/orga/app/components/ui/learner-header-info.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
 
 export default class LearnerHeaderInfo extends Component {

--- a/orga/app/components/ui/participation-status.js
+++ b/orga/app/components/ui/participation-status.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ParticipationStatus extends Component {
   @service intl;

--- a/orga/app/components/ui/previous-page-button.js
+++ b/orga/app/components/ui/previous-page-button.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class PreviousPageButton extends Component {

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ActivityController extends Controller {
   @service router;

--- a/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 

--- a/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class NewController extends Controller {

--- a/orga/app/controllers/authenticated/campaigns/participant-assessment/analysis.js
+++ b/orga/app/controllers/authenticated/campaigns/participant-assessment/analysis.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AnalysisController extends Controller {
   @service intl;

--- a/orga/app/controllers/authenticated/campaigns/participant-assessment/results.js
+++ b/orga/app/controllers/authenticated/campaigns/participant-assessment/results.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ResultsController extends Controller {
   @service intl;

--- a/orga/app/controllers/authenticated/campaigns/participant-profile.js
+++ b/orga/app/controllers/authenticated/campaigns/participant-profile.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ProfileController extends Controller {
   @service intl;

--- a/orga/app/controllers/authenticated/campaigns/update.js
+++ b/orga/app/controllers/authenticated/campaigns/update.js
@@ -1,9 +1,10 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UpdateController extends Controller {
   @service router;
+
   @action
   update() {
     return this.model.campaign

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListController extends Controller {

--- a/orga/app/controllers/authenticated/organization-participants/organization-participant.js
+++ b/orga/app/controllers/authenticated/organization-participants/organization-participant.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class OrganizationParticipant extends Controller {

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -1,7 +1,8 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+
 export default class ListController extends Controller {
   @service currentUser;
   @service notifications;

--- a/orga/app/controllers/authenticated/sco-organization-participants/sco-organization-participant.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/sco-organization-participant.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class ScoOrganizationParticipant extends Controller {

--- a/orga/app/controllers/authenticated/sup-organization-participants/import.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/import.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ListController extends Controller {
   @service router;

--- a/orga/app/controllers/authenticated/sup-organization-participants/sup-organization-participant.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/sup-organization-participant.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class SupOrganizationParticipant extends Controller {

--- a/orga/app/controllers/authenticated/team/list.js
+++ b/orga/app/controllers/authenticated/team/list.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const DEFAULT_PAGE_NUMBER = 1;

--- a/orga/app/controllers/authenticated/team/list/members.js
+++ b/orga/app/controllers/authenticated/team/list/members.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MembersController extends Controller {
   @service currentUser;

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 

--- a/orga/app/controllers/join-request.js
+++ b/orga/app/controllers/join-request.js
@@ -2,7 +2,8 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import get from 'lodash/get';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class JoinRequestController extends Controller {
   @service store;
 

--- a/orga/app/controllers/login.js
+++ b/orga/app/controllers/login.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginController extends Controller {
   @service intl;

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const ENGLISH_LOCALE = 'en';

--- a/orga/app/helpers/display-campaign-errors.js
+++ b/orga/app/helpers/display-campaign-errors.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class extends Helper {
   @service errorMessages;

--- a/orga/app/helpers/text-with-multiple-lang.js
+++ b/orga/app/helpers/text-with-multiple-lang.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe, isHTMLSafe } from '@ember/template';
 
 export default class textWithMultipleLang extends Helper {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -1,6 +1,6 @@
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 import ENV from 'pix-orga/config/environment';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class Campaign extends Model {
   @service store;

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ApplicationRoute extends Route {

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class AuthenticatedRoute extends Route {

--- a/orga/app/routes/authenticated/campaigns/campaign.js
+++ b/orga/app/routes/authenticated/campaigns/campaign.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CampaignRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class ActivityRoute extends Route {
   @service store;
 

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 export default class AssessmentResultsRoute extends Route {
   @service store;
 

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ProfilesRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
   queryParams = {

--- a/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
   queryParams = {

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 

--- a/orga/app/routes/authenticated/campaigns/participant-assessment.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AssessmentRoute extends Route {
   @service router;

--- a/orga/app/routes/authenticated/campaigns/participant-profile.js
+++ b/orga/app/routes/authenticated/campaigns/participant-profile.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ProfileRoute extends Route {
   @service router;

--- a/orga/app/routes/authenticated/campaigns/update.js
+++ b/orga/app/routes/authenticated/campaigns/update.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UpdateRoute extends Route {
   @service currentUser;

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationsRoute extends Route {
   @service currentUser;

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ListRoute extends Route {

--- a/orga/app/routes/authenticated/organization-participants/organization-participant.js
+++ b/orga/app/routes/authenticated/organization-participants/organization-participant.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganizationParticipantRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/organization-participants/organization-participant/activity.js
+++ b/orga/app/routes/authenticated/organization-participants/organization-participant/activity.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ActivityRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class PreselectTargetProfileRoute extends Route {

--- a/orga/app/routes/authenticated/sco-organization-participants.js
+++ b/orga/app/routes/authenticated/sco-organization-participants.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ScoOrganizationParticipantsRoute extends Route {

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 import Route from '@ember/routing/route';

--- a/orga/app/routes/authenticated/sco-organization-participants/sco-organization-participant.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/sco-organization-participant.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import RSVP from 'rsvp';
 
 export default class ScoOrganizationParticipantRoute extends Route {

--- a/orga/app/routes/authenticated/sco-organization-participants/sco-organization-participant/activity.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/sco-organization-participant/activity.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ActivityRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/sup-organization-participants.js
+++ b/orga/app/routes/authenticated/sup-organization-participants.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class SupOrganizationParticipantsRoute extends Route {

--- a/orga/app/routes/authenticated/sup-organization-participants/import.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/import.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ImportRoute extends Route {

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 import Route from '@ember/routing/route';

--- a/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SupOrganizationParticipantRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant/activity.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant/activity.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ActivityRoute extends Route {
   @service store;

--- a/orga/app/routes/authenticated/team/list.js
+++ b/orga/app/routes/authenticated/team/list.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';

--- a/orga/app/routes/authenticated/team/new.js
+++ b/orga/app/routes/authenticated/team/new.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class NewRoute extends Route {

--- a/orga/app/routes/join-when-authenticated.js
+++ b/orga/app/routes/join-when-authenticated.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class JoinWhenAuthenticatedRoute extends Route {
   @service session;

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class JoinRoute extends Route {
   @service router;

--- a/orga/app/routes/login.js
+++ b/orga/app/routes/login.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;

--- a/orga/app/routes/logout.js
+++ b/orga/app/routes/logout.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class LogoutRoute extends Route {

--- a/orga/app/routes/not-found.js
+++ b/orga/app/routes/not-found.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NotFoundRoute extends Route {
   @service router;

--- a/orga/app/routes/terms-of-service.js
+++ b/orga/app/routes/terms-of-service.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class TermsOfServiceRoute extends Route {

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-orga/services/locale';
 


### PR DESCRIPTION
## :unicorn: Problème
[Depuis la version 4.1 d'Ember](https://blog.emberjs.com/ember-4-1-released/), une nouvelle manière plus explicite d'importer les services existe. [Voir la RFC ](https://github.com/emberjs/rfcs/blob/master/text/0752-inject-service.md)qui explique en détail le choix d'Ember.js

## :robot: Proposition
Utiliser la nouvelle manière : 
```javascript
import { service } from '@ember/service';
```
au lieu de : 
```javascript
import { inject as service } from '@ember/service';
```

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK