### PR TITLE
[FEATURE] Enregistrement au fur et à mesure des challenges passés en certif V3 (PIX-8452).

### DIFF
--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -1,5 +1,5 @@
 import { CertificationVersion } from '../models/CertificationVersion.js';
-import { FlashAssessmentAlgorithm } from '../models/index.js';
+import { CertificationChallenge, FlashAssessmentAlgorithm } from '../models/index.js';
 import { MAX_NEXT_GEN_CERTIFICATION_CHALLENGES } from '../constants.js';
 
 const getNextChallengeForCertification = async function ({
@@ -34,7 +34,21 @@ const getNextChallengeForCertification = async function ({
       estimatedLevel,
     });
 
-    return pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
+    const challenge = pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
+
+    const certificationChallenge = new CertificationChallenge({
+      associatedSkillName: challenge.skill.name,
+      associatedSkillId: challenge.skill.id,
+      challengeId: challenge.id,
+      courseId: certificationCourse.getId(),
+      competenceId: challenge.competenceId,
+      isNeutralized: false,
+      certifiableBadgeKey: null,
+    });
+
+    await certificationChallengeRepository.save({ certificationChallenge });
+
+    return challenge;
   } else {
     return certificationChallengeRepository
       .getNextNonAnsweredChallengeByCourseId(assessment.id, assessment.certificationCourseId)

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_spec.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_spec.js
@@ -75,6 +75,10 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
     mockLearningContent(learningContentObjects);
   });
 
+  afterEach(async function () {
+    await knex('certification-challenges').delete();
+  });
+
   describe('GET /api/assessments/:assessment_id/next', function () {
     const assessmentId = 1;
     const userId = 1234;
@@ -117,7 +121,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           clock.restore();
         });
 
-        it('should return a challenge', async function () {
+        it('should save and return a challenge', async function () {
           // given
           const options = {
             method: 'GET',
@@ -132,7 +136,10 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
 
           // then
           const assessmentsInDb = await knex('assessments').where('id', assessmentId).first('lastQuestionDate');
+          const { count: countSavedChallenge } = await knex('certification-challenges').count('* AS count').first();
+
           expect(assessmentsInDb.lastQuestionDate).to.deep.equal(lastQuestionDate);
+          expect(countSavedChallenge).to.equal(1);
           expect(response.result.data.id).to.be.oneOf([
             firstChallengeId,
             secondChallengeId,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -82,6 +82,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const certificationCourseRepository = {
             get: sinon.stub(),
           };
+          const certificationChallengeRepository = {
+            save: sinon.stub(),
+          };
           const algorithmDataFetcherService = {
             fetchForFlashCampaigns: sinon.stub(),
           };
@@ -122,6 +125,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             flashAssessmentResultRepository,
             pickChallengeService,
             certificationCourseRepository,
+            certificationChallengeRepository,
             locale,
           });
 
@@ -136,7 +140,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const answerRepository = Symbol('AnswerRepository');
           const challengeRepository = Symbol('ChallengeRepository');
           const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
-          const nextChallengeToAnswer = domainBuilder.buildChallenge();
+          const answeredChallenge = domainBuilder.buildChallenge();
+          const answer = domainBuilder.buildAnswer({ challengeId: answeredChallenge.id });
           const v3CertificationCourse = domainBuilder.buildCertificationCourse({
             version: CertificationVersion.V3,
           });
@@ -144,11 +149,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const certificationCourseRepository = {
             get: sinon.stub(),
           };
+          const certificationChallengeRepository = {
+            save: sinon.stub(),
+          };
           const algorithmDataFetcherService = {
             fetchForFlashCampaigns: sinon.stub(),
-          };
-          const pickChallengeService = {
-            chooseNextChallenge: sinon.stub(),
           };
           const locale = 'fr-FR';
 
@@ -162,18 +167,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               locale,
             })
             .resolves({
-              allAnswers: [],
-              challenges: [nextChallengeToAnswer],
+              allAnswers: [answer],
+              challenges: [answeredChallenge],
               estimatedLevel: 0,
             });
-
-          const chooseNextChallengeImpl = sinon.stub();
-          chooseNextChallengeImpl
-            .withArgs({
-              possibleChallenges: [nextChallengeToAnswer],
-            })
-            .rejects(new AssessmentEndedError());
-          pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
 
           // when
           const error = await catchErr(getNextChallengeForCertification)({
@@ -182,8 +179,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             answerRepository,
             challengeRepository,
             flashAssessmentResultRepository,
-            pickChallengeService,
             certificationCourseRepository,
+            certificationChallengeRepository,
             locale,
           });
 


### PR DESCRIPTION
## :unicorn: Problème

Nous ne connaissons pas les challenges passés par le candidat durant la certification V3. Il sera important de les connaître pour le calcul du score à venir.

## :robot: Proposition

Enregistrement des challenges au fur et à mesure que ceux-si sont proposés au candidat.

## :rainbow: Remarques

Un test unitaire a été amélioré dans `get-next-challenge-for-certification`

## :100: Pour tester

   • créer une session dans pix certif pour un centre de certification taggué pilote nextGen
   •inscrire un candidat à cette session
   • se connecter à app avec un utilisateur certifiable
   • cliquer sur le menu “Certification”
   • entrer le numéro de la session créée en étape 1, puis les info perso du candidat inscrit en étape 2
   • confirmer la présence du candidat depuis l’espace surveillant
   • entrer le code d’accès à la session
   • cliquer sur “Commencer mon test”
   • passer des épreuves
  • Vérifier que les challenges ont été enregistrés dans la table `certification-challenges`
