### PR TITLE
[FEATURE] Pix1D - Prévenir l'élève s'il n'a pas terminé son activité à la validation (PIX-8281)

### DIFF
--- a/1d/app/pods/components/answer-feedback/component.js
+++ b/1d/app/pods/components/answer-feedback/component.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class AnswerFeedback extends Component {
+  get title() {
+    if (this.args.answer?.result === 'ok') {
+      return 'Tu as réussi !';
+    } else if (this.args.answer?.result === 'aband') {
+      return 'Tu es sûr de vouloir passer ?';
+    }
+    return 'Ce n’est pas la bonne réponse';
+  }
+}

--- a/1d/app/pods/components/answer-feedback/template.hbs
+++ b/1d/app/pods/components/answer-feedback/template.hbs
@@ -1,11 +1,16 @@
-<PixModal @title="Pix1D" @showModal={{@answerHasBeenValidated}} @onCloseButtonClick={{@nextAction}}>
+<PixModal
+  class="answer"
+  @title={{this.title}}
+  @showModal={{@answerHasBeenValidated}}
+  @onCloseButtonClick={{@nextAction}}
+>
   <:content>
-    <div class="answer">
+    <div class="answer__content">
       <span class="answer__span">
         {{#if (eq @answer.result "ok")}}
-          Bravo ! C'est la bonne réponse !
+          Bravo ! C'est la bonne réponse.
         {{else if (eq @answer.result "aband")}}
-          Tu as passé. Tu réessaieras plus tard
+          Si tu passes l’activité, une autre activité plus simple te sera proposée.
         {{else}}
           Mauvaise réponse. Tu peux passer à la suite.
         {{/if}}
@@ -14,7 +19,15 @@
   </:content>
   <:footer>
     <div class="modal-footer">
-      <PixButton @triggerAction={{@nextAction}}>Je continue</PixButton>
+      <PixButton class="pix1d-button pix1d-button--modal" @triggerAction={{@nextAction}}>
+        {{#if (eq @answer.result "ok")}}
+          Je continue
+        {{else if (eq @answer.result "aband")}}
+          Oui, je passe
+        {{else}}
+          Je continue
+        {{/if}}
+      </PixButton>
     </div>
   </:footer>
 </PixModal>

--- a/1d/app/pods/components/challenge/challenge-actions/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-actions/template.hbs
@@ -1,6 +1,6 @@
 <div class="challenge-actions">
   <PixButton
-    class="challenge-actions__skip-button"
+    class="pix1d-button pix1d-button--skip"
     @isDisabled={{@isDisabled}}
     @triggerAction={{@skipChallenge}}
     @shape="rounded"
@@ -11,7 +11,7 @@
     </span>
   </PixButton>
   <PixButton
-    class="challenge-actions__verify-button"
+    class="pix1d-button"
     @isDisabled={{@isDisabled}}
     @triggerAction={{@validateAnswer}}
     @shape="rounded"

--- a/1d/app/pods/components/challenge/item/component.js
+++ b/1d/app/pods/components/challenge/item/component.js
@@ -9,6 +9,7 @@ export default class Item extends Component {
   @tracked answerHasBeenValidated = false;
   @tracked answer = null;
   @tracked answerValue = null;
+  @tracked showWarningModal = false;
 
   @action
   setAnswerValue(value) {
@@ -21,14 +22,18 @@ export default class Item extends Component {
 
   @action
   async validateAnswer() {
-    this.answer = this._createAnswer(this.args.challenge);
-    this.answer.value = this.answerValue;
-    this.answer.assessment = this.args.assessment;
-    try {
-      await this.answer.save();
-      this.answerHasBeenValidated = true;
-    } catch (error) {
-      this.answer.rollbackAttributes();
+    if (this.answerValue) {
+      this.answer = this._createAnswer(this.args.challenge);
+      this.answer.value = this.answerValue;
+      this.answer.assessment = this.args.assessment;
+      try {
+        await this.answer.save();
+        this.answerHasBeenValidated = true;
+      } catch (error) {
+        this.answer.rollbackAttributes();
+      }
+    } else {
+      this.showWarningModal = true;
     }
   }
 
@@ -41,9 +46,15 @@ export default class Item extends Component {
   @action
   resume() {
     this.answerHasBeenValidated = false;
+    this.answerValue = null;
     //TODO: Réinitiliser this.answer
     //On voulait réinitialiser this.answer à null pour repartir sur de bonnes bases,
     //mais on ne le fait pas car sinon on affiche une valeur non désirée dans la modale;
     this.router.transitionTo('assessment.resume');
+  }
+
+  @action
+  onCloseWarningModal() {
+    this.showWarningModal = false;
   }
 }

--- a/1d/app/pods/components/challenge/item/template.hbs
+++ b/1d/app/pods/components/challenge/item/template.hbs
@@ -25,3 +25,5 @@
   @answerHasBeenValidated={{this.answerHasBeenValidated}}
   @nextAction={{this.resume}}
 />
+
+<WarningFeedback @showWarningModal={{this.showWarningModal}} @onClose={{this.onCloseWarningModal}} />

--- a/1d/app/pods/components/warning-feedback/template.hbs
+++ b/1d/app/pods/components/warning-feedback/template.hbs
@@ -1,0 +1,22 @@
+<PixModal
+  class="warning"
+  @title="Tu n'as pas terminé"
+  @showModal={{@showWarningModal}}
+  @onCloseButtonClick={{@onClose}}
+>
+  <:content>
+    <p>
+      Pour valider la mission, tu dois terminer l'activité.
+    </p>
+    <p>
+      Sinon, clique sur
+      <b>Je passe</b>
+      pour faire une nouvelle activité.
+    </p>
+  </:content>
+  <:footer>
+    <div class="modal-footer">
+      <PixButton class="pix1d-button pix1d-button--modal" @triggerAction={{@onClose}}>Oui, j'ai compris</PixButton>
+    </div>
+  </:footer>
+</PixModal>

--- a/1d/app/styles/app.scss
+++ b/1d/app/styles/app.scss
@@ -1,4 +1,6 @@
 @charset "utf-8";
+@import 'globals/fonts';
+@import 'globals/buttons';
 @import 'components/challenge-actions';
 @import 'components/challenge-embed-simulator';
 @import 'components/answer';
@@ -7,7 +9,7 @@
 @import 'components/home';
 @import 'components/mission';
 @import 'components/card';
-@import 'globals/fonts';
+@import 'components/warning';
 
 body {
   text-align: center;
@@ -16,3 +18,8 @@ body {
   font-family: $font-nunito;
   font-weight: 600;
 }
+
+b {
+  font-weight: bold;
+}
+

--- a/1d/app/styles/components/answer.scss
+++ b/1d/app/styles/components/answer.scss
@@ -1,7 +1,17 @@
-.answer{
-  margin: 2rem 1rem 1rem;
-  display: flex;
-  flex-direction: column;
+.pix-modal.answer {
+  background-color: #EBEFFF;
+}
+
+.pix-modal.answer .pix-modal__content {
+  font-size: 1.125rem;
+}
+
+.answer {
+  &__content {
+    margin: 2rem 1rem 1rem;
+    display: flex;
+    flex-direction: column;
+  }
 
   &__span{
     margin-bottom: 1rem;

--- a/1d/app/styles/components/challenge-actions.scss
+++ b/1d/app/styles/components/challenge-actions.scss
@@ -1,34 +1,5 @@
 .challenge-actions {
   display: flex;
   justify-content: space-around;
-
-  &__skip-button {
-    background-color: white;
-    color: #556bcc;
-    border: 1px solid #556BCC;
-    box-shadow: 0 3px #495aa0;
-    font-size: 1.25rem;
-    padding: 16px 48px;
-    border-radius: 30px;
-
-    &:hover {
-      color: white;
-    }
-  }
-
-  &__verify-button {
-    background-color: #556bcc;
-    color: white;
-    border: 1px solid #556BCC;
-    box-shadow: 0 3px #495aa0;
-    font-size: 1.25rem;
-    padding: 16px 48px;
-    border-radius: 30px;
-  }
 }
 
-.pix-button--background-blue.challenge-actions__skip-button, .pix-button--background-blue.challenge-actions__verify-button {
-  &:hover {
-    background-color: #495AA0;
-  }
-}

--- a/1d/app/styles/components/mission.scss
+++ b/1d/app/styles/components/mission.scss
@@ -68,10 +68,6 @@
   }
 }
 
-b {
-  font-weight: bold;
-}
-
 ul{
   text-align: left;
   font-weight: 400;

--- a/1d/app/styles/components/warning.scss
+++ b/1d/app/styles/components/warning.scss
@@ -1,0 +1,13 @@
+.pix-modal.warning {
+  background-color: #EBEFFF;
+}
+
+.pix-modal.warning .pix-modal__content {
+  font-size: 1.125rem;
+}
+
+.pix-button--background-blue.warning__button {
+  &:hover {
+    background-color: #495AA0;
+  }
+}

--- a/1d/app/styles/globals/_buttons.scss
+++ b/1d/app/styles/globals/_buttons.scss
@@ -1,0 +1,28 @@
+.pix1d-button {
+  background-color: #556bcc;
+  color: white;
+  border: 1px solid #556BCC;
+  box-shadow: 0 3px #495aa0;
+  font-size: 1.25rem;
+  padding: 16px 48px;
+  border-radius: 30px;
+
+  &--modal {
+    font-size: 1rem;
+  }
+
+  &--skip {
+    background-color: white;
+    color: #556bcc;
+
+    &:hover, &:focus {
+      color: white;
+    }
+  }
+}
+
+.pix-button--background-blue.pix1d-button {
+  &:hover, &:focus {
+    background-color: #495AA0;
+  }
+}

--- a/1d/mirage/config.js
+++ b/1d/mirage/config.js
@@ -20,9 +20,10 @@ export default function () {
     return schema.challenges.find(1);
   });
 
-  this.post('/answers', (schema) => {
+  this.post('/answers', (schema, request) => {
+    const answerValue = JSON.parse(request.requestBody).data.attributes?.value;
     return schema.create('answer', {
-      result: 'ok',
+      result: answerValue === '#ABAND#' ? 'aband' : 'ok',
     });
   });
 

--- a/1d/tests/acceptance/display-answer-modal_test.js
+++ b/1d/tests/acceptance/display-answer-modal_test.js
@@ -1,20 +1,25 @@
-import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click } from '@ember/test-helpers';
 
 module('Acceptance | Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('displays answer modal', async function (assert) {
-    const assessment = this.server.create('assessment');
-    this.server.create('challenge');
-    // when
-    const screen = await visit(`/assessments/${assessment.id}/challenges`);
-    await clickByText('Je vérifie');
+  module('when user clicks on skip button', function () {
+    test('displays answer modal', async function (assert) {
+      const assessment = this.server.create('assessment');
+      this.server.create('challenge');
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      await click(within(document.querySelector('.challenge-actions')).getByRole('button', { name: 'Je passe' }));
 
-    // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse !")).exists();
+      // then
+      assert
+        .dom(screen.getByText('Si tu passes l’activité, une autre activité plus simple te sera proposée.'))
+        .exists();
+    });
   });
 });

--- a/1d/tests/acceptance/display-warning-modal_test.js
+++ b/1d/tests/acceptance/display-warning-modal_test.js
@@ -1,0 +1,22 @@
+import { visit, within } from '@1024pix/ember-testing-library';
+import { module, skip } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click } from '@ember/test-helpers';
+
+module('Acceptance | Challenge', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  //TODO Trouver comment tester l'affichage réel de la popup. L'assert répond toujours ok :(
+  skip('displays warning modal', async function (assert) {
+    const assessment = this.server.create('assessment');
+    this.server.create('challenge');
+    // when
+    const screen = await visit(`/assessments/${assessment.id}/challenges`);
+    await click(within(document.querySelector('.challenge-actions')).getByRole('button', { name: 'Je vérifie' }));
+
+    // then
+    assert.dom(screen.getByText("Pour valider la mission, tu dois terminer l'activité.")).isVisible();
+  });
+});

--- a/1d/tests/integration/components/answer_test.js
+++ b/1d/tests/integration/components/answer_test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | answer', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('displays felicitations when the answer is correct', async function (assert) {
+  test('displays kudos when the answer is correct', async function (assert) {
     // given & when
     this.set('answer', {
       result: 'ok',
@@ -14,7 +14,7 @@ module('Integration | Component | answer', function (hooks) {
     const screen = await render(hbs`<AnswerFeedback @answer={{this.answer}} @answerHasBeenValidated={{true}} />`);
 
     // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse !")).exists();
+    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
   });
 
   test('displays try later when the challenge is skipped', async function (assert) {
@@ -25,7 +25,7 @@ module('Integration | Component | answer', function (hooks) {
     const screen = await render(hbs`<AnswerFeedback @answer={{this.answer}} @answerHasBeenValidated={{true}} />`);
 
     // then
-    assert.dom(screen.getByText('Tu as passé. Tu réessaieras plus tard')).exists();
+    assert.dom(screen.getByText('Si tu passes l’activité, une autre activité plus simple te sera proposée.')).exists();
   });
 
   test('displays bad response when the answer is not correct', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un élève ne réalise pas une activité dans un embed et valide, on considère que sa réponse est fausse.

## :robot: Proposition
Ajouter une modale à la validation pour indiquer à l'élève qu'il n'a pas terminé l'activité, et qu'il peut soit, après avoir fermé la popup : 

- Faire l'activité, puis valider
- Passer

## :rainbow: Remarques
Les popups n'ayant aucun design, uniformiser avec le design existant (taille de police / couleur / forme des boutons).

## :100: Pour tester
Accéder à une mission Pix1D. Valider la 1ère épreuve sans avoir réalisé aucune action dans l'embed.
La popup s'affiche et explique les différentes options. Elle n'est pas trop laide.