### PR TITLE
[TECH] Nettoyage des fichiers de l'ajout de la modale pour détacher un profil cible (PIX-8450)

### DIFF
--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -7,7 +7,7 @@
           <th><label for="name">Nom</label></th>
           <th><label for="type">Type</label></th>
           <th><label for="externalId">Identifiant externe</label></th>
-          {{#if @showDetachColumn}}
+          {{#if this.isSuperAdminOrMetier}}
             <th>Actions</th>
           {{/if}}
         </tr>
@@ -48,7 +48,7 @@
               class="table-admin-input form-control"
             />
           </td>
-          {{#if @showDetachColumn}}
+          {{#if this.isSuperAdminOrMetier}}
             <td></td>
           {{/if}}
         </tr>

--- a/admin/tests/integration/components/organizations/list-items_test.js
+++ b/admin/tests/integration/components/organizations/list-items_test.js
@@ -51,13 +51,37 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
   @detachOrganizations={{this.detachOrganizations}}
-  @showDetachColumn={{true}}
 />`
       );
 
       // then
       assert.strictEqual(screen.getAllByRole('button', { name: 'Détacher' }).length, this.organizations.length);
       assert.dom(screen.getByText('Actions')).exists();
+    });
+
+    test('it should open confirm modal when click on "Détacher" button', async function (assert) {
+      //given
+      this.targetProfile = { name: 'super profil cible' };
+
+      //when
+      const screen = await render(
+        hbs`<Organizations::ListItems
+  @organizations={{this.organizations}}
+  @externalId='{{@externalId}}'
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+  @targetProfileName={{this.targetProfile.name}}
+/>`
+      );
+
+      const detachButton = screen.getAllByRole('button', { name: 'Détacher' })[0];
+      await click(detachButton);
+
+      await screen.findByRole('dialog');
+      const modalTitle = await screen.getByRole('heading', { name: "Détacher l'organisation du profil cible" });
+      //then
+      assert.dom(modalTitle).exists();
     });
 
     test('it should detach an organization when click on "Détacher" button', async function (assert) {
@@ -69,7 +93,6 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
   @detachOrganizations={{this.detachOrganizations}}
-  @showDetachColumn={{true}}
 />`
       );
       const detachButton = screen.getAllByRole('button', { name: 'Détacher' })[0];


### PR DESCRIPTION
## :unicorn: Problème
Suite à cette [PR](https://github.com/1024pix/pix/pull/6452), il restait des paramètres inutiles dans les tests, ainsi qu'un oubli de changement de condition dans le fichier .hbs

## :robot: Proposition
Nettoyer et corriger ces deux fichiers

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Admin en tant que SuperAdmin ou Metier
- Vérifier que dans la page d'un profil cible la colonne Actions existe ainsi que le bouton détacher associé
- Vérifier que la modale s'ouvre bien au clic sur ce bouton
- Se connecter maintenant en tant que Support à Pix Admin
- Retourner sur la page précédente
- Vérifier que la colonne Actions ainsi que les boutons ne sont plus affichés
- 🐱 
