### PR TITLE
[FEATURE] Afficher la notion de progressivité sur les résultats thématiques en lacunes non certifiants (PIX-8057)

### DIFF
--- a/mon-pix/app/components/badge-card.hbs
+++ b/mon-pix/app/components/badge-card.hbs
@@ -1,16 +1,24 @@
 <div id="{{@title}}" class="badge-card">
-  <div class="badge-card__text">
-    <p class="badge-card__status">
-      {{#if @isAcquired}}
-        <FaIcon @icon="circle-check" class="badge-card-status__acquired-icon" />
-        {{t "pages.skill-review.badge-card.acquired"}}
-      {{else}}
-        <FaIcon @icon="circle-xmark" class="badge-card-status__not-acquired-icon" />
-        {{t "pages.skill-review.badge-card.not-acquired"}}
+  <div class="badge-card__content">
+    <div class="badge-card-content__header">
+      <p class="badge-card-content-header__status">
+        {{#if @isAcquired}}
+          <FaIcon @icon="circle-check" class="badge-card-content-header-status__acquired-icon" />
+          {{t "pages.skill-review.badge-card.acquired"}}
+        {{else}}
+          <FaIcon @icon="circle-xmark" class="badge-card-content-header-status__not-acquired-icon" />
+          {{t "pages.skill-review.badge-card.not-acquired"}}
+        {{/if}}
+      </p>
+      {{#if @isAlwaysVisible}}
+        <PixProgressGauge
+          @value={{@acquisitionPercentage}}
+          @label={{t "pages.skill-review.badge-card.progress-bar-label"}}
+        />
       {{/if}}
-    </p>
-    <h3 class="badge-card-text__title">{{@title}}</h3>
-    <p class="badge-card-text__message">
+    </div>
+    <h3 class="badge-card-content__title">{{@title}}</h3>
+    <p class="badge-card-content__message">
       <MarkdownToHtml @markdown={{@message}} />
     </p>
   </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -251,6 +251,8 @@
           <BadgeCard
             @title={{badge.title}}
             @message={{badge.message}}
+            @isAlwaysVisible={{badge.isAlwaysVisible}}
+            @acquisitionPercentage={{badge.acquisitionPercentage}}
             @imageUrl={{badge.imageUrl}}
             @altMessage={{badge.altMessage}}
             @isAcquired={{badge.isAcquired}}

--- a/mon-pix/app/models/campaign-participation-badge.js
+++ b/mon-pix/app/models/campaign-participation-badge.js
@@ -10,6 +10,7 @@ export default class CampaignParticipationBadge extends Badge {
   @attr('boolean') isAlwaysVisible;
   @attr('boolean') isCertifiable;
   @attr('boolean') isValid;
+  @attr('number') acquisitionPercentage;
 
   // includes
   @hasMany('skillSetResult') skillSetResults;

--- a/mon-pix/app/styles/components/_badge-card.scss
+++ b/mon-pix/app/styles/components/_badge-card.scss
@@ -23,7 +23,7 @@
     min-height: 200px;
   }
 
-  &__text {
+  &__content {
     display: flex;
     flex-direction: column;
     max-width: 70%;
@@ -34,27 +34,6 @@
       flex: 1 1 40%;
       min-width: 300px;
       max-width: 300px;
-    }
-  }
-
-  &-text {
-    &__title {
-      margin: 1em 0;
-      color: $pix-neutral-100;
-      font-weight: $font-medium;
-      font-size: 1.12rem;
-      font-family: $font-roboto;
-      letter-spacing: 0.028rem;
-    }
-
-    &__message {
-      margin-bottom: 0;
-      color: $pix-neutral-45;
-      font-weight: $font-normal;
-      font-size: 0.85rem;
-      font-family: $font-roboto;
-      line-height: 1.2rem;
-      letter-spacing: 0.0093rem;
     }
   }
 
@@ -77,14 +56,47 @@
   }
 }
 
-.badge-card-status {
+.badge-card-content {
+  &__header {
+    display: flex;
+    gap: $pix-spacing-s;
+    align-items: center;
+  }
+
+  &__title {
+    @extend %pix-title-xs;
+
+    margin: 12px 0 $pix-spacing-xs;
+    color: $pix-neutral-100;
+  }
+
+  &__message {
+    @extend %pix-body-s;
+
+    margin-bottom: 0;
+    color: $pix-neutral-45;
+  }
+}
+
+.badge-card-content-header {
+    &__status {
+      @extend %pix-body-s;
+
+      padding: $pix-spacing-xxs $pix-spacing-xs;
+      white-space: nowrap;
+      background-color: $pix-neutral-10;
+      border-radius: 8px;
+    }
+  }
+
+.badge-card-content-header-status {
   &__acquired-icon {
-    margin-right: 4px;
+    margin-right:  $pix-spacing-xxs;
     color: $pix-success-50;
   }
 
   &__not-acquired-icon {
-    margin-right: 4px;
+    margin-right:  $pix-spacing-xxs;
     color: $pix-neutral-50;
   }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^36.0.0",
+        "@1024pix/pix-ui": "^36.0.1",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.0.tgz",
-      "integrity": "sha512-gFXFofvHxXZ754qNx6WH5y0UwHJkKWOxpEbOz4gsi0UbDKxU7eIVN8Jc7Y2I7rstHKxWGr+dGdM1J9p9jrVeXQ==",
+      "version": "36.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.1.tgz",
+      "integrity": "sha512-RWmb+iiW6CSqaaUiz/74STXuPsh3d0ren+It6BLNRAUFgRGoPRCXzLxqZAqDIjIr/J+JusXWT6x1tT/vnAjcsQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -40650,9 +40650,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.0.tgz",
-      "integrity": "sha512-gFXFofvHxXZ754qNx6WH5y0UwHJkKWOxpEbOz4gsi0UbDKxU7eIVN8Jc7Y2I7rstHKxWGr+dGdM1J9p9jrVeXQ==",
+      "version": "36.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-36.0.1.tgz",
+      "integrity": "sha512-RWmb+iiW6CSqaaUiz/74STXuPsh3d0ren+It6BLNRAUFgRGoPRCXzLxqZAqDIjIr/J+JusXWT6x1tT/vnAjcsQ==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^36.0.0",
+    "@1024pix/pix-ui": "^36.0.1",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -159,6 +159,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
           altMessage: 'Yon won a Yellow badge',
           imageUrl: '/images/badges/yellow.svg',
           message: 'Congrats, you won a Yellow badge',
+          acquisitionPercentage: 100,
           isAcquired: true,
           isValid: true,
           isCertifiable: false,
@@ -168,6 +169,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
           imageUrl: '/images/badges/green.svg',
           message: 'Congrats, you won a Green badge',
           isAcquired: false,
+          acquisitionPercentage: 20,
           isValid: true,
           isAlwaysVisible: true,
           isCertifiable: false,
@@ -177,6 +179,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
           imageUrl: '/images/badges/pink.svg',
           message: 'Congrats, you won a pink badge',
           isAcquired: false,
+          acquisitionPercentage: 0,
           isValid: true,
           isAlwaysVisible: false,
           isCertifiable: true,
@@ -186,10 +189,16 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
         });
 
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
         assert.strictEqual(findAll('.badge-card').length, 2);
+        assert.strictEqual(
+          screen
+            .getByRole('progressbar', { name: 'Pourcentage de réussite du résultat thématique' })
+            .textContent.trim(),
+          '20%'
+        );
       });
 
       module('when campaign has stages', function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -12,22 +12,134 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
   hooks.beforeEach(function () {
     possibleBadgesCombinations = [
-      { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-      { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
-      { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-      { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-      { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-      { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
-      { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
-      { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
-      { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-      { id: 39, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: false },
-      { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-      { id: 41, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-      { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-      { id: 43, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: false },
-      { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
-      { id: 45, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+      {
+        id: 30,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 10,
+      },
+      {
+        id: 31,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 15,
+      },
+      {
+        id: 32,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 1,
+      },
+      {
+        id: 33,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 67,
+      },
+      {
+        id: 34,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 56,
+      },
+      {
+        id: 35,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 100,
+      },
+      {
+        id: 36,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 0,
+      },
+      {
+        id: 37,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 0,
+      },
+      {
+        id: 38,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 30,
+      },
+      {
+        id: 39,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 98,
+      },
+      {
+        id: 40,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 67,
+      },
+      {
+        id: 41,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 32,
+      },
+      {
+        id: 42,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 34,
+      },
+      {
+        id: 43,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 3,
+      },
+      {
+        id: 44,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 0,
+      },
+      {
+        id: 45,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 100,
+      },
     ];
 
     const model = {
@@ -339,7 +451,7 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
   });
 
   module('#notCertifiableBadges', function () {
-    test('should only return acquired and not certifiable badges', function (assert) {
+    test('should only return not certifiable badges', function (assert) {
       // given
       component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
 
@@ -348,12 +460,54 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
       // then
       assert.deepEqual(notCertifiableBadges, [
-        { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-        { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
-        { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
-        { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
-        { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-        { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+        {
+          id: 34,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 56,
+        },
+        {
+          id: 35,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: true,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 100,
+        },
+        {
+          id: 36,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 0,
+        },
+        {
+          id: 37,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: false,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 0,
+        },
+        {
+          id: 42,
+          isAcquired: false,
+          isCertifiable: false,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 34,
+        },
+        {
+          id: 44,
+          isAcquired: false,
+          isCertifiable: false,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 0,
+        },
       ]);
     });
   });
@@ -368,8 +522,22 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
       // then
       assert.deepEqual(acquiredBadges, [
-        { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+        {
+          id: 30,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 10,
+        },
+        {
+          id: 31,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 15,
+        },
       ]);
     });
   });
@@ -384,10 +552,38 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
       // then
       assert.deepEqual(acquiredBadges, [
-        { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-        { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-        { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+        {
+          id: 32,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 1,
+        },
+        {
+          id: 33,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 67,
+        },
+        {
+          id: 38,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 30,
+        },
+        {
+          id: 40,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 67,
+        },
       ]);
     });
   });
@@ -402,12 +598,54 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
       // then
       assert.deepEqual(acquiredBadges, [
-        { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
-        { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-        { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-        { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+        {
+          id: 30,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 10,
+        },
+        {
+          id: 31,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 15,
+        },
+        {
+          id: 32,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 1,
+        },
+        {
+          id: 33,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 67,
+        },
+        {
+          id: 38,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 30,
+        },
+        {
+          id: 40,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 67,
+        },
       ]);
     });
   });

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -12,22 +12,134 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
   hooks.beforeEach(function () {
     possibleBadgesCombinations = [
-      { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-      { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
-      { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-      { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-      { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-      { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
-      { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
-      { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
-      { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-      { id: 39, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: false },
-      { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-      { id: 41, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-      { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-      { id: 43, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: false },
-      { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
-      { id: 45, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+      {
+        id: 30,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 10,
+      },
+      {
+        id: 31,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 15,
+      },
+      {
+        id: 32,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 1,
+      },
+      {
+        id: 33,
+        isAcquired: true,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 67,
+      },
+      {
+        id: 34,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 56,
+      },
+      {
+        id: 35,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 100,
+      },
+      {
+        id: 36,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 0,
+      },
+      {
+        id: 37,
+        isAcquired: true,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 0,
+      },
+      {
+        id: 38,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 30,
+      },
+      {
+        id: 39,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 98,
+      },
+      {
+        id: 40,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 67,
+      },
+      {
+        id: 41,
+        isAcquired: false,
+        isCertifiable: true,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 32,
+      },
+      {
+        id: 42,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 34,
+      },
+      {
+        id: 43,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: true,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 3,
+      },
+      {
+        id: 44,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: true,
+        acquisitionPercentage: 0,
+      },
+      {
+        id: 45,
+        isAcquired: false,
+        isCertifiable: false,
+        isValid: false,
+        isAlwaysVisible: false,
+        acquisitionPercentage: 100,
+      },
     ];
 
     const model = {
@@ -308,12 +420,54 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
       // then
       assert.deepEqual(notCertifiableBadges, [
-        { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-        { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
-        { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
-        { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
-        { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
-        { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+        {
+          id: 34,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 56,
+        },
+        {
+          id: 35,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: true,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 100,
+        },
+        {
+          id: 36,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 0,
+        },
+        {
+          id: 37,
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: false,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 0,
+        },
+        {
+          id: 42,
+          isAcquired: false,
+          isCertifiable: false,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 34,
+        },
+        {
+          id: 44,
+          isAcquired: false,
+          isCertifiable: false,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 0,
+        },
       ]);
     });
   });
@@ -328,8 +482,22 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
       // then
       assert.deepEqual(acquiredBadges, [
-        { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+        {
+          id: 30,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 10,
+        },
+        {
+          id: 31,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 15,
+        },
       ]);
     });
   });
@@ -344,10 +512,38 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
       // then
       assert.deepEqual(acquiredBadges, [
-        { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-        { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-        { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+        {
+          id: 32,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 1,
+        },
+        {
+          id: 33,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 67,
+        },
+        {
+          id: 38,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 30,
+        },
+        {
+          id: 40,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 67,
+        },
       ]);
     });
   });
@@ -362,12 +558,54 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
       // then
       assert.deepEqual(acquiredBadges, [
-        { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
-        { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
-        { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
-        { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
-        { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+        {
+          id: 30,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 10,
+        },
+        {
+          id: 31,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 15,
+        },
+        {
+          id: 32,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 1,
+        },
+        {
+          id: 33,
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: false,
+          acquisitionPercentage: 67,
+        },
+        {
+          id: 38,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 30,
+        },
+        {
+          id: 40,
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          acquisitionPercentage: 67,
+        },
       ]);
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1376,6 +1376,7 @@
       },
       "already-shared": "Thank you, your results have been submitted!",
       "badge-card": {
+        "progress-bar-label": "Badge result percentage",
         "acquired": "Awarded",
         "not-acquired": "Not awarded"
       },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1376,9 +1376,9 @@
       },
       "already-shared": "Thank you, your results have been submitted!",
       "badge-card": {
-        "progress-bar-label": "Badge result percentage",
         "acquired": "Awarded",
-        "not-acquired": "Not awarded"
+        "not-acquired": "Not awarded",
+        "progress-bar-label": "Badge result percentage"
       },
       "badges-title": "Your thematic results",
       "details": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1376,6 +1376,7 @@
       },
       "already-shared": "Merci, vos résultats ont bien été envoyés !",
       "badge-card": {
+        "progress-bar-label": "Pourcentage de réussite du résultat thématique",
         "acquired": "Obtenu",
         "not-acquired": "Non obtenu"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1376,9 +1376,9 @@
       },
       "already-shared": "Merci, vos résultats ont bien été envoyés !",
       "badge-card": {
-        "progress-bar-label": "Pourcentage de réussite du résultat thématique",
         "acquired": "Obtenu",
-        "not-acquired": "Non obtenu"
+        "not-acquired": "Non obtenu",
+        "progress-bar-label": "Pourcentage de réussite du résultat thématique"
       },
       "badges-title": "Vos résultats thématiques",
       "details": {


### PR DESCRIPTION
## :unicorn: Problème
On souhaite afficher une notion de progressivité sur les résultats thématiques en lacunes.

## :robot: Proposition
Afficher une barre de progression sur les résultats thématiques.

## :rainbow: Remarques
Pour le moment, on ajoute la notion de progressivité sur les résultats thématiques non certifiants. Le travail pour les résultats thématiques certifiants sera fait prochainement.

## :100: Pour tester
Se connecter avec `jaune.attend@example.net` et aller sur la campagne `PROCOMP51`.
Visualiser que la notion de progressivité est présente sur les résultats thématiques en lacunes.
