### PR TITLE
[FEATURE] Modifier le texte sur la double mire SSO PIX-8407

### DIFF
--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
@@ -42,7 +42,7 @@ module('Integration | Component | authentication | login-or-register-oidc', func
     );
   });
 
-  module('on login form', function () {
+  module('on register form', function () {
     test('should display elements for OIDC identity provider', async function (assert) {
       // given & when
       const screen = await render(
@@ -78,7 +78,7 @@ module('Integration | Component | authentication | login-or-register-oidc', func
     });
   });
 
-  module('on register form', function () {
+  module('on login form', function () {
     test('should display elements for OIDC identity provider', async function (assert) {
       // given & when
       const screen = await render(
@@ -88,7 +88,7 @@ module('Integration | Component | authentication | login-or-register-oidc', func
       // then
       assert.ok(
         screen.getByRole('heading', {
-          name: this.intl.t('pages.login-or-register-oidc.register-form.title'),
+          name: this.intl.t('pages.login-or-register-oidc.login-form.title'),
           level: 2,
         })
       );

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -996,7 +996,7 @@
       "title": "Créez votre compte Pix",
       "login-form": {
         "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées",
-        "title": "Vous avez déjà un compte Pix ?",
+        "title": "J'ai déjà un compte Pix",
         "email": "Email address",
         "password": "Password",
         "button": "Log in"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -996,7 +996,7 @@
       "title": "Créez votre compte Pix",
       "login-form": {
         "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées",
-        "title": "Vous avez déjà un compte Pix ?",
+        "title": "J'ai déjà un compte Pix",
         "email": "Adresse e-mail",
         "password": "Mot de passe",
         "button": "Je me connecte"


### PR DESCRIPTION
## :unicorn: Problème
Sur la partie création de compte de la double mire OIDC, nous utilisons le tutoiement pour nous adresser à l'utilisateur, tandis que sur la partie connexion, nous utilisons le vouvoiement.

## :robot: Proposition

- Remplacer le titre de la partie de droite “Vous avez déjà un compte Pix?" par "J'ai déjà un compte Pix" 
- Ne pas mettre de point d’interrogation

## :rainbow: Remarques
C'est une solution temporaire. Il faudrait revoir tout le wording pour que ce soit cohérent avec les autres doubles mires. 

## :100: Pour tester

1. Se connecter à Pix via SSO (Pole Emploi pour .fr et FBW pour .org)
2. Lorsque vous arrivez sur la double mire, vérifier que dans la partie droite, celle de la connexion, il y a bien écrit "J'ai déjà un compte Pix" .