### PR TITLE
[TECH] Supprimer les faux positifs sur les tests automatisés en utilisant VScode (PIX-8463).

### DIFF
--- a/api/tests/integration/domain/services/organization-learners-csv-service_test.js
+++ b/api/tests/integration/domain/services/organization-learners-csv-service_test.js
@@ -1,3 +1,4 @@
+import * as url from 'url';
 import _ from 'lodash';
 import { expect, catchErr } from '../../../test-helper.js';
 import { CsvImportError } from '../../../../lib/domain/errors.js';
@@ -5,12 +6,14 @@ import { extractOrganizationLearnersInformation } from '../../../../lib/domain/s
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 const i18n = getI18n();
 
+const fixturesDirPath = `${url.fileURLToPath(new URL('../../../', import.meta.url))}tooling/fixtures/`;
+
 describe('Integration | Services | organization-learners-csv-service', function () {
   describe('extractOrganizationLearnersInformation', function () {
     it('should parse two organizationLearners information', async function () {
       // given
       const organization = { id: 123, isAgriculture: true };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-csv-with-two-valid-students.csv`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-csv-with-two-valid-students.csv`;
       const expectedOrganizationLearners = [
         {
           lastName: 'Corse',
@@ -61,7 +64,7 @@ describe('Integration | Services | organization-learners-csv-service', function 
     it('when the encoding is not supported it throws an error', async function () {
       // given
       const organization = { id: 123, isAgriculture: true };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-csv-with-unknown-encoding.csv`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-csv-with-unknown-encoding.csv`;
       // when
       const error = await catchErr(extractOrganizationLearnersInformation)(path, organization, i18n);
 
@@ -73,7 +76,7 @@ describe('Integration | Services | organization-learners-csv-service', function 
     it('should abort parsing and reject with duplicate national student id error', async function () {
       // given
       const organization = { id: 123, isAgriculture: true };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-csv-with-duplicate-national-student-id.csv`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-csv-with-duplicate-national-student-id.csv`;
       // when
       const error = await catchErr(extractOrganizationLearnersInformation)(path, organization, i18n);
 
@@ -86,7 +89,7 @@ describe('Integration | Services | organization-learners-csv-service', function 
     it('should abort parsing and reject with missing national student id error', async function () {
       // given
       const organization = { id: 123, isAgriculture: true };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-csv-with-no-national-student-id.csv`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-csv-with-no-national-student-id.csv`;
       // when
       const error = await catchErr(extractOrganizationLearnersInformation)(path, organization, i18n);
 

--- a/api/tests/integration/domain/services/organization-learners-xml-service_test.js
+++ b/api/tests/integration/domain/services/organization-learners-xml-service_test.js
@@ -1,6 +1,9 @@
+import * as url from 'url';
 import { expect, catchErr } from '../../../test-helper.js';
 import { SiecleXmlImportError } from '../../../../lib/domain/errors.js';
 import * as organizationLearnersXmlService from '../../../../lib/domain/services/organization-learners-xml-service.js';
+
+const fixturesDirPath = `${url.fileURLToPath(new URL('../../../', import.meta.url))}tooling/fixtures/`;
 
 describe('Integration | Services | organization-learnerz-xml-service', function () {
   describe('extractOrganizationLearnersInformationFromSIECLE', function () {
@@ -8,7 +11,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const validUAIFromSIECLE = '123ABC';
       const organization = { externalId: validUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-two-valid-students.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-two-valid-students.xml`;
       const expectedOrganizationLearners = [
         {
           lastName: 'HANDMADE',
@@ -60,7 +63,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const validUAIFromSIECLE = '123ABC';
       const organization = { externalId: validUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-registrations-no-longer-in-school.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-registrations-no-longer-in-school.xml`;
       const expectedOrganizationLearners = [];
 
       // when
@@ -77,7 +80,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const wrongUAIFromSIECLE = '123ABC';
       const organization = { externalId: wrongUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-wrong-uai.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-wrong-uai.xml`;
       // when
       const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
         path,
@@ -93,7 +96,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const wrongUAIFromSIECLE = '123ABC';
       const organization = { externalId: wrongUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-no-uai.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-no-uai.xml`;
       // when
       const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
         path,
@@ -109,7 +112,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const validUAIFromSIECLE = '123ABC';
       const organization = { externalId: validUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-duplicate-national-student-id.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-duplicate-national-student-id.xml`;
       // when
       const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
         path,
@@ -126,7 +129,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const validUAIFromSIECLE = '123ABC';
       const organization = { externalId: validUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-duplicate-national-student-id-and-unclosed-tag.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-duplicate-national-student-id-and-unclosed-tag.xml`;
       // when
       const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
         path,
@@ -143,7 +146,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const validUAIFromSIECLE = '123ABC';
       const organization = { externalId: validUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-with-no-national-student-id.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-with-no-national-student-id.xml`;
       // when
       const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
         path,
@@ -159,7 +162,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       // given
       const validUAIFromSIECLE = '123ABC';
       const organization = { externalId: validUAIFromSIECLE };
-      const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-student-with-no-sex.xml`;
+      const path = `${fixturesDirPath}/siecle-file/siecle-student-with-no-sex.xml`;
       // when
       const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
         path,
@@ -174,7 +177,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
         // given
         const validUAIFromSIECLE = '123ABC';
         const organization = { externalId: validUAIFromSIECLE };
-        const path = `${process.cwd()}/tests/tooling/fixtures/siecle-file/siecle-french-student-with-no-birth-city-code.xml`;
+        const path = `${fixturesDirPath}/siecle-file/siecle-french-student-with-no-birth-city-code.xml`;
         // when
         const error = await catchErr(organizationLearnersXmlService.extractOrganizationLearnersInformationFromSIECLE)(
           path,

--- a/api/tests/integration/scripts/prod/archive-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/archive-campaigns_test.js
@@ -1,8 +1,11 @@
+import * as url from 'url';
 import { expect, databaseBuilder, knex, sinon } from '../../../test-helper.js';
 import { archiveCampaigns } from '../../../../scripts/prod/archive-campaigns.js';
 import lodash from 'lodash';
 
 const { noop } = lodash;
+
+const fixturesDirPath = `${url.fileURLToPath(new URL('../../../', import.meta.url))}tooling/fixtures/`;
 
 describe('Script | Prod | Archive Campaign', function () {
   let clock;
@@ -18,7 +21,7 @@ describe('Script | Prod | Archive Campaign', function () {
 
   describe('#archiveCampaigns', function () {
     it('archives all given campaigns', async function () {
-      const file = './tests/tooling/fixtures/campaigns-to-archive.csv';
+      const file = `${fixturesDirPath}/campaigns-to-archive.csv`;
 
       const logger = {
         setTotal: () => {
@@ -47,7 +50,7 @@ describe('Script | Prod | Archive Campaign', function () {
     });
 
     it('archives all archivable campaigns', async function () {
-      const file = './tests/tooling/fixtures/campaigns-unarchivable.csv';
+      const file = `${fixturesDirPath}/campaigns-unarchivable.csv`;
 
       const logger = {
         setTotal: () => {


### PR DESCRIPTION
## :unicorn: Problème

Selon où on lance les commandes, les tests ne passent pas.
Cela empêche par exemple certains outils de dev (IDE par ex) de lancer les tests. Et donc de bénéficier de la puissance de nos outils.

## :robot: Proposition

Ne plus être dépendant de l'endroit d'execution des tests dans les tests.

## :rainbow: Remarques

⚠️ Si vous testez sous VSCode il est conseillé de mettre à jour votre `settings.json` selon les nouvelles directives de configuration (suite passage ESM, etc.).
Une PR avec les bonnes valeurs correctes est d'ailleurs en cours de review : https://github.com/1024pix/pix/pull/6434


Exemple OK dans VSCode avec l'extension Mocha Test Explorer

![image](https://github.com/1024pix/pix/assets/170271/48f7d254-3cd5-47ce-af93-bdbb95c918c3)


## :100: Pour tester
* `npm ci && npm test` OK
* Dans votre IDE (testé seulement avec VSCode), tous les tests passent désormais
