### PR TITLE
[TECH] Créer le feature toggle d'activation du niveau 7 (PIX-8394).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -222,6 +222,7 @@ const configuration = (function () {
       isDifferentiatedTimeInvigilatorPortalEnabled: isFeatureEnabled(
         process.env.FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL
       ),
+      isLevel7Enabled: isFeatureEnabled(process.env.FT_LEVEL7_ENABLED),
     },
 
     infra: {
@@ -362,6 +363,7 @@ const configuration = (function () {
     config.featureToggles.isMassiveSessionManagementEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
     config.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled = true;
+    config.featureToggles.isLevel7Enabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -30,6 +30,7 @@ const schema = Joi.object({
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL: Joi.string().optional().valid('true', 'false'),
+  FT_LEVEL7_ENABLED: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -852,6 +852,13 @@ FT_TRAINING_RECOMMENDATION=false
 # default: false
 # FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL=true
 
+# Enable the level 7 challenges feature
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_LEVEL7_ENABLED=false
+
 # =====
 # CPF
 # =====

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -25,6 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-massive-session-management-enabled': false,
             'is-pix1d-enabled': true,
             'is-differentiated-time-invigilator-portal-enabled': true,
+            'is-level7-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isLevel7Enabled;
+}

--- a/mon-pix/tests/unit/services/feature-toggles_test.js
+++ b/mon-pix/tests/unit/services/feature-toggles_test.js
@@ -9,7 +9,9 @@ module('Unit | Service | feature-toggles', function (hooks) {
   setupTest(hooks);
 
   module('feature toggles are loaded', function (hooks) {
-    const featureToggles = Object.create({});
+    const featureToggles = Object.create({
+      isLevel7Enabled: false,
+    });
 
     let storeStub;
 
@@ -29,6 +31,18 @@ module('Unit | Service | feature-toggles', function (hooks) {
 
       // then
       assert.deepEqual(featureToggleService.featureToggles, featureToggles);
+    });
+
+    test('it should initialize the feature toggle isLevel7Enabled to false', async function (assert) {
+      // given
+      const featureToggleService = this.owner.lookup('service:featureToggles');
+      featureToggleService.set('store', storeStub);
+
+      // when
+      await featureToggleService.load();
+
+      // then
+      assert.false(featureToggleService.featureToggles.isLevel7Enabled);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Afin d'attaquer sereinement l'ouverture sur Pix du niveau 7, il faut mettre en place un interrupteur sur l'activation de celui-ci.

## :robot: Proposition
Créer un feature toggle que l'on nommera, de manière originale et ambitieuse, FT_LEVEL7_ENABLED. 

## :rainbow: Remarques
Je voulais mettre un tiret du bas (underscore pour les franglophones) entre LEVEL et 7 (FT_LEVEL_7_ENABLED) mais il semble qu'il y ait un mécanisme qui m'échappe qui remplace supprime ce tiret lors de la sérialisation. 

## :100: Pour tester
- Lancer Pix, regarder les appels API, trouver l'appel API des feature toggles, vérifier la présence de notre nouveau feature toggle. 