### PR TITLE
[FEATURE] Afficher une bannière annonçant l'ouverture de l'import de session en masse sur Pix Certif (PIX-6964).

### DIFF
--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -10,6 +10,9 @@ export default class AuthenticatedController extends Controller {
   @tracked isBannerVisible = true;
   @service router;
   @service currentUser;
+  @service featureToggles;
+  @service currentDomain;
+  @service intl;
 
   get showBanner() {
     const isOnFinalizationPage = this.router.currentRouteName === 'authenticated.sessions.finalize';
@@ -18,6 +21,19 @@ export default class AuthenticatedController extends Controller {
       this.isBannerVisible &&
       !isOnFinalizationPage &&
       !this.currentUser.currentAllowedCertificationCenterAccess.isAccessRestricted
+    );
+  }
+
+  get showMassImportBanner() {
+    const isScoManagingStudents = this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
+    const topLevelDomain = this.currentDomain.getExtension();
+    const currentLanguage = this.intl.t('current-lang');
+    const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
+
+    return (
+      this.featureToggles.featureToggles.isMassiveSessionManagementEnabled &&
+      !isScoManagingStudents &&
+      !isOrgTldAndEnglishCurrentLanguage
     );
   }
 

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -67,6 +67,12 @@
 
     {{/if}}
 
+    {{#if this.showMassImportBanner}}
+      <PixBanner @canCloseBanner="true">
+        {{t "pages.banner.information" htmlSafe=true}}
+      </PixBanner>
+    {{/if}}
+
     <div class="page">
       {{outlet}}
     </div>

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -11,6 +11,10 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
   setupMirage(hooks);
   setupIntl(hooks);
 
+  hooks.beforeEach(function () {
+    server.create('feature-toggle', { isMassiveSessionManagementEnabled: true });
+  });
+
   hooks.afterEach(function () {
     const notificationMessagesService = this.owner.lookup('service:notifications');
     notificationMessagesService.clearAll();
@@ -316,7 +320,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
         // when
         const screen = await visit(`/sessions/${sessionWithoutCandidates.id}/candidats`);
-        screen.debug;
         await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
 
         // then
@@ -359,7 +362,9 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           );
           await fillIn(screen.getByLabelText('E-mail de convocation'), 'roooooar@example.net');
 
-          await click(screen.getByRole('button', { name: 'Fermer' }));
+          // TODO: remove this getAllByRole (isMassiveSessionManagementEnabled)
+          const closeButtons = screen.getAllByRole('button', { name: 'Fermer' });
+          await click(closeButtons[1]);
 
           // when
           await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -18,6 +18,8 @@ module('Acceptance | Session Finalization', function (hooks) {
   let session;
 
   hooks.beforeEach(function () {
+    server.create('feature-toggle', { isMassiveSessionManagementEnabled: true });
+
     allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
       isAccessBlockedCollege: false,
       isAccessBlockedLycee: false,
@@ -206,7 +208,10 @@ module('Acceptance | Session Finalization', function (hooks) {
           await screen.findByRole('dialog');
           const allDeleteIssueReportButtons = screen.getAllByRole('button', { name: 'Supprimer le signalement' });
           await click(allDeleteIssueReportButtons[0]);
-          await click(screen.getByRole('button', { name: 'Fermer' }));
+
+          // TODO: remove this getAllByRole (isMassiveSessionManagementEnabled)
+          const closeButtons = screen.getAllByRole('button', { name: 'Fermer' });
+          await click(closeButtons[1]);
 
           // then
           assert.dom(screen.getByText('1 signalement')).exists();

--- a/certif/tests/unit/components/no-session-panel_test.js
+++ b/certif/tests/unit/components/no-session-panel_test.js
@@ -28,7 +28,7 @@ module('Unit | Component | no-session-panel', function (hooks) {
             currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
           }
           class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+            featureToggles = { isMassiveSessionManagementEnabled: true };
           }
           class CurrentDomainStub extends Service {
             getExtension = sinon.stub().returns('org');
@@ -62,7 +62,7 @@ module('Unit | Component | no-session-panel', function (hooks) {
             currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
           }
           class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+            featureToggles = { isMassiveSessionManagementEnabled: true };
           }
           class CurrentDomainStub extends Service {
             getExtension = sinon.stub().returns('org');
@@ -98,7 +98,7 @@ module('Unit | Component | no-session-panel', function (hooks) {
           currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
         }
         class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+          featureToggles = { isMassiveSessionManagementEnabled: true };
         }
         class CurrentDomainStub extends Service {
           getExtension = sinon.stub().returns('fr');

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import Service from '@ember/service';
+import sinon from 'sinon';
 
 module('Unit | Controller | authenticated', function (hooks) {
   setupTest(hooks);
@@ -185,6 +186,195 @@ module('Unit | Controller | authenticated', function (hooks) {
 
       // then
       assert.true(showBanner);
+    });
+  });
+
+  module('#get showMassImportBanner', function () {
+    module('when isMassiveSessionManagementEnabled is on', function () {
+      test('should return false when certif center is SCO IsManagingStudents', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = run(() =>
+          store.createRecord('allowed-certification-center-access', {
+            id: 123,
+            name: 'Sunnydale',
+            type: 'SCO',
+            isAccessBlockedCollege: false,
+            isAccessBlockedLycee: false,
+            isAccessBlockedAEFE: false,
+            isAccessBlockedAgri: false,
+            isRelatedToManagingStudentsOrganization: true,
+          })
+        );
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: true };
+        }
+        class CurrentDomainStub extends Service {
+          getExtension = sinon.stub().returns('fr');
+        }
+        class IntlStub extends Service {
+          t = sinon.stub().returns('fr');
+        }
+
+        this.owner.register('service:current-domain', CurrentDomainStub);
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        this.owner.register('service:intl', IntlStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        const controller = this.owner.lookup('controller:authenticated');
+
+        // when
+        const showMassImportBanner = controller.showMassImportBanner;
+
+        // then
+        assert.false(showMassImportBanner);
+      });
+
+      module('when top level domain is org', function () {
+        module('when current language is french', function () {
+          test('should render import template button', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+              type: 'SUP',
+            });
+
+            class CurrentUserStub extends Service {
+              currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+            }
+            class FeatureTogglesStub extends Service {
+              featureToggles = { isMassiveSessionManagementEnabled: true };
+            }
+            class CurrentDomainStub extends Service {
+              getExtension = sinon.stub().returns('org');
+            }
+            class IntlStub extends Service {
+              t = sinon.stub().returns('fr');
+            }
+
+            this.owner.register('service:current-domain', CurrentDomainStub);
+            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            this.owner.register('service:intl', IntlStub);
+            this.owner.register('service:current-user', CurrentUserStub);
+            const controller = this.owner.lookup('controller:authenticated');
+
+            // when
+            const showMassImportBanner = controller.showMassImportBanner;
+
+            // then
+            assert.true(showMassImportBanner);
+          });
+        });
+
+        module('when current language is english', function () {
+          test('should not render import template button', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+              type: 'SUP',
+            });
+
+            class CurrentUserStub extends Service {
+              currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+            }
+            class FeatureTogglesStub extends Service {
+              featureToggles = { isMassiveSessionManagementEnabled: true };
+            }
+            class CurrentDomainStub extends Service {
+              getExtension = sinon.stub().returns('org');
+            }
+            class IntlStub extends Service {
+              t = sinon.stub().returns('en');
+            }
+
+            this.owner.register('service:current-domain', CurrentDomainStub);
+            this.owner.register('service:featureToggles', FeatureTogglesStub);
+            this.owner.register('service:intl', IntlStub);
+            this.owner.register('service:current-user', CurrentUserStub);
+            const controller = this.owner.lookup('controller:authenticated');
+
+            // when
+            const showMassImportBanner = controller.showMassImportBanner;
+
+            // then
+            assert.false(showMassImportBanner);
+          });
+        });
+      });
+
+      module('when top level domain is fr', function () {
+        test('should render import template button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: true };
+          }
+          class CurrentDomainStub extends Service {
+            getExtension = sinon.stub().returns('fr');
+          }
+
+          class IntlStub extends Service {
+            t = sinon.stub().returns('en');
+          }
+
+          this.owner.register('service:current-domain', CurrentDomainStub);
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+          this.owner.register('service:intl', IntlStub);
+          const controller = this.owner.lookup('controller:authenticated');
+
+          // when
+          const showMassImportBanner = controller.showMassImportBanner;
+
+          // then
+          assert.true(showMassImportBanner);
+        });
+      });
+    });
+
+    module('when isMassiveSessionManagementEnabled is off', function () {
+      test('should not render import template button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SUP',
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: false };
+        }
+        class CurrentDomainStub extends Service {
+          getExtension = sinon.stub().returns('fr');
+        }
+
+        class IntlStub extends Service {
+          t = sinon.stub().returns('en');
+        }
+
+        this.owner.register('service:current-domain', CurrentDomainStub);
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.owner.register('service:intl', IntlStub);
+        const controller = this.owner.lookup('controller:authenticated');
+
+        // when
+        const showMassImportBanner = controller.showMassImportBanner;
+
+        // then
+        assert.false(showMassImportBanner);
+      });
     });
   });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -190,6 +190,9 @@
     }
   },
   "pages": {
+    "banner": {
+      "information": "Important : depuis le 30 juin une nouvelle fonctionnalité est disponible pour vous permettre de créer ou éditer plusieurs sessions à la fois. L'ancienne méthode de création individuelle de session reste disponible. <br> Consultez <a href=\"https://cloud.pix.fr/s/m4pDYQAAMo5ZE9P\" class=\"link\" target=\"_blank\" rel=\"noreferrer\">ici</a> le guide d'utilisation de la gestion massive des sessions."
+    },
     "candidates": {
       "add": {
         "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -190,6 +190,9 @@
     }
   },
   "pages": {
+    "banner": {
+      "information": "Important : depuis le 30 juin une nouvelle fonctionnalité est disponible pour vous permettre de créer ou éditer plusieurs sessions à la fois. L'ancienne méthode de création individuelle de session reste disponible. <br> Consultez <a href=\"https://cloud.pix.fr/s/m4pDYQAAMo5ZE9P\" class=\"link\" target=\"_blank\" rel=\"noreferrer\">ici</a> le guide d'utilisation de la gestion massive des sessions."
+    },
     "candidates": {
       "add": {
         "actions": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la fonctionnalité permettant d'importer en masse des session et candidat sur Pix Certif  n'est pas disponible pour les utilisateurs (sous feature toggle). 
Or nous souhaitons rendre disponible cette fonctionnalité sous peu et leur communiquer l'information. 

## :robot: Proposition
Afficher une bannière indiquant que la nouvelle fonctionnalité est désormais dispo.

## :rainbow: Remarques
Cette bannière ne s'affiche pas pour : 

- Les espaces SCO gérant des élèves (is managing student)
- en domaine .org / en anglais.
- si le FT est à false.

## :100: Pour tester
(Le FT `FT_MASSIVE_SESSION_MANAGEMENT` de la RA est à true)

Se connecter sur Pix Certif : 

1/ - en .fr avec certifsup@example.net
- constater que la bannière s'affiche. Cliquer sur le lien et s'assurer qu'on accède au guide.
- constater que les boutons pour créer des sessions en masse est visible.

2/ - en .fr avec certifsco@example.net
- constater que la bannière ne s'affiche pas. 
- Passer dans le centre AEFE
- constater que la bannière s'affiche.

3/ - en .org ET en français : 
- avec certifsco@example.net, constater que la bannière s'affiche.

4/ - en org ET en anglais : 
- constater que la bannière ne s'affiche pas.

5/ - Passer le FT à false et constater que la bannière ne s'affiche pas.