### PR TITLE
[BUGFIX] Corrige le script test:api:watch cassé depuis le passage aux modules ESM

### DIFF
--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -8,7 +8,8 @@
     "package.json",
     "db",
     "translations",
-    ".env"
+    ".env",
+    "tests"
   ],
   "ignore": [
     "db/seeds",

--- a/api/package.json
+++ b/api/package.json
@@ -161,7 +161,7 @@
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
-    "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
+    "test:api:watch": "NODE_ENV=test nodemon --exec 'mocha --recursive tests --reporter dot'",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint"
   },


### PR DESCRIPTION
## :unicorn: Problème
mocha ne supporte pas l'option watch avec les modules ESM. Voir https://github.com/mochajs/mocha/issues/4374.

## :robot: Proposition
Utiliser nodemon que l'on a déjà pour lancer l'API.

## :rainbow: Remarques
Pour que cela fonctionne j'ai du rajouter le fait d'écouter les changements dans les fichiers de tests. Cela change le comportement lorsque l'API est lancée, chaque changement dans les tests va la relancer.

## :100: Pour tester
1. Faire un npm run test:api:watch depuis le dossier API et voir que les tests se lancent bien
2. Faire un changement dans les tests, et constater que les tests se relancent.
