### PR TITLE
[FEATURE] Empêcher un challenge d'être enregistré deux fois pendant une certif V3 (PIX-8470).

### DIFF
--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 class CertificationChallenge {
   constructor({
     id,
@@ -17,6 +19,18 @@ class CertificationChallenge {
     this.courseId = courseId;
     this.isNeutralized = isNeutralized;
     this.certifiableBadgeKey = certifiableBadgeKey;
+  }
+
+  static from({ challenge, certificationCourseId, isNeutralized, certifiableBadgeKey }) {
+    return new CertificationChallenge({
+      associatedSkillName: challenge.associatedSkillName ?? challenge.skill.name,
+      associatedSkillId: challenge.associatedSkillId ?? challenge.skill.id,
+      challengeId: challenge.id,
+      courseId: certificationCourseId,
+      competenceId: challenge.competenceId,
+      isNeutralized: _.isUndefined(isNeutralized) ? challenge.isNeutralized : isNeutralized,
+      certifiableBadgeKey: _.isUndefined(certifiableBadgeKey) ? challenge.certifiableBadgeKey : certifiableBadgeKey,
+    });
   }
 
   static createForPixCertification({ associatedSkillName, associatedSkillId, challengeId, competenceId }) {

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -46,7 +46,14 @@ const getNextChallengeForCertification = async function ({
       certifiableBadgeKey: null,
     });
 
-    await certificationChallengeRepository.save({ certificationChallenge });
+    const alreadySavedChallenge = await certificationChallengeRepository.getByChallengeIdAndCourseId({
+      challengeId: certificationChallenge.challengeId,
+      courseId: certificationChallenge.courseId,
+    });
+
+    if (!alreadySavedChallenge) {
+      await certificationChallengeRepository.save({ certificationChallenge });
+    }
 
     return challenge;
   } else {

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -36,12 +36,9 @@ const getNextChallengeForCertification = async function ({
 
     const challenge = pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
 
-    const certificationChallenge = new CertificationChallenge({
-      associatedSkillName: challenge.skill.name,
-      associatedSkillId: challenge.skill.id,
-      challengeId: challenge.id,
-      courseId: certificationCourse.getId(),
-      competenceId: challenge.competenceId,
+    const certificationChallenge = CertificationChallenge.from({
+      challenge,
+      certificationCourseId: certificationCourse.getId(),
       isNeutralized: false,
       certifiableBadgeKey: null,
     });

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -4,6 +4,8 @@ import { DomainTransaction } from '../DomainTransaction.js';
 import { BookshelfCertificationChallenge } from '../orm-models/CertificationChallenge.js';
 import { logger } from '../../infrastructure/logger.js';
 import { AssessmentEndedError } from '../../domain/errors.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { CertificationChallenge } from '../../domain/models/CertificationChallenge.js';
 
 const logContext = {
   zone: 'certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId',
@@ -25,6 +27,16 @@ const save = async function ({ certificationChallenge, domainTransaction = Domai
   return bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationChallenge, savedCertificationChallenge);
 };
 
+const getByChallengeIdAndCourseId = async function ({ challengeId, courseId }) {
+  const certificationChallenge = await knex('certification-challenges').where({ challengeId, courseId }).first();
+
+  if (!certificationChallenge) {
+    return;
+  }
+
+  return new CertificationChallenge(certificationChallenge);
+};
+
 const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, courseId) {
   const answeredChallengeIds = Bookshelf.knex('answers').select('challengeId').where({ assessmentId });
 
@@ -43,4 +55,4 @@ const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, cour
   return bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationChallenge, certificationChallenge);
 };
 
-export { save, getNextNonAnsweredChallengeByCourseId };
+export { save, getByChallengeIdAndCourseId, getNextNonAnsweredChallengeByCourseId };

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -34,7 +34,10 @@ const getByChallengeIdAndCourseId = async function ({ challengeId, courseId }) {
     return;
   }
 
-  return new CertificationChallenge(certificationChallenge);
+  return CertificationChallenge.from({
+    challenge: certificationChallenge,
+    certificationCourseId: courseId,
+  });
 };
 
 const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, courseId) {

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -33,6 +33,34 @@ describe('Integration | Repository | Certification Challenge', function () {
     });
   });
 
+  describe('#getByChallengeIdAndCourseId', function () {
+    it('should return a certification challenge', async function () {
+      // given
+      const challengeId = 'challengeId';
+      const certifCourseId1 = databaseBuilder.factory.buildCertificationCourse().id;
+      const certifCourseId2 = databaseBuilder.factory.buildCertificationCourse().id;
+      const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certifCourseId1,
+        challengeId,
+      });
+      databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certifCourseId2,
+        challengeId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const saveCertificationChallenge = await certificationChallengeRepository.getByChallengeIdAndCourseId({
+        challengeId,
+        courseId: certifCourseId1,
+      });
+
+      // then
+      expect(saveCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);
+      expect(saveCertificationChallenge.id).to.equal(certificationChallenge.id);
+    });
+  });
+
   describe('#getNextNonAnsweredChallengeByCourseId', function () {
     context('no non answered certification challenge', function () {
       let certificationCourseId, assessmentId;

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -57,7 +57,7 @@ describe('Integration | Repository | Certification Challenge', function () {
 
       // then
       expect(saveCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);
-      expect(saveCertificationChallenge.id).to.equal(certificationChallenge.id);
+      expect(saveCertificationChallenge.challengeId).to.equal(certificationChallenge.id);
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -118,9 +118,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             .returns(nextChallengeToAnswer);
           pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
 
-          const alreadySavedCertificationChallenge = new CertificationChallenge({
-            challengeId: nextChallengeToAnswer.id,
-            courseId: v3CertificationCourse.getId(),
+          const alreadySavedCertificationChallenge = CertificationChallenge.from({
+            challenge: nextChallengeToAnswer,
+            certificationCourseId: v3CertificationCourse.getId(),
           });
 
           certificationChallengeRepository.getByChallengeIdAndCourseId

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -3,6 +3,7 @@ import { getNextChallengeForCertification } from '../../../../lib/domain/usecase
 import { Assessment } from '../../../../lib/domain/models/Assessment.js';
 import { CertificationVersion } from '../../../../lib/domain/models/CertificationVersion.js';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
+import { CertificationChallenge } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', function () {
   describe('#getNextChallengeForCertification', function () {
@@ -69,7 +70,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
 
     context('for a v3 certification', function () {
       context('when there are challenges left to answer', function () {
-        it('should return the next Challenge', async function () {
+        it('should save the returned the next challenge', async function () {
           // given
           const answerRepository = Symbol('AnswerRepository');
           const challengeRepository = Symbol('ChallengeRepository');
@@ -84,6 +85,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           };
           const certificationChallengeRepository = {
             save: sinon.stub(),
+            getByChallengeIdAndCourseId: sinon.stub(),
           };
           const algorithmDataFetcherService = {
             fetchForFlashCampaigns: sinon.stub(),
@@ -116,6 +118,18 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             .returns(nextChallengeToAnswer);
           pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
 
+          const alreadySavedCertificationChallenge = new CertificationChallenge({
+            challengeId: nextChallengeToAnswer.id,
+            courseId: v3CertificationCourse.getId(),
+          });
+
+          certificationChallengeRepository.getByChallengeIdAndCourseId
+            .withArgs({
+              challengeId: alreadySavedCertificationChallenge.challengeId,
+              courseId: alreadySavedCertificationChallenge.courseId,
+            })
+            .resolves();
+
           // when
           const challenge = await getNextChallengeForCertification({
             algorithmDataFetcherService,
@@ -131,6 +145,89 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
 
           // then
           expect(challenge).to.equal(nextChallengeToAnswer);
+        });
+
+        context('when resuming the session', function () {
+          it('should not save the returned challenge', async function () {
+            // given
+            const answerRepository = Symbol('AnswerRepository');
+            const challengeRepository = Symbol('ChallengeRepository');
+            const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
+            const alreadySeenChallenge = domainBuilder.buildChallenge();
+            const v3CertificationCourse = domainBuilder.buildCertificationCourse({
+              version: CertificationVersion.V3,
+            });
+            const assessment = domainBuilder.buildAssessment();
+            const certificationCourseRepository = {
+              get: sinon.stub(),
+            };
+            const certificationChallengeRepository = {
+              save: sinon.stub(),
+              getByChallengeIdAndCourseId: sinon.stub(),
+            };
+            const algorithmDataFetcherService = {
+              fetchForFlashCampaigns: sinon.stub(),
+            };
+            const pickChallengeService = {
+              chooseNextChallenge: sinon.stub(),
+            };
+            const locale = 'fr-FR';
+
+            certificationCourseRepository.get
+              .withArgs(assessment.certificationCourseId)
+              .resolves(v3CertificationCourse);
+            algorithmDataFetcherService.fetchForFlashCampaigns
+              .withArgs({
+                answerRepository,
+                challengeRepository,
+                flashAssessmentResultRepository,
+                assessmentId: assessment.id,
+                locale,
+              })
+              .resolves({
+                allAnswers: [],
+                challenges: [alreadySeenChallenge],
+                estimatedLevel: 0,
+              });
+
+            const chooseNextChallengeImpl = sinon.stub();
+            chooseNextChallengeImpl
+              .withArgs({
+                possibleChallenges: [alreadySeenChallenge],
+              })
+              .returns(alreadySeenChallenge);
+
+            pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
+
+            const alreadySavedCertificationChallenge = new CertificationChallenge({
+              challengeId: alreadySeenChallenge.id,
+              courseId: v3CertificationCourse.getId(),
+            });
+
+            certificationChallengeRepository.getByChallengeIdAndCourseId
+              .withArgs({
+                challengeId: alreadySavedCertificationChallenge.challengeId,
+                courseId: alreadySavedCertificationChallenge.courseId,
+              })
+              .resolves(alreadySeenChallenge);
+
+            // when
+            const challenge = await getNextChallengeForCertification({
+              algorithmDataFetcherService,
+              assessment,
+              answerRepository,
+              challengeRepository,
+              flashAssessmentResultRepository,
+              pickChallengeService,
+              certificationCourseRepository,
+              certificationChallengeRepository,
+              locale,
+            });
+
+            // then
+            expect(challenge).to.equal(alreadySeenChallenge);
+            expect(certificationChallengeRepository.save).not.to.have.been.called;
+          });
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème

Lorsque nous passons une session de certification V3, si nous sommes amenés à quitter la session pour une raison X ou Y, et que nous reprenons celle-ci ultérieurement, le challenge proposé est enregistré de nouveau en base de données.

## :robot: Proposition

Ajout d'une méthode dans le `certification-challenge-repository` permettant de savoir si un challenge a déjà été enregistré ou non pour un certification-course donné

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

• créer une session dans pix certif pour un centre de certification taggué pilote nextGen : certifv3@example.net
• inscrire un candidat à cette session
• se connecter à app avec un utilisateur certifiable : certifiable-contenu-user@example.net
• cliquer sur le menu “Certification”
• entrer le numéro de la session créée en étape 1, puis les info perso du candidat inscrit en étape 2
• confirmer la présence du candidat depuis l’espace surveillant
• entrer le code d’accès à la session
• cliquer sur “Commencer mon test”
• passer des épreuves
• quitter la session
• reprendre la session avec l'autorisation du surveillant
• passer la question de reprise
• Vérifier que le challenge de pré et post-reprise n'a pas été enregistré deux fosi dans la table `certification-challenges`
