### PR TITLE
[FEATURE] Ajouter les toaster de notifications pour la suppression des prescrits (PIX-7956)

### DIFF
--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -7,7 +7,7 @@ export default class ListController extends Controller {
   @service currentUser;
   @service router;
   @service store;
-  @service notifications
+  @service notifications;
   @service intl;
 
   @tracked pageNumber = 1;
@@ -58,9 +58,21 @@ export default class ListController extends Controller {
         listLearners.map(({ id }) => id)
       );
       this.send('refreshModel');
-      this.notifications.sendSuccess(this.intl.t('pages.organization-participants.action-bar.success-message', { count: listLearners.length, firstname: listLearners[0].firstName, lastname: listLearners[0].lastName}));
+      this.notifications.sendSuccess(
+        this.intl.t('pages.organization-participants.action-bar.success-message', {
+          count: listLearners.length,
+          firstname: listLearners[0].firstName,
+          lastname: listLearners[0].lastName,
+        })
+      );
     } catch {
-
+      this.notifications.sendError(
+        this.intl.t('pages.organization-participants.action-bar.error-message', {
+          count: listLearners.length,
+          firstname: listLearners[0].firstName,
+          lastname: listLearners[0].lastName,
+        })
+      );
     }
   }
 }

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -7,6 +7,8 @@ export default class ListController extends Controller {
   @service currentUser;
   @service router;
   @service store;
+  @service notifications
+  @service intl;
 
   @tracked pageNumber = 1;
   @tracked pageSize = 50;
@@ -50,10 +52,15 @@ export default class ListController extends Controller {
 
   @action
   async deleteOrganizationLearners(listLearners) {
-    await this.store.adapterFor('organization-participant').deleteParticipants(
-      this.currentUser.organization.id,
-      listLearners.map(({ id }) => id)
-    );
-    this.send('refreshModel');
+    try {
+      await this.store.adapterFor('organization-participant').deleteParticipants(
+        this.currentUser.organization.id,
+        listLearners.map(({ id }) => id)
+      );
+      this.send('refreshModel');
+      this.notifications.sendSuccess(this.intl.t('pages.organization-participants.action-bar.success-message', { count: listLearners.length, firstname: listLearners[0].firstName, lastname: listLearners[0].lastName}));
+    } catch {
+
+    }
   }
 }

--- a/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
@@ -1,8 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/organization-participants', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   module('#triggerFiltering', function () {
     module('when the filters contain the field fullName', function () {
@@ -50,6 +53,37 @@ module('Unit | Controller | authenticated/organization-participants', function (
       // then
       assert.strictEqual(controller.fullName, null);
       assert.strictEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#deleteOrganizationLearners', function (hooks) {
+    let controller;
+    let deleteParticipants;
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('organization-participant');
+      deleteParticipants = sinon.stub(adapter, 'deleteParticipants');
+      controller = this.owner.lookup('controller:authenticated/organization-participants/list');
+      controller.notifications = { sendSuccess: sinon.stub() };
+      controller.send = sinon.stub();
+      controller.currentUser = { organization: { id: 1 } };
+    });
+
+    test('success case', async function(assert) {
+      //given
+      const listLearners = [{ id: 1, firstName: 'Red', lastName: 'Bull' }];
+      deleteParticipants.resolves();  
+
+      // when
+      await controller.deleteOrganizationLearners(listLearners);
+
+      //then
+      assert.true(deleteParticipants.calledWith(1, [1]));
+      assert.true(controller.send.calledWith('refreshModel'));
+      assert.true(controller.notifications.sendSuccess.calledWith(
+        this.intl.t('pages.organization-participants.action-bar.success-message', 
+        { count: listLearners.length, firstname: listLearners[0].firstName, lastname: listLearners[0].lastName})
+      ));
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
@@ -64,15 +64,15 @@ module('Unit | Controller | authenticated/organization-participants', function (
       const adapter = store.adapterFor('organization-participant');
       deleteParticipants = sinon.stub(adapter, 'deleteParticipants');
       controller = this.owner.lookup('controller:authenticated/organization-participants/list');
-      controller.notifications = { sendSuccess: sinon.stub() };
+      controller.notifications = { sendSuccess: sinon.stub(), sendError: sinon.stub() };
       controller.send = sinon.stub();
       controller.currentUser = { organization: { id: 1 } };
     });
 
-    test('success case', async function(assert) {
+    test('success case', async function (assert) {
       //given
       const listLearners = [{ id: 1, firstName: 'Red', lastName: 'Bull' }];
-      deleteParticipants.resolves();  
+      deleteParticipants.resolves();
 
       // when
       await controller.deleteOrganizationLearners(listLearners);
@@ -80,10 +80,39 @@ module('Unit | Controller | authenticated/organization-participants', function (
       //then
       assert.true(deleteParticipants.calledWith(1, [1]));
       assert.true(controller.send.calledWith('refreshModel'));
-      assert.true(controller.notifications.sendSuccess.calledWith(
-        this.intl.t('pages.organization-participants.action-bar.success-message', 
-        { count: listLearners.length, firstname: listLearners[0].firstName, lastname: listLearners[0].lastName})
-      ));
+      assert.true(
+        controller.notifications.sendSuccess.calledWith(
+          this.intl.t('pages.organization-participants.action-bar.success-message', {
+            count: listLearners.length,
+            firstname: listLearners[0].firstName,
+            lastname: listLearners[0].lastName,
+          })
+        )
+      );
+      assert.true(controller.notifications.sendError.notCalled);
+    });
+
+    test('failed case', async function (assert) {
+      //given
+      const listLearners = [{ id: 1, firstName: 'Red', lastName: 'Bull' }];
+      deleteParticipants.rejects();
+
+      // when
+      await controller.deleteOrganizationLearners(listLearners);
+
+      //then
+      assert.true(deleteParticipants.calledWith(1, [1]));
+      assert.true(controller.send.notCalled);
+      assert.true(controller.notifications.sendSuccess.notCalled);
+      assert.true(
+        controller.notifications.sendError.calledWith(
+          this.intl.t('pages.organization-participants.action-bar.error-message', {
+            count: listLearners.length,
+            firstname: listLearners[0].firstName,
+            lastname: listLearners[0].lastName,
+          })
+        )
+      );
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -772,7 +772,8 @@
       "action-bar": {
         "information": "{count, plural, =1 {{count} selected participant} other {{count} selected participants}}",
         "delete-button": "Delete",
-        "success-message":"{count, plural, =1 {{firstname} {lastname} has successfully been deleted from the participants list} other {The {count} selected participants have successfully been deleted from the list}}"
+        "success-message":"{count, plural, =1 {{firstname} {lastname} has successfully been deleted from the participants list.} other {The {count} selected participants have successfully been deleted from the list.}}",
+        "error-message":"{count, plural, =1 {An error has occurred. {firstname} {lastname} has not been deleted from the participants list.}}"
       },
       "deletion-modal": {
         "confirmation-checkbox":"I confirm that I have understood the impacts of the {count} deletions",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -771,7 +771,8 @@
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}",
       "action-bar": {
         "information": "{count, plural, =1 {{count} selected participant} other {{count} selected participants}}",
-        "delete-button": "Delete"
+        "delete-button": "Delete",
+        "success-message":"{count, plural, =1 {{firstname} {lastname} has successfully been deleted from the participants list} other {The {count} selected participants have successfully been deleted from the list}}"
       },
       "deletion-modal": {
         "confirmation-checkbox":"I confirm that I have understood the impacts of the {count} deletions",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -775,7 +775,8 @@
       "action-bar": {
         "information": "{count, plural, =1 {{count} participant sélectionné} other {{count} participants sélectionnés}}",
         "delete-button": "Supprimer",
-        "success-message":"{count, plural, =1 {{firstname} {lastname} a bien été supprimé de la liste des participants} other {Les {count} participants sélectionnés ont bien été supprimés de la liste}}"
+        "success-message":"{count, plural, =1 {{firstname} {lastname} a bien été supprimé de la liste des participants.} other {Les {count} participants sélectionnés ont bien été supprimés de la liste.}}",
+        "error-message":"{count, plural, =1 {Une erreur est survenue, {firstname} {lastname} n'a pas été supprimé de la liste des participants.} other {Une erreur est survenue, les {count} participants sélectionnés n'ont pas été supprimés de la liste.}}"
       },
       "deletion-modal": {
         "confirmation-checkbox":"Je confirme avoir bien compris les impacts des {count} suppressions",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -774,7 +774,8 @@
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}",
       "action-bar": {
         "information": "{count, plural, =1 {{count} participant sélectionné} other {{count} participants sélectionnés}}",
-        "delete-button": "Supprimer"
+        "delete-button": "Supprimer",
+        "success-message":"{count, plural, =1 {{firstname} {lastname} a bien été supprimé de la liste des participants} other {Les {count} participants sélectionnés ont bien été supprimés de la liste}}"
       },
       "deletion-modal": {
         "confirmation-checkbox":"Je confirme avoir bien compris les impacts des {count} suppressions",


### PR DESCRIPTION
## :unicorn: Problème
Dans les tickets précédents, nous avons ajouté les checkboxes et le bandeau de suppression. Ici, il s'agissait d'ajouter un toaster (🍞  🧈 ) pour notifier l'utilisateur d'un succès ou d'un échec.

Les commits précédents :

https://github.com/1024pix/pix/pull/6364
https://github.com/1024pix/pix/pull/6371
https://github.com/1024pix/pix/pull/6410
https://github.com/1024pix/pix/pull/6422
https://github.com/1024pix/pix/pull/6421
https://github.com/1024pix/pix/pull/6452

## :robot: Proposition
RAS

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur Pix Orga est vérifier que les toaster s'affichent. ( pour le cas erreur, "facultatif")