### PR TITLE
[FEATURE] ajout d'une colonne à la liste de campagnes pour afficher leurs codes (PIX-8477)

### DIFF
--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -24,7 +24,7 @@
       </colgroup>
       <thead>
         <tr>
-          <Table::Header>{{t "pages.campaigns-list.table.column.campaign"}}</Table::Header>
+          <Table::Header>{{t "pages.campaigns-list.table.column.name"}}</Table::Header>
           <Table::Header>{{t "pages.campaigns-list.table.column.code"}}</Table::Header>
           {{#unless @listOnlyCampaignsOfCurrentUser}}
             <Table::Header class="hide-on-mobile">{{t "pages.campaigns-list.table.column.created-by"}}</Table::Header>
@@ -47,7 +47,7 @@
                 {{campaign.name}}
               </LinkTo>
             </td>
-            <td class="table__column--small">{{campaign.code}}</td>
+            <td class="table__column--small" {{on "click" this.stopPropagation}}>{{campaign.code}}</td>
             {{#unless @listOnlyCampaignsOfCurrentUser}}
               <td class="table__column--truncated hide-on-mobile">{{campaign.ownerFullName}}</td>
             {{/unless}}

--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -14,6 +14,7 @@
       <caption class="screen-reader-only">{{this.caption}}</caption>
       <colgroup class="table__column">
         <col class="table__column--wide" />
+        <col class="table__column--small" />
         {{#unless @listOnlyCampaignsOfCurrentUser}}
           <col class="table__column--wide hide-on-mobile" />
         {{/unless}}
@@ -24,6 +25,7 @@
       <thead>
         <tr>
           <Table::Header>{{t "pages.campaigns-list.table.column.campaign"}}</Table::Header>
+          <Table::Header>{{t "pages.campaigns-list.table.column.code"}}</Table::Header>
           {{#unless @listOnlyCampaignsOfCurrentUser}}
             <Table::Header class="hide-on-mobile">{{t "pages.campaigns-list.table.column.created-by"}}</Table::Header>
           {{/unless}}
@@ -45,6 +47,7 @@
                 {{campaign.name}}
               </LinkTo>
             </td>
+            <td class="table__column--small">{{campaign.code}}</td>
             {{#unless @listOnlyCampaignsOfCurrentUser}}
               <td class="table__column--truncated hide-on-mobile">{{campaign.ownerFullName}}</td>
             {{/unless}}

--- a/orga/app/components/campaign/list.js
+++ b/orga/app/components/campaign/list.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class List extends Component {
   @service intl;
@@ -10,5 +11,10 @@ export default class List extends Component {
     } else {
       return this.intl.t('pages.campaigns-list.table.description-my-campaigns');
     }
+  }
+
+  @action
+  stopPropagation(event) {
+    event.stopPropagation();
   }
 }

--- a/orga/tests/integration/components/campaign/list_test.js
+++ b/orga/tests/integration/components/campaign/list_test.js
@@ -122,6 +122,34 @@ module('Integration | Component | Campaign::List', function (hooks) {
       assert.dom(screen.getByText('campagne 2')).exists();
     });
 
+    test('it should display the code of the campaigns', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const campaign1 = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+      });
+      const campaign2 = store.createRecord('campaign', {
+        id: 2,
+        name: 'campagne 2',
+        code: 'BBBBBB222',
+      });
+      const campaigns = [campaign1, campaign2];
+
+      this.set('campaigns', campaigns);
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText('AAAAAA111')).exists();
+      assert.dom(screen.getByText('BBBBBB222')).exists();
+    });
+
     test('it should display the owner of the campaigns', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -590,10 +590,10 @@
       "no-campaign": "No campaign. To start, click on 'Create a campaign'.",
       "table": {
         "column": {
-          "campaign": "Name of the campaign",
           "code": "Code",
           "created-by": "Owner",
           "created-on": "Created on",
+          "name": "Name of the campaign",
           "participants": "Participants",
           "results": "Results submitted"
         },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -591,13 +591,14 @@
       "table": {
         "column": {
           "campaign": "Name of the campaign",
+          "code": "Code",
           "created-by": "Owner",
           "created-on": "Created on",
           "participants": "Participants",
           "results": "Results submitted"
         },
-        "description-all-campaigns": "This is the list of all the campaigns created in you Pix Orga. It includes their owner name, creation date, number of participants and number of received results.",
-        "description-my-campaigns": "This is the list of the campaigns you own. It includes their creation date, number of participants and number of received results.",
+        "description-all-campaigns": "This is the list of all the campaigns created in you Pix Orga. It includes their code, their owner name, creation date, number of participants and number of received results.",
+        "description-my-campaigns": "This is the list of the campaigns you own. It includes their code, their creation date, number of participants and number of received results.",
         "empty": "No campaign",
         "row-title": "Campaign"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -593,10 +593,10 @@
       "no-campaign": "Aucune campagne, pour commencer cliquez sur le bouton 'Créer une campagne'.",
       "table": {
         "column": {
-          "campaign": "Nom de la campagne",
           "code": "Code",
           "created-by": "Propriétaire",
           "created-on": "Créée le",
+          "name": "Nom de la campagne",
           "participants": "Participants",
           "results": "Résultats reçus"
         },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -594,13 +594,14 @@
       "table": {
         "column": {
           "campaign": "Nom de la campagne",
+          "code": "Code",
           "created-by": "Propriétaire",
           "created-on": "Créée le",
           "participants": "Participants",
           "results": "Résultats reçus"
         },
-        "description-all-campaigns": "Ce tableau comporte la liste de toutes les campagnes créées dans votre espace Pix Orga. Il indique pour chaque campagne leur propriétaire, leur date de création, le nombre de participants et le nombre de résultats reçus.",
-        "description-my-campaigns": "Ce tableau comporte la liste des campagnes dont vous êtes propriétaire. Il indique pour chaque campagne leur date de création, le nombre de participants et le nombre de résultats reçus.",
+        "description-all-campaigns": "Ce tableau comporte la liste de toutes les campagnes créées dans votre espace Pix Orga. Il indique pour chaque campagne leur code, leur propriétaire, leur date de création, le nombre de participants et le nombre de résultats reçus.",
+        "description-my-campaigns": "Ce tableau comporte la liste des campagnes dont vous êtes propriétaire. Il indique pour chaque campagne leur code, leur date de création, le nombre de participants et le nombre de résultats reçus.",
         "empty": "Aucune campagne",
         "row-title": "Campagne"
       },


### PR DESCRIPTION
## :unicorn: Problème
Suite à des retours d’usages, de prescripteurs SCO, on nous a demander d’afficher le code campagne dans la liste des campagnes pour aller plus vite dans l’envoi des codes aux élèves.

## :robot: Proposition
Ajouter une colonne dans le tableau de la liste des campagnes pour TOUTES les organisations
Rajouter cette information juste après le nom de la campagne.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter
- atterrir sur la page des campagnes
- remarquer l'affichage des codes campagnes dans le tableau
- 🎉 c'est fini, des bisous