### PR TITLE
[FEATURE] Ajoute le champ areKnowledgeElementsResettable dans la table target-profiles (PIX-8486)

### DIFF
--- a/api/db/migrations/20230623135203_add-column-areKnowledgeElementsResettable-in-target-profiles-table.js
+++ b/api/db/migrations/20230623135203_add-column-areKnowledgeElementsResettable-in-target-profiles-table.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TARGET_PROFILES = 'target-profiles';
+const ARE_KNOWLEDGE_ELEMENTS_RESETTABLE = 'areKnowledgeElementsResettable';
+
+const up = async function (knex) {
+  await knex.schema.table(TARGET_PROFILES, function (table) {
+    table.boolean(ARE_KNOWLEDGE_ELEMENTS_RESETTABLE).defaultTo(false);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TARGET_PROFILES, function (table) {
+    table.dropColumn(ARE_KNOWLEDGE_ELEMENTS_RESETTABLE);
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
Pour avoir la possibilité de remettre à zero un parcour, on a besoin un moyen pour savoir si on peut remettre à zero le parcour

## :robot: Proposition
Ajoute un nouveau champ `areKnowledgeElementsResettable` dans le base a donne dans le table `target-profiles` pour savoir si on peut remettre a zero

## :rainbow: Remarques
pas de remarques

## :100: Pour tester
aller sur la base a donne
aller sur la table : `target-profiles` 
verifier que le nouveau champ `areKnowledgeElementsResettable` est la et remplir avec false par defaut
