### PR TITLE
[TECH] Récupération du dernier challenge vu lors d'une reprise de session (PIX-8258).

### DIFF
--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 class CertificationChallenge {
   constructor({
     id,
@@ -19,19 +17,6 @@ class CertificationChallenge {
     this.courseId = courseId;
     this.isNeutralized = isNeutralized;
     this.certifiableBadgeKey = certifiableBadgeKey;
-  }
-
-  static from({ challenge, certificationCourseId, isNeutralized, certifiableBadgeKey }) {
-    return new CertificationChallenge({
-      id: challenge.id,
-      associatedSkillName: challenge.associatedSkillName ?? challenge.skill.name,
-      associatedSkillId: challenge.associatedSkillId ?? challenge.skill.id,
-      challengeId: challenge.challengeId,
-      courseId: certificationCourseId,
-      competenceId: challenge.competenceId,
-      isNeutralized: _.isUndefined(isNeutralized) ? challenge.isNeutralized : isNeutralized,
-      certifiableBadgeKey: _.isUndefined(certifiableBadgeKey) ? challenge.certifiableBadgeKey : certifiableBadgeKey,
-    });
   }
 
   static createForPixCertification({ associatedSkillName, associatedSkillId, challengeId, competenceId }) {

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -23,9 +23,10 @@ class CertificationChallenge {
 
   static from({ challenge, certificationCourseId, isNeutralized, certifiableBadgeKey }) {
     return new CertificationChallenge({
+      id: challenge.id,
       associatedSkillName: challenge.associatedSkillName ?? challenge.skill.name,
       associatedSkillId: challenge.associatedSkillId ?? challenge.skill.id,
-      challengeId: challenge.id,
+      challengeId: challenge.challengeId,
       courseId: certificationCourseId,
       competenceId: challenge.competenceId,
       isNeutralized: _.isUndefined(isNeutralized) ? challenge.isNeutralized : isNeutralized,

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -56,14 +56,7 @@ const getNextChallengeForCertification = async function ({
       certifiableBadgeKey: null,
     });
 
-    const alreadySavedChallenge = await certificationChallengeRepository.getByChallengeIdAndCourseId({
-      challengeId: challenge.id,
-      courseId: certificationChallenge.courseId,
-    });
-
-    if (!alreadySavedChallenge) {
-      await certificationChallengeRepository.save({ certificationChallenge });
-    }
+    await certificationChallengeRepository.save({ certificationChallenge });
 
     return challenge;
   } else {

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -62,9 +62,7 @@ const getNextNonAnsweredChallengeByCourseIdForV3 = async function (assessmentId,
   logContext.challengeId = certificationChallenge.id;
   logger.trace(logContext, 'found challenge');
 
-  return CertificationChallenge.from({
-    challenge: certificationChallenge,
-  });
+  return new CertificationChallenge(certificationChallenge);
 };
 
 export { save, getNextNonAnsweredChallengeByCourseId, getNextNonAnsweredChallengeByCourseIdForV3 };

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -27,19 +27,6 @@ const save = async function ({ certificationChallenge, domainTransaction = Domai
   return bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationChallenge, savedCertificationChallenge);
 };
 
-const getByChallengeIdAndCourseId = async function ({ challengeId, courseId }) {
-  const certificationChallenge = await knex('certification-challenges').where({ challengeId, courseId }).first();
-
-  if (!certificationChallenge) {
-    return;
-  }
-
-  return CertificationChallenge.from({
-    challenge: certificationChallenge,
-    certificationCourseId: courseId,
-  });
-};
-
 const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, courseId) {
   const answeredChallengeIds = Bookshelf.knex('answers').select('challengeId').where({ assessmentId });
 
@@ -80,9 +67,4 @@ const getNextNonAnsweredChallengeByCourseIdForV3 = async function (assessmentId,
   });
 };
 
-export {
-  save,
-  getByChallengeIdAndCourseId,
-  getNextNonAnsweredChallengeByCourseId,
-  getNextNonAnsweredChallengeByCourseIdForV3,
-};
+export { save, getNextNonAnsweredChallengeByCourseId, getNextNonAnsweredChallengeByCourseIdForV3 };

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -148,6 +148,58 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           ]);
         });
       });
+
+      context('When resuming certification session after leaving', function () {
+        it('should return the last challenge the user has seen before leaving the session', async function () {
+          const user = databaseBuilder.factory.buildUser({ id: userId });
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot: true }).id;
+          const sessionId = databaseBuilder.factory.buildSession({
+            certificationCenterId,
+            version: CertificationVersion.V3,
+          }).id;
+          databaseBuilder.factory.buildCertificationCandidate({
+            userId: user.id,
+            sessionId,
+          });
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            isPublished: false,
+            version: CertificationVersion.V3,
+            userId: user.id,
+            sessionId,
+          }).id;
+          databaseBuilder.factory.buildCertificationChallenge({
+            associatedSkillName: '@web3',
+            associatedSkillId: skillWeb3Id,
+            challengeId: secondChallengeId,
+            competenceId,
+            courseId: certificationCourseId,
+          });
+          databaseBuilder.factory.buildAssessment({
+            id: assessmentId,
+            type: Assessment.types.CERTIFICATION,
+            certificationCourseId,
+            userId: user.id,
+            lastQuestionDate: new Date('2020-01-20'),
+            state: 'started',
+            lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+          });
+          databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
+          await databaseBuilder.commit();
+
+          // given
+          const options = {
+            method: 'GET',
+            url: `/api/assessments/${assessmentId}/next`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.result.data.id).to.equal(secondChallengeId);
+        });
+      });
     });
   });
 });

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -201,5 +201,57 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
         });
       });
     });
+
+    context('When passing a V2 certification session', function () {
+      context('When resuming certification session after leaving', function () {
+        it('should return the last challenge the user has seen before leaving the session', async function () {
+          const user = databaseBuilder.factory.buildUser({ id: userId });
+          const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot: true }).id;
+          const sessionId = databaseBuilder.factory.buildSession({
+            certificationCenterId,
+          }).id;
+          databaseBuilder.factory.buildCertificationCandidate({
+            userId: user.id,
+            sessionId,
+          });
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            isPublished: false,
+            userId: user.id,
+            sessionId,
+          }).id;
+          databaseBuilder.factory.buildCertificationChallenge({
+            associatedSkillName: '@web3',
+            associatedSkillId: skillWeb3Id,
+            challengeId: firstChallengeId,
+            competenceId,
+            courseId: certificationCourseId,
+          });
+          databaseBuilder.factory.buildAssessment({
+            id: assessmentId,
+            type: Assessment.types.CERTIFICATION,
+            certificationCourseId,
+            userId: user.id,
+            lastQuestionDate: new Date('2020-01-20'),
+            state: 'started',
+            lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+          });
+          databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
+          await databaseBuilder.commit();
+
+          // given
+          const options = {
+            method: 'GET',
+            url: `/api/assessments/${assessmentId}/next`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.result.data.id).to.equal(firstChallengeId);
+        });
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -34,34 +34,6 @@ describe('Integration | Repository | Certification Challenge', function () {
     });
   });
 
-  describe('#getByChallengeIdAndCourseId', function () {
-    it('should return a certification challenge', async function () {
-      // given
-      const challengeId = 'challengeId';
-      const certifCourseId1 = databaseBuilder.factory.buildCertificationCourse().id;
-      const certifCourseId2 = databaseBuilder.factory.buildCertificationCourse().id;
-      const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
-        courseId: certifCourseId1,
-        challengeId,
-      });
-      databaseBuilder.factory.buildCertificationChallenge({
-        courseId: certifCourseId2,
-        challengeId,
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const savedCertificationChallenge = await certificationChallengeRepository.getByChallengeIdAndCourseId({
-        challengeId,
-        courseId: certifCourseId1,
-      });
-
-      // then
-      expect(savedCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);
-      expect(savedCertificationChallenge.id).to.equal(certificationChallenge.id);
-    });
-  });
-
   describe('#getNextNonAnsweredChallengeByCourseId', function () {
     context('no non answered certification challenge', function () {
       let certificationCourseId, assessmentId;

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -3,6 +3,7 @@ import { expect, knex, domainBuilder, databaseBuilder } from '../../../test-help
 import { CertificationChallenge } from '../../../../lib/domain/models/CertificationChallenge.js';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
 import * as certificationChallengeRepository from '../../../../lib/infrastructure/repositories/certification-challenge-repository.js';
+import { CertificationVersion } from '../../../../lib/domain/models/CertificationVersion.js';
 
 describe('Integration | Repository | Certification Challenge', function () {
   describe('#save', function () {
@@ -50,14 +51,14 @@ describe('Integration | Repository | Certification Challenge', function () {
       await databaseBuilder.commit();
 
       // when
-      const saveCertificationChallenge = await certificationChallengeRepository.getByChallengeIdAndCourseId({
+      const savedCertificationChallenge = await certificationChallengeRepository.getByChallengeIdAndCourseId({
         challengeId,
         courseId: certifCourseId1,
       });
 
       // then
-      expect(saveCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);
-      expect(saveCertificationChallenge.challengeId).to.equal(certificationChallenge.id);
+      expect(savedCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);
+      expect(savedCertificationChallenge.id).to.equal(certificationChallenge.id);
     });
   });
 
@@ -146,6 +147,106 @@ describe('Integration | Repository | Certification Challenge', function () {
           assessmentId,
           certificationCourseId
         );
+
+        // then
+        expect(nextCertificationChallenge).to.be.instanceOf(CertificationChallenge);
+        expect(nextCertificationChallenge.id).to.equal(firstUnansweredChallengeId);
+      });
+    });
+  });
+
+  describe('#getNextNonAnsweredChallengeByCourseIdForV3', function () {
+    context('no non answered certification challenge', function () {
+      let certificationCourseId, assessmentId;
+      before(async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser({}).id;
+        certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          userId,
+          version: CertificationVersion.V3,
+        }).id;
+        assessmentId = databaseBuilder.factory.buildAssessment({ userId, certificationCourseId }).id;
+        const challenge = databaseBuilder.factory.buildCertificationChallenge({
+          challengeId: 'recChallenge1',
+          courseId: certificationCourseId,
+          associatedSkill: '@brm7',
+          competenceId: 'recCompetenceId1',
+        });
+        databaseBuilder.factory.buildAnswer({
+          challengeId: challenge.challengeId,
+          value: 'Un Pancake',
+          assessmentId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return null if no non answered challenge is found', async function () {
+        // when
+        const result = await certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3(
+          assessmentId,
+          certificationCourseId
+        );
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+
+    context('there is some non answered certification challenge(s)', function () {
+      let certificationCourseId, assessmentId;
+      const firstUnansweredChallengeId = 1;
+
+      before(async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser({}).id;
+        certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          userId,
+          version: CertificationVersion.V3,
+        }).id;
+        assessmentId = databaseBuilder.factory.buildAssessment({ userId, certificationCourseId }).id;
+        const answeredChallenge = databaseBuilder.factory.buildCertificationChallenge({
+          challengeId: 'recChallenge1',
+          courseId: certificationCourseId,
+          associatedSkillName: '@brm7',
+          competenceId: 'recCompetenceId1',
+        });
+        const firstUnansweredChallengeById = {
+          id: firstUnansweredChallengeId,
+          challengeId: 'recChallenge2',
+          courseId: certificationCourseId,
+          associatedSkillName: '@brm24',
+          competenceId: 'recCompetenceId2',
+          createdAt: '2020-06-20T00:00:00Z',
+        };
+        const secondUnansweredChallengeById = {
+          id: firstUnansweredChallengeId + 1,
+          challengeId: 'recChallenge2',
+          courseId: certificationCourseId,
+          associatedSkillName: '@brm24',
+          competenceId: 'recCompetenceId2',
+          createdAt: '2020-06-21T00:00:00Z',
+        };
+
+        // "Second" is inserted first as we check the order is chosen on the specified id
+        databaseBuilder.factory.buildCertificationChallenge(secondUnansweredChallengeById);
+        databaseBuilder.factory.buildCertificationChallenge(firstUnansweredChallengeById);
+        databaseBuilder.factory.buildAnswer({
+          challengeId: answeredChallenge.challengeId,
+          value: 'Un Pancake',
+          assessmentId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should get challenges in the creation order', async function () {
+        // when
+        const nextCertificationChallenge =
+          await certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3(
+            assessmentId,
+            certificationCourseId
+          );
 
         // then
         expect(nextCertificationChallenge).to.be.instanceOf(CertificationChallenge);

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -70,22 +70,25 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
 
     context('for a v3 certification', function () {
       context('when there are challenges left to answer', function () {
-        it('should save the returned the next challenge', async function () {
+        it('should save the returned next challenge', async function () {
           // given
           const answerRepository = Symbol('AnswerRepository');
-          const challengeRepository = Symbol('ChallengeRepository');
           const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
           const nextChallengeToAnswer = domainBuilder.buildChallenge();
           const v3CertificationCourse = domainBuilder.buildCertificationCourse({
             version: CertificationVersion.V3,
           });
           const assessment = domainBuilder.buildAssessment();
+          const challengeRepository = {
+            get: sinon.stub(),
+          };
           const certificationCourseRepository = {
             get: sinon.stub(),
           };
           const certificationChallengeRepository = {
             save: sinon.stub(),
             getByChallengeIdAndCourseId: sinon.stub(),
+            getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
           };
           const algorithmDataFetcherService = {
             fetchForFlashCampaigns: sinon.stub(),
@@ -96,6 +99,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const locale = 'fr-FR';
 
           certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(v3CertificationCourse);
+          certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3
+            .withArgs(assessment.id, assessment.certificationCourseId)
+            .resolves(null);
+          challengeRepository.get.resolves();
           algorithmDataFetcherService.fetchForFlashCampaigns
             .withArgs({
               answerRepository,
@@ -148,68 +155,46 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
         });
 
         context('when resuming the session', function () {
-          it('should not save the returned challenge', async function () {
+          it('should return the last seen challenge', async function () {
             // given
             const answerRepository = Symbol('AnswerRepository');
-            const challengeRepository = Symbol('ChallengeRepository');
             const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
-            const alreadySeenChallenge = domainBuilder.buildChallenge();
-            const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-              version: CertificationVersion.V3,
-            });
-            const assessment = domainBuilder.buildAssessment();
+            const algorithmDataFetcherService = Symbol('algorithmDataFetcherService');
+            const pickChallengeService = Symbol('pickChallengeService');
+            const locale = 'fr-FR';
+
             const certificationCourseRepository = {
               get: sinon.stub(),
             };
             const certificationChallengeRepository = {
               save: sinon.stub(),
               getByChallengeIdAndCourseId: sinon.stub(),
+              getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
             };
-            const algorithmDataFetcherService = {
-              fetchForFlashCampaigns: sinon.stub(),
+            const challengeRepository = {
+              get: sinon.stub(),
             };
-            const pickChallengeService = {
-              chooseNextChallenge: sinon.stub(),
-            };
-            const locale = 'fr-FR';
+
+            const v3CertificationCourse = domainBuilder.buildCertificationCourse({
+              version: CertificationVersion.V3,
+            });
+            const assessment = domainBuilder.buildAssessment();
+
+            const nonAnsweredCertificationChallenge = domainBuilder.buildCertificationChallenge({
+              courseId: v3CertificationCourse.getId(),
+            });
+
+            const lastSeenChallenge = domainBuilder.buildChallenge({
+              id: nonAnsweredCertificationChallenge.challengeId,
+            });
 
             certificationCourseRepository.get
               .withArgs(assessment.certificationCourseId)
               .resolves(v3CertificationCourse);
-            algorithmDataFetcherService.fetchForFlashCampaigns
-              .withArgs({
-                answerRepository,
-                challengeRepository,
-                flashAssessmentResultRepository,
-                assessmentId: assessment.id,
-                locale,
-              })
-              .resolves({
-                allAnswers: [],
-                challenges: [alreadySeenChallenge],
-                estimatedLevel: 0,
-              });
-
-            const chooseNextChallengeImpl = sinon.stub();
-            chooseNextChallengeImpl
-              .withArgs({
-                possibleChallenges: [alreadySeenChallenge],
-              })
-              .returns(alreadySeenChallenge);
-
-            pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
-
-            const alreadySavedCertificationChallenge = new CertificationChallenge({
-              challengeId: alreadySeenChallenge.id,
-              courseId: v3CertificationCourse.getId(),
-            });
-
-            certificationChallengeRepository.getByChallengeIdAndCourseId
-              .withArgs({
-                challengeId: alreadySavedCertificationChallenge.challengeId,
-                courseId: alreadySavedCertificationChallenge.courseId,
-              })
-              .resolves(alreadySeenChallenge);
+            certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3
+              .withArgs(assessment.id, assessment.certificationCourseId)
+              .resolves(nonAnsweredCertificationChallenge);
+            challengeRepository.get.withArgs(nonAnsweredCertificationChallenge.challengeId).resolves(lastSeenChallenge);
 
             // when
             const challenge = await getNextChallengeForCertification({
@@ -225,7 +210,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             });
 
             // then
-            expect(challenge).to.equal(alreadySeenChallenge);
+            expect(challenge).to.equal(lastSeenChallenge);
             expect(certificationChallengeRepository.save).not.to.have.been.called;
           });
         });
@@ -235,7 +220,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
         it('should return the AssessmentEndedError', async function () {
           // given
           const answerRepository = Symbol('AnswerRepository');
-          const challengeRepository = Symbol('ChallengeRepository');
           const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
           const answeredChallenge = domainBuilder.buildChallenge();
           const answer = domainBuilder.buildAnswer({ challengeId: answeredChallenge.id });
@@ -246,8 +230,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const certificationCourseRepository = {
             get: sinon.stub(),
           };
+          const challengeRepository = {
+            get: sinon.stub(),
+          };
           const certificationChallengeRepository = {
             save: sinon.stub(),
+            getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
           };
           const algorithmDataFetcherService = {
             fetchForFlashCampaigns: sinon.stub(),
@@ -255,6 +243,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const locale = 'fr-FR';
 
           certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(v3CertificationCourse);
+          certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3
+            .withArgs(assessment.id, assessment.certificationCourseId)
+            .resolves(null);
+          challengeRepository.get.resolves();
           algorithmDataFetcherService.fetchForFlashCampaigns
             .withArgs({
               answerRepository,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -3,7 +3,6 @@ import { getNextChallengeForCertification } from '../../../../lib/domain/usecase
 import { Assessment } from '../../../../lib/domain/models/Assessment.js';
 import { CertificationVersion } from '../../../../lib/domain/models/CertificationVersion.js';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
-import { CertificationChallenge } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', function () {
   describe('#getNextChallengeForCertification', function () {
@@ -87,7 +86,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           };
           const certificationChallengeRepository = {
             save: sinon.stub(),
-            getByChallengeIdAndCourseId: sinon.stub(),
             getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
           };
           const algorithmDataFetcherService = {
@@ -125,18 +123,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             .returns(nextChallengeToAnswer);
           pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
 
-          const alreadySavedCertificationChallenge = CertificationChallenge.from({
-            challenge: nextChallengeToAnswer,
-            certificationCourseId: v3CertificationCourse.getId(),
-          });
-
-          certificationChallengeRepository.getByChallengeIdAndCourseId
-            .withArgs({
-              challengeId: alreadySavedCertificationChallenge.challengeId,
-              courseId: alreadySavedCertificationChallenge.courseId,
-            })
-            .resolves();
-
           // when
           const challenge = await getNextChallengeForCertification({
             algorithmDataFetcherService,
@@ -168,7 +154,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             };
             const certificationChallengeRepository = {
               save: sinon.stub(),
-              getByChallengeIdAndCourseId: sinon.stub(),
               getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
             };
             const challengeRepository = {


### PR DESCRIPTION
## :unicorn: Problème

Lorsque qu'un candidat retourne sur une session de certification qu'il a au préalable quitté après l'avoir démarrée, nous souhaitons que celui-ci retourne sur la dernière question qu'il ait vue avant de quitter.

⚠️ Le comportement est déjà "implémenté" via ce que l'on pourrait qualifier d'effet de bord. En effet, la sélection d'une question parmi le pool de questions possiblement posées au candidat est toujours la même grâce à l'`assessmentId` que nous utilisons et qui est responsable du caractère pseudo-aléatoire du choix de question. Celui-ci ne variant pas au cours de la session, la question proposée au candidat sera donc toujours la même.

## :robot: Proposition

Nous préférons vérifier l'existence en BDD d'une question à laquelle le candidat n'a pas encore répondu, mettant de côté la connaissance de l'algo de sélection des questions.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

• créer une session dans pix certif pour un centre de certification taggué pilote V3.
• inscrire un candidat à cette session.
• se connecter à app avec un utilisateur certifiable.
• cliquer sur le menu “Certification”.
• entrer le numéro de la session créée en étape 1, puis les info perso du candidat inscrit en étape 2.
• confirmer la présence du candidat depuis l’espace surveillant.
• entrer le code d’accès à la session.
• cliquer sur “Commencer mon test”
• passer des épreuves.
• quitter la session en regardant le numéro du challenge en base.
• reprendre la session avec l'autorisation du surveillant.
• Vérifier que le challenge de reprise correspond au challenge vu lorsque vous avez quitté la session.
