### PR TITLE
[FEATURE] Ajout du code campagne dans l'export csv des campagnes (PIX-8478)

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -158,6 +158,7 @@ function _createHeaderOfCSV(targetProfile, idPixLabel, organization, translate, 
   return [
     translate('campaign-export.common.organization-name'),
     translate('campaign-export.common.campaign-id'),
+    translate('campaign-export.common.campaign-code'),
     translate('campaign-export.common.campaign-name'),
     translate('campaign-export.assessment.target-profile-name'),
     translate('campaign-export.common.participant-lastname'),

--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -19,6 +19,7 @@ class CampaignProfilesCollectionResultLine {
     const line = [
       this.organization.name,
       this.campaign.id,
+      this.campaign.code,
       this.campaign.name,
       this.campaignParticipationResult.participantLastName,
       this.campaignParticipationResult.participantFirstName,

--- a/api/lib/infrastructure/plugins/i18n.js
+++ b/api/lib/infrastructure/plugins/i18n.js
@@ -10,6 +10,10 @@ const options = {
   languageHeaderField: 'Accept-Language',
   objectNotation: true,
   updateFiles: false,
+  mustacheConfig: {
+    tags: ['{', '}'],
+    disable: false,
+  },
 };
 
 export { plugin, options };

--- a/api/lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -47,6 +47,7 @@ class CampaignProfilesCollectionExport {
     const header = [
       this.translate('campaign-export.common.organization-name'),
       this.translate('campaign-export.common.campaign-id'),
+      this.translate('campaign-export.common.campaign-code'),
       this.translate('campaign-export.common.campaign-name'),
       this.translate('campaign-export.common.participant-lastname'),
       this.translate('campaign-export.common.participant-firstname'),

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -92,6 +92,7 @@ class CampaignAssessmentCsvLine {
     return [
       this.organization.name,
       this.campaign.id,
+      this.campaign.code,
       this.campaign.name,
       this.targetProfile.name,
       this.campaignParticipationInfo.participantLastName,

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -131,6 +131,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
       const csvSecondLine =
         `"${organization.name}";` +
         `${campaign.id};` +
+        `"${campaign.code}";` +
         `"'${campaign.name}";` +
         `"'${targetProfile.name}";` +
         `"'${organizationLearner.lastName}";` +

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -156,6 +156,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         const expectedCsvSecondLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"'${campaign.name}";` +
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
@@ -236,6 +237,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         const expectedCsvSecondLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"'${campaign.name}";` +
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +
@@ -318,6 +320,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         const expectedCsvSecondLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"'${campaign.name}";` +
           `"'${organizationLearner.lastName}";` +
           `"'${organizationLearner.firstName}";` +

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -113,6 +113,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -180,6 +181,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -243,6 +245,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -305,6 +308,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -376,6 +380,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -447,6 +452,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -510,6 +516,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       const csvExpected =
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
+        '"Code";' +
         '"Nom de la campagne";' +
         '"Parcours";' +
         '"Nom du Participant";' +
@@ -573,6 +580,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       const csvExpected =
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
+        '"Code";' +
         '"Nom de la campagne";' +
         '"Parcours";' +
         '"Nom du Participant";' +
@@ -656,6 +664,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvHeaderExpected =
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
+      '"Code";' +
       '"Nom de la campagne";' +
       '"Parcours";' +
       '"Nom du Participant";' +
@@ -676,6 +685,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     const csvParticipantResultExpected =
       `"${organization.name}";` +
       `${campaign.id};` +
+      `"${campaign.code}";` +
       `"${campaign.name}";` +
       `"${targetProfile.name}";` +
       `"${participantInfo.participantLastName}";` +
@@ -710,6 +720,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       campaignCsvExportService,
       stageCollectionRepository,
     });
+
     const csv = await csvPromise;
 
     // then

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -55,6 +55,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
         campaign.id = 123;
+        campaign.code = 'ABCDEF';
         campaign.name = 'test';
         organization.name = 'Umbrella';
 
@@ -73,6 +74,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         const csvExcpectedLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"${campaign.name}";` +
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
@@ -107,6 +109,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
 
         campaign.id = 123;
+        campaign.code = 'ABCDEF';
         campaign.name = 'test';
         organization.name = 'Umbrella';
 
@@ -125,6 +128,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         const csvExcpectedLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"${campaign.name}";` +
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
@@ -161,6 +165,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
 
         campaign.id = 123;
+        campaign.code = 'ABCDEF';
         campaign.name = 'test';
         organization.name = 'Umbrella';
 
@@ -179,6 +184,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         const csvExcpectedLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"${campaign.name}";` +
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
@@ -219,6 +225,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
 
         campaign.id = 123;
+        campaign.code = 'ABCDEF';
         campaign.name = 'test';
         organization.name = 'Umbrella';
 
@@ -237,6 +244,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         const csvExcpectedLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"${campaign.name}";` +
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
@@ -279,6 +287,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
         campaign.id = 123;
+        campaign.code = 'ABCDEF';
         campaign.name = 'test';
         organization.name = 'Umbrella';
 
@@ -299,6 +308,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
         const csvExcpectedLine =
           `"${organization.name}";` +
           `${campaign.id};` +
+          `"${campaign.code}";` +
           `"${campaign.name}";` +
           `"${campaignParticipationResultData.participantLastName}";` +
           `"${campaignParticipationResultData.participantFirstName}";` +
@@ -341,6 +351,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -360,6 +371,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
@@ -397,6 +409,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -416,6 +429,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
@@ -460,6 +474,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -479,6 +494,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
@@ -522,6 +538,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -542,6 +559,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
@@ -580,6 +598,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -600,6 +619,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
@@ -638,6 +658,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(0);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -658,6 +679,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +
@@ -703,6 +725,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
 
           campaign.id = 123;
+          campaign.code = 'ABCDEF';
           campaign.name = 'test';
           organization.name = 'Umbrella';
 
@@ -722,6 +745,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-result-line', f
           const csvExcpectedLine =
             `"${organization.name}";` +
             `${campaign.id};` +
+            `"${campaign.code}";` +
             `"${campaign.name}";` +
             `"${campaignParticipationResultData.participantLastName}";` +
             `"${campaignParticipationResultData.participantFirstName}";` +

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -59,6 +59,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
       const expectedHeader =
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
+        '"Code";' +
         '"Nom de la campagne";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
@@ -98,6 +99,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
       const expectedHeader =
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
+        '"Code";' +
         '"Nom de la campagne";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
@@ -138,6 +140,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
       const expectedHeader =
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
+        '"Code";' +
         '"Nom de la campagne";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
@@ -177,6 +180,7 @@ describe('Unit | Serializer | CSV | campaign-profiles-collection-export', functi
       const expectedHeader =
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
+        '"Code";' +
         '"Nom de la campagne";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -15,37 +15,42 @@ function _computeExpectedColumnsIndex(campaign, organization, badges, stages) {
   return {
     ORGANIZATION_NAME: 0,
     CAMPAIGN_ID: 1,
-    CAMPAIGN_NAME: 2,
-    TARGET_PROFILE_NAME: 3,
-    PARTICIPANT_LAST_NAME: 4,
-    PARTICIPANT_FIRST_NAME: 5,
-    DIVISION: 6,
-    GROUP: 6 + divisionPresenceModifier,
-    STUDENT_NUMBER_COL: 6 + divisionPresenceModifier + groupPresenceModifier,
-    EXTERNAL_ID: 6 + studentNumberPresenceModifier + divisionPresenceModifier + groupPresenceModifier,
+    CAMPAIGN_CODE: 2,
+    CAMPAIGN_NAME: 3,
+    TARGET_PROFILE_NAME: 4,
+    PARTICIPANT_LAST_NAME: 5,
+    PARTICIPANT_FIRST_NAME: 6,
+    DIVISION: 7,
+    GROUP: 7 + divisionPresenceModifier,
+    STUDENT_NUMBER_COL: 7 + divisionPresenceModifier + groupPresenceModifier,
+    EXTERNAL_ID: 7 + studentNumberPresenceModifier + divisionPresenceModifier + groupPresenceModifier,
     PARTICIPATION_PROGRESSION:
-      6 + divisionPresenceModifier + groupPresenceModifier + studentNumberPresenceModifier + externalIdPresenceModifier,
-    PARTICIPATION_CREATED_AT:
       7 + divisionPresenceModifier + groupPresenceModifier + studentNumberPresenceModifier + externalIdPresenceModifier,
-    PARTICIPATION_IS_SHARED:
+    PARTICIPATION_CREATED_AT:
       8 + divisionPresenceModifier + groupPresenceModifier + studentNumberPresenceModifier + externalIdPresenceModifier,
-    PARTICIPATION_SHARED_AT:
+    PARTICIPATION_IS_SHARED:
       9 + divisionPresenceModifier + groupPresenceModifier + studentNumberPresenceModifier + externalIdPresenceModifier,
-    BADGE:
+    PARTICIPATION_SHARED_AT:
       10 +
       divisionPresenceModifier +
       groupPresenceModifier +
       studentNumberPresenceModifier +
       externalIdPresenceModifier,
+    BADGE:
+      11 +
+      divisionPresenceModifier +
+      groupPresenceModifier +
+      studentNumberPresenceModifier +
+      externalIdPresenceModifier,
     STAGE_REACHED:
-      10 +
+      11 +
       divisionPresenceModifier +
       groupPresenceModifier +
       studentNumberPresenceModifier +
       externalIdPresenceModifier +
       badgePresenceModifier,
     PARTICIPATION_PERCENTAGE:
-      10 +
+      11 +
       divisionPresenceModifier +
       groupPresenceModifier +
       studentNumberPresenceModifier +
@@ -53,7 +58,7 @@ function _computeExpectedColumnsIndex(campaign, organization, badges, stages) {
       badgePresenceModifier +
       stagesPresenceModifier,
     DETAILS_START:
-      11 +
+      12 +
       divisionPresenceModifier +
       groupPresenceModifier +
       studentNumberPresenceModifier +
@@ -105,6 +110,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
       const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
       expect(csvLine[cols.ORGANIZATION_NAME], 'organization name').to.equal(organization.name);
       expect(csvLine[cols.CAMPAIGN_ID], 'campaign id').to.equal(campaign.id);
+      expect(csvLine[cols.CAMPAIGN_CODE], 'campaign code').to.equal(campaign.code);
       expect(csvLine[cols.CAMPAIGN_NAME], 'campaign name').to.equal(campaign.name);
       expect(csvLine[cols.TARGET_PROFILE_NAME], 'target profile name').to.equal(targetProfile.name);
       expect(csvLine[cols.PARTICIPANT_LAST_NAME], 'participant last name').to.equal(

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -27,6 +27,7 @@
       "thematic-result-name": "{name} (Y/N)"
     },
     "common": {
+      "campaign-code": "Code",
       "campaign-id": "Campaign ID",
       "campaign-name": "Campaign's name",
       "file-name": "Results-{name}-{id}-{date}.csv",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -39,6 +39,7 @@
       "thematic-result-name": "{name} obtenu (O/N)"
     },
     "common": {
+      "campaign-code": "Code",
       "campaign-id": "ID Campagne",
       "campaign-name": "Nom de la campagne",
       "file-name": "Resultats-{name}-{id}-{date}.csv",


### PR DESCRIPTION
## :unicorn: Problème
Suite à des retours d’usages, de prescripteurs SCO, on nous a demandé d’afficher le code campagne dans la liste des campagnes et dans leurs exports csv pour aller plus vite dans l’envoi des codes aux élèves.

## :robot: Proposition
Ajouter une colonne dans l’export csv des campagnes pour toutes les organisations
Rajouter cette information juste après l’id de la campagne

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga
- Aller sur une campagne (évaluation ou collecte de profil)
- Cliquer sur Exporter les résultats
- Vérifier dans le fichier téléchargé que la colonne "Code" existe après l'ID de la campagne, ainsi que le code correspondant
- Faire la même chose pour l'autre type de campagne
- 🐱 