### PR TITLE
[BUGFIX] Trace seulement les vraies erreurs dans l'API (PIX-8484)

### DIFF
--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -51,6 +51,9 @@ const plugin = {
     });
 
     server.events.on('request', function (request, event) {
+      if (event.channel !== 'error') {
+        return;
+      }
       if (event.error) {
         logger.error(
           {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -97,7 +97,6 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-unicorn": "^47.0.0",
         "eslint-plugin-yml": "^1.0.0",
-        "flush-write-stream": "^2.0.0",
         "form-data": "^4.0.0",
         "inquirer": "^9.0.0",
         "mocha": "^10.0.0",
@@ -108,7 +107,6 @@
         "prettier": "^2.7.1",
         "sinon": "^15.0.0",
         "sinon-chai": "^3.7.0",
-        "split2": "^4.1.0",
         "stream-to-promise": "^3.0.0"
       },
       "engines": {
@@ -6002,16 +6000,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
-    },
-    "node_modules/flush-write-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-2.0.0.tgz",
-      "integrity": "sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -17113,16 +17101,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
-    },
-    "flush-write-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-2.0.0.tgz",
-      "integrity": "sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      }
     },
     "follow-redirects": {
       "version": "1.15.2",

--- a/api/package.json
+++ b/api/package.json
@@ -104,7 +104,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^47.0.0",
     "eslint-plugin-yml": "^1.0.0",
-    "flush-write-stream": "^2.0.0",
     "form-data": "^4.0.0",
     "inquirer": "^9.0.0",
     "mocha": "^10.0.0",
@@ -115,7 +114,6 @@
     "prettier": "^2.7.1",
     "sinon": "^15.0.0",
     "sinon-chai": "^3.7.0",
-    "split2": "^4.1.0",
     "stream-to-promise": "^3.0.0"
   },
   "overrides": {


### PR DESCRIPTION
## :unicorn: Problème
Nous tracons actuellement beaucoup d'erreurs en production car les usecases lancent des exceptions pour gérer les erreurs (validation, etc ...). Ces erreurs sont ensuite rattrapées par l'error-manager qui les transforme en réponse http de type 4xx.
Mais dans l'intervalle, hapi déclenche un événement 'request' avec un channel 'internal' que nous tracions par défaut alors qu'aucune erreur n'était réellement renvoyée.

## :robot: Proposition
Filtrer les channels de request de hapi pour ne prendre que celle d'error. voir https://hapi.dev/api/?v=21.3.2#-request-event.

## :rainbow: Remarques
Les tests sur le sujet étaient incorrects car en fait nous ne tracions que le premier message et pas les suivants.

## :100: Pour tester
1. Lancer l'API
2. Lancer la commande curl suivante: `curl 'http://localhost:3000/api/token' -X POST  --data-raw 'grant_type=password&username=a%40a.fr&password=a&scope=mon-pix'`
3. Constater dans les logs du serveur qu'il y a seulement un log request completed mais pas de log error.
4. Revenir sur dev et faire la même chose pour constater qu'il y a 2 logs.
