### PR TITLE
[BUGFIX] Rectifier l'alignement des réponses d'un QROCm passé (PIX-8488).

### DIFF
--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -19,7 +19,8 @@
     }
   }
 
-  &.correction-qroc-box-answer--wrong {
+  &.correction-qroc-box-answer--wrong,
+  &.correction-qroc-box-answer--aband {
     vertical-align: -2.5em;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

L'alignement n'est pas bon lorsqu'une épreuve QROCm est juste passée.

![image](https://github.com/1024pix/pix/assets/7335131/6330a592-baeb-4312-b6a9-ab36980f3018)

## :robot: Proposition

Rectifier cet alignement pour qu'il corresponde à ce que l'on a lorsque les réponses sont mauvaises.

## :100: Pour tester

Passer ces épreuves pour vérifier le style des solutions :

- https://app-pr6495.review.pix.fr/challenges/rec22pH8nuM16u6Is/preview
- https://app-pr6495.review.pix.fr/challenges/challenge2CMbKqOFeZvbjp/preview
- https://app-pr6495.review.pix.fr/challenges/challenge28kwuFJjZlaJs8/preview
- https://app-pr6495.review.pix.fr/challenges/challengeZVBoM4yUQAX3F/preview
