### PR TITLE
[FEATURE] Retourner le nouveau champ areKnowledgeElementsResettable dans l'API

### DIFF
--- a/api/db/database-builder/factory/build-target-profile.js
+++ b/api/db/database-builder/factory/build-target-profile.js
@@ -15,6 +15,7 @@ const buildTargetProfile = function ({
   comment = null,
   category = 'OTHER',
   migration_status = 'N/A',
+  areKnowledgeElementsResettable = false,
 } = {}) {
   ownerOrganizationId = _.isUndefined(ownerOrganizationId) ? buildOrganization().id : ownerOrganizationId;
 
@@ -31,6 +32,7 @@ const buildTargetProfile = function ({
     comment,
     category,
     migration_status,
+    areKnowledgeElementsResettable,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'target-profiles',

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -23,10 +23,10 @@ const findPaginatedFilteredTargetProfileSummariesForAdmin = async function (requ
   return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries, meta);
 };
 
-const getTargetProfileForAdmin = async function (request) {
+const getTargetProfileForAdmin = async function (request, h, dependencies = { targetProfileForAdminSerializer }) {
   const targetProfileId = request.params.id;
   const targetProfileForAdmin = await usecases.getTargetProfileForAdmin({ targetProfileId });
-  return targetProfileForAdminSerializer.serialize(targetProfileForAdmin);
+  return dependencies.targetProfileForAdminSerializer.serialize(targetProfileForAdmin);
 };
 
 const findPaginatedFilteredTargetProfileOrganizations = async function (request) {

--- a/api/lib/domain/models/TargetProfileForAdmin.js
+++ b/api/lib/domain/models/TargetProfileForAdmin.js
@@ -11,6 +11,7 @@ class TargetProfileForAdmin {
     imageUrl,
     category,
     isSimplifiedAccess,
+    areKnowledgeElementsResettable,
     badges,
     stageCollection,
     areas = [],
@@ -29,6 +30,7 @@ class TargetProfileForAdmin {
     this.imageUrl = imageUrl;
     this.category = category;
     this.isSimplifiedAccess = isSimplifiedAccess;
+    this.areKnowledgeElementsResettable = areKnowledgeElementsResettable;
     this.badges = badges;
     this.stageCollection = stageCollection;
     this.areas = areas.map(

--- a/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -26,7 +26,8 @@ const get = async function ({ id, locale = FRENCH_FRANCE }) {
       'target-profiles.comment',
       'target-profiles.ownerOrganizationId',
       'target-profiles.category',
-      'target-profiles.isSimplifiedAccess'
+      'target-profiles.isSimplifiedAccess',
+      'target-profiles.areKnowledgeElementsResettable'
     )
     .where('id', id)
     .first();

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -23,6 +23,7 @@ const serialize = function (targetProfiles) {
       'imageUrl',
       'category',
       'isSimplifiedAccess',
+      'areKnowledgeElementsResettable',
       'badges',
       'stageCollection',
       'areas',

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, catchErr, mockLearningContent, domainBuilder } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import * as targetProfileForAdminRepository from '../../../../lib/infrastructure/repositories/target-profile-for-admin-repository.js';
 import { TargetProfileForAdmin } from '../../../../lib/domain/models/TargetProfileForAdmin.js';
@@ -32,6 +32,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           comment: 'i like it',
           category: 'SOME_CATEGORY',
           isSimplifiedAccess: true,
+          areKnowledgeElementsResettable: false,
         });
         databaseBuilder.factory.buildTargetProfileTube({
           targetProfileId: targetProfileDB.id,
@@ -124,6 +125,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           comment: 'i like it',
           category: 'SOME_CATEGORY',
           isSimplifiedAccess: true,
+          areKnowledgeElementsResettable: true,
         });
         databaseBuilder.factory.buildTargetProfileTube({
           targetProfileId: targetProfileDB.id,
@@ -436,6 +438,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           imageUrl: targetProfileDB.imageUrl,
           category: targetProfileDB.category,
           isSimplifiedAccess: targetProfileDB.isSimplifiedAccess,
+          areKnowledgeElementsResettable: targetProfileDB.areKnowledgeElementsResettable,
           badges: [expectedBadge1, expectedBadge2],
           stageCollection: expectedStageCollection,
           areas: [areaA],
@@ -461,6 +464,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           comment: 'i like it',
           category: 'SOME_CATEGORY',
           isSimplifiedAccess: true,
+          areKnowledgeElementsResettable: false,
         });
         databaseBuilder.factory.buildTargetProfileTube({
           targetProfileId: targetProfileDB.id,
@@ -580,6 +584,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           imageUrl: targetProfileDB.imageUrl,
           category: targetProfileDB.category,
           isSimplifiedAccess: targetProfileDB.isSimplifiedAccess,
+          areKnowledgeElementsResettable: targetProfileDB.areKnowledgeElementsResettable,
           areas: [areaA],
           competences: [compA_areaA],
           thematics: [themA_compA_areaA],

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -1,4 +1,4 @@
-import { expect, sinon, hFake, domainBuilder } from '../../../test-helper.js';
+import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
 import { targetProfileController } from '../../../../lib/application/target-profiles/target-profile-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
@@ -333,6 +333,39 @@ describe('Unit | Controller | target-profile-controller', function () {
       // then
       expect(usecases.findPaginatedTargetProfileTrainingSummaries).to.have.been.calledWith(useCaseParameters);
       expect(queryParamsUtils.extractParameters).to.have.been.calledOnce;
+      expect(response).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#getTargetProfileForAdmin', function () {
+    it('should return targetProfileForAdmin', async function () {
+      // given
+      const targetProfileId = 123;
+      const expectedResult = Symbol('serialized-target-profile-for-admin');
+      const targetProfileForAdmin = Symbol('targetProfileForAdmin');
+      const useCaseParameters = {
+        targetProfileId,
+      };
+
+      sinon.stub(usecases, 'getTargetProfileForAdmin').withArgs(useCaseParameters).resolves(targetProfileForAdmin);
+
+      const targetProfileForAdminSerializer = {
+        serialize: sinon.stub(),
+      };
+      targetProfileForAdminSerializer.serialize.withArgs(targetProfileForAdmin).returns(expectedResult);
+
+      // when
+      const response = await targetProfileController.getTargetProfileForAdmin(
+        {
+          params: {
+            id: targetProfileId,
+          },
+        },
+        hFake,
+        { targetProfileForAdminSerializer }
+      );
+
+      // then
       expect(response).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js';
 import { TargetProfileForAdmin } from '../../../../../lib/domain/models/TargetProfileForAdmin.js';
 
@@ -103,6 +103,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
         imageUrl: 'some/image/url',
         category: 'OTHER',
         isSimplifiedAccess: true,
+        areKnowledgeElementsResettable: false,
         badges: [badge1, badge2],
         stageCollection,
         areas: [area, area2],
@@ -185,6 +186,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             'image-url': 'some/image/url',
             'is-public': true,
             'is-simplified-access': true,
+            'are-knowledge-elements-resettable': false,
             'max-level': 7,
             name: 'Mon Super profil cible',
             outdated: true,


### PR DESCRIPTION
## :unicorn: Problème
Un PIX Admin a besoin de savoir si un Profile Cible peut remettre à zero

## :robot: Proposition
On cherche dans le base a donné et retour dans le API le champ `areKnowledgeElementsResettable` dans `target-profile` pour savoir si un Profile cible est remettable à zero

## :rainbow: Remarques
pas de remarques

## :100: Pour tester
Aller a PIX admin sur la page Profile Cibles
Ouvrir le dev tools sur la onglet Network et choisir un profile cible
Regarde le réponse et verifier que le champ `are-knowledge-elements-resettable` est la

