### PR TITLE
[TECH] Amélioration et correction des certification complémentaire dans les nouveaux seeds (PIX-8506).

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -50,4 +50,67 @@ buildComplementaryCertification.clea = function ({
   });
 };
 
+buildComplementaryCertification.droit = function ({
+  id = databaseBuffer.getNextId(),
+  minimumReproducibilityRate = 75,
+  minimumEarnedPix = null,
+  hasComplementaryReferential = false,
+  hasExternalJury = false,
+  certificationExtraTime = 45,
+}) {
+  return buildComplementaryCertification({
+    id,
+    label: 'Pix+ Droit',
+    key: ComplementaryCertification.PIX_PLUS_DROIT,
+    createdAt: new Date('2020-01-01'),
+    minimumReproducibilityRate,
+    minimumEarnedPix,
+    hasComplementaryReferential,
+    hasExternalJury,
+    certificationExtraTime,
+  });
+};
+
+buildComplementaryCertification.pixEdu1erDegre = function ({
+  id = databaseBuffer.getNextId(),
+  minimumReproducibilityRate = 70,
+  minimumEarnedPix = null,
+  hasComplementaryReferential = false,
+  hasExternalJury = true,
+  certificationExtraTime = 45,
+}) {
+  return buildComplementaryCertification({
+    id,
+    label: 'Pix+ Édu 1er degré',
+    key: ComplementaryCertification.PIX_PLUS_EDU_1ER_DEGRE,
+    createdAt: new Date('2020-01-01'),
+    minimumReproducibilityRate,
+    minimumEarnedPix,
+    hasComplementaryReferential,
+    hasExternalJury,
+    certificationExtraTime,
+  });
+};
+
+buildComplementaryCertification.pixEdu2ndDegre = function ({
+  id = databaseBuffer.getNextId(),
+  minimumReproducibilityRate = 70,
+  minimumEarnedPix = null,
+  hasComplementaryReferential = false,
+  hasExternalJury = true,
+  certificationExtraTime = 45,
+}) {
+  return buildComplementaryCertification({
+    id,
+    label: 'Pix+ Édu 2nd degré',
+    key: ComplementaryCertification.PIX_PLUS_EDU_2ND_DEGRE,
+    createdAt: new Date('2020-01-01'),
+    minimumReproducibilityRate,
+    minimumEarnedPix,
+    hasComplementaryReferential,
+    hasExternalJury,
+    certificationExtraTime,
+  });
+};
+
 export { buildComplementaryCertification };

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -3,12 +3,14 @@ import { badges } from '../../../constants.js';
 const { ROLES } = PIX_ADMIN;
 
 // IDS
-/// USERS
+// COMPLEMENTARY CERTIFICATIONS
 const CLEA_COMPLEMENTARY_CERTIFICATION_ID = 52;
 const PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID = 53;
 const PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 54;
 const PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 55;
-const REAL_PIX_SUPER_ADMIN = 90000;
+
+// USERS
+const REAL_PIX_SUPER_ADMIN_ID = 90000;
 
 // TARGET PROFILES
 const CLEA_TARGET_PROFILE_ID = 56;
@@ -75,13 +77,13 @@ async function commonBuilder({ databaseBuilder }) {
 
 function _createSuperAdmin(databaseBuilder) {
   databaseBuilder.factory.buildUser.withRawPassword({
-    id: REAL_PIX_SUPER_ADMIN,
+    id: REAL_PIX_SUPER_ADMIN_ID,
     firstName: 'NextSuper',
     lastName: 'NextAdmin',
     email: 'superadmin@example.net',
     rawPassword: 'pix123',
   });
-  databaseBuilder.factory.buildPixAdminRole({ userId: REAL_PIX_SUPER_ADMIN, role: ROLES.SUPER_ADMIN });
+  databaseBuilder.factory.buildPixAdminRole({ userId: REAL_PIX_SUPER_ADMIN_ID, role: ROLES.SUPER_ADMIN });
 }
 
 function _createTags(databaseBuilder) {
@@ -100,7 +102,7 @@ function _createComplementaryCertifications(databaseBuilder) {
   _createClea(databaseBuilder);
   _createDroit(databaseBuilder);
   _createPixEdu1erDegre(databaseBuilder);
-  _createPixEdu2emeDegre(databaseBuilder);
+  _createPixEdu2ndDegre(databaseBuilder);
 }
 
 function _createClea(databaseBuilder) {
@@ -247,12 +249,8 @@ function _createClea(databaseBuilder) {
 }
 
 function _createDroit(databaseBuilder) {
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'Pix+ Droit',
-    key: 'DROIT',
+  databaseBuilder.factory.buildComplementaryCertification.droit({
     id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 75,
-    minimumEarnedPix: null,
   });
   databaseBuilder.factory.buildTargetProfile({
     id: PIX_DROIT_TARGET_PROFILE_ID,
@@ -617,13 +615,8 @@ function _createDroit(databaseBuilder) {
 }
 
 function _createPixEdu1erDegre(databaseBuilder) {
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'Pix+ Édu 1er degré',
-    key: badges.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  databaseBuilder.factory.buildComplementaryCertification.pixEdu1erDegre({
     id: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 70,
-    minimumEarnedPix: null,
-    hasExternalJury: true,
   });
   databaseBuilder.factory.buildTargetProfile({
     id: PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID,
@@ -868,14 +861,9 @@ function _createPixEdu1erDegre(databaseBuilder) {
   });
 }
 
-function _createPixEdu2emeDegre(databaseBuilder) {
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'Pix+ Édu 2nd degré',
-    key: badges.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+function _createPixEdu2ndDegre(databaseBuilder) {
+  databaseBuilder.factory.buildComplementaryCertification.pixEdu2ndDegre({
     id: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 70,
-    minimumEarnedPix: null,
-    hasExternalJury: true,
   });
   databaseBuilder.factory.buildTargetProfile({
     id: PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID,


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un test fonctionnel d'ajout de candidat via l'ODS sur Pix Certif, un comportement non souhaité se passait sur les certif complémentaire Pix+Edu. 

<img width="394" alt="Capture d’écran 2023-06-28 à 11 33 32" src="https://github.com/1024pix/pix/assets/58915422/f364425d-1b64-4f91-a756-958ef62cf1f1">

Il était alors impossible d'ajouter une certif Edu à un candidat.

## :robot: Proposition
Corriger les seeds en erreur.

## :rainbow: Remarques
Les keys des certif Pix+Edu étaient erronée. On se basait sur la key des `complementary-certification-badges` et non celle des `complementary-certifications`

--

En revanche, nous ne sommes pas parvenus à comprendre pourquoi la key (erronée) s'affichait dans l'ODS

## :100: Pour tester
Reproduire l'erreur en testant le scénario en local avec les nouveaux seeds `USE_NEW_SEEDS=true npm run db:reset`, puis tester en RA avec la correction


- Se connecter sur Pix Certif avec certif-pro@example.net
- Cliquer sur une session existante et cliquer sur l'onglet candidat
- Télécharger l'ODS et constater pour les 2 dernières colonnes Pix+Edu: 

 - l'erreur 🚫(si local)
 - que tout est normal ✅ (si RA)

- Modifier l'ODS pour ajouter une certif Edu à un candidat qui n'en a pas
- Constater : 
 - que l'ajout ne se fait pas 🚫 (si local)
 - que l'ajout se fait ✅ (si RA)
