### PR TITLE
[FEATURE] Ajouter un feature flag pour contextualiser l'activation de la suppression des participants (Pix-8500)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -10,7 +10,7 @@
         <:manager as |allSelected someSelected toggleAll selectedParticipants reset|>
           <InElement @destinationId={{this.headerId}}>
             <tr>
-              {{#if this.isUserAdmin}}
+              {{#if this.canDeleteParticipant}}
                 <Table::Header class="table__column--small">
                   <PixCheckbox
                     @screenReaderOnly={{true}}
@@ -107,7 +107,7 @@
             {{on "click" (fn @onClickLearner participant.id)}}
             class="tr--clickable"
           >
-            {{#if this.isUserAdmin}}
+            {{#if this.canDeleteParticipant}}
               <td class="table__column" {{on "click" (fn this.onClick toggleParticipant)}}>
                 <PixCheckbox @screenReaderOnly={{true}} @checked={{isParticipantSelected}}>
                   {{t

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -3,14 +3,16 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-
+import ENV from 'pix-orga/config/environment';
 export default class List extends Component {
   @tracked showDeletionModal = false;
 
   @service currentUser;
 
-  get isUserAdmin() {
-    return this.currentUser.isAdminInOrganization;
+  get canDeleteParticipant() {
+    const isFeatureEnabled = ENV.APP.FT_DELETE_PARTICIPANT;
+
+    return isFeatureEnabled && this.currentUser.isAdminInOrganization;
   }
 
   get headerId() {

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -113,6 +113,7 @@ module.exports = function (environment) {
   };
 
   if (environment === 'development') {
+    ENV.APP.FT_DELETE_PARTICIPANT = true;
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
     ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
     // ENV.APP.LOG_RESOLVER = true;
@@ -151,6 +152,8 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.APP.FT_DELETE_PARTICIPANT = _isFeatureEnabled(process.env.FT_DELETE_PARTICIPANT) || false;
+
     if (analyticsEnabled) {
       ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
     }

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -5,6 +5,7 @@ import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import sinon from 'sinon';
+import ENV from 'pix-orga/config/environment';
 
 module('Integration | Component | OrganizationParticipant::List', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -694,6 +695,12 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       this.triggerFiltering = sinon.stub();
       this.set('fullNameFilter', null);
       this.set('certificabilityFilter', []);
+
+      ENV.APP.FT_DELETE_PARTICIPANT = true;
+    });
+
+    hooks.afterEach(function () {
+      ENV.APP.FT_DELETE_PARTICIPANT = false;
     });
 
     test('it should display checkboxes', async function (assert) {
@@ -1068,7 +1075,15 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     });
   });
 
-  module('when user is not admin of organisation', function () {
+  module('when user is not admin of organisation', function (hooks) {
+    hooks.beforeEach(function () {
+      ENV.APP.FT_DELETE_PARTICIPANT = true;
+    });
+
+    hooks.afterEach(function () {
+      ENV.APP.FT_DELETE_PARTICIPANT = false;
+    });
+
     test('it should not display checkboxes', async function (assert) {
       //given
       class CurrentUserStub extends Service {


### PR DESCRIPTION
## :unicorn: Problème
La suppression du prescrit est prête, nous ne pouvons pas merger la PR de suite. 

## :robot: Proposition
Ajouter un feature flag pour activer la feature au moment voulu afin de ne pas attendre la date de communication

## :rainbow: Remarques
RAS

## :100: Pour tester
Changer la variable d'environnement sur la RA afin de vérifier que le FT fonctionne