### PR TITLE
[BUGFIX] Suppression d'un objet non existant lors de la génération des nouvelles seeds.

### DIFF
--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -7,7 +7,7 @@ function _buildUserWithCnavAuthenticationMethod(databaseBuilder) {
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-    identityProvider: OidcIdentityProviders.CNAV.service.code,
+    identityProvider: OidcIdentityProviders.CNAV.code,
     userId: user.id,
   });
 }
@@ -19,7 +19,7 @@ function _buildUserWithFwbAuthenticationMethod(databaseBuilder) {
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-    identityProvider: OidcIdentityProviders.FWB.service.code,
+    identityProvider: OidcIdentityProviders.FWB.code,
     userId: user.id,
   });
 }
@@ -31,7 +31,7 @@ function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
     userId: user.id,
   });
 }


### PR DESCRIPTION
## :unicorn: Problème

Une erreur est générée à la création des nouvelles seeds.
L'objet `OidcIdentityProviders` fait appel à un objet nesté `service` qui n'existe pas dans l'export.

<img width="877" alt="Capture d’écran 2023-06-28 à 13 52 13" src="https://github.com/1024pix/pix/assets/36371437/4593d397-b7ac-44b0-822c-3b29d87d7f2a">

## :robot: Proposition

Suppression du `.service` dans les données utilisées 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Reset la base avec des nouvelles seeds et vérifier qu'il n'y ait plus d'erreur.
