### PR TITLE
[BUGFIX] Ajout de la version de session pour l'import en masse (PIX-8510).

### DIFF
--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { config } from '../../config.js';
+import { CertificationVersion } from './CertificationVersion.js';
 
 const CREATED = 'created';
 const FINALIZED = 'finalized';
@@ -40,7 +41,7 @@ class Session {
     certificationCenterId,
     assignedCertificationOfficerId,
     supervisorPassword = Session.generateSupervisorPassword(),
-    version,
+    version = CertificationVersion.V2,
   } = {}) {
     this.id = id;
     this.accessCode = accessCode;

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
@@ -37,7 +37,6 @@ describe('Acceptance | Controller | certification-centers-controller-post-create
           accessCode: 'accessCode',
           supervisorPassword: 'KV2CP',
           certificationCandidates: [],
-          version: 2,
         };
         const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
           sessions: [sessionToSave],


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'import en masse, nous avons omis d'ajouter le numéro de version par défaut à la session, résultant en une erreur lors de la sauvegarde à cause de la contrainte non nulle en BDD

## :robot: Proposition

Ajout d'un numéro de version par défaut à la session.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Tester l'import en masse.
