### PR TITLE
[FEATURE] Suppression de l'onglet Profil pour les certifications V3 (PIX-8494).

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -43,6 +43,7 @@ export default class Certification extends Model {
   @attr() pixScore;
   @attr() competencesWithMark;
   @attr('boolean', { defaultValue: false }) isPublished;
+  @attr('number') version;
   @belongsTo('complementary-certification-course-result-with-external')
   complementaryCertificationCourseResultWithExternal;
   @belongsTo('common-complementary-certification-course-result') commonComplementaryCertificationCourseResult;

--- a/admin/app/templates/authenticated/certifications/certification.hbs
+++ b/admin/app/templates/authenticated/certifications/certification.hbs
@@ -9,9 +9,11 @@
   <LinkTo @route="authenticated.certifications.certification.details" @model={{@model.id}} class="navbar-item">
     Détails
   </LinkTo>
-  <LinkTo @route="authenticated.certifications.certification.profile" @model={{@model.id}} class="navbar-item">
-    Profil
-  </LinkTo>
+  {{#if (eq @model.version 2)}}
+    <LinkTo @route="authenticated.certifications.certification.profile" @model={{@model.id}} class="navbar-item">
+      Profil
+    </LinkTo>
+  {{/if}}
 </nav>
 <section>
   {{outlet}}

--- a/admin/tests/acceptance/authenticated/certifications/certification/certification_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/certification_test.js
@@ -1,0 +1,76 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
+
+module('Acceptance | Route | routes/authenticated/certifications/certification', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('when certification is V3', function () {
+    test('it should not display the profile tab', async function (assert) {
+      // given
+      this.server.create('user', { id: 888 });
+
+      const certification = this.server.create('certification', {
+        id: 123,
+        firstName: 'Bora Horza',
+        lastName: 'Gobuchul',
+        birthdate: '1987-07-24',
+        birthplace: 'Sorpen',
+        userId: 888,
+        sex: 'M',
+        isCancelled: false,
+        birthCountry: 'JAPON',
+        birthInseeCode: '99217',
+        birthPostalCode: null,
+        competencesWithMark: [],
+        listChallengesAndAnswers: [],
+        createdAt: new Date('2020-01-01'),
+        version: 3,
+      });
+
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: 'Profil' })).doesNotExist();
+    });
+  });
+
+  module('when certification is V2', function () {
+    test('it should display the profile tab', async function (assert) {
+      // given
+      this.server.create('user', { id: 888 });
+
+      const certification = this.server.create('certification', {
+        id: 123,
+        firstName: 'Bora Horza',
+        lastName: 'Gobuchul',
+        birthdate: '1987-07-24',
+        birthplace: 'Sorpen',
+        userId: 888,
+        sex: 'M',
+        isCancelled: false,
+        birthCountry: 'JAPON',
+        birthInseeCode: '99217',
+        birthPostalCode: null,
+        competencesWithMark: [],
+        listChallengesAndAnswers: [],
+        createdAt: new Date('2020-01-01'),
+        version: 2,
+      });
+
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Profil' })).exists();
+    });
+  });
+});

--- a/api/lib/domain/models/JuryCertification.js
+++ b/api/lib/domain/models/JuryCertification.js
@@ -28,6 +28,7 @@ class JuryCertification {
     certificationIssueReports,
     complementaryCertificationCourseResultWithExternal,
     commonComplementaryCertificationCourseResult,
+    version,
   }) {
     this.certificationCourseId = certificationCourseId;
     this.sessionId = sessionId;
@@ -55,6 +56,7 @@ class JuryCertification {
     this.certificationIssueReports = certificationIssueReports;
     this.complementaryCertificationCourseResultWithExternal = complementaryCertificationCourseResultWithExternal;
     this.commonComplementaryCertificationCourseResult = commonComplementaryCertificationCourseResult;
+    this.version = version;
   }
 
   static from({
@@ -98,6 +100,7 @@ class JuryCertification {
       certificationIssueReports,
       complementaryCertificationCourseResultWithExternal,
       commonComplementaryCertificationCourseResult,
+      version: juryCertificationDTO.version,
     });
   }
 }

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -80,6 +80,7 @@ function _selectJuryCertifications() {
       isPublished: 'certification-courses.isPublished',
       createdAt: 'certification-courses.createdAt',
       completedAt: 'certification-courses.completedAt',
+      version: 'certification-courses.version',
       assessmentId: 'assessments.id',
       assessmentResultId: 'assessment-results.id',
       pixScore: 'assessment-results.pixScore',

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -37,6 +37,7 @@ const serialize = function (juryCertification) {
       'commonComplementaryCertificationCourseResult',
       'complementaryCertificationCourseResultWithExternal',
       'certificationIssueReports',
+      'version',
     ],
 
     commonComplementaryCertificationCourseResult: {

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -342,6 +342,7 @@ describe('Acceptance | API | Certification Course', function () {
           'comment-for-candidate': 'comment candidate',
           'comment-for-jury': 'comment jury',
           'comment-for-organization': 'comment organization',
+          version: 2,
           'competences-with-mark': [
             {
               area_code: '3',

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -166,6 +166,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         commentForJury: 'Un commentaire jury',
         competenceMarks: [expectedCompetenceMark],
         certificationIssueReports: [],
+        version: 2,
         commonComplementaryCertificationCourseResult: {
           acquired: true,
           id: 123,

--- a/api/tests/tooling/domain-builder/factory/build-jury-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-certification.js
@@ -1,3 +1,4 @@
+import { CertificationVersion } from '../../../../lib/domain/models/CertificationVersion.js';
 import { JuryCertification } from '../../../../lib/domain/models/JuryCertification.js';
 import { buildCertificationIssueReport } from './build-certification-issue-report.js';
 import { buildCompetenceMark } from './build-competence-mark.js';
@@ -29,6 +30,7 @@ const buildJuryCertification = function ({
   certificationIssueReports = [buildCertificationIssueReport()],
   commonComplementaryCertificationCourseResult = null,
   complementaryCertificationCourseResultWithExternal = {},
+  version = CertificationVersion.V2,
 } = {}) {
   return new JuryCertification({
     certificationCourseId,
@@ -57,6 +59,7 @@ const buildJuryCertification = function ({
     certificationIssueReports,
     commonComplementaryCertificationCourseResult,
     complementaryCertificationCourseResultWithExternal,
+    version,
   });
 };
 

--- a/api/tests/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/unit/domain/models/JuryCertification_test.js
@@ -29,6 +29,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         commentForCandidate: 'coucou',
         commentForOrganization: 'comment',
         commentForJury: 'ça va',
+        version: 2,
       };
     });
 
@@ -108,6 +109,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         commentForCandidate: 'coucou',
         commentForOrganization: 'comment',
         commentForJury: 'ça va',
+        version: 2,
         competenceMarks: [expectedCompetenceMark],
         certificationIssueReports,
         commonComplementaryCertificationCourseResult,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -38,6 +38,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
         commentForOrganization: 'comment',
         commentForJury: 'ça va',
         competenceMarks,
+        version: 2,
         certificationIssueReports,
         commonComplementaryCertificationCourseResult:
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
@@ -101,6 +102,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             'comment-for-candidate': 'coucou',
             'comment-for-jury': 'ça va',
             'comment-for-organization': 'comment',
+            version: 2,
           },
           relationships: {
             'certification-issue-reports': {


### PR DESCRIPTION
## :unicorn: Problème

La certif v3 n’est plus corrélée avec le positionnement comme l’est la certification actuelle. En effet, l’algo de choix des épreuves actuel va sélectionner 3 questions par compétence certifiable d’un candidat. Le nouvel algorithme de choix des questions ne regarde pas du tout ce que le candidat a fait dans le cadre de son positionnement.

Dans pix Admin > page de détails d’une certification, un onglet “Profil” permet de visualiser les acquis validés par un candidat dans le cadre de son positionnement au moment de son test, vs. les acquis proposés lors de son test de certif. L’affichage de cet onglet est cassé pour les certif v3, mais n’est de toute façon plus pertinent avec la philosophie de la certif v3.

## :robot: Proposition

Affichage de l'onglet en fonction de la version de la certification

## :rainbow: Remarques

## :100: Pour tester

créer une session avec un CDC isV3Pilot 
 rejoindre la session puis lancer un test de certification
 dans Pix Admin > Certifications : ouvrir la page de détails de la certification préalablement lancée
  résultat : PAS d’onglet “Profil” affiché
 ouvrir la page de détails d’une certification v2
 résultat : l’onglet “Profil” est toujours affichée
