### PR TITLE
[FEATURE] Possibilité pour les centres V3 pilotes d'importer en masses des sessions (PIX-8511).

### DIFF
--- a/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
@@ -3,12 +3,15 @@ import bluebird from 'bluebird';
 import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';
 import { Session } from '../../models/Session.js';
 import { CertificationCandidate } from '../../models/CertificationCandidate.js';
+import { CertificationVersion } from '../../models/CertificationVersion.js';
 
 const createSessions = async function ({
   userId,
   cachedValidatedSessionsKey,
+  certificationCenterId,
   certificationCandidateRepository,
   sessionRepository,
+  certificationCenterRepository,
   temporarySessionsStorageForMassImportService,
 }) {
   const temporaryCachedSessions = await temporarySessionsStorageForMassImportService.getByKeyAndUserId({
@@ -19,6 +22,8 @@ const createSessions = async function ({
   if (!temporaryCachedSessions) {
     throw new NotFoundError();
   }
+
+  const { isV3Pilot } = await certificationCenterRepository.get(certificationCenterId);
 
   await DomainTransaction.execute(async (domainTransaction) => {
     return await bluebird.mapSeries(temporaryCachedSessions, async (sessionDTO) => {
@@ -32,6 +37,7 @@ const createSessions = async function ({
           sessionRepository,
           sessionDTO,
           domainTransaction,
+          isV3Pilot,
         });
         sessionId = id;
       }
@@ -59,8 +65,11 @@ function _hasCandidates(certificationCandidates) {
   return certificationCandidates.length > 0;
 }
 
-async function _saveNewSessionReturningId({ sessionRepository, sessionDTO, domainTransaction }) {
-  const sessionToSave = new Session({ ...sessionDTO });
+async function _saveNewSessionReturningId({ sessionRepository, sessionDTO, domainTransaction, isV3Pilot }) {
+  const sessionToSave = new Session({
+    ...sessionDTO,
+    version: isV3Pilot ? CertificationVersion.V3 : CertificationVersion.V2,
+  });
   return await sessionRepository.save(sessionToSave, domainTransaction);
 }
 

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
@@ -11,58 +11,121 @@ describe('Acceptance | Controller | certification-centers-controller-post-create
       await knex('users').delete();
     });
 
-    context('when user confirm sessions for import', function () {
-      it('should return status 201', async function () {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const { name: certificationCenter, id: certificationCenterId } =
-          databaseBuilder.factory.buildCertificationCenter({
-            type: 'SUP',
-            externalId: '1234AB',
+    context('when certification center is not V3 Pilot', function () {
+      context('when user confirm sessions for import', function () {
+        it('should return status 201', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const { name: certificationCenter, id: certificationCenterId } =
+            databaseBuilder.factory.buildCertificationCenter({
+              type: 'SUP',
+              externalId: '1234AB',
+              isV3Pilot: false,
+            });
+          databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId,
           });
-        databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          userId,
-          certificationCenterId,
+          const sessionToSave = {
+            id: undefined,
+            certificationCenterId,
+            certificationCenter,
+            address: '3 rue du Chateau',
+            examiner: 'John Smith',
+            room: 'room',
+            date: '2023-01-01',
+            time: '11:00',
+            accessCode: 'accessCode',
+            supervisorPassword: 'KV2CP',
+            certificationCandidates: [],
+          };
+          const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
+            sessions: [sessionToSave],
+            userId,
+          });
+          await databaseBuilder.commit();
+          const server = await createServer();
+
+          const options = {
+            method: 'POST',
+            url: `/api/certification-centers/${certificationCenterId}/sessions/confirm-for-mass-import`,
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            payload: { data: { attributes: { cachedValidatedSessionsKey: newCachedSessionUUID } } },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          const sessions = await knex('sessions');
+          expect(sessions.length).to.equal(1);
+          expect(sessions[0].certificationCenter).to.equal(certificationCenter);
+          expect(sessions[0].supervisorPassword).to.equal(sessionToSave.supervisorPassword);
+          expect(sessions[0].version).to.equal(2);
+          expect(response.statusCode).to.equal(201);
         });
-        const sessionToSave = {
-          id: undefined,
-          certificationCenterId,
-          certificationCenter,
-          address: '3 rue du Chateau',
-          examiner: 'John Smith',
-          room: 'room',
-          date: '2023-01-01',
-          time: '11:00',
-          accessCode: 'accessCode',
-          supervisorPassword: 'KV2CP',
-          certificationCandidates: [],
-        };
-        const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
-          sessions: [sessionToSave],
-          userId,
+      });
+    });
+
+    context('when certification center is V3 Pilot', function () {
+      context('when user confirm sessions for import', function () {
+        it('should return status 201', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const { name: certificationCenter, id: certificationCenterId } =
+            databaseBuilder.factory.buildCertificationCenter({
+              type: 'SUP',
+              externalId: '1234AB',
+              isV3Pilot: true,
+            });
+          databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId,
+          });
+          const sessionToSave = {
+            id: undefined,
+            certificationCenterId,
+            certificationCenter,
+            address: '3 rue du Chateau',
+            examiner: 'John Smith',
+            room: 'room',
+            date: '2023-01-01',
+            time: '11:00',
+            accessCode: 'accessCode',
+            supervisorPassword: 'KV2CP',
+            certificationCandidates: [],
+          };
+          const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
+            sessions: [sessionToSave],
+            userId,
+          });
+          await databaseBuilder.commit();
+          const server = await createServer();
+
+          const options = {
+            method: 'POST',
+            url: `/api/certification-centers/${certificationCenterId}/sessions/confirm-for-mass-import`,
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            payload: { data: { attributes: { cachedValidatedSessionsKey: newCachedSessionUUID } } },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          const sessions = await knex('sessions');
+          expect(sessions.length).to.equal(1);
+          expect(sessions[0].certificationCenter).to.equal(certificationCenter);
+          expect(sessions[0].supervisorPassword).to.equal(sessionToSave.supervisorPassword);
+          expect(sessions[0].version).to.equal(3);
+          expect(response.statusCode).to.equal(201);
         });
-        await databaseBuilder.commit();
-        const server = await createServer();
-
-        const options = {
-          method: 'POST',
-          url: `/api/certification-centers/${certificationCenterId}/sessions/confirm-for-mass-import`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          payload: { data: { attributes: { cachedValidatedSessionsKey: newCachedSessionUUID } } },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        const sessions = await knex('sessions');
-        expect(sessions.length).to.equal(1);
-        expect(sessions[0].certificationCenter).to.equal(certificationCenter);
-        expect(sessions[0].supervisorPassword).to.equal(sessionToSave.supervisorPassword);
-        expect(response.statusCode).to.equal(201);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Pour corriger la gestion massive des sessions qui doit être activée en prod dès que possible, le correctif consiste à donner une version par défaut à toutes les sessions créées via la création/édition en masse de session, cette version par défaut étant la v2. Cela n’est donc pas compatible avec la création/édition en masse de sessions par nos centres pilotes qui créeront des sessions v3.

## :robot: Proposition

Chercher si le centre des certification est `isV3Pilot` afin de de déterminer la version des sessions

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Avec les nouvelles seeds:
• Importer en masse des sessions avec un centre de certification avec `isV3Pilot` à `false`. Vérifier que la ou les sessions créées ont une `version : 2`
• Importer en masse des sessions avec un centre de certification avec `isV3Pilot` à `true`. Vérifier que la ou les sessions créées ont une `version : 3`
