### PR TITLE
[BUGFIX] Ajouter la possibilité de trier la page élèves par Classe (PIX-8479)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -796,6 +796,7 @@ const register = async function (server) {
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
             'sort[participationCount]': Joi.string().empty(''),
             'sort[lastnameSort]': Joi.string().empty(''),
+            'sort[divisionSort]': Joi.string().empty(''),
           }),
         },
         handler: organizationController.findPaginatedFilteredScoParticipants,

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -87,6 +87,7 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
   const orderByClause = [
     'view-active-organization-learners.lastName',
     'view-active-organization-learners.firstName',
+    'view-active-organization-learners.division',
     'view-active-organization-learners.id',
   ];
   if (sort?.participationCount) {
@@ -99,6 +100,13 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
     orderByClause.unshift({
       column: 'view-active-organization-learners.lastName',
       order: sort.lastnameSort == 'desc' ? 'desc' : 'asc',
+    });
+  }
+
+  if (sort?.divisionSort) {
+    orderByClause.unshift({
+      column: 'view-active-organization-learners.division',
+      order: sort.divisionSort == 'desc' ? 'desc' : 'asc',
     });
   }
 

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -835,174 +835,255 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
     });
 
     describe('When sco participants are sorted', function () {
-      it('should return sco participants sorted by ascendant participation count', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+      describe('by participation count', function () {
+        it('should return sco participants sorted by ascendant', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
 
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: otherCampaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId3,
-        });
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-          organizationId,
-          sort: {
-            participationCount: 'asc',
-          },
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: otherCampaignId,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                participationCount: 'asc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(organizationLearnerId2);
+          expect(participants[1].id).to.equal(organizationLearnerId3);
+          expect(participants[2].id).to.equal(organizationLearnerId1);
         });
 
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(organizationLearnerId2);
-        expect(participants[1].id).to.equal(organizationLearnerId3);
-        expect(participants[2].id).to.equal(organizationLearnerId1);
+        it('should return sco participants sorted by descendant', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: otherCampaignId,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                participationCount: 'desc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(organizationLearnerId1);
+          expect(participants[1].id).to.equal(organizationLearnerId3);
+          expect(participants[2].id).to.equal(organizationLearnerId2);
+        });
+
+        it('should return sco participants sorted by name if identical participation count', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Aaaah',
+          }).id;
+          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Dupont',
+          }).id;
+          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Dupond',
+          }).id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                participationCount: 'asc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(organizationLearnerId3);
+          expect(participants[1].id).to.equal(organizationLearnerId2);
+          expect(participants[2].id).to.equal(organizationLearnerId1);
+        });
       });
 
-      it('should return sco participants sorted by descendant participation count', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+      describe('by lastname', function () {
+        it('should return sco participants sorted by ascendant', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const narutoId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Naruto',
+          }).id;
+          const sasukeId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Sasuke',
+          }).id;
+          const itachiId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Itachi',
+          }).id;
 
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: otherCampaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId3,
-        });
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-          organizationId,
-          sort: {
-            participationCount: 'desc',
-          },
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                lastnameSort: 'asc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(itachiId);
+          expect(participants[1].id).to.equal(narutoId);
+          expect(participants[2].id).to.equal(sasukeId);
         });
 
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(organizationLearnerId1);
-        expect(participants[1].id).to.equal(organizationLearnerId3);
-        expect(participants[2].id).to.equal(organizationLearnerId2);
+        it('should return sco participants sorted by descendant', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const narutoId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Naruto',
+          }).id;
+          const sasukeId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Sasuke',
+          }).id;
+          const itachiId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Itachi',
+          }).id;
+
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                lastnameSort: 'desc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(sasukeId);
+          expect(participants[1].id).to.equal(narutoId);
+          expect(participants[2].id).to.equal(itachiId);
+        });
       });
 
-      it('should return sco participants sorted by name if participation count are identical', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Aaaah',
-        }).id;
-        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Dupont',
-        }).id;
-        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Dupond',
-        }).id;
+      describe('by divisions', function () {
+        it('should return sco participants sorted by ascendant', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const narutoId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Naruto',
+            division: '3A',
+          }).id;
+          const sasukeId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Sasuke',
+            division: '5A',
+          }).id;
+          const itachiId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Itachi',
+            division: '3B',
+          }).id;
 
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-          organizationId,
-          sort: {
-            participationCount: 'asc',
-          },
-        });
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                divisionSort: 'asc',
+              },
+            });
 
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(organizationLearnerId3);
-        expect(participants[1].id).to.equal(organizationLearnerId2);
-        expect(participants[2].id).to.equal(organizationLearnerId1);
-      });
-
-      it('should return sco participants sorted by ascendant lastname', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const narutoId = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Naruto',
-        }).id;
-        const sasukeId = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Sasuke',
-        }).id;
-        const itachiId = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Itachi',
-        }).id;
-
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-          organizationId,
-          sort: {
-            lastnameSort: 'asc',
-          },
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(narutoId);
+          expect(participants[1].id).to.equal(itachiId);
+          expect(participants[2].id).to.equal(sasukeId);
         });
 
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(itachiId);
-        expect(participants[1].id).to.equal(narutoId);
-        expect(participants[2].id).to.equal(sasukeId);
-      });
+        it('should return sco participants sorted by descendant', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const narutoId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Naruto',
+            division: '3A',
+          }).id;
+          const sasukeId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Sasuke',
+            division: '5A',
+          }).id;
+          const itachiId = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Itachi',
+            division: '3B',
+          }).id;
 
-      it('should return sco participants sorted by descendant lastname', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const narutoId = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Naruto',
-        }).id;
-        const sasukeId = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Sasuke',
-        }).id;
-        const itachiId = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          lastName: 'Itachi',
-        }).id;
+          await databaseBuilder.commit();
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                divisionSort: 'desc',
+              },
+            });
 
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-          organizationId,
-          sort: {
-            lastnameSort: 'desc',
-          },
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(sasukeId);
+          expect(participants[1].id).to.equal(itachiId);
+          expect(participants[2].id).to.equal(narutoId);
         });
-
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(sasukeId);
-        expect(participants[1].id).to.equal(narutoId);
-        expect(participants[2].id).to.equal(itachiId);
       });
     });
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -629,6 +629,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         query: {
           'sort[participationCount]': 'asc',
           'sort[lastnameSort]': 'asc',
+          'sort[divisionSort]': 'desc',
         },
       };
       usecases.findPaginatedFilteredScoParticipants.resolves({});
@@ -644,6 +645,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         sort: {
           participationCount: 'asc',
           lastnameSort: 'asc',
+          divisionSort: 'desc',
         },
       });
     });

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -14,17 +14,6 @@
 <div class="panel">
   <table class="table content-text content-text--small">
     <caption class="screen-reader-only">{{t "pages.sco-organization-participants.table.description"}}</caption>
-    <colgroup class="table__column">
-      <col />
-      <col />
-      <col class="table__column--center" />
-      <col />
-      <col />
-      <col class="table__column--right" />
-      <col class="table__column--center" />
-      <col class="table__column--center" />
-      <col class="hide-on-mobile" />
-    </colgroup>
     <thead>
       <tr>
         <Table::HeaderSort

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -31,7 +31,17 @@
         <Table::Header @size="medium">
           {{t "pages.sco-organization-participants.table.column.date-of-birth"}}
         </Table::Header>
-        <Table::Header @size="medium">{{t "pages.sco-organization-participants.table.column.division"}}</Table::Header>
+        <Table::HeaderSort
+          @display="left"
+          @size="medium"
+          @onSort={{@sortByDivision}}
+          @order={{@divisionSort}}
+          @ariaLabelDefaultSort={{t "pages.sco-organization-participants.table.column.division.ariaLabelDefaultSort"}}
+          @ariaLabelSortUp={{t "pages.sco-organization-participants.table.column.division.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t "pages.sco-organization-participants.table.column.division.ariaLabelSortDown"}}
+        >
+          {{t "pages.sco-organization-participants.table.column.division.label"}}
+        </Table::HeaderSort>
         <Table::Header @size="medium">
           {{t "pages.sco-organization-participants.table.column.login-method"}}
         </Table::Header>

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -21,6 +21,7 @@ export default class ListController extends Controller {
   @tracked pageSize = 50;
   @tracked participationCountOrder = null;
   @tracked lastnameSort = 'asc';
+  @tracked divisionSort = null;
 
   @action
   goToLearnerPage(learnerId, event) {
@@ -31,6 +32,7 @@ export default class ListController extends Controller {
   @action
   sortByParticipationCount(value) {
     this.participationCountOrder = value;
+    this.divisionSort = null;
     this.pageNumber = null;
     this.lastnameSort = null;
   }
@@ -38,7 +40,16 @@ export default class ListController extends Controller {
   @action
   sortByLastname(value) {
     this.lastnameSort = value;
+    this.divisionSort = null;
     this.participationCountOrder = null;
+    this.pageNumber = null;
+  }
+
+  @action
+  sortByDivision(value) {
+    this.divisionSort = value;
+    this.participationCountOrder = null;
+    this.lastnameSort = null;
     this.pageNumber = null;
   }
 

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -13,6 +13,7 @@ export default class ListRoute extends Route {
     pageSize: { refreshModel: true },
     participationCountOrder: { refreshModel: true },
     lastnameSort: { refreshModel: true },
+    divisionSort: { refreshModel: true },
   };
 
   @service currentUser;
@@ -30,6 +31,7 @@ export default class ListRoute extends Route {
       sort: {
         participationCount: params.participationCountOrder,
         lastnameSort: params.lastnameSort,
+        divisionSort: params.divisionSort,
       },
       page: {
         number: params.pageNumber,
@@ -48,6 +50,7 @@ export default class ListRoute extends Route {
       controller.pageSize = 50;
       controller.participationCountOrder = null;
       controller.lastnameSort = 'asc';
+      controller.divisionSort = null;
     }
   }
 

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -17,6 +17,8 @@
     @participationCountOrder={{this.participationCountOrder}}
     @sortByParticipationCount={{this.sortByParticipationCount}}
     @sortByLastname={{this.sortByLastname}}
+    @sortByDivision={{this.sortByDivision}}
+    @divisionSort={{this.divisionSort}}
     @lastnameSort={{this.lastnameSort}}
   />
 

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -406,20 +406,21 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   });
 
   module('when user is sorting the table', function () {
-    test('it should trigger ascending sort on participation count column', async function (assert) {
-      // given
+    module('Participant count column', function () {
+      test('it should trigger ascending sort on participation count column', async function (assert) {
+        // given
 
-      this.set('participationCountOrder', null);
+        this.set('participationCountOrder', null);
 
-      const sortByParticipationCount = sinon.spy();
+        const sortByParticipationCount = sinon.spy();
 
-      this.set('sortByParticipationCount', sortByParticipationCount);
-      this.set('divisions', []);
-      this.set('connectionTypes', []);
-      this.set('certificability', []);
-      this.set('search', null);
+        this.set('sortByParticipationCount', sortByParticipationCount);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
   @students={{this.students}}
   @onFilter={{this.noop}}
   @searchFilter={{this.search}}
@@ -432,31 +433,31 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @sortByParticipationCount={{this.sortByParticipationCount}}
 />`);
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelDefaultSort')
-        )
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelDefaultSort')
+          )
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
-      // given
-      this.set('participationCountOrder', 'desc');
+      test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
+        // given
+        this.set('participationCountOrder', 'desc');
 
-      const sortByParticipationCount = sinon.spy();
+        const sortByParticipationCount = sinon.spy();
 
-      this.set('sortByParticipationCount', sortByParticipationCount);
-      this.set('divisions', []);
-      this.set('connectionTypes', []);
-      this.set('certificability', []);
-      this.set('search', null);
+        this.set('sortByParticipationCount', sortByParticipationCount);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
   @students={{this.students}}
   @onFilter={{this.noop}}
   @searchFilter={{this.search}}
@@ -469,31 +470,31 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @sortByParticipationCount={{this.sortByParticipationCount}}
 />`);
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown')
-        )
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown')
+          )
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
-      // given
-      this.set('participationCountOrder', 'asc');
+      test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
+        // given
+        this.set('participationCountOrder', 'asc');
 
-      const sortByParticipationCount = sinon.spy();
+        const sortByParticipationCount = sinon.spy();
 
-      this.set('sortByParticipationCount', sortByParticipationCount);
-      this.set('divisions', []);
-      this.set('connectionTypes', []);
-      this.set('certificability', []);
-      this.set('search', null);
+        this.set('sortByParticipationCount', sortByParticipationCount);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
   @students={{this.students}}
   @onFilter={{this.noop}}
   @searchFilter={{this.search}}
@@ -506,32 +507,34 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @sortByParticipationCount={{this.sortByParticipationCount}}
 />`);
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelSortUp')
-        )
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelSortUp')
+          )
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
-      assert.ok(true);
+        // then
+        sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
+        assert.ok(true);
+      });
     });
 
-    test('it should trigger ascending sort on lastname column', async function (assert) {
-      // given
+    module('lastname column', function () {
+      test('it should trigger ascending sort on lastname column', async function (assert) {
+        // given
 
-      this.set('lastnameSort', null);
+        this.set('lastnameSort', null);
 
-      const sortByLastname = sinon.spy();
+        const sortByLastname = sinon.spy();
 
-      this.set('sortByLastname', sortByLastname);
-      this.set('divisions', []);
-      this.set('connectionTypes', []);
-      this.set('certificability', []);
-      this.set('search', null);
+        this.set('sortByLastname', sortByLastname);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
   @students={{this.students}}
   @onFilter={{this.noop}}
   @searchFilter={{this.search}}
@@ -544,31 +547,31 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @sortByLastname={{this.sortByLastname}}
 />`);
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.sco-organization-participants.table.column.last-name.ariaLabelDefaultSort')
-        )
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.last-name.ariaLabelDefaultSort')
+          )
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByLastname, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByLastname, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger ascending sort on lastname column when it is already sort descending', async function (assert) {
-      // given
-      this.set('lastnameSort', 'desc');
+      test('it should trigger ascending sort on lastname column when it is already sort descending', async function (assert) {
+        // given
+        this.set('lastnameSort', 'desc');
 
-      const sortByLastname = sinon.spy();
+        const sortByLastname = sinon.spy();
 
-      this.set('sortByLastname', sortByLastname);
-      this.set('divisions', []);
-      this.set('connectionTypes', []);
-      this.set('certificability', []);
-      this.set('search', null);
+        this.set('sortByLastname', sortByLastname);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
   @students={{this.students}}
   @onFilter={{this.noop}}
   @searchFilter={{this.search}}
@@ -581,31 +584,31 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @sortByLastname={{this.sortByLastname}}
 />`);
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.sco-organization-participants.table.column.last-name.ariaLabelSortDown')
-        )
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.last-name.ariaLabelSortDown')
+          )
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByLastname, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByLastname, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger descending sort on lastname column when it is already sort ascending', async function (assert) {
-      // given
-      this.set('lastnameSort', 'asc');
+      test('it should trigger descending sort on lastname column when it is already sort ascending', async function (assert) {
+        // given
+        this.set('lastnameSort', 'asc');
 
-      const sortByLastname = sinon.spy();
+        const sortByLastname = sinon.spy();
 
-      this.set('sortByLastname', sortByLastname);
-      this.set('divisions', []);
-      this.set('connectionTypes', []);
-      this.set('certificability', []);
-      this.set('search', null);
+        this.set('sortByLastname', sortByLastname);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
 
-      const screen = await render(hbs`<ScoOrganizationParticipant::List
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
   @students={{this.students}}
   @onFilter={{this.noop}}
   @searchFilter={{this.search}}
@@ -618,14 +621,131 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @sortByLastname={{this.sortByLastname}}
 />`);
 
-      // when
-      await click(
-        screen.getByLabelText(this.intl.t('pages.sco-organization-participants.table.column.last-name.ariaLabelSortUp'))
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.last-name.ariaLabelSortUp')
+          )
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByLastname, 'desc');
-      assert.ok(true);
+        // then
+        sinon.assert.calledWithExactly(sortByLastname, 'desc');
+        assert.ok(true);
+      });
+    });
+
+    module('division column', function () {
+      test('it should trigger ascending sort', async function (assert) {
+        // given
+
+        this.set('divisionSort', null);
+
+        const sortByDivision = sinon.spy();
+
+        this.set('sortByDivision', sortByDivision);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
+
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+  @divisionSort={{this.divisionSort}}
+  @sortByDivision={{this.sortByDivision}}
+/>`);
+
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.division.ariaLabelDefaultSort')
+          )
+        );
+
+        // then
+        sinon.assert.calledWithExactly(sortByDivision, 'asc');
+        assert.ok(true);
+      });
+
+      test('it should trigger ascending sort when it is already sort descending', async function (assert) {
+        // given
+        this.set('divisionSort', 'desc');
+
+        const sortByDivision = sinon.spy();
+
+        this.set('sortByDivision', sortByDivision);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
+
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+  @divisionSort={{this.divisionSort}}
+  @sortByDivision={{this.sortByDivision}}
+/>`);
+
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.division.ariaLabelSortDown')
+          )
+        );
+
+        // then
+        sinon.assert.calledWithExactly(sortByDivision, 'asc');
+        assert.ok(true);
+      });
+
+      test('it should trigger descending sort when it is already sort ascending', async function (assert) {
+        // given
+        this.set('divisionSort', 'asc');
+
+        const sortByDivision = sinon.spy();
+
+        this.set('sortByDivision', sortByDivision);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
+
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+  @divisionSort={{this.divisionSort}}
+  @sortByDivision={{this.sortByDivision}}
+/>`);
+
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.division.ariaLabelSortUp')
+          )
+        );
+
+        // then
+        sinon.assert.calledWithExactly(sortByDivision, 'desc');
+        assert.ok(true);
+      });
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
@@ -176,4 +176,40 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       assert.strictEqual(controller.pageNumber, null);
     });
   });
+
+  module('#sortByLastname', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.lastnameSort = null;
+      controller.divisionSort = 'king';
+      controller.participationCountOrder = 'Godzilla';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByLastname('desc');
+
+      // then
+      assert.strictEqual(controller.lastnameSort, 'desc');
+      assert.strictEqual(controller.divisionSort, null);
+      assert.strictEqual(controller.participationCountOrder, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#sortByParticipationCount', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.participationCountOrder = null;
+      controller.divisionSort = 'king';
+      controller.lastnameSort = 'T-Rex';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByParticipationCount('desc');
+
+      // then
+      assert.strictEqual(controller.participationCountOrder, 'desc');
+      assert.strictEqual(controller.lastnameSort, null);
+      assert.strictEqual(controller.divisionSort, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
 });

--- a/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
@@ -158,4 +158,22 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       });
     });
   });
+
+  module('#sortByDivision', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.divisionSort = null;
+      controller.participationCountOrder = 'Godzilla';
+      controller.lastnameSort = 'Kong';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByDivision('desc');
+
+      // then
+      assert.strictEqual(controller.divisionSort, 'desc');
+      assert.strictEqual(controller.participationCountOrder, null);
+      assert.strictEqual(controller.lastnameSort, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -980,7 +980,12 @@
       "table": {
         "column": {
           "date-of-birth": "Date of birth",
-          "division": "Class",
+          "division": {
+            "ariaLabelDefaultSort": "The table is currently not sorted by class. Click to sort by alphanumeric order.",
+            "ariaLabelSortDown": "The table is sorted by class, in reverse alphanumeric order. Click to sort by alphanumeric order.",
+            "ariaLabelSortUp": "The table is sorted by class, in alphanumeric order. Click to sort by reverse alphanumeric order.",
+            "label": "Class"
+          },
           "first-name": "First name",
           "is-certifiable": {
             "eligible": "Eligible",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -983,7 +983,12 @@
       "table": {
         "column": {
           "date-of-birth": "Date de naissance",
-          "division": "Classe",
+          "division":  {
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par classe. Cliquez pour trier par ordre alphanumérique.",
+            "ariaLabelSortDown": "Le tableau est trié par classe, dans l'ordre alphanumérique inverse. Cliquez pour trier par ordre alphanumérique.",
+            "ariaLabelSortUp": "Le tableau est trié par classe, dans l'ordre alphanumérique. Cliquez pour trier par ordre alphanumérique inverse.",
+            "label": "Classe"
+          },
           "first-name": "Prénom",
           "is-certifiable": {
             "eligible": "Certifiable",


### PR DESCRIPTION
## :unicorn: Problème
Suite à des retours d’usages, de prescripteurs SCO, on nous a demander de pouvoir trier la colonne classe quand il souhaitait faire des recherches sur la certificabilité de toutes ses classes. 

## :robot: Proposition
Ajouter la possibilité de faire un filtre sur la colonne Classe sur la page élèves des organisations SCO

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur Pix Orga avec un organisation SCO. 
Aller sur la page élèves.
Vérifier que le tri est possible ET fonctionnelle sur la colonne Classe.
Revue Fonctionnelle Terminée.