### PR TITLE
[FEATURE] Affiche la remise à zéro des acquis dans le détail du profil cible dans Pix Admin (PIX-8521).

### DIFF
--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable  --}}
 {{page-title "Profil " @model.id " | Pix Admin" replace=true}}
 <header class="page-header">
   <div class="page-title">
@@ -30,6 +31,7 @@
               {{@model.ownerOrganizationId}}
             </LinkTo>
           </li>
+          <li><span class="bold">Permettre la remise à zero des acquis du Profil Cible : </span>{{this.areKnowledgeElementsResettable}}</li>
           {{#if @model.description}}
             <li>
               <span class="bold">Description : </span>

--- a/admin/app/components/target-profiles/target-profile.js
+++ b/admin/app/components/target-profiles/target-profile.js
@@ -26,6 +26,10 @@ export default class TargetProfile extends Component {
     return this.args.model.isSimplifiedAccess ? 'Oui' : 'Non';
   }
 
+  get areKnowledgeElementsResettable() {
+    return this.args.model.areKnowledgeElementsResettable ? 'Oui' : 'Non';
+  }
+
   @action
   toggleEditMode() {
     this.isEditMode = !this.isEditMode;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -1,5 +1,5 @@
 import { memberAction } from 'ember-api-actions';
-import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import ENV from 'pix-admin/config/environment';
 import { service } from '@ember/service';
 import formatList from '../utils/format-select-options';
@@ -28,6 +28,7 @@ export default class TargetProfile extends Model {
   @attr('string') ownerOrganizationId;
   @attr('string') category;
   @attr('boolean') isSimplifiedAccess;
+  @attr('boolean') areKnowledgeElementsResettable;
   @attr('number') maxLevel;
 
   @hasMany('badge') badges;

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -1,4 +1,4 @@
-import { clickByName, visit, fillByLabel } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
@@ -77,6 +77,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
         comment: 'Commentaire Privé.',
         category: 'SUBJECT',
         isSimplifiedAccess: true,
+        areKnowledgeElementsResettable: false,
       });
 
       // when
@@ -89,6 +90,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       assert.dom(_findByNestedText(screen, 'Public : Oui')).exists();
       assert.dom(_findByNestedText(screen, 'Obsolète : Non')).exists();
       assert.dom(_findByNestedText(screen, 'Parcours Accès Simplifié : Oui')).exists();
+      assert.dom(_findByNestedText(screen, 'Permettre la remise à zero des acquis du Profil Cible : Non')).exists();
       assert.dom(screen.getByText('456')).exists();
       assert.dom(screen.getByText('Top profil cible.')).exists();
       assert.dom(screen.getByText('Commentaire Privé.')).exists();


### PR DESCRIPTION
## :unicorn: Problème
Nous ne pouvons pas voir si un profile cible est rejouable

## :robot: Proposition
Nous affichons si profile cible est rejouable ou pas

## :rainbow: Remarques
pas de remarques

## :100: Pour tester
Aller sur admin et la page profile cible
Cliquer sur un profile cible
Verifier que un nouveau ligne `Permettre la remise à zero des acquis du Profil Cible : Oui/Non` apparaitre dans les details de profile cible
