### PR TITLE
[FEATURE] Afficher la notion de progressivité sur les résultats thématiques certifiants (PIX-8440)

### DIFF
--- a/mon-pix/app/components/badge-card-certifiable.hbs
+++ b/mon-pix/app/components/badge-card-certifiable.hbs
@@ -4,18 +4,30 @@
     {{unless this.isStillValid 'badge-card-certifiable badge-card-certifiable--not-acquired'}}"
 >
   <div class="badge-card-certifiable__header">
-    <div class="badge-card__status">
-      <h3>
-        <span>
-          {{#if this.isStillValid}}
-            <FaIcon @icon="circle-check" class="badge-card-status__acquired-icon" />
-          {{else}}
-            <FaIcon @icon="times-circle" class="badge-card-status__not-acquired-icon" />
-          {{/if}}
-        </span>
-        {{@title}}
-      </h3>
+    <div class="badge-card-certifiable-header__content">
+      <p class="badge-card-certifiable-header-content__status">
+        {{#if this.isStillValid}}
+          <FaIcon @icon="circle-check" class="badge-card-content-header-status__acquired-icon" />
+          {{t "pages.skill-review.badge-card.acquired"}}
+        {{else}}
+          <FaIcon @icon="circle-xmark" class="badge-card-content-header-status__not-acquired-icon" />
+          {{t "pages.skill-review.badge-card.not-acquired"}}
+        {{/if}}
+      </p>
+      {{#if this.showProgression}}
+        <PixProgressGauge
+          class="badge-card-certifiable-header-content__progression"
+          @value={{@acquisitionPercentage}}
+          @label={{t "pages.skill-review.badge-card.progress-bar-label"}}
+        />
+      {{/if}}
     </div>
+    <h3 class="badge-card-certifiable-header__title">
+      {{@title}}
+    </h3>
   </div>
-  <div class="badge-card-certifiable__image"><img src="{{@imageUrl}}" alt="{{@altMessage}}" /></div>
+  <div
+    class="badge-card-certifiable__image
+      {{unless this.isStillValid 'badge-card-certifiable__image badge-card-certifiable__image--not-acquired'}}"
+  ><img src="{{@imageUrl}}" alt="{{@altMessage}}" /></div>
 </div>

--- a/mon-pix/app/components/badge-card-certifiable.js
+++ b/mon-pix/app/components/badge-card-certifiable.js
@@ -4,4 +4,8 @@ export default class BadgeCardCertifiable extends Component {
   get isStillValid() {
     return this.args.isValid && this.args.isAcquired;
   }
+
+  get showProgression() {
+    return !this.args.isValid || (this.args.isAlwaysVisible && !this.args.isAcquired);
+  }
 }

--- a/mon-pix/app/components/badge-card.hbs
+++ b/mon-pix/app/components/badge-card.hbs
@@ -10,7 +10,7 @@
           {{t "pages.skill-review.badge-card.not-acquired"}}
         {{/if}}
       </p>
-      {{#if @isAlwaysVisible}}
+      {{#if this.showProgression}}
         <PixProgressGauge
           @value={{@acquisitionPercentage}}
           @label={{t "pages.skill-review.badge-card.progress-bar-label"}}

--- a/mon-pix/app/components/badge-card.js
+++ b/mon-pix/app/components/badge-card.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class BadgeCard extends Component {
+  get showProgression() {
+    return this.args.isAlwaysVisible && !this.args.isAcquired;
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -237,6 +237,8 @@
             @isAcquired={{badge.isAcquired}}
             @isValid={{badge.isValid}}
             @isCertifiable={{badge.isCertifiable}}
+            @isAlwaysVisible={{badge.isAlwaysVisible}}
+            @acquisitionPercentage={{badge.acquisitionPercentage}}
           />
         {{/each}}
       </div>

--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -12,29 +12,23 @@
   align-items: center;
   justify-content: center;
   margin-bottom: 20px;
-  padding: 20px 35px;
+  padding: $pix-spacing-m;
   background-color: $pix-success-5;
   border-radius: 16px;
 
+  &__header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   &--not-acquired {
     background-color: $pix-neutral-10;
-    filter: grayscale(1);
-  }
-
-  &__header {
-    margin-bottom: $pix-spacing-s;
-    text-align: center;
-  }
-
-  &__header h3 {
-    font-weight: $font-normal;
-    font-size: 1.25rem;
   }
 
   @include device-is('tablet') {
     flex-grow: 0;
     width: calc(50% - 10px);
-    height: 253px;
 
     &:nth-child(even) {
       margin-left: 20px;
@@ -43,5 +37,43 @@
     &:first-child:last-child {
       width: 100%;
     }
+  }
+
+  &__image {
+    &--not-acquired {
+      filter: grayscale(1);
+    }
+  }
+}
+
+.badge-card-certifiable-header {
+  &__content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $pix-spacing-s;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__title {
+    @extend %pix-title-xs;
+
+    margin: $pix-spacing-xs 0 $pix-spacing-s;
+  }
+}
+
+.badge-card-certifiable-header-content {
+  &__status {
+    @extend %pix-body-s;
+
+    width: fit-content;
+    padding: $pix-spacing-xxs $pix-spacing-xs;
+    white-space: nowrap;
+    background-color: $pix-neutral-0;
+    border-radius: 8px;
+  }
+
+  &__progression {
+    inline-size: 7rem;
   }
 }

--- a/mon-pix/app/styles/components/_badge-card.scss
+++ b/mon-pix/app/styles/components/_badge-card.scss
@@ -27,8 +27,7 @@
     display: flex;
     flex-direction: column;
     max-width: 70%;
-    padding: 24px;
-    padding-right: 16px;
+    padding: $pix-spacing-m $pix-spacing-s $pix-spacing-m $pix-spacing-m;
 
     @include device-is('desktop') {
       flex: 1 1 40%;
@@ -43,7 +42,7 @@
     justify-content: center;
     min-width: 120px;
     max-width: 120px;
-    padding: 16px;
+    padding: $pix-spacing-s;
     background-color: $pix-neutral-10;
 
     img {
@@ -79,24 +78,24 @@
 }
 
 .badge-card-content-header {
-    &__status {
-      @extend %pix-body-s;
+  &__status {
+    @extend %pix-body-s;
 
-      padding: $pix-spacing-xxs $pix-spacing-xs;
-      white-space: nowrap;
-      background-color: $pix-neutral-10;
-      border-radius: 8px;
-    }
+    padding: $pix-spacing-xxs $pix-spacing-xs;
+    white-space: nowrap;
+    background-color: $pix-neutral-10;
+    border-radius: 8px;
   }
+}
 
 .badge-card-content-header-status {
   &__acquired-icon {
-    margin-right:  $pix-spacing-xxs;
+    margin-right: $pix-spacing-xxs;
     color: $pix-success-50;
   }
 
   &__not-acquired-icon {
-    margin-right:  $pix-spacing-xxs;
+    margin-right: $pix-spacing-xxs;
     color: $pix-neutral-50;
   }
 }

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -185,8 +185,56 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
           isAlwaysVisible: false,
           isCertifiable: true,
         });
+        const acquiredIsValidCertifiableBadge = server.create('campaign-participation-badge', {
+          altMessage: 'Yon won a blue badge',
+          imageUrl: '/images/badges/blue.svg',
+          message: 'Congrats, you won a blue badge',
+          acquisitionPercentage: 63,
+          isAcquired: true,
+          isValid: true,
+          isCertifiable: true,
+          isAlwaysVisible: false,
+        });
+        const acquiredCertifiableNotValidBadge = server.create('campaign-participation-badge', {
+          altMessage: 'Yon won a white badge',
+          imageUrl: '/images/badges/white.svg',
+          message: 'Congrats, you won a white badge',
+          isAcquired: true,
+          acquisitionPercentage: 88,
+          isValid: false,
+          isAlwaysVisible: false,
+          isCertifiable: true,
+        });
+        const unacquiredCertifiableHiddenBadge = server.create('campaign-participation-badge', {
+          altMessage: 'Yon won a red badge',
+          imageUrl: '/images/badges/red.svg',
+          message: 'Congrats, you won a red badge',
+          isAcquired: false,
+          acquisitionPercentage: 0,
+          isValid: true,
+          isAlwaysVisible: false,
+          isCertifiable: true,
+        });
+        const unacquiredCertifiableDisplayedBadge = server.create('campaign-participation-badge', {
+          altMessage: 'Yon won a brown badge',
+          imageUrl: '/images/badges/brown.svg',
+          message: 'Congrats, you won a brown badge',
+          isAcquired: false,
+          acquisitionPercentage: 67,
+          isValid: true,
+          isAlwaysVisible: true,
+          isCertifiable: true,
+        });
         campaignParticipationResult.update({
-          campaignParticipationBadges: [acquiredBadge, unacquiredDisplayedBadge, unacquiredHiddenBadge],
+          campaignParticipationBadges: [
+            acquiredBadge,
+            unacquiredDisplayedBadge,
+            unacquiredHiddenBadge,
+            acquiredIsValidCertifiableBadge,
+            acquiredCertifiableNotValidBadge,
+            unacquiredCertifiableHiddenBadge,
+            unacquiredCertifiableDisplayedBadge,
+          ],
         });
 
         // when
@@ -196,7 +244,19 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
         assert.strictEqual(findAll('.badge-card').length, 2);
         assert.strictEqual(
           screen
-            .getByRole('progressbar', { name: 'Pourcentage de réussite du résultat thématique' })
+            .getAllByRole('progressbar', { name: 'Pourcentage de réussite du résultat thématique' })[0]
+            .textContent.trim(),
+          '88%'
+        );
+        assert.strictEqual(
+          screen
+            .getAllByRole('progressbar', { name: 'Pourcentage de réussite du résultat thématique' })[1]
+            .textContent.trim(),
+          '67%'
+        );
+        assert.strictEqual(
+          screen
+            .getAllByRole('progressbar', { name: 'Pourcentage de réussite du résultat thématique' })[2]
             .textContent.trim(),
           '20%'
         );

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -163,6 +163,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
           isAcquired: true,
           isValid: true,
           isCertifiable: false,
+          isAlwaysVisible: true,
         });
         const unacquiredDisplayedBadge = server.create('campaign-participation-badge', {
           altMessage: 'Yon won a green badge',


### PR DESCRIPTION
## :unicorn: Problème
On souhaite afficher une notion de progressivité sur les résultats thématiques certifiants en lacunes et ceux qui ont été acquis mais qui ne sont plus valides.

## :robot: Proposition
Afficher une barre de progression sur les résultats thématiques certifiants.

## :100: Pour tester
**Badge non certifiant :** 
Se connecter avec `jaune.attend@example.net` et aller sur la campagne `PROCOMP51`.
Visualiser que la notion de progressivité n'existe pas sur les résultats thématiques acquis.

**Badge certifiant :**
Se connecter avec `certifedu.1er.initiale@example.net` et aller sur la campagne `CAMPEDU03`.
Visualiser que le résultat thématique est bien acquis et n'a pas la notion de progressivité.

Se connecter avec `certif-success@example.net` et aller sur la campagne `CAMPCLEA3`.
1. Visualiser que le résultat thématique est bien acquis mais qu'il n'est pas valide donc la notion de progressivité s'affiche.
2. Visualiser que le résultat thématique est bien en lacune et possède la notion de progressivité.
