### PR TITLE
[BUGFIX] Permettre de revenir dans une organisation PRO après suppression (Pix-8527)

### DIFF
--- a/api/db/migrations/20230630132006_add-deleted-at-for-one-active-organization-learners.js
+++ b/api/db/migrations/20230630132006_add-deleted-at-for-one-active-organization-learners.js
@@ -1,0 +1,43 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-learners';
+const NEW_CONSTRAINT_NAME = 'one_active_organization_learner';
+const DELETEDAT_COLUMN = 'deletedAt';
+const DELETEDBY_COLUMN = 'deletedBy';
+const USERID_COLUMN = 'userId';
+const ORGANIZATIONID_COLUMN = 'organizationId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique(['userId', 'organizationId']);
+  });
+
+  return knex.raw(
+    `CREATE UNIQUE INDEX :name: ON :table: (:userId:, :organizationId: ) WHERE :deletedAt: IS NULL AND :deletedBy: IS NULL;`,
+    {
+      name: NEW_CONSTRAINT_NAME,
+      table: TABLE_NAME,
+      userId: USERID_COLUMN,
+      organizationId: ORGANIZATIONID_COLUMN,
+      deletedAt: DELETEDAT_COLUMN,
+      deletedBy: DELETEDBY_COLUMN,
+    }
+  );
+};
+
+const down = async function (knex) {
+  await knex.raw(`DROP INDEX :name:;`, { name: NEW_CONSTRAINT_NAME });
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(['userId', 'organizationId']);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -366,13 +366,6 @@ function _buildParticipations({ databaseBuilder }) {
       { firstName: 'Antoine', lastName: 'Boiduvin', createdAt: new Date('2022-02-07') },
       { firstName: 'Brandone', lastName: 'Bro', createdAt: new Date('2022-02-07') },
       { firstName: 'Jean', lastName: 'Sérien', createdAt: new Date('2022-02-07') },
-      {
-        firstName: 'Alex',
-        lastName: 'Deleted',
-        createdAt: new Date('2022-02-07'),
-        deletedBy: 1,
-        deletedAt: new Date('2023-05-01'),
-      },
     ],
   });
 
@@ -459,7 +452,7 @@ function _buildAssessmentParticipations({ databaseBuilder, users }) {
   const userIdsNotShared2 = [users[6], users[7]];
   const userIdsCompletedShared = [users[10], users[12]];
   const userIdsCompletedShared2 = [users[0], users[9]];
-  const userIdsCompletedSharedWith2Badges = [users[3], users[11], users[14]];
+  const userIdsCompletedSharedWith2Badges = [users[3], users[11]];
 
   userIdsNotCompleted.forEach((user) =>
     participateToAssessmentCampaign({
@@ -595,12 +588,11 @@ function _buildProfilesCollectionParticipations({ databaseBuilder, users }) {
   const certifRegularUser4 = { id: CERTIF_REGULAR_USER4_ID, createdAt: new Date('2022-02-06') };
   const certifRegularUser5 = { id: CERTIF_REGULAR_USER5_ID, createdAt: new Date('2022-02-07') };
   const userIdsNotShared = [users[1], users[2], users[3], users[4], users[5], users[6], users[7], users[8]];
-  const userIdsShared = [users[0], users[9], users[10], users[11], users[12], users[14]];
+  const userIdsShared = [users[0], users[9], users[10], users[11], users[12]];
   const userIdsCertifiable = [
     users[10].id,
     users[11].id,
     users[12].id,
-    users[14].id,
     certifRegularUser1.id,
     certifRegularUser2.id,
     certifRegularUser3.id,

--- a/api/lib/infrastructure/repositories/organization-learners-management/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learners-management/campaign-participation-repository.js
@@ -2,6 +2,7 @@ const removeByOrganizationLearnerIds = function ({ organizationLearnerIds, userI
   return domainTransaction
     .knexTransaction('campaign-participations')
     .whereIn('organizationLearnerId', organizationLearnerIds)
+    .whereNull('deletedAt')
     .update({ deletedAt: new Date(), deletedBy: userId });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on supprime un `organization-learners` sur une Organisation PRO, il récupére l' id de `organization-learners` supprimé au lieu d'en créer un nouveau. ( merci le onConflict )

## :robot: Proposition
Mettre à jour la contrainte contenant `userId, organizationId `pour lui rajouter `deletedAt` `deletedBy` afin de permettre de revenir dans une organisations sous un nouveau `organization-learners`

## :rainbow: Remarques
Ajout de test gérant ces conditions.

## :100: Pour tester
Participer a une campagne, se faire supprimer, constater l'absence de participant, Participer a une nouvelle campagne, vérifier la présence d'un nouveau participant
