### PR TITLE
[BUGFIX] Améliorer le texte sur la double mire SSO (PIX-8529)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1123,7 +1123,7 @@
         "login-unauthorized-error": "There was an error in the email address or password entered."
       },
       "login-form": {
-        "title": "Vous avez déjà un compte Pix ?",
+        "title": "I already have a Pix account.",
         "button": "Log in",
         "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées",
         "email": "Email address",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1123,7 +1123,7 @@
         "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects."
       },
       "login-form": {
-        "title": "Vous avez déjà un compte Pix ?",
+        "title": "J’ai déjà un compte Pix",
         "button": "Je me connecte",
         "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées",
         "email": "Adresse e-mail",


### PR DESCRIPTION
## :unicorn: Problème
Sur la partie création de compte de la double mire OIDC, nous utilisons le tutoiement pour nous adresser à l'utilisateur, tandis que sur la partie connexion, nous utilisons le vouvoiement.

## :robot: Proposition

- Remplacer le titre de la partie de droite “Vous avez déjà un compte Pix?" par "J'ai déjà un compte Pix" 
- Ne pas mettre de point d’interrogation

## :rainbow: Remarques
C'est une solution temporaire. Il faudrait revoir tout le wording pour que ce soit cohérent avec les autres doubles mires. 
Cette PR fait suite à la suppression des modifications apportées par la #6463.

## :100: Pour tester

1. Se connecter à Pix via SSO (Pole Emploi pour .fr ou FWB pour .org)
2. Lorsque vous arrivez sur la double mire, vérifier que dans la partie droite, celle de la connexion, il y a bien écrit "J'ai déjà un compte Pix" .