### PR TITLE
[TECH] Vérrouiller la version Node de l'API en v16

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -109,8 +109,8 @@
         "stream-to-promise": "^3.0.0"
       },
       "engines": {
-        "node": ">=16.15 <18",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.15",
+        "npm": "^8.13.2"
       },
       "optionalDependencies": {
         "nyc": "^15.1.0"

--- a/api/package.json
+++ b/api/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": ">=16.15 <18",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.15",
+    "npm": "^8.13.2"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
## :unicorn: Problème
Depuis #6240, on a permis à la version de Node de l'API de monter en v17. Ce n'est pas souhaitable car [les versions impaires de Node ne sont pas des LTS](https://nodejs.dev/en/about/releases/).

## :robot: Proposition
Forcer l'usage de la version 16 dans le `engines`.

## :rainbow: Remarques
On a repris le format d'écriture de nos dépendances npm.

## :100: Pour tester
Vérifier que la CI passe