### PR TITLE
[DOCS] S'assurer d'une version minimale de Node.js

### DIFF
--- a/docs/adr/0018-specifier-version-nodejs.md
+++ b/docs/adr/0018-specifier-version-nodejs.md
@@ -4,7 +4,9 @@ Date : 2020-01-18
 
 ## État
 
-Accepté
+Amendé par [0049-specifier-version-nodejs.md][0049]
+
+[0049]: ./0049-specifier-version-nodejs.md
 
 ## Contexte
 

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -23,7 +23,7 @@ Par exemple, si l'on spécifie la version 16 :
 - dans la CI, on peut utiliser la `16.2.8` 
 - dans le PAAS, on peut utiliser la `16.5.1`
 Nous avons constaté plusieurs limites à ce choix :
-- L'API ne fonctionne plus en version antérieure à Node@v16.15. L'ADR précédant ne nous permet pas de fixer de version mineure minimum donc un risque d'incompatibilité est présent.
+- Un bug corrigé par la [PR 6512](https://github.com/1024pix/pix/pull/6512) nous oblige à fixer une version minimale.
 - Fixer la version majeure uniquement peut provoquer des problèmes de reproductibilité car nos 3 environnements ont chacun une version de Node différente. Notamment en local, il est arrivé que certains développeurs restent en version antérieure à la 16.15 lorsque nous avons dû supprimer la compatibilité de ces versions.
 
 ### Solution n°1 : Forcer la même version exacte minimum de Node sur tous les environnements

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -79,16 +79,16 @@ Fort de ces expérimentations, l'équipe propose de choisir [la solution 1](### 
 
 ## Conséquences
 
-Il faut migrer le format d'écriture des numéros de versions de Node et npm :
+Il faut migrer le format d'écriture des numéros de versions de Node.js :
 - Dans les `.nvmrc`, préciser le numéro de version exacte. Exemple : `16.20.1`
 - Dans les `package.json`, préciser le numéro de version exacte minimum de `node`. On propose d'utiliser le même format que pour les dépendances. Exemple : `^16.20.1`.
-- Dans les `package.json`, préciser le numéro de version exacte minimum de `npm`. Exemple : `^8.13.2`.
+- Dans les `package.json`, ne pas préciser le numéro de version exacte minimum de `npm` pour utiliser celle embarquée par défaut par Node.js. On peut directement supprimer cette contrainte pour éviter les soucis lors des futures de migration de Node.
 
 > **Note**
 >
 > Suite à cette implémentation, les développeurs devront relancer un `nvm install`, cela deviendra une habitude.
 
-Renovate nous proposera dès lors les montées de versions groupées de Node et npm dès qu'une nouvelle version de l'image Node Circle CI est publiée.
+Renovate nous proposera dès lors les montées de versions groupées de Node dès qu'une nouvelle version de l'image Node Circle CI est publiée.
 
 On peut commencer cette migration par le monorepo, avant de migrer nos dépendances comme `pix-ui`.
 

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -84,10 +84,6 @@ Il faut migrer le format d'écriture des numéros de versions de Node.js :
 - Dans les `package.json`, préciser le numéro de version exacte minimum de `node`. On propose d'utiliser le même format que pour les dépendances. Exemple : `^16.20.1`.
 - Dans les `package.json`, ne pas préciser le numéro de version exacte minimum de `npm` pour utiliser celle embarquée par défaut par Node.js. On peut directement supprimer cette contrainte pour éviter les soucis lors des futures de migration de Node.
 
-> **Note**
->
-> Suite à cette implémentation, les développeurs devront relancer un `nvm install`, cela deviendra une habitude.
-
 Renovate nous proposera dès lors les montées de versions groupées de Node dès qu'une nouvelle version de l'image Node Circle CI est publiée.
 
 On peut commencer cette migration par le monorepo, avant de migrer nos dépendances comme `pix-ui`.

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -61,7 +61,7 @@ Notre CI évoluerai de son côté, pour éviter la synchronisation avec les imag
 
 ### Solution n°3 : Ajouter la version mineure minimum de Node en local et sur le PAAS
 
-Permettre de spécifier une version mineure (en plus de la majeure) pour préciser la version minimale nécessaire. C'est ce qui a été fait sur le PAAS pour l'API avec #6512 car elle ne fonctionnait plus avec des versions inférieures à la 16.15 de Node.
+Permettre de spécifier une version mineure (en plus de la majeure) pour préciser la version minimale nécessaire. 
 
 #### Avantages
 - Gestion plus fine de la compatibilité.

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -93,4 +93,5 @@ Renovate nous proposera dès lors les montées de versions groupées de Node dè
 
 On peut commencer cette migration par le monorepo, avant de migrer nos dépendances comme `pix-ui`.
 
-Sur le PAAS, rien ne change car on utilisera toujours la dernière version disponible.
+Sur le PaaS, dans sa version actuelle, rien ne change car on utilisera toujours la dernière version disponible.
+À l'avenir, la version du PaaS sera synchronisée avec les 2 autres versions.

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -18,13 +18,13 @@ Avec l'ADR 18, nous avons choisi :
 - PAAS : préciser la version majeure de Node uniquement.
 - CI : préciser une version exacte de Node.
 - Local : préciser la version majeure de Node uniquement.
-Par exemple, si l'on spécifie la version 16 : 
-- en local, on peut utiliser la `16.1.0`
-- dans la CI, on peut utiliser la `16.2.8` 
-- dans le PAAS, on peut utiliser la `16.5.1`
+
 Nous avons constaté plusieurs limites à ce choix :
 - Un bug corrigé par la [PR 6512](https://github.com/1024pix/pix/pull/6512) nous oblige à fixer une version minimale.
-- Fixer la version majeure uniquement peut provoquer des problèmes de reproductibilité car nos 3 environnements ont chacun une version de Node différente. Notamment en local, il est arrivé que certains développeurs restent en version antérieure à la 16.15 lorsque nous avons dû supprimer la compatibilité de ces versions.
+- Fixer la version majeure uniquement peut provoquer des problèmes de reproductibilité car nos 3 environnements ont chacun une version de Node différente. Notamment en local, il est arrivé que certain(e)s développeurs(euses) restent en version antérieure à la 16.15 lorsque nous avons dû supprimer la compatibilité de ces versions. Par exemple, si l'on spécifie la version 16 :
+  * en local, on peut utiliser la `16.1.0`.
+  * dans la CI, on peut utiliser la `16.2.8`.
+  * dans le PAAS, on peut utiliser la `16.15.0`.
 
 ### Solution n°1 : Forcer la même version exacte minimum de Node sur tous les environnements
 

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -1,0 +1,72 @@
+# 18. Spécifier la version de NodeJS
+
+Date : 2023-07-03
+
+Remplace l'[ADR #18](./0018-specifier-version-nodejs.md).
+
+## État
+
+Amende [0018-specifier-version-nodejs.md][0018]
+
+[0018]: ./0018-specifier-version-nodejs.md
+
+En discussion
+
+## Contexte
+
+Suite à l'ADR 18, nous avons constaté plusieurs limites à notre manière de préciser les versions de Node.js compatibles :
+- On ne peut pas fixer de version mineure de Node.js malgré que l'API ne fonctionne pas dans les version antérieures à la 16.15. Toute personne souhaitant installer Pix peut avoir ce soucis.
+- Les développeurs peuvent ne pas monter leur version de Node.js pendant très longtemps, ce qui induit un écart important entre la version utilisée en local, de la CI et de l'exécution en production. Cet écart ne permet pas de prévoir les comportements de l'application entre ces 3 environnements.
+- Ces écarts sont assez difficiles à comprendre.
+
+### Solution n°1 : Forcer la même version complète de Node sur les environnements
+
+On peut mettre à jour les 3 versions correspondantes aux 3 environnements en même temps.
+
+#### Avantages
+- Pas d'écart de version possible entre les 3 environnements.
+- Clarification du choix de version : toujours la même.
+- Moins de gestion de compatibilité sur des versions non gérées.
+- Probablement automatisable.
+- Mises à jour de Node pour les développeurs plus régulière.
+
+#### Inconvénients
+- Mises à jour de Node pour les développeurs plus régulière, nécessite des `nvm install`/`nvm use`.
+- On calque les montées de versions de Node au bon vouloir de Circle CI de mettre à jour leurs images.
+- Retard minime possible à cause du délai de mise à jour des versions de Node côté Circle CI.
+
+### Solution n°2 : Forcer la même version complète de Node dans le .nvmrc et le `engines`.
+
+Pour ne pas se lier à Circle CI.
+
+#### Avantages
+- Aucun écart lié à Node entre l'environnement de dev et de production.
+- Écart de version minime entre les 3 environnements.
+- Moins de gestion de compatibilité sur des versions non gérées.
+- Probablement automatisable.
+- Mises à jour de Node pour les développeurs plus régulière.
+- Minimise les soucis de sécurité potentiels en production.
+
+#### Inconvénients
+- La CI peut ne pas être exactement la même version que les 2 autres environnements.
+- Mises à jour de Node pour les développeurs plus régulière, nécessite des `nvm install`/`nvm use`.
+
+### Solution n°3 : Ajouter une version mineure de Node dans le .nvmrc et le `engines`
+
+Permettre de spécifier une version mineure (en plus de la majeure) pour préciser la version minimale nécessaire. C'est ce qui a été fait pour l'API avec #6512 car elle ne fonctionnait plus à partir d'une certaine version mineure de Node.
+
+#### Avantages
+- Gestion plus fine de la compatibilité.
+- Permet de forcer la mise à jour des développeurs quand une version mineure n'est plus compatible.
+- Garantie qu'on utilise la dernière version de Node en production donc normalement une meilleure sécurité.
+
+#### Inconvénients
+- C'est subjectif de savoir si une montée de version est nécessaire ou pas. Il faut préciser quand est-ce que c'est nécessaire ?
+- L'écart entre les versions des 3 environnements (et les soucis que ça cause) reste présent.
+
+## Décision
+A discuter en Tech Days avant de faire une proposition.
+
+## Conséquences
+
+/!\ Compatibilité Pix UI lors de la mise à jour.

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -18,7 +18,10 @@ Avec l'ADR 18, nous avons choisi :
 - PAAS : préciser la version majeure de Node uniquement.
 - CI : préciser une version exacte de Node.
 - Local : préciser la version majeure de Node uniquement.
-
+Par exemple, si l'on spécifie la version 16 : 
+- en local, on peut utiliser la `16.1.0`
+- dans la CI, on peut utiliser la `16.2.8` 
+- dans le PAAS, on peut utiliser la `16.5.1`
 Nous avons constaté plusieurs limites à ce choix :
 - L'API ne fonctionne plus en version antérieure à Node@v16.15. L'ADR précédant ne nous permet pas de fixer de version mineure minimum donc un risque d'incompatibilité est présent.
 - Fixer la version majeure uniquement peut provoquer des problèmes de reproductibilité car nos 3 environnements ont chacun une version de Node différente. Notamment en local, il est arrivé que certains développeurs restent en version antérieure à la 16.15 lorsque nous avons dû supprimer la compatibilité de ces versions.

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -28,7 +28,7 @@ Nous avons constaté plusieurs limites à ce choix :
 
 ### Solution n°1 : Forcer la même version exacte minimum de Node sur tous les environnements
 
-Cette solution consiste à mettre à jour les 3 versions des 3 environnements en même temps.
+Cette solution consiste à mettre à jour la version de node dans chacun des 3 environnements en même temps.
 
 #### Avantages
 - Limite l'écart de version possible entre les 3 environnements.

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -26,7 +26,7 @@ Nous avons constaté plusieurs limites à ce choix :
   * dans la CI, on peut utiliser la `16.2.8`.
   * dans le PAAS, on peut utiliser la `16.15.0`.
 
-### Solution n°1 : Forcer la même version exacte minimum de Node sur tous les environnements
+### Solution n°1 : Spécifier la même version exacte minimum de Node sur tous les environnements
 
 Cette solution consiste à mettre à jour la version de node dans chacun des 3 environnements en même temps.
 
@@ -43,7 +43,7 @@ Cette solution consiste à mettre à jour la version de node dans chacun des 3 e
 - On synchronise les montées de versions de Node avec les mises à jour des images Node de Circle CI.
 - Retard minime possible à cause du délai de mise à jour des versions de Node côté Circle CI.
 
-### Solution n°2 : Forcer la même version exacte minimum de Node en local et sur le PAAS
+### Solution n°2 : Spécifier la même version exacte minimum de Node en local et sur le PAAS
 
 Notre CI évoluerai de son côté, pour éviter la synchronisation avec les images Node Circle CI.
 
@@ -80,7 +80,7 @@ NB : Après six mois, les versions impaires (9, 11, etc.), ne sont plus maintenu
 
 En faisant évoluer [notre configuration Renovate](https://github.com/1024pix/renovate-config), nous avons observé que l'outil force l'ajout du numéro de patch si on précise la version mineure requise.
 
-Fort de ces expérimentations, l'équipe propose de choisir [la solution 1](### Solution n°1 : Forcer la même version exacte minimum de Node sur tous les environnements).
+Fort de ces expérimentations, l'équipe propose de choisir la solution 1.
 
 ## Conséquences
 

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -16,7 +16,7 @@ En discussion
 
 Avec l'ADR 18, nous avons choisi :
 - PAAS : préciser la version majeure de Node uniquement.
-- CI : préciser une version exacte de Node.
+- CI : préciser une version exacte de Node (parce que imposé par la CI).
 - Local : préciser la version majeure de Node uniquement.
 
 Nous avons constaté plusieurs limites à ce choix :

--- a/docs/adr/0049-specifier-version-nodejs.md
+++ b/docs/adr/0049-specifier-version-nodejs.md
@@ -71,7 +71,9 @@ Permettre de spécifier une version mineure (en plus de la majeure) pour précis
 
 ## Décision
 
-Lors des Tech Days 2023, une équipe s'est formée sur le sujet des montées de version. Après avoir corrigé la version de Node embarquée dans l'API qui était impaire, nous avons expérimenté les montées de version automatisées de Node sur [un fork du monorepo](https://github.com/1024pix/pix-renovate-test).
+Lors des Tech Days 2023, une équipe s'est formée sur le sujet des montées de version. Après avoir corrigé la version de Node embarquée dans l'API qui était non maintenue nous avons expérimenté les montées de version automatisées de Node sur [un fork du monorepo](https://github.com/1024pix/pix-renovate-test).
+
+NB : Après six mois, les versions impaires (9, 11, etc.), ne sont plus maintenues et sont donc hors LTS [voir la doc](https://nodejs.dev/en/about/releases/)
 
 En faisant évoluer [notre configuration Renovate](https://github.com/1024pix/renovate-config), nous avons observé que l'outil force l'ajout du numéro de patch si on précise la version mineure requise.
 


### PR DESCRIPTION
## :unicorn: Problème
Depuis l'[ADR 18](https://github.com/1024pix/pix/blob/dev/docs/adr/0018-specifier-version-nodejs.md) nous avons quelques limites sur notre manière de préciser la version de Node.js utilisée.

## :robot: Proposition
Avec l'équipe Tech Days "UP", nous proposons une remise à jour de cet ADR.

Deadline pour les retours : 4 août 2023.

## :rainbow: Remarques
Ce nouvel ADR fait suite à de nombreuses discussions dans l'équipe, sa conclusion nous parait être le meilleur compromis qu'on puisse proposer pour le moment même si elle induit un petit changement sur notre manière de travailler.

## :100: Pour tester
N/A
