### PR TITLE
[BUG] Retirer la colonne Actions de la liste d'Organisations (PIX-8535)

### DIFF
--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -7,7 +7,7 @@
           <th><label for="name">Nom</label></th>
           <th><label for="type">Type</label></th>
           <th><label for="externalId">Identifiant externe</label></th>
-          {{#if this.isSuperAdminOrMetier}}
+          {{#if @showDetachColumn}}
             <th>Actions</th>
           {{/if}}
         </tr>
@@ -48,7 +48,7 @@
               class="table-admin-input form-control"
             />
           </td>
-          {{#if this.isSuperAdminOrMetier}}
+          {{#if @showDetachColumn}}
             <td></td>
           {{/if}}
         </tr>
@@ -66,7 +66,7 @@
               <td>{{organization.name}}</td>
               <td>{{organization.type}}</td>
               <td>{{organization.externalId}}</td>
-              {{#if this.isSuperAdminOrMetier}}
+              {{#if @showDetachColumn}}
                 <td>
                   <PixButton @backgroundColor="red" @size="small" @triggerAction={{(fn this.openModal organization)}}>
                     Détacher

--- a/admin/app/components/organizations/list-items.js
+++ b/admin/app/components/organizations/list-items.js
@@ -5,14 +5,9 @@ import { inject as service } from '@ember/service';
 
 export default class ActionsOnUsersRoleInOrganization extends Component {
   @service notifications;
-  @service currentUser;
 
   @tracked showModal = false;
   @tracked organizationToDetach;
-
-  get isSuperAdminOrMetier() {
-    return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
-  }
 
   @action
   openModal(organization) {

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -61,5 +61,6 @@
     @goToOrganizationPage={{@goToOrganizationPage}}
     @detachOrganizations={{@detachOrganizations}}
     @targetProfileName={{@targetProfile.name}}
+    @showDetachColumn={{this.isSuperAdminOrMetier}}
   />
 </section>

--- a/admin/app/components/target-profiles/organizations.js
+++ b/admin/app/components/target-profiles/organizations.js
@@ -8,9 +8,14 @@ export default class Organizations extends Component {
   @service store;
   @service notifications;
   @service router;
+  @service currentUser;
 
   @tracked organizationsToAttach = '';
   @tracked existingTargetProfile = '';
+
+  get isSuperAdminOrMetier() {
+    return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
+  }
 
   get isDisabledAttachOrganizationsFromExistingTargetProfile() {
     return this.existingTargetProfile === '';

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -24,6 +24,7 @@
       @type={{this.type}}
       @externalId={{this.externalId}}
       @triggerFiltering={{this.triggerFiltering}}
+      @showDetachColumn={{false}}
     />
   </section>
 </main>

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -54,6 +54,18 @@ module('Acceptance | Organizations | List', function (hooks) {
       assert.dom(screen.getByLabelText('Organisation Tac')).exists();
     });
 
+    test('it should not show an Actions column', async function (assert) {
+      // given
+      server.create('organization', { name: 'Tic' });
+      server.create('organization', { name: 'Tac' });
+
+      // when
+      const screen = await visit('/organizations/list');
+
+      // then
+      assert.dom(screen.queryByText('Actions')).doesNotExist();
+    });
+
     test('it should allow creation of a new organization', async function (assert) {
       // given & when
       const screen = await visit('/organizations/list');

--- a/admin/tests/integration/components/organizations/list-items_test.js
+++ b/admin/tests/integration/components/organizations/list-items_test.js
@@ -25,7 +25,6 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
 
   test('it should not display an Actions column to detach organizations', async function (assert) {
     // given
-    currentUser.adminMember = { isSupport: true };
     const screen = await render(
       hbs`<Organizations::ListItems
   @organizations={{this.organizations}}
@@ -33,6 +32,7 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
   @detachOrganizations={{this.detachOrganizations}}
+  @showDetachColumn={{false}}
 />`
     );
 
@@ -51,6 +51,7 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
   @detachOrganizations={{this.detachOrganizations}}
+  @showDetachColumn={{true}}
 />`
       );
 
@@ -72,6 +73,7 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
   @triggerFiltering={{this.triggerFiltering}}
   @detachOrganizations={{this.detachOrganizations}}
   @targetProfileName={{this.targetProfile.name}}
+  @showDetachColumn={{true}}
 />`
       );
 
@@ -93,6 +95,7 @@ module('Integration | Component | Organizations::ListItems', function (hooks) {
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @triggerFiltering={{this.triggerFiltering}}
   @detachOrganizations={{this.detachOrganizations}}
+  @showDetachColumn={{true}}
 />`
       );
       const detachButton = screen.getAllByRole('button', { name: 'Détacher' })[0];

--- a/admin/tests/integration/components/target-profiles/organizations_test.js
+++ b/admin/tests/integration/components/target-profiles/organizations_test.js
@@ -118,6 +118,75 @@ module('Integration | Component | TargetProfiles::Organizations', function (hook
     assert.dom('[placeholder="1135"]').hasValue('1');
   });
 
+  test('it should show a column to detach organization from profile-cible', async function (assert) {
+    // given
+    const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
+    const organizations = [organization1];
+    organizations.meta = { page: 1, pageSize: 1 };
+    this.organizations = organizations;
+
+    // when
+    const screen = await render(
+      hbs`<TargetProfiles::Organizations
+  @organizations={{this.organizations}}
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+/>`
+    );
+
+    const detachButton = await screen.queryByRole('button', { name: 'Détacher' });
+    assert.dom(detachButton).exists();
+  });
+
+  test('it should not show a column to detach organization from profile-cible if not super-admin', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: false };
+
+    const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
+    const organizations = [organization1];
+    organizations.meta = { page: 1, pageSize: 1 };
+    this.organizations = organizations;
+
+    // when
+    const screen = await render(
+      hbs`<TargetProfiles::Organizations
+  @organizations={{this.organizations}}
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+/>`
+    );
+
+    const detachButton = await screen.queryByRole('button', { name: 'Détacher' });
+    assert.dom(detachButton).doesNotExist();
+  });
+
+  test('it should show a column to detach organization from profile-cible if metier', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: false, isMetier: true };
+
+    const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
+    const organizations = [organization1];
+    organizations.meta = { page: 1, pageSize: 1 };
+    this.organizations = organizations;
+
+    // when
+    const screen = await render(
+      hbs`<TargetProfiles::Organizations
+  @organizations={{this.organizations}}
+  @goToOrganizationPage={{this.goToOrganizationPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @detachOrganizations={{this.detachOrganizations}}
+/>`
+    );
+
+    const detachButton = await screen.queryByRole('button', { name: 'Détacher' });
+    assert.dom(detachButton).exists();
+  });
+
   test('it should disable buttons when the inputs are empty', async function (assert) {
     // given
     const organizations = [];


### PR DESCRIPTION
## :unicorn: Problème
La colonne Actions permettant de détacher une organisation d'un profil cible est également visible sur la simple liste d'organisations en plus de la liste d'organisations rattachées à un profile cible.

## :robot: Proposition
Cacher cette colonne sur la liste des orgas

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter à PixAdmin en tant que SuperAdmin (puis en tant que métier et en tant que support)
- aller sur la page Organizations et remarquer l'absence de la colonne action

- aller sur la page /target-profiles/{id}/organizations
- observer la présence de la colonne Actions si vous êtes SuperAdmin ou Métier mais son absence si vous êtes Support.
- tada 🎉 