### PR TITLE
[BUGFIX] Jeter une erreur si fichier d'import en masse de session vide (PIX-8543)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -34,20 +34,9 @@ function deserializeForSessionsImport({ parsedCsvData, hasBillingMode }) {
 
   const csvBillingModeKey = headers.billingMode;
   const csvPrepaymentCodeKey = headers.prepaymentCode;
-  const firstCsvLine = parsedCsvData[0];
+  const firstCsvLine = parsedCsvData?.[0];
 
-  if (
-    _isScoAndHasBillingModeColumnsInCsv({
-      hasBillingMode,
-      firstCsvLine,
-      csvBillingModeKey,
-      csvPrepaymentCodeKey,
-    })
-  ) {
-    throw new FileValidationError('CSV_HEADERS_NOT_VALID');
-  }
-
-  _verifyHeaders({ expectedHeadersKeys, headers, firstCsvLine, hasBillingMode });
+  _verifiyFileIntegrity({ firstCsvLine, hasBillingMode, csvBillingModeKey, csvPrepaymentCodeKey, expectedHeadersKeys });
 
   parsedCsvData.forEach((lineDTO, index) => {
     const dataFromColumnName = _getDataFromColumnNames({ expectedHeadersKeys, headers, line: lineDTO });
@@ -228,6 +217,28 @@ function _getComplementaryCertificationLabel(key, COMPLEMENTARY_CERTIFICATION_SU
   return key.replace(COMPLEMENTARY_CERTIFICATION_SUFFIX, '').trim();
 }
 
+function _verifiyFileIntegrity({
+  firstCsvLine,
+  hasBillingMode,
+  csvBillingModeKey,
+  csvPrepaymentCodeKey,
+  expectedHeadersKeys,
+}) {
+  if (
+    _isCsvEmpty(firstCsvLine) ||
+    _isScoAndHasBillingModeColumnsInCsv({
+      hasBillingMode,
+      firstCsvLine,
+      csvBillingModeKey,
+      csvPrepaymentCodeKey,
+    })
+  ) {
+    throw new FileValidationError('CSV_HEADERS_NOT_VALID');
+  }
+
+  _verifyHeaders({ expectedHeadersKeys, headers, firstCsvLine, hasBillingMode });
+}
+
 function _verifyHeaders({ expectedHeadersKeys, firstCsvLine, headers, hasBillingMode }) {
   expectedHeadersKeys.forEach((key) => {
     const matchingCsvColumnValue = firstCsvLine[headers[key]];
@@ -331,6 +342,10 @@ function _createCandidate({
 
 function _generateUniqueKey({ address, room, date, time }) {
   return address + room + date + time;
+}
+
+function _isCsvEmpty(firstCsvLine) {
+  return !firstCsvLine;
 }
 
 function serializeLine(lineArray) {

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -76,6 +76,37 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
   });
 
   describe('#deserializeForSessionsImport', function () {
+    describe('when csv is empty', function () {
+      it('should throw an error', async function () {
+        const parsedCsvData = [];
+
+        // when
+        const error = await catchErr(csvSerializer.deserializeForSessionsImport)({
+          parsedCsvData,
+          hasBillingMode: true,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(FileValidationError);
+        expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+      });
+    });
+
+    describe('when csv is undefined', function () {
+      it('should throw an error', async function () {
+        const parsedCsvData = undefined;
+
+        // when
+        const error = await catchErr(csvSerializer.deserializeForSessionsImport)({
+          parsedCsvData,
+          hasBillingMode: true,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(FileValidationError);
+        expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+      });
+    });
     describe('when one or more headers are missing', function () {
       it('should throw an error', async function () {
         const parsedCsvData = [


### PR DESCRIPTION
## :unicorn: Problème
Suite à des erreurs 500 en Prod, nous avons constaté que le cas d'un csv vide n'est pas géré

## :robot: Proposition
Jeter une erreur quand un csv d'import en masse est vide

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Depuis pix-certif
- Depuis un centre no sco
- tenter d'importer en masse avec un fichier vide
- constater l'erreur

![image](https://github.com/1024pix/pix/assets/37305474/e0d8add1-faed-44a0-be99-78852f5fa517)
