### PR TITLE
[TECH] :wrench: Unifier la version d'image postgres utilisée

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,7 +4,7 @@ version: '3'
 services:
 
   postgres:
-    image: postgres:13.3-alpine
+    image: postgres:14.6-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:13.7-alpine
+    image: postgres:14.6-alpine
     container_name: pix-e2e-postgres
     environment:
       POSTGRES_DB: pix


### PR DESCRIPTION
## :unicorn: Problème

Les versions de postgres utilisées dans les différentes références aux images docker du projet diffèrent.

## :robot: Proposition

Unifier toutes les versions avec celle utilisée sur nos environnements de production

## :100: Pour tester

Valider le démarrage des conteneurs décrit dans les docker-compose
