### PR TITLE
[TECH] Mise à jour des tests basés sur le niveau max (PIX-8269)

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -398,6 +398,7 @@ function _buildCampaign({
 }
 
 let emailIndex = 0;
+
 async function _createOrRetrieveUsersAndLearners(databaseBuilder, organizationId, requiredParticipantCount) {
   const userAndLearnerIds = [];
 
@@ -448,13 +449,21 @@ async function _createOrRetrieveUsersAndLearners(databaseBuilder, organizationId
 
 async function _getProfile(profileName) {
   let answersAndKnowledgeElements;
-  if (profileName === 'BEGINNER')
-    answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForBeginnerProfile();
-  if (profileName === 'INTERMEDIATE')
-    answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForIntermediateProfile();
-  if (profileName === 'ADVANCED')
-    answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForAdvancedProfile();
-  if (profileName === 'PERFECT')
-    answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForPerfectProfile();
+  switch (profileName) {
+    case 'BEGINNER':
+      answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForBeginnerProfile();
+      break;
+    case 'INTERMEDIATE':
+      answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForIntermediateProfile();
+      break;
+    case 'ADVANCED':
+      answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForAdvancedProfile();
+      break;
+    case 'PERFECT':
+      answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForPerfectProfile();
+      break;
+    default:
+      answersAndKnowledgeElements = await profileTooling.getAnswersAndKnowledgeElementsForPerfectProfile();
+  }
   return answersAndKnowledgeElements;
 }

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { MAX_REACHABLE_LEVEL, MAX_REACHABLE_PIX_SCORE } from '../../../../lib/domain/constants.js';
 
 import {
   expect,
@@ -101,8 +102,8 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
               'pix-score': 2,
               'shared-at': sharedAt,
               'can-retry': false,
-              'max-reachable-level': 5,
-              'max-reachable-pix-score': 640,
+              'max-reachable-level': MAX_REACHABLE_LEVEL,
+              'max-reachable-pix-score': MAX_REACHABLE_PIX_SCORE,
             },
             relationships: {
               scorecards: {

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -12,6 +12,7 @@ import * as organizationRepository from '../../../../lib/infrastructure/reposito
 import * as userRepository from '../../../../lib/infrastructure/repositories/user-repository.js';
 import * as placementProfileService from '../../../../lib/domain/services/placement-profile-service.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
+import { MAX_REACHABLE_LEVEL, MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../lib/domain/constants.js';
 
 describe('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', function () {
   describe('#startWritingCampaignProfilesCollectionResultsToStream', function () {
@@ -168,8 +169,8 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           '2;' +
           '1;' +
           '12;' +
-          '5;' +
-          '40';
+          `${MAX_REACHABLE_LEVEL};` +
+          `${MAX_REACHABLE_PIX_BY_COMPETENCE}`;
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
@@ -250,8 +251,8 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           '2;' +
           '1;' +
           '12;' +
-          '5;' +
-          '40';
+          `${MAX_REACHABLE_LEVEL};` +
+          `${MAX_REACHABLE_PIX_BY_COMPETENCE}`;
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
@@ -334,8 +335,8 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           '2;' +
           '1;' +
           '12;' +
-          '5;' +
-          '40';
+          `${MAX_REACHABLE_LEVEL};` +
+          `${MAX_REACHABLE_PIX_BY_COMPETENCE}`;
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../test-helper.js';
 import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
 import { Scorecard } from '../../../../lib/domain/models/Scorecard.js';
-import { constants } from '../../../../lib/domain/constants.js';
+import { constants, MAX_REACHABLE_LEVEL, MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../lib/domain/constants.js';
 
 describe('Unit | Domain | Models | Scorecard', function () {
   let computeDaysSinceLastKnowledgeElementStub;
@@ -184,8 +184,8 @@ describe('Unit | Domain | Models | Scorecard', function () {
         //when
         actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
 
-        expect(actualScorecard.level).to.equal(5);
-        expect(actualScorecard.earnedPix).to.equal(40);
+        expect(actualScorecard.level).to.equal(MAX_REACHABLE_LEVEL);
+        expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
       });
 
       it('should have the competence level not capped at the maximum value if we allow it', function () {
@@ -199,7 +199,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
         });
 
         expect(actualScorecard.level).to.equal(15);
-        expect(actualScorecard.earnedPix).to.equal(40);
+        expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
       });
     });
 

--- a/api/tests/unit/domain/services/scoring/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-service_test.js
@@ -39,7 +39,7 @@ describe('Unit | Service | Scoring Service', function () {
       ];
 
       const expectedScoring = {
-        realTotalPixScoreForCompetence: 56,
+        realTotalPixScoreForCompetence: MAX_REACHABLE_PIX_BY_COMPETENCE + PIX_COUNT_BY_LEVEL * 2,
         pixScoreForCompetence: MAX_REACHABLE_PIX_BY_COMPETENCE,
         currentLevel: MAX_REACHABLE_LEVEL,
         pixAheadForNextLevel: 0,
@@ -63,9 +63,9 @@ describe('Unit | Service | Scoring Service', function () {
         const allowExcessLevel = true;
         const allowExcessPix = true;
         const expectedScoring = {
-          realTotalPixScoreForCompetence: 56,
-          pixScoreForCompetence: 56,
-          currentLevel: 7,
+          realTotalPixScoreForCompetence: MAX_REACHABLE_PIX_BY_COMPETENCE + PIX_COUNT_BY_LEVEL * 2,
+          pixScoreForCompetence: MAX_REACHABLE_PIX_BY_COMPETENCE + PIX_COUNT_BY_LEVEL * 2,
+          currentLevel: MAX_REACHABLE_LEVEL + 2,
           pixAheadForNextLevel: 0,
         };
 
@@ -84,13 +84,30 @@ describe('Unit | Service | Scoring Service', function () {
 
   describe('#calculatePixScore', function () {
     it('returns the Pix score and limit the score', function () {
+      const unreachableScore = MAX_REACHABLE_PIX_BY_COMPETENCE + 3000;
+      const maxEarnedPixByKnowledgeElement = MAX_REACHABLE_PIX_BY_COMPETENCE;
+      const belowMaxEarnedPix = 1;
+      const expectedPixScore = 2 * maxEarnedPixByKnowledgeElement + belowMaxEarnedPix;
+
       const knowledgeElements = [
-        domainBuilder.buildKnowledgeElement({ competenceId: 'competence1', skillId: 'skill1.1', earnedPix: 8 }),
-        domainBuilder.buildKnowledgeElement({ competenceId: 'competence1', skillId: 'skill1.2', earnedPix: 35 }),
-        domainBuilder.buildKnowledgeElement({ competenceId: 'competence2', skillId: 'skill2.1', earnedPix: 1 }),
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceEarnedPixCapped',
+          skillId: 'skill1.1',
+          earnedPix: unreachableScore,
+        }),
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competence2',
+          skillId: 'skill2.1',
+          earnedPix: maxEarnedPixByKnowledgeElement,
+        }),
+        domainBuilder.buildKnowledgeElement({
+          competenceId: 'competence3',
+          skillId: 'skill2.2',
+          earnedPix: belowMaxEarnedPix,
+        }),
       ];
 
-      expect(scoringService.calculatePixScore(knowledgeElements)).to.be.equal(41);
+      expect(scoringService.calculatePixScore(knowledgeElements)).to.be.equal(expectedPixScore);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -14,6 +14,7 @@ import { Assessment } from '../../../../lib/domain/models/Assessment.js';
 import { CertificationCourse } from '../../../../lib/domain/models/CertificationCourse.js';
 import { ComplementaryCertificationCourse } from '../../../../lib/domain/models/ComplementaryCertificationCourse.js';
 import _ from 'lodash';
+import { MAX_REACHABLE_LEVEL } from '../../../../lib/domain/constants.js';
 
 describe('Unit | UseCase | retrieve-last-or-create-certification-course', function () {
   let clock;
@@ -423,7 +424,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   certificationCandidate: foundCertificationCandidate,
                   challenges: [challenge1, challenge2],
                   verificationCode,
-                  maxReachableLevelOnCertificationDate: 5,
+                  maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                 });
                 const savedCertificationCourse = domainBuilder.buildCertificationCourse(
                   certificationCourseToSave.toDTO(),
@@ -512,7 +513,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   certificationCandidate: foundCertificationCandidate,
                   challenges: [],
                   verificationCode,
-                  maxReachableLevelOnCertificationDate: 5,
+                  maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                   version: 3,
                 });
                 const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -631,7 +632,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         certificationCandidate: foundCertificationCandidate,
                         challenges: [challengePlus1, challengePlus2, challengePlus3, challenge1, challenge2],
                         verificationCode,
-                        maxReachableLevelOnCertificationDate: 5,
+                        maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                         complementaryCertificationCourses: [complementaryCertificationCourse],
                       });
 
@@ -756,7 +757,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         certificationCandidate: foundCertificationCandidate,
                         challenges: [challengePlus1, challengePlus2, challengePlus3, challenge1, challenge2],
                         verificationCode,
-                        maxReachableLevelOnCertificationDate: 5,
+                        maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                         complementaryCertificationCourses: [complementaryCertificationCourse],
                       });
 
@@ -860,7 +861,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           certificationCandidate: foundCertificationCandidate,
                           challenges: [challenge1, challenge2],
                           verificationCode,
-                          maxReachableLevelOnCertificationDate: 5,
+                          maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                         });
 
                         const savedCertificationCourse = domainBuilder.buildCertificationCourse(
@@ -974,7 +975,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           certificationCandidate: foundCertificationCandidate,
                           challenges: [challenge1, challenge2],
                           verificationCode,
-                          maxReachableLevelOnCertificationDate: 5,
+                          maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                           complementaryCertificationCourses: [complementaryCertificationCourse],
                         });
 
@@ -1086,7 +1087,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         certificationCandidate: foundCertificationCandidate,
                         challenges: [challenge1, challenge2],
                         verificationCode,
-                        maxReachableLevelOnCertificationDate: 5,
+                        maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                         complementaryCertificationCourses: [],
                       });
 
@@ -1183,7 +1184,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       certificationCandidate: foundCertificationCandidate,
                       challenges: [challenge1, challenge2],
                       verificationCode,
-                      maxReachableLevelOnCertificationDate: 5,
+                      maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                     });
 
                     const savedCertificationCourse = domainBuilder.buildCertificationCourse(

--- a/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -1,5 +1,6 @@
 import { expect, domainBuilder } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/profile-serializer.js';
+import { MAX_REACHABLE_LEVEL } from '../../../../../lib/domain/constants.js';
 
 describe('Unit | Serializer | JSONAPI | profile', function () {
   describe('#serialize()', function () {
@@ -18,13 +19,13 @@ describe('Unit | Serializer | JSONAPI | profile', function () {
         color: '2',
       };
       const expectedScorecards = [
-        domainBuilder.buildUserScorecard({ id: 'rec1', area: area1 }),
-        domainBuilder.buildUserScorecard({ id: 'rec2', area: area2 }),
+        domainBuilder.buildUserScorecard({ id: 'rec1', area: area1, level: MAX_REACHABLE_LEVEL }),
+        domainBuilder.buildUserScorecard({ id: 'rec2', area: area2, level: MAX_REACHABLE_LEVEL }),
       ];
       const profile = {
         scorecards: expectedScorecards,
         pixScore: 45,
-        maxReachableLevel: 6,
+        maxReachableLevel: MAX_REACHABLE_LEVEL,
         maxReachablePixScore: 768,
       };
 
@@ -33,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | profile', function () {
           type: 'Profiles',
           attributes: {
             'pix-score': 45,
-            'max-reachable-level': 6,
+            'max-reachable-level': MAX_REACHABLE_LEVEL,
             'max-reachable-pix-score': 768,
           },
           relationships: {
@@ -78,7 +79,7 @@ describe('Unit | Serializer | JSONAPI | profile', function () {
               'is-progressable': false,
               'is-resettable': false,
               'is-started': true,
-              level: 6,
+              level: MAX_REACHABLE_LEVEL,
               name: 'Mener une troupe à la bataille',
               'percentage-ahead-of-next-level': 37.5,
               'pix-score-ahead-of-next-level': 3,
@@ -125,7 +126,7 @@ describe('Unit | Serializer | JSONAPI | profile', function () {
               'is-progressable': false,
               'is-resettable': false,
               'is-started': true,
-              level: 6,
+              level: MAX_REACHABLE_LEVEL,
               name: 'Mener une troupe à la bataille',
               'percentage-ahead-of-next-level': 37.5,
               'pix-score-ahead-of-next-level': 3,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/scorecard-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/scorecard-serializer_test.js
@@ -1,5 +1,6 @@
 import { expect, domainBuilder } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer.js';
+import { MAX_REACHABLE_LEVEL } from '../../../../../lib/domain/constants.js';
 
 describe('Unit | Serializer | JSONAPI | scorecard-serializer', function () {
   describe('#serialize()', function () {
@@ -9,7 +10,10 @@ describe('Unit | Serializer | JSONAPI | scorecard-serializer', function () {
         domainBuilder.buildTutorial({ id: 'recTuto2' }),
       ];
 
-      const scorecardObject = domainBuilder.buildUserScorecard({ tutorials: expectedTutorials });
+      const scorecardObject = domainBuilder.buildUserScorecard({
+        level: MAX_REACHABLE_LEVEL,
+        tutorials: expectedTutorials,
+      });
 
       const expectedSerializedScorecard = {
         data: {
@@ -31,7 +35,7 @@ describe('Unit | Serializer | JSONAPI | scorecard-serializer', function () {
             'is-progressable': false,
             'is-resettable': false,
             'is-started': true,
-            level: 6,
+            level: MAX_REACHABLE_LEVEL,
             name: 'Mener une troupe à la bataille',
             'percentage-ahead-of-next-level': 37.5,
             'pix-score-ahead-of-next-level': 3,


### PR DESCRIPTION
## :unicorn: Problème
Certains tests ont pour prérequis que la variable d'environnement `MAX_REACHABLE_LEVEL` soit égale à 5. On aimerait pouvoir s'assurer que ces tests soient toujours valables avec d'autres niveaux.

## :robot: Proposition
Nous avons rendu certains tests dynamiques en remplaçant des valeurs en dur avec la variable de configuration `MAX_REACHABLE_LEVEL`.

## :rainbow: Remarques
Certains tests n'ont pas pu être mis à jour, ils dépendent trop du niveau 5 et demandent beaucoup plus de travail pour devenir dynamiques.

## :100: Pour tester
S'assurer que les test fonctionnent toujours.
