### PR TITLE
[BUGFIX] Import en masse impossible avec des certifications complémentaires (PIX-8531)

### DIFF
--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -111,6 +111,34 @@ const getUniqueCandidates = function (candidates) {
   return { uniqueCandidates, duplicateCandidateErrors };
 };
 
+const getValidatedComplementaryCertificationForMassImport = async function ({
+  complementaryCertifications = [],
+  line,
+  complementaryCertificationRepository,
+}) {
+  const certificationCandidateErrors = [];
+
+  if (complementaryCertifications?.length > 1) {
+    _addToErrorList({
+      errorList: certificationCandidateErrors,
+      line,
+      codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code],
+    });
+
+    return { certificationCandidateErrors, complementaryCertification: null };
+  }
+
+  if (complementaryCertifications?.[0]) {
+    const complementaryCertification = await complementaryCertificationRepository.getByLabel({
+      label: complementaryCertifications[0],
+    });
+
+    return { certificationCandidateErrors, complementaryCertification };
+  }
+
+  return { certificationCandidateErrors, complementaryCertification: null };
+};
+
 const getValidatedCandidateBirthInformation = async function ({
   candidate,
   isSco,
@@ -189,7 +217,13 @@ const validateCandidateEmails = async function ({ candidate, line, dependencies 
   return certificationCandidateErrors;
 };
 
-export { validateSession, getUniqueCandidates, getValidatedCandidateBirthInformation, validateCandidateEmails };
+export {
+  validateSession,
+  getUniqueCandidates,
+  getValidatedCandidateBirthInformation,
+  validateCandidateEmails,
+  getValidatedComplementaryCertificationForMassImport,
+};
 
 function _isDateAndTimeValid(session) {
   return dayjs(`${session.date} ${session.time}`, 'YYYY-MM-DD HH:mm', true).isValid();

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -116,16 +116,16 @@ const getValidatedComplementaryCertificationForMassImport = async function ({
   line,
   complementaryCertificationRepository,
 }) {
-  const certificationCandidateErrors = [];
+  const certificationCandidateComplementaryErrors = [];
 
-  if (complementaryCertifications?.length > 1) {
+  if (_hasMoreThanOneComplementaryCertifications(complementaryCertifications)) {
     _addToErrorList({
-      errorList: certificationCandidateErrors,
+      errorList: certificationCandidateComplementaryErrors,
       line,
       codes: [CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code],
     });
 
-    return { certificationCandidateErrors, complementaryCertification: null };
+    return { certificationCandidateComplementaryErrors, complementaryCertification: null };
   }
 
   if (complementaryCertifications?.[0]) {
@@ -133,10 +133,10 @@ const getValidatedComplementaryCertificationForMassImport = async function ({
       label: complementaryCertifications[0],
     });
 
-    return { certificationCandidateErrors, complementaryCertification };
+    return { certificationCandidateComplementaryErrors, complementaryCertification };
   }
 
-  return { certificationCandidateErrors, complementaryCertification: null };
+  return { certificationCandidateComplementaryErrors, complementaryCertification: null };
 };
 
 const getValidatedCandidateBirthInformation = async function ({
@@ -224,6 +224,10 @@ export {
   validateCandidateEmails,
   getValidatedComplementaryCertificationForMassImport,
 };
+
+function _hasMoreThanOneComplementaryCertifications(complementaryCertifications) {
+  return complementaryCertifications?.length > 1;
+}
 
 function _isDateAndTimeValid(session) {
   return dayjs(`${session.date} ${session.time}`, 'YYYY-MM-DD HH:mm', true).isValid();

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -102,22 +102,22 @@ async function _createValidCertificationCandidates({
       translate,
     });
 
-    const certificationCandidateErrorsList = [];
+    const certificationCandidateErrors = [];
 
-    const complementaryCertificationValidation =
+    const { certificationCandidateComplementaryErrors, complementaryCertification } =
       await sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport({
         complementaryCertifications: certificationCandidate.complementaryCertifications,
         line: certificationCandidate.line,
         complementaryCertificationRepository,
       });
 
-    certificationCandidateErrorsList.push(...complementaryCertificationValidation.certificationCandidateErrors);
+    certificationCandidateErrors.push(...certificationCandidateComplementaryErrors);
 
     const domainCertificationCandidate = new CertificationCandidate({
       ...certificationCandidate,
       sessionId,
       billingMode: billingMode || certificationCandidate.billingMode,
-      complementaryCertification: complementaryCertificationValidation.complementaryCertification,
+      complementaryCertification,
     });
 
     const candidateBirthInformationValidation =
@@ -130,10 +130,10 @@ async function _createValidCertificationCandidates({
         certificationCpfCityRepository,
       });
 
-    certificationCandidateErrorsList.push(...candidateBirthInformationValidation.certificationCandidateErrors);
+    certificationCandidateErrors.push(...candidateBirthInformationValidation.certificationCandidateErrors);
 
-    if (certificationCandidateErrorsList?.length > 0) {
-      sessionsMassImportReport.addErrorReports(certificationCandidateErrorsList);
+    if (certificationCandidateErrors?.length > 0) {
+      sessionsMassImportReport.addErrorReports(certificationCandidateErrors);
     } else {
       domainCertificationCandidate.updateBirthInformation(candidateBirthInformationValidation.cpfBirthInformation);
     }

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -164,7 +164,7 @@ function _hasSessionIdAndCandidateInformation(data) {
 
 function _getDataFromColumnNames({ expectedHeadersKeys, headers, line }) {
   const data = {};
-  data.complementaryCertification = _extractComplementaryCertificationLabelFromLine(line);
+  data.complementaryCertifications = _extractComplementaryCertificationLabelsFromLine(line);
 
   expectedHeadersKeys.forEach((key) => {
     const headerLabel = headers[key];
@@ -187,21 +187,20 @@ function _getDataFromColumnNames({ expectedHeadersKeys, headers, line }) {
   return data;
 }
 
-function _extractComplementaryCertificationLabelFromLine(line) {
-  let complementaryCertificationLabel = null;
+function _extractComplementaryCertificationLabelsFromLine(line) {
+  const complementaryCertificationLabels = [];
 
   Object.keys(line).map((header) => {
     if (_isComplementaryCertification(header)) {
       const complementaryCertificationValue = line[header];
       if (_isTrueValue(complementaryCertificationValue)) {
-        complementaryCertificationLabel = _getComplementaryCertificationLabel(
-          header,
-          COMPLEMENTARY_CERTIFICATION_SUFFIX
+        complementaryCertificationLabels.push(
+          _getComplementaryCertificationLabel(header, COMPLEMENTARY_CERTIFICATION_SUFFIX)
         );
       }
     }
   });
-  return complementaryCertificationLabel;
+  return complementaryCertificationLabels;
 }
 
 function _isTrueValue(complementaryCertificationValue) {
@@ -317,7 +316,7 @@ function _createCandidate({
   billingMode,
   prepaymentCode,
   sex,
-  complementaryCertification,
+  complementaryCertifications,
   line,
 }) {
   return {
@@ -335,7 +334,7 @@ function _createCandidate({
     billingMode,
     prepaymentCode,
     sex,
-    complementaryCertification,
+    complementaryCertifications,
     line,
   };
 }

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -444,7 +444,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         const line = 12;
 
         // when
-        const { certificationCandidateErrors, complementaryCertification } =
+        const { certificationCandidateComplementaryErrors, complementaryCertification } =
           await sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport({
             complementaryCertifications,
             line,
@@ -452,7 +452,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           });
 
         // then
-        expect(certificationCandidateErrors).to.be.empty;
+        expect(certificationCandidateComplementaryErrors).to.be.empty;
         expect(complementaryCertification).to.deep.null;
       });
     });
@@ -467,7 +467,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         };
 
         // when
-        const { certificationCandidateErrors, complementaryCertification } =
+        const { certificationCandidateComplementaryErrors, complementaryCertification } =
           await sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport({
             complementaryCertifications,
             line,
@@ -475,7 +475,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           });
 
         // then
-        expect(certificationCandidateErrors).to.be.empty;
+        expect(certificationCandidateComplementaryErrors).to.be.empty;
         expect(complementaryCertification).to.deep.equal({ id: 3, key: 'EDU_2ND_DEGRE', label: 'Pix+ Édu 2nd degré' });
       });
     });
@@ -487,7 +487,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         const line = 12;
 
         // when
-        const { certificationCandidateErrors, complementaryCertification } =
+        const { certificationCandidateComplementaryErrors, complementaryCertification } =
           await sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport({
             complementaryCertifications,
             line,
@@ -495,7 +495,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           });
 
         // then
-        expect(certificationCandidateErrors).to.deep.equal([
+        expect(certificationCandidateComplementaryErrors).to.deep.equal([
           {
             code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
             line,

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -37,6 +37,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
 
     sessionsImportValidationService = {
+      getValidatedComplementaryCertificationForMassImport: sinon.stub(),
       getValidatedCandidateBirthInformation: sinon.stub(),
       validateSession: sinon.stub(),
       getUniqueCandidates: sinon.stub(),
@@ -53,6 +54,11 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       const userId = 1234;
       const cachedValidatedSessionsKey = 'uuid';
       const validSessionData = _createValidSessionData();
+      const complementaryCertification = { id: 3, key: 'EDU_2ND_DEGRE', label: 'Pix+ Édu 2nd degré' };
+      sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
+        certificationCandidateErrors: [],
+        complementaryCertification,
+      });
       sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
         certificationCandidateErrors: [],
         cpfBirthInformation: {
@@ -119,6 +125,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
               externalId: 'htehte',
               extraTimePercentage: '20',
               billingMode: 'FREE',
+              complementaryCertification,
             }),
           ],
           supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
@@ -144,6 +151,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
               externalId: 'htehte',
               extraTimePercentage: '20',
               billingMode: 'FREE',
+              complementaryCertification,
             }),
           ],
           supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
@@ -203,11 +211,16 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         cpfBirthInformationValidation3.success({ ...candidate3 });
         sessionsImportValidationService.getValidatedCandidateBirthInformation
           .onFirstCall()
-          .resolves({ cpfBirthInformation: cpfBirthInformationValidation1 })
+          .resolves({ certificationCandidateErrors: [], cpfBirthInformation: cpfBirthInformationValidation1 })
           .onSecondCall()
-          .resolves({ cpfBirthInformation: cpfBirthInformationValidation2 })
+          .resolves({ certificationCandidateErrors: [], cpfBirthInformation: cpfBirthInformationValidation2 })
           .onThirdCall()
-          .resolves({ cpfBirthInformation: cpfBirthInformationValidation3 });
+          .resolves({ certificationCandidateErrors: [], cpfBirthInformation: cpfBirthInformationValidation3 });
+
+        sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
+          certificationCandidateErrors: [],
+          complementaryCertification: null,
+        });
 
         sessionsImportValidationService.validateCandidateEmails.resolves([]);
         temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
@@ -270,6 +283,10 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
   context('when session or candidate information is not valid', function () {
     it('should not save in temporary storage', async function () {
       // given
+      sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
+        certificationCandidateErrors: [],
+        complementaryCertification: null,
+      });
       sessionsImportValidationService.validateSession.resolves([
         { code: 'Veuillez indiquer un nom de site.', isBlocking: true },
       ]);
@@ -319,6 +336,10 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           },
         ];
 
+        sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
+          certificationCandidateErrors: [],
+          complementaryCertification: null,
+        });
         sessionsImportValidationService.validateSession.resolves(['Veuillez indiquer un nom de site.']);
         sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
           certificationCandidateErrors: ['lastName required'],
@@ -368,6 +389,10 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           },
         ];
 
+        sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
+          certificationCandidateErrors: [],
+          complementaryCertification: null,
+        });
         sessionsImportValidationService.validateSession.resolves([]);
         sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
           certificationCandidateErrors: [],

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -56,7 +56,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       const validSessionData = _createValidSessionData();
       const complementaryCertification = { id: 3, key: 'EDU_2ND_DEGRE', label: 'Pix+ Édu 2nd degré' };
       sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
-        certificationCandidateErrors: [],
+        certificationCandidateComplementaryErrors: [],
         complementaryCertification,
       });
       sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
@@ -218,7 +218,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           .resolves({ certificationCandidateErrors: [], cpfBirthInformation: cpfBirthInformationValidation3 });
 
         sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
-          certificationCandidateErrors: [],
+          certificationCandidateComplementaryErrors: [],
           complementaryCertification: null,
         });
 
@@ -284,7 +284,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     it('should not save in temporary storage', async function () {
       // given
       sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
-        certificationCandidateErrors: [],
+        certificationCandidateComplementaryErrors: [],
         complementaryCertification: null,
       });
       sessionsImportValidationService.validateSession.resolves([
@@ -337,7 +337,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         ];
 
         sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
-          certificationCandidateErrors: [],
+          certificationCandidateComplementaryErrors: [],
           complementaryCertification: null,
         });
         sessionsImportValidationService.validateSession.resolves(['Veuillez indiquer un nom de site.']);
@@ -390,7 +390,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         ];
 
         sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
-          certificationCandidateErrors: [],
+          certificationCandidateComplementaryErrors: [],
           complementaryCertification: null,
         });
         sessionsImportValidationService.validateSession.resolves([]);
@@ -471,6 +471,10 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           },
         ];
 
+        sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
+          certificationCandidateComplementaryErrors: [],
+          complementaryCertification: null,
+        });
         sessionsImportValidationService.validateSession.resolves([]);
         sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
           certificationCandidateErrors: [],

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -492,7 +492,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
-                  complementaryCertification: null,
+                  complementaryCertifications: [],
                   line: 2,
                 },
                 {
@@ -510,7 +510,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
-                  complementaryCertification: null,
+                  complementaryCertifications: [],
                   line: 4,
                 },
               ],
@@ -540,7 +540,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
-                  complementaryCertification: null,
+                  complementaryCertifications: [],
                   line: 3,
                 },
               ],
@@ -593,7 +593,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   prepaymentCode: '43',
                   resultRecipientEmail: 'robindahood@email.fr',
                   sex: 'M',
-                  complementaryCertification: null,
+                  complementaryCertifications: [],
                   line: 2,
                 },
                 {
@@ -611,7 +611,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   prepaymentCode: '43',
                   resultRecipientEmail: 'robindahood@email.fr',
                   sex: 'M',
-                  complementaryCertification: null,
+                  complementaryCertifications: [],
                   line: 3,
                 },
               ],
@@ -664,7 +664,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
-                  complementaryCertification: null,
+                  complementaryCertifications: [],
                   line: 3,
                 },
               ],
@@ -725,7 +725,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                     billingMode: '',
                     prepaymentCode: expectedParsedPrepaymentCode,
                     sex: '',
-                    complementaryCertification: null,
+                    complementaryCertifications: [],
                     line: 2,
                   },
                 ],
@@ -772,7 +772,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 prepaymentCode: '43',
                 resultRecipientEmail: 'robindahood@email.fr',
                 sex: 'M',
-                complementaryCertification: 'Pix certif complementaire',
+                complementaryCertifications: ['Pix certif complementaire'],
                 line: 2,
               },
             ],
@@ -805,7 +805,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             extraTimePercentage: '',
             billingMode: 'Prépayée',
             prepaymentCode: '43',
-            complementaryCertification: null,
+            complementaryCertifications: [],
           };
 
           const candidateWithoutFirstName = {
@@ -823,7 +823,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             extraTimePercentage: '',
             billingMode: 'Prépayée',
             prepaymentCode: '43',
-            complementaryCertification: null,
+            complementaryCertifications: [],
           };
 
           const candidateWithoutBirthdate = {
@@ -841,7 +841,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             extraTimePercentage: '',
             billingMode: 'Prépayée',
             prepaymentCode: '43',
-            complementaryCertification: null,
+            complementaryCertifications: [],
           };
 
           const candidateWithoutSex = {
@@ -859,7 +859,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             extraTimePercentage: '',
             billingMode: 'Prépayée',
             prepaymentCode: '43',
-            complementaryCertification: null,
+            complementaryCertifications: [],
           };
 
           const candidateWithoutBillingMode = {
@@ -877,7 +877,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             extraTimePercentage: '',
             billingMode: '',
             prepaymentCode: '43',
-            complementaryCertification: null,
+            complementaryCertifications: [],
           };
 
           const candidateWithoutBirthCountry = {
@@ -895,7 +895,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             extraTimePercentage: '',
             billingMode: 'Prépayée',
             prepaymentCode: '43',
-            complementaryCertification: null,
+            complementaryCertifications: [],
           };
 
           // given


### PR DESCRIPTION
## :unicorn: Problème

Suite au refacto interdisant plusieurs certifications complémentaires, l'import de sessions en masse ne fonctionne plus si il y a une certification complémentaires.

## :robot: Proposition

* Gérer le fait que rien dans le modele CSV d'import en masse n'empêche d'indiquer plusieurs certifications complémentaires à 'oui' en entrée
* Rétablir le fonctionnement du cas nominal (une seule certification)
* Détecter et renvoyer une erreur si le CSV comprend plusieurs certifications complémentaires à 'oui'
![image](https://github.com/1024pix/pix/assets/170271/452ec0af-ed02-4652-ba0c-4d83a3d5cc70)



## :rainbow: Remarques

Suite à revue @P-Jeremy j'ai du jouer avec les contraintes suivantes 

* Ne pas renvoyer de reporting d'erreur à l'étape de serialisation
* Détecter l'erreur via le `sessionsImportValidationService`

Il y a peut-être un petit refacto à réaliser autour de la méthode `getValidatedCandidateBirthInformation`. Son nom diverge des responsabilités qu'elle porte actuellement.

## :100: Pour tester

Contexte :
* Sur Pix Certif, par exemple avec user `certif-pro@example.net`
* Télécharger le modèle d'import en masse

Tester :
* Non reg: Importer un cas valide sans certification complémentaire
* Bugfix : faire un autre import valide, mais avec une certification complémentaire
* Bugfix : faire un autre import mais avec au moins deux certifications complémentaires à 'oui'
  * Vérifier que l'erreur sur Pix Certif s'affiche
