### PR TITLE
[FEATURE][ORGA] Ajouter la sélection multiple d'élèves (PIX-8468)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -14,137 +14,40 @@
 <div class="panel">
   <table class="table content-text content-text--small">
     <caption class="screen-reader-only">{{t "pages.sco-organization-participants.table.description"}}</caption>
-    <thead>
-      <tr>
-        <Table::HeaderSort
-          @display="left"
-          @size="medium"
-          @onSort={{@sortByLastname}}
-          @order={{@lastnameSort}}
-          @ariaLabelDefaultSort={{t "pages.organization-participants.table.column.last-name.ariaLabelDefaultSort"}}
-          @ariaLabelSortUp={{t "pages.organization-participants.table.column.last-name.ariaLabelSortUp"}}
-          @ariaLabelSortDown={{t "pages.organization-participants.table.column.last-name.ariaLabelSortDown"}}
-        >
-          {{t "pages.organization-participants.table.column.last-name.label"}}
-        </Table::HeaderSort>
-        <Table::Header @size="wide">{{t "pages.sco-organization-participants.table.column.first-name"}}</Table::Header>
-        <Table::Header @size="medium">
-          {{t "pages.sco-organization-participants.table.column.date-of-birth"}}
-        </Table::Header>
-        <Table::HeaderSort
-          @display="left"
-          @size="medium"
-          @onSort={{@sortByDivision}}
-          @order={{@divisionSort}}
-          @ariaLabelDefaultSort={{t "pages.sco-organization-participants.table.column.division.ariaLabelDefaultSort"}}
-          @ariaLabelSortUp={{t "pages.sco-organization-participants.table.column.division.ariaLabelSortUp"}}
-          @ariaLabelSortDown={{t "pages.sco-organization-participants.table.column.division.ariaLabelSortDown"}}
-        >
-          {{t "pages.sco-organization-participants.table.column.division.label"}}
-        </Table::HeaderSort>
-        <Table::Header @size="medium">
-          {{t "pages.sco-organization-participants.table.column.login-method"}}
-        </Table::Header>
-        <Table::HeaderSort
-          @size="medium"
-          @align="center"
-          @onSort={{@sortByParticipationCount}}
-          @order={{@participationCountOrder}}
-          @ariaLabelDefaultSort={{t
-            "pages.sco-organization-participants.table.column.participation-count.ariaLabelDefaultSort"
-          }}
-          @ariaLabelSortUp={{t "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortUp"}}
-          @ariaLabelSortDown={{t
-            "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown"
-          }}
-        >
-          {{t "pages.sco-organization-participants.table.column.participation-count.label"}}
-        </Table::HeaderSort>
-        <Table::Header @size="medium" @align="center">
-          {{t "pages.sco-organization-participants.table.column.last-participation-date"}}
-        </Table::Header>
-        <Table::Header @size="medium" @align="center">
-          <div class="sco-organization-participant-list-page__certificability-header">
-            {{t "pages.sco-organization-participants.table.column.is-certifiable.label"}}
-            <Ui::CertificabilityTooltip
-              @aria-label={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
-              @content={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip.content"}}
+    <thead id={{this.headerId}} />
+
+    <tbody>
+      <SelectableList @items={{@students}}>
+        <:manager as |allSelected someSelected toggleAll|>
+          <InElement @destinationId={{this.headerId}}>
+            <ScoOrganizationParticipant::TableHeaders
+              @showCheckbox={{this.showCheckbox}}
+              @lastnameSort={{@lastnameSort}}
+              @onSortByLastname={{@sortByLastname}}
+              @participationCountOrder={{@participationCountOrder}}
+              @onSortByParticipationCount={{@sortByParticipationCount}}
+              @divisionSort={{@divisionSort}}
+              @onSortByDivision={{@sortByDivision}}
+              @allSelected={{allSelected}}
+              @someSelected={{someSelected}}
+              @onToggleAll={{toggleAll}}
+              @hasStudents={{this.hasStudents}}
             />
-          </div>
-        </Table::Header>
-        <Table::Header class="hide-on-mobile organization-participant-list-page__actions-header">
-          {{t "common.actions.global"}}
-        </Table::Header>
-      </tr>
-    </thead>
-
-    {{#if @students}}
-      <tbody>
-        {{#each @students as |student index|}}
-          <tr
-            aria-label={{t "pages.sco-organization-participants.table.row-title"}}
-            {{on "click" (fn @onClickLearner student.id)}}
-            class="tr--clickable"
-          >
-            <td class="ellipsis">
-              <LinkTo
-                @route="authenticated.sco-organization-participants.sco-organization-participant"
-                @model={{student.id}}
-              >
-                {{student.lastName}}
-              </LinkTo>
-            </td>
-            <td class="ellipsis" title={{student.firstName}}>{{student.firstName}}</td>
-            <td>{{dayjs-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
-            <td class="ellipsis">{{student.division}}</td>
-            <td class="sco-organization-participant-list-page__authentication-methods">
-              {{#each student.authenticationMethods as |authenticationMethod|}}
-                <p>{{t (get this.connectionTypes authenticationMethod)}}</p>
-              {{/each}}
-            </td>
-            <td class="table__column--center">{{student.participationCount}}</td>
-            <td>
-              {{#if student.lastParticipationDate}}
-                <div class="organization-participant-list-page__last-participation">
-                  <span>{{dayjs-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>
-                  <Ui::LastParticipationDateTooltip
-                    @id={{index}}
-                    @campaignName={{student.campaignName}}
-                    @campaignType={{student.campaignType}}
-                    @participationStatus={{student.participationStatus}}
-                  />
-                </div>
-              {{/if}}
-            </td>
-            <td class="table__column--center">
-              <Ui::IsCertifiable @isCertifiable={{student.isCertifiable}} />
-              {{#if student.certifiableAt}}
-                <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
-                    student.certifiableAt
-                    "DD/MM/YYYY"
-                    allow-empty=true
-                  }}</span>
-              {{/if}}
-            </td>
-            <td class="organization-participant-list-page__actions hide-on-mobile">
-              {{#if student.isAssociated}}
-                <Dropdown::IconTrigger
-                  @icon="ellipsis-vertical"
-                  @dropdownButtonClass="organization-participant-list-page__dropdown-button"
-                  @dropdownContentClass="organization-participant-list-page__dropdown-content"
-                  @ariaLabel={{t "pages.sco-organization-participants.actions.show-actions"}}
-                >
-                  <Dropdown::Item @onClick={{fn this.openAuthenticationMethodModal student}}>
-                    {{t "pages.sco-organization-participants.actions.manage-account"}}
-                  </Dropdown::Item>
-                </Dropdown::IconTrigger>
-              {{/if}}
-            </td>
-          </tr>
-        {{/each}}
-
-      </tbody>
-    {{/if}}
+          </InElement>
+        </:manager>
+        <:item as |student toggleStudent isStudentSelected index|>
+          <ScoOrganizationParticipant::TableRow
+            @showCheckbox={{this.showCheckbox}}
+            @index={{index}}
+            @student={{student}}
+            @isStudentSelected={{isStudentSelected}}
+            @openAuthenticationMethodModal={{this.openAuthenticationMethodModal}}
+            @onToggleStudent={{(fn this.addStopPropagationOnFunction toggleStudent)}}
+            @onClickLearner={{(fn @onClickLearner student.id)}}
+          />
+        </:item>
+      </SelectableList>
+    </tbody>
   </table>
   {{#if (eq @students.meta.participantCount 0)}}
     <Ui::EmptyState

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
+import { guidFor } from '@ember/object/internals';
 
 export default class ScoList extends Component {
   @service currentUser;
@@ -40,6 +41,18 @@ export default class ScoList extends Component {
     ];
   }
 
+  get showCheckbox() {
+    return this.currentUser?.organization.type === 'SCO' && this.currentUser?.organization.isManagingStudents;
+  }
+
+  get headerId() {
+    return guidFor(this) + 'mainCheckbox';
+  }
+
+  get hasStudents() {
+    return Boolean(this.args.students.length);
+  }
+
   @action
   openAuthenticationMethodModal(student, event) {
     event.stopPropagation();
@@ -50,5 +63,11 @@ export default class ScoList extends Component {
   @action
   closeAuthenticationMethodModal() {
     this.isShowingAuthenticationMethodModal = false;
+  }
+
+  @action
+  addStopPropagationOnFunction(toggleStudent, event) {
+    event.stopPropagation();
+    toggleStudent();
   }
 }

--- a/orga/app/components/sco-organization-participant/table-headers.hbs
+++ b/orga/app/components/sco-organization-participant/table-headers.hbs
@@ -1,0 +1,70 @@
+<tr>
+  {{#if @showCheckbox}}
+    <Table::Header @size="small">
+      <PixCheckbox
+        @screenReaderOnly={{true}}
+        @checked={{@someSelected}}
+        @isIndeterminate={{(not @allSelected)}}
+        disabled={{(not @hasStudents)}}
+        {{on "click" @onToggleAll}}
+      >{{t "pages.sco-organization-participants.table.column.mainCheckbox"}}</PixCheckbox>
+    </Table::Header>
+  {{/if}}
+  <Table::HeaderSort
+    @display="left"
+    @size="medium"
+    @onSort={{@onSortByLastname}}
+    @order={{@lastnameSort}}
+    @ariaLabelDefaultSort={{t "pages.organization-participants.table.column.last-name.ariaLabelDefaultSort"}}
+    @ariaLabelSortUp={{t "pages.organization-participants.table.column.last-name.ariaLabelSortUp"}}
+    @ariaLabelSortDown={{t "pages.organization-participants.table.column.last-name.ariaLabelSortDown"}}
+  >
+    {{t "pages.organization-participants.table.column.last-name.label"}}
+  </Table::HeaderSort>
+  <Table::Header @size="wide">{{t "pages.sco-organization-participants.table.column.first-name"}}</Table::Header>
+  <Table::Header @size="medium">
+    {{t "pages.sco-organization-participants.table.column.date-of-birth"}}
+  </Table::Header>
+  <Table::HeaderSort
+    @display="left"
+    @size="medium"
+    @onSort={{@onSortByDivision}}
+    @order={{@divisionSort}}
+    @ariaLabelDefaultSort={{t "pages.sco-organization-participants.table.column.division.ariaLabelDefaultSort"}}
+    @ariaLabelSortUp={{t "pages.sco-organization-participants.table.column.division.ariaLabelSortUp"}}
+    @ariaLabelSortDown={{t "pages.sco-organization-participants.table.column.division.ariaLabelSortDown"}}
+  >
+    {{t "pages.sco-organization-participants.table.column.division.label"}}
+  </Table::HeaderSort>
+  <Table::Header @size="medium">
+    {{t "pages.sco-organization-participants.table.column.login-method"}}
+  </Table::Header>
+  <Table::HeaderSort
+    @size="medium"
+    @align="center"
+    @onSort={{@onSortByParticipationCount}}
+    @order={{@participationCountOrder}}
+    @ariaLabelDefaultSort={{t
+      "pages.sco-organization-participants.table.column.participation-count.ariaLabelDefaultSort"
+    }}
+    @ariaLabelSortUp={{t "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortUp"}}
+    @ariaLabelSortDown={{t "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown"}}
+  >
+    {{t "pages.sco-organization-participants.table.column.participation-count.label"}}
+  </Table::HeaderSort>
+  <Table::Header @size="medium" @align="center">
+    {{t "pages.sco-organization-participants.table.column.last-participation-date"}}
+  </Table::Header>
+  <Table::Header @size="medium" @align="center">
+    <div class="sco-organization-participant-list-page__certificability-header">
+      {{t "pages.sco-organization-participants.table.column.is-certifiable.label"}}
+      <Ui::CertificabilityTooltip
+        @aria-label={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
+        @content={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip.content"}}
+      />
+    </div>
+  </Table::Header>
+  <Table::Header class="hide-on-mobile organization-participant-list-page__actions-header">
+    {{t "common.actions.global"}}
+  </Table::Header>
+</tr>

--- a/orga/app/components/sco-organization-participant/table-row.hbs
+++ b/orga/app/components/sco-organization-participant/table-row.hbs
@@ -1,0 +1,68 @@
+<tr
+  aria-label={{t "pages.sco-organization-participants.table.row-title"}}
+  {{on "click" @onClickLearner}}
+  class="tr--clickable"
+>
+  {{#if @showCheckbox}}
+    <td class="table__column" {{on "click" @onToggleStudent}}>
+      <PixCheckbox @screenReaderOnly={{true}} @checked={{@isStudentSelected}}>
+        {{t
+          "pages.sco-organization-participants.table.column.checkbox"
+          firstname=@student.firstName
+          lastname=@student.lastName
+        }}
+      </PixCheckbox>
+    </td>
+  {{/if}}
+  <td class="ellipsis">
+    <LinkTo @route="authenticated.sco-organization-participants.sco-organization-participant" @model={{@student.id}}>
+      {{@student.lastName}}
+    </LinkTo>
+  </td>
+  <td class="ellipsis" title={{@student.firstName}}>{{@student.firstName}}</td>
+  <td>{{dayjs-format @student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
+  <td class="ellipsis">{{@student.division}}</td>
+  <td class="sco-organization-participant-list-page__authentication-methods">
+    {{#each @student.authenticationMethods as |authenticationMethod|}}
+      <p>{{t (get this.connectionTypes authenticationMethod)}}</p>
+    {{/each}}
+  </td>
+  <td class="table__column--center">{{@student.participationCount}}</td>
+  <td>
+    {{#if @student.lastParticipationDate}}
+      <div class="organization-participant-list-page__last-participation">
+        <span>{{dayjs-format @student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>
+        <Ui::LastParticipationDateTooltip
+          @id={{@index}}
+          @campaignName={{@student.campaignName}}
+          @campaignType={{@student.campaignType}}
+          @participationStatus={{@student.participationStatus}}
+        />
+      </div>
+    {{/if}}
+  </td>
+  <td class="table__column--center">
+    <Ui::IsCertifiable @isCertifiable={{@student.isCertifiable}} />
+    {{#if @student.certifiableAt}}
+      <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
+          @student.certifiableAt
+          "DD/MM/YYYY"
+          allow-empty=true
+        }}</span>
+    {{/if}}
+  </td>
+  <td class="organization-participant-list-page__actions hide-on-mobile">
+    {{#if @student.isAssociated}}
+      <Dropdown::IconTrigger
+        @icon="ellipsis-vertical"
+        @dropdownButtonClass="organization-participant-list-page__dropdown-button"
+        @dropdownContentClass="organization-participant-list-page__dropdown-content"
+        @ariaLabel={{t "pages.sco-organization-participants.actions.show-actions"}}
+      >
+        <Dropdown::Item @onClick={{fn @openAuthenticationMethodModal @student}}>
+          {{t "pages.sco-organization-participants.actions.manage-account"}}
+        </Dropdown::Item>
+      </Dropdown::IconTrigger>
+    {{/if}}
+  </td>
+</tr>

--- a/orga/app/components/sco-organization-participant/table-row.js
+++ b/orga/app/components/sco-organization-participant/table-row.js
@@ -1,0 +1,8 @@
+import { CONNECTION_TYPES } from '../../helpers/connection-types';
+import Component from '@glimmer/component';
+
+export default class TableRow extends Component {
+  get connectionTypes() {
+    return CONNECTION_TYPES;
+  }
+}

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -1045,4 +1045,62 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       assert.contains('L’administrateur doit importer la base élèves en cliquant sur le bouton importer.');
     });
   });
+
+  module('when organization has type "SCO" and manage students', function () {
+    test('displays checkboxes', async function (assert) {
+      // given
+      this.set('noop', sinon.stub());
+
+      store = this.owner.lookup('service:store');
+
+      const division = store.createRecord('division', { id: '3BF', name: '3BF' });
+      class CurrentUserStub extends Service {
+        organization = store.createRecord('organization', {
+          id: 1,
+          divisions: [division],
+          type: 'SCO',
+          isManagingStudents: true,
+        });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const students = [{ id: 1, firstName: 'Spider', lastName: 'Man' }];
+      this.set('students', students);
+      this.set('search', null);
+      this.set('divisions', []);
+      this.set('connectionTypes', []);
+      this.set('certificability', []);
+
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @lastnameSort={{this.noop}}
+  @sortByLastname={{this.noop}}
+  @participationCountOrder={{this.noop}}
+  @sortByParticipationCount={{this.noop}}
+  @divisionSort={{this.noop}}
+  @sortByDivision={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+/>`);
+
+      const mainCheckbox = screen.getByRole('checkbox', {
+        name: this.intl.t('pages.sco-organization-participants.table.column.mainCheckbox'),
+      });
+      const studentCheckBox = screen.getByRole('checkbox', {
+        name: this.intl.t('pages.sco-organization-participants.table.column.checkbox', {
+          firstname: students[0].firstName,
+          lastname: students[0].lastName,
+        }),
+      });
+
+      // then
+      assert.dom(mainCheckbox).exists();
+      assert.dom(studentCheckBox).exists();
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -980,6 +980,7 @@
       "page-title": "Students",
       "table": {
         "column": {
+          "checkbox": "Select/Unselect {firstname} {lastname}",
           "date-of-birth": "Date of birth",
           "division": {
             "ariaLabelDefaultSort": "The table is currently not sorted by class. Click to sort by alphanumeric order.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1006,6 +1006,7 @@
           },
           "last-participation-date": "Latest participation",
           "login-method": "Log in method(s)",
+          "mainCheckbox": "Select/Unselect whole column",
           "participation-count": {
             "ariaLabelDefaultSort": "The array is not yet sorted by number of participations. Click to sort ascending.",
             "ariaLabelSortDown": "The array is sorted by descending number of participations. Click to sort ascending.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -983,6 +983,7 @@
       "page-title": "Élèves",
       "table": {
         "column": {
+          "checkbox": "Sélectionner/Déselectionner {firstname} {lastname}",
           "date-of-birth": "Date de naissance",
           "division":  {
             "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par classe. Cliquez pour trier par ordre alphanumérique.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1009,6 +1009,7 @@
           },
           "last-participation-date": "Dernière participation",
           "login-method": "Méthode(s) de connexion",
+          "mainCheckbox": "Selectionner/Deselectionner toute la colonne",
           "participation-count": {
             "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par nombre de participations. Cliquez pour trier par ordre croissant.",
             "ariaLabelSortDown": "Le tableau est trié par nombre de participation décroissant. Cliquez pour trier en ordre croissant.",


### PR DESCRIPTION
## :unicorn: Problème

Actuellement il n'est pas possible de faire une sélection multiple sur la liste des élèves pour faire une réinitialisation de mots de passes en masse.

## :robot: Proposition

Reprendre le travail qui a été effectué par l'équipe prescription et l'appliquer sur le tableau listant les élèves.
La fonctionnalité de sélection multiple s'affichera uniquement lorsque l'organisation est de type `SCO` et qu'elle gère des élèves.

## :rainbow: Remarques

Se trouve uniquement dans cette PR la sélection multiple d'élèves. Les autres fonctionnalités seront implémentées dans d'autres PRs.

## :100: Pour tester

- Se connecter sur Pix Orga avec le compte `sco.admin@example.net`
- Sélectionner le  `Collège Night Watch` comme organisation
- Cliquer sur l'onglet `Élèves`
- Constater l'affichage de checkboxes dans la première colonne
- Cliquer sur la checkbox principale
- Constater que toute la liste est sélectionnée
- Décocher quelques lignes
- Constater que la checkbox principale affiche un état dit `intermédiaire`
