### PR TITLE
[FEATURE] Afficher le nombre d'élèves sélectionnés dans le bandeau en bas de page (PIX-8469)

### DIFF
--- a/orga/app/components/sco-organization-participant/action-bar.hbs
+++ b/orga/app/components/sco-organization-participant/action-bar.hbs
@@ -1,0 +1,10 @@
+<Ui::ActionBar>
+  <:information>
+    {{t "pages.sco-organization-participants.action-bar.information" count=@count}}
+  </:information>
+  <:actions>
+    <PixButton @triggerAction={{@openResetPasswordModal}} type="button" @backgroundColor="red">
+      {{t "pages.sco-organization-participants.action-bar.reset-password-button"}}
+    </PixButton>
+  </:actions>
+</Ui::ActionBar>

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -18,7 +18,7 @@
 
     <tbody>
       <SelectableList @items={{@students}}>
-        <:manager as |allSelected someSelected toggleAll|>
+        <:manager as |allSelected someSelected toggleAll selectedStudents reset|>
           <InElement @destinationId={{this.headerId}}>
             <ScoOrganizationParticipant::TableHeaders
               @showCheckbox={{this.showCheckbox}}
@@ -34,6 +34,17 @@
               @hasStudents={{this.hasStudents}}
             />
           </InElement>
+          <InElement @destinationId={{this.paginationControlId}} @waitForElement={{true}}>
+            <Table::PaginationControl @pagination={{@students.meta}} @onChange={{reset}} />
+          </InElement>
+          {{#if someSelected}}
+            <InElement @destinationId={{this.actionBarId}}>
+              <ScoOrganizationParticipant::ActionBar
+                @count={{selectedStudents.length}}
+                @openResetPasswordModal={{this.openResetPasswordModal}}
+              />
+            </InElement>
+          {{/if}}
         </:manager>
         <:item as |student toggleStudent isStudentSelected index|>
           <ScoOrganizationParticipant::TableRow
@@ -60,6 +71,8 @@
     </div>
   {{/if}}
 </div>
+<div id={{this.actionBarId}} />
+<div id={{this.paginationControlId}} />
 
 <ScoOrganizationParticipant::ManageAuthenticationMethodModal
   @organizationId={{this.currentUser.organization.id}}
@@ -67,5 +80,3 @@
   @display={{this.isShowingAuthenticationMethodModal}}
   @onClose={{this.closeAuthenticationMethodModal}}
 />
-
-<Table::PaginationControl @pagination={{@students.meta}} />

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -49,6 +49,14 @@ export default class ScoList extends Component {
     return guidFor(this) + 'mainCheckbox';
   }
 
+  get actionBarId() {
+    return guidFor(this) + 'actionBar';
+  }
+
+  get paginationControlId() {
+    return guidFor(this) + 'paginationCOntrol';
+  }
+
   get hasStudents() {
     return Boolean(this.args.students.length);
   }
@@ -63,6 +71,11 @@ export default class ScoList extends Component {
   @action
   closeAuthenticationMethodModal() {
     this.isShowingAuthenticationMethodModal = false;
+  }
+
+  @action
+  openResetPasswordModal(students, event) {
+    event.stopPropagation();
   }
 
   @action

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -1103,4 +1103,56 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       assert.dom(studentCheckBox).exists();
     });
   });
+
+  module('action bar', function () {
+    test('displays action bar', async function (assert) {
+      //given
+      const students = [{ id: 1, firstName: 'Spider', lastName: 'Man' }];
+
+      store = this.owner.lookup('service:store');
+
+      const division = store.createRecord('division', { id: '3BF', name: '3BF' });
+
+      class CurrentUserStub extends Service {
+        organization = store.createRecord('organization', {
+          id: 1,
+          divisions: [division],
+          type: 'SCO',
+          isManagingStudents: true,
+        });
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      this.set('students', students);
+      this.set('search', null);
+      this.set('divisions', []);
+      this.set('connectionTypes', []);
+      this.set('certificability', []);
+
+      //when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @lastnameSort={{this.noop}}
+  @sortByLastname={{this.noop}}
+  @participationCountOrder={{this.noop}}
+  @sortByParticipationCount={{this.noop}}
+  @divisionSort={{this.noop}}
+  @sortByDivision={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+/>`);
+
+      const firstStudent = screen.getAllByRole('checkbox')[1];
+      await click(firstStudent);
+
+      //then
+      assert
+        .dom(screen.getByText(this.intl.t('pages.sco-organization-participants.action-bar.information', { count: 1 })))
+        .exists();
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -885,6 +885,10 @@
     },
     "sco-organization-participants": {
       "title": "{count, plural, =0 {Students} =1 {Student ({count})} other {Students ({count})}}",
+      "action-bar": {
+        "information": "{count, plural, =1 {{count} student selected} other {{count} students selected}}",
+        "reset-password-button": "Reset passwords for selected students"
+      },
       "actions": {
         "import-file": {
           "file-type-separator": " or ",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -888,6 +888,10 @@
     },
     "sco-organization-participants": {
       "title": "{count, plural, =0 {Élèves} =1 {Élève ({count})} other {Élèves ({count})}}",
+      "action-bar": {
+        "information": "{count, plural, =1 {{count} élève sélectionné} other {{count} élèves sélectionnés}}",
+        "reset-password-button": "Réinitialiser les mots de passes des élèves sélectionnés"
+      },
       "actions": {
         "import-file": {
           "file-type-separator": " ou ",
@@ -985,7 +989,7 @@
         "column": {
           "checkbox": "Sélectionner/Déselectionner {firstname} {lastname}",
           "date-of-birth": "Date de naissance",
-          "division":  {
+          "division": {
             "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par classe. Cliquez pour trier par ordre alphanumérique.",
             "ariaLabelSortDown": "Le tableau est trié par classe, dans l'ordre alphanumérique inverse. Cliquez pour trier par ordre alphanumérique.",
             "ariaLabelSortUp": "Le tableau est trié par classe, dans l'ordre alphanumérique. Cliquez pour trier par ordre alphanumérique inverse.",


### PR DESCRIPTION
## :unicorn: Problème

Il n'y a pas de possibilité de voir le nombre d'élèves actuellement sélectionné.

## :robot: Proposition

Afficher un bandeau en page de bas uniquement lorsqu'au moins un élève est sélectionné. Ce bandeau devra contenir :
- le nombre d'élèves sélectionné
- un bouton d’action (pas d’action dans le cadre de ce ticket) avec le titre suivant : `Réinitialiser les mots de passes des élèves sélectionnés`

## :rainbow: Remarques

- Au changement de page, les élèves sélectionnés seront désélectionnés. Nous devons discuter de ce comportement avec notre PO. Un ticket pourrait être créé suite à cette discussion pour modifier le comportement.
- Wording à revoir pour le bouton de réinitialisation de mot de passe car trop long.
- Revoir les seeds pour ajouter plus d'élèves pour tester la déselection des élèves sélectionnés dans la page précédente.

## :100: Pour tester

- Se connecter sur Pix Orga avec le compte `allorga@example.net`
- Changer d'organisation vers `Collège Nightwatch`
- Cliquer sur l'onglet `Élèves`
- Sélectionner quelques élèves de la listes
- Constater l'affichage du bandeau en bas de page contenant le nombre d'élèves sélectionnés ainsi que le bouton pour réinitialiser les mots de passes (ce bouton ne fait rien pour le moment)
