### PR TITLE
[FEATURE] Création en masse de campagnes depuis un fichier CSV (PIX-8520).

### DIFF
--- a/admin/app/adapters/campaigns-import.js
+++ b/admin/app/adapters/campaigns-import.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class CampaignsImportAdapter extends ApplicationAdapter {
+  addCampaignsCsv(files) {
+    if (!files || files.length === 0) return;
+
+    const url = `${this.host}/${this.namespace}/admin/campaigns`;
+    return this.ajax(url, 'POST', { data: files[0] });
+  }
+}

--- a/admin/app/components/administration/campaigns-import.hbs
+++ b/admin/app/components/administration/campaigns-import.hbs
@@ -1,0 +1,16 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">{{t "components.administration.campaigns-import.title"}}</h2>
+  </header>
+  <p>{{t "components.administration.campaigns-import.description"}}</p>
+  <br />
+  <PixButtonUpload
+    @id="campaigns-file-upload"
+    @onChange={{this.importCampaigns}}
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+    accept=".csv"
+  >
+    {{t "components.administration.campaigns-import.upload-button"}}
+  </PixButtonUpload>
+</section>

--- a/admin/app/components/administration/campaigns-import.js
+++ b/admin/app/components/administration/campaigns-import.js
@@ -1,0 +1,38 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class CampaignsImport extends Component {
+  @service intl;
+  @service notifications;
+  @service router;
+  @service store;
+
+  @action
+  async importCampaigns(files) {
+    this.notifications.clearAll();
+
+    const adapter = this.store.adapterFor('campaigns-import');
+    try {
+      await adapter.addCampaignsCsv(files);
+      this.notifications.success(this.intl.t('components.administration.campaigns-import.notifications.success'));
+    } catch (errorResponse) {
+      const errors = errorResponse.errors;
+
+      if (!errors) {
+        return this.notifications.error(this.intl.t('common.notifications.generic-error'));
+      }
+      errors.forEach((error) => {
+        switch (error.code) {
+          case 'MISSING_REQUIRED_FIELD_NAMES':
+            this.notifications.error(`${error.meta}`, { autoClear: false });
+            break;
+          default:
+            this.notifications.error(error.detail, { autoClear: false });
+        }
+      });
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}

--- a/admin/app/components/administration/organizations-import.hbs
+++ b/admin/app/components/administration/organizations-import.hbs
@@ -9,7 +9,6 @@
     @onChange={{this.importOrganizations}}
     @backgroundColor="transparent-light"
     @isBorderVisible={{true}}
-    @size="small"
     accept=".csv"
   >
     {{t "components.administration.organizations-import.upload-button"}}

--- a/admin/app/templates/authenticated/administration.hbs
+++ b/admin/app/templates/authenticated/administration.hbs
@@ -12,6 +12,8 @@
     <Tools::NewTag />
 
     <Administration::OrganizationsImport />
+
+    <Administration::CampaignsImport />
   </main>
 
 </div>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -443,6 +443,8 @@ export default function () {
     return schema.create('tag', { name: tagName });
   });
 
+  this.post('/admin/campaigns', async () => new Response(204));
+
   this.get('/oidc/identity-providers', () => {
     return {
       data: [

--- a/admin/tests/integration/components/administration/campaigns-import_test.js
+++ b/admin/tests/integration/components/administration/campaigns-import_test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { triggerEvent } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import sinon from 'sinon';
+import Service from '@ember/service';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  administration/campaigns-import', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  setupMirage(hooks);
+
+  module('when import succeeds', function () {});
+  test('it displays a success notification', async function (assert) {
+    // given
+    const file = new Blob(['foo'], { type: `valid-file` });
+    const notificationSuccessStub = sinon.stub();
+    class NotificationsStub extends Service {
+      success = notificationSuccessStub;
+      clearAll = sinon.stub();
+    }
+    this.owner.register('service:notifications', NotificationsStub);
+
+    // when
+    const screen = await render(hbs`<Administration::CampaignsImport />`);
+    const input = await screen.findByLabelText(this.intl.t('components.administration.campaigns-import.upload-button'));
+    await triggerEvent(input, 'change', { files: [file] });
+
+    // then
+    assert.ok(true);
+    sinon.assert.calledWith(
+      notificationSuccessStub,
+      this.intl.t('components.administration.campaigns-import.notifications.success')
+    );
+  });
+
+  module('when import fails', function () {
+    test('it displays an error notification', async function (assert) {
+      // given
+      this.server.post(
+        '/admin/campaigns/import-csv',
+        () =>
+          new Response(
+            422,
+            {},
+            { errors: [{ status: '422', title: "Un soucis avec l'import", code: '422', detail: 'Erreur d’import' }] }
+          ),
+        422
+      );
+      const file = new Blob(['foo'], { type: `valid-file` });
+      const notificationErrorStub = sinon.stub().returns();
+      class NotificationsStub extends Service {
+        error = notificationErrorStub;
+        clearAll = sinon.stub();
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      const screen = await render(hbs`<Administration::CampaignsImport />`);
+      const input = await screen.findByLabelText(
+        this.intl.t('components.administration.campaigns-import.upload-button')
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(notificationErrorStub.called);
+    });
+  });
+});

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -18,6 +18,14 @@
   },
   "components": {
     "administration": {
+      "campaigns-import": {
+        "title": "Création en masse de campagnes",
+        "description": "Les campagnes déjà existantes ne seront pas modifiées. Il n'y a pas de contrôle pour empêcher les doublons.",
+        "notifications": {
+          "success": "Les campagnes ont bien été créées."
+        },
+        "upload-button": "Importer un fichier CSV"
+      },
       "organizations-import": {
         "title": "Création en masse d'organisations",
         "description": "Les organisations déjà existantes ne seront pas modifiées.",


### PR DESCRIPTION
## :unicorn: Problème

Actuellement il est fastidieux de répondre aux nouvelles demandes de création de campagnes en masse.

## :robot: Proposition
L'équipe prescription propose d'ajouter la fonctionnalité de création en masse de campagnes depuis un fichier CSV, via l'onglet `Administration` de `pix-admin`, accessible uniquement au rôle `SuperAdmin`.

## :rainbow: Remarques
Les boutons d'upload de fichiers occupent toute la largeur de la section. Cela est du fait que ces boutons sont des label + input.

## :100: Pour tester
Créer un fichier csv avec ce contenu : 
```csv
Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe*;Identifiant du créateur*;Titre du parcours;Descriptif du parcours
5000;chaussette;76;numéro d'étudiant;90000;;
5000;chaussette2;76;INE;90000;Titre;Ma superbe description
```


Se connecter à la review app avec le compte `superadmin@example.net`.
Se rendre sur l'onglet `Administration`.
Cliquer que `Importer un fichier` dans la section `Création de campagnes en masse`.
Choisir un fichier csv contenant les campagnes à créer.
Valider.
Se rendre sur `/organizations/5000/campaigns`
Apprécier.
