### PR TITLE
[TECH] Permettre de bloquer l'accès sur PixAdmin du versioning des profils cibles via Feature Toggle (PIX-8575).

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isTargetProfileVersioningEnabled;
+}

--- a/admin/mirage/factories/feature-toggle.js
+++ b/admin/mirage/factories/feature-toggle.js
@@ -2,4 +2,5 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,
+  isTargetProfileVersioningEnabled: true,
 });

--- a/admin/tests/unit/services/feature-toggles_test.js
+++ b/admin/tests/unit/services/feature-toggles_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
-import Object from '@ember/object';
 import Service from '@ember/service';
 
 module('Unit | Service | feature toggles', function (hooks) {
@@ -10,8 +9,9 @@ module('Unit | Service | feature toggles', function (hooks) {
   module('feature toggles are loaded', function () {
     test('should load the feature toggles', async function (assert) {
       // Given
-      const featureToggles = Object.create({
-        isTotoEnabled: false,
+      const store = this.owner.lookup('service:store');
+      const featureToggles = store.createRecord('feature-toggle', {
+        isTargetProfileVersioningEnabled: false,
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(featureToggles),
@@ -23,7 +23,7 @@ module('Unit | Service | feature toggles', function (hooks) {
       await featureToggleService.load();
 
       // Then
-      assert.false(featureToggleService.featureToggles.isTotoEnabled);
+      assert.deepEqual(featureToggleService.featureToggles, featureToggles);
     });
   });
 });

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,5 +1,4 @@
 import * as dotenv from 'dotenv';
-dotenv.config();
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable n/no-process-env */
 import path from 'path';
@@ -9,6 +8,8 @@ import ms from 'ms';
 import { getArrayOfStrings } from '../lib/infrastructure/utils/string-utils.js';
 
 import * as url from 'url';
+
+dotenv.config();
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -219,6 +220,7 @@ const configuration = (function () {
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT
       ),
       isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
+      isTargetProfileVersioningEnabled: isFeatureEnabled(process.env.FT_TARGET_PROFILE_VERSIONING),
       isDifferentiatedTimeInvigilatorPortalEnabled: isFeatureEnabled(
         process.env.FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL
       ),
@@ -369,6 +371,7 @@ const configuration = (function () {
     config.featureToggles.isMassiveSessionManagementEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
     config.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled = true;
+    config.featureToggles.isTargetProfileVersioningEnabled = true;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -30,6 +30,7 @@ const schema = Joi.object({
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL: Joi.string().optional().valid('true', 'false'),
+  FT_TARGET_PROFILE_VERSIONING: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -882,6 +882,13 @@ FT_TRAINING_RECOMMENDATION=false
 # default: false
 # FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL=true
 
+# Enable the new versioning of target profile
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_TARGET_PROFILE_VERSIONING=true
+
 # =====
 # CPF
 # =====

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -25,6 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-massive-session-management-enabled': false,
             'is-pix1d-enabled': true,
             'is-differentiated-time-invigilator-portal-enabled': true,
+            'is-target-profile-versioning-enabled': true,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs de Pix Admin risquent de cliquer sur cette nouvelle page en cours de développement avec de potentielles erreurs ainsi générées ou une incompréhension tant que le développement n’est pas terminé.

## :robot: Proposition
Créer un feature toggle pour masquer l’icône dans la barre de navigation à gauche de Pix Admin qui permettrait d’accéder à la nouvelle fonctionnalité et à la page listant les certifications complémentaires

Le FT (Feature Toggle) est nommé `FT_TARGET_PROFILE_VERSIONING`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier que les tests passent.
- Sur Pix Admin, ouvrir la console et vérifier que l'appel des FT `api/feature-toggles?id=0` retourne bien notre FT `isTargetProfileVersioningEnabled` à true