### PR TITLE
[BUGFIX] Corrige les typos dans la modale de confirmation de suppression de participants (PIX-8617).

### DIFF
--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -748,8 +748,8 @@
         "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions",
         "delete-button": "Oui, je supprime",
         "many-items": {
-          "title": "Êtes vous sûr de vouloir supprimer '<strong>'{count}'</strong>' participants ?",
-          "content": "Ces participants ne seront plus visibles dans Pix Orga.'<br/>'Toutes leurs participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses pour leurs campagnes. Ils ne pourront pas participer à nouveau aux campagnes auxquelles ils avaient participé par le passé. Cependant des participations à de nouvelles campagne resteront possible.'<br/><strong>'Attention, cette action est irréversible.'</strong>'"
+          "title": "Êtes-vous sûr(e) de vouloir supprimer '<strong>'{count}'</strong>' participants ?",
+          "content": "Ces participants ne seront plus visibles dans Pix Orga.'<br/>'Toutes leurs participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses pour leurs campagnes. Ils ne pourront pas participer à nouveau aux campagnes auxquelles ils avaient participé par le passé. Cependant des participations à de nouvelles campagnes resteront possibles.'<br/><strong>'Attention, cette action est irréversible.'</strong>'"
         },
         "one-item": {
           "title": "Supprimer '<strong>'{firstname} {lastname}'</strong>' de vos participants ?",


### PR DESCRIPTION
## :unicorn: Problème
Il y a des fautes d'orthographe dans la modale de confirmation de suppression de participants dans `pix-orga`.

## :robot: Proposition
Correction des erreurs suivantes : 

- “Êtes vous sûr” remplacé par :  “Êtes-vous sûr(e)"
- [...] des participations à de nouvelles campagne resteront possible remplacé par [...] des participations à de nouvelles campagnes resteront possibles

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à `pix-orga` avec un compte administrateur d'organisation.
Dans l'onglet `Participants`, sélectionner un participant.
Cliquer sur le bouton `Supprimer`.
Vérifier que la modale de confirmation s'affiche sans faute.
