### PR TITLE
[FEATURE] Voir la liste des sessions de certif V3 à traiter (PIX-8335).

### DIFF
--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -2,6 +2,10 @@ import Controller from '@ember/controller';
 
 export default class ListController extends Controller {
   get sessionsWithRequiredActionCount() {
-    return this.model.length;
+    return this.model.v2Sessions.length;
+  }
+
+  get sessionsWithRequiredActionCountVersion3() {
+    return this.model.v3Sessions.length;
   }
 }

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -9,7 +9,7 @@ export default class AuthenticatedSessionsWithRequiredActionListController exten
 
   @tracked assignedToSelfOnly = false;
 
-  @computed('assignedToSelfOnly', 'currentUser.adminMember.fullName', 'model')
+  @computed('assignedToSelfOnly', 'currentUser.adminMember.fullName', 'model.withRequiredAction')
   get filteredSessions() {
     const sessions = this.model;
     if (this.assignedToSelfOnly) {

--- a/admin/app/models/with-required-action-session.js
+++ b/admin/app/models/with-required-action-session.js
@@ -7,6 +7,7 @@ export default class WithRequiredActionSession extends Model {
   @attr() sessionTime;
   @attr() finalizedAt;
   @attr() assignedCertificationOfficerName;
+  @attr() version;
 
   get printableDateAndTime() {
     const formattedSessionDate = this.sessionDate.split('-').reverse().join('/');

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -4,7 +4,19 @@ import { service } from '@ember/service';
 export default class AuthenticatedSessionsListRoute extends Route {
   @service store;
 
-  model() {
-    return this.store.query('with-required-action-session', {});
+  async model() {
+    const v3Sessions = await this.store.query('with-required-action-session', {
+      filter: {
+        version: 3,
+      },
+    });
+
+    const v2Sessions = await this.store.query('with-required-action-session', {
+      filter: {
+        version: 2,
+      },
+    });
+
+    return { v2Sessions, v3Sessions };
   }
 }

--- a/admin/app/routes/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/routes/authenticated/sessions/list/with-required-action.js
@@ -1,7 +1,14 @@
 import Route from '@ember/routing/route';
 
 export default class AuthenticatedSessionsWithRequiredActionListRoute extends Route {
-  model() {
-    return this.modelFor('authenticated.sessions.list');
+  queryParams = {
+    version: { refreshModel: true },
+  };
+
+  model(_, transition) {
+    if (transition.to.queryParams.version === '3') {
+      return this.modelFor('authenticated.sessions.list').v3Sessions;
+    }
+    return this.modelFor('authenticated.sessions.list').v2Sessions;
   }
 }

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -3,12 +3,13 @@
   flex-direction: column;
 
   &__navbar {
-    margin: 10px;
-    margin-top: 20px;
+    display: flex;
+    margin: 20px 10px 10px;
+  }
 
-    .navbar-item {
-      width: max-content;
-      padding: 0 20px;
+  .navbar-item {
+    &--right {
+      margin-left: auto;
     }
   }
 
@@ -28,7 +29,6 @@
 }
 
 .session-to-be-publish {
-
   &__publish-all {
     display: flex;
     flex-direction: row-reverse;

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -4,7 +4,7 @@
     <h1 class="page-title">Toutes les sessions de certifications</h1>
   </div>
   <nav class="navbar session-list__navbar">
-    <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
+    <LinkTo @route="authenticated.sessions.list.with-required-action" @query={{hash version=2}} class="navbar-item">
       Sessions à traiter ({{this.sessionsWithRequiredActionCount}})
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.to-be-published" class="navbar-item">
@@ -12,6 +12,13 @@
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
       Toutes les sessions
+    </LinkTo>
+    <LinkTo
+      @route="authenticated.sessions.list.with-required-action"
+      @query={{hash version=3}}
+      class="navbar-item navbar-item--right"
+    >
+      Sessions à traiter nextgen ({{this.sessionsWithRequiredActionCountVersion3}})
     </LinkTo>
   </nav>
 </header>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -38,6 +38,7 @@ import {
   updateTraining,
 } from './handlers/trainings';
 import { findFrameworkAreas } from './handlers/frameworks';
+import { getWithRequiredActionSessions } from './handlers/get-with-required-action-sessions';
 
 export default function makeServer(config) {
   const finalConfig = {
@@ -91,10 +92,7 @@ function routes() {
     const toBePublishedSessions = schema.toBePublishedSessions.all();
     return toBePublishedSessions;
   });
-  this.get('/admin/sessions/with-required-action', (schema) => {
-    const withRequiredActionSessions = schema.withRequiredActionSessions.all();
-    return withRequiredActionSessions;
-  });
+  this.get('/admin/sessions/with-required-action', getWithRequiredActionSessions);
   this.patch('/admin/sessions/:id/publish', () => {
     return new Response(204);
   });

--- a/admin/mirage/handlers/get-with-required-action-sessions.js
+++ b/admin/mirage/handlers/get-with-required-action-sessions.js
@@ -1,0 +1,6 @@
+export function getWithRequiredActionSessions(schema, request) {
+  const queryParams = request.queryParams;
+  const withRequiredActionSessions = schema.withRequiredActionSessions.all();
+
+  return withRequiredActionSessions.filter((session) => `${session.version}` === queryParams['filter[version]']);
+}

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
@@ -54,33 +54,89 @@ module('Acceptance | authenticated/sessions/list/with required action', function
       assert.dom(screen.getByRole('link', { name: 'Sessions de certifications' })).hasClass('active');
     });
 
-    test('it should display sessions with required action informations', async function (assert) {
-      assert.expect(8);
-      // given
-      const finalizedAt = new Date('2021-02-01T03:00:00Z');
-      server.create('with-required-action-session', {
-        id: '1',
-        certificationCenterName: 'Centre SCO des Anne-Étoiles',
-        finalizedAt,
-        sessionDate: '2021-01-01',
-        sessionTime: '17:00:00',
-        assignedCertificationOfficerName: 'Officer1',
-      });
-      server.create('with-required-action-session', {
-        id: '2',
-        certificationCenterName: 'Centre SUP et rieur',
-        finalizedAt,
-        sessionDate: '2022-07-12',
-        sessionTime: '10:10:00',
-        assignedCertificationOfficerName: 'Officer2',
-      });
+    module('when clicking on the sessions to be treated tab', function () {
+      test('it should only display V2 sessions with required action informations', async function (assert) {
+        assert.expect(12);
+        // given
+        const finalizedAt = new Date('2021-02-01T03:00:00Z');
+        server.create('with-required-action-session', {
+          id: '1',
+          certificationCenterName: 'Centre SCO des Anne-Étoiles',
+          finalizedAt,
+          sessionDate: '2021-01-01',
+          sessionTime: '17:00:00',
+          assignedCertificationOfficerName: 'Officer1',
+          version: 2,
+        });
+        server.create('with-required-action-session', {
+          id: '2',
+          certificationCenterName: 'Centre SUP et rieur',
+          finalizedAt,
+          sessionDate: '2022-07-12',
+          sessionTime: '10:10:00',
+          assignedCertificationOfficerName: 'Officer2',
+          version: 2,
+        });
+        server.create('with-required-action-session', {
+          id: '3',
+          certificationCenterName: 'Centre V3',
+          finalizedAt,
+          sessionDate: '2022-02-17',
+          sessionTime: '11:10:00',
+          assignedCertificationOfficerName: 'Officer3',
+          version: 3,
+        });
 
-      // when
-      const screen = await visit('/sessions/list/with-required-action');
+        // when
+        const screen = await visit('/sessions/list/with-required-action?version=2');
 
-      // then
-      _assertSession1InformationsAreDisplayed(assert, screen);
-      _assertSession2InformationsAreDisplayed(assert, screen);
+        // then
+        _assertSession1InformationsAreDisplayed(assert, screen);
+        _assertSession2InformationsAreDisplayed(assert, screen);
+        _assertSession3InformationsAreNotDisplayed(assert, screen);
+      });
+    });
+
+    module('when clicking on the next gen sessions to be treated tab', function () {
+      test('it should only display V3 sessions with required action informations', async function (assert) {
+        assert.expect(8);
+        // given
+        const finalizedAt = new Date('2021-02-01T03:00:00Z');
+        server.create('with-required-action-session', {
+          id: '1',
+          certificationCenterName: 'Centre SCO des Anne-Étoiles',
+          finalizedAt,
+          sessionDate: '2021-01-01',
+          sessionTime: '17:00:00',
+          assignedCertificationOfficerName: 'Officer1',
+          version: 2,
+        });
+        server.create('with-required-action-session', {
+          id: '2',
+          certificationCenterName: 'Centre SUP et rieur',
+          finalizedAt,
+          sessionDate: '2022-07-12',
+          sessionTime: '10:10:00',
+          assignedCertificationOfficerName: 'Officer2',
+          version: 2,
+        });
+        server.create('with-required-action-session', {
+          id: '3',
+          certificationCenterName: 'Centre V3',
+          finalizedAt,
+          sessionDate: '2022-02-17',
+          sessionTime: '11:10:00',
+          assignedCertificationOfficerName: 'Officer3',
+          version: 3,
+        });
+
+        // when
+        const screen = await visit('/sessions/list/with-required-action?version=3');
+
+        // then
+        _assertSession3InformationsAreDisplayed(assert, screen);
+        _assertSessions1andSession2InformationsAreNotDisplayed(assert, screen);
+      });
     });
 
     module('When clicking on the display only my sessions button', function () {
@@ -96,6 +152,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
           sessionDate,
           sessionTime,
           assignedCertificationOfficerName: 'John Doe',
+          version: 2,
         });
         server.create('with-required-action-session', {
           id: '2',
@@ -104,6 +161,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
           sessionDate,
           sessionTime,
           assignedCertificationOfficerName: 'Officer2',
+          version: 2,
         });
         const screen = await visit('/sessions/list/with-required-action');
 
@@ -133,4 +191,25 @@ function _assertSession2InformationsAreDisplayed(assert, screen) {
   assert.dom(screen.getByText('2')).exists();
   assert.dom(screen.getByText('12/07/2022 à 10:10:00')).exists();
   assert.dom(screen.getByText('Officer2')).exists();
+}
+
+function _assertSession3InformationsAreNotDisplayed(assert, screen) {
+  assert.dom(screen.queryByText('Centre V3')).doesNotExist();
+  assert.dom(screen.queryByText('3')).doesNotExist();
+  assert.dom(screen.queryByText('17/02/2022 à 11:10:00')).doesNotExist();
+  assert.dom(screen.queryByText('Officer3')).doesNotExist();
+}
+
+function _assertSession3InformationsAreDisplayed(assert, screen) {
+  assert.dom(screen.getByText('Centre V3')).exists();
+  assert.dom(screen.getByText('3')).exists();
+  assert.dom(screen.getByText('17/02/2022 à 11:10:00')).exists();
+  assert.dom(screen.getByText('Officer3')).exists();
+}
+
+function _assertSessions1andSession2InformationsAreNotDisplayed(assert, screen) {
+  assert.dom(screen.queryByText('Centre SCO des Anne-Étoiles')).doesNotExist();
+  assert.dom(screen.queryByText('Officer1')).doesNotExist();
+  assert.dom(screen.queryByText('Centre SUP et rieur')).doesNotExist();
+  assert.dom(screen.queryByText('Officer2')).doesNotExist();
 }

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -35,7 +35,7 @@ module('Acceptance | Session List', function (hooks) {
 
     test('it should display the number of sessions with required actions', async function (assert) {
       // given
-      server.createList('with-required-action-session', 10);
+      server.createList('with-required-action-session', 10, { version: 2 });
 
       // when
       const screen = await visit('/sessions/list');

--- a/admin/tests/unit/routes/authenticated/sessions/list_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list_test.js
@@ -19,26 +19,33 @@ module('Unit | Route | authenticated/sessions/list', function (hooks) {
     test('it should fetch the list of sessions with required action', async function (assert) {
       // given
       const route = this.owner.lookup('route:authenticated/sessions/list');
-      const sessionsWithRequiredAction = [
+      const v2Sessions = [
         {
           certificationCenterName: 'Centre SCO des Anne-Solo',
           finalizedAt: '2020-04-15T15:00:34.000Z',
         },
       ];
+
+      const v3Sessions = [
+        {
+          certificationCenterName: 'Centre SCO v3',
+          finalizedAt: '2020-04-15T15:00:34.000Z',
+        },
+      ];
       const queryStub = sinon.stub();
-      queryStub.withArgs('with-required-action-session', {}).resolves(sessionsWithRequiredAction);
+      queryStub.withArgs('with-required-action-session', { filter: { version: 2 } }).resolves(v2Sessions);
+      queryStub.withArgs('with-required-action-session', { filter: { version: 3 } }).resolves(v3Sessions);
+
       store.query = queryStub;
 
       // when
       const result = await route.model();
 
       // then
-      assert.deepEqual(result, [
-        {
-          certificationCenterName: 'Centre SCO des Anne-Solo',
-          finalizedAt: '2020-04-15T15:00:34.000Z',
-        },
-      ]);
+      assert.deepEqual(result, {
+        v2Sessions,
+        v3Sessions,
+      });
     });
   });
 });

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -56,6 +56,7 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createV3Session({ databaseBuilder });
   await _createPublishedSession({ databaseBuilder });
   await _createProStartedSession({ databaseBuilder });
+  await _createIssueReportCategories({ databaseBuilder });
 }
 
 export { teamCertificationDataBuilder };
@@ -417,4 +418,25 @@ async function _createComplementaryCertificationCampaign({ databaseBuilder }) {
 function _createCodeCampaign(complementaryCertificationId) {
   const campaignCode = `${complementaryCertificationId}`.padStart(9, 'CERTIF_');
   return campaignCode;
+}
+
+async function _createIssueReportCategories({ databaseBuilder }) {
+  const candidateInformationChangeId = databaseBuilder.factory.buildIssueReportCategory({
+    name: 'CANDIDATE_INFORMATIONS_CHANGES',
+    isDeprecated: false,
+    isImpactful: false,
+  }).id;
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'NAME_OR_BIRTHDATE',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: candidateInformationChangeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'EXTRA_TIME_PERCENTAGE',
+    isDeprecated: false,
+    isImpactful: false,
+    issueReportCategoryId: candidateInformationChangeId,
+  });
 }

--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -1,6 +1,7 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as toBePublishedSessionSerializer from '../../infrastructure/serializers/jsonapi/to-be-published-session-serializer.js';
 import * as withRequiredActionSessionSerializer from '../../infrastructure/serializers/jsonapi/with-required-action-session-serializer.js';
+import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 
 const findFinalizedSessionsToPublish = async function (request, h, dependencies = { toBePublishedSessionSerializer }) {
   const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
@@ -12,7 +13,8 @@ const findFinalizedSessionsWithRequiredAction = async function (
   h,
   dependencies = { withRequiredActionSessionSerializer },
 ) {
-  const finalizedSessionsWithRequiredAction = await usecases.findFinalizedSessionsWithRequiredAction();
+  const { filter } = extractParameters(request.query);
+  const finalizedSessionsWithRequiredAction = await usecases.findFinalizedSessionsWithRequiredAction(filter);
   return dependencies.withRequiredActionSessionSerializer.serialize(finalizedSessionsWithRequiredAction);
 };
 

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -106,6 +106,11 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/admin/sessions/with-required-action',
       config: {
+        validate: {
+          query: Joi.object({
+            'filter[version]': Joi.number(),
+          }),
+        },
         pre: [
           {
             method: (request, h) =>

--- a/api/lib/domain/usecases/find-finalized-sessions-with-required-action.js
+++ b/api/lib/domain/usecases/find-finalized-sessions-with-required-action.js
@@ -1,5 +1,5 @@
-const findFinalizedSessionsWithRequiredAction = function ({ finalizedSessionRepository }) {
-  return finalizedSessionRepository.findFinalizedSessionsWithRequiredAction();
+const findFinalizedSessionsWithRequiredAction = function ({ finalizedSessionRepository, version }) {
+  return finalizedSessionRepository.findFinalizedSessionsWithRequiredAction({ version });
 };
 
 export { findFinalizedSessionsWithRequiredAction };

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
@@ -16,7 +16,7 @@ describe('Acceptance | Controller | finalized-session-controller-find-finalized-
         databaseBuilder.factory.buildSession({ id: 121 });
         databaseBuilder.factory.buildSession({ id: 333 });
         databaseBuilder.factory.buildSession({ id: 323 });
-        databaseBuilder.factory.buildSession({ id: 423 });
+        databaseBuilder.factory.buildSession({ id: 423, version: 3 });
 
         databaseBuilder.factory.buildFinalizedSession({ sessionId: 121, isPublishable: false, publishedAt: null });
         databaseBuilder.factory.buildFinalizedSession({ sessionId: 333, isPublishable: false, publishedAt: null });
@@ -44,6 +44,43 @@ describe('Acceptance | Controller | finalized-session-controller-find-finalized-
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.have.lengthOf(2);
         expect(response.result.data[0].type).to.equal('with-required-action-sessions');
+      });
+      context('When requesting only version 3', function () {
+        it('should return a 200 status code response with JSON API serialized', async function () {
+          await insertUserWithRoleSuperAdmin();
+
+          databaseBuilder.factory.buildSession({ id: 121 });
+          databaseBuilder.factory.buildSession({ id: 333, version: 3 });
+          databaseBuilder.factory.buildSession({ id: 323 });
+          databaseBuilder.factory.buildSession({ id: 423 });
+
+          databaseBuilder.factory.buildFinalizedSession({ sessionId: 121, isPublishable: false, publishedAt: null });
+          databaseBuilder.factory.buildFinalizedSession({ sessionId: 333, isPublishable: false, publishedAt: null });
+          databaseBuilder.factory.buildFinalizedSession({ sessionId: 323, isPublishable: true, publishedAt: null });
+          databaseBuilder.factory.buildFinalizedSession({
+            sessionId: 423,
+            isPublishable: false,
+            publishedAt: '2021-01-02',
+          });
+
+          await databaseBuilder.commit();
+
+          const server = await createServer();
+          const options = {
+            method: 'GET',
+            url: '/api/admin/sessions/with-required-action?filter[version]=3',
+            payload: {},
+            headers: { authorization: generateValidRequestAuthorizationHeader() },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.data).to.have.lengthOf(1);
+          expect(response.result.data[0].type).to.equal('with-required-action-sessions');
+        });
       });
     });
   });

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -75,6 +75,43 @@ describe('Unit | Controller | finalized-session', function () {
         // then
         expect(response).to.deep.equal(serializedFinalizedSessions);
       });
+      context('When filtering on version number', function () {
+        it('should find finalized sessions with required action', async function () {
+          // given
+          const version = 3;
+          request = {
+            payload: {},
+            query: {
+              'filter[version]': version,
+            },
+            auth: {
+              credentials: {
+                userId,
+              },
+            },
+          };
+
+          const foundFinalizedSessions = Symbol('foundSession');
+          sinon.stub(usecases, 'findFinalizedSessionsWithRequiredAction');
+          usecases.findFinalizedSessionsWithRequiredAction.withArgs({ version }).resolves(foundFinalizedSessions);
+
+          const withRequiredActionSessionSerializer = {
+            serialize: sinon.stub(),
+          };
+          const serializedFinalizedSessions = Symbol('serializedSession');
+          withRequiredActionSessionSerializer.serialize
+            .withArgs(foundFinalizedSessions)
+            .resolves(serializedFinalizedSessions);
+
+          // when
+          const response = await finalizedSessionController.findFinalizedSessionsWithRequiredAction(request, hFake, {
+            withRequiredActionSessionSerializer,
+          });
+
+          // then
+          expect(response).to.deep.equal(serializedFinalizedSessions);
+        });
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/find-finalized-sessions-with-required-action_test.js
+++ b/api/tests/unit/domain/usecases/find-finalized-sessions-with-required-action_test.js
@@ -10,7 +10,10 @@ describe('Unit | UseCase | findFinalizedSessionsWithRequiredAction', function ()
       };
 
       const sessionsWithRequiredActions = [
-        domainBuilder.buildFinalizedSession({ isPublishable: false, publishedAt: null }),
+        {
+          ...domainBuilder.buildFinalizedSession({ isPublishable: false, publishedAt: null }),
+          version: 2,
+        },
       ];
 
       finalizedSessionRepository.findFinalizedSessionsWithRequiredAction.resolves(sessionsWithRequiredActions);
@@ -19,6 +22,30 @@ describe('Unit | UseCase | findFinalizedSessionsWithRequiredAction', function ()
 
       // then
       expect(result).to.deep.equal(sessionsWithRequiredActions);
+    });
+    context('when filtering on a specific version', function () {
+      it('should get a list of publishable sessions', async function () {
+        // given
+        const finalizedSessionRepository = {
+          findFinalizedSessionsWithRequiredAction: sinon.stub(),
+        };
+
+        const sessionsWithRequiredActions = [
+          {
+            ...domainBuilder.buildFinalizedSession({ isPublishable: false, publishedAt: null }),
+            version: 3,
+          },
+        ];
+
+        finalizedSessionRepository.findFinalizedSessionsWithRequiredAction
+          .withArgs({ version: 3 })
+          .resolves(sessionsWithRequiredActions);
+        // when
+        const result = await findFinalizedSessionsWithRequiredAction({ finalizedSessionRepository, version: 3 });
+
+        // then
+        expect(result).to.deep.equal(sessionsWithRequiredActions);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Une phase pilote pour la certification nextGen va être organisée auprès de quelques centres sélectionnés. Lors de cette phase, le pôle certif souhaite pouvoir identifier simplement les certifications à traiter (= qui nécessite une action manuelle de leur part) afin d’apporter une attention particulière à ces certifs.

⚠️ En ajoutant les certif nextGen à la liste des sessions à traiter, elles vont se perdre dans un amas de sessions et la différence entre certif actuelle et certif nextGen ne sera pas évidente.

## :robot: Proposition

Dans Pix Admin > menu “Sessions de certification” : ajout  d'un onglet “Sessions à traiter nextGen”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

• Dans pix certif, créer une session pour un centre taggué comme pilote nextGen
• Inscrire un candidat à cette certif
• Sur pix-app, rejoindre cette session et lancer le test de certification
• Répondre à la dernière question du test (qu'importe le résultat)
• Finaliser la session avec un signalement de type C1 (modif infos persos candidat) ou C6 (fraude)
• Dans pix admin, cliquer sur le menu “Sessions de certification”

**résultat** : un nouvel onglet “Sessions à traiter nextGen” est affiché

• Cliquer sur l’onglet

**résultat** : la session finalisée préalablement est affichée dans cette liste
