### PR TITLE
[BUMP] Met à jour Pix UI en version 38 dans Pix Admin (PIX-8619).

### DIFF
--- a/admin/app/components/campaigns/update.hbs
+++ b/admin/app/components/campaigns/update.hbs
@@ -48,6 +48,7 @@
         rows="8"
         @maxlength="5000"
         @value={{this.form.customLandingPageText}}
+        {{on "change" (fn this.updateFormValue "customLandingPageText")}}
         class="form-control {{if (v-get this.form 'customLandingPageText' 'isInvalid') 'is-invalid'}}"
       />
 
@@ -67,6 +68,7 @@
           rows="8"
           @maxlength="5000"
           @value={{this.form.customResultPageText}}
+          {{on "change" (fn this.updateFormValue "customResultPageText")}}
           class="form-control {{if (v-get this.form 'customResultPageText' 'isInvalid') 'is-invalid'}}"
         />
         {{#if (v-get this.form "customResultPageText" "isInvalid")}}

--- a/admin/app/components/campaigns/update.js
+++ b/admin/app/components/campaigns/update.js
@@ -132,4 +132,9 @@ export default class Update extends Component {
       await this._update();
     }
   }
+
+  @action
+  updateFormValue(key, event) {
+    this.form[key] = event.target.value;
+  }
 }

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -28,18 +28,20 @@
         <div class="radio-button-container">
           <PixRadioButton
             name="sex"
-            @label="Femme"
             checked={{if (eq this.sex "F") true}}
             {{on "change" (fn this.updateSexValue "F")}}
             required
-          />
+          >
+            Femme
+          </PixRadioButton>
           <PixRadioButton
             name="sex"
-            @label="Homme"
             checked={{if (eq this.sex "M") true}}
             {{on "change" (fn this.updateSexValue "M")}}
             required
-          />
+          >
+            Homme
+          </PixRadioButton>
         </div>
       </div>
 
@@ -74,18 +76,20 @@
           <div class="radio-button-container">
             <PixRadioButton
               name="birth-geo-code-option"
-              @label="Code INSEE"
               checked={{if (eq this.selectedBirthGeoCodeOption "insee") true}}
               {{on "change" (fn this.selectBirthGeoCodeOption "insee")}}
               required
-            />
+            >
+              Code INSEE
+            </PixRadioButton>
             <PixRadioButton
               name="birth-geo-code-option"
-              @label="Code postal"
               checked={{if (eq this.selectedBirthGeoCodeOption "postal") true}}
               {{on "change" (fn this.selectBirthGeoCodeOption "postal")}}
               required
-            />
+            >
+              Code postal
+            </PixRadioButton>
           </div>
         </div>
       {{/if}}

--- a/admin/app/components/sessions/jury-comment.hbs
+++ b/admin/app/components/sessions/jury-comment.hbs
@@ -6,6 +6,7 @@
         <PixTextarea
           placeholder="Ajouter un commentaire…"
           @value={{this.commentBeingEdited}}
+          {{on "change" this.updateCommentBeingEdited}}
           class="jury-comment__field"
           @id="jury-comment-field"
           aria-label="Texte du commentaire"

--- a/admin/app/components/sessions/jury-comment.js
+++ b/admin/app/components/sessions/jury-comment.js
@@ -62,6 +62,11 @@ export default class JuryComment extends Component {
     }
   }
 
+  @action
+  updateCommentBeingEdited(event) {
+    this.commentBeingEdited = event.target.value;
+  }
+
   get commentExists() {
     return this.comment !== null;
   }

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -77,7 +77,8 @@
         @isBorderVisible={{true}}
         @size="small"
         @triggerAction={{@toggleEditMode}}
-      >Annuler</PixButton>
+      >Annuler
+      </PixButton>
       <PixButton @backgroundColor="green" @size="small" @type="submit">
         Enregistrer
       </PixButton>

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -8,11 +8,11 @@
         @label="Nom (obligatoire) : "
         required={{true}}
         aria-required={{true}}
-        {{on "change" this.updateTargetProfileName}}
+        {{on "change" (fn this.updateTargetProfileValue "name")}}
       />
       <PixSelect
         @label="Catégorie :"
-        @onChange={{this.onCategoryChange}}
+        @onChange={{fn this.updateTargetProfileValue "category"}}
         @value={{@targetProfile.category}}
         @options={{this.optionsList}}
         @placeholder="-"
@@ -44,7 +44,7 @@
           type="number"
           aria-required={{true}}
           placeholder="7777"
-          {{on "change" this.updateOwnerOrganizationId}}
+          {{on "change" (fn this.updateTargetProfileValue "ownerOrganizationId")}}
         />
       </div>
     </Card>
@@ -63,7 +63,7 @@
         @label="Lien de l'image du profil cible : "
         @information="L'url à saisir doit être celle d'OVH. Veuillez
           vous rapprocher des équipes tech et produit pour la réalisation de celle-ci."
-        {{on "change" this.updateImageUrl}}
+        {{on "change" (fn this.updateTargetProfileValue "imageUrl")}}
       />
       <div class="form-group">
         <label class="textarea-label" for="description">Description : </label>

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -73,12 +73,20 @@
           @maxlength="500"
           rows="4"
           @value={{@targetProfile.description}}
+          {{on "change" (fn this.updateTargetProfileValue "description")}}
         />
       </div>
 
       <div class="form-group">
         <label class="textarea-label" for="comment">Commentaire (usage interne) : </label>
-        <PixTextarea class="form-control" id="comment" @maxlength="500" rows="4" @value={{@targetProfile.comment}} />
+        <PixTextarea
+          class="form-control"
+          id="comment"
+          @maxlength="500"
+          rows="4"
+          @value={{@targetProfile.comment}}
+          {{on "change" (fn this.updateTargetProfileValue "comment")}}
+        />
       </div>
     </Card>
   </section>

--- a/admin/app/components/target-profiles/create-target-profile-form.js
+++ b/admin/app/components/target-profiles/create-target-profile-form.js
@@ -44,6 +44,11 @@ export default class CreateTargetProfileForm extends Component {
   }
 
   @action
+  updateTargetProfileValue(key, event) {
+    this.args.targetProfile[key] = event.target.value;
+  }
+
+  @action
   async onSubmit(event) {
     try {
       this.submitting = true;

--- a/admin/app/components/target-profiles/create-target-profile-form.js
+++ b/admin/app/components/target-profiles/create-target-profile-form.js
@@ -16,26 +16,6 @@ export default class CreateTargetProfileForm extends Component {
   }
 
   @action
-  onCategoryChange(value) {
-    this.args.targetProfile.category = value;
-  }
-
-  @action
-  updateTargetProfileName(event) {
-    this.args.targetProfile.name = event.target.value;
-  }
-
-  @action
-  updateOwnerOrganizationId(event) {
-    this.args.targetProfile.ownerOrganizationId = event.target.value;
-  }
-
-  @action
-  updateImageUrl(event) {
-    this.args.targetProfile.imageUrl = event.target.value;
-  }
-
-  @action
   updateTubes(tubesWithLevel) {
     this.selectedTubes = tubesWithLevel.map(({ id, level }) => ({
       id,

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -44,18 +44,20 @@
     {{#if this.mustChooseStageType}}
       <PixRadioButton
         name="stageType"
-        @label="Palier par seuil"
         @value="threshold"
         checked={{this.isStageTypeThresholdChecked}}
         {{on "change" this.onStageTypeChange}}
-      />
+      >
+        Palier par seuil
+      </PixRadioButton>
       <PixRadioButton
         name="stageType"
-        @label="Palier par niveau"
         @value="level"
         checked={{this.isStageTypeLevelChecked}}
         {{on "change" this.onStageTypeChange}}
-      />
+      >
+        Palier par niveau
+      </PixRadioButton>
     {{/if}}
     <div class="add-stage-actions">
       <PixButton

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -69,6 +69,7 @@
           @maxlength="500"
           class={{if (v-get this.form "description" "isInvalid") "form-control is-invalid" "form-control"}}
           @value={{this.form.description}}
+          {{on "change" (fn this.updateFormValue "description")}}
         />
       </div>
       <div class="form-field">
@@ -86,6 +87,7 @@
           @maxlength="500"
           class={{if (v-get this.form "comment" "isInvalid") "form-control is-invalid" "form-control"}}
           @value={{this.form.comment}}
+          {{on "change" (fn this.updateFormValue "comment")}}
         />
       </div>
       <div class="form-actions">

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -51,7 +51,7 @@
           @information="L'url à saisir doit être celle d'OVH. Veuillez
             vous rapprocher des équipes tech et produit pour la réalisation de celle-ci."
           @value={{this.form.imageUrl}}
-          {{on "change" this.onImageUrlChanged}}
+          {{on "change" (fn this.updateFormValue "imageUrl")}}
         />
       </div>
       <div class="form-field">

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -93,6 +93,11 @@ export default class UpdateTargetProfile extends Component {
     this.form.imageUrl = event.target.value;
   }
 
+  @action
+  updateFormValue(key, event) {
+    this.form[key] = event.target.value;
+  }
+
   async _updateTargetProfile() {
     const model = this.args.model;
     model.name = this.form.name;

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -89,11 +89,6 @@ export default class UpdateTargetProfile extends Component {
   }
 
   @action
-  onImageUrlChanged(event) {
-    this.form.imageUrl = event.target.value;
-  }
-
-  @action
   updateFormValue(key, event) {
     this.form[key] = event.target.value;
   }

--- a/admin/app/styles/components/certification/candidate-edit-modal.scss
+++ b/admin/app/styles/components/certification/candidate-edit-modal.scss
@@ -28,6 +28,13 @@
       .radio-button-container {
         display: flex;
         gap: 10px;
+
+        // PixUI defines a margin-top to stack radio buttons vertically.
+        // In our case, we want the radio buttons to be stacked horizontally
+        // so we reset the margin-top value.
+        .pix-radio-button + .pix-radio-button {
+          margin-top: 0;
+        }
       }
     }
   }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.7.0",
-        "@1024pix/pix-ui": "^32.0.0",
+        "@1024pix/pix-ui": "34.0.0",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-32.0.0.tgz",
-      "integrity": "sha512-0XuRmP3Tw56m5TinwHMTec+NVo38zRE+j786lOWPicjPUrnxheh866tXP66wsmoMkhxvp75+5U7GbV0RW7rXLw==",
+      "version": "34.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.0.0.tgz",
+      "integrity": "sha512-jWrJSOvTJVGT5nbSSLJNcBUplCOzDMqMlATnUDfYeGiCFc2cM8c7CXxmy1MujRQSAQzvc2yY2hTGyBXh8CuBMg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -36754,9 +36754,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-32.0.0.tgz",
-      "integrity": "sha512-0XuRmP3Tw56m5TinwHMTec+NVo38zRE+j786lOWPicjPUrnxheh866tXP66wsmoMkhxvp75+5U7GbV0RW7rXLw==",
+      "version": "34.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.0.0.tgz",
+      "integrity": "sha512-jWrJSOvTJVGT5nbSSLJNcBUplCOzDMqMlATnUDfYeGiCFc2cM8c7CXxmy1MujRQSAQzvc2yY2hTGyBXh8CuBMg==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.7.0",
-        "@1024pix/pix-ui": "34.0.0",
+        "@1024pix/pix-ui": "35.0.0",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.0.0.tgz",
-      "integrity": "sha512-jWrJSOvTJVGT5nbSSLJNcBUplCOzDMqMlATnUDfYeGiCFc2cM8c7CXxmy1MujRQSAQzvc2yY2hTGyBXh8CuBMg==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
+      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -36754,9 +36754,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-34.0.0.tgz",
-      "integrity": "sha512-jWrJSOvTJVGT5nbSSLJNcBUplCOzDMqMlATnUDfYeGiCFc2cM8c7CXxmy1MujRQSAQzvc2yY2hTGyBXh8CuBMg==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
+      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.7.0",
-        "@1024pix/pix-ui": "35.0.0",
+        "@1024pix/pix-ui": "38.0.0",
         "@1024pix/stylelint-config": "^3.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
-      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-38.0.0.tgz",
+      "integrity": "sha512-p+7qHMgRKpjE5qKHLzruzp5RY4qeT8Sae7YtBmzXaqNpLwpLWRcFXE9Zl908yy/5+rcLqX8FdVUeBLSwPw2QyA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -249,8 +249,7 @@
         "lodash.debounce": "^4.0.8"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -36754,9 +36753,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-35.0.0.tgz",
-      "integrity": "sha512-ZBi/ULblRlYI3TyHhJmjidExSR7M+9mnzllKP5Sf2SlbfTvOFNmLAM05WxgxdwCBeNipiC1LYqWvtivTO/4cbA==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-38.0.0.tgz",
+      "integrity": "sha512-p+7qHMgRKpjE5qKHLzruzp5RY4qeT8Sae7YtBmzXaqNpLwpLWRcFXE9Zl908yy/5+rcLqX8FdVUeBLSwPw2QyA==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.7.0",
-    "@1024pix/pix-ui": "^32.0.0",
+    "@1024pix/pix-ui": "34.0.0",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.7.0",
-    "@1024pix/pix-ui": "34.0.0",
+    "@1024pix/pix-ui": "35.0.0",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.7.0",
-    "@1024pix/pix-ui": "35.0.0",
+    "@1024pix/pix-ui": "38.0.0",
     "@1024pix/stylelint-config": "^3.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Pix Admin utilise une ancienne version de Pix UI dont les boutons de téléversement (PixUploadButton) occupent la largeur totale du conteneur.

## :robot: Proposition
Utiliser la version 38 de Pix UI qui corrige la largeur du PixUploadButton.

## :rainbow: Remarques
RAS

## :100: Pour tester

Se connecter à Pix Admin en tant que SuperAdmin.
Vérifier que les boutons n'occupent pas la largeur de l'écran dans l'onglet `Administration`.
Dans toutes les pages, vérifier le bon affichage de l'ensemble des cases à cocher et des boutons radio.