### PR TITLE
[FEATURE] Configurer les probabilités de choix d'épreuve dans les simulateurs

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -10,6 +10,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   warmpUpLength: Joi.number().integer().min(0),
   forcedCompetencies: Joi.array().items(Joi.string()),
   useObsoleteChallenges: Joi.boolean(),
+  challengePickProbability: Joi.number().min(0).max(100),
 });
 
 const register = async (server) => {

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -38,7 +38,7 @@ async function simulateFlashAssessmentScenario(
     _.range(0, numberOfIterations).map(async (index) => {
       const pickChallenge = dependencies.pickChallengeService.chooseNextChallenge(
         `${assessmentId}-${index}`,
-        challengePickProbability
+        challengePickProbability,
       );
 
       const usecaseParams = _.omitBy(

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -344,6 +344,7 @@ const configuration = (function () {
 
     v3Certification: {
       numberOfChallengesPerCourse: process.env.V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE || 20,
+      defaultProbabilityToPickChallenge: parseInt(process.env.DEFAULT_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
     },
   };
 

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -18,7 +18,7 @@ const pickChallenge = function ({ skills, randomSeed, locale }) {
 
 const chooseNextChallenge = function (
   seed,
-  probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge
+  probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge,
 ) {
   const pseudoRandomContext = pseudoRandom.create(seed);
   return function ({ possibleChallenges }) {

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -3,6 +3,7 @@ import hashInt from 'hash-int';
 import * as pseudoRandom from '../../infrastructure/utils/pseudo-random.js';
 const NON_EXISTING_ITEM = null;
 const VALIDATED_STATUS = 'validé';
+const DEFAULT_PROBABILITY_TO_PICK_CHALLENGE = 51;
 
 const pickChallenge = function ({ skills, randomSeed, locale }) {
   if (skills.length === 0) {
@@ -15,12 +16,10 @@ const pickChallenge = function ({ skills, randomSeed, locale }) {
   return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge);
 };
 
-const chooseNextChallenge = function (seed) {
+const chooseNextChallenge = function (seed, probabilityToPickChallenge = DEFAULT_PROBABILITY_TO_PICK_CHALLENGE) {
   const pseudoRandomContext = pseudoRandom.create(seed);
   return function ({ possibleChallenges }) {
-    const PROBABILITY_TO_BE_PICKED = 51;
-
-    const challengeIndex = pseudoRandomContext.binaryTreeRandom(PROBABILITY_TO_BE_PICKED, possibleChallenges.length);
+    const challengeIndex = pseudoRandomContext.binaryTreeRandom(probabilityToPickChallenge, possibleChallenges.length);
 
     return possibleChallenges[challengeIndex];
   };

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import hashInt from 'hash-int';
 import * as pseudoRandom from '../../infrastructure/utils/pseudo-random.js';
+import { config } from '../../config.js';
 const NON_EXISTING_ITEM = null;
 const VALIDATED_STATUS = 'validé';
-const DEFAULT_PROBABILITY_TO_PICK_CHALLENGE = 51;
 
 const pickChallenge = function ({ skills, randomSeed, locale }) {
   if (skills.length === 0) {
@@ -16,7 +16,10 @@ const pickChallenge = function ({ skills, randomSeed, locale }) {
   return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge);
 };
 
-const chooseNextChallenge = function (seed, probabilityToPickChallenge = DEFAULT_PROBABILITY_TO_PICK_CHALLENGE) {
+const chooseNextChallenge = function (
+  seed,
+  probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge
+) {
   const pseudoRandomContext = pseudoRandom.create(seed);
   return function ({ possibleChallenges }) {
     const challengeIndex = pseudoRandomContext.binaryTreeRandom(probabilityToPickChallenge, possibleChallenges.length);

--- a/api/sample.env
+++ b/api/sample.env
@@ -708,6 +708,13 @@ TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
 # default: 20
 V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE=
 
+# Probability to pick a challenge amongst others
+#
+# presence: optional
+# type: Integer
+# default: 51
+DEFAULT_PROBABILITY_TO_PICK_CHALLENGE=
+
 # ========
 # MAX REACHABLE LEVEL
 # ========

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -159,7 +159,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
               challengePickProbability,
             },
             null,
-            { 'accept-language': 'en' }
+            { 'accept-language': 'en' },
           );
 
           // then
@@ -178,7 +178,7 @@ describe('Integration | Application | Scoring-simulator | scenario-simulator-con
                   discriminant: challenge1.discriminant,
                 },
               ],
-            ])
+            ]),
           );
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, dans le cadre de l’algorithme Flash, les probabilités de choix d’une épreuve parmi les 5 meilleurs épreuves sont fixée à 51% pour la première épreuve.

Les épreuves sont choisies comme suit :
51% de chance de choisir la première épreuve.
Si la première épreuve n’est pas choisie, 51% de choisir la deuxième et ainsi de suite.

L'équipe data souhaiterai tester de nouvelles probabilités pour étudier leur influence.

## :robot: Proposition
Ajout d'un paramètre dans la requête du simulateur permettant de configurer cette probabilité

## :100: Pour tester
```
TOKEN=$(curl 'https://api-pr6581.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr6581.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity","assessmentId": "1234", "capacity": 1.5, "challengePickProbability": 40 }' | jq '.'
```

