### PR TITLE
[TECH] Refacto de l'API /habilitations pour les complémentaires (PIX-8631).

### DIFF
--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -14,7 +14,7 @@ export default class CertificationCenter extends Model {
   @attr() dataProtectionOfficerLastName;
   @attr() dataProtectionOfficerEmail;
 
-  @hasMany('habilitation') habilitations;
+  @hasMany('complementary-certification') habilitations;
 
   get typeLabel() {
     return types.find((type) => type.value === this.type).label;

--- a/admin/app/models/complementary-certification.js
+++ b/admin/app/models/complementary-certification.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
-export default class Habilitation extends Model {
+export default class ComplementaryCertification extends Model {
   @attr() key;
   @attr() label;
 }

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -8,7 +8,7 @@ export default class CertificationCentersGetRoute extends Route {
 
   async model(params) {
     const certificationCenter = await this.store.findRecord('certification-center', params.certification_center_id);
-    const habilitations = await this.store.findAll('habilitation');
+    const habilitations = await this.store.findAll('complementary-certification');
 
     return RSVP.hash({
       certificationCenter,

--- a/admin/app/routes/authenticated/certification-centers/new.js
+++ b/admin/app/routes/authenticated/certification-centers/new.js
@@ -8,7 +8,7 @@ export default class NewRoute extends Route {
   model() {
     return RSVP.hash({
       certificationCenter: this.store.createRecord('certification-center'),
-      habilitations: this.store.findAll('habilitation'),
+      habilitations: this.store.findAll('complementary-certification'),
     });
   }
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -400,8 +400,8 @@ export default function () {
     return schema.countries.all();
   });
 
-  this.get('/habilitations', (schema) => {
-    return schema.habilitations.all();
+  this.get('/complementary-certifications', (schema) => {
+    return schema.complementaryCertifications.all();
   });
 
   this.put('/admin/sessions/:id/comment', (schema, request) => {

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -20,8 +20,8 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     });
     await createAuthenticateSession({ userId });
 
-    server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
-    server.create('habilitation', { key: 'A', label: 'Pix+Autre' });
+    server.create('complementary-certification', { key: 'S', label: 'Pix+Surf' });
+    server.create('complementary-certification', { key: 'A', label: 'Pix+Autre' });
 
     const name = 'name';
     const type = { label: 'Organisation professionnelle', value: 'PRO' };

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -48,8 +48,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   test('should display Certification center habilitations', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const habilitation1 = server.create('habilitation', { key: 'E', label: 'Pix+Edu' });
-    const habilitation2 = server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
+    const habilitation1 = server.create('complementary-certification', { key: 'E', label: 'Pix+Edu' });
+    const habilitation2 = server.create('complementary-certification', { key: 'S', label: 'Pix+Surf' });
 
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
@@ -69,8 +69,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   test('should highlight the habilitations of the current certification center', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const habilitation1 = server.create('habilitation', { key: 'E', label: 'Pix+Edu' });
-    const habilitation2 = server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
+    const habilitation1 = server.create('complementary-certification', { key: 'E', label: 'Pix+Edu' });
+    const habilitation2 = server.create('complementary-certification', { key: 'S', label: 'Pix+Surf' });
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
       externalId: 'ABCDEF',
@@ -78,7 +78,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       habilitations: [habilitation1, habilitation2],
     });
 
-    server.create('habilitation', { key: 'S', label: 'Pix+Autre' });
+    server.create('complementary-certification', { key: 'S', label: 'Pix+Autre' });
 
     // when
     const screen = await visit(`/certification-centers/${certificationCenter.id}`);
@@ -151,8 +151,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         externalId: 'ABCDEF',
         type: 'SCO',
       });
-      server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
-      server.create('habilitation', { key: 'A', label: 'Pix+Autre' });
+      server.create('complementary-certification', { key: 'S', label: 'Pix+Surf' });
+      server.create('complementary-certification', { key: 'A', label: 'Pix+Autre' });
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Editer les informations');

--- a/admin/tests/integration/components/certification-centers/creation-form_test.js
+++ b/admin/tests/integration/components/certification-centers/creation-form_test.js
@@ -59,8 +59,8 @@ module('Integration | Component | certification-centers/creation-form', function
     test('should add habilitation to certification center on checked checkbox', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const habilitation1 = store.createRecord('habilitation', { key: 'E', label: 'Pix+Edu' });
-      const habilitation2 = store.createRecord('habilitation', { key: 'S', label: 'Pix+Surf' });
+      const habilitation1 = store.createRecord('complementary-certification', { key: 'E', label: 'Pix+Edu' });
+      const habilitation2 = store.createRecord('complementary-certification', { key: 'S', label: 'Pix+Surf' });
       this.certificationCenter = store.createRecord('certification-center');
       this.habilitations = EmberArray([habilitation1, habilitation2]);
       this.stub = () => {};
@@ -84,8 +84,8 @@ module('Integration | Component | certification-centers/creation-form', function
     test('should remove habilitation to certification center on unchecked checkbox', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const habilitation1 = store.createRecord('habilitation', { key: 'E', label: 'Pix+Edu' });
-      const habilitation2 = store.createRecord('habilitation', { key: 'S', label: 'Pix+Surf' });
+      const habilitation1 = store.createRecord('complementary-certification', { key: 'E', label: 'Pix+Edu' });
+      const habilitation2 = store.createRecord('complementary-certification', { key: 'S', label: 'Pix+Surf' });
       this.certificationCenter = store.createRecord('certification-center', {
         habilitations: [habilitation2],
       });

--- a/admin/tests/integration/components/certification-centers/information-view_test.js
+++ b/admin/tests/integration/components/certification-centers/information-view_test.js
@@ -7,8 +7,8 @@ import ArrayProxy from '@ember/array/proxy';
 function _createEmberDataHabilitations(store) {
   return ArrayProxy.create({
     content: [
-      store.createRecord('habilitation', { id: 0, key: 'DROIT', label: 'Pix+Droit' }),
-      store.createRecord('habilitation', { id: 1, key: 'CLEA', label: 'Cléa' }),
+      store.createRecord('complementary-certification', { id: 0, key: 'DROIT', label: 'Pix+Droit' }),
+      store.createRecord('complementary-certification', { id: 1, key: 'CLEA', label: 'Cléa' }),
     ],
   });
 }

--- a/admin/tests/unit/routes/authenticated/certification-centers/get_test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get_test.js
@@ -15,7 +15,7 @@ module('Unit | Route | authenticated/certification-centers/get', function (hooks
     store.findRecord = sinon.stub();
     store.findRecord.withArgs('certification-center', 777).resolves(certificationCenter);
     store.findAll = sinon.stub();
-    store.findAll.withArgs('habilitation').resolves(habilitations);
+    store.findAll.withArgs('complementary-certification').resolves(habilitations);
 
     // when
     const result = await route.model({ certification_center_id: 777 });

--- a/api/lib/application/complementary-certifications/index.js
+++ b/api/lib/application/complementary-certifications/index.js
@@ -5,7 +5,7 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/habilitations',
+      path: '/api/complementary-certifications',
       config: {
         pre: [
           {
@@ -20,7 +20,7 @@ const register = async function (server) {
           },
         ],
         handler: complementaryCertificationController.findComplementaryCertifications,
-        tags: ['api'],
+        tags: ['api', 'admin'],
         notes: [
           'Cette route est utilisée par Pix Admin',
           'Elle renvoie la liste des certifications complémentaires existantes.',

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
@@ -31,6 +31,9 @@ const serialize = function (certificationCenters, meta) {
       'dataProtectionOfficerEmail',
       'habilitations',
     ],
+    typeForAttribute: (attribute) => {
+      if (attribute === 'habilitations') return 'complementary-certifications';
+    },
     certificationCenterMemberships: {
       ref: 'id',
       ignoreRelationshipData: true,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
@@ -7,6 +7,9 @@ import { CertificationCenter } from '../../../domain/models/CertificationCenter.
 const serialize = function (certificationCenters, meta) {
   return new Serializer('certification-center', {
     attributes: ['name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships', 'habilitations'],
+    typeForAttribute: (attribute) => {
+      if (attribute === 'habilitations') return 'complementary-certifications';
+    },
     certificationCenterMemberships: {
       ref: 'id',
       ignoreRelationshipData: true,

--- a/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -4,10 +4,10 @@ const { Serializer } = jsonapiSerializer;
 
 import { ComplementaryCertification } from '../../../domain/models/ComplementaryCertification.js';
 
-const serialize = function (habilitation) {
-  return new Serializer('habilitation', {
+const serialize = function (complementaryCertifications) {
+  return new Serializer('complementary-certification', {
     attributes: ['label', 'key'],
-  }).serialize(habilitation);
+  }).serialize(complementaryCertifications);
 };
 
 const deserialize = function (jsonAPI) {

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -85,7 +85,7 @@ describe('Acceptance | API | Certification Center', function () {
                   data: [
                     {
                       id: '12',
-                      type: 'habilitations',
+                      type: 'complementary-certifications',
                     },
                   ],
                 },
@@ -120,7 +120,7 @@ describe('Acceptance | API | Certification Center', function () {
           included: [
             {
               id: '12',
-              type: 'habilitations',
+              type: 'complementary-certifications',
               attributes: {
                 label: 'Pix+Edu 1er degré',
                 key: 'EDU_1ER_DEGRE',
@@ -196,7 +196,7 @@ describe('Acceptance | API | Certification Center', function () {
                 habilitations: {
                   data: [
                     {
-                      type: 'habilitations',
+                      type: 'complementary-certifications',
                       id: `${complementaryCertification.id}`,
                     },
                   ],
@@ -234,7 +234,7 @@ describe('Acceptance | API | Certification Center', function () {
                 habilitations: {
                   data: [
                     {
-                      type: 'habilitations',
+                      type: 'complementary-certifications',
                       id: `${complementaryCertification.id}`,
                     },
                   ],

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -15,13 +15,13 @@ describe('Acceptance | API | complementary-certification-controller', function (
     server = await createServer();
   });
 
-  describe('GET /api/habilitations/', function () {
+  describe('GET /api/complementary-certifications/', function () {
     it('should return 200 HTTP status code', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
       const options = {
         method: 'GET',
-        url: '/api/habilitations',
+        url: '/api/complementary-certifications',
         headers: {
           authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
         },
@@ -46,7 +46,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
       expect(response.result).to.deep.equal({
         data: [
           {
-            type: 'habilitations',
+            type: 'complementary-certifications',
             id: '1',
             attributes: {
               label: 'Pix+ Edu 1er degré',
@@ -54,7 +54,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
             },
           },
           {
-            type: 'habilitations',
+            type: 'complementary-certifications',
             id: '2',
             attributes: {
               label: 'Cléa Numérique',

--- a/api/tests/unit/application/complementary-certifications/index_test.js
+++ b/api/tests/unit/application/complementary-certifications/index_test.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../../lib/application/security-pre-ha
 import * as moduleUnderTest from '../../../../lib/application/complementary-certifications/index.js';
 
 describe('Unit | Application | Router | complementary-certifications-router', function () {
-  describe('GET /api/habilitations', function () {
+  describe('GET /api/complementary-certifications', function () {
     it('should return 403 HTTP status code when the user authenticated is not SuperAdmin', async function () {
       // given
       sinon
@@ -15,7 +15,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/habilitations');
+      const response = await httpTestServer.request('GET', '/api/complementary-certifications');
 
       // then
       expect(response.statusCode).to.equal(403);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
@@ -89,7 +89,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
               data: [
                 {
                   id: '1',
-                  type: 'habilitations',
+                  type: 'complementary-certifications',
                 },
               ],
             },
@@ -98,7 +98,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
         included: [
           {
             id: '1',
-            type: 'habilitations',
+            type: 'complementary-certifications',
             attributes: {
               key: 'SURF',
               label: 'Pix+surf',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
@@ -39,7 +39,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
               data: [
                 {
                   id: '1',
-                  type: 'habilitations',
+                  type: 'complementary-certifications',
                 },
               ],
             },
@@ -48,7 +48,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
         included: [
           {
             id: '1',
-            type: 'habilitations',
+            type: 'complementary-certifications',
             attributes: {
               key: 'SURF',
               label: 'Pix+surf',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
@@ -26,7 +26,7 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
         data: [
           {
             id: '11',
-            type: 'habilitations',
+            type: 'complementary-certifications',
             attributes: {
               label: 'Pix+Edu',
               key: 'EDU',
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
           },
           {
             id: '22',
-            type: 'habilitations',
+            type: 'complementary-certifications',
             attributes: {
               label: 'Cléa Numérique',
               key: 'CLEA',


### PR DESCRIPTION
## :unicorn: Problème

- L'API qui s'appelle `/habilitations` renvoie la liste des certifications complémentaires
- Un nouvel usage dans le cadre de l'affichage de la liste des certif complémentaires rend ce nom de endpoint incohérent
- Cela s'applique notamment au type de la réponse par json-api

## :robot: Proposition

- Remplacer `/habilitations` par `/complementary-certifications`
- Renommer le type json api

## :rainbow: Remarques

- A noter que le terme 'habilitations' reste utilisé dans Pix Admin dans le sens où il désigne le(s) complémentaire(s) que un centre est habilité à passer

## :100: Pour tester

### Pix Admin

- Pix Admin avec le compte superadmin@example.net
- Afficher la liste des centres de certifications
- Créer un nouveau centre avec au moins une certification complémentaires habilitée
- Vérification que la coche est verte après validation
- Editer, modifier les certifications complémentaires habilitées
