### PR TITLE
[TECH] Harmoniser le nommage des Github actions

### DIFF
--- a/.github/workflows/check-api-config-changed-dev.yaml
+++ b/.github/workflows/check-api-config-changed-dev.yaml
@@ -1,4 +1,5 @@
-name: Notify team if API configuration file has been changed
+name: Notify team if API configuration file has been changed on dev
+
 on:
   push:
     branches:

--- a/.github/workflows/notify-api-configuration-changed.yaml
+++ b/.github/workflows/notify-api-configuration-changed.yaml
@@ -1,4 +1,4 @@
-name: Merge on Dev
+name: Notify team if API configuration file has been changed
 on:
   push:
     branches:
@@ -9,11 +9,11 @@ permissions:
   pull-requests: read
 
 jobs:
-  notify-team:
-    name: Notify team on config file changed
+  check-and-notify:
+    name: Check and notify
     runs-on: ubuntu-latest
     steps:
-      - name: Notify team on config file change
+      - name: Run external action
         uses: 1024pix/notify-team-on-config-file-change@v1
         with:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## :unicorn: Problème
3 Github actions portent le nom de ce qu'elles font.
1 Github action porte le nom de l'évènement déclencheur.

## :robot: Proposition
La renommer pour qu'elle porte le nom de ce qu'elle fait.

## :100: Pour tester
Merger et vérifier le résultat https://github.com/1024pix/pix/actions
