### PR TITLE
[FEATURE] Ajoute la création d'une campagne à partir d'une campagne existante (PIX-8622).

### DIFF
--- a/api/db/seeds/data/team-prescription/build-campaigns.js
+++ b/api/db/seeds/data/team-prescription/build-campaigns.js
@@ -1,0 +1,28 @@
+import { SCO_ORGANIZATION_ID, SCO_ORGANIZATION_USER_ID } from './constants.js';
+
+function _createScoCampaigns(databaseBuilder) {
+  databaseBuilder.factory.buildCampaign({
+    organizationId: SCO_ORGANIZATION_ID,
+    ownerId: SCO_ORGANIZATION_USER_ID,
+    name: "Campagne d'évaluation SCO",
+  });
+  databaseBuilder.factory.buildCampaign({
+    organizationId: SCO_ORGANIZATION_ID,
+    ownerId: SCO_ORGANIZATION_USER_ID,
+    name: 'Campagne de collecte de profil SCO - envoi simple',
+    type: 'PROFILES_COLLECTION',
+    title: null,
+  });
+  databaseBuilder.factory.buildCampaign({
+    organizationId: SCO_ORGANIZATION_ID,
+    ownerId: SCO_ORGANIZATION_USER_ID,
+    name: 'Campagne de collecte de profil SCO - envoi multiple',
+    type: 'PROFILES_COLLECTION',
+    title: null,
+    multipleSendings: true,
+  });
+}
+
+export function buildCampaigns(databaseBuilder) {
+  _createScoCampaigns(databaseBuilder);
+}

--- a/api/db/seeds/data/team-prescription/build-organization.js
+++ b/api/db/seeds/data/team-prescription/build-organization.js
@@ -8,7 +8,7 @@ function _createScoOrganization(databaseBuilder) {
     isManagingStudents: false,
     externalId: 'PRESCRIPTION',
   });
-  databaseBuilder.factory.buildUser({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: SCO_ORGANIZATION_USER_ID,
     firstName: 'Orga Sco',
     lastName: 'Team Prescription',
@@ -17,6 +17,7 @@ function _createScoOrganization(databaseBuilder) {
     lang: 'fr',
     rawPassword: DEFAULT_PASSWORD,
     shouldChangePassword: false,
+    pixOrgaTermsOfServiceAccepted: true,
   });
   databaseBuilder.factory.buildMembership({
     userId: SCO_ORGANIZATION_USER_ID,

--- a/api/db/seeds/data/team-prescription/data-builder.js
+++ b/api/db/seeds/data/team-prescription/data-builder.js
@@ -1,7 +1,9 @@
+import { buildCampaigns } from './build-campaigns.js';
 import { buildOrganizations } from './build-organization.js';
 
 async function teamPrescriptionDataBuilder({ databaseBuilder }) {
   buildOrganizations(databaseBuilder);
+  buildCampaigns(databaseBuilder);
 }
 
 export { teamPrescriptionDataBuilder };

--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -65,6 +65,13 @@ Fonctionnalité: Gestion des Campagnes
     Et je clique sur "Créer la campagne"
     Alors je vois le détail de la campagne "Campagne de l'Ouest"
 
+  Scénario: Je duplique une campagne d'évaluation
+    Étant donné que je suis connecté à Pix Orga
+    Lorsque je duplique la campagne "1"
+    Alors je suis redirigé vers la page "creation"
+    Et je clique sur "Créer la campagne"
+    Alors je vois le détail de la campagne "Copie de Campagne de la Néra"
+
   Scénario: J'archive et je désarchive une campagne
     Étant donné que je suis connecté à Pix Orga
     Et je clique sur "Campagne du Mur"

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -2,36 +2,46 @@ When(`je vais sur la page d'accès à une campagne`, () => {
   cy.visitMonPix(`/campagnes`);
 });
 
-When(`je vais sur la campagne {string} avec l'identifiant {string}`, (campaignCode, participantExternalId) => {
-  cy.visitMonPix(`/campagnes/${campaignCode}?participantExternalId=${participantExternalId}`);
-});
+When(
+  `je vais sur la campagne {string} avec l'identifiant {string}`,
+  (campaignCode, participantExternalId) => {
+    cy.visitMonPix(
+      `/campagnes/${campaignCode}?participantExternalId=${participantExternalId}`
+    );
+  }
+);
 
 When(`j'ouvre le sujet {string}`, (tubeName) => {
-  cy.contains(tubeName).closest('[aria-label="Sujet"]').within(() => {
-    cy.get('button').click();
-  });
+  cy.contains(tubeName)
+    .closest('[aria-label="Sujet"]')
+    .within(() => {
+      cy.get("button").click();
+    });
 });
 
 Then(`je vois la page \(d'\)/\(de \){string} de la campagne`, (page) => {
-  cy.url().should('include', page);
+  cy.url().should("include", page);
 });
 
-When(`je saisis la date de naissance {int}-{int}-{int}`, (dayOfBirth, monthOfBirth, yearOfBirth) => {
-  cy.get('input#dayOfBirth').type(dayOfBirth);
-  cy.get('input#monthOfBirth').type(monthOfBirth);
-  cy.get('input#yearOfBirth').type(yearOfBirth);
-});
+When(
+  `je saisis la date de naissance {int}-{int}-{int}`,
+  (dayOfBirth, monthOfBirth, yearOfBirth) => {
+    cy.get("input#dayOfBirth").type(dayOfBirth);
+    cy.get("input#monthOfBirth").type(monthOfBirth);
+    cy.get("input#yearOfBirth").type(yearOfBirth);
+  }
+);
 
 Then(`je vois {int} campagne\(s\)`, (campaignsCount) => {
-  cy.get('[aria-label="Campagne"]').should('have.lengthOf', campaignsCount);
+  cy.get('[aria-label="Campagne"]').should("have.lengthOf", campaignsCount);
 });
 
 Then(`je vois {int} tutoriel\(s\)`, (tutorialsCount) => {
-  cy.get('[aria-label="Tutoriel"]').should('have.lengthOf', tutorialsCount);
+  cy.get('[aria-label="Tutoriel"]').should("have.lengthOf", tutorialsCount);
 });
 
 When(`je recherche une campagne avec le nom {string}`, (campaignSearchName) => {
-  cy.get('input#name').type(campaignSearchName);
+  cy.get("input#name").type(campaignSearchName);
 });
 
 Then(`je vois le détail de la campagne {string}`, (campaignName) => {
@@ -39,56 +49,88 @@ Then(`je vois le détail de la campagne {string}`, (campaignName) => {
 });
 
 Then(`je vois {int} participants`, (numberOfParticipants) => {
-  cy.get('[aria-label="Participant"]').should('have.lengthOf', numberOfParticipants);
+  cy.get('[aria-label="Participant"]').should(
+    "have.lengthOf",
+    numberOfParticipants
+  );
 });
 
 Then(`je vois {int} profils`, (numberOfProfiles) => {
-  cy.get('[aria-label="Profil"]').should('have.lengthOf', numberOfProfiles);
+  cy.get('[aria-label="Profil"]').should("have.lengthOf", numberOfProfiles);
 });
 
-When(`je vois {int} résultats par compétence`, (numberOfResultsByCompetence) => {
-  if(numberOfResultsByCompetence === 0) {
-    cy.get('.table__empty').should('contain', 'En attente de résultat');
-  } else {
-    cy.get('[aria-label="Compétence"]').should('have.lengthOf', numberOfResultsByCompetence);
+When(
+  `je vois {int} résultats par compétence`,
+  (numberOfResultsByCompetence) => {
+    if (numberOfResultsByCompetence === 0) {
+      cy.get(".table__empty").should("contain", "En attente de résultat");
+    } else {
+      cy.get('[aria-label="Compétence"]').should(
+        "have.lengthOf",
+        numberOfResultsByCompetence
+      );
+    }
   }
-});
+);
 
-When(`je vois {int} résultats pour la compétence`, (numberOfResultsByCompetence) => {
-  cy.get('.skill-review-competence__row').should('have.lengthOf', numberOfResultsByCompetence);
-});
+When(
+  `je vois {int} résultats pour la compétence`,
+  (numberOfResultsByCompetence) => {
+    cy.get(".skill-review-competence__row").should(
+      "have.lengthOf",
+      numberOfResultsByCompetence
+    );
+  }
+);
 
-When(`je vois la formation recommandée ayant le titre {string}`, (trainingName) => {
-  cy.get('.training-card-content__title').should('contain', trainingName);
-});
+When(
+  `je vois la formation recommandée ayant le titre {string}`,
+  (trainingName) => {
+    cy.get(".training-card-content__title").should("contain", trainingName);
+  }
+);
 
 Then(`je vois la moyenne des résultats à {int}%`, (averageResult) => {
-  cy.contains('Résultat moyen').parents().within(() => cy.contains(`${averageResult} %`));
+  cy.contains("Résultat moyen")
+    .parents()
+    .within(() => cy.contains(`${averageResult} %`));
 });
 
 Then(`je vois un résultat global à {int}%`, (globalResult) => {
-  cy.get('[aria-label="Résultat global"]').invoke('text').then((text) => {
-    //TODO: update cypress to handle insecable space https://glebbahmutov.com/cypress-examples/6.5.0/recipes/non-breaking-space.html#via-cy-contains
-    expect(text.replace(/\u00a0/g, ' ')).contains(`${globalResult} %`);
-  });
+  cy.get('[aria-label="Résultat global"]')
+    .invoke("text")
+    .then((text) => {
+      //TODO: update cypress to handle insecable space https://glebbahmutov.com/cypress-examples/6.5.0/recipes/non-breaking-space.html#via-cy-contains
+      expect(text.replace(/\u00a0/g, " ")).contains(`${globalResult} %`);
+    });
 });
 
 Then(`je vois que j'ai partagé mon profil`, () => {
-  cy.contains('Merci, votre profil a bien été envoyé !');
+  cy.contains("Merci, votre profil a bien été envoyé !");
 });
 
 Then(`je vois que j'ai envoyé les résultats`, () => {
-  cy.contains('Merci, vos résultats ont bien été envoyés !');
+  cy.contains("Merci, vos résultats ont bien été envoyés !");
 });
 
 Then(`je vois {int} sujets`, (tubeCount) => {
-  cy.get('[aria-label="Sujet"]').should('have.lengthOf', tubeCount);
+  cy.get('[aria-label="Sujet"]').should("have.lengthOf", tubeCount);
 });
 
-Then(`je vois que le sujet {string} est {string}`, (tubeName, recommendationLevel) => {
-  cy.contains(tubeName).closest('[aria-label="Sujet"]').get(`[aria-label="${recommendationLevel}"]`);
-});
+Then(
+  `je vois que le sujet {string} est {string}`,
+  (tubeName, recommendationLevel) => {
+    cy.contains(tubeName)
+      .closest('[aria-label="Sujet"]')
+      .get(`[aria-label="${recommendationLevel}"]`);
+  }
+);
 
 When('je clique sur le bouton "Associer"', () => {
-  cy.contains('button', 'Associer').click();
+  cy.contains("button", "Associer").click();
+});
+
+When(`je duplique la campagne {string}`, (id) => {
+  const urn = `/campagnes/creation?source=${id}`;
+  cy.visitOrga(urn);
 });

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -29,7 +29,7 @@
     <PixSelect
       @options={{this.campaignOwnerOptions}}
       @onChange={{this.onChangeCampaignOwner}}
-      @value={{this.ownerId}}
+      @value="{{this.campaign.ownerId}}"
       @isSearchable={{true}}
       @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
       @searchLabel={{t "pages.campaign-creation.owner.search-placeholder"}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -14,6 +14,7 @@
       class="input"
       maxlength="255"
       {{on "change" this.onChangeCampaignName}}
+      @value={{this.campaign.name}}
       required={{true}}
       aria-required={{true}}
     />
@@ -59,6 +60,7 @@
         @value="assess-participants"
         {{on "change" this.setCampaignGoal}}
         aria-describedby="campaign-goal-assessment-info"
+        checked={{this.isCampaignGoalAssessment}}
       >
         {{t "pages.campaign-creation.purpose.assessment"}}
       </PixRadioButton>
@@ -68,6 +70,7 @@
         @value="collect-participants-profile"
         {{on "change" this.setCampaignGoal}}
         aria-describedby="campaign-goal-profiles-collection-info"
+        checked={{this.isCampaignGoalProfileCollection}}
       >
         {{t "pages.campaign-creation.purpose.profiles-collection"}}
       </PixRadioButton>
@@ -108,26 +111,26 @@
         @onChange={{this.selectTargetProfile}}
         @categoriesLabel={{t "pages.campaign-creation.target-profiles-category-label"}}
         @categoriesPlaceholder={{t "pages.campaign-creation.target-profiles-category-placeholder"}}
-        @value={{this.targetProfile.id}}
+        @value={{this.campaign.targetProfile.id}}
         @requiredText={{t "common.form.mandatory-fields-title"}}
         @errorMessage={{if @errors.targetProfile (t "api-error-messages.campaign-creation.target-profile-required")}}
         @isSearchable={{true}}
         @searchLabel={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
       />
-      {{#if this.targetProfile}}
+      {{#if this.campaign.targetProfile}}
         <div class="form__field-info" id="target-profile-info">
           <span class="form__field-info-title">
             <FaIcon @icon="circle-info" class="form__field-info-icon" />
-            <span>{{this.targetProfile.name}}</span>
+            <span>{{this.campaign.targetProfile.name}}</span>
           </span>
 
           <Campaign::TargetProfileDetails
             class="form__field-info-message"
-            @targetProfileDescription={{this.targetProfile.description}}
-            @hasStages={{this.targetProfile.hasStage}}
-            @hasBadges={{gt this.targetProfile.thematicResultCount 0}}
-            @targetProfileTubesCount={{this.targetProfile.tubeCount}}
-            @targetProfileThematicResultCount={{this.targetProfile.thematicResultCount}}
+            @targetProfileDescription={{this.campaign.targetProfile.description}}
+            @hasStages={{this.campaign.targetProfile.hasStage}}
+            @hasBadges={{gt this.campaign.targetProfile.thematicResultCount 0}}
+            @targetProfileTubesCount={{this.campaign.targetProfile.tubeCount}}
+            @targetProfileThematicResultCount={{this.campaign.targetProfile.thematicResultCount}}
           />
         </div>
       {{/if}}
@@ -146,6 +149,7 @@
           @value="false"
           {{on "change" (fn this.selectMultipleSendingsStatus false)}}
           aria-describedby="multiple-sendings-info"
+          checked={{not this.campaign.multipleSendings}}
         >
           {{t "pages.campaign-creation.no"}}
         </PixRadioButton>
@@ -155,6 +159,7 @@
           @value="true"
           {{on "change" (fn this.selectMultipleSendingsStatus true)}}
           aria-describedby="multiple-sendings-info"
+          checked={{this.campaign.multipleSendings}}
         >
           {{t "pages.campaign-creation.yes"}}
         </PixRadioButton>
@@ -175,10 +180,20 @@
       <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
       {{t "pages.campaign-creation.external-id-label.question-label"}}
     </p>
-    <PixRadioButton name="external-id-label" @value="false" {{on "change" this.doNotAskLabelIdPix}}>
+    <PixRadioButton
+      name="external-id-label"
+      @value="false"
+      {{on "change" this.doNotAskLabelIdPix}}
+      checked={{this.isExternalIdNotSelectedChecked}}
+    >
       {{t "pages.campaign-creation.no"}}
     </PixRadioButton>
-    <PixRadioButton name="external-id-label" @value="true" {{on "change" this.askLabelIdPix}}>
+    <PixRadioButton
+      name="external-id-label"
+      @value="true"
+      {{on "change" this.askLabelIdPix}}
+      checked={{this.isExternalIdSelectedChecked}}
+    >
       {{t "pages.campaign-creation.yes"}}
     </PixRadioButton>
   </div>
@@ -193,6 +208,7 @@
         maxlength="255"
         @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
         {{on "change" this.onChangeExternalIdLabel}}
+        @value={{this.campaign.idPixLabel}}
       />
       {{#if @errors.idPixLabel}}
         <div class="form__error error-message">
@@ -210,6 +226,7 @@
         @name="campaign-title"
         maxlength="50"
         {{on "change" this.onChangeCampaignTitle}}
+        @value={{this.campaign.title}}
       />
     </div>
   {{/if}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -13,7 +13,7 @@
       type="text"
       class="input"
       maxlength="255"
-      {{on "change" this.onChangeCampaignName}}
+      {{on "change" (fn this.onChangeCampaignValue "name")}}
       @value={{this.campaign.name}}
       required={{true}}
       aria-required={{true}}
@@ -207,7 +207,7 @@
         @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
         @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
-        {{on "change" this.onChangeExternalIdLabel}}
+        {{on "change" (fn this.onChangeCampaignValue "idPixLabel")}}
         @value={{this.campaign.idPixLabel}}
       />
       {{#if @errors.idPixLabel}}
@@ -225,7 +225,7 @@
         @id="campaign-title"
         @name="campaign-title"
         maxlength="50"
-        {{on "change" this.onChangeCampaignTitle}}
+        {{on "change" (fn this.onChangeCampaignValue "title")}}
         @value={{this.campaign.title}}
       />
     </div>

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -9,7 +9,7 @@ export default class CreateForm extends Component {
   @service intl;
 
   @tracked campaign;
-  @tracked wantIdPix = false;
+  @tracked wantIdPix = Boolean(this.campaign.idPixLabel);
   @tracked multipleSendingsEnabled = true;
   @tracked targetProfile;
   @tracked targetProfilesOptions = [];
@@ -65,6 +65,14 @@ export default class CreateForm extends Component {
 
   get isCampaignGoalProfileCollection() {
     return this.campaign.type === 'PROFILES_COLLECTION';
+  }
+
+  get isExternalIdNotSelectedChecked() {
+    return this.campaign.idPixLabel === null;
+  }
+
+  get isExternalIdSelectedChecked() {
+    return this.wantIdPix === true;
   }
 
   @action

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -110,18 +110,8 @@ export default class CreateForm extends Component {
   }
 
   @action
-  onChangeCampaignName(event) {
-    this.campaign.name = event.target.value;
-  }
-
-  @action
-  onChangeExternalIdLabel(event) {
-    this.campaign.idPixLabel = event.target.value;
-  }
-
-  @action
-  onChangeCampaignTitle(event) {
-    this.campaign.title = event.target.value;
+  onChangeCampaignValue(key, event) {
+    this.campaign[key] = event.target.value;
   }
 
   @action

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -11,7 +11,6 @@ export default class CreateForm extends Component {
   @tracked campaign;
   @tracked wantIdPix = Boolean(this.campaign.idPixLabel);
   @tracked multipleSendingsEnabled = true;
-  @tracked targetProfile;
   @tracked targetProfilesOptions = [];
 
   constructor() {

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -10,7 +10,6 @@ export default class CreateForm extends Component {
 
   @tracked campaign;
   @tracked wantIdPix = Boolean(this.campaign.idPixLabel);
-  @tracked multipleSendingsEnabled = true;
   @tracked targetProfilesOptions = [];
 
   constructor() {
@@ -95,7 +94,6 @@ export default class CreateForm extends Component {
 
   @action
   selectMultipleSendingsStatus(value) {
-    this.multipleSendingsEnabled = value;
     this.campaign.multipleSendings = value;
   }
 

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -13,13 +13,11 @@ export default class CreateForm extends Component {
   @tracked multipleSendingsEnabled = true;
   @tracked targetProfile;
   @tracked targetProfilesOptions = [];
-  @tracked ownerId;
 
   constructor() {
     super(...arguments);
     this.campaign = this.args.campaign;
     this._setTargetProfilesOptions(this.args.targetProfiles);
-    this.ownerId = this.currentUser.prescriber.id;
     this.isMultipleSendingAssessmentEnabled = this.currentUser.prescriber.enableMultipleSendingAssessment;
   }
 

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -11,8 +11,6 @@ export default class CreateForm extends Component {
   @tracked campaign;
   @tracked wantIdPix = false;
   @tracked multipleSendingsEnabled = true;
-  @tracked isCampaignGoalAssessment = null;
-  @tracked isCampaignGoalProfileCollection = null;
   @tracked targetProfile;
   @tracked targetProfilesOptions = [];
   @tracked ownerId;
@@ -65,6 +63,14 @@ export default class CreateForm extends Component {
     }
   }
 
+  get isCampaignGoalAssessment() {
+    return this.campaign.type === 'ASSESSMENT';
+  }
+
+  get isCampaignGoalProfileCollection() {
+    return this.campaign.type === 'PROFILES_COLLECTION';
+  }
+
   @action
   askLabelIdPix() {
     this.wantIdPix = true;
@@ -92,16 +98,12 @@ export default class CreateForm extends Component {
   @action
   setCampaignGoal(event) {
     if (event.target.value === 'collect-participants-profile') {
-      this.isCampaignGoalAssessment = false;
-      this.isCampaignGoalProfileCollection = true;
       this.campaign.multipleSendings = true;
       this.campaign.title = null;
       this.campaign.targetProfile = null;
       this.targetProfile = null;
       this.campaign.type = 'PROFILES_COLLECTION';
     } else {
-      this.isCampaignGoalAssessment = true;
-      this.isCampaignGoalProfileCollection = false;
       this.campaign.multipleSendings = false;
       this.campaign.type = 'ASSESSMENT';
     }

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -17,9 +17,7 @@ export default class CreateForm extends Component {
 
   constructor() {
     super(...arguments);
-    this.campaign = {
-      organization: this.currentUser.organization,
-    };
+    this.campaign = this.args.campaign;
     this._setTargetProfilesOptions(this.args.targetProfiles);
     this.ownerId = this.currentUser.prescriber.id;
     this.isMultipleSendingAssessmentEnabled = this.currentUser.prescriber.enableMultipleSendingAssessment;
@@ -85,8 +83,9 @@ export default class CreateForm extends Component {
 
   @action
   selectTargetProfile(targetProfileId) {
-    this.targetProfile = this.args.targetProfiles.find((targetProfile) => targetProfile.id === targetProfileId);
-    this.campaign.targetProfile = this.targetProfile;
+    this.campaign.targetProfile = this.args.targetProfiles.find(
+      (targetProfile) => targetProfile.id === targetProfileId,
+    );
   }
 
   @action
@@ -98,14 +97,9 @@ export default class CreateForm extends Component {
   @action
   setCampaignGoal(event) {
     if (event.target.value === 'collect-participants-profile') {
-      this.campaign.multipleSendings = true;
-      this.campaign.title = null;
-      this.campaign.targetProfile = null;
-      this.targetProfile = null;
-      this.campaign.type = 'PROFILES_COLLECTION';
+      this.campaign.setType('PROFILES_COLLECTION');
     } else {
-      this.campaign.multipleSendings = false;
-      this.campaign.type = 'ASSESSMENT';
+      this.campaign.setType('ASSESSMENT');
     }
   }
 
@@ -128,14 +122,13 @@ export default class CreateForm extends Component {
   onChangeCampaignOwner(newOwnerId) {
     const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
     if (selectedMember) {
-      this.ownerId = selectedMember.id;
+      this.campaign.ownerId = selectedMember.id;
     }
   }
 
   @action
   onSubmit(event) {
     event.preventDefault();
-    this.campaign.ownerId = this.ownerId;
     this.args.onSubmit(this.campaign);
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -13,12 +13,11 @@ export default class NewController extends Controller {
   @tracked errors;
 
   @action
-  async createCampaign(campaignAttributes) {
+  async createCampaign() {
     this.notifications.clearAll();
     this.errors = null;
 
     try {
-      this.model.campaign.setProperties(campaignAttributes);
       await this.model.campaign.save();
     } catch (errorResponse) {
       errorResponse.errors.forEach((error) => {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -1,4 +1,4 @@
-import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import ENV from 'pix-orga/config/environment';
 import { service } from '@ember/service';
 
@@ -87,5 +87,17 @@ export default class Campaign extends Model {
   async unarchive() {
     await this.store.adapterFor('campaign').unarchive(this);
     return this.store.findRecord('campaign', this.id);
+  }
+
+  setType(type) {
+    if (type === 'ASSESSMENT') {
+      this.multipleSendings = false;
+    }
+    if (type === 'PROFILES_COLLECTION') {
+      this.multipleSendings = true;
+      this.title = null;
+      this.targetProfile = null;
+    }
+    this.type = type;
   }
 }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -1,21 +1,48 @@
 import { service } from '@ember/service';
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
+import pick from 'lodash/pick';
 
 export default class NewRoute extends Route {
   @service store;
   @service currentUser;
+  @service intl;
 
-  async model() {
+  queryParams = {
+    source: { refreshModel: true },
+  };
+
+  async model(params) {
     const organization = this.currentUser.organization;
+    await organization.targetProfiles;
     const membersSortedByFullName = await this.store.findAll('member-identity', {
       adapterOptions: { organizationId: organization.id },
     });
 
-    return RSVP.hash({
-      campaign: this.store.createRecord('campaign', { organizationId: organization.id }),
+    let campaignAttributes;
+    if (params?.source) {
+      const from = await this.store.findRecord('campaign', params.source);
+      campaignAttributes = pick(from, [
+        'type',
+        'title',
+        'description',
+        'targetProfileId',
+        'ownerId',
+        'multipleSendings',
+        'idPixLabel',
+        'customLandingPageText',
+      ]);
+      campaignAttributes.name = `${this.intl.t('pages.campaign-creation.copy-of')} ${from.name}`;
+      campaignAttributes.targetProfile = this.store.peekRecord('target-profile', campaignAttributes.targetProfileId);
+    }
+
+    return {
+      campaign: this.store.createRecord('campaign', {
+        organization,
+        ownerId: this.currentUser.prescriber.id,
+        ...(campaignAttributes ?? campaignAttributes),
+      }),
       targetProfiles: organization.targetProfiles,
       membersSortedByFullName,
-    });
+    };
   }
 }

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -12,8 +12,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  const prescriber = EmberObject.create({ fullName: 'Adam Troisjour', id: 1, enableMultipleSendingAssessment: false });
-  const defaultMembers = [prescriber];
+  let prescriber;
+  let defaultMembers;
+  let store;
 
   hooks.beforeEach(function () {
     this.createCampaignSpy = (event) => {
@@ -21,10 +22,23 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     };
     this.cancelSpy = () => {};
     this.errors = {};
+
+    store = this.owner.lookup('service:store');
+
+    prescriber = store.createRecord('prescriber', {
+      firstName: 'Adam',
+      lastName: 'Troisjour',
+      id: '1',
+      enableMultipleSendingAssessment: false,
+    });
+
     class CurrentUserStub extends Service {
       prescriber = prescriber;
     }
+
+    defaultMembers = [prescriber];
     this.owner.register('service:current-user', CurrentUserStub);
+    this.set('campaign', store.createRecord('campaign', { ownerId: prescriber.id }));
     this.set('defaultMembers', defaultMembers);
     this.targetProfiles = [];
   });
@@ -33,6 +47,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     // when
     await render(
       hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -52,6 +67,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     // when
     const screen = await render(
       hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -65,10 +81,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.dom(screen.getByText(t('pages.campaign-creation.owner.title'))).exists();
   });
 
-  test("it should auto complete owner field with current user's full name", async function (assert) {
+  test("it should auto complete owner field with owner's full name", async function (assert) {
     // when
     const screen = await render(
       hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -87,6 +104,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     // when
     const screen = await render(
       hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -104,6 +122,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -119,9 +138,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     });
 
     test('it should display the purpose explanation of an assessment campaign', async function (assert) {
-      // given
-      this.campaign = EmberObject.create({});
-
       // when
       await render(
         hbs`<Campaign::CreateForm
@@ -144,7 +160,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       test('it should display informations about target profile', async function (assert) {
         // given
         this.targetProfiles = [
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '1',
             name: 'targetProfile1',
             description: 'description1',
@@ -152,7 +168,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             thematicResultCount: 12,
             hasStage: true,
           }),
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '2',
             name: 'targetProfile2',
             description: 'description2',
@@ -165,6 +181,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // when
         const screen = await render(
           hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @targetProfiles={{this.targetProfiles}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
@@ -186,7 +203,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       test('it should display a message about result', async function (assert) {
         // given
         this.targetProfiles = [
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '1',
             name: 'targetProfile1',
             description: 'description1',
@@ -194,7 +211,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             thematicResultCount: 12,
             hasStage: true,
           }),
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '2',
             name: 'targetProfile2',
             description: 'description2',
@@ -207,6 +224,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // when
         const screen = await render(
           hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @targetProfiles={{this.targetProfiles}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
@@ -226,7 +244,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         test('it should display options in alphapetical order', async function (assert) {
           // given
           this.targetProfiles = [
-            EmberObject.create({
+            store.createRecord('target-profile', {
               id: '1',
               name: 'targetProfile4',
               description: 'description4',
@@ -235,7 +253,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               hasStage: true,
               category: 'B',
             }),
-            EmberObject.create({
+            store.createRecord('target-profile', {
               id: '2',
               name: 'targetProfile3',
               description: 'description3',
@@ -244,7 +262,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               hasStage: false,
               category: 'B',
             }),
-            EmberObject.create({
+            store.createRecord('target-profile', {
               id: '3',
               name: 'targetProfile2',
               description: 'description2',
@@ -253,7 +271,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               hasStage: true,
               category: 'A',
             }),
-            EmberObject.create({
+            store.createRecord('target-profile', {
               id: '4',
               name: 'targetProfile1',
               description: 'description1',
@@ -267,6 +285,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           // when
           const screen = await render(
             hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @targetProfiles={{this.targetProfiles}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
@@ -289,7 +308,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         test('it should display options with OTHER category at last position', async function (assert) {
           // given
           this.targetProfiles = [
-            EmberObject.create({
+            store.createRecord('target-profile', {
               id: '2',
               name: 'targetProfile3',
               description: 'description3',
@@ -298,7 +317,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               hasStage: false,
               category: 'OTHER',
             }),
-            EmberObject.create({
+            store.createRecord('target-profile', {
               id: '1',
               name: 'targetProfile4',
               description: 'description4',
@@ -312,6 +331,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           // when
           const screen = await render(
             hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @targetProfiles={{this.targetProfiles}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
@@ -336,7 +356,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     module('when the user wants to clear the content of the target profile input', function (hooks) {
       hooks.beforeEach(function () {
         this.targetProfiles = [
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '1',
             name: 'targetProfile1',
             description: 'description1',
@@ -350,6 +370,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // when
         await render(
           hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -367,7 +388,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       test('it should display multiple sendings field', async function (assert) {
         // given
         this.targetProfiles = [
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '1',
             name: 'targetProfile1',
             description: 'description1',
@@ -375,7 +396,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             thematicResultCount: 12,
             hasStage: true,
           }),
-          EmberObject.create({
+          store.createRecord('target-profile', {
             id: '2',
             name: 'targetProfile2',
             description: 'description2',
@@ -384,16 +405,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             hasStage: false,
           }),
         ];
-        const prescriber = EmberObject.create({
-          fullName: 'Adam Troisjour',
-          id: 1,
-          enableMultipleSendingAssessment: true,
-        });
-        this.set('defaultMembers', [prescriber]);
+        prescriber.enableMultipleSendingAssessment = true;
 
         // when
         const screen = await render(
           hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @targetProfiles={{this.targetProfiles}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
@@ -417,6 +434,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -435,6 +453,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -450,9 +469,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     });
 
     test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
-      // given
-      this.campaign = EmberObject.create({});
-
       // when
       await render(
         hbs`<Campaign::CreateForm
@@ -477,6 +493,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -495,6 +512,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -514,6 +532,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -531,6 +550,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       const screen = await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -554,6 +574,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     const screen = await render(
       hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -569,7 +590,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     // when
     await clickByName(t('pages.campaign-creation.actions.create'));
 
-    sinon.assert.calledWithMatch(this.createCampaignSpy, { name: 'Ma campagne', targetProfile });
+    sinon.assert.calledWithExactly(this.createCampaignSpy, this.campaign);
     // then
     assert.ok(true);
   });
@@ -602,6 +623,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}
@@ -633,6 +655,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // when
       await render(
         hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
   @onCancel={{this.cancelSpy}}
   @errors={{this.errors}}

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -20,6 +20,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         { id: 7, fullName: 'Thierry Golo' },
       ];
       const component = await createGlimmerComponent('component:campaign/create-form', {
+        campaign: {},
         membersSortedByFullName,
         targetProfiles: [],
       });
@@ -29,7 +30,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       await component.onChangeCampaignOwner(newOwnerId);
 
       //then
-      assert.deepEqual(component.ownerId, 7);
+      assert.deepEqual(component.campaign.ownerId, 7);
     });
   });
 
@@ -41,6 +42,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const component = await createGlimmerComponent('component:campaign/create-form', {
+        campaign: {},
         targetProfiles: [],
         membersSortedByFullName: [{ id: 1, fullName: 'Just me' }],
       });
@@ -59,6 +61,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const component = await createGlimmerComponent('component:campaign/create-form', {
+        campaign: {},
         targetProfiles: [],
         membersSortedByFullName: [{ id: 1, fullName: 'Just me' }],
       });

--- a/orga/tests/unit/routes/authenticated/campaigns/new_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new_test.js
@@ -1,11 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import setupIntl from '../../../../helpers/setup-intl';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
 module('Unit | Route | authenticated/campaigns/new', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   test('should return members', async function (assert) {
     // given
@@ -15,6 +17,7 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
       organization = EmberObject.create({
         id: 12345,
       });
+      prescriber = { id: Symbol('prescriber id') };
     }
     this.owner.register('service:current-user', CurrentUserStub);
 
@@ -31,5 +34,103 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
 
     //then
     assert.strictEqual(result.membersSortedByFullName, members);
+  });
+
+  test('should return an empty campaign when there is no given source', async function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/campaigns/new');
+
+    const organization = EmberObject.create({
+      id: 12345,
+    });
+
+    const prescriber = { id: Symbol('prescriber id') };
+
+    class CurrentUserStub extends Service {
+      organization = organization;
+      prescriber = prescriber;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    const members = Symbol('list of members sorted by firstnames and lastnames');
+
+    const expectedCampaignAttributes = {
+      organization,
+      ownerId: prescriber.id,
+    };
+
+    const duplicatedCampaignRecord = Symbol('duplicated campaign record');
+
+    const findAllStub = sinon.stub();
+    const createRecordStub = sinon.stub();
+
+    const storeStub = {
+      findAll: findAllStub.resolves(members),
+      createRecord: createRecordStub.resolves(duplicatedCampaignRecord),
+    };
+    route.store = storeStub;
+
+    // when
+    const model = await route.model();
+
+    assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
+    sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
+  });
+
+  test('should prefill campaign attributes from given source campaign', async function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/campaigns/new');
+
+    const organization = EmberObject.create({
+      id: 12345,
+    });
+
+    class CurrentUserStub extends Service {
+      organization = organization;
+      prescriber = { id: Symbol('prescriber id') };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    const members = Symbol('list of members sorted by firstnames and lastnames');
+    const sourceCampaign = {
+      name: 'A real campaign name',
+      type: Symbol('campaign type'),
+      title: Symbol('campaign title'),
+      description: Symbol('campaign description'),
+      targetProfileId: Symbol('campaign target profile id'),
+      ownerId: Symbol('campaign owner id'),
+      multipleSendings: Symbol('campaign multiple sendings activation'),
+      idPixLabel: Symbol('campaign external id'),
+      customLandingPageText: Symbol('campaign custom landing page text'),
+    };
+    const targetProfile = Symbol('campaign target profile');
+
+    const expectedCampaignAttributes = {
+      ...sourceCampaign,
+      name: 'Copie de A real campaign name',
+      targetProfile,
+      organization,
+    };
+
+    const duplicatedCampaignRecord = Symbol('duplicated campaign record');
+
+    const findAllStub = sinon.stub();
+    const findRecordStub = sinon.stub();
+    const peekRecordStub = sinon.stub();
+    const createRecordStub = sinon.stub();
+
+    const storeStub = {
+      findAll: findAllStub.resolves(members),
+      createRecord: createRecordStub.resolves(duplicatedCampaignRecord),
+      findRecord: findRecordStub.resolves(sourceCampaign),
+      peekRecord: peekRecordStub.returns(targetProfile),
+    };
+    route.store = storeStub;
+
+    // when
+    const model = await route.model({ source: Symbol('source campaign id') });
+
+    assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
+    sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -348,6 +348,7 @@
         "create": "Create a campaign",
         "delete": "Delete"
       },
+      "copy-of": "Copy of",
       "external-id-label": {
         "label": "external user ID label",
         "question-label": "Do you need an external user ID?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -351,6 +351,7 @@
         "create": "Créer la campagne",
         "delete": "Effacer"
       },
+      "copy-of": "Copie de",
       "external-id-label": {
         "label": "Libellé de l’identifiant",
         "question-label": "Souhaitez-vous demander un identifiant externe ?",
@@ -984,7 +985,7 @@
       "table": {
         "column": {
           "date-of-birth": "Date de naissance",
-          "division":  {
+          "division": {
             "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par classe. Cliquez pour trier par ordre alphanumérique.",
             "ariaLabelSortDown": "Le tableau est trié par classe, dans l'ordre alphanumérique inverse. Cliquez pour trier par ordre alphanumérique.",
             "ariaLabelSortUp": "Le tableau est trié par classe, dans l'ordre alphanumérique. Cliquez pour trier par ordre alphanumérique inverse.",


### PR DESCRIPTION
## :unicorn: Problème

Nos prescripteurs ont énormément de campagnes à créer, pour lesquelles seuls quelques paramètres changent (comme le profil cible ou le titre de la campagne).
Au moment de la rentrée par exemple, les professeurs d'école de chaque classe créent des campagnes 6ième, 5ième, 4ième, ou encore les enseignants du supérieur pour toutes les différentes licences etc.

## :robot: Proposition

On permet le pré-remplissage du formulaire de création de campagne à partir des attributs d'une campagne source.
Ce pré-remplissage se fait en spécifiant l'identifiant de la campagne source dans un paramètre de recherche de l'URL (`query param`) comme suit :
`/campagnes/creation?source=#identifiant de la campagne source#`.


## :rainbow: Remarques

L'ensemble des attributs est copié dont le propriétaire et l'organisation.
Seul le nom de la campagne est préfixé par "Copie de " afin de montrer au créateur de la campagne qu'il vient de dupliquer une campagne.


On en profite pour faire un coup de propre sur le formulaire de création de campagne et les tests associés.


## :100: Pour tester

Se connecter à Pix Orga.
Saisir l'URL de création de campagne en spécifiant la campagne à dupliquer : `/campagnes/creation?source=#identifiant de la campagne source#`.
Vérifier que le formulaire affiché est pré-rempli.
Tester pour des campagnes sources de différents types et différents paramètres (avec et sans libellé d'identifiant externe, campagne d'évaluation, envoi multiple, etc).
