### PR TITLE
[TECH] Spécifie la version spécifique d'ember-data sur orga qui fonctionne

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -52,7 +52,7 @@
         "ember-cli-showdown": "^7.0.0",
         "ember-click-outside": "^6.0.0",
         "ember-cookies": "^0.5.2",
-        "ember-data": "^4.0.2",
+        "ember-data": "~4.0.2",
         "ember-dayjs": "^0.12.0",
         "ember-fetch": "^8.1.2",
         "ember-intl": "^5.7.2",

--- a/orga/package.json
+++ b/orga/package.json
@@ -81,7 +81,7 @@
     "ember-cli-showdown": "^7.0.0",
     "ember-click-outside": "^6.0.0",
     "ember-cookies": "^0.5.2",
-    "ember-data": "^4.0.2",
+    "ember-data": "~4.0.2",
     "ember-dayjs": "^0.12.0",
     "ember-fetch": "^8.1.2",
     "ember-intl": "^5.7.2",


### PR DESCRIPTION
## :unicorn: Problème
La version d'ember-data sur orga est spécifié dans le package.json avec ^ alors qu'en réalité nous ne supportons pas les versions mineurs suivantes.
Suite de #6543

## :robot: Proposition
Spécifier l’intervalle de versio d'ember-data qui sont actuellement résolu dans le package-lock.

## :100: Pour tester
Constater dans le package-lock que la version d'ember-data n'a pas changé.
