### PR TITLE
[FEATURE] Génération d'un fichier CSV contenant les informations des élèves dont le mot de passe a été modifié (PIX-8474)

### DIFF
--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -1,6 +1,6 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as scoOrganizationLearnerSerializer from '../../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
-import * as requestReponseUtils from '../../infrastructure/utils/request-response-utils.js';
+import * as requestResponseUtils from '../../infrastructure/utils/request-response-utils.js';
 import * as studentInformationForAccountRecoverySerializer from '../../infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer.js';
 
 const reconcileScoOrganizationLearnerManually = async function (
@@ -80,7 +80,7 @@ const createAndReconcileUserToOrganizationLearner = async function (
   h,
   dependencies = {
     scoOrganizationLearnerSerializer,
-    requestReponseUtils,
+    requestResponseUtils,
   }
 ) {
   const payload = request.payload.data.attributes;
@@ -92,7 +92,7 @@ const createAndReconcileUserToOrganizationLearner = async function (
     username: payload.username,
     withUsername: payload['with-username'],
   };
-  const locale = dependencies.requestReponseUtils.extractLocaleFromRequest(request);
+  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
   await usecases.createAndReconcileUserToOrganizationLearner({
     userAttributes,

--- a/api/lib/domain/models/OrganizationLearnerPasswordDTO.js
+++ b/api/lib/domain/models/OrganizationLearnerPasswordDTO.js
@@ -1,0 +1,9 @@
+class OrganizationLearnerPasswordDTO {
+  constructor({ division, password, username }) {
+    this.division = division;
+    this.password = password;
+    this.username = username;
+  }
+}
+
+export { OrganizationLearnerPasswordDTO };

--- a/api/lib/domain/usecases/generate-reset-organization-learners-password.js
+++ b/api/lib/domain/usecases/generate-reset-organization-learners-password.js
@@ -1,0 +1,25 @@
+const FILE_HEADERS = [
+  {
+    label: 'Identifiant',
+    value: 'username',
+  },
+  {
+    label: 'Mot de passe',
+    value: 'password',
+  },
+  {
+    label: 'Classe',
+    value: 'division',
+  },
+];
+
+async function generateResetOrganizationLearnersPassword({ organizationLearnersGeneratedPassword, writeCsvUtils }) {
+  const generatedCsvContent = await writeCsvUtils.getCsvContent({
+    data: organizationLearnersGeneratedPassword,
+    fileHeaders: FILE_HEADERS,
+  });
+
+  return generatedCsvContent;
+}
+
+export { generateResetOrganizationLearnersPassword };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -193,6 +193,7 @@ import * as userService from '../../domain/services/user-service.js';
 import * as userToCreateRepository from '../../infrastructure/repositories/user-to-create-repository.js';
 import * as userValidator from '../validators/user-validator.js';
 import * as verifyCertificateCodeService from '../../domain/services/verify-certificate-code-service.js';
+import * as writeCsvUtils from '../../infrastructure/utils/csv/write-csv-utils.js';
 import * as writeOdsUtils from '../../infrastructure/utils/ods/write-ods-utils.js';
 import { CampaignParticipationsStatsRepository as campaignParticipationsStatsRepository } from '../../infrastructure/repositories/campaign-participations-stats-repository.js';
 import { campaignParticipantActivityRepository } from '../../infrastructure/repositories/campaign-participant-activity-repository.js';
@@ -411,6 +412,7 @@ const dependencies = {
   userToCreateRepository,
   userValidator,
   verifyCertificateCodeService,
+  writeCsvUtils,
   writeOdsUtils,
 };
 

--- a/api/lib/domain/usecases/update-organization-learners-password.js
+++ b/api/lib/domain/usecases/update-organization-learners-password.js
@@ -10,6 +10,7 @@ const updateOrganizationLearnersPassword = async function ({
   organizationId,
   organizationLearnersId,
   userId,
+  domainTransaction,
   encryptionService,
   passwordGenerator,
   authenticationMethodRepository,
@@ -67,7 +68,10 @@ const updateOrganizationLearnersPassword = async function ({
     })
   );
 
-  await authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged({ usersToUpdateWithNewPassword });
+  await authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged({
+    usersToUpdateWithNewPassword,
+    domainTransaction,
+  });
 
   return organizationLearnersGeneratedPassword;
 };

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -672,7 +672,7 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
 
   describe('PUT /api/sco-organization-learners/passwords', function () {
     context('when successfully update organization learners passwords', function () {
-      it('returns an HTTP status code 200', async function () {
+      it('returns an HTTP status code 200 with generated CSV file', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
 
@@ -699,7 +699,7 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
         await databaseBuilder.commit();
 
         // when
-        const { statusCode } = await server.inject({
+        const { headers, payload, statusCode } = await server.inject({
           method: 'PUT',
           url: `${BASE_PATH}/passwords`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
@@ -715,6 +715,13 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
 
         // then
         expect(statusCode).to.equal(200);
+        expect(headers['content-type']).to.equal('text/csv;charset=utf-8');
+        expect(headers['content-disposition']).to.contains('_organization_learners_password_reset.csv');
+
+        // eslint-disable-next-line no-unused-vars
+        const [fileHeaders, firstRow, ...unusedRows] = payload.split('\n').map((row) => row.trim());
+        expect(fileHeaders).to.equal('"Identifiant";"Mot de passe";"Classe"');
+        expect(firstRow).to.match(/^"paul";|"jacques";/);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -1211,12 +1211,12 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       const authenticationMethods = await knex('authentication-methods')
         .pluck('authenticationComplement')
         .whereIn('userId', [pierre.id, paul.id]);
+      const expectedAuthenticationMethods = [
+        { password: pierreNewHashedPassword, shouldChangePassword: true },
+        { password: paulNewHashedPassword, shouldChangePassword: true },
+      ];
 
-      expect(authenticationMethods[0].password).to.equal(pierreNewHashedPassword);
-      expect(authenticationMethods[0].shouldChangePassword).to.be.true;
-
-      expect(authenticationMethods[1].password).to.equal(paulNewHashedPassword);
-      expect(authenticationMethods[1].shouldChangePassword).to.be.true;
+      expect(authenticationMethods).to.have.deep.members(expectedAuthenticationMethods);
     });
 
     describe('when database transaction fails', function () {

--- a/api/tests/unit/domain/usecases/generate-reset-organization-learners-password-csv_test.js
+++ b/api/tests/unit/domain/usecases/generate-reset-organization-learners-password-csv_test.js
@@ -1,0 +1,32 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { generateResetOrganizationLearnersPassword } from '../../../../lib/domain/usecases/generate-reset-organization-learners-password.js';
+import { OrganizationLearnerPasswordDTO } from '../../../../lib/domain/models/OrganizationLearnerPasswordDTO.js';
+
+describe('Unit | UseCases | Generate reset organization learners csv', function () {
+  it('returns generated CSV content', async function () {
+    // given
+    const organizationLearnersGeneratedPassword = [
+      new OrganizationLearnerPasswordDTO({
+        division: '3A',
+        password: '123456@Bc',
+        username: 'brown',
+      }),
+      new OrganizationLearnerPasswordDTO({
+        division: '3A',
+        password: '123456@Bc',
+        username: 'sugar',
+      }),
+    ];
+    const expectedCsvContent = 'username;password;classe\nbrown;123456@Bc;3A\nsugar;123456@Bc;3A\n';
+    const writeCsvUtils = { getCsvContent: sinon.stub().resolves(expectedCsvContent) };
+
+    // when
+    const generatedCsvContent = await generateResetOrganizationLearnersPassword({
+      organizationLearnersGeneratedPassword,
+      writeCsvUtils,
+    });
+
+    // then
+    expect(generatedCsvContent).to.equal(expectedCsvContent);
+  });
+});

--- a/api/tests/unit/domain/usecases/update-organization-learners-password_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-learners-password_test.js
@@ -6,6 +6,7 @@ import {
   ORGANIZATION_LEARNER_WITHOUT_USERNAME_CODE,
   USER_DOES_NOT_BELONG_TO_ORGANIZATION_CODE,
 } from '../../../../lib/domain/constants/update-organization-learners-password-errors.js';
+import { OrganizationLearnerPasswordDTO } from '../../../../lib/domain/models/OrganizationLearnerPasswordDTO.js';
 
 describe('Unit | UseCases | Update organization learners password', function () {
   const hashedPassword = '21fedcba';
@@ -29,13 +30,13 @@ describe('Unit | UseCases | Update organization learners password', function () 
     context(
       'when a list of organization learners with an authentication method "identifiant" is provided',
       function () {
-        it('updates organization learners passwords and returns true', async function () {
+        it('updates organization learners passwords and returns organization learners with their generated password', async function () {
           // given
           const studentIds = ['3', '4'];
           const organizationId = 1;
           const organizationLearnersId = [
-            { organizationId: 1, userId: studentIds[0] },
-            { organizationId: 1, userId: studentIds[1] },
+            { organizationId: 1, userId: studentIds[0], division: '3B' },
+            { organizationId: 1, userId: studentIds[1], division: '3B' },
           ];
           const userId = 2;
           const userWithMemberships = { id: 2, hasAccessToOrganization: sinon.stub().returns(true) };
@@ -54,7 +55,7 @@ describe('Unit | UseCases | Update organization learners password', function () 
           authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged = sinon.stub().resolves();
 
           // when
-          const result = await updateOrganizationLearnersPassword({
+          const organizationLearnersGeneratedPassword = await updateOrganizationLearnersPassword({
             organizationId,
             organizationLearnersId,
             userId,
@@ -72,7 +73,18 @@ describe('Unit | UseCases | Update organization learners password', function () 
           expect(authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged).to.have.been.calledWith({
             usersToUpdateWithNewPassword: userIdHashedPassword,
           });
-          expect(result).to.be.true;
+          expect(organizationLearnersGeneratedPassword).to.have.deep.members([
+            new OrganizationLearnerPasswordDTO({
+              username: 'Paul',
+              password: generatedPassword,
+              division: '3B',
+            }),
+            new OrganizationLearnerPasswordDTO({
+              username: 'Jacques',
+              password: generatedPassword,
+              division: '3B',
+            }),
+          ]);
         });
       }
     );

--- a/api/tests/unit/domain/usecases/update-organization-learners-password_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-learners-password_test.js
@@ -48,6 +48,7 @@ describe('Unit | UseCases | Update organization learners password', function () 
             { userId: studentIds[0], hashedPassword },
             { userId: studentIds[1], hashedPassword },
           ];
+          const domainTransaction = Symbol('transaction');
 
           organizationLearnerRepository.findByIds = sinon.stub().resolves(organizationLearnersId);
           userRepository.getWithMemberships = sinon.stub().resolves(userWithMemberships);
@@ -59,6 +60,7 @@ describe('Unit | UseCases | Update organization learners password', function () 
             organizationId,
             organizationLearnersId,
             userId,
+            domainTransaction,
             authenticationMethodRepository,
             organizationLearnerRepository,
             userRepository,
@@ -72,6 +74,7 @@ describe('Unit | UseCases | Update organization learners password', function () 
           expect(encryptionService.hashPassword).to.have.been.callCount(2);
           expect(authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged).to.have.been.calledWith({
             usersToUpdateWithNewPassword: userIdHashedPassword,
+            domainTransaction,
           });
           expect(organizationLearnersGeneratedPassword).to.have.deep.members([
             new OrganizationLearnerPasswordDTO({

--- a/orga/app/adapters/sco-organization-participant.js
+++ b/orga/app/adapters/sco-organization-participant.js
@@ -8,14 +8,23 @@ export default class ScoOrganizationParticipantAdapter extends ApplicationAdapte
     return `${this.host}/${this.namespace}/organizations/${organizationId}/sco-participants`;
   }
 
-  resetOrganizationLearnersPassword(organizationId, organizationLearnersIds) {
+  async resetOrganizationLearnersPassword({ fetch, fileSaver, organizationId, organizationLearnersIds, token }) {
     const url = `${this.host}/${this.namespace}/sco-organization-learners/passwords`;
-    return this.ajax(url, 'PUT', {
-      data: {
+    const payload = JSON.stringify(
+      {
         data: {
           attributes: { 'organization-id': organizationId, 'organization-learners-id': organizationLearnersIds },
         },
       },
+      null,
+      2
+    );
+    const request = fetch(url, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: payload,
     });
+
+    return fileSaver.save({ fetcher: () => request });
   }
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -394,7 +394,12 @@ export default function () {
   });
 
   this.put('/sco-organization-learners/passwords', () => {
-    return emptyData;
+    const headers = {
+      'Content-Type': 'text/csv;charset=utf-8',
+      'Content-Disposition': 'attachment; filename=content.csv',
+    };
+    const csvContent = 'Identifiant;Mot de passe;Classe\nuser1;password1;1A\n';
+    return new Response(200, headers, csvContent);
   });
 
   this.post('/sco-organization-learners/username-password-generation', (schema) => {

--- a/orga/tests/unit/adapters/sco-organization-participant_test.js
+++ b/orga/tests/unit/adapters/sco-organization-participant_test.js
@@ -23,4 +23,45 @@ module('Unit | Adapters | sco-organization-participant', function (hooks) {
       assert.strictEqual(query.organizationId, undefined);
     });
   });
+
+  module('#resetOrganizationLearnersPassword', function () {
+    test('resets organization learners password and saves a CSV file', async function (assert) {
+      // given
+      const fetch = sinon.stub().resolves();
+      const fileSaver = { save: sinon.stub().resolves() };
+      const organizationId = 1;
+      const organizationLearnersIds = [23, 789];
+      const token = 'best token ever';
+      adapter.host = 'pix.local';
+      adapter.namespace = 'api';
+
+      // when
+      await adapter.resetOrganizationLearnersPassword({
+        fetch,
+        fileSaver,
+        organizationId,
+        organizationLearnersIds,
+        token,
+      });
+
+      // then
+      const expectedUrl = `${adapter.host}/${adapter.namespace}/sco-organization-learners/passwords`;
+      const expectedOptions = {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          {
+            data: {
+              attributes: { 'organization-id': organizationId, 'organization-learners-id': organizationLearnersIds },
+            },
+          },
+          null,
+          2
+        ),
+      };
+      sinon.assert.calledWith(fetch, expectedUrl, expectedOptions);
+      sinon.assert.calledOnce(fileSaver.save);
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Pour le moment, une fois l'action de réinitialisation confirmée, la modale se ferme. Les élèves sont désélectionnés mais aucun fichier CSV n'est téléchargé.

## :robot: Proposition

Permettre le téléchargement du fichier CSV une fois que l'action de réinitialisation est effective.

##### API
- Ajout d'un nouveau usecase pour générer le contenu du fichier CSV
- Le fichier doit contenir 3 colonnes : `Identifiant`, `Mot de passe`, et `Classe`
- Utilisation d'une transaction en cas d'erreur après réinitialisation des mots de passe

##### Front
- Initier le téléchargement du fichier CSV

## :rainbow: Remarques

Les notifications de succès ou d'erreur seront traitées dans un autre ticket.

## :100: Pour tester

- Se connecter à Pix Orga sur le compte `allorga@example.net`
- Choisir l'organisation `Collège The Night Watch`
- Cliquer sur l'onglet `Élèves`
- Sélectionner tous les élèves
- Cliquer sur le bouton `Réinitialiser ....`
- À l'affichage de la modale, cliquer sur le bouton `Confirmer`
- Constater le téléchargement d'un fichier CSV, la fermeture de la modale et la désélection des élèves
- Ouvrir le fichier CSV
- Vérifier que le contenu est ok
