### PR TITLE
[FEATURE] Corriger le script de mise à jour des url de PixOrga (PIX-8414) 

### DIFF
--- a/api/scripts/prod/update-documentation-url.js
+++ b/api/scripts/prod/update-documentation-url.js
@@ -1,68 +1,25 @@
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import * as url from 'url';
 
-async function updateDocumentationUrl() {
-  // common cases
-  await _updateProOrganizations();
-
-  await _updateSUPOrganizations();
-
-  await _updateSCOOrganizations();
-
-  // specific cases
-  await _updateAufOrganizations();
-
-  await _updateEfenhOrganizations();
-
-  await _updateDiputacioDeBarcelonaOrganizations();
-
-  await _updatePriveHorsContratOrganizations();
-
-  await _updatePromSocOrganizations();
-
-  await _updateInternationalOrganizations();
-
-  await _updateDocEnglishOrganizations();
-
-  await _updateMedNumOrganizations();
-
-  await _updateAEFEOrganizations();
-
-  await _updateMLFOrganizations();
-
-  await _updateAGRIOrganizations();
-
-  await _updateCPAMOrganizations();
-
-  await _updateCNAFOrganizations();
-
-  await _updateCNAVOrganizations();
-
-  await _updateACOSSOrganizations();
-
-  await _updateINSTITUT410Organizations();
-
-  await _updateUCANSSOrganizations();
-
-  await _updateSECTEUR_CHIMIEOrganizations();
-
-  await _updateEDUSERVICESOrganizations();
-
-  await _updatePIXTERRITOIRESOrganizations();
-}
-
 const URL = {
   AEFE: 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8',
   MLF: 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8',
   MEDNUM: 'https://view.genial.ly/6048a0d3757f980dc010d6d4',
   SCO: 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f',
-  AGRI: 'https://view.genial.ly/5f85a0b87812e90d12b7b593',
+  AGRICULTURE: 'https://view.genial.ly/5f85a0b87812e90d12b7b593',
   PRIVE_HORS_CONTRAT: 'https://view.genial.ly/602e3786dd02300d9c14ac3f',
   EFENH: 'https://view.genial.ly/63b2a4ae12e4fc0018c73fbf',
 
   PROMSOC: 'https://crp.education/documentation-pix-orga-eps/',
+  SUP_FWB: 'https://crp.education/documentation-pix-orga-es/',
 
   //LIEN COOL
+  PRO: 'https://cloud.pix.fr/s/documentation_pix_orga',
+  INTERINDUSTRIES: 'https://cloud.pix.fr/s/opco2i_entreprises',
+  INTERNATIONAL: 'https://cloud.pix.fr/s/doc_pix_orga_francophone',
+  DOC_ENGLISH: 'https://cloud.pix.fr/s/doc_pix_orga_english',
+  AUF: 'https://cloud.pix.fr/s/documentation_auf',
+  DIPUTACIO_DE_BARCELONA: 'https://cloud.pix.fr/s/documentacion_en_espanol',
   CPAM: 'https://cloud.pix.fr/s/deploiement_cnam',
   CNAF: 'https://cloud.pix.fr/s/deploiement_cnaf',
   CNAV: 'https://cloud.pix.fr/s/deploiement_cnav',
@@ -72,223 +29,70 @@ const URL = {
   SECTEUR_CHIMIE: 'https://cloud.pix.fr/s/deploiement_branchechimie',
   EDUSERVICES: 'https://cloud.pix.fr/s/deploiement_eduservices',
   PIXTERRITOIRES: 'https://cloud.pix.fr/s/deploiement_pixterritoires',
+  EXPE_MADA: 'https://cloud.pix.fr/s/documentation_madagascar',
+  PIC: 'https://cloud.pix.fr/s/kit_pix_emploi',
+  MISSION_LOCALE: 'https://cloud.pix.fr/s/kit_pix_emploi',
+  CAP_EMPLOI: 'https://cloud.pix.fr/s/kit_pix_emploi',
+  EPIDE: 'https://cloud.pix.fr/s/kit_pix_emploi',
+  E2C: 'https://cloud.pix.fr/s/deploiement_e2c',
 
   //LIEN PAS COOL
-  PRO: 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4',
   SUP: 'https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo',
-  INTERNATIONAL: 'https://cloud.pix.fr/s/sR2FPjfq9krTmJY',
-  DOC_ENGLISH: 'https://cloud.pix.fr/s/nftApJjLct8mki8',
-  AUF: 'https://cloud.pix.fr/s/F8aek7qjA2d6A4T',
-  DIPUTACIO_DE_BARCELONA: 'https://cloud.pix.fr/s/AdTPdGMbKWYqfKR',
 };
+
+const orderedProTag = [
+  { tag: 'INTERNATIONAL', url: URL.INTERNATIONAL },
+  { tag: 'DOC ENGLISH', url: URL.DOC_ENGLISH },
+  { tag: 'PROMSOC', url: URL.PROMSOC },
+  { tag: 'AUF', url: URL.AUF },
+  { tag: 'MEDNUM', url: URL.MEDNUM },
+  { tag: 'EFENH', url: URL.EFENH },
+  { tag: 'DIPUTACIO DE BARCELONA', url: URL.DIPUTACIO_DE_BARCELONA },
+  { tag: 'PRIVE HORS CONTRAT', url: URL.PRIVE_HORS_CONTRAT },
+  { tag: 'PIC', url: URL.PIC },
+  { tag: 'MISSION LOCALE', url: URL.MISSION_LOCALE },
+  { tag: 'CAP EMPLOI', url: URL.CAP_EMPLOI },
+  { tag: 'EPIDE', url: URL.EPIDE },
+  { tag: 'E2C', url: URL.E2C },
+  { tag: 'CPAM', url: URL.CPAM },
+  { tag: 'CNAF', url: URL.CNAF },
+  { tag: 'CNAV', url: URL.CNAV },
+  { tag: 'ACOSS', url: URL.ACOSS },
+  { tag: 'INSTITUT 4.10', url: URL.INSTITUT410 },
+  { tag: 'UCANSS', url: URL.UCANSS },
+  { tag: 'SECTEUR CHIMIE', url: URL.SECTEUR_CHIMIE },
+  { tag: 'EDUSERVICES', url: URL.EDUSERVICES },
+  { tag: 'PIXTERRITOIRES', url: URL.PIXTERRITOIRES },
+  { tag: 'INTERINDUSTRIES', url: URL.INTERINDUSTRIES },
+  { tag: 'EXPE MADA', url: URL.EXPE_MADA },
+  { tag: 'SUP-FWB', url: URL.SUP_FWB },
+];
+
+async function updateDocumentationUrl() {
+  // common cases
+  await _updateProOrganizations();
+
+  await _updateSUPOrganizations();
+
+  await _updateSCOOrganizations();
+
+  // SCO Cases
+  await _updateAEFEOrganizations();
+
+  await _updateMLFOrganizations();
+
+  await _updateAGRIOrganizations();
+
+  // Ordered Pro Cases
+  for await (const proTag of orderedProTag) {
+    await _updateURLFromTag(proTag);
+  }
+}
 
 export { updateDocumentationUrl, URL };
 
 async function _updateProOrganizations() {
   await knex('organizations').where('type', 'PRO').update({ documentationUrl: URL.PRO });
-}
-
-async function _updateAufOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'AUF' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AUF });
-}
-async function _updateEfenhOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'SCO', 'tags.name': 'EFENH' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.EFENH });
-}
-async function _updateDiputacioDeBarcelonaOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'DIPUTACIO DE BARCELONA' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.DIPUTACIO_DE_BARCELONA });
-}
-async function _updatePriveHorsContratOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ 'tags.name': 'PRIVE HORS CONTRAT' })
-    .whereIn('type', ['PRO', 'SUP'])
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.PRIVE_HORS_CONTRAT });
-}
-
-async function _updatePromSocOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ 'tags.name': 'PROMSOC' })
-    .whereIn('type', ['PRO', 'SUP'])
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.PROMSOC });
-}
-
-async function _updateInternationalOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ 'tags.name': 'INTERNATIONAL' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.INTERNATIONAL });
-}
-
-async function _updateDocEnglishOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'DOC ENGLISH' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.DOC_ENGLISH });
-}
-
-async function _updateCPAMOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'CPAM' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.CPAM });
-}
-
-async function _updateCNAFOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'CNAF' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.CNAF });
-}
-
-async function _updateCNAVOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'CNAV' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.CNAV });
-}
-
-async function _updateACOSSOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'ACOSS' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.ACOSS });
-}
-
-async function _updateINSTITUT410Organizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'INSTITUT 4.10' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.INSTITUT410 });
-}
-
-async function _updateUCANSSOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'UCANSS' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.UCANSS });
-}
-
-async function _updateSECTEUR_CHIMIEOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'SECTEUR CHIMIE' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.SECTEUR_CHIMIE });
-}
-
-async function _updateEDUSERVICESOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'EDUSERVICES' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.EDUSERVICES });
-}
-
-async function _updatePIXTERRITOIRESOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'PIXTERRITOIRES' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.PIXTERRITOIRES });
-}
-
-async function _updateMedNumOrganizations() {
-  const ids = await knex
-    .select('organizations.id')
-    .from('organizations')
-    .leftJoin('organization-tags', 'organizationId', 'organizations.id')
-    .leftJoin('tags', 'tagId', 'tags.id')
-    .where({ type: 'PRO', 'tags.name': 'MEDNUM' })
-    .pluck('organizations.id');
-
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.MEDNUM });
 }
 
 async function _updateSUPOrganizations() {
@@ -337,7 +141,18 @@ async function _updateAGRIOrganizations() {
     .where({ 'tags.name': 'AGRICULTURE' })
     .pluck('organizations.id');
 
-  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AGRI });
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AGRICULTURE });
+}
+
+async function _updateURLFromTag({ tag, url }) {
+  const ids = await knex
+    .from('organizations')
+    .join('organization-tags', 'organizationId', 'organizations.id')
+    .join('tags', 'tagId', 'tags.id')
+    .where({ 'tags.name': tag })
+    .pluck('organizations.id');
+
+  await knex('organizations').whereIn('id', ids).update({ documentationUrl: url });
 }
 
 const modulePath = url.fileURLToPath(import.meta.url);

--- a/api/tests/integration/scripts/prod/update-documentation-url_test.js
+++ b/api/tests/integration/scripts/prod/update-documentation-url_test.js
@@ -1,5 +1,6 @@
 import { expect, databaseBuilder, knex } from '../../../test-helper.js';
 import { updateDocumentationUrl, URL } from '../../../../scripts/prod/update-documentation-url.js';
+import sample from 'lodash/sample.js';
 
 describe('updateDocumentationUrl', function () {
   context('when the organization is PRO', function () {
@@ -93,8 +94,8 @@ describe('updateDocumentationUrl', function () {
       });
     });
 
-    context('when the organization is AGRI', function () {
-      it('uses the AGRI documentation', async function () {
+    context('when the organization is AGRICULTURE', function () {
+      it('uses the AGRICULTURE documentation', async function () {
         const { id: organizationId } = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           isManagingStudents: true,
@@ -108,7 +109,7 @@ describe('updateDocumentationUrl', function () {
 
         const { documentationUrl } = await knex('organizations').first();
 
-        expect(documentationUrl).equal(URL.AGRI);
+        expect(documentationUrl).equal(URL.AGRICULTURE);
       });
 
       context('when the organization is not managing students', function () {
@@ -133,118 +134,30 @@ describe('updateDocumentationUrl', function () {
     });
   });
 
-  context('when the organization is INTERNATIONAL', function () {
-    context('when the organization is PRO', function () {
-      it('uses the INTERNATIONAL documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+  context(`regardless organization type`, function () {
+    let organizationId;
+    const organizationType = ['PRO', 'SUP', 'SCO'];
+    beforeEach(async function () {
+      const type = sample(organizationType);
 
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.INTERNATIONAL);
-      });
+      organizationId = databaseBuilder.factory.buildOrganization({ type, isManagingStudents: false }).id;
+      await databaseBuilder.commit();
     });
 
-    context('when the organization is SCO', function () {
-      it('uses the INTERNATIONAL documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+    it('sets right documentation URL for INTERNATIONAL', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        await updateDocumentationUrl();
+      await updateDocumentationUrl();
 
-        const { documentationUrl } = await knex('organizations').first();
+      const { documentationUrl } = await knex('organizations').first();
 
-        expect(documentationUrl).to.equal(URL.INTERNATIONAL);
-      });
+      expect(documentationUrl).equal(URL.INTERNATIONAL);
     });
 
-    context('when the organization is SUP', function () {
-      it('uses the INTERNATIONAL documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SUP',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERNATIONAL' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.equal(URL.INTERNATIONAL);
-      });
-    });
-  });
-
-  context('when the organization is PRIVE HORS CONTRAT', function () {
-    context('when the organization is PRO', function () {
-      it('uses the PRIVE HORS CONTRAT documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.PRIVE_HORS_CONTRAT);
-      });
-    });
-
-    context('when the organization is SUP', function () {
-      it('uses the PRIVE HORS CONTRAT documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.PRIVE_HORS_CONTRAT);
-      });
-    });
-
-    context('when the organization is SCO', function () {
-      it('does not the PRIVE HORS CONTRAT documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.PRIVE_HORS_CONTRAT);
-      });
-    });
-  });
-
-  context('when the organization is DOC ENGLISH', function () {
-    it('uses the DOC ENGLISH documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for DOC ENGLISH', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DOC ENGLISH' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -257,82 +170,20 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.DOC_ENGLISH);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the DOC ENGLISH documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DOC ENGLISH' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+    it('sets right documentation URL for PROMSOC', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        await updateDocumentationUrl();
+      await updateDocumentationUrl();
 
-        const { documentationUrl } = await knex('organizations').first();
+      const { documentationUrl } = await knex('organizations').first();
 
-        expect(documentationUrl).to.not.equal(URL.DOC_ENGLISH);
-      });
-    });
-  });
-
-  context('when the organization is PROMSOC', function () {
-    context('when the organization is PRO', function () {
-      it('uses the PROMSOC documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.PROMSOC);
-      });
+      expect(documentationUrl).equal(URL.PROMSOC);
     });
 
-    context('when the organization is SUP', function () {
-      it('uses the PROMSOC documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.PROMSOC);
-      });
-    });
-
-    context('when the organization is SCO', function () {
-      it('does not the PROMSOC documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PROMSOC' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.PROMSOC);
-      });
-    });
-  });
-
-  context('when the organization is AUF', function () {
-    it('uses the AUF documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for AUF', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AUF' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -345,122 +196,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.AUF);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the AUF documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'AUF' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.AUF);
-      });
-    });
-  });
-
-  context('when the organization is EFENH', function () {
-    context('when the organization is SCO', function () {
-      it('uses the EFENH documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.EFENH);
-      });
-    });
-
-    context('when the organization is SUP', function () {
-      it('does not the EFENH documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SUP',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.EFENH);
-      });
-    });
-
-    context('when the organization is PRO', function () {
-      it('does not the EFENH documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'PRO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.EFENH);
-      });
-    });
-  });
-
-  context('when the organization is DIPUTACIO DE BARCELONA', function () {
-    context('when the organization is PRO', function () {
-      it('uses the DIPUTACIO DE BARCELONA documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DIPUTACIO DE BARCELONA' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).equal(URL.DIPUTACIO_DE_BARCELONA);
-      });
-    });
-
-    context('when the organization is not PRO', function () {
-      it('does not the DIPUTACIO DE BARCELONA documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DIPUTACIO DE BARCELONA' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.DIPUTACIO_DE_BARCELONA);
-      });
-    });
-  });
-
-  context('when the organization is MEDNUM', function () {
-    it('uses the MEDNUM documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for MEDNUM', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MEDNUM' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -473,29 +209,111 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.MEDNUM);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the MEDNUM documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MEDNUM' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+    it('sets right documentation URL for EFENH', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EFENH' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        await updateDocumentationUrl();
+      await updateDocumentationUrl();
 
-        const { documentationUrl } = await knex('organizations').first();
+      const { documentationUrl } = await knex('organizations').first();
 
-        expect(documentationUrl).to.not.equal(URL.MEDNUM);
-      });
+      expect(documentationUrl).equal(URL.EFENH);
     });
-  });
 
-  context('when the organization is CPAM', function () {
-    it('uses the CPAM documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for DIPUTACIO DE BARCELONA', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'DIPUTACIO DE BARCELONA' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.DIPUTACIO_DE_BARCELONA);
+    });
+
+    it('sets right documentation URL for PRIVE HORS CONTRAT', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PRIVE HORS CONTRAT' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.PRIVE_HORS_CONTRAT);
+    });
+
+    it('sets right documentation URL for PIC', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PIC' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.PIC);
+    });
+
+    it('sets right documentation URL for MISSION LOCALE', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'MISSION LOCALE' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.MISSION_LOCALE);
+    });
+
+    it('sets right documentation URL for CAP EMPLOI', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CAP EMPLOI' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.CAP_EMPLOI);
+    });
+
+    it('sets right documentation URL for EPIDE', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EPIDE' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.EPIDE);
+    });
+
+    it('sets right documentation URL for E2C', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'E2C' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.E2C);
+    });
+
+    it('sets right documentation URL for CPAM', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CPAM' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -508,29 +326,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.CPAM);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the CPAM documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CPAM' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.CPAM);
-      });
-    });
-  });
-
-  context('when the organization is CNAF', function () {
-    it('uses the CPAM documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for CNAF', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CNAF' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -543,29 +339,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.CNAF);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the CNAF documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CNAF' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.CNAF);
-      });
-    });
-  });
-
-  context('when the organization is CNAV', function () {
-    it('uses the CNAV documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for CNAV', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CNAV' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -578,29 +352,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.CNAV);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the CNAV documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'CNAV' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.CNAV);
-      });
-    });
-  });
-
-  context('when the organization is ACOSS', function () {
-    it('uses the ACOSS documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for ACOSS', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'ACOSS' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -613,29 +365,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.ACOSS);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the ACOSS documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'ACOSS' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.ACOSS);
-      });
-    });
-  });
-
-  context('when the organization is INSTITUT 4.10', function () {
-    it('uses the INSTITUT 4.10 documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for INSTITUT410', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INSTITUT 4.10' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -648,29 +378,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.INSTITUT410);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the INSTITUT 4.10 documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INSTITUT 4.10' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.INSTITUT410);
-      });
-    });
-  });
-
-  context('when the organization is UCANSS', function () {
-    it('uses the UCANSS documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for UCANSS', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'UCANSS' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -683,29 +391,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.UCANSS);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the UCANSS documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'UCANSS' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.UCANSS);
-      });
-    });
-  });
-
-  context('when the organization is SECTEUR_CHIMIE', function () {
-    it('uses the SECTEUR_CHIMIE documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for SECTEUR_CHIMIE', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'SECTEUR CHIMIE' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -718,29 +404,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.SECTEUR_CHIMIE);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the SECTEUR_CHIMIE documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'SECTEUR CHIMIE' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.SECTEUR_CHIMIE);
-      });
-    });
-  });
-
-  context('when the organization is EDUSERVICES', function () {
-    it('uses the EDUSERVICES documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for EDUSERVICES', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EDUSERVICES' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -753,29 +417,7 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.EDUSERVICES);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the EDUSERVICES documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EDUSERVICES' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-
-        await databaseBuilder.commit();
-
-        await updateDocumentationUrl();
-
-        const { documentationUrl } = await knex('organizations').first();
-
-        expect(documentationUrl).to.not.equal(URL.EDUSERVICES);
-      });
-    });
-  });
-
-  context('when the organization is PIXTERRITOIRES', function () {
-    it('uses the PIXTERRITOIRES documentation', async function () {
-      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+    it('sets right documentation URL for PIXTERRITOIRES', async function () {
       const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PIXTERRITOIRES' });
       databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
@@ -788,23 +430,43 @@ describe('updateDocumentationUrl', function () {
       expect(documentationUrl).equal(URL.PIXTERRITOIRES);
     });
 
-    context('when the organization is not PRO', function () {
-      it('does not the PIXTERRITOIRES documentation', async function () {
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
-          type: 'SCO',
-          documentationUrl: 'toto',
-        });
-        const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'PIXTERRITOIRES' });
-        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+    it('sets right documentation URL for INTERINDUSTRIES', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'INTERINDUSTRIES' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
 
-        await databaseBuilder.commit();
+      await databaseBuilder.commit();
 
-        await updateDocumentationUrl();
+      await updateDocumentationUrl();
 
-        const { documentationUrl } = await knex('organizations').first();
+      const { documentationUrl } = await knex('organizations').first();
 
-        expect(documentationUrl).to.not.equal(URL.PIXTERRITOIRES);
-      });
+      expect(documentationUrl).equal(URL.INTERINDUSTRIES);
+    });
+
+    it('sets right documentation URL for EXPE MADA', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'EXPE MADA' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.EXPE_MADA);
+    });
+
+    it('sets right documentation URL for SUP-FWB', async function () {
+      const { id: tagId } = databaseBuilder.factory.buildTag({ name: 'SUP-FWB' });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+      await databaseBuilder.commit();
+
+      await updateDocumentationUrl();
+
+      const { documentationUrl } = await knex('organizations').first();
+
+      expect(documentationUrl).equal(URL.SUP_FWB);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite au dernier lancement du script des Tag en prod, il s'est avéré que beaucoup d'organisme ont perdu le lien qui leur était dédié. Cela vient d'un écart entre le url existante et celle défini dans le fichier sur lequel nous nous basions pour mettre à jour le script

## :robot: Proposition
Après avoir fait le point avec les équipes PRO, nous avons une liste exhaustive des tags / url disponible

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer le script et vérifier que les urls sont bien à jour par rapport à leur Tag