### PR TITLE
[FEATURE] Dupliquer une campagne d'un simple clic (PIX-8635)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -67,7 +67,9 @@ Fonctionnalité: Gestion des Campagnes
 
   Scénario: Je duplique une campagne d'évaluation
     Étant donné que je suis connecté à Pix Orga
-    Lorsque je duplique la campagne "1"
+    Et je clique sur "Campagne de la Néra"
+    Et je clique sur "Paramètres"
+    Lorsque je clique sur "Dupliquer"
     Alors je suis redirigé vers la page "creation"
     Et je clique sur "Créer la campagne"
     Alors je vois le détail de la campagne "Copie de Campagne de la Néra"

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -129,8 +129,3 @@ Then(
 When('je clique sur le bouton "Associer"', () => {
   cy.contains("button", "Associer").click();
 });
-
-When(`je duplique la campagne {string}`, (id) => {
-  const urn = `/campagnes/creation?source=${id}`;
-  cy.visitOrga(urn);
-});

--- a/orga/app/components/campaign/settings/view.hbs
+++ b/orga/app/components/campaign/settings/view.hbs
@@ -94,6 +94,9 @@
       <PixButtonLink @route="authenticated.campaigns.update" @model={{@campaign.id}} @backgroundColor="grey">
         {{t "pages.campaign-settings.actions.edit"}}
       </PixButtonLink>
+      <PixButtonLink @route="authenticated.campaigns.new" @query={{this.queryForDuplicate}} @backgroundColor="grey">
+        {{t "pages.campaign-settings.actions.duplicate"}}
+      </PixButtonLink>
       <PixButton @triggerAction={{fn this.archiveCampaign @campaign.id}} @backgroundColor="grey">
         {{t "pages.campaign-settings.actions.archive"}}
       </PixButton>

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -50,6 +50,10 @@ export default class CampaignView extends Component {
     );
   }
 
+  get queryForDuplicate() {
+    return { source: this.args.campaign.id };
+  }
+
   @action
   async archiveCampaign(campaignId) {
     try {

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -12,6 +12,8 @@ export default class NewController extends Controller {
 
   @tracked errors;
 
+  queryParams = ['source'];
+
   @action
   async createCampaign() {
     this.notifications.clearAll();
@@ -35,6 +37,10 @@ export default class NewController extends Controller {
 
   @action
   cancel() {
-    this.router.transitionTo('authenticated.campaigns');
+    if (this.source) {
+      this.router.transitionTo('authenticated.campaigns.campaign.settings', this.source);
+    } else {
+      this.router.transitionTo('authenticated.campaigns');
+    }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -41,8 +41,6 @@ export default class NewRoute extends Route {
           );
         }
       } catch {
-        console.log('Campaign not found');
-        console.log({ router: this.router });
         this.router.replaceWith('authenticated.campaigns.new', { queryParams: { source: null } });
       }
     }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -57,4 +57,10 @@ export default class NewRoute extends Route {
       membersSortedByFullName,
     };
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('source', null);
+    }
+  }
 }

--- a/orga/app/styles/components/campaign/settings/campaign-settings.scss
+++ b/orga/app/styles/components/campaign/settings/campaign-settings.scss
@@ -81,9 +81,10 @@
   padding: 24px;
   width: 100%;
   box-sizing: border-box;
+  gap: 32px;
 
-  > *:first-child {
-    margin-right: 32px;
+  > *:last-child {
+    margin-left: auto;
   }
 }
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/new_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/new_test.js
@@ -11,15 +11,32 @@ module('Unit | Controller | authenticated/campaigns/new', function (hooks) {
   });
 
   module('#action cancel', function () {
-    test('it should call transitionTo with appropriate arguments', function (assert) {
-      // given
-      controller.router = { transitionTo: sinon.stub() };
+    module('when source is empty', function () {
+      test('it should call transitionTo with appropriate arguments', function (assert) {
+        // given
+        controller.router = { transitionTo: sinon.stub() };
 
-      // when
-      controller.cancel();
+        // when
+        controller.cancel();
 
-      // then
-      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns'));
+        // then
+        assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns'));
+      });
+    });
+
+    module('when source is filled with a campaign id', function () {
+      test('it should call transitionTo with appropriate arguments', function (assert) {
+        // given
+        const source = Symbol('Source campaign id');
+        controller.source = source;
+        controller.router = { transitionTo: sinon.stub() };
+
+        // when
+        controller.cancel();
+
+        // then
+        assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.campaign.settings', source));
+      });
     });
   });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/new_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new_test.js
@@ -259,4 +259,14 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
       });
     });
   });
+
+  module('resetController', function () {
+    test('should reset source to null when isExiting true', function (assert) {
+      const route = this.owner.lookup('route:authenticated/campaigns/new');
+
+      const controller = { set: sinon.stub() };
+      route.resetController(controller, true);
+      assert.true(controller.set.calledWithExactly('source', null));
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -541,6 +541,7 @@
       "title": "Settings",
       "actions": {
         "archive": "Archive",
+        "duplicate": "Duplicate",
         "edit": "Edit"
       },
       "campaign-type": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -544,6 +544,7 @@
       "title": "Paramètres",
       "actions": {
         "archive": "Archiver",
+        "duplicate": "Dupliquer",
         "edit": "Modifier"
       },
       "campaign-type": {


### PR DESCRIPTION
## :unicorn: Problème
Nos prescripteurs ont énormément de campagnes à créer parfois seulement avec un PC ou un titre de campagne à changer. Au moment de la rentrée par exemple avec les professeurs SCO de chaque classe créant des campagnes 6ième, 5ième, 4ième, ou encore les enseignants du SUP avec toutes les différentes licences etc.

Suite de cette PR : 
- https://github.com/1024pix/pix/pull/6586


## :robot: Proposition

- Affichage du bouton dupliquer dans l’onglet paramètres
- mettre les boutons au bon endroit dans cet onglet
- à gauche modifier et dupliquer
- à droite le bouton archiver

## :rainbow: Remarques

La maquette prévoit l'ajout d'icônes dans les boutons "Modifier", "Dupliquer" et "Archiver" mais le `PixButtonLink` dans sa forme actuelle ne permet l'ajout d'icône.
Le style des boutons a donc été conservé.

## :100: Pour tester

- Se connecter à Pix Orga
- Aller dans les paramètres d'une campagne
- Appuyer sur le bouton Dupliquer
- Vérifier que les infos de la campagne précédente ont bien été reprises dans la copie
- 🐱 
