### PR TITLE
[FEATURE] Supprimer le feature toggle FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL (PIX-7837).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -221,9 +221,6 @@ const configuration = (function () {
       ),
       isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
       isTargetProfileVersioningEnabled: isFeatureEnabled(process.env.FT_TARGET_PROFILE_VERSIONING),
-      isDifferentiatedTimeInvigilatorPortalEnabled: isFeatureEnabled(
-        process.env.FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL,
-      ),
     },
 
     infra: {
@@ -371,7 +368,6 @@ const configuration = (function () {
 
     config.featureToggles.isMassiveSessionManagementEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
-    config.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled = true;
     config.featureToggles.isTargetProfileVersioningEnabled = true;
 
     config.mailing.enabled = false;

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -29,7 +29,6 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
-  FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL: Joi.string().optional().valid('true', 'false'),
   FT_TARGET_PROFILE_VERSIONING: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -882,13 +882,6 @@ FT_TRAINING_RECOMMENDATION=false
 # default: false
 # FT_PIX_1D_ENABLED=false
 
-# Enable the differentiated time invigilator portal feature
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL=true
-
 # Enable the new versioning of target profile
 #
 # presence: optional

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,7 +24,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-massive-session-management-enabled': false,
             'is-pix1d-enabled': true,
-            'is-differentiated-time-invigilator-portal-enabled': true,
             'is-target-profile-versioning-enabled': true,
           },
         },

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -1,14 +1,4 @@
 <li class="session-supervising-candidate-in-list">
-  {{#if this.isCheckboxToBeDisplayed}}
-    <PixInput
-      @id={{concat "candidate-checkbox-" @candidate.id}}
-      class="session-supervising-candidate-in-list__checkbox"
-      type="checkbox"
-      checked={{@candidate.authorizedToStart}}
-      @ariaLabel={{this.authorizationButtonAriaLabel}}
-      {{on "click" (fn this.toggleCandidate @candidate)}}
-    />
-  {{/if}}
   <div class="session-supervising-candidate-in-list__candidate-data">
     <div class="session-supervising-candidate-in-list__full-name">
       {{@candidate.lastName}}
@@ -16,14 +6,6 @@
     </div>
     <div class="session-supervising-candidate-in-list__details">
       {{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}
-      {{#unless this.shouldDisplayTheoricalEndDatetime}}
-        {{#if @candidate.extraTimePercentage}}
-          ·
-          {{t "common.forms.certification-labels.extratime"}}
-          :
-          {{format-percentage @candidate.extraTimePercentage}}
-        {{/if}}
-      {{/unless}}
       {{#if this.shouldDisplayEnrolledComplementaryCertification}}
         <p class="session-supervising-candidate-in-list-details__enrolment">
           <span class="session-supervising-candidate-in-list-details-enrolment__icon"><FaIcon @icon="award" /></span>
@@ -43,31 +25,28 @@
           {{t "pages.session-supervising.candidate-in-list.complementary-certification-non-eligibility-warning"}}
         </PixMessage>
       {{/if}}
-
-      {{#if this.shouldDisplayTheoricalEndDatetime}}
-        {{#if @candidate.hasStarted}}
-          <p class="session-supervising-candidate-in-list-details-time">
-            <FaIcon @icon="clock" @prefix="far" class="session-supervising-candidate-in-list-details-time__clock" />
-            <div class="session-supervising-candidate-in-list-details-time__text">
-              <span class="session-supervising-candidate-in-list-details-time__text__startdatetime">
-                {{t "pages.session-supervising.candidate-in-list.start-date-time"}}
-                <time>{{this.candidateStartTime}}</time>
+      {{#if @candidate.hasStarted}}
+        <p class="session-supervising-candidate-in-list-details-time">
+          <FaIcon @icon="clock" @prefix="far" class="session-supervising-candidate-in-list-details-time__clock" />
+          <div class="session-supervising-candidate-in-list-details-time__text">
+            <span class="session-supervising-candidate-in-list-details-time__text__startdatetime">
+              {{t "pages.session-supervising.candidate-in-list.start-date-time"}}
+              <time>{{this.candidateStartTime}}</time>
+            </span>
+            <span class="session-supervising-candidate-in-list-details-time__text__end-date-time">
+              {{t "pages.session-supervising.candidate-in-list.end-date-time"}}
+              <time>{{this.candidateTheoricalEndDateTime}}</time>
+            </span>
+            {{#if @candidate.extraTimePercentage}}
+              <span class="session-supervising-candidate-in-list-details-time__text__extra-time-percentage">
+                {{t
+                  "pages.session-supervising.candidate-in-list.extratime"
+                  extraTimePercentage=(format-percentage @candidate.extraTimePercentage)
+                }}
               </span>
-              <span class="session-supervising-candidate-in-list-details-time__text__end-date-time">
-                {{t "pages.session-supervising.candidate-in-list.end-date-time"}}
-                <time>{{this.candidateTheoricalEndDateTime}}</time>
-              </span>
-              {{#if @candidate.extraTimePercentage}}
-                <span class="session-supervising-candidate-in-list-details-time__text__extra-time-percentage">
-                  {{t
-                    "pages.session-supervising.candidate-in-list.extratime"
-                    extraTimePercentage=(format-percentage @candidate.extraTimePercentage)
-                  }}
-                </span>
-              {{/if}}
-            </div>
-          </p>
-        {{/if}}
+            {{/if}}
+          </div>
+        </p>
       {{/if}}
 
     </div>
@@ -106,15 +85,6 @@
         </span>
       {{/if}}
     </div>
-    {{#if @candidate.hasStarted}}
-      {{#unless this.shouldDisplayTheoricalEndDatetime}}
-        <span class="session-supervising-candidate-in-list__start-time">
-          {{t "common.forms.certification-labels.candidate-status.start"}}
-          :
-          <time>{{this.candidateStartTime}}</time>
-        </span>
-      {{/unless}}
-    {{/if}}
   </div>
   {{#if this.optionsMenuShouldBeDisplayed}}
     <div class="session-supervising-candidate-in-list__menu">

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -7,7 +7,6 @@ import dayjs from 'dayjs';
 export default class CandidateInList extends Component {
   @service notifications;
   @service intl;
-  @service featureToggles;
 
   @tracked isMenuOpen = false;
   @tracked isConfirmationModalDisplayed = false;
@@ -18,19 +17,7 @@ export default class CandidateInList extends Component {
   @tracked actionOnConfirmation;
 
   get isConfirmButtonToBeDisplayed() {
-    return (
-      !this.args.candidate.hasStarted &&
-      !this.args.candidate.hasCompleted &&
-      this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
-    );
-  }
-
-  get isCheckboxToBeDisplayed() {
-    return (
-      !this.args.candidate.hasStarted &&
-      !this.args.candidate.hasCompleted &&
-      !this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
-    );
+    return !this.args.candidate.hasStarted && !this.args.candidate.hasCompleted;
   }
 
   get optionsMenuShouldBeDisplayed() {
@@ -38,14 +25,7 @@ export default class CandidateInList extends Component {
   }
 
   get shouldDisplayEnrolledComplementaryCertification() {
-    return (
-      this.args.candidate.enrolledComplementaryCertificationLabel &&
-      this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled
-    );
-  }
-
-  get shouldDisplayTheoricalEndDatetime() {
-    return this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled;
+    return this.args.candidate.enrolledComplementaryCertificationLabel;
   }
 
   get shouldDisplayNonEligibilityWarning() {
@@ -60,9 +40,7 @@ export default class CandidateInList extends Component {
   }
 
   _isReconciliated() {
-    return (
-      this.featureToggles.featureToggles.isDifferentiatedTimeInvigilatorPortalEnabled && this.args.candidate.userId
-    );
+    return this.args.candidate.userId;
   }
 
   get authorizationButtonLabel() {

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,5 +2,4 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isMassiveSessionManagementEnabled;
-  @attr('boolean') isDifferentiatedTimeInvigilatorPortalEnabled;
 }

--- a/certif/mirage/factories/feature-toggle.js
+++ b/certif/mirage/factories/feature-toggle.js
@@ -3,5 +3,4 @@ import { Factory } from 'miragejs';
 export default Factory.extend({
   id: 0,
   isMassiveSessionManagementEnabled: true,
-  isDifferentiatedTimeInvigilatorPortalEnabled: true,
 });

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -4,7 +4,6 @@ import { click, fillIn } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticateSession } from '../helpers/test-init';
 import sinon from 'sinon';
-import { later } from '@ember/runloop';
 import ENV from 'pix-certif/config/environment';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -22,161 +21,6 @@ module('Acceptance | Session supervising', function (hooks) {
       allowedCertificationCenterAccesses: [],
     });
     await authenticateSession(certificationPointOfContact.id);
-  });
-
-  module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function () {
-    module('When there are candidates on the session', function () {
-      test('it should display candidates entries', async function (assert) {
-        // given
-        const sessionId = 12345;
-        server.create('feature-toggle', { isDifferentiatedTimeInvigilatorPortalEnabled: true });
-        this.sessionForSupervising = server.create('session-for-supervising', {
-          id: sessionId,
-          certificationCandidates: [
-            server.create('certification-candidate-for-supervising', {
-              id: 123,
-              firstName: 'John',
-              lastName: 'Doe',
-              birthdate: '1984-05-28',
-              extraTimePercentage: '8',
-              authorizedToStart: true,
-            }),
-            server.create('certification-candidate-for-supervising', {
-              id: 456,
-              firstName: 'Star',
-              lastName: 'Lord',
-              birthdate: '1983-06-28',
-              extraTimePercentage: 12,
-              authorizedToStart: false,
-            }),
-            server.create('certification-candidate-for-supervising', {
-              id: 789,
-              firstName: 'Buffy',
-              lastName: 'Summers',
-              birthdate: '1987-05-28',
-              extraTimePercentage: '6',
-              authorizedToStart: true,
-            }),
-            server.create('certification-candidate-for-supervising', {
-              id: 1000,
-              firstName: 'Rupert',
-              lastName: 'Giles',
-              birthdate: '1934-06-28',
-              extraTimePercentage: '15',
-              authorizedToStart: false,
-            }),
-          ],
-        });
-
-        const screen = await visit('/connexion-espace-surveillant');
-        await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
-        await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
-
-        // when
-        await click(screen.getByRole('button', { name: 'Surveiller la session' }));
-
-        // then
-        assert
-          .dom(
-            screen.getByRole('button', {
-              name: "Confirmer la présence de l'élève Star Lord",
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('button', {
-              name: "Confirmer la présence de l'élève Rupert Giles",
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('button', {
-              name: "Annuler la confirmation de présence de l'élève John Doe",
-            }),
-          )
-          .exists();
-        assert
-          .dom(
-            screen.getByRole('button', {
-              name: "Annuler la confirmation de présence de l'élève Buffy Summers",
-            }),
-          )
-          .exists();
-      });
-    });
-
-    test('when supervisor checks the candidate, it should update authorizedToStart', async function (assert) {
-      // given
-      const sessionId = 12345;
-      server.create('feature-toggle', { isDifferentiatedTimeInvigilatorPortalEnabled: true });
-      this.sessionForSupervising = server.create('session-for-supervising', {
-        id: sessionId,
-        certificationCandidates: [
-          server.create('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'John',
-            lastName: 'Doe',
-            birthdate: '1984-05-28',
-            extraTimePercentage: '8',
-            authorizedToStart: false,
-          }),
-        ],
-      });
-
-      const firstVisit = await visit('/connexion-espace-surveillant');
-      await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
-      await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
-      await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
-
-      // when
-      await click(firstVisit.getByRole('button', { name: "Confirmer la présence de l'élève John Doe" }));
-
-      // then
-      const secondVisit = await visit('/connexion-espace-surveillant');
-      await fillIn(secondVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
-      await fillIn(secondVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
-      await click(secondVisit.getByRole('button', { name: 'Surveiller la session' }));
-
-      assert
-        .dom(secondVisit.getByRole('button', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
-        .exists();
-      assert
-        .dom(secondVisit.queryByRole('button', { name: "Confirmer la présence de l'élève John Doe" }))
-        .doesNotExist();
-    });
-
-    test('when supervisor cancel the presence of the candidate, it should update authorizedToStart', async function (assert) {
-      // given
-      const sessionId = 12345;
-      server.create('feature-toggle', { isDifferentiatedTimeInvigilatorPortalEnabled: true });
-      this.sessionForSupervising = server.create('session-for-supervising', {
-        id: sessionId,
-        certificationCandidates: [
-          server.create('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'John',
-            lastName: 'Doe',
-            birthdate: '1984-05-28',
-            extraTimePercentage: '8',
-            authorizedToStart: false,
-          }),
-        ],
-      });
-
-      const firstVisit = await visit('/connexion-espace-surveillant');
-      await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
-      await fillIn(firstVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
-      await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
-
-      // when
-      await click(firstVisit.getByRole('button', { name: "Confirmer la présence de l'élève John Doe" }));
-      await click(firstVisit.getByRole('button', { name: "Annuler la confirmation de présence de l'élève John Doe" }));
-
-      // then
-      assert.false(server.schema.certificationCandidateForSupervisings.find(123).authorizedToStart);
-    });
   });
 
   module('When there are candidates on the session', function () {
@@ -202,6 +46,22 @@ module('Acceptance | Session supervising', function (hooks) {
             extraTimePercentage: 12,
             authorizedToStart: false,
           }),
+          server.create('certification-candidate-for-supervising', {
+            id: 789,
+            firstName: 'Buffy',
+            lastName: 'Summers',
+            birthdate: '1987-05-28',
+            extraTimePercentage: '6',
+            authorizedToStart: true,
+          }),
+          server.create('certification-candidate-for-supervising', {
+            id: 1000,
+            firstName: 'Rupert',
+            lastName: 'Giles',
+            birthdate: '1934-06-28',
+            extraTimePercentage: '15',
+            authorizedToStart: false,
+          }),
         ],
       });
 
@@ -214,54 +74,33 @@ module('Acceptance | Session supervising', function (hooks) {
 
       // then
       assert
-        .dom(screen.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
+        .dom(
+          screen.getByRole('button', {
+            name: "Confirmer la présence de l'élève Star Lord",
+          }),
+        )
         .exists();
-      assert.dom(screen.getByRole('checkbox', { name: "Confirmer la présence de l'élève Star Lord" })).exists();
-    });
-
-    test('should refresh the candidate list periodically', async function (assert) {
-      // given
-      sinon.stub(ENV.APP, 'sessionSupervisingPollingRate').value(100);
-
-      const sessionForSupervising = server.create('session-for-supervising', {
-        id: 12345,
-        certificationCandidates: [
-          server.create('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'John',
-            lastName: 'Doe',
-            birthdate: '1984-05-28',
-            extraTimePercentage: '8',
-            authorizedToStart: true,
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: "Confirmer la présence de l'élève Rupert Giles",
           }),
-          server.create('certification-candidate-for-supervising', {
-            id: 456,
-            firstName: 'Star',
-            lastName: 'Lord',
-            birthdate: '1983-06-28',
-            extraTimePercentage: 12,
-            authorizedToStart: false,
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: "Annuler la confirmation de présence de l'élève John Doe",
           }),
-        ],
-      });
-
-      let getSessionForSupervisingCount = 0;
-      server.get('/sessions/:id/supervising', () => {
-        getSessionForSupervisingCount++;
-        return sessionForSupervising;
-      });
-
-      // when
-      const screen = await visit('/connexion-espace-surveillant');
-      await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
-      await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
-      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
-
-      // then
-      assert.expect(1);
-      later(() => {
-        assert.deepEqual(getSessionForSupervisingCount, 4);
-      }, 300);
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: "Annuler la confirmation de présence de l'élève Buffy Summers",
+          }),
+        )
+        .exists();
     });
   });
 
@@ -288,19 +127,21 @@ module('Acceptance | Session supervising', function (hooks) {
     await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
 
     // when
-    await click(firstVisit.getByRole('checkbox', { name: "Confirmer la présence de l'élève John Doe" }));
+    await click(firstVisit.getByRole('button', { name: "Confirmer la présence de l'élève John Doe" }));
 
     // then
     const secondVisit = await visit('/connexion-espace-surveillant');
     await fillIn(secondVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
     await fillIn(secondVisit.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
     await click(secondVisit.getByRole('button', { name: 'Surveiller la session' }));
+
     assert
-      .dom(secondVisit.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
-      .isChecked();
+      .dom(secondVisit.getByRole('button', { name: "Annuler la confirmation de présence de l'élève John Doe" }))
+      .exists();
+    assert.dom(secondVisit.queryByRole('button', { name: "Confirmer la présence de l'élève John Doe" })).doesNotExist();
   });
 
-  test('when supervisor checks and unchecks the candidate, it should update authorizedToStart', async function (assert) {
+  test('when supervisor cancel the presence of the candidate, it should update authorizedToStart', async function (assert) {
     // given
     const sessionId = 12345;
     this.sessionForSupervising = server.create('session-for-supervising', {
@@ -323,8 +164,8 @@ module('Acceptance | Session supervising', function (hooks) {
     await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
 
     // when
-    await click(firstVisit.getByRole('checkbox', { name: "Confirmer la présence de l'élève John Doe" }));
-    await click(firstVisit.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève John Doe" }));
+    await click(firstVisit.getByRole('button', { name: "Confirmer la présence de l'élève John Doe" }));
+    await click(firstVisit.getByRole('button', { name: "Annuler la confirmation de présence de l'élève John Doe" }));
 
     // then
     assert.false(server.schema.certificationCandidateForSupervisings.find(123).authorizedToStart);

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -1,9 +1,7 @@
 import { module, test } from 'qunit';
-import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
-import { waitForDialogClose } from '../../../helpers/wait-for';
 
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
@@ -15,419 +13,11 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: false };
-    }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
   });
 
-  module('when FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL is enabled', function (hooks) {
-    hooks.beforeEach(async function () {
-      store = this.owner.lookup('service:store');
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-    });
-
-    test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        id: 123,
-        enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
-      });
-
-      // when
-      const screen = await renderScreen(hbs`
-      <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-    `);
-
-      // then
-      assert.dom(screen.getByText('Inscription à Super Certification Complémentaire')).exists();
-    });
-
-    test('it renders the candidates information with a confirmation button', async function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        id: 123,
-        firstName: 'Gamora',
-        lastName: 'Zen Whoberi Ben Titan',
-        birthdate: '1984-05-28',
-        extraTimePercentage: 0.08,
-        authorizedToStart: false,
-        assessmentStatus: null,
-        complementaryCertification: null,
-      });
-
-      // when
-      const screen = await renderScreen(hbs`
-      <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-    `);
-
-      // then
-      assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
-      assert.dom(screen.getByText('28/05/1984')).exists();
-      assert.dom(screen.queryByText('temps majoré')).doesNotExist();
-      assert
-        .dom(
-          screen.queryByRole('button', {
-            name: "Annuler la confirmation de présence de l'élève Gamora Zen Whoberi Ben Titan",
-          }),
-        )
-        .doesNotExist();
-      assert
-        .dom(screen.getByRole('button', { name: "Confirmer la présence de l'élève Gamora Zen Whoberi Ben Titan" }))
-        .exists();
-    });
-
-    module('when the candidate is authorized to start', function () {
-      test('it renders the cancel confirmation button', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 456,
-          firstName: 'Star',
-          lastName: 'Lord',
-          birthdate: '1983-06-28',
-          extraTimePercentage: 0.12,
-          authorizedToStart: true,
-          assessmentStatus: null,
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-        // then
-        assert.dom(screen.getByText('Lord Star')).exists();
-        assert.dom(screen.getByText('28/06/1983')).exists();
-        assert
-          .dom(screen.getByRole('button', { name: "Annuler la confirmation de présence de l'élève Star Lord" }))
-          .exists();
-        assert.dom(screen.queryByRole('button', { name: "Confirmer la présence de l'élève Star Lord" })).doesNotExist();
-      });
-
-      test('it does not render the time nor extra time', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 456,
-          firstName: 'Star',
-          lastName: 'Lord',
-          startDateTime: new Date('2022-10-19T14:30:15Z'),
-          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-          extraTimePercentage: 12,
-          authorizedToStart: true,
-          assessmentStatus: null,
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-        // then
-        assert
-          .dom(screen.getByRole('button', { name: "Annuler la confirmation de présence de l'élève Star Lord" }))
-          .exists();
-        assert.dom(screen.queryByText('Début :')).doesNotExist();
-        assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
-        assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
-      });
-    });
-
-    module('when the confirmation button is clicked', function () {
-      module('when the candidate is already authorized', function () {
-        test('it calls the argument callback with candidate and false', async function (assert) {
-          // given
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-          }
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'Toto',
-            lastName: 'Tutu',
-            birthdate: '1984-05-28',
-            extraTimePercentage: 0.08,
-            authorizedToStart: true,
-            assessmentResult: null,
-          });
-          this.toggleCandidate = sinon.spy();
-
-          const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />`);
-
-          const cancelButton = screen.getByRole('button', {
-            name: "Annuler la confirmation de présence de l'élève Toto Tutu",
-          });
-
-          // when
-          await click(cancelButton);
-
-          // then
-          sinon.assert.calledOnceWithExactly(this.toggleCandidate, this.candidate);
-          assert.ok(true);
-        });
-      });
-
-      module('when the candidate is not authorized to start', function () {
-        test('it calls the argument callback with candidate', async function (assert) {
-          // given
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-          }
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'Toto',
-            lastName: 'Tutu',
-            birthdate: '1984-05-28',
-            extraTimePercentage: 0.08,
-            authorizedToStart: false,
-            assessmentResult: null,
-          });
-          this.toggleCandidate = sinon.spy();
-
-          const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
-          const confirmationButton = screen.getByRole('button', {
-            name: "Confirmer la présence de l'élève Toto Tutu",
-          });
-
-          // when
-          await click(confirmationButton);
-
-          // then
-          sinon.assert.calledOnceWithExactly(this.toggleCandidate, this.candidate);
-          assert.ok(true);
-        });
-
-        test('it does not render the time nor extra time', async function (assert) {
-          // given
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-          }
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 456,
-            firstName: 'Toto',
-            lastName: 'Tutu',
-            startDateTime: new Date('2022-10-19T14:30:15Z'),
-            theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-            extraTimePercentage: 12,
-            authorizedToStart: false,
-            assessmentStatus: null,
-          });
-
-          // when
-          const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-        `);
-
-          // then
-          assert.dom(screen.getByRole('button', { name: "Confirmer la présence de l'élève Toto Tutu" })).exists();
-          assert.dom(screen.queryByText('Début :')).doesNotExist();
-          assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
-          assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
-        });
-      });
-    });
-
-    module('when the candidate is reconciliated before starting the session', function () {
-      module('when the candidate is no longer eligible to the complementary certification', function () {
-        test('should render a warning message', async function (assert) {
-          // given
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
-            userId: 678,
-            isStillEligibleToComplementaryCertification: false,
-          });
-
-          // when
-          const screen = await renderScreen(hbs`
-            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-          `);
-
-          // then
-          assert
-            .dom(
-              screen.getByText(
-                'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
-              ),
-            )
-            .exists();
-        });
-      });
-
-      module('when the candidate is still eligible to the complementary certification', function () {
-        test('should not render a warning message', async function (assert) {
-          // given
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
-            userId: 678,
-            isStillEligibleToComplementaryCertification: true,
-          });
-
-          // when
-          const screen = await renderScreen(hbs`
-            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-          `);
-
-          // then
-          assert
-            .dom(
-              screen.queryByText(
-                'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
-              ),
-            )
-            .doesNotExist();
-        });
-      });
-    });
-
-    module('when the candidate is not reconciliated before starting the session', function () {
-      test('should not render a warning message', async function (assert) {
-        // given
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 123,
-          enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
-          isStillEligibleToComplementaryCertification: false,
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-          `);
-
-        // then
-        assert
-          .dom(
-            screen.queryByText(
-              'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
-            ),
-          )
-          .doesNotExist();
-      });
-    });
-
-    module('when the candidate has started the test', function () {
-      test('it renders the time and extra time', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 456,
-          startDateTime: new Date('2022-10-19T14:30:15Z'),
-          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-          extraTimePercentage: 0.12,
-          authorizedToStart: false,
-          assessmentStatus: 'started',
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-        // then
-        assert.dom(screen.getByText('En cours')).exists();
-        assert.dom(screen.getByText('Début :')).exists();
-        assert.dom(screen.getByText('Fin théorique :')).exists();
-        assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
-      });
-    });
-
-    module('when the candidate has left the session and has been authorized to resume', function () {
-      test('it renders the time and extra time', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 456,
-          startDateTime: new Date('2022-10-19T14:30:15Z'),
-          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-          extraTimePercentage: 0.12,
-          authorizedToStart: true,
-          assessmentStatus: 'started',
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-        // then
-        assert.dom(screen.getByText('Autorisé à reprendre')).exists();
-        assert.dom(screen.getByText('Début :')).exists();
-        assert.dom(screen.getByText('Fin théorique :')).exists();
-        assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
-      });
-    });
-
-    module('when the candidate has completed the test', function () {
-      test('it does not render the time nor extra time', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 456,
-          startDateTime: new Date('2022-10-19T14:30:15Z'),
-          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-          extraTimePercentage: 12,
-          authorizedToStart: false,
-          assessmentStatus: 'completed',
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-        // then
-        assert.dom(screen.getByText('Terminé')).exists();
-        assert.dom(screen.queryByText('Début :')).doesNotExist();
-        assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
-        assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
-      });
-    });
-  });
-
-  test('it renders the candidates information with an unchecked checkbox', async function (assert) {
-    // given
+  test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
     this.candidate = store.createRecord('certification-candidate-for-supervising', {
       id: 123,
-      firstName: 'Gamora',
-      lastName: 'Zen Whoberi Ben Titan',
-      birthdate: '1984-05-28',
-      extraTimePercentage: 0.08,
-      authorizedToStart: false,
-      assessmentStatus: null,
       enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
     });
 
@@ -437,23 +27,45 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     `);
 
     // then
+    assert.dom(screen.getByText('Inscription à Super Certification Complémentaire')).exists();
+  });
+
+  test('it renders the candidates information with a confirmation button', async function (assert) {
+    // given
+    this.candidate = store.createRecord('certification-candidate-for-supervising', {
+      id: 123,
+      firstName: 'Gamora',
+      lastName: 'Zen Whoberi Ben Titan',
+      birthdate: '1984-05-28',
+      extraTimePercentage: 0.08,
+      authorizedToStart: false,
+      assessmentStatus: null,
+      complementaryCertification: null,
+    });
+
+    // when
+    const screen = await renderScreen(hbs`
+      <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+    `);
+
+    // then
     assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
-    assert.dom(screen.getByText('28/05/1984 · Temps majoré : 8 %')).exists();
-    assert.dom(screen.queryByText('Inscription à Super Certification Complémentaire')).doesNotExist();
-    assert
-      .dom(screen.getByRole('checkbox', { name: "Confirmer la présence de l'élève Gamora Zen Whoberi Ben Titan" }))
-      .isNotChecked();
+    assert.dom(screen.getByText('28/05/1984')).exists();
+    assert.dom(screen.queryByText('temps majoré')).doesNotExist();
     assert
       .dom(
-        screen.queryByText(
-          'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
-        ),
+        screen.queryByRole('button', {
+          name: "Annuler la confirmation de présence de l'élève Gamora Zen Whoberi Ben Titan",
+        }),
       )
       .doesNotExist();
+    assert
+      .dom(screen.getByRole('button', { name: "Confirmer la présence de l'élève Gamora Zen Whoberi Ben Titan" }))
+      .exists();
   });
 
   module('when the candidate is authorized to start', function () {
-    test('it renders the checkbox checked', async function (assert) {
+    test('it renders the cancel confirmation button', async function (assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 456,
@@ -472,20 +84,22 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
       // then
       assert.dom(screen.getByText('Lord Star')).exists();
-      assert.dom(screen.getByText('28/06/1983 · Temps majoré : 12 %')).exists();
+      assert.dom(screen.getByText('28/06/1983')).exists();
       assert
-        .dom(screen.getByRole('checkbox', { name: "Annuler la confirmation de présence de l'élève Star Lord" }))
-        .isChecked();
+        .dom(screen.getByRole('button', { name: "Annuler la confirmation de présence de l'élève Star Lord" }))
+        .exists();
+      assert.dom(screen.queryByRole('button', { name: "Confirmer la présence de l'élève Star Lord" })).doesNotExist();
     });
 
-    test('it does not display neither "en cours" label nor the options menu button', async function (assert) {
+    test('it does not render the time nor extra time', async function (assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        id: 789,
-        firstName: 'Rocket',
-        lastName: 'Racoon',
-        birthdate: '1982-07-28',
-        extraTimePercentage: null,
+        id: 456,
+        firstName: 'Star',
+        lastName: 'Lord',
+        startDateTime: new Date('2022-10-19T14:30:15Z'),
+        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+        extraTimePercentage: 12,
         authorizedToStart: true,
         assessmentStatus: null,
       });
@@ -496,559 +110,16 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       `);
 
       // then
-      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).doesNotExist();
-      assert.dom(screen.queryByText('En cours')).doesNotExist();
+      assert
+        .dom(screen.getByRole('button', { name: "Annuler la confirmation de présence de l'élève Star Lord" }))
+        .exists();
+      assert.dom(screen.queryByText('Début :')).doesNotExist();
+      assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
+      assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
     });
   });
 
-  module('when the candidate has started the test', function () {
-    module('when the candidate has not left the session', function () {
-      test('it displays the "en cours" label, the start time and the options menu button', async function (assert) {
-        // given
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 789,
-          firstName: 'Rocket',
-          lastName: 'Racoon',
-          birthdate: '1982-07-28',
-          extraTimePercentage: null,
-          authorizedToStart: false,
-          assessmentStatus: 'started',
-          startDateTime: new Date('2022-10-19T14:30:15Z'),
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-        `);
-
-        // then
-        assert.dom(screen.getByText('Racoon Rocket')).exists();
-        assert.dom(screen.getByText('28/07/1982')).exists();
-        assert.dom(screen.getByText('En cours')).exists();
-        assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
-        assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
-        assert
-          .dom(
-            screen.queryByRole('button', {
-              name: 'Afficher les options du candidat',
-            }),
-          )
-          .exists();
-      });
-    });
-
-    module('when the candidate has left the session and has been authorized to resume', function () {
-      test('it displays the "Autorisé à reprendre" label, the start time and the options menu button', async function (assert) {
-        // given
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 789,
-          firstName: 'Rocket',
-          lastName: 'Racoon',
-          birthdate: '1982-07-28',
-          extraTimePercentage: null,
-          authorizedToStart: true,
-          assessmentStatus: 'started',
-          startDateTime: new Date('2022-10-19T14:30:15Z'),
-        });
-
-        // when
-        const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-        `);
-
-        // then
-        assert.dom(screen.getByText('Autorisé à reprendre')).exists();
-        assert.dom(screen.queryByText('En cours')).doesNotExist();
-      });
-    });
-
-    module('when the candidate options button is clicked', function () {
-      test('it displays the "autoriser la reprise" option', async function (assert) {
-        // given
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 1123,
-          firstName: 'Drax',
-          lastName: 'The Destroyer',
-          birthdate: '1928-08-27',
-          extraTimePercentage: null,
-          authorizedToStart: true,
-          assessmentStatus: 'started',
-        });
-
-        const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-        `);
-
-        // when
-        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Autoriser la reprise du test' })).exists();
-      });
-
-      test('it displays the "Terminer le test" option', async function (assert) {
-        // given
-        this.candidate = store.createRecord('certification-candidate-for-supervising', {
-          id: 1123,
-          firstName: 'Drax',
-          lastName: 'The Destroyer',
-          birthdate: '1928-08-27',
-          extraTimePercentage: null,
-          authorizedToStart: true,
-          assessmentStatus: 'started',
-        });
-        this.toggleCandidate = sinon.spy();
-        const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
-
-        // when
-        await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Terminer le test' })).exists();
-      });
-
-      module('when the "autoriser la reprise" option is clicked', function () {
-        test('it displays a confirmation modal', async function (assert) {
-          // given
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 1123,
-            firstName: 'Drax',
-            lastName: 'The Destroyer',
-            birthdate: '1928-08-27',
-            extraTimePercentage: null,
-            authorizedToStart: true,
-            assessmentStatus: 'started',
-          });
-
-          const screen = await renderScreen(hbs`
-            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-          `);
-
-          // when
-          await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-          await screen.findByRole('dialog');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: "Je confirme l'autorisation" })).exists();
-          assert.dom(screen.getByText('Autoriser Drax The Destroyer à reprendre son test ?')).exists();
-          assert
-            .dom(
-              screen.getByText(
-                "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
-              ),
-            )
-            .exists();
-        });
-
-        module('when the confirmation modal "Annuler" button is clicked', function () {
-          test('it closes the confirmation modal', async function (assert) {
-            // given
-            this.candidate = store.createRecord('certification-candidate-for-supervising', {
-              id: 1123,
-              firstName: 'Drax',
-              lastName: 'The Destroyer',
-              birthdate: '1928-08-27',
-              extraTimePercentage: null,
-              authorizedToStart: true,
-              assessmentStatus: 'started',
-            });
-
-            const screen = await renderScreen(hbs`
-              <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-            `);
-
-            // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-            await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-            await screen.findByRole('dialog');
-            await click(screen.getByRole('button', { name: 'Annuler et fermer la fenêtre de confirmation' }));
-            await waitForDialogClose();
-
-            // then
-            assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
-          });
-        });
-
-        module('when the confirmation modal "Fermer" button is clicked', function () {
-          test('it closes the confirmation modal', async function (assert) {
-            // given
-            this.candidate = store.createRecord('certification-candidate-for-supervising', {
-              id: 1123,
-              firstName: 'Drax',
-              lastName: 'The Destroyer',
-              birthdate: '1928-08-27',
-              extraTimePercentage: null,
-              authorizedToStart: true,
-              assessmentStatus: 'started',
-            });
-
-            const screen = await renderScreen(hbs`
-              <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-            `);
-
-            // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-            await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-            await screen.findByRole('dialog');
-            await click(screen.getByRole('button', { name: 'Fermer' }));
-            await waitForDialogClose();
-
-            // then
-            assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
-          });
-        });
-
-        module('when the confirmation modal "Je confirme…" button is clicked', function () {
-          module('when the authorization succeeds', function () {
-            test('it closes the modal and displays a success notification', async function (assert) {
-              // given
-              this.candidate = store.createRecord('certification-candidate-for-supervising', {
-                firstName: 'Yondu',
-                lastName: 'Undonta',
-                authorizedToStart: true,
-                assessmentStatus: 'started',
-              });
-              this.authorizeTestResume = sinon.stub().resolves();
-              const screen = await renderScreen(hbs`
-                <SessionSupervising::CandidateInList
-                  @candidate={{this.candidate}}
-                  @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
-                />
-                <NotificationContainer @position="bottom-right" />
-              `);
-
-              // when
-              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-              await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-              await screen.findByRole('dialog');
-              await click(screen.getByRole('button', { name: "Je confirme l'autorisation" }));
-              await waitForDialogClose();
-
-              // then
-              sinon.assert.calledOnce(this.authorizeTestResume);
-              assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
-              assert.dom(screen.getByText('Succès ! Yondu Undonta peut reprendre son test de certification.')).exists();
-            });
-          });
-
-          module('when the authorization fails', function () {
-            test('it closes the modal and displays an error notification', async function (assert) {
-              // given
-              this.candidate = store.createRecord('certification-candidate-for-supervising', {
-                firstName: 'Vance',
-                lastName: 'Astro',
-                authorizedToStart: true,
-                assessmentStatus: 'started',
-              });
-              this.authorizeTestResume = sinon.stub().rejects({ errors: [] });
-              const screen = await renderScreen(hbs`
-                <SessionSupervising::CandidateInList
-                  @candidate={{this.candidate}}
-                  @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
-                />
-                <NotificationContainer @position="bottom-right" />
-              `);
-
-              // when
-              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-              await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-              await screen.findByRole('dialog');
-              await click(screen.getByRole('button', { name: "Je confirme l'autorisation" }));
-              await waitForDialogClose();
-
-              // then
-              sinon.assert.calledOnce(this.authorizeTestResume);
-              assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
-              assert
-                .dom(
-                  screen.getByText(
-                    "Une erreur est survenue, Vance Astro n'a pas pu être autorisé à reprendre son test.",
-                  ),
-                )
-                .exists();
-            });
-          });
-
-          module('when the candidate could not be found', function () {
-            test('it closes the modal and displays an error notification', async function (assert) {
-              // given
-              this.candidate = store.createRecord('certification-candidate-for-supervising', {
-                firstName: 'Vance',
-                lastName: 'Astro',
-                authorizedToStart: true,
-                assessmentStatus: 'started',
-              });
-              this.authorizeTestResume = sinon.stub().rejects({ errors: [{ code: 'CANDIDATE_NOT_FOUND' }] });
-              const screen = await renderScreen(hbs`
-                <SessionSupervising::CandidateInList
-                  @candidate={{this.candidate}}
-                  @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
-                />
-                <NotificationContainer @position="bottom-right" />
-              `);
-
-              // when
-              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-              await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-              await screen.findByRole('dialog');
-              await click(screen.getByRole('button', { name: "Je confirme l'autorisation" }));
-              await waitForDialogClose();
-
-              // then
-              sinon.assert.calledOnce(this.authorizeTestResume);
-              assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
-              assert
-                .dom(screen.getByText("Une erreur est survenue, le candidat Vance Astro n'a pas été trouvé."))
-                .exists();
-            });
-          });
-        });
-      });
-
-      module('when the "Terminer le test" option is clicked', function () {
-        test('it displays a confirmation modal', async function (assert) {
-          // given
-          this.candidate = store.createRecord('certification-candidate-for-supervising', {
-            id: 1123,
-            firstName: 'Drax',
-            lastName: 'The Destroyer',
-            birthdate: '1928-08-27',
-            extraTimePercentage: null,
-            authorizedToStart: true,
-            assessmentStatus: 'started',
-          });
-          this.toggleCandidate = sinon.spy();
-          const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
-
-          // when
-          await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Terminer le test' }));
-          await screen.findByRole('dialog');
-          const actions = screen.getAllByRole('button', { name: 'Terminer le test' });
-
-          // then
-          assert.strictEqual(actions.length, 2);
-          assert
-            .dom(
-              screen.getByText(
-                'Attention : cette action entraîne la fin de son test de certification et est irréversible.',
-              ),
-            )
-            .exists();
-          assert.dom(screen.getByRole('heading', { name: 'Terminer le test de Drax The Destroyer ?' })).exists();
-        });
-
-        module('when the confirmation modal "Annuler" button is clicked', function () {
-          test('it closes the confirmation modal', async function (assert) {
-            // given
-            this.candidate = store.createRecord('certification-candidate-for-supervising', {
-              id: 1123,
-              firstName: 'Drax',
-              lastName: 'The Destroyer',
-              birthdate: '1928-08-27',
-              extraTimePercentage: null,
-              authorizedToStart: true,
-              assessmentStatus: 'started',
-            });
-            this.toggleCandidate = sinon.spy();
-            const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
-
-            // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-            await click(screen.getByRole('button', { name: 'Terminer le test' }));
-            await screen.findByRole('dialog');
-            await click(screen.getByRole('button', { name: 'Annuler et fermer la fenêtre de confirmation' }));
-            await waitForDialogClose();
-
-            // then
-            assert.dom(screen.getByRole('button', { name: 'Afficher les options du candidat' })).exists();
-            assert
-              .dom(screen.queryByRole('heading', { name: 'Terminer le test de Drax The Destroyer ?' }))
-              .doesNotExist();
-          });
-        });
-
-        module('when the confirmation modal "Fermer" button is clicked', function () {
-          test('it closes the confirmation modal', async function (assert) {
-            // given
-            this.candidate = store.createRecord('certification-candidate-for-supervising', {
-              id: 1123,
-              firstName: 'Drax',
-              lastName: 'The Destroyer',
-              birthdate: '1928-08-27',
-              extraTimePercentage: null,
-              authorizedToStart: true,
-              assessmentStatus: 'started',
-            });
-            this.toggleCandidate = sinon.spy();
-            const screen = await renderScreen(hbs`
-          <SessionSupervising::CandidateInList
-            @candidate={{this.candidate}}
-            @toggleCandidate={{this.toggleCandidate}}
-          />
-        `);
-
-            // when
-            await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-            await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
-            await screen.findByRole('dialog');
-
-            await click(screen.getByRole('button', { name: 'Fermer' }));
-            await waitForDialogClose();
-
-            // then
-            assert
-              .dom(screen.queryByRole('heading', { name: 'Autoriser Drax The Destroyer à reprendre son test ?' }))
-              .doesNotExist();
-          });
-        });
-
-        module('when the confirmation modal "Terminer le test" button is clicked', function () {
-          module('when the end by supervisors succeeds', function () {
-            test('it closes the end test modal and displays a success notification', async function (assert) {
-              // given
-              this.candidate = store.createRecord('certification-candidate-for-supervising', {
-                firstName: 'Yondu',
-                lastName: 'Undonta',
-                authorizedToStart: true,
-                assessmentStatus: 'started',
-              });
-              this.toggleCandidate = sinon.spy();
-              this.endAssessmentForCandidate = sinon.stub().resolves();
-              const screen = await renderScreen(hbs`
-                <SessionSupervising::CandidateInList
-                  @candidate={{this.candidate}}
-                  @toggleCandidate={{this.toggleCandidate}}
-                  @onSupervisorEndAssessment={{this.endAssessmentForCandidate}}
-                />
-                <NotificationContainer @position="bottom-right" />
-              `);
-
-              // when
-              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-              await click(screen.getByRole('button', { name: 'Terminer le test' }));
-              await screen.findByRole('dialog');
-              const [, endTestModal] = screen.getAllByRole('button', { name: 'Terminer le test' });
-              await click(endTestModal);
-              await waitForDialogClose();
-
-              // then
-              sinon.assert.calledOnce(this.endAssessmentForCandidate);
-              assert.dom(screen.getByText('Succès ! Le test de Yondu Undonta est terminé.')).exists();
-            });
-          });
-
-          module('when the end by supervisor fails', function () {
-            test('it closes the end test modal and displays an error notification', async function (assert) {
-              // given
-              this.candidate = store.createRecord('certification-candidate-for-supervising', {
-                firstName: 'Vance',
-                lastName: 'Astro',
-                authorizedToStart: true,
-                assessmentStatus: 'started',
-              });
-              this.toggleCandidate = sinon.spy();
-              this.endAssessmentBySupervisor = sinon.stub().rejects();
-              const screen = await renderScreen(hbs`
-                <SessionSupervising::CandidateInList
-                  @candidate={{this.candidate}}
-                  @toggleCandidate={{this.toggleCandidate}}
-                  @onSupervisorEndAssessment={{this.endAssessmentBySupervisor}}
-                />
-                <NotificationContainer @position="bottom-right" />
-              `);
-
-              // when
-              await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-              await click(screen.getByRole('button', { name: 'Terminer le test' }));
-              await screen.findByRole('dialog');
-
-              const [, endTestModal] = screen.getAllByRole('button', { name: 'Terminer le test' });
-              await click(endTestModal);
-              await waitForDialogClose();
-
-              // then
-              sinon.assert.calledOnce(this.endAssessmentBySupervisor);
-              assert.dom(screen.queryByRole('heading', { name: 'Terminer le test de Vance Astro ?' })).doesNotExist();
-              assert
-                .dom(screen.getByText("Une erreur est survenue, le test de Vance Astro n'a pas pu être terminé."))
-                .exists();
-            });
-          });
-        });
-      });
-    });
-  });
-
-  module('when the candidate has completed the test', function () {
-    test('it displays the "terminé" label and no options menu', async function (assert) {
-      // given
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        firstName: 'Martinex',
-        lastName: "T'Naga",
-        birthdate: '1979-08-27',
-        extraTimePercentage: null,
-        authorizedToStart: true,
-        assessmentStatus: 'completed',
-      });
-
-      // when
-      const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-      // then
-      assert.dom(screen.getByText("T'Naga Martinex")).exists();
-      assert.dom(screen.getByText('27/08/1979')).exists();
-      assert.dom(screen.getByText('Terminé')).exists();
-      assert.dom(screen.queryByRole('checkbox', { name: "T'Naga Martinex" })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).doesNotExist();
-    });
-  });
-
-  module("when the candidate's test has been ended by supervisor", function () {
-    test('it displays the "terminé" label and no options menu', async function (assert) {
-      // given
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        firstName: 'Stakar',
-        lastName: 'Ogord',
-        birthdate: '1976-09-26',
-        extraTimePercentage: null,
-        authorizedToStart: true,
-        assessmentStatus: 'endedBySupervisor',
-      });
-
-      // when
-      const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
-
-      // then
-      assert.dom(screen.getByText('Ogord Stakar')).exists();
-      assert.dom(screen.getByText('26/09/1976')).exists();
-      assert.dom(screen.getByText('Terminé')).exists();
-      assert.dom(screen.queryByRole('checkbox', { name: 'Ogord Stakar' })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).doesNotExist();
-    });
-  });
-
-  module('when the checkbox is clicked', function () {
+  module('when the confirmation button is clicked', function () {
     module('when the candidate is already authorized', function () {
       test('it calls the argument callback with candidate and false', async function (assert) {
         // given
@@ -1068,10 +139,13 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             @candidate={{this.candidate}}
             @toggleCandidate={{this.toggleCandidate}}
           />`);
-        const checkbox = screen.getByRole('checkbox');
+
+        const cancelButton = screen.getByRole('button', {
+          name: "Annuler la confirmation de présence de l'élève Toto Tutu",
+        });
 
         // when
-        await checkbox.click();
+        await click(cancelButton);
 
         // then
         sinon.assert.calledOnceWithExactly(this.toggleCandidate, this.candidate);
@@ -1079,7 +153,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       });
     });
 
-    module('when the candidate is not authorized', function () {
+    module('when the candidate is not authorized to start', function () {
       test('it calls the argument callback with candidate', async function (assert) {
         // given
         this.candidate = store.createRecord('certification-candidate-for-supervising', {
@@ -1099,15 +173,196 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             @toggleCandidate={{this.toggleCandidate}}
           />
         `);
-        const checkbox = screen.getByRole('checkbox');
+        const confirmationButton = screen.getByRole('button', {
+          name: "Confirmer la présence de l'élève Toto Tutu",
+        });
 
         // when
-        await checkbox.click();
+        await click(confirmationButton);
 
         // then
         sinon.assert.calledOnceWithExactly(this.toggleCandidate, this.candidate);
         assert.ok(true);
       });
+
+      test('it does not render the time nor extra time', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 456,
+          firstName: 'Toto',
+          lastName: 'Tutu',
+          startDateTime: new Date('2022-10-19T14:30:15Z'),
+          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+          extraTimePercentage: 12,
+          authorizedToStart: false,
+          assessmentStatus: null,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+        `);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: "Confirmer la présence de l'élève Toto Tutu" })).exists();
+        assert.dom(screen.queryByText('Début :')).doesNotExist();
+        assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
+        assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
+      });
+    });
+  });
+
+  module('when the candidate is reconciliated before starting the session', function () {
+    module('when the candidate is no longer eligible to the complementary certification', function () {
+      test('should render a warning message', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
+          userId: 678,
+          isStillEligibleToComplementaryCertification: false,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
+            ),
+          )
+          .exists();
+      });
+    });
+
+    module('when the candidate is still eligible to the complementary certification', function () {
+      test('should not render a warning message', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
+          userId: 678,
+          isStillEligibleToComplementaryCertification: true,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
+
+        // then
+        assert
+          .dom(
+            screen.queryByText(
+              'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
+            ),
+          )
+          .doesNotExist();
+      });
+    });
+  });
+
+  module('when the candidate is not reconciliated before starting the session', function () {
+    test('should not render a warning message', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 123,
+        enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
+        isStillEligibleToComplementaryCertification: false,
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+            <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+          `);
+
+      // then
+      assert
+        .dom(
+          screen.queryByText(
+            'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
+          ),
+        )
+        .doesNotExist();
+    });
+  });
+
+  module('when the candidate has started the test', function () {
+    test('it renders the time and extra time', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        startDateTime: new Date('2022-10-19T14:30:15Z'),
+        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+        extraTimePercentage: 0.12,
+        authorizedToStart: false,
+        assessmentStatus: 'started',
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+      `);
+
+      // then
+      assert.dom(screen.getByText('En cours')).exists();
+      assert.dom(screen.getByText('Début :')).exists();
+      assert.dom(screen.getByText('Fin théorique :')).exists();
+      assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
+    });
+  });
+
+  module('when the candidate has left the session and has been authorized to resume', function () {
+    test('it renders the time and extra time', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        startDateTime: new Date('2022-10-19T14:30:15Z'),
+        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+        extraTimePercentage: 0.12,
+        authorizedToStart: true,
+        assessmentStatus: 'started',
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+      `);
+
+      // then
+      assert.dom(screen.getByText('Autorisé à reprendre')).exists();
+      assert.dom(screen.getByText('Début :')).exists();
+      assert.dom(screen.getByText('Fin théorique :')).exists();
+      assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
+    });
+  });
+
+  module('when the candidate has completed the test', function () {
+    test('it does not render the time nor extra time', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        startDateTime: new Date('2022-10-19T14:30:15Z'),
+        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+        extraTimePercentage: 12,
+        authorizedToStart: false,
+        assessmentStatus: 'completed',
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+      `);
+
+      // then
+      assert.dom(screen.getByText('Terminé')).exists();
+      assert.dom(screen.queryByText('Début :')).doesNotExist();
+      assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
+      assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
     });
   });
 });

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillIn, click } from '@ember/test-helpers';
-import Service from '@ember/service';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import { hbs } from 'ember-cli-htmlbars';
@@ -13,10 +12,6 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isDifferentiatedTimeInvigilatorPortalEnabled: false };
-    }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
   });
 
   module('when there are candidates', function () {

--- a/certif/tests/unit/services/featureToggles_test.js
+++ b/certif/tests/unit/services/featureToggles_test.js
@@ -11,7 +11,7 @@ module('Unit | Service | feature toggles', function (hooks) {
     test('should load the feature toggles', async function (assert) {
       // Given
       const featureToggles = Object.create({
-        isDifferentiatedTimeInvigilatorPortalEnabled: false,
+        isMassiveSessionManagementEnabled: false,
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(featureToggles),


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix actuelle concernant le MVP de la gestion des temps différenciés de certification par le surveillant, plusieurs modifications ont été apportées à l’Espace Surveillant afin d’aider le surveillant dans sa tâche.

Cette fonctionnalité a été rendu disponible en production le 27 juin, il n'est dont plus nécessaire de garder le feature toggle.

## :robot: Proposition
Supprimer le feature toggle FT_DIFFERENTIATED_TIME_INVIGILATOR_PORTAL

## :100: Pour tester

- Se connecter sur Pix Certif avec certif-pro@example.net
- Constater que l'appel api feature-toggle ne renvoie plus le FT
- Aller dans l'espace surveillant et renseigner les infos trouvable dans la page de détails de la session 7007
- Constater que l'on a bien le bouton de confirmation (plus de checkbox)
- Confirmer la présence de l'élève Jean Jean
- Se connecter sur Pix App avec certif-success@example.net
- Cliquer dans l'onglet certifications
- Renseigner les infos de l'élève 7007 Jean Jean 01/01/2000
- Renseigner le code candidat (trouvable dans le détail de la session sur Pix Certif)
- Revenir dans l'espace surveillant et constater que les infos candidats sont présentes :
 -  heure théorique
 - l'inscription à la certif complémentaire
 - temps majoré (si utilisateur est éligible) sinon bandeau jaune dans le cas contraire
 
<img width="591" alt="Capture d’écran 2023-07-18 à 11 46 11" src="https://github.com/1024pix/pix/assets/58915422/ccbcd653-7594-4113-902e-ce35d29b99df">

