### PR TITLE
[FEATURE] renvoyer l'information de la jointure entre un profile cible et une campagne dans l'API admin (PIX-8645).

### DIFF
--- a/api/lib/domain/models/TargetProfileForAdmin.js
+++ b/api/lib/domain/models/TargetProfileForAdmin.js
@@ -12,6 +12,7 @@ class TargetProfileForAdmin {
     category,
     isSimplifiedAccess,
     areKnowledgeElementsResettable,
+    hasLinkedCampaign,
     badges,
     stageCollection,
     areas = [],
@@ -31,6 +32,7 @@ class TargetProfileForAdmin {
     this.category = category;
     this.isSimplifiedAccess = isSimplifiedAccess;
     this.areKnowledgeElementsResettable = areKnowledgeElementsResettable;
+    this.hasLinkedCampaign = hasLinkedCampaign;
     this.badges = badges;
     this.stageCollection = stageCollection;
     this.areas = areas.map(

--- a/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -48,6 +48,7 @@ async function _toDomain(targetProfileDTO, tubesData, locale) {
   const { areas, competences, thematics, tubes } = await _getLearningContent(targetProfileDTO.id, tubesData, locale);
   const badges = await _findBadges(targetProfileDTO.id);
   const stageCollection = await _getStageCollection(targetProfileDTO.id);
+  const hasLinkedCampaign = await _hasLinkedCampaign(targetProfileDTO.id);
 
   return new TargetProfileForAdmin({
     ...targetProfileDTO,
@@ -57,6 +58,7 @@ async function _toDomain(targetProfileDTO, tubesData, locale) {
     competences,
     thematics,
     tubes,
+    hasLinkedCampaign,
   });
 }
 
@@ -147,4 +149,10 @@ async function _getStageCollection(targetProfileId) {
     .first();
 
   return new StageCollection({ id: targetProfileId, stages, maxLevel });
+}
+
+async function _hasLinkedCampaign(targetProfileId) {
+  const campaigns = await knex('campaigns').where({ targetProfileId }).first();
+
+  return Boolean(campaigns);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -24,6 +24,7 @@ const serialize = function (targetProfiles) {
       'category',
       'isSimplifiedAccess',
       'areKnowledgeElementsResettable',
+      'hasLinkedCampaign',
       'badges',
       'stageCollection',
       'areas',

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
@@ -1,4 +1,11 @@
-import { catchErr, databaseBuilder, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
+import {
+  catchErr,
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  mockLearningContent,
+  learningContentBuilder,
+} from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import * as targetProfileForAdminRepository from '../../../../lib/infrastructure/repositories/target-profile-for-admin-repository.js';
 import { TargetProfileForAdmin } from '../../../../lib/domain/models/TargetProfileForAdmin.js';
@@ -439,6 +446,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           category: targetProfileDB.category,
           isSimplifiedAccess: targetProfileDB.isSimplifiedAccess,
           areKnowledgeElementsResettable: targetProfileDB.areKnowledgeElementsResettable,
+          hasLinkedCampaign: false,
           badges: [expectedBadge1, expectedBadge2],
           stageCollection: expectedStageCollection,
           areas: [areaA],
@@ -585,6 +593,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           category: targetProfileDB.category,
           isSimplifiedAccess: targetProfileDB.isSimplifiedAccess,
           areKnowledgeElementsResettable: targetProfileDB.areKnowledgeElementsResettable,
+          hasLinkedCampaign: false,
           areas: [areaA],
           competences: [compA_areaA],
           thematics: [themA_compA_areaA],
@@ -593,6 +602,25 @@ describe('Integration | Repository | target-profile-for-admin', function () {
           stageCollection: expectedStageCollection,
         });
         expect(actualTargetProfile).to.deepEqualInstance(expectedTargetProfile);
+      });
+    });
+
+    context('when target profile has a linked campaign', function () {
+      it('should return target profile with hasLinkedCampaign at true', async function () {
+        // given
+        const { id } = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildCampaign({ targetProfileId: id });
+        await databaseBuilder.commit();
+
+        const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
+        const learningContentObjects = learningContentBuilder([learningContent]);
+        mockLearningContent(learningContentObjects);
+
+        // when
+        const actualTargetProfile = await targetProfileForAdminRepository.get({ id });
+
+        // then
+        expect(actualTargetProfile.hasLinkedCampaign).to.be.true;
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -104,6 +104,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
         category: 'OTHER',
         isSimplifiedAccess: true,
         areKnowledgeElementsResettable: false,
+        hasLinkedCampaign: false,
         badges: [badge1, badge2],
         stageCollection,
         areas: [area, area2],
@@ -191,6 +192,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             name: 'Mon Super profil cible',
             outdated: true,
             'owner-organization-id': 12,
+            'has-linked-campaign': false,
           },
           relationships: {
             areas: {


### PR DESCRIPTION
## :unicorn: Problème

Nous n'avons pas la connaissance de l'utilisation d'un profil cible par une campagne active.

## :robot: Proposition

Via l'API, renvoyer cette information dans la route `/api/admin/target-profiles/{id}`.

## :100: Pour tester

Se connecter sur Admin en RA

#### 1️⃣ Target-profile relié à au moins une campagne

- Dans un terminal :

```
scalingo --region osc-fr1 --app pix-api-review-pr6627 pgsql-console
```

```
SELECT COUNT(*) FROM "campaigns" WHERE "targetProfileId" = 56;
```
> Retourne 2.

- Visiter la page https://admin-pr6627.review.pix.fr/target-profiles/56/details
- Vérifier qu'on a bien une requête du target-profile `56` avec la donnée `has-linked-campaign: true` 

#### 2️⃣ Target-profile relié à aucune campagne

```
SELECT COUNT(*) FROM "campaigns" WHERE "targetProfileId" = 76;
```
> Retourne 0.

- Visiter la page https://admin-pr6627.review.pix.fr/target-profiles/76/details 
- Vérifier qu'on a bien une requête du target-profile `76` avec la donnée `has-linked-campaign: false` 