### PR TITLE
[POC] Utiliser l'API native Javascript pour lire les consignes

### DIFF
--- a/mon-pix/app/components/challenge-statement.hbs
+++ b/mon-pix/app/components/challenge-statement.hbs
@@ -3,6 +3,12 @@
   {{#if this.challengeInstruction}}
     <div class="challenge-statement__instruction-section">
       <MarkdownToHtmlUnsafe @class="challenge-statement-instruction__text" @markdown={{this.challengeInstruction}} />
+      <PixIconButton
+        @ariaLabel="Lire la consigne à haute voix"
+        @withBackground="true"
+        @icon="volume-high"
+        @triggerAction={{this.readTheInstruction}}
+      />
 
       {{#if @challenge.hasValidEmbedDocument}}
         <div class="sr-only">{{t "pages.challenge.statement.sr-only.embed"}}</div>

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -47,6 +47,18 @@ export default class ChallengeStatement extends Component {
   }
 
   @action
+  readTheInstruction() {
+    if (!window.speechSynthesis.speaking) {
+      const utterance = new SpeechSynthesisUtterance();
+
+      utterance.text = this._removeMarkDown(this.challengeInstruction);
+      utterance.lang = this.intl.get('locale')[0] === 'fr' ? 'fr-FR' : 'en-GB';
+
+      window.speechSynthesis.speak(utterance);
+    }
+  }
+
+  @action
   toggleAlternativeInstruction() {
     this.displayAlternativeInstruction = !this.displayAlternativeInstruction;
   }
@@ -66,6 +78,18 @@ export default class ChallengeStatement extends Component {
       const newFirstChar = PREFERRED_ATTACHMENT_FORMATS.indexOf(extension) >= 0 ? 'A' : 'Z';
       return newFirstChar + extension;
     });
+  }
+
+  _removeMarkDown(text) {
+    let cleanText;
+
+    cleanText = text.replaceAll(/\*\*(.+?)\*\*/g, '$1');
+    cleanText = cleanText.replaceAll(/_(.+?)_/g, '$1');
+    cleanText = cleanText.replaceAll(/~~(.+?)~~/g, '$1');
+    cleanText = cleanText.replaceAll(/`(.+?)`/g, '$1');
+    cleanText = cleanText.replaceAll(/```(.+?)```/g, '$1');
+
+    return cleanText;
   }
 
   _initialiseDefaultAttachment() {

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -13,6 +13,10 @@ export default class Router extends EmberRouter {
 
   init() {
     this.on('routeDidChange', () => {
+      if (window.speechSynthesis?.speaking) {
+        window.speechSynthesis.cancel();
+      }
+
       window.scrollTo(0, 0);
     });
   }

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -37,6 +37,7 @@ module.exports = function () {
       'up-right-from-square',
       'user',
       'xmark',
+      'volume-high',
     ],
     'free-regular-svg-icons': ['bookmark', 'clock', 'copy', 'thumbs-up'],
   };


### PR DESCRIPTION
## :unicorn: Problème
Certains utilisateurs comprennent bien le français à l'oral mais ne sont pas en capacité de bien le lire correctement

## :robot: Proposition
Ajouter un petit bouton pour lancer la lecture de la consigne

## :rainbow: Remarques
l'API SpeechSynthesisUtterance prend en paramètre la lang au format `BCP 47`. Rajouter ce format de lang de les fichiers Json pour savoir quelle type de lecture l'on souhaite ? ou au global pour la gestion de la lang et non plus simplement fr / en

## :100: Pour tester
Se connecter avec un compte (eval-sco@example.net new seeds, ou jaune.attend@example.net ancien seeds) et lancer une carte sur mon-pix