### PR TITLE
[BUMP] Met à jour ember-cookies en version 1.0

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -44,7 +44,7 @@
         "ember-cli-notifications": "^8.0.0",
         "ember-cli-sass": "^11.0.1",
         "ember-composable-helpers": "^5.0.0",
-        "ember-cookies": "^0.5.2",
+        "ember-cookies": "^1.0.0",
         "ember-data": "~4.0.2",
         "ember-dayjs": "^0.12.0",
         "ember-export-application-global": "^2.0.1",
@@ -16580,16 +16580,15 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-data": {
@@ -16827,40 +16826,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-fetch": {
@@ -17331,41 +17296,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-inflector": {
@@ -48675,13 +48605,12 @@
       }
     },
     "ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       }
     },
     "ember-data": {
@@ -48867,33 +48796,6 @@
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
       "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
       "dev": true
-    },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true
-        }
-      }
     },
     "ember-fetch": {
       "version": "8.1.2",
@@ -49258,34 +49160,6 @@
       "requires": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true
-        }
       }
     },
     "ember-inflector": {
@@ -51637,7 +51511,7 @@
       "requires": {
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       }
     },

--- a/certif/package.json
+++ b/certif/package.json
@@ -76,7 +76,7 @@
     "ember-cli-notifications": "^8.0.0",
     "ember-cli-sass": "^11.0.1",
     "ember-composable-helpers": "^5.0.0",
-    "ember-cookies": "^0.5.2",
+    "ember-cookies": "^1.0.0",
     "ember-data": "~4.0.2",
     "ember-dayjs": "^0.12.0",
     "ember-export-application-global": "^2.0.1",
@@ -118,6 +118,9 @@
   "overrides": {
     "ember-keyboard": {
       "@ember/test-helpers": "^3.0.0"
+    },
+    "ember-simple-auth": {
+      "ember-cookies": "^1.0.0"
     }
   }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -51,7 +51,7 @@
         "ember-cli-mirage": "^2.3.2",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-test-loader": "^3.0.0",
-        "ember-cookies": "^0.5.2",
+        "ember-cookies": "^1.0.0",
         "ember-data": "~4.0.2",
         "ember-dayjs": "^0.12.0",
         "ember-decorators": "^6.1.1",
@@ -16939,16 +16939,15 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-data": {
@@ -17370,40 +17369,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/ember-fetch": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
@@ -17691,41 +17656,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-in-element-polyfill": {
@@ -48725,13 +48655,12 @@
       }
     },
     "ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       }
     },
     "ember-data": {
@@ -49039,33 +48968,6 @@
       "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
       "dev": true
     },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true
-        }
-      }
-    },
     "ember-fetch": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
@@ -49305,34 +49207,6 @@
       "requires": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true
-        }
       }
     },
     "ember-in-element-polyfill": {
@@ -50777,7 +50651,7 @@
       "requires": {
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       }
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -83,7 +83,7 @@
     "ember-cli-mirage": "^2.3.2",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-test-loader": "^3.0.0",
-    "ember-cookies": "^0.5.2",
+    "ember-cookies": "^1.0.0",
     "ember-data": "~4.0.2",
     "ember-dayjs": "^0.12.0",
     "ember-decorators": "^6.1.1",
@@ -133,6 +133,9 @@
   "overrides": {
     "ember-keyboard": {
       "@ember/test-helpers": "^3.0.0"
+    },
+    "ember-simple-auth": {
+      "ember-cookies": "^1.0.0"
     }
   }
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -51,7 +51,7 @@
         "ember-cli-sass": "^11.0.1",
         "ember-cli-showdown": "^7.0.0",
         "ember-click-outside": "^6.0.0",
-        "ember-cookies": "^0.5.2",
+        "ember-cookies": "^1.0.0",
         "ember-data": "~4.0.2",
         "ember-dayjs": "^0.12.0",
         "ember-fetch": "^8.1.2",
@@ -18630,16 +18630,15 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-data": {
@@ -18917,31 +18916,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/ember-fetch": {
@@ -19469,32 +19443,6 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/ember-inflector": {
@@ -50864,13 +50812,12 @@
       }
     },
     "ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       }
     },
     "ember-data": {
@@ -51081,27 +51028,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
-        }
-      }
-    },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
         }
       }
     },
@@ -51509,28 +51435,6 @@
             "ensure-posix-path": "^1.1.0",
             "matcher-collection": "^2.0.0",
             "minimatch": "^3.0.4"
-          }
-        }
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
           }
         }
       }
@@ -52917,7 +52821,7 @@
       "requires": {
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       }
     },

--- a/orga/package.json
+++ b/orga/package.json
@@ -80,7 +80,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-cli-showdown": "^7.0.0",
     "ember-click-outside": "^6.0.0",
-    "ember-cookies": "^0.5.2",
+    "ember-cookies": "^1.0.0",
     "ember-data": "~4.0.2",
     "ember-dayjs": "^0.12.0",
     "ember-fetch": "^8.1.2",
@@ -116,5 +116,10 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.1"
+  },
+  "overrides": {
+    "ember-simple-auth": {
+      "ember-cookies": "^1.0.0"
+    }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
ember-cookies n'est pas a jour sur les applications du mono-repo.

## :robot: Proposition
Le mettre à jour, en forcant la résolution coté ember-simple-auth, ce qui ne pose pas de problème (pas de changement d'API).

## :100: Pour tester
:green_circle:  tests
