### PR TITLE
[BUGFIX] Corriger la création de campagne en masse via l'import de fichier CSV (PIX-8659).

### DIFF
--- a/api/db/migrations/20230719092108_remove_default_campaign_type.js
+++ b/api/db/migrations/20230719092108_remove_default_campaign_type.js
@@ -1,0 +1,26 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'campaigns';
+const COLUMN_NAME = 'type';
+
+const up = async function (knex) {
+  await knex(TABLE_NAME).update(COLUMN_NAME, 'ASSESSMENT').where(COLUMN_NAME, '');
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().defaultTo('').alter();
+  });
+};
+
+export { up, down };

--- a/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
+++ b/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
@@ -1,3 +1,5 @@
+import { CampaignTypes } from '../../models/CampaignTypes.js';
+
 const createCampaigns = async function ({
   campaignsToCreate,
   campaignAdministrationRepository,
@@ -15,6 +17,7 @@ const createCampaigns = async function ({
         ...campaign,
         ownerId: administrator.user.id,
         code: await campaignCodeGenerator.generate(campaignRepository),
+        type: CampaignTypes.ASSESSMENT,
       };
     }),
   );

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -163,7 +163,6 @@ const requiredFieldNamesForCampaignsImport = [
   "Identifiant de l'organisation*",
   'Nom de la campagne*',
   'Identifiant du profil cible*',
-  "Libellé de l'identifiant externe*",
   'Identifiant du créateur*',
 ];
 
@@ -206,7 +205,7 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     organizationId: data["Identifiant de l'organisation*"],
     name: data['Nom de la campagne*'],
     targetProfileId: data['Identifiant du profil cible*'],
-    idPixLabel: data["Libellé de l'identifiant externe*"],
+    idPixLabel: data["Libellé de l'identifiant externe"],
     creatorId: data['Identifiant du créateur*'],
     title: data['Titre du parcours'],
     customLandingPageText: data['Descriptif du parcours'],

--- a/api/tests/acceptance/application/campaign-administration/create-campaigns_test.js
+++ b/api/tests/acceptance/application/campaign-administration/create-campaigns_test.js
@@ -31,7 +31,7 @@ describe('Acceptance | Application | campaign-controller-create-campaigns', func
         const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
         await databaseBuilder.commit();
 
-        const buffer = `Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe*;Identifiant du créateur*;Titre du parcours;Descriptif du parcours
+        const buffer = `Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours
           ${organizationId};Parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};
           ${organizationId};Autre parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};Titre;Superbe descriptif de parcours`;
         const options = {

--- a/api/tests/integration/infrastructure/repositories/campaigns-administration/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaigns-administration/campaign-repository_test.js
@@ -95,6 +95,7 @@ describe('Integration | Infrastructure | Repository | Campaign Administration | 
           customLandingPageText: 'CampaignToCreate',
           ownerId: userId,
           creatorId: userId,
+          type: 'ASSESSMENT',
         },
       ];
 
@@ -111,6 +112,7 @@ describe('Integration | Infrastructure | Repository | Campaign Administration | 
           'creatorId',
           'createdAt',
           'ownerId',
+          'type',
         )
         .where('name', campaignsToCreate[0].name)
         .first();

--- a/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
@@ -39,6 +39,7 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
       {
         organizationId: organization.id,
         name: 'My Campaign',
+        type: 'ASSESSMENT',
         targetProfileId: 3,
         ownerId: administrator.id,
         creatorId: 1,
@@ -47,6 +48,7 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
       {
         organizationId: organization.id,
         name: 'My Campaign',
+        type: 'ASSESSMENT',
         targetProfileId: 3,
         ownerId: administrator.id,
         creatorId: 2,

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1048,7 +1048,6 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         "Identifiant de l'organisation*",
         'Nom de la campagne*',
         'Identifiant du profil cible*',
-        "Libellé de l'identifiant externe*",
         'Identifiant du créateur*',
       ];
 
@@ -1066,7 +1065,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
-      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe*;Identifiant du créateur*;Titre du parcours;Descriptif du parcours\n";
+      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours\n";
 
     it('should return parsed campaign data', async function () {
       // given
@@ -1196,21 +1195,6 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         expect(error).to.be.instanceOf(FileValidationError);
         expect(error.code).to.equal('CSV_CONTENT_NOT_VALID');
         expect(error.meta).to.equal('"empty" is not a valid value for "Nom de la campagne*"');
-      });
-    });
-
-    describe('when pixIdLabel field is not valid', function () {
-      it('should throw an error', async function () {
-        // given
-        const campaignWithoutPixIdLabelCsv = `${headerCsv}1;chaussette;1234;`;
-
-        // when
-        const error = await catchErr(csvSerializer.parseForCampaignsImport)(campaignWithoutPixIdLabelCsv);
-
-        // then
-        expect(error).to.be.instanceOf(FileValidationError);
-        expect(error.code).to.equal('CSV_CONTENT_NOT_VALID');
-        expect(error.meta).to.equal('"empty" is not a valid value for "Libellé de l\'identifiant externe*"');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Quand on rejoint une campagne créée via l'import csv, ca fonctionne pas : on a une page blanche.
Après analyse, cela vient du fait que les campagnes sont créées sans type.

## :robot: Proposition
Supprimer la valeur par défaut pour la colonne `type` dans la table `campaigns`.
Les campagnes créées sans type sont modifiées pour affecter la valeur `ASSESSEMENT`.

## :rainbow: Remarques
On en profite également pour rendre optionnel la colonne "Libellé de l'identifiant externe" dans le fichier CSV.

## :100: Pour tester
Sur PIX Admin, importer un campaign via CSV.
Rejoindre la campaign sur PIX App
Verifier que ca fonctionne
