### PR TITLE
[BUGFIX] Corriger le bug de sélection de la catégorie (PIX-8680)

### DIFF
--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -12,7 +12,7 @@
       />
       <PixSelect
         @label="Catégorie :"
-        @onChange={{fn this.updateTargetProfileValue "category"}}
+        @onChange={{this.updateCategory}}
         @value={{@targetProfile.category}}
         @options={{this.optionsList}}
         @placeholder="-"

--- a/admin/app/components/target-profiles/create-target-profile-form.js
+++ b/admin/app/components/target-profiles/create-target-profile-form.js
@@ -29,6 +29,11 @@ export default class CreateTargetProfileForm extends Component {
   }
 
   @action
+  updateCategory(value) {
+    this.args.targetProfile['category'] = value;
+  }
+
+  @action
   async onSubmit(event) {
     try {
       this.submitting = true;


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, dans la création des profils cibles, le sélecteur de catégorie ne fonctionne plus depuis la [PR-8619](https://github.com/1024pix/pix/pull/6578). La catégorie était bloqué sur Autres (et c'était visiblement pas une feature).

## :robot: Proposition
Utiliser la fonction onChange du design system au lieu de la fonction native onChange. 

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à Pix Admin (superadmin@example.net)
- Aller sur Profils Cibles
- Créer un nouveau profil cible (en haut à droite)
- Renseigner les infos obligatoires
- Vérifier que dans le select Catégories, on puisse choisir autre chose que "Autres"
- Vérifier que la création fonctionne