### PR TITLE
[FEATURE] Configurer la remise à zéro d'un profil cible (PIX-8444)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -31,7 +31,7 @@
               {{@model.ownerOrganizationId}}
             </LinkTo>
           </li>
-          <li><span class="bold">Permettre la remise à zero des acquis du Profil Cible : </span>{{this.areKnowledgeElementsResettable}}</li>
+          <li><span class="bold">{{t "pages.target-profiles.resettable-checkbox.label"}} : </span>{{this.areKnowledgeElementsResettable}}</li>
           {{#if @model.description}}
             <li>
               <span class="bold">Description : </span>

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -93,7 +93,7 @@
       <div class="form-field">
         <PixCheckbox
           @checked={{this.form.areKnowledgeElementsResettable}}
-          onChange={{fn this.updateFormValue "areKnowledgeElementsResettable"}}
+          onChange={{this.updateAreKnowledgeElementsResettableValue}}
         >
           {{t "pages.target-profiles.resettable-checkbox.label"}}
         </PixCheckbox>

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -90,6 +90,14 @@
           {{on "change" (fn this.updateFormValue "comment")}}
         />
       </div>
+      <div class="form-field">
+        <PixCheckbox
+          @checked={{this.form.areKnowledgeElementsResettable}}
+          onChange={{fn this.updateFormValue "areKnowledgeElementsResettable"}}
+        >
+          {{t "pages.target-profiles.resettable-checkbox.label"}}
+        </PixCheckbox>
+      </div>
       <div class="form-actions">
         <PixButton
           @backgroundColor="transparent-light"

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -61,7 +61,6 @@ class Form extends Object.extend(Validations) {
   @tracked comment;
   @tracked category;
   @tracked imageUrl;
-  @tracked areKnowledgeElementsResettable;
 }
 
 export default class UpdateTargetProfile extends Component {
@@ -88,6 +87,11 @@ export default class UpdateTargetProfile extends Component {
   @action
   onCategoryChange(value) {
     this.form.category = value;
+  }
+
+  @action
+  updateAreKnowledgeElementsResettableValue(event) {
+    this.form.areKnowledgeElementsResettable = event.target.checked;
   }
 
   @action

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -61,6 +61,7 @@ class Form extends Object.extend(Validations) {
   @tracked comment;
   @tracked category;
   @tracked imageUrl;
+  @tracked areKnowledgeElementsResettable;
 }
 
 export default class UpdateTargetProfile extends Component {
@@ -74,6 +75,7 @@ export default class UpdateTargetProfile extends Component {
     this.form.comment = this.args.model.comment || null;
     this.form.category = this.args.model.category || null;
     this.form.imageUrl = this.args.model.imageUrl || null;
+    this.form.areKnowledgeElementsResettable = this.args.model.areKnowledgeElementsResettable;
 
     this.optionsList = this.optionsList = optionsCategoryList;
   }
@@ -100,6 +102,7 @@ export default class UpdateTargetProfile extends Component {
     model.comment = this.form.comment;
     model.category = this.form.category;
     model.imageUrl = this.form.imageUrl;
+    model.areKnowledgeElementsResettable = this.form.areKnowledgeElementsResettable;
 
     try {
       await model.save();

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -127,11 +127,10 @@ function findTargetProfileBadges(schema) {
 
 function updateTargetProfile(schema, request) {
   const payload = JSON.parse(request.requestBody);
-  const newName = payload.data.attributes.name;
   const id = request.params.id;
 
   const targetProfile = schema.targetProfiles.find(id);
-  targetProfile.update({ name: newName });
+  targetProfile.update(payload.data.attributes);
   return new Response(204);
 }
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -1,4 +1,5 @@
 import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import setupIntl from '../../../../helpers/setup-intl';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
@@ -7,6 +8,7 @@ import { click, currentURL } from '@ember/test-helpers';
 
 module('Acceptance | Target Profile Management', function (hooks) {
   setupApplicationTest(hooks);
+  setupIntl(hooks);
   setupMirage(hooks);
 
   module('Access restriction stuff', function () {
@@ -90,7 +92,9 @@ module('Acceptance | Target Profile Management', function (hooks) {
       assert.dom(_findByNestedText(screen, 'Public : Oui')).exists();
       assert.dom(_findByNestedText(screen, 'Obsolète : Non')).exists();
       assert.dom(_findByNestedText(screen, 'Parcours Accès Simplifié : Oui')).exists();
-      assert.dom(_findByNestedText(screen, 'Permettre la remise à zero des acquis du Profil Cible : Non')).exists();
+      assert
+        .dom(_findByNestedText(screen, `${this.intl.t('pages.target-profiles.resettable-checkbox.label')} : Non`))
+        .exists();
       assert.dom(screen.getByText('456')).exists();
       assert.dom(screen.getByText('Top profil cible.')).exists();
       assert.dom(screen.getByText('Commentaire Privé.')).exists();
@@ -105,11 +109,18 @@ module('Acceptance | Target Profile Management', function (hooks) {
         description: 'description initiale',
         comment: 'commentaire initial',
         category: 'OTHER',
+        areKnowledgeElementsResettable: true,
       });
 
       // when
       const screen = await visit('/target-profiles/1');
       await clickByName('Éditer');
+      assert
+        .dom(screen.getByRole('checkbox', { name: this.intl.t('pages.target-profiles.resettable-checkbox.label') }))
+        .isChecked();
+      await click(
+        screen.getByRole('checkbox', { name: this.intl.t('pages.target-profiles.resettable-checkbox.label') }),
+      );
       await fillByLabel('* Nom', 'nom modifié');
       await click(screen.getByRole('button', { name: 'Catégorie :' }));
       await screen.findByRole('listbox');
@@ -122,6 +133,9 @@ module('Acceptance | Target Profile Management', function (hooks) {
       assert.strictEqual(currentURL(), '/target-profiles/1/details');
       assert.dom(screen.getByRole('heading', { name: 'nom modifié', level: 2 })).exists();
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
+      assert
+        .dom(_findByNestedText(screen, `${this.intl.t('pages.target-profiles.resettable-checkbox.label')} : Non`))
+        .exists();
       await clickByName('Éditer');
       assert.dom(screen.getByDisplayValue('description modifiée')).exists();
       assert.dom(screen.getByDisplayValue('commentaire modifié')).exists();

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -46,6 +46,11 @@
         "login-no-permission": "You don't have the permission to connect."
       }
     },
+    "target-profiles": {
+      "resettable-checkbox": {
+        "label": "Allow resetting for evaluation-type campaigns when multiple submissions are enabled for the organisation"
+      }
+    },
     "trainings": {
       "training": {
         "targetProfiles": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -61,6 +61,11 @@
         }
       }
     },
+    "target-profiles": {
+      "resettable-checkbox": {
+        "label": "Permettre la remise à zéro des acquis du profil cible"
+      }
+    },
     "trainings": {
       "training": {
         "targetProfiles": {

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -400,6 +400,7 @@ const register = async function (server) {
                 description: Joi.string().required().allow(null).max(500),
                 comment: Joi.string().required().allow(null).max(500),
                 category: Joi.string().required(),
+                'are-knowledge-elements-resettable': Joi.boolean().required(),
               },
             },
           }).options({ allowUnknown: true }),

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { sendJsonApiError, BadRequestError } from '../http-errors.js';
+import { BadRequestError, sendJsonApiError } from '../http-errors.js';
 import { securityPreHandlers } from '../security-pre-handlers.js';
 import { targetProfileController } from './target-profile-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
@@ -190,6 +190,7 @@ const register = async function (server) {
                     level: Joi.number().required(),
                   })
                   .required(),
+                'are-knowledge-elements-resettable': Joi.boolean().required(),
               },
             },
           }),

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -74,8 +74,23 @@ const attachOrganizationsFromExistingTargetProfile = async function (request, h)
 
 const updateTargetProfile = async function (request, h) {
   const id = request.params.id;
-  const { name, 'image-url': imageUrl, description, comment, category } = request.payload.data.attributes;
-  await usecases.updateTargetProfile({ id, name, imageUrl, description, comment, category });
+  const {
+    name,
+    'image-url': imageUrl,
+    description,
+    comment,
+    category,
+    'are-knowledge-elements-resettable': areKnowledgeElementsResettable,
+  } = request.payload.data.attributes;
+  await usecases.updateTargetProfile({
+    id,
+    name,
+    imageUrl,
+    description,
+    comment,
+    category,
+    areKnowledgeElementsResettable,
+  });
   return h.response({}).code(204);
 };
 

--- a/api/lib/domain/models/TargetProfileForCreation.js
+++ b/api/lib/domain/models/TargetProfileForCreation.js
@@ -1,8 +1,19 @@
 import { validate } from '../validators/target-profile/creation-command-validation.js';
+
 const DEFAULT_IMAGE_URL = 'https://images.pix.fr/profil-cible/Illu_GEN.svg';
 
 class TargetProfileForCreation {
-  constructor({ name, category, description, comment, isPublic, imageUrl, ownerOrganizationId, tubes }) {
+  constructor({
+    name,
+    category,
+    description,
+    comment,
+    isPublic,
+    imageUrl,
+    ownerOrganizationId,
+    tubes,
+    areKnowledgeElementsResettable,
+  }) {
     this.name = name;
     this.category = category;
     this.description = description;
@@ -11,6 +22,7 @@ class TargetProfileForCreation {
     this.imageUrl = imageUrl;
     this.ownerOrganizationId = ownerOrganizationId;
     this.tubes = tubes;
+    this.areKnowledgeElementsResettable = areKnowledgeElementsResettable;
   }
 
   static fromCreationCommand(creationCommand) {
@@ -24,6 +36,7 @@ class TargetProfileForCreation {
       imageUrl: creationCommand.imageUrl || DEFAULT_IMAGE_URL,
       ownerOrganizationId: creationCommand.ownerOrganizationId,
       tubes: creationCommand.tubes,
+      areKnowledgeElementsResettable: creationCommand.areKnowledgeElementsResettable,
     });
   }
 }

--- a/api/lib/domain/usecases/update-target-profile.js
+++ b/api/lib/domain/usecases/update-target-profile.js
@@ -7,6 +7,7 @@ const updateTargetProfile = async function ({
   description,
   comment,
   category,
+  areKnowledgeElementsResettable,
   targetProfileForUpdateRepository,
 }) {
   validate({ name, imageUrl, description, comment, category });
@@ -17,6 +18,7 @@ const updateTargetProfile = async function ({
     description,
     comment,
     category,
+    areKnowledgeElementsResettable,
   });
 };
 

--- a/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
@@ -1,12 +1,21 @@
 import { knex } from '../../../db/knex-database-connection.js';
 
-const update = async function ({ targetProfileId, name, imageUrl, description, comment, category }) {
+const update = async function ({
+  targetProfileId,
+  name,
+  imageUrl,
+  description,
+  comment,
+  category,
+  areKnowledgeElementsResettable,
+}) {
   const targetProfileToUpdate = {
     name,
     imageUrl,
     description,
     comment,
     category,
+    areKnowledgeElementsResettable,
   };
   return knex('target-profiles').where({ id: targetProfileId }).update(targetProfileToUpdate);
 };

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -3,7 +3,7 @@ import { BookshelfTargetProfile } from '../orm-models/TargetProfile.js';
 import * as targetProfileAdapter from '../adapters/target-profile-adapter.js';
 import * as bookshelfToDomainConverter from '../utils/bookshelf-to-domain-converter.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { NotFoundError, ObjectValidationError, InvalidSkillSetError } from '../../domain/errors.js';
+import { InvalidSkillSetError, NotFoundError, ObjectValidationError } from '../../domain/errors.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import { TargetProfile } from '../../domain/models/TargetProfile.js';
 
@@ -19,6 +19,7 @@ const create = async function ({ targetProfileForCreation, domainTransaction }) 
     'isPublic',
     'imageUrl',
     'ownerOrganizationId',
+    'areKnowledgeElementsResettable',
   ]);
   const [{ id: targetProfileId }] = await knexConn(TARGET_PROFILE_TABLE).insert(targetProfileRawData).returning('id');
 

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -23,6 +23,7 @@ const deserializeCreationCommand = function (json) {
     imageUrl: json.data.attributes['image-url'],
     ownerOrganizationId: json.data.attributes['owner-organization-id'],
     tubes: json.data.attributes['tubes'],
+    areKnowledgeElementsResettable: json.data.attributes['are-knowledge-elements-resettable'],
   };
 };
 

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -1,15 +1,16 @@
 import {
+  databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-  databaseBuilder,
   knex,
-  mockLearningContent,
   learningContentBuilder,
   MockDate,
+  mockLearningContent,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
 import lodash from 'lodash';
+
 const { omit } = lodash;
 
 describe('Acceptance | Route | target-profiles', function () {
@@ -104,6 +105,7 @@ describe('Acceptance | Route | target-profiles', function () {
               'image-url': 'http://some/image.ok',
               'owner-organization-id': '1',
               tubes: [{ id: 'recTube1', level: 5 }],
+              'are-knowledge-elements-resettable': true,
             },
           },
         },
@@ -113,7 +115,9 @@ describe('Acceptance | Route | target-profiles', function () {
       const response = await server.inject(options);
 
       // then
-      const { id: targetProfileId } = await knex('target-profiles').select('id').first();
+      const { id: targetProfileId, areKnowledgeElementsResettable } = await knex('target-profiles')
+        .select('id', 'areKnowledgeElementsResettable')
+        .first();
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal({
         data: {
@@ -121,6 +125,7 @@ describe('Acceptance | Route | target-profiles', function () {
           id: `${targetProfileId}`,
         },
       });
+      expect(areKnowledgeElementsResettable).to.be.true;
     });
   });
 

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -305,6 +305,7 @@ describe('Acceptance | Route | target-profiles', function () {
               comment: 'Amazing comment',
               category: 'OTHER',
               'image-url': 'http://valid-uri.com/image.png',
+              'are-knowledge-elements-resettable': false,
             },
           },
         },

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
@@ -12,6 +12,7 @@ describe('Integration | Repository | Target-profile-for-update', function () {
         description: 'old description',
         comment: 'old comment',
         category: 'old category',
+        areKnowledgeElementsResettable: false,
       });
       await databaseBuilder.commit();
       const updatedData = {
@@ -21,6 +22,7 @@ describe('Integration | Repository | Target-profile-for-update', function () {
         description: 'new description',
         comment: 'new comment',
         category: 'new category',
+        areKnowledgeElementsResettable: true,
       };
 
       // when
@@ -33,6 +35,7 @@ describe('Integration | Repository | Target-profile-for-update', function () {
       expect(targetProfileFromDB.description).to.equal('new description');
       expect(targetProfileFromDB.comment).to.equal('new comment');
       expect(targetProfileFromDB.category).to.equal('new category');
+      expect(targetProfileFromDB.areKnowledgeElementsResettable).to.be.true;
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, catchErr, knex, domainBuilder } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../test-helper.js';
 import { TargetProfile } from '../../../../lib/domain/models/TargetProfile.js';
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
-import { NotFoundError, ObjectValidationError, InvalidSkillSetError } from '../../../../lib/domain/errors.js';
+import { InvalidSkillSetError, NotFoundError, ObjectValidationError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | Target-profile', function () {
   describe('#create', function () {
@@ -24,6 +24,7 @@ describe('Integration | Repository | Target-profile', function () {
         isPublic: true,
         imageUrl: 'mon-image/stylée',
         ownerOrganizationId: 1,
+        areKnowledgeElementsResettable: true,
       });
 
       // when
@@ -36,7 +37,16 @@ describe('Integration | Repository | Target-profile', function () {
 
       // then
       const targetProfileInDB = await knex('target-profiles')
-        .select(['name', 'category', 'description', 'comment', 'isPublic', 'imageUrl', 'ownerOrganizationId'])
+        .select([
+          'name',
+          'category',
+          'description',
+          'comment',
+          'isPublic',
+          'imageUrl',
+          'ownerOrganizationId',
+          'areKnowledgeElementsResettable',
+        ])
         .where({ id: targetProfileId })
         .first();
       expect(targetProfileInDB).to.deep.equal({
@@ -47,6 +57,7 @@ describe('Integration | Repository | Target-profile', function () {
         isPublic: true,
         imageUrl: 'mon-image/stylée',
         ownerOrganizationId: 1,
+        areKnowledgeElementsResettable: true,
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-for-creation.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-for-creation.js
@@ -9,6 +9,7 @@ const buildTargetProfileForCreation = function ({
   imageUrl = 'image/url',
   ownerOrganizationId = null,
   tubes = [{ id: 'recTubeId', level: 8 }],
+  areKnowledgeElementsResettable = false,
 } = {}) {
   return new TargetProfileForCreation({
     name,
@@ -19,6 +20,7 @@ const buildTargetProfileForCreation = function ({
     imageUrl,
     ownerOrganizationId,
     tubes,
+    areKnowledgeElementsResettable,
   });
 };
 

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -649,6 +649,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
           comment: 'commentaire changé.',
           category: 'OTHER',
           'image-url': 'some image',
+          'are-knowledge-elements-resettable': false,
         },
       },
     };
@@ -931,6 +932,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
             'image-url': 'http://some/image.ok',
             'owner-organization-id': null,
             tubes: [{ id: 'recTube1', level: '5' }],
+            'are-knowledge-elements-resettable': false,
           },
         },
       };

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -70,6 +70,7 @@ describe('Unit | Controller | target-profile-controller', function () {
           data: {
             attributes: {
               name: 'Pixer123',
+              'are-knowledge-elements-resettable': false,
               description: 'description changée',
               comment: 'commentaire changée',
               'image-url': 'image changée',
@@ -93,6 +94,7 @@ describe('Unit | Controller | target-profile-controller', function () {
           description: 'description changée',
           comment: 'commentaire changée',
           imageUrl: 'image changée',
+          areKnowledgeElementsResettable: false,
         });
       });
     });

--- a/api/tests/unit/domain/usecases/create-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/create-target-profile_test.js
@@ -31,6 +31,7 @@ describe('Unit | UseCase | create-target-profile', function () {
       imageUrl: 'mon-image/stylée',
       ownerOrganizationId: 1,
       tubes: [{ id: 'tubeId', level: 2 }],
+      areKnowledgeElementsResettable: false,
     };
 
     const error = await catchErr(createTargetProfile)({
@@ -70,6 +71,7 @@ describe('Unit | UseCase | create-target-profile', function () {
       imageUrl: 'mon-image/stylée',
       ownerOrganizationId: 1,
       tubes: [{ id: 'tubeId', level: 2 }],
+      areKnowledgeElementsResettable: false,
     };
     await createTargetProfile({
       targetProfileCreationCommand,
@@ -116,6 +118,7 @@ describe('Unit | UseCase | create-target-profile', function () {
       imageUrl: 'mon-image/stylée',
       ownerOrganizationId: 1,
       tubes: [{ id: 'tubeId', level: 2 }],
+      areKnowledgeElementsResettable: false,
     };
     const targetProfileId = await createTargetProfile({
       targetProfileCreationCommand,

--- a/api/tests/unit/domain/usecases/update-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/update-target-profile_test.js
@@ -207,6 +207,7 @@ describe('Unit | UseCase | update-target-profile', function () {
       description: 'description changée',
       comment: 'commentaire changé',
       category: 'OTHER',
+      areKnowledgeElementsResettable: false,
     };
     const targetProfileToUpdate = {
       targetProfileId: 123,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -73,6 +73,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
               { id: 'tubeId1', level: '5' },
               { id: 'tubeId2', level: '7' },
             ],
+            'are-knowledge-elements-resettable': true,
           },
         },
       };
@@ -93,6 +94,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
           { id: 'tubeId1', level: '5' },
           { id: 'tubeId2', level: '7' },
         ],
+        areKnowledgeElementsResettable: true,
       };
       expect(deserializedTargetProfileCreationCommand).to.deep.equal(expectedTargetProfileCreationCommand);
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix admin, dans l’entrée PC, à l'[édition d’un PC](https://admin.pix.fr/target-profiles/2508/details), permettre l’activation de la remise à zéro des acquis du profil cible.

## :robot: Proposition
Ajout d’une case à cocher “Permettre la remise à zéro des acquis du PC” dans l'édition d'un profil cible

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter à Pix Admin en tant que Super Admin
- Aller sur la page d'un profil cible
- Editer ce profil cible
- Vérifier que la case à cocher de remise à zéro des acquis du PC est présente
- Vérifier que cette case met bien à jour le profil cible
- 🐱 
