### PR TITLE
[FEATURE] Empêcher la modification de paliers si un profil cible est relié à une campagne (PIX-8644).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -378,6 +378,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.TargetProfileInvalidError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.StageModificationForbiddenForLinkedTargetProfileError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.NoStagesForCampaign) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/application/stage-collections/stage-collection-controller.js
+++ b/api/lib/application/stage-collections/stage-collection-controller.js
@@ -1,12 +1,9 @@
-import * as stageCollectionRepository from '../../infrastructure/repositories/target-profile-management/stage-collection-repository.js';
-import { StageCollectionUpdate } from '../../domain/models/target-profile-management/StageCollectionUpdate.js';
+import { usecases } from '../../domain/usecases/index.js';
 
 const update = async function (request, h) {
   const targetProfileId = request.params.id;
-  const stagesDTO = request.payload.data.attributes.stages;
-  const stageCollection = await stageCollectionRepository.getByTargetProfileId(targetProfileId);
-  const stageCollectionUpdate = new StageCollectionUpdate({ stagesDTO, stageCollection });
-  await stageCollectionRepository.update(stageCollectionUpdate);
+  const stagesFromPayload = request.payload.data.attributes.stages;
+  await usecases.createOrUpdateStageCollection({ targetProfileId, stagesFromPayload });
   return h.response({}).code(204);
 };
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -924,6 +924,14 @@ class TargetProfileInvalidError extends DomainError {
   }
 }
 
+class StageModificationForbiddenForLinkedTargetProfileError extends DomainError {
+  constructor(targetProfileId) {
+    super(
+      `Le profil cible ${targetProfileId} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
+    );
+  }
+}
+
 class OrganizationTagNotFound extends DomainError {
   constructor(message = 'Le tag de l’organization n’existe pas.') {
     super(message);
@@ -1414,6 +1422,7 @@ export {
   SessionWithIdAndInformationOnMassImportError,
   SessionWithMissingAbortReasonError,
   SiecleXmlImportError,
+  StageModificationForbiddenForLinkedTargetProfileError,
   SupervisorAccessNotAuthorizedError,
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,

--- a/api/lib/domain/usecases/create-or-update-stage-collection.js
+++ b/api/lib/domain/usecases/create-or-update-stage-collection.js
@@ -1,0 +1,51 @@
+import { StageCollectionUpdate } from '../models/target-profile-management/StageCollectionUpdate.js';
+import { StageModificationForbiddenForLinkedTargetProfileError } from '../errors.js';
+
+const createOrUpdateStageCollection = async function ({
+  targetProfileId,
+  stagesFromPayload,
+  stageCollectionForTargetProfileRepository: stageCollectionRepository,
+  targetProfileForAdminRepository,
+}) {
+  const targetProfileForAdmin = await targetProfileForAdminRepository.get({ id: targetProfileId });
+
+  if (
+    targetProfileForAdmin.hasLinkedCampaign &&
+    !_areStagesFromPayloadUpdatable({
+      targetProfileStages: targetProfileForAdmin.stageCollection.stages,
+      stagesFromPayload,
+    })
+  ) {
+    throw new StageModificationForbiddenForLinkedTargetProfileError(targetProfileId);
+  }
+
+  const stageCollection = await stageCollectionRepository.getByTargetProfileId(targetProfileId);
+  const stageCollectionUpdate = new StageCollectionUpdate({ stagesDTO: stagesFromPayload, stageCollection });
+
+  return stageCollectionRepository.update(stageCollectionUpdate);
+};
+
+function _areStagesFromPayloadUpdatable({ targetProfileStages, stagesFromPayload }) {
+  const hasDifferentNumberOfStages = targetProfileStages.length !== stagesFromPayload.length;
+  if (hasDifferentNumberOfStages) return false;
+
+  const hasAddedStage = stagesFromPayload.find((stage) => !stage.id);
+  if (hasAddedStage) return false;
+
+  return !_hasThresholdOrLevelModification({ targetProfileStages, stagesFromPayload });
+}
+
+function _hasThresholdOrLevelModification({ targetProfileStages, stagesFromPayload }) {
+  return Boolean(
+    stagesFromPayload.find((stageFromPayload) => {
+      const stageWithSameIdFromTargetProfileStages = targetProfileStages.find((stage) => {
+        return Number(stage.id) === Number(stageFromPayload.id);
+      });
+      const hasThresholdDiff = stageFromPayload.threshold !== stageWithSameIdFromTargetProfileStages.threshold;
+      const hasLevelDiff = stageFromPayload.level !== stageWithSameIdFromTargetProfileStages.level;
+      return hasThresholdDiff || hasLevelDiff;
+    }),
+  );
+}
+
+export { createOrUpdateStageCollection };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -164,6 +164,7 @@ import * as skillRepository from '../../infrastructure/repositories/skill-reposi
 import * as skillSetRepository from '../../infrastructure/repositories/skill-set-repository.js';
 import * as smartRandom from '../../domain/services/algorithm-methods/smart-random.js';
 import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
+import * as stageCollectionForTargetProfileRepository from '../../infrastructure/repositories/target-profile-management/stage-collection-repository.js';
 import * as studentRepository from '../../infrastructure/repositories/student-repository.js';
 import * as supOrganizationLearnerRepository from '../../infrastructure/repositories/sup-organization-learner-repository.js';
 import * as supOrganizationParticipantRepository from '../../infrastructure/repositories/sup-organization-participant-repository.js';
@@ -383,6 +384,7 @@ const dependencies = {
   skillSetRepository,
   smartRandom,
   stageCollectionRepository,
+  stageCollectionForTargetProfileRepository,
   studentRepository,
   supOrganizationLearnerRepository,
   supOrganizationParticipantRepository,

--- a/api/tests/acceptance/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/acceptance/application/stage-collections/stage-collection-controller_test.js
@@ -1,0 +1,101 @@
+import {
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  knex,
+  generateValidRequestAuthorizationHeader,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | Controller | stage-collection', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('PATCH api/admin/stage-collections/{id}', function () {
+    beforeEach(function () {
+      const learningContent = [{ id: 'recArea0', competences: [] }];
+      const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+      mockLearningContent(learningContentObjects);
+    });
+
+    afterEach(async function () {
+      await knex('campaigns').delete();
+      await knex('stages').delete();
+      await knex('target-profiles').delete();
+    });
+
+    context('when the target-profile is not linked to a campaign', function () {
+      it('should return a 204 HTTP status code after updating the stage collection', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRole();
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/admin/stage-collections/${targetProfile.id}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(user.id),
+          },
+          payload: {
+            data: {
+              type: 'stage-collections',
+              attributes: {
+                stages: [
+                  domainBuilder.buildStage({ id: null, threshold: 0 }),
+                  domainBuilder.buildStage({ id: null, threshold: 10 }),
+                ],
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    context('when the target-profile is linked to a campaign', function () {
+      it('should return a 412 HTTP status code after updating the stage collection', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRole();
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/admin/stage-collections/${targetProfile.id}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(user.id),
+          },
+          payload: {
+            data: {
+              type: 'stage-collections',
+              attributes: {
+                stages: [
+                  domainBuilder.buildStage({ id: null, threshold: 0 }),
+                  domainBuilder.buildStage({ id: null, threshold: 10 }),
+                ],
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(412);
+      });
+    });
+  });
+});

--- a/api/tests/integration/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/integration/application/stage-collections/stage-collection-controller_test.js
@@ -1,9 +1,19 @@
-import { expect, knex, databaseBuilder, hFake } from '../../../test-helper.js';
+import { expect, knex, databaseBuilder, mockLearningContent, hFake } from '../../../test-helper.js';
 import { stageCollectionController } from '../../../../lib/application/stage-collections/stage-collection-controller.js';
 import * as stageCollectionRepository from '../../../../lib/infrastructure/repositories/target-profile-management/stage-collection-repository.js';
 
 describe('Integration | Application | stage-collection-controller', function () {
   context('update', function () {
+    beforeEach(function () {
+      const learningContent = {
+        areas: [],
+        competences: [],
+        thematics: [],
+        tubes: [{ id: 'tubeId1' }],
+      };
+      mockLearningContent(learningContent);
+    });
+
     afterEach(async function () {
       await knex('stages').delete();
     });

--- a/api/tests/integration/infrastructure/repositories/target-profile-management/stage-collection-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-management/stage-collection-repository_test.js
@@ -1,0 +1,158 @@
+import _ from 'lodash';
+import { expect, databaseBuilder, domainBuilder, knex } from '../../../../test-helper.js';
+import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/target-profile-management/stage-collection-repository.js';
+import { StageCollectionUpdate } from '../../../../../lib/domain/models/target-profile-management/StageCollectionUpdate.js';
+
+describe('Integration | Infrastructure | Repository | target-profile-management | stage-collection-repository', function () {
+  afterEach(async function () {
+    await knex('stages').delete();
+  });
+
+  describe('#getByTargetProfileId', function () {
+    context('when no stage exists in database', function () {
+      it('should return an empty array', async function () {
+        // given
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        await databaseBuilder.commit();
+
+        // when
+        const result = await stageCollectionRepository.getByTargetProfileId(targetProfileId);
+        const savedStages = result.stages;
+
+        // then
+        expect(savedStages).to.deep.equal([]);
+      });
+    });
+
+    context('when stage exists in database', function () {
+      it('should return an existing stage', async function () {
+        // given
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const stage = databaseBuilder.factory.buildStage({
+          targetProfileId,
+          threshold: 0,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await stageCollectionRepository.getByTargetProfileId(targetProfileId);
+        const savedStages = result.stages;
+
+        // then
+        expect(savedStages).to.have.lengthOf(1);
+        expect(savedStages[0]).to.deep.equal(stage);
+      });
+    });
+  });
+
+  describe('#update', function () {
+    it('should update an existing stage', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const firstStage = databaseBuilder.factory.buildStage({
+        targetProfileId,
+        threshold: 0,
+        title: 'initial first stage title',
+        message: '...',
+        prescriberTitle: '...',
+        prescriberDescription: '...',
+      });
+      const secondStage = databaseBuilder.factory.buildStage({
+        targetProfileId,
+        threshold: 10,
+        title: '...',
+        message: '...',
+        prescriberTitle: '...',
+        prescriberDescription: '...',
+      });
+      await databaseBuilder.commit();
+
+      const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({
+        id: targetProfileId,
+        stages: [firstStage, secondStage],
+      });
+
+      const updatedFirstStage = { ...firstStage, title: 'updated title' };
+      const stageCollectionUpdate = new StageCollectionUpdate({
+        stagesDTO: [updatedFirstStage, secondStage],
+        stageCollection,
+      });
+
+      // when
+      await stageCollectionRepository.update(stageCollectionUpdate);
+
+      // then
+      const savedStages = await knex.from('stages');
+      expect(_.omit(savedStages[0], ['createdAt', 'updatedAt'])).to.deep.equal(updatedFirstStage);
+      expect(_.omit(savedStages[1], ['createdAt', 'updatedAt'])).to.deep.equal(secondStage);
+    });
+
+    it('should be possible to add a new stage', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const existingStage = databaseBuilder.factory.buildStage({
+        targetProfileId,
+        threshold: 0,
+        prescriberTitle: '...',
+        prescriberDescription: '...',
+      });
+      await databaseBuilder.commit();
+
+      const newStage = domainBuilder.buildStage({
+        id: null,
+        targetProfileId,
+        threshold: 10,
+        title: 'New stage',
+        prescriberTitle: '...',
+        prescriberDescription: '...',
+      });
+
+      const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({
+        id: targetProfileId,
+        stages: [existingStage],
+      });
+
+      const stageCollectionUpdate = new StageCollectionUpdate({
+        stagesDTO: [existingStage, newStage],
+        stageCollection,
+      });
+
+      // when
+      await stageCollectionRepository.update(stageCollectionUpdate);
+
+      // then
+      const savedStages = await knex.from('stages');
+      expect(savedStages).to.have.lengthOf(2);
+      expect(_.omit(savedStages[0], ['id', 'createdAt', 'updatedAt'])).to.deep.include(_.omit(newStage, ['id']));
+      expect(_.omit(savedStages[1], ['createdAt', 'updatedAt'])).to.deep.include(existingStage);
+    });
+
+    it('should be possible to delete an existing stage', async function () {
+      // given
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const firstStage = databaseBuilder.factory.buildStage({
+        targetProfileId,
+        threshold: 0,
+      });
+      const secondStage = databaseBuilder.factory.buildStage({
+        targetProfileId,
+        threshold: 10,
+      });
+      await databaseBuilder.commit();
+
+      const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({
+        id: targetProfileId,
+        stages: [firstStage, secondStage],
+      });
+
+      const stageCollectionUpdate = new StageCollectionUpdate({ stagesDTO: [firstStage], stageCollection });
+
+      // when
+      await stageCollectionRepository.update(stageCollectionUpdate);
+
+      // then
+      const savedStage = await knex.from('stages');
+      expect(savedStage).to.have.lengthOf(1);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/create-or-update-stage-collection_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-stage-collection_test.js
@@ -1,0 +1,244 @@
+import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
+import { createOrUpdateStageCollection } from '../../../../lib/domain/usecases/create-or-update-stage-collection.js';
+import { StageModificationForbiddenForLinkedTargetProfileError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | UseCase | create or update stage collection', function () {
+  context('when the target profile is not linked to a campaign', function () {
+    let targetProfileForAdminRepository;
+
+    beforeEach(function () {
+      targetProfileForAdminRepository = {
+        get: sinon.stub().resolves({
+          id: 1,
+          hasLinkedCampaign: false,
+        }),
+      };
+    });
+
+    it('should be possible to add a new stage', async function () {
+      // given
+      const newStages = [
+        domainBuilder.buildStage({
+          id: null,
+          threshold: 0,
+          title: 'First stage',
+          message: 'First message',
+          prescriberTitle: 'First prescriber title',
+          prescriberDescription: 'First prescriber description',
+        }),
+        domainBuilder.buildStage({ id: null, threshold: 10, title: 'Second stage', message: 'Second message' }),
+      ];
+
+      const stageCollectionForTargetProfileRepository = {
+        getByTargetProfileId: sinon.stub().resolves(
+          domainBuilder.buildStageCollectionForTargetProfileManagement({
+            stages: [],
+          }),
+        ),
+        update: sinon.stub(),
+      };
+
+      // when
+      await createOrUpdateStageCollection({
+        stagesFromPayload: newStages,
+        targetProfileId: 1,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(stageCollectionForTargetProfileRepository.update).to.have.been.called;
+    });
+
+    it('should be possible to update existing stages', async function () {
+      // given
+      const alreadyExistingStages = [
+        domainBuilder.buildStage({
+          id: 1,
+          threshold: 0,
+          title: 'First stage',
+          message: 'First message',
+        }),
+        domainBuilder.buildStage({ id: 2, threshold: 10, title: 'Second stage', message: 'Second message' }),
+      ];
+
+      const stageCollectionForTargetProfileRepository = {
+        getByTargetProfileId: sinon.stub().resolves(
+          domainBuilder.buildStageCollectionForTargetProfileManagement({
+            stages: alreadyExistingStages,
+          }),
+        ),
+        update: sinon.stub(),
+      };
+
+      // when
+      await createOrUpdateStageCollection({
+        stagesFromPayload: [
+          { ...alreadyExistingStages[0], title: 'updated title' },
+          { ...alreadyExistingStages[1], threshold: 99 },
+        ],
+        targetProfileId: 1,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(stageCollectionForTargetProfileRepository.update).to.have.been.called;
+    });
+  });
+
+  context('when the target profile is linked to a campaign', function () {
+    let stages;
+    let targetProfile;
+    let stageCollectionForTargetProfileRepository;
+    let targetProfileForAdminRepository;
+
+    beforeEach(function () {
+      stages = [
+        domainBuilder.buildStage({
+          id: 1,
+          threshold: 0,
+          level: undefined,
+          title: 'first stage',
+          message: 'initial first message',
+          prescriberTitle: 'initial first prescriber title',
+          prescriberDescription: 'initial first description',
+        }),
+        domainBuilder.buildStage({
+          id: 2,
+          threshold: 10,
+          level: undefined,
+          title: 'second stage',
+          message: 'initial second message',
+          prescriberTitle: 'initial second prescriber title',
+          prescriberDescription: 'initial second description',
+        }),
+      ];
+
+      stageCollectionForTargetProfileRepository = {
+        getByTargetProfileId: sinon.stub().resolves(
+          domainBuilder.buildStageCollectionForTargetProfileManagement({
+            stages,
+          }),
+        ),
+        update: sinon.stub(),
+      };
+
+      targetProfileForAdminRepository = {
+        get: sinon.stub().resolves({
+          id: 1,
+          hasLinkedCampaign: true,
+          stageCollection: { stages },
+        }),
+      };
+
+      targetProfile = domainBuilder.buildTargetProfileForAdmin();
+    });
+
+    it('should be possible to update all stage fields that are not threshold or level', async function () {
+      // given
+      const stagesFromPayload = [
+        {
+          ...stages[0],
+          title: 'updated title',
+          message: 'updated message',
+          prescriberTitle: 'updated prescriber title',
+          prescriberDescription: 'updated prescriber description',
+        },
+        { ...stages[1] },
+      ];
+
+      // when
+      await createOrUpdateStageCollection({
+        stagesFromPayload,
+        targetProfileId: targetProfile.id,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(stageCollectionForTargetProfileRepository.update).to.have.been.called;
+    });
+
+    it('should throw a specific error if there is a new stage', async function () {
+      // given
+      const newStage = domainBuilder.buildStage({ id: null });
+      const stagesFromPayload = stages.push(newStage);
+
+      // when
+      const error = await catchErr(createOrUpdateStageCollection)({
+        stagesFromPayload,
+        targetProfileId: targetProfile.id,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(StageModificationForbiddenForLinkedTargetProfileError);
+      expect(error.message).to.be.equal(
+        `Le profil cible ${targetProfile.id} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
+      );
+      expect(stageCollectionForTargetProfileRepository.update).to.not.have.been.called;
+    });
+
+    it('should throw a specific error if a saved stage is deleted', async function () {
+      // given
+      const stagesFromPayload = stages.pop();
+
+      // when
+      const error = await catchErr(createOrUpdateStageCollection)({
+        stagesFromPayload,
+        targetProfileId: targetProfile.id,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(StageModificationForbiddenForLinkedTargetProfileError);
+      expect(error.message).to.be.equal(
+        `Le profil cible ${targetProfile.id} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
+      );
+      expect(stageCollectionForTargetProfileRepository.update).to.not.have.been.called;
+    });
+
+    it('should throw a specific error if there is an update of any threshold', async function () {
+      // given
+      const stagesFromPayload = [stages[0], { ...stages[1], threshold: 99 }];
+
+      // when
+      const error = await catchErr(createOrUpdateStageCollection)({
+        stagesFromPayload,
+        targetProfileId: targetProfile.id,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(StageModificationForbiddenForLinkedTargetProfileError);
+      expect(error.message).to.be.equal(
+        `Le profil cible ${targetProfile.id} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
+      );
+      expect(stageCollectionForTargetProfileRepository.update).to.not.have.been.called;
+    });
+
+    it('should throw a specific error if there is an update of any level', async function () {
+      // given
+      const stagesFromPayload = [stages[0], { ...stages[1], level: 1 }];
+
+      // when
+      const error = await catchErr(createOrUpdateStageCollection)({
+        stagesFromPayload,
+        targetProfileId: targetProfile.id,
+        stageCollectionForTargetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(StageModificationForbiddenForLinkedTargetProfileError);
+      expect(error.message).to.be.equal(
+        `Le profil cible ${targetProfile.id} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
+      );
+      expect(stageCollectionForTargetProfileRepository.update).to.not.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Les paliers peuvent être modifiés, supprimés et ajoutés sans restriction à toute étape. Le prescripteur et l’utilisateur peuvent donc être surpris par des changements. C’est ce qu’on veut éviter.

## :robot: Proposition

Lorsque qu'un profil-cible est rattaché à une campagne, dans l'API, empêcher le déclenchement de la mise à jour des paliers pour chacun de ces cas :
- **ajout** ou **suppression** d'un palier
- **modification** des champs **seuil** ou **niveau** d'un palier

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Se connecter à [Admin en RA](https://admin-pr6671.review.pix.fr/)

### 1️⃣ _Profil-cible relié à une campagne_

- [Visiter le profil-cible n°1000003](https://admin-pr6671.review.pix.fr/target-profiles/1000003/insights)
- **Éditer le champ tous les champs autres que `seuil`** :
  > ✅ L'enregistrement est censé se passer sans encombre.
- **Essayer d'éditer le champ `seuil`** :
  > ❌ Vérifier la présence d'un message d'erreur en bas à droite de l'écran.
- Revenir à la liste des paliers et **essayer d'ajouter un nouveau palier**.
  > ❌ Vérifier la présence d'un message d'erreur en bas à droite de l'écran.
- **Essayer de supprimer le deuxième palier**.
  > ❌ Vérifier la présence d'un message d'erreur en bas à droite de l'écran.

- **Réitérer** ce process mais **avec des paliers par niveau** : [profil cible n°5000](https://admin-pr6671.review.pix.fr/target-profiles/5000/insights).

### 2️⃣ _Profil-cible non-relié à une campagne_

- [Visiter le profil-cible n°5001](https://admin-pr6671.review.pix.fr/target-profiles/5001/insights)
- **Éditer le champ tous les champs autres que `seuil`** :
  > ✅ L'enregistrement est censé se passer sans encombre.
- **Essayer d'éditer le champ `seuil`** :
  > ✅ L'enregistrement est censé se passer sans encombre.
- Revenir à la liste des paliers et **essayer d'ajouter un nouveau palier**.
  > ✅ L'action est censée se passer sans encombre.
- **Essayer de supprimer le deuxième palier**.
  > ✅ L'action est censée se passer sans encombre.

- **Réitérer** ce process mais **avec un profil-cible non-rattaché avec des paliers par niveau** : [profil cible n°1000009](https://admin-pr6671.review.pix.fr/target-profiles/1000009/insights)

