### PR TITLE
[FEATURE](admin) Empêcher l'ajout, la suppression et la modification de seuil ou niveau d'un palier lorsqu'une campagne est associé au profil cible. (PIX-8646)

### DIFF
--- a/admin/app/components/stages/stage.hbs
+++ b/admin/app/components/stages/stage.hbs
@@ -19,6 +19,7 @@
       @toggleEditMode={{@toggleEditMode}}
       @availableLevels={{@availableLevels}}
       @unavailableThresholds={{@unavailableThresholds}}
+      @hasLinkedCampaign={{@hasLinkedCampaign}}
       @onUpdate={{@onUpdate}}
     />
   {{else}}

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -1,4 +1,5 @@
 <section class="page-section">
+
   <form class="form stage-form" {{on "submit" this.updateStage}}>
     <div class="form-field">
       {{#if @stage.isFirstSkill}}
@@ -11,7 +12,7 @@
         <Stages::StageLevelSelect
           @id="threshold-or-level"
           @availableLevels={{@availableLevels}}
-          @isDisabled={{this.isDisabled}}
+          @isDisabled={{this.isThresholdOrLevelDisabled}}
           @onChange={{this.setLevel}}
           @value={{this.level}}
         />
@@ -25,7 +26,7 @@
           @validationStatus={{this.thresholdStatus}}
           @requiredLabel="Champ obligatoire"
           type="number"
-          readonly={{this.isDisabled}}
+          readonly={{this.isThresholdOrLevelDisabled}}
           @value={{this.threshold}}
           @ariaLabel="Seuil du palier"
           min="0"

--- a/admin/app/components/stages/update-stage.js
+++ b/admin/app/components/stages/update-stage.js
@@ -25,8 +25,7 @@ export default class UpdateStage extends Component {
     this.message = this.args.stage.message;
     this.prescriberTitle = this.args.stage.prescriberTitle;
     this.prescriberDescription = this.args.stage.prescriberDescription;
-
-    this.isDisabled = this.threshold === 0 || this.level === '0';
+    this.isThresholdOrLevelDisabled = this.threshold === 0 || this.level === '0' || this.args.hasLinkedCampaign;
   }
 
   async _updateStage() {

--- a/admin/app/components/target-profiles/insights.hbs
+++ b/admin/app/components/target-profiles/insights.hbs
@@ -17,6 +17,23 @@
 
   <section class="insights__section">
     <h2 class="insights-section__title">Paliers</h2>
+
+    {{#if @targetProfile.hasLinkedCampaign}}
+      <PixBanner
+        @type={{this.type}}
+        @actionLabel={{this.actionLabel}}
+        @actionUrl={{this.actionUrl}}
+        @canCloseBanner={{this.canCloseBanner}}
+      >
+        <p>Ce profil cible est associé à une campagne, vous ne pouvez donc pas :</p>
+        <ul>
+          <li>ajouter un nouveau palier</li>
+          <li>supprimer un palier existant</li>
+          <li>modifier les seuils ou niveaux des paliers existants</li>
+        </ul>
+      </PixBanner>
+    {{/if}}
+
     <TargetProfiles::Stages
       @imageUrl={{@targetProfile.imageUrl}}
       @targetProfileId={{@targetProfile.id}}

--- a/admin/app/components/target-profiles/insights.hbs
+++ b/admin/app/components/target-profiles/insights.hbs
@@ -35,6 +35,7 @@
     {{/if}}
 
     <TargetProfiles::Stages
+      @hasLinkedCampaign={{@targetProfile.hasLinkedCampaign}}
       @imageUrl={{@targetProfile.imageUrl}}
       @targetProfileId={{@targetProfile.id}}
       @maxLevel={{@targetProfile.maxLevel}}

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -32,6 +32,7 @@
                   @stage={{stage}}
                   @deleteStage={{this.deleteStage}}
                   @collectionHasNonZeroStages={{this.collectionHasNonZeroStages}}
+                  @hasLinkedCampaign={{@hasLinkedCampaign}}
                 />
               {{/if}}
             {{/each}}
@@ -41,56 +42,58 @@
     {{else}}
       <div class="table__empty">Aucun palier associé</div>
     {{/if}}
-    {{#if this.mustChooseStageType}}
-      <PixRadioButton
-        name="stageType"
-        @value="threshold"
-        checked={{this.isStageTypeThresholdChecked}}
-        {{on "change" this.onStageTypeChange}}
-      >
-        Palier par seuil
-      </PixRadioButton>
-      <PixRadioButton
-        name="stageType"
-        @value="level"
-        checked={{this.isStageTypeLevelChecked}}
-        {{on "change" this.onStageTypeChange}}
-      >
-        Palier par niveau
-      </PixRadioButton>
-    {{/if}}
-    <div class="add-stage-actions">
-      <PixButton
-        class="stages-new-stage"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @triggerAction={{this.addStage}}
-        @isDisabled={{this.isAddStageDisabled}}
-        @iconBefore="plus"
-      >
-        Nouveau palier
-      </PixButton>
-      {{#if @stageCollection.hasStages}}
-        <PixTooltip @id="tooltip-stage" @isWide="true">
-          <:triggerElement>
-            <PixButton
-              class="stages-new-stage"
-              @backgroundColor="transparent-light"
-              @isBorderVisible={{true}}
-              @triggerAction={{this.addFirstSkillStage}}
-              @isDisabled={{this.isAddFirstSkillStageDisabled}}
-              @iconBefore="plus"
-            >
-              Nouveau palier "1er acquis"
-            </PixButton>
-          </:triggerElement>
-          <:tooltip>
-            Le palier 1er acquis est obtenu dès un acquis réussi par le participant. Il se verra alors attribuer une
-            étoile à la fin de son parcours.
-          </:tooltip>
-        </PixTooltip>
+    {{#if this.canAddNewStage}}
+      {{#if this.mustChooseStageType}}
+        <PixRadioButton
+          name="stageType"
+          @value="threshold"
+          checked={{this.isStageTypeThresholdChecked}}
+          {{on "change" this.onStageTypeChange}}
+        >
+          Palier par seuil
+        </PixRadioButton>
+        <PixRadioButton
+          name="stageType"
+          @value="level"
+          checked={{this.isStageTypeLevelChecked}}
+          {{on "change" this.onStageTypeChange}}
+        >
+          Palier par niveau
+        </PixRadioButton>
       {{/if}}
-    </div>
+      <div class="add-stage-actions">
+        <PixButton
+          class="stages-new-stage"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.addStage}}
+          @isDisabled={{this.isAddStageDisabled}}
+          @iconBefore="plus"
+        >
+          Nouveau palier
+        </PixButton>
+        {{#if @stageCollection.hasStages}}
+          <PixTooltip @id="tooltip-stage" @isWide="true">
+            <:triggerElement>
+              <PixButton
+                class="stages-new-stage"
+                @backgroundColor="transparent-light"
+                @isBorderVisible={{true}}
+                @triggerAction={{this.addFirstSkillStage}}
+                @isDisabled={{this.isAddFirstSkillStageDisabled}}
+                @iconBefore="plus"
+              >
+                Nouveau palier "1er acquis"
+              </PixButton>
+            </:triggerElement>
+            <:tooltip>
+              Le palier 1er acquis est obtenu dès un acquis réussi par le participant. Il se verra alors attribuer une
+              étoile à la fin de son parcours.
+            </:tooltip>
+          </PixTooltip>
+        {{/if}}
+      </div>
+    {{/if}}
     {{#if this.hasNewStage}}
       <div class="stages-actions form-actions">
         <PixButton

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -121,6 +121,10 @@ export default class Stages extends Component {
     return (this.mustChooseStageType && this.stageType == null) || !this.hasAvailableStages;
   }
 
+  get canAddNewStage() {
+    return !this.args.hasLinkedCampaign;
+  }
+
   @action
   async createStages(event) {
     event.preventDefault();

--- a/admin/app/components/target-profiles/stages/stage.hbs
+++ b/admin/app/components/target-profiles/stages/stage.hbs
@@ -27,7 +27,7 @@
     >
       Voir détail
     </PixButtonLink>
-    {{#unless this.isZeroStageAmongOtherStages}}
+    {{#if this.canDeleteStage}}
       <PixButton
         @backgroundColor="red"
         @isBorderVisible={{true}}
@@ -66,6 +66,6 @@
           </PixButton>
         </:footer>
       </PixModal>
-    {{/unless}}
+    {{/if}}
   </td>
 </tr>

--- a/admin/app/components/target-profiles/stages/stage.js
+++ b/admin/app/components/target-profiles/stages/stage.js
@@ -16,4 +16,8 @@ export default class Stage extends Component {
       this.args.collectionHasNonZeroStages
     );
   }
+
+  get canDeleteStage() {
+    return !this.isZeroStageAmongOtherStages && !this.args.hasLinkedCampaign;
+  }
 }

--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -26,6 +26,7 @@
           <li><span class="bold">Public : </span>{{this.isPublic}}</li>
           <li><span class="bold">Parcours Accès Simplifié : </span>{{this.isSimplifiedAccess}}</li>
           <li><span class="bold">Obsolète : </span>{{this.isOutdated}}</li>
+          <li><span class="bold">Est associé à une campagne : </span>{{this.hasLinkedCampaign}}</li>
           <li><span class="bold">Organisation de référence : </span>
             <LinkTo @route="authenticated.organizations.get" @model={{@model.ownerOrganizationId}}>
               {{@model.ownerOrganizationId}}

--- a/admin/app/components/target-profiles/target-profile.js
+++ b/admin/app/components/target-profiles/target-profile.js
@@ -30,6 +30,10 @@ export default class TargetProfile extends Component {
     return this.args.model.areKnowledgeElementsResettable ? 'Oui' : 'Non';
   }
 
+  get hasLinkedCampaign() {
+    return this.args.model.hasLinkedCampaign ? 'Oui' : 'Non';
+  }
+
   @action
   toggleEditMode() {
     this.isEditMode = !this.isEditMode;

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/stages/stage.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/stages/stage.js
@@ -20,6 +20,10 @@ export default class StageController extends Controller {
     );
   }
 
+  get hasLinkedCampaign() {
+    return this.model.targetProfile.hasLinkedCampaign;
+  }
+
   @action
   toggleEditMode() {
     this.isEditMode = !this.isEditMode;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -29,6 +29,7 @@ export default class TargetProfile extends Model {
   @attr('string') category;
   @attr('boolean') isSimplifiedAccess;
   @attr('boolean') areKnowledgeElementsResettable;
+  @attr('boolean') hasLinkedCampaign;
   @attr('number') maxLevel;
 
   @hasMany('badge') badges;

--- a/admin/app/styles/components/target-profiles/insights.scss
+++ b/admin/app/styles/components/target-profiles/insights.scss
@@ -1,5 +1,4 @@
 .insights {
-
   &__section {
     padding: 0;
     margin-bottom: 30px;
@@ -7,11 +6,10 @@
 }
 
 .insights-section {
-
   &__title {
     font-size: 1.4rem;
     display: inline-block;
-    margin-bottom: 20px;
+    margin-bottom: $pix-spacing-m;
   }
 
   &__button {
@@ -25,8 +23,25 @@
   }
 }
 
-.insights-section-button {
+.insights__section > .pix-banner {
+  margin-bottom: $pix-spacing-m;
 
+  ul,
+  ol {
+    list-style: revert;
+    padding-left: 1.75em;
+
+    &:not(:first-child) {
+      margin-top: 0.5em;
+    }
+  }
+
+  li + li {
+    margin-top: 0.25em;
+  }
+}
+
+.insights-section-button {
   &__icon {
     margin-right: 4px;
   }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/stages/stage.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/stages/stage.hbs
@@ -3,6 +3,7 @@
   @targetProfileName={{@model.targetProfile.name}}
   @availableLevels={{this.availableLevels}}
   @unavailableThresholds={{this.unavailableThresholds}}
+  @hasLinkedCampaign={{this.hasLinkedCampaign}}
   @toggleEditMode={{this.toggleEditMode}}
   @isEditMode={{this.isEditMode}}
   @onUpdate={{this.update}}

--- a/admin/mirage/factories/target-profile.js
+++ b/admin/mirage/factories/target-profile.js
@@ -42,6 +42,10 @@ export default Factory.extend({
     return false;
   },
 
+  hasLinkedCampaign() {
+    return false;
+  },
+
   maxLevel() {
     return 1000;
   },

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -92,6 +92,33 @@ module('Acceptance | Target Profile Insights', function (hooks) {
     });
 
     module('Stages', function () {
+      test('it should display a warning if target profile is linked to a campaign', async function (assert) {
+        // given
+        targetProfile.update({ hasLinkedCampaign: true });
+
+        // when
+        const screen = await visit('/target-profiles/1');
+        await clickByName('Clés de lecture');
+
+        // then
+        assert.strictEqual(currentURL(), '/target-profiles/1/insights');
+        assert.dom(screen.getByText('Ce profil cible est associé à une campagne, vous ne pouvez donc pas :')).exists();
+      });
+      test('it should not display this warning if target profile is not linked to a campaign', async function (assert) {
+        // given
+        targetProfile.update({ hasLinkedCampaign: false });
+
+        // when
+        const screen = await visit('/target-profiles/1');
+        await clickByName('Clés de lecture');
+
+        // then
+        assert.strictEqual(currentURL(), '/target-profiles/1/insights');
+        assert
+          .dom(screen.queryByText('Ce profil cible est associé à une campagne, vous ne pouvez donc pas :'))
+          .doesNotExist();
+      });
+
       test('it should display existing stages', async function (assert) {
         // given
         const stage1 = server.create('stage', { id: 100, title: 'premier palier' });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -79,6 +79,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
         comment: 'Commentaire Privé.',
         category: 'SUBJECT',
         isSimplifiedAccess: true,
+        hasLinkedCampaign: true,
         areKnowledgeElementsResettable: false,
       });
 
@@ -95,6 +96,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       assert
         .dom(_findByNestedText(screen, `${this.intl.t('pages.target-profiles.resettable-checkbox.label')} : Non`))
         .exists();
+      assert.dom(_findByNestedText(screen, 'Est associé à une campagne : Oui')).exists();
       assert.dom(screen.getByText('456')).exists();
       assert.dom(screen.getByText('Top profil cible.')).exists();
       assert.dom(screen.getByText('Commentaire Privé.')).exists();

--- a/admin/tests/integration/components/stages/stage_test.js
+++ b/admin/tests/integration/components/stages/stage_test.js
@@ -135,6 +135,7 @@ module('Integration | Component | Stages::Stage', function (hooks) {
       assert.dom(screen.getByRole('textbox', { name: 'Titre pour le prescripteur' })).exists();
     });
   });
+
   module('when stage type is level', function (hooks) {
     hooks.beforeEach(function () {
       isEditMode = false;
@@ -174,6 +175,35 @@ module('Integration | Component | Stages::Stage', function (hooks) {
       );
       // then
       assert.dom(screen.queryByText('Éditer')).exists();
+    });
+  });
+
+  module('when target profile is linked to a campaign', function () {
+    test('should not be possible to edit level or threshold', async function (assert) {
+      // given
+      isEditMode = true;
+      toggleEditMode = sinon.stub();
+      stage = {
+        id: 34,
+        isTypeLevel: false,
+        threshold: 40,
+        title: 'palier 3',
+        message: 'mon message',
+        prescriberTitle: 'titre du prescriteur',
+        prescriberDescription: 'description de prescripteur',
+      };
+      this.set('isEditMode', isEditMode);
+      this.set('stage', stage);
+      this.set('toggleEditMode', toggleEditMode);
+      this.set('hasLinkedCampaign', true);
+
+      //when
+      const screen = await render(
+        hbs`<Stages::Stage @stage={{this.stage}} @toggleEditMode={{this.toggleEditMode}} @isEditMode={{this.isEditMode}} @hasLinkedCampaign={{this.hasLinkedCampaign}} />`,
+      );
+
+      // then
+      assert.dom(screen.getByRole('spinbutton', { name: 'Seuil du palier' })).hasAttribute('readonly');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les paliers des profils cibles peuvent être modifiés, supprimés et ajoutés sans aucune restriction et à tout moment.
Le prescripteur et l’utilisateur peuvent donc être surpris par des changements inopportuns. Un seuil précédemment atteint peut subitement disparaître. Ce comportement pour le moins déceptif peut entraîner pleurs et insultes. Il faut y remédier.

## :robot: Proposition
Nous savons désormais, par retour d'API, si une campagne est associée au profil cible consulté. Cela nous permet de bloquer l'édition des seuils et de prévenir la suppression ou l'ajout de nouveaux paliers. Astucieux.

## :rainbow: Remarques
Il fait chaud.

## :100: Pour tester

**Cas 1: Campagne démarée après la création des paliers** 

- Se connecter à PIX admin
- Créez un nouveau profil cible, il est préférable de le rendre public pour tester plus facilement.
- Ajouter quelques paliers de niveaux ou de seuils.
- Vérifier que l'ajout, la modification et la suppression des paliers sont toujours disponibles à ce stade.
- Se connecter à PIX orga, créer une campagne basée sur le profil cible créé précédemment.
- Retourner sur l'admin, vérifier qu'il n'est pas possible d'ajouter ou de supprimer de nouveaux paliers. Vérifier également que dans l'édition du palier, il n'est pas possible de modifier le seuil ou le niveau, selon ce que vous avez choisi précédemment.
- Étape supplémentaire: si vous voulez être exhaustif, pour pouvez recommencer les précédentes étapes en choisissant cette fois des paliers par seuil si vous aviez choisi par niveau et inversement.


**Cas 2: Campagne démarée avant la création des paliers** 

- Se connecter derechef à PIX admin.
- Créez un nouveau profil cible, vous commencez à maîtriser à ce stade.
- Ne créez pas de paliers !
- Connectez-vous à PIX orga (`contenu-orga-pro@example.net`).
- Créez une campagne associée à votre profil cible tout neuf.
- Dès lors, sur PIX admin, vérifiez qu'il vous est impossible de créer des paliers (il est possible que vous ayez besoin de recharger la page).

