### PR TITLE
[FEATURE] Afficher les badges de la certification complémentaire sur la page de détails sur Pix Admin (PIX-8679).

### DIFF
--- a/api/tests/integration/infrastructure/repositories/complementary-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-repository_test.js
@@ -1,6 +1,9 @@
-import { expect, databaseBuilder, domainBuilder } from '../../../test-helper.js';
-import * as complementaryCertificationRepository from '../../../../lib/infrastructure/repositories/complementary-certification-repository.js';
-import { ComplementaryCertificationForAdmin } from '../../../../lib/domain/models/ComplementaryCertificationForAdmin.js';
+import { databaseBuilder, domainBuilder, expect } from "../../../test-helper.js";
+import * as complementaryCertificationRepository
+  from "../../../../lib/infrastructure/repositories/complementary-certification-repository.js";
+import {
+  ComplementaryCertificationForAdmin
+} from "../../../../lib/domain/models/ComplementaryCertificationForAdmin.js";
 
 describe('Integration | Repository | complementary-certification-repository', function () {
   describe('#findAll', function () {
@@ -104,7 +107,7 @@ describe('Integration | Repository | complementary-certification-repository', fu
   });
 
   describe('#getTargetProfileById', function () {
-    it('should return the complementary certification and current target profile by its id', async function () {
+    it('should return the complementary certification and current target profile with badges', async function () {
       // given
       databaseBuilder.factory.buildComplementaryCertification({
         id: 1,
@@ -122,27 +125,9 @@ describe('Integration | Repository | complementary-certification-repository', fu
 
       const oldTargetProfile = databaseBuilder.factory.buildTargetProfile({ id: 222, name: 'oldTarget' });
 
-      const currentBadge = databaseBuilder.factory.buildBadge({
-        targetProfileId: currentTarget.id,
-        key: 'badgeGood',
-      });
-
-      const oldBadge = databaseBuilder.factory.buildBadge({
-        targetProfileId: oldTargetProfile.id,
-        key: 'badge',
-      });
-
-      databaseBuilder.factory.buildComplementaryCertificationBadge({
-        badgeId: currentBadge.id,
-        complementaryCertificationId: complementaryCertification.id,
-        createdAt: new Date('2023-10-10'),
-      });
-
-      databaseBuilder.factory.buildComplementaryCertificationBadge({
-        badgeId: oldBadge.id,
-        complementaryCertificationId: complementaryCertification.id,
-        createdAt: new Date('2020-10-10'),
-      });
+      const currentComplementaryCertificationBadgeId = _createComplementaryCertificationBadge({ targetProfileId: currentTarget.id, complementaryCertificationId: complementaryCertification.id, createdAt: new Date('2023-10-10'), label: 'badgeGood', level: 1}).id;
+      const currentComplementaryCertificationBadgeId2 = _createComplementaryCertificationBadge({ targetProfileId: currentTarget.id, complementaryCertificationId: complementaryCertification.id, createdAt: new Date('2023-10-10'), label: 'badgeGood2', level: 1}).id;
+      _createComplementaryCertificationBadge({ targetProfileId: oldTargetProfile.id, complementaryCertificationId: complementaryCertification.id, createdAt: new Date('2020-10-10'), label: 'oldBadge', level: 1}).id;
 
       await databaseBuilder.commit();
 
@@ -160,9 +145,42 @@ describe('Integration | Repository | complementary-certification-repository', fu
           currentTargetProfile: {
             id: 999,
             name: 'currentTarget',
+            badges: [
+              {
+                id: currentComplementaryCertificationBadgeId,
+                level: 1,
+                name: "badgeGood",
+              },
+              {
+                id: currentComplementaryCertificationBadgeId2,
+                level: 1,
+                name: "badgeGood2",
+              }
+            ]
           },
         }),
       );
     });
   });
 });
+
+function _createComplementaryCertificationBadge({
+  targetProfileId,
+  complementaryCertificationId,
+  createdAt,
+  label,
+  level
+}) {
+  const badgeId = databaseBuilder.factory.buildBadge({
+    targetProfileId,
+    key: label,
+  }).id;
+
+  return databaseBuilder.factory.buildComplementaryCertificationBadge({
+    badgeId,
+    complementaryCertificationId,
+    createdAt,
+    label,
+    level,
+  });
+}


### PR DESCRIPTION
## :unicorn: Problème
Le versioning des profils cibles et des résultats thématiques certifiants doit permettre d’assurer la pérennité des certifications complémentaires Pix en conservant un historique des différentes versions de profil cible et de RT certifiants sur lesquels elles sont basées.

Or elle n'existe pas pour le moment sur Pix Admin.

L'implémentation est pour le moment protégée par un feature toggle (implémenté par https://github.com/1024pix/pix/pull/6573).

## :robot: Proposition
Afficher les badges certifiants lié à la certification complémentaire

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
