### PR TITLE
[FEATURE] Voir les sessions V3 dans les sessions à traiter de Pix-Admin (PIX-8335).

### DIFF
--- a/admin/app/components/with-required-action-sessions/list-items.hbs
+++ b/admin/app/components/with-required-action-sessions/list-items.hbs
@@ -6,6 +6,7 @@
         <th>Centre de certification</th>
         <th>Date de session</th>
         <th>Date de finalisation</th>
+        <th>Version</th>
         <th>Qui ?</th>
       </tr>
     </thead>
@@ -22,6 +23,7 @@
             <td>{{withRequiredActionSession.certificationCenterName}}</td>
             <td>{{withRequiredActionSession.printableDateAndTime}}</td>
             <td>{{withRequiredActionSession.printableFinalizationDate}}</td>
+            <td>{{withRequiredActionSession.version}}</td>
             <td class="session-list__item--align-center">
               {{#if withRequiredActionSession.assignedCertificationOfficerName}}
                 {{withRequiredActionSession.assignedCertificationOfficerName}}

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -1,21 +1,17 @@
 import Controller from '@ember/controller';
-import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 
 export default class AuthenticatedSessionsWithRequiredActionListController extends Controller {
-  @service currentUser;
+  @tracked v2sessionsOnly = false;
 
-  @tracked assignedToSelfOnly = false;
-
-  @computed('assignedToSelfOnly', 'currentUser.adminMember.fullName', 'model')
+  @computed('v2sessionsOnly', 'model')
   get filteredSessions() {
     const sessions = this.model;
-    if (this.assignedToSelfOnly) {
-      return sessions.filter(
-        (session) => session.assignedCertificationOfficerName === this.currentUser.adminMember.fullName,
-      );
+    const versionNumber = 2;
+    if (this.v2sessionsOnly) {
+      return sessions.filter((session) => session.version === versionNumber);
     }
     return sessions;
   }

--- a/admin/app/models/with-required-action-session.js
+++ b/admin/app/models/with-required-action-session.js
@@ -7,6 +7,7 @@ export default class WithRequiredActionSession extends Model {
   @attr() sessionTime;
   @attr() finalizedAt;
   @attr() assignedCertificationOfficerName;
+  @attr() version;
 
   get printableDateAndTime() {
     const formattedSessionDate = this.sessionDate.split('-').reverse().join('/');

--- a/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
+++ b/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
@@ -1,12 +1,7 @@
 {{page-title "Sessions à traiter"}}
 <span class="session-list__self-toogle">
-  <p>Afficher uniquement mes sessions</p>
-  <XToggle
-    @size="small"
-    @theme="light"
-    @value={{this.assignedToSelfOnly}}
-    @onToggle={{fn (mut this.assignedToSelfOnly)}}
-  />
+  <p>Afficher uniquement les sessions V2</p>
+  <XToggle @size="small" @theme="light" @value={{this.v2sessionsOnly}} @onToggle={{fn (mut this.v2sessionsOnly)}} />
 </span>
 
 <WithRequiredActionSessions::ListItems @withRequiredActionSessions={{this.filteredSessions}} />

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
@@ -55,7 +55,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
     });
 
     test('it should display sessions with required action informations', async function (assert) {
-      assert.expect(8);
+      assert.expect(10);
       // given
       const finalizedAt = new Date('2021-02-01T03:00:00Z');
       server.create('with-required-action-session', {
@@ -65,6 +65,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
         sessionDate: '2021-01-01',
         sessionTime: '17:00:00',
         assignedCertificationOfficerName: 'Officer1',
+        version: 101,
       });
       server.create('with-required-action-session', {
         id: '2',
@@ -73,6 +74,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
         sessionDate: '2022-07-12',
         sessionTime: '10:10:00',
         assignedCertificationOfficerName: 'Officer2',
+        version: 102,
       });
 
       // when
@@ -83,7 +85,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
       _assertSession2InformationsAreDisplayed(assert, screen);
     });
 
-    module('When clicking on the display only my sessions button', function () {
+    module('When clicking on the display only V2 sessions button', function () {
       test('it should filter the sessions', async function (assert) {
         // given
         const sessionDate = '2021-01-01';
@@ -96,6 +98,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
           sessionDate,
           sessionTime,
           assignedCertificationOfficerName: 'John Doe',
+          version: 2,
         });
         server.create('with-required-action-session', {
           id: '2',
@@ -104,6 +107,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
           sessionDate,
           sessionTime,
           assignedCertificationOfficerName: 'Officer2',
+          version: 3,
         });
         const screen = await visit('/sessions/list/with-required-action');
 
@@ -116,6 +120,8 @@ module('Acceptance | authenticated/sessions/list/with required action', function
         assert.dom(screen.getByText('1')).exists();
         assert.dom(screen.getByText('01/01/2021 à 17:00:00')).exists();
         assert.dom(screen.getByText('John Doe')).exists();
+        assert.dom(screen.getByText('2')).exists();
+        assert.dom(screen.queryByText('3')).doesNotExist();
       });
     });
   });
@@ -126,6 +132,7 @@ function _assertSession1InformationsAreDisplayed(assert, screen) {
   assert.dom(screen.getByText('1')).exists();
   assert.dom(screen.getByText('01/01/2021 à 17:00:00')).exists();
   assert.dom(screen.getByText('Officer1')).exists();
+  assert.dom(screen.getByText('101')).exists();
 }
 
 function _assertSession2InformationsAreDisplayed(assert, screen) {
@@ -133,4 +140,5 @@ function _assertSession2InformationsAreDisplayed(assert, screen) {
   assert.dom(screen.getByText('2')).exists();
   assert.dom(screen.getByText('12/07/2022 à 10:10:00')).exists();
   assert.dom(screen.getByText('Officer2')).exists();
+  assert.dom(screen.getByText('102')).exists();
 }

--- a/api/db/database-builder/factory/build-finalized-session.js
+++ b/api/db/database-builder/factory/build-finalized-session.js
@@ -9,6 +9,7 @@ const buildFinalizedSession = function ({
   date = '2019-12-25',
   publishedAt = null,
   assignedCertificationOfficerName = null,
+  version = 2,
 } = {}) {
   const values = {
     sessionId,
@@ -19,6 +20,7 @@ const buildFinalizedSession = function ({
     date,
     publishedAt,
     assignedCertificationOfficerName,
+    version,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20230720143643_add-version-column-to-finalized-sessions.js
+++ b/api/db/migrations/20230720143643_add-version-column-to-finalized-sessions.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'finalized-sessions';
+const COLUMN_NAME = 'version';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME);
+  });
+
+  await knex(TABLE_NAME).update({ [COLUMN_NAME]: 2 });
+
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -6,6 +6,7 @@ import {
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 } from '../common/common-builder.js';
+import { issueReportCategoriesBuilder } from '../certification/issue-report-categories-builder.js';
 
 const TEAM_CERTIFICATION_OFFSET_ID = 7000;
 // IDS
@@ -47,6 +48,7 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createV3Session({ databaseBuilder });
   await _createPublishedSession({ databaseBuilder });
   await _createStartedSession({ databaseBuilder });
+  await _createIssueReportCategories({ databaseBuilder });
 }
 
 export { teamCertificationDataBuilder };
@@ -381,4 +383,8 @@ async function _createStartedSession({ databaseBuilder }) {
       hasComplementaryCertificationsToRegister: true,
     },
   });
+}
+
+async function _createIssueReportCategories({ databaseBuilder }) {
+  await issueReportCategoriesBuilder({ databaseBuilder });
 }

--- a/api/lib/domain/events/AutoJuryDone.js
+++ b/api/lib/domain/events/AutoJuryDone.js
@@ -1,11 +1,20 @@
 class AutoJuryDone {
-  constructor({ sessionId, finalizedAt, certificationCenterName, sessionDate, sessionTime, hasExaminerGlobalComment }) {
+  constructor({
+    sessionId,
+    finalizedAt,
+    certificationCenterName,
+    sessionDate,
+    sessionTime,
+    hasExaminerGlobalComment,
+    version,
+  }) {
     this.sessionId = sessionId;
     this.finalizedAt = finalizedAt;
     this.certificationCenterName = certificationCenterName;
     this.sessionDate = sessionDate;
     this.sessionTime = sessionTime;
     this.hasExaminerGlobalComment = hasExaminerGlobalComment;
+    this.version = version;
   }
 }
 

--- a/api/lib/domain/events/SessionFinalized.js
+++ b/api/lib/domain/events/SessionFinalized.js
@@ -1,11 +1,20 @@
 class SessionFinalized {
-  constructor({ sessionId, finalizedAt, hasExaminerGlobalComment, sessionDate, sessionTime, certificationCenterName }) {
+  constructor({
+    sessionId,
+    finalizedAt,
+    hasExaminerGlobalComment,
+    sessionDate,
+    sessionTime,
+    certificationCenterName,
+    version,
+  }) {
     this.sessionId = sessionId;
     this.finalizedAt = finalizedAt;
     this.hasExaminerGlobalComment = hasExaminerGlobalComment;
     this.sessionDate = sessionDate;
     this.sessionTime = sessionTime;
     this.certificationCenterName = certificationCenterName;
+    this.version = version;
   }
 }
 

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -66,6 +66,7 @@ async function handleAutoJury({
       sessionDate: event.sessionDate,
       sessionTime: event.sessionTime,
       hasExaminerGlobalComment: event.hasExaminerGlobalComment,
+      version: event.version,
     }),
   ];
 }

--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -26,6 +26,7 @@ async function handleSessionFinalized({
     hasExaminerGlobalComment: event.hasExaminerGlobalComment,
     hasSupervisorAccess,
     juryCertificationSummaries,
+    version: event.version,
   });
 
   await finalizedSessionRepository.save(finalizedSession);

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -8,6 +8,7 @@ class FinalizedSession {
     isPublishable,
     publishedAt,
     assignedCertificationOfficerName,
+    version = 2,
   } = {}) {
     this.sessionId = sessionId;
     this.finalizedAt = finalizedAt;
@@ -17,6 +18,7 @@ class FinalizedSession {
     this.isPublishable = isPublishable;
     this.publishedAt = publishedAt;
     this.assignedCertificationOfficerName = assignedCertificationOfficerName;
+    this.version = version;
   }
 
   static from({
@@ -28,6 +30,7 @@ class FinalizedSession {
     hasExaminerGlobalComment,
     juryCertificationSummaries,
     hasSupervisorAccess,
+    version,
   }) {
     return new FinalizedSession({
       sessionId,
@@ -42,6 +45,7 @@ class FinalizedSession {
         _hasNoUnfinishedWithoutAbortReason(juryCertificationSummaries) &&
         _hasAllFinishedEndTestScreensSeenByExaminer(hasSupervisorAccess, juryCertificationSummaries),
       publishedAt: null,
+      version,
     });
   }
 

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -72,6 +72,7 @@ const finalizeSession = async function ({
     certificationCenterName: finalizedSession.certificationCenter,
     sessionDate: finalizedSession.date,
     sessionTime: finalizedSession.time,
+    version: finalizedSession.version,
   });
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/with-required-action-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/with-required-action-session-serializer.js
@@ -14,6 +14,7 @@ const serialize = function (finalizedSessions) {
       'finalizedAt',
       'certificationCenterName',
       'assignedCertificationOfficerName',
+      'version',
     ],
   }).serialize(finalizedSessions);
 };

--- a/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
@@ -19,6 +19,7 @@ describe('Integration | Repository | Finalized-session', function () {
           sessionDate: '2021-01-01',
           sessionTime: '14:00:00',
           isPublishable: true,
+          version: 3,
         });
 
         // when
@@ -36,6 +37,7 @@ describe('Integration | Repository | Finalized-session', function () {
           isPublishable: true,
           publishedAt: null,
           assignedCertificationOfficerName: null,
+          version: 3,
         });
       });
     });
@@ -69,6 +71,7 @@ describe('Integration | Repository | Finalized-session', function () {
           certificationCenterName: 'A certification center name',
           date: '2021-01-01',
           time: '14:00:00',
+          version: 2,
         });
 
         await databaseBuilder.commit();
@@ -89,6 +92,7 @@ describe('Integration | Repository | Finalized-session', function () {
           isPublishable: false,
           publishedAt: null,
           assignedCertificationOfficerName: 'David Gilmour',
+          version: 2,
         });
       });
     });
@@ -118,6 +122,7 @@ describe('Integration | Repository | Finalized-session', function () {
           isPublishable: finalizedSession.isPublishable,
           publishedAt: null,
           assignedCertificationOfficerName: null,
+          version: 2,
         });
       });
     });
@@ -149,6 +154,7 @@ describe('Integration | Repository | Finalized-session', function () {
           isPublishable: true,
           publishedAt: null,
           finalizedAt: new Date('2021-01-01'),
+          version: 3,
         });
 
         databaseBuilder.factory.buildFinalizedSession({
@@ -177,6 +183,7 @@ describe('Integration | Repository | Finalized-session', function () {
             isPublishable: publishableFinalizedSession2.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
+            version: 2,
           },
           {
             sessionId: publishableFinalizedSession1.sessionId,
@@ -187,6 +194,7 @@ describe('Integration | Repository | Finalized-session', function () {
             isPublishable: publishableFinalizedSession1.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
+            version: 2,
           },
           {
             sessionId: publishableFinalizedSession3.sessionId,
@@ -197,6 +205,7 @@ describe('Integration | Repository | Finalized-session', function () {
             isPublishable: publishableFinalizedSession3.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
+            version: 3,
           },
         ]);
       });
@@ -231,6 +240,7 @@ describe('Integration | Repository | Finalized-session', function () {
           isPublishable: false,
           publishedAt: null,
           finalizedAt: new Date('2021-01-01'),
+          version: 3,
         });
 
         databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null });
@@ -253,6 +263,7 @@ describe('Integration | Repository | Finalized-session', function () {
             isPublishable: firstFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
+            version: 2,
           },
           {
             sessionId: secondFinalizedSession.sessionId,
@@ -263,6 +274,7 @@ describe('Integration | Repository | Finalized-session', function () {
             isPublishable: secondFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
+            version: 2,
           },
           {
             sessionId: thirdFinalizedSession.sessionId,
@@ -273,6 +285,7 @@ describe('Integration | Repository | Finalized-session', function () {
             isPublishable: thirdFinalizedSession.isPublishable,
             publishedAt: null,
             assignedCertificationOfficerName: null,
+            version: 3,
           },
         ]);
       });

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -35,6 +35,7 @@ describe('Unit | Domain | Events | handle-session-finalized', function () {
       certificationCenterName: 'A certification center name',
       sessionDate: '2021-01-29',
       sessionTime: '14:00',
+      version: 3,
     });
     const juryCertificationSummary = new JuryCertificationSummary({
       id: 1,
@@ -75,6 +76,7 @@ describe('Unit | Domain | Events | handle-session-finalized', function () {
       hasExaminerGlobalComment: false,
       hasSupervisorAccess: true,
       juryCertificationSummaries: [juryCertificationSummary],
+      version: event.version,
     });
     expect(finalizedSessionRepository.save).to.have.been.calledWithExactly(
       new FinalizedSession({
@@ -86,6 +88,7 @@ describe('Unit | Domain | Events | handle-session-finalized', function () {
         isPublishable: true,
         hasSupervisorAccess: true,
         publishedAt: null,
+        version: event.version,
       }),
     );
   });

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -261,6 +261,7 @@ describe('Unit | UseCase | finalize-session', function () {
           certificationCenter: 'a certification center name',
           date: '2019-12-12',
           time: '16:00:00',
+          version: 3,
         });
         clock = sinon.useFakeTimers(now);
         const validReportForFinalization = domainBuilder.buildCertificationReport({
@@ -303,6 +304,7 @@ describe('Unit | UseCase | finalize-session', function () {
             certificationCenterName: 'a certification center name',
             sessionDate: '2019-12-12',
             sessionTime: '16:00:00',
+            version: 3,
           }),
         );
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/with-required-action-session_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/with-required-action-session_test.js
@@ -15,6 +15,7 @@ describe('Unit | Serializer | JSONAPI | with-required-action-session-serializer'
         isPublishable: false,
         publishedAt: null,
         assignedCertificationOfficerName: 'Anne Star',
+        version: 3,
       });
 
       const expectedJsonApi = {
@@ -28,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | with-required-action-session-serializer'
             'finalized-at': new Date('2019-04-28T02:42:26Z'),
             'certification-center-name': 'Centre des Anne-Etoile',
             'assigned-certification-officer-name': 'Anne Star',
+            version: 3,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème

Une phase pilote pour la certification nextGen va être organisée auprès de quelques centres sélectionnés. Lors de cette phase, le pôle certif souhaite pouvoir identifier simplement les certifications à traiter (= qui nécessite une action manuelle de leur part) afin d’apporter une attention particulière à ces certifs.

## :robot: Proposition

Dans Pix Admin > menu “Sessions de certification” : Remplacement de l'onglet `Afficher uniquement mes sessions` (non utilisé) par `Afficher uniquement les sessions V2` (sessions qui seront les plus nombreuses)

## :rainbow: Remarques

Ceci est la deuxième tentative d'implémentation de la feature, faisant suite à la PR #6577 dans laquelle nous étions passés par des query parameters.

## :100: Pour tester

Pour ne pas refaire tout le process : 
- Aller dans pix-admin > menu “Sessions de certification”
Vérifier du bon fonctionnement du switch (une session V2 `7007` et une session V3 `7006` ont été créées pour l'occasion ) et du bon affichage du numéro de version de chaque session.

Pour refaire tout le process:

Schéma à réitérer pour au moins 2 sessions (une session V2 et une session V3)

• Dans pix certif
• Inscrire un candidat à cette certif
• Sur pix-app, rejoindre cette session et lancer le test de certification
• Répondre à la dernière question du test (qu'importe le résultat)
• Finaliser la session avec un signalement de type C1 (modif infos persos candidat) ou C6 (fraude)

----

Une fois les deux sessions finalisées, aller dans pix-admin > menu “Sessions de certification”
Cliquer sur le toggle `Afficher uniquement les sessions V2`
Constater que les sessions V3 ne sont pas visibles