### PR TITLE
[FEATURE] Afficher les badges certifiants de la certification complementaire dans Pix Admin (PIX-8679)

### DIFF
--- a/admin/app/components/complementary-certifications/list.hbs
+++ b/admin/app/components/complementary-certifications/list.hbs
@@ -3,19 +3,15 @@
     <table>
       <thead>
         <tr>
-          <th class="table__column table__column--id">
-            <label for="id">ID</label>
-          </th>
-          <th>
-            <label for="name">Nom</label>
-          </th>
+          <th class="table__column--id">ID</th>
+          <th>Nom</th>
         </tr>
       </thead>
 
       <tbody>
         {{#each @complementaryCertifications as |complementaryCertification|}}
-          <tr aria-label="">
-            <td class="table__column table__column--id">{{complementaryCertification.id}}</td>
+          <tr>
+            <td class="table__column--id">{{complementaryCertification.id}}</td>
             <td>
               <LinkTo
                 @route="authenticated.complementary-certifications.complementary-certification"

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
@@ -1,5 +1,28 @@
 <section class="page-section">
   <div class="content-text content-text--small">
-    TODO: Section liste des résultats thématique
+    <h2 class="complementary-certification-details__badges-title">
+      Résultats thématiques certifiants du profil cible actuel
+    </h2>
+    <div class="table-admin">
+      <table>
+        <thead>
+          <tr>
+            <th class="table__column--id">ID</th>
+            <th>Nom du résultat thématique</th>
+            <th>Niveau</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {{#each @badges as |badge|}}
+            <tr>
+              <td>{{badge.id}}</td>
+              <td>{{badge.label}}</td>
+              <td>{{badge.level}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
@@ -1,15 +1,17 @@
 <section class="page-section">
   <div class="content-text content-text--small">
     <h2 class="complementary-certification-details__badges-title">
-      Résultats thématiques certifiants du profil cible actuel
+      {{t "components.complementary-certifications.target-profiles.badges-list.title"}}
     </h2>
     <div class="table-admin">
       <table>
         <thead>
           <tr>
-            <th class="table__column--id">ID</th>
-            <th>Nom du résultat thématique</th>
-            <th>Niveau</th>
+            <th class="table__column--id">{{t
+                "components.complementary-certifications.target-profiles.badges-list.header.id"
+              }}</th>
+            <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}</th>
+            <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}</th>
           </tr>
         </thead>
 

--- a/admin/app/components/complementary-certifications/target-profiles/information.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.hbs
@@ -3,18 +3,15 @@
     <h1 class="complementary-certification-details__title">Certification complémentaire</h1>
 
     <span class="complementary-certification-details__label">{{@complementaryCertification.label}}</span>
-    <ul class="complementary-certification-details__list">
-      <li>Profil cible actuel :
-        <LinkTo
-          @route="authenticated.target-profiles.target-profile"
-          @model={{@complementaryCertification.currentTargetProfile.id}}
-          class="complementary-certification-details-list__link"
-        >
-          {{@complementaryCertification.currentTargetProfile.name}}
-        </LinkTo>
-      </li>
-      <li>Date de rattachement : TODO</li>
-    </ul>
+    <span class="complementary-certification-details__target-profile">Profil cible actuel :
+      <LinkTo
+        @route="authenticated.target-profiles.target-profile"
+        @model={{@complementaryCertification.currentTargetProfile.id}}
+        class="complementary-certification-details-target-profile__link"
+      >
+        {{@complementaryCertification.currentTargetProfile.name}}
+      </LinkTo>
+    </span>
 
     <PixButton>Rattacher un nouveau profil cible</PixButton>
 

--- a/admin/app/styles/components/complementary-certifications/details.scss
+++ b/admin/app/styles/components/complementary-certifications/details.scss
@@ -22,23 +22,16 @@
     letter-spacing: -0.04em;
   }
 
-  &__list {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    margin-top: $pix-spacing-s;
+  &__target-profile {
+    margin: $pix-spacing-s 0;
     font-family: $font-roboto;
     font-size: 16px;
-    font-weight: 400;
-    line-height: 24px;
-    letter-spacing: 0;
-    text-align: left;
     color: $pix-neutral-70;
   }
 }
 
 
-.complementary-certification-details-list {
+.complementary-certification-details-target-profile {
   &__link {
     color: $pix-primary;
 

--- a/admin/app/styles/components/complementary-certifications/details.scss
+++ b/admin/app/styles/components/complementary-certifications/details.scss
@@ -24,9 +24,16 @@
 
   &__target-profile {
     margin: $pix-spacing-s 0;
-    font-family: $font-roboto;
     font-size: 16px;
     color: $pix-neutral-70;
+  }
+
+  &__badges-title {
+    font-family: $font-open-sans;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 28px;
+    padding-bottom: $pix-spacing-s;
   }
 }
 

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
@@ -10,6 +10,6 @@
 
 <main class="page-body">
   <ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{@model}} />
-  <ComplementaryCertifications::TargetProfiles::BadgesList />
+  <ComplementaryCertifications::TargetProfiles::BadgesList @badges={{@model.currentTargetProfile.badges}} />
   <ComplementaryCertifications::TargetProfiles::Log />
 </main>

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -7,10 +7,31 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::B
   setupRenderingTest(hooks);
 
   test("it should display complementary certification's badges list", async function (assert) {
-    // given & when
-    const screen = await render(hbs`<ComplementaryCertifications::TargetProfiles::BadgesList />`);
+    // given
+    const store = this.owner.lookup('service:store');
+    const complementaryCertification = store.createRecord('complementary-certification', {
+      label: 'MARIANNE CERTIF',
+      currentTargetProfile: {
+        name: 'ALEX TARGET',
+        id: 3,
+        badges: [
+          { id: 1023, label: 'Badge Cascade', level: 3 },
+          { id: 1025, label: 'Badge Volcan', level: 1 },
+        ],
+      },
+    });
+    this.badges = complementaryCertification.currentTargetProfile.badges;
+
+    // when
+    const screen = await render(
+      hbs`<ComplementaryCertifications::TargetProfiles::BadgesList @badges={{this.badges}} />`,
+    );
 
     // then
-    assert.dom(screen.getByText('TODO: Section liste des résultats thématique')).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'ID' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom du résultat thématique' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
+    assert.dom(screen.getByRole('row', { name: '1023 Badge Cascade 3' })).exists();
+    assert.dom(screen.getByRole('row', { name: '1025 Badge Volcan 1' })).exists();
   });
 });

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | ComplementaryCertifications::TargetProfiles::BadgesList', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test("it should display complementary certification's badges list", async function (assert) {
     // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -27,6 +27,18 @@
         "upload-button": "Import CSV file"
       }
     },
+    "complementary-certifications": {
+      "target-profiles": {
+        "badges-list": {
+          "title": "Résultats thématiques certifiants du profil cible actuel",
+          "header": {
+            "id": "ID",
+            "level": "Niveau",
+            "name": "Nom du résultat thématique"
+          }
+        }
+      }
+    },
     "organizations": {
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -35,6 +35,18 @@
         "upload-button": "Importer un fichier CSV"
       }
     },
+    "complementary-certifications": {
+      "target-profiles": {
+        "badges-list": {
+          "title": "Résultats thématiques certifiants du profil cible actuel",
+          "header": {
+            "id": "ID",
+            "level": "Niveau",
+            "name": "Nom du résultat thématique"
+          }
+        }
+      }
+    },
     "organizations": {
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"

--- a/api/lib/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-repository.js
@@ -1,4 +1,4 @@
-import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
+import { ComplementaryCertification } from '../../domain/models/index.js';
 import { ComplementaryCertificationForAdmin } from '../../domain/models/ComplementaryCertificationForAdmin.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
@@ -21,7 +21,7 @@ const getByLabel = async function ({ label }) {
 };
 
 const getTargetProfileById = async function ({ complementaryCertificationId }) {
-  const targetProfile = await knex('complementary-certification-badges')
+  const currentProfile = await knex('complementary-certification-badges')
     .select({
       id: 'target-profiles.id',
       name: 'target-profiles.name',
@@ -32,6 +32,15 @@ const getTargetProfileById = async function ({ complementaryCertificationId }) {
     .orderBy('complementary-certification-badges.createdAt', 'desc')
     .first();
 
+  const currentTargetProfileBadges = await knex('badges')
+    .select({
+      id: 'badges.id',
+      label: 'complementary-certification-badges.label',
+      level: 'complementary-certification-badges.level',
+    })
+    .leftJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
+    .where({ targetProfileId: currentProfile.id });
+
   const complementaryCertification = await knex
     .from('complementary-certifications')
     .where({ id: complementaryCertificationId })
@@ -39,7 +48,7 @@ const getTargetProfileById = async function ({ complementaryCertificationId }) {
 
   return new ComplementaryCertificationForAdmin({
     ...complementaryCertification,
-    currentTargetProfile: { ...targetProfile },
+    currentTargetProfile: { ...currentProfile, badges: [...currentTargetProfileBadges] },
   });
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -12,7 +12,24 @@ const serialize = function (complementaryCertifications) {
 
 const serializeForAdmin = function (complementaryCertification) {
   return new Serializer('complementary-certification', {
-    attributes: ['label', 'key', 'currentTargetProfile'],
+    transform: (record) => {
+      const currentTargetProfile = {
+        ...record.currentTargetProfile,
+        badges: record.currentTargetProfile?.badges.map((badge) => ({ ...badge })),
+      };
+
+      return {
+        ...record,
+        currentTargetProfile,
+      };
+    },
+    attributes: ['label', 'key', 'currentTargetProfile', 'badges'],
+    currentTargetProfile: {
+      attributes: ['id', 'name', 'badges'],
+      badges: {
+        attributes: ['id', 'label', 'level'],
+      },
+    },
   }).serialize(complementaryCertification);
 };
 

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -93,11 +93,26 @@ describe('Acceptance | API | complementary-certification-controller', function (
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 999, name: 'Target' });
 
       const badge1 = databaseBuilder.factory.buildBadge({
+        id: 198,
+        key: 'badge1',
+        targetProfileId: targetProfile.id,
+      });
+
+      const badge2 = databaseBuilder.factory.buildBadge({
+        id: 298,
+        key: 'badge2',
         targetProfileId: targetProfile.id,
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         badgeId: badge1.id,
+        label: 'another badge label',
+        complementaryCertificationId: complementaryCertification.id,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        badgeId: badge2.id,
+        label: 'badge label',
         complementaryCertificationId: complementaryCertification.id,
       });
 
@@ -116,6 +131,18 @@ describe('Acceptance | API | complementary-certification-controller', function (
             label: 'Pix+ Édu 2nd degré',
             key: 'EDU_2ND_DEGRE',
             'current-target-profile': {
+              badges: [
+                {
+                  id: 198,
+                  level: 1,
+                  label: 'another badge label',
+                },
+                {
+                  id: 298,
+                  level: 1,
+                  label: 'badge label',
+                },
+              ],
               id: 999,
               name: 'Target',
             },

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-for-admin.js
@@ -4,7 +4,7 @@ const buildComplementaryCertificationForAdmin = function ({
   id = 1,
   label = 'Complementary certification name',
   key = 'COMPLEMENTARY_CERTIFICATION_KEY',
-  currentTargetProfile = { id: 12, name: 'Target' },
+  currentTargetProfile = { id: 12, name: 'Target', badges: [] },
 } = {}) {
   return new ComplementaryCertificationForAdmin({
     id,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
@@ -48,11 +48,20 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
   describe('#serializeForAdmin', function () {
     it('should convert a ComplementaryCertification model object into JSON API data', function () {
       // given
+      const badges = [
+        { id: 1, label: 'badge 1', level: 1, otherProp: true },
+        { id: 2, label: 'badge 2', level: 2, otherProp: false },
+      ];
+      // Fonctionne si c'est un "plain object", si on passe par un constructeur: i.e. new Badge(), il serialize tout
+      // cf. json-api-serializer/serializer-utils.js l. 171j
+
+      const currentTargetProfile = domainBuilder.buildTargetProfile({ id: 999, name: 'Target', badges });
+
       const complementaryCertifications = domainBuilder.buildComplementaryCertificationForAdmin({
         id: 11,
         label: 'Pix+Edu',
         key: 'EDU',
-        currentTargetProfile: { id: 999, name: 'Target' },
+        currentTargetProfile,
       });
 
       // when
@@ -61,16 +70,20 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
       // then
       expect(json).to.deep.equal({
         data: {
+          type: 'complementary-certifications',
+          id: '11',
           attributes: {
+            label: 'Pix+Edu',
+            key: 'EDU',
             'current-target-profile': {
               id: 999,
               name: 'Target',
+              badges: [
+                { id: 1, label: 'badge 1', level: 1 },
+                { id: 2, label: 'badge 2', level: 2 },
+              ],
             },
-            key: 'EDU',
-            label: 'Pix+Edu',
           },
-          id: '11',
-          type: 'complementary-certifications',
         },
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Le versioning des profils cibles et des résultats thématiques certifiants doit permettre d’assurer la pérennité des certifications complémentaires Pix en conservant un historique des différentes versions de profil cible et de RT certifiants sur lesquels elles sont basées.

Or elle n'existe pas pour le moment sur Pix Admin.

L'implémentation est pour le moment protégée par un feature toggle (implémenté par https://github.com/1024pix/pix/pull/6573).

## :robot: Proposition
Afficher les badges certifiants lié à la certification complémentaire

## :rainbow: Remarques
Suppression de l'info de la date de rattachement dans le premier bloc. Elle sera déjà affiché dans la partie historique (pas encore dev)

Amélioration de la table qui liste les certif complémentaire (label inutiles relié à rien qui nuit à l'a11Y)

## :100: Pour tester

- Sur PixAdmin avec le compte superadmin@example.net
- Cliquer sur l'icône dans le menu latéral nommé "certifications complémentaire" (icône tampon)
- Cliquer sur un des liens
- Constater que l'on ne voit plus la mention de la date de rattachement dans le premier bloc
- Constater que le deuxième bloc contient les badges relié à la target profil courante (voir BDD pour comparer)