### PR TITLE
[FEATURE] Éviter la présence d'éléments block dans des labels d'épreuve

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -6,7 +6,7 @@
         {{#each this._blocks as |block|}}
           {{#if block.text}}
             <label for="qroc_input">
-              <MarkdownToHtml class="qroc_input-label" @extensions="remove-paragraph-tags" @markdown={{block.text}} />
+              <MarkdownToHtml @isInline={{true}} @extensions="remove-paragraph-tags" @markdown={{block.text}} />
             </label>
           {{/if}}
 
@@ -14,6 +14,7 @@
             {{#if (eq block.type "select")}}
               <div class="challenge-response__proposal challenge-response__proposal--selector">
                 <PixSelect
+                  @id="qroc_input"
                   data-uid="qroc-proposal-uid"
                   data-test="challenge-response-proposal-selector"
                   @isDisabled={{this.isAnswerFieldDisabled}}

--- a/mon-pix/app/components/markdown-to-html.hbs
+++ b/mon-pix/app/components/markdown-to-html.hbs
@@ -1,3 +1,7 @@
-<div class={{@class}} ...attributes>
+{{#if @isInline}}
   {{this.html}}
-</div>
+{{else}}
+  <div class={{@class}} ...attributes>
+    {{this.html}}
+  </div>
+{{/if}}

--- a/mon-pix/app/components/qcm-proposals.hbs
+++ b/mon-pix/app/components/qcm-proposals.hbs
@@ -9,7 +9,7 @@
         {{on "click" (fn this.checkboxClicked labeledCheckbox.value)}}
         data-test="challenge-response-proposal-selector"
       >
-        <MarkdownToHtml @class="proposal-text" @markdown={{labeledCheckbox.label}} />
+        <MarkdownToHtml @isInline={{true}} @extensions="remove-paragraph-tags" @markdown={{labeledCheckbox.label}} />
       </PixCheckbox>
 
     </p>

--- a/mon-pix/app/components/qcu-proposals.hbs
+++ b/mon-pix/app/components/qcu-proposals.hbs
@@ -11,7 +11,7 @@
       class="qcu-proposals__radio"
       data-test="challenge-response-proposal-selector"
     >
-      <MarkdownToHtml @class="qcu-panel__text proposal-text" @markdown={{labeledRadio.label}} />
+      <MarkdownToHtml @isInline={{true}} @extensions="remove-paragraph-tags" @markdown={{labeledRadio.label}} />
     </PixRadioButton>
   </p>
 {{/each}}

--- a/mon-pix/app/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.hbs
@@ -12,11 +12,7 @@
       {{#if block.input}}
         {{#if block.text}}
           <label for="{{block.input}}">
-            <MarkdownToHtml
-              @markdown={{block.text}}
-              @extensions="remove-paragraph-tags"
-              class="correction-qrocm-text__label"
-            />
+            <MarkdownToHtml @isInline={{true}} @extensions="remove-paragraph-tags" @markdown={{block.text}} />
           </label>
         {{/if}}
 

--- a/mon-pix/app/components/qrocm-proposal.hbs
+++ b/mon-pix/app/components/qrocm-proposal.hbs
@@ -24,13 +24,8 @@
       {{#if block.input}}
         <div class="qrocm-proposal__input">
           {{#if block.text}}
-            <label for="{{block.input}}">
-              <MarkdownToHtml
-                @markdown={{block.text}}
-                @extensions="remove-paragraph-tags"
-                class="qrocm-proposal__label"
-                data-test="qrocm-label-{{index}}"
-              />
+            <label for="{{block.input}}" data-test="qrocm-label-{{index}}">
+              <MarkdownToHtml @isInline={{true}} @extensions="remove-paragraph-tags" @markdown={{block.text}} />
             </label>
           {{/if}}
 

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -3,7 +3,7 @@ import { click, find, findAll, currentURL, fillIn, triggerEvent } from '@ember/t
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Displaying a QROC challenge', function (hooks) {
   setupApplicationTest(hooks);
@@ -88,19 +88,18 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
     });
 
     module('When challenge is not already answered', function (hooks) {
+      let screen;
+
       hooks.beforeEach(async function () {
         // when
-        await visit(`/assessments/${assessment.id}/challenges/0`);
+        screen = await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
       test('should render challenge information and question', function (assert) {
         // then
-        assert.strictEqual(
-          find('.challenge-statement-instruction__text').textContent.trim(),
-          qrocChallenge.instruction,
-        );
-        assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Entrez le <em>prénom</em> de B. Gates :'));
+        assert.ok(screen.getByText(qrocChallenge.instruction));
+        assert.ok(screen.getByLabelText('Entrez le prénom de B. Gates :'));
+        assert.ok(screen.getByPlaceholderText('prénom'));
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
@@ -266,19 +265,18 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
     });
 
     module('When challenge is not already answered', function (hooks) {
+      let screen;
+
       hooks.beforeEach(async function () {
         // when
-        await visit(`/assessments/${assessment.id}/challenges/0`);
+        screen = await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
       test('should render challenge information and question', function (assert) {
         // then
-        assert.strictEqual(
-          find('.challenge-statement-instruction__text').textContent.trim(),
-          qrocChallenge.instruction,
-        );
-        assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Entrez le <em>prénom</em> de B. Gates :'));
+        assert.ok(screen.getByText(qrocChallenge.instruction));
+        assert.ok(screen.getByLabelText('Entrez le prénom de B. Gates :'));
+        assert.ok(screen.getByPlaceholderText('prénom'));
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
@@ -386,15 +384,12 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
     module('When challenge is not already answered', function () {
       test('should render challenge information and question', async function (assert) {
         // given
-        await visit(`/assessments/${assessment.id}/challenges/0`);
+        const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // then
-        assert.strictEqual(
-          find('.challenge-statement-instruction__text').textContent.trim(),
-          qrocChallenge.instruction,
-        );
-        assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Select: '));
+        assert.ok(screen.getByText(qrocChallenge.instruction));
+        assert.ok(screen.getByText(/Select:/, { exact: false, selector: 'label' }));
+        assert.ok(screen.getByRole('button', { name: /Select:/ }));
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
@@ -404,7 +399,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click('.challenge-actions__action-validate');
 
         // when
-        await clickByName('saladAriaLabel');
+        await click(screen.getByRole('button', { name: /Select:/ }));
         await screen.findByRole('listbox');
         await click(screen.getByRole('option', { name: 'mango' }));
 
@@ -419,7 +414,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         assert.dom('.challenge-response__alert').exists();
 
         // when
-        await clickByName('saladAriaLabel');
+        await click(screen.getByRole('button', { name: /Select:/ }));
         await screen.findByRole('listbox');
         await click(screen.getByRole('option', { name: 'mango' }));
 
@@ -432,7 +427,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
 
         // when
-        await clickByName('saladAriaLabel');
+        await click(screen.getByRole('button', { name: /Select:/ }));
         await screen.findByRole('listbox');
         await click(screen.getByRole('option', { name: 'mango' }));
 

--- a/mon-pix/tests/integration/components/qcu-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals_test.js
@@ -31,12 +31,15 @@ module('Integration | Component | QCU proposals', function (hooks) {
       this.set('answerChanged', answerChangedHandler);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<QcuProposals @answers={{this.answers}} @proposals={{this.proposals}} @answerChanged={{this.answerChanged}} />`,
       );
 
       // then
-      assert.dom('.proposal-text').exists({ count: 3 });
+      assert.strictEqual(screen.getAllByRole('radio').length, 3);
+      assert.ok(screen.getByLabelText('prop 1'));
+      assert.ok(screen.getByLabelText('prop 2'));
+      assert.ok(screen.getByLabelText('prop 3'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -42,6 +42,8 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
     { format: 'unreferenced_format', input: INPUT },
   ].forEach((data) => {
     module(`Whatever the format (testing "${data.format}" format)`, function (hooks) {
+      let screen;
+
       hooks.beforeEach(async function () {
         // given
         this.set('answer', answer);
@@ -50,16 +52,18 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
         this.challenge.set('format', data.format);
 
         // when
-        await render(hbs`<QrocmIndSolutionPanel
+        screen = await render(hbs`<QrocmIndSolutionPanel
           @answer={{this.answer}}
           @solution={{this.solution}}
           @challenge={{this.challenge}} />`);
       });
 
-      test('should dqrocm-ind-solution-panel-test.jsisplay the labels', function (assert) {
-        const labels = findAll('.correction-qrocm-text__label');
-
+      test('should display the labels', function (assert) {
+        const labels = screen.getAllByText((_, element) => element.tagName.toLowerCase() === 'label');
         assert.strictEqual(labels.length, 3);
+        assert.strictEqual(labels[0].innerHTML.trim(), '<strong>blabla</strong> :');
+        assert.strictEqual(labels[1].innerHTML.trim(), '<br>Carte mémoire (SD) :');
+        assert.strictEqual(labels[2].innerHTML.trim(), '<br>answer :');
       });
 
       module('When the answer is correct', function () {


### PR DESCRIPTION
## :unicorn: Problème

Pour des raisons d'accessibilité, on ne souhaite pas avoir de `<div>` ou de `<p>` dans des balises `<label>`.
Critère 8.2 de l'audit d'a11y.

## :robot: Proposition

Permettre au composant `<MardownToHtml />` de ne pas avoir de tag parent et d'afficher directement le contenu.

## :100: Pour tester

**Visiter les épreuves suivantes** et vérifier que **le style est toujours bon** et qu'**il n'y a plus de div ou de paragraphe en enfant direct du label d'un input** :

- QCM : [/challenges/recLt9uwa2dR3IYpi/preview](https://app-pr6681.review.pix.fr/challenges/recLt9uwa2dR3IYpi/preview)
- QCM avec lien dans les labels : [/challenges/rec25g8nc1SC2Wd60/preview](https://app-pr6681.review.pix.fr/challenges/rec25g8nc1SC2Wd60/preview)
- QCU : [/challenges/recT0Ks2EDgoDgEKc/preview](https://app-pr6681.review.pix.fr/challenges/recT0Ks2EDgoDgEKc/preview)
- QROC : [/challenges/recNanzf3oEjJ7vA9/preview](https://app-pr6681.review.pix.fr/challenges/recNanzf3oEjJ7vA9/preview)
- QROCm : [/challenges/rec2jQSdF8spj4lVr/preview](https://app-pr6681.review.pix.fr/challenges/rec2jQSdF8spj4lVr/preview)