### PR TITLE
[FEATURE] Afficher des notifications de succès et d'erreur pour la réinitialisation en masse des mots de passe temporaires des élèves sur Pix Orga (PIX-8475)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -1,13 +1,17 @@
+import fetch from 'fetch';
+
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { guidFor } from '@ember/object/internals';
-import fetch from 'fetch';
+
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
+import ENV from 'pix-orga/config/environment';
 
 export default class ScoList extends Component {
   @service currentUser;
+  @service notifications;
   @service intl;
   @service store;
   @service session;
@@ -106,8 +110,47 @@ export default class ScoList extends Component {
       });
       this.closeResetPasswordModal();
       resetSelectedStudents();
-    } catch (error) {
-      console.log(error);
+      this.notifications.sendSuccess(
+        this.intl.t('pages.sco-organization-participants.messages.password-reset-success'),
+      );
+    } catch (fetchErrors) {
+      const error = Array.isArray(fetchErrors) && fetchErrors.length > 0 && fetchErrors[0];
+      let errorMessage;
+      switch (error?.code) {
+        case 'USER_DOES_NOT_BELONG_TO_ORGANIZATION':
+          errorMessage = this.intl.t(
+            'api-error-messages.student-password-reset.user-does-not-belong-to-organization-error',
+          );
+          break;
+        case 'ORGANIZATION_LEARNER_DOES_NOT_BELONG_TO_ORGANIZATION':
+          errorMessage = this.intl.t(
+            'api-error-messages.student-password-reset.organization-learner-does-not-belong-to-organization-error',
+          );
+          break;
+        case 'ORGANIZATION_LEARNER_WITHOUT_USERNAME':
+          errorMessage = this.intl.t(
+            'api-error-messages.student-password-reset.organization-learner-without-username-error',
+          );
+          break;
+        default:
+          errorMessage = this.intl.t(this._getI18nKeyByStatus(error.status));
+      }
+      this.notifications.sendError(errorMessage);
+    }
+  }
+
+  _getI18nKeyByStatus(status) {
+    switch (status) {
+      case 400:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 401:
+        return ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.I18N_KEY;
+      case 422:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 504:
+        return ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.I18N_KEY;
+      default:
+        return ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY;
     }
   }
 

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -81,6 +81,7 @@
         "qunit-dom": "^2.0.0",
         "sass": "^1.57.1",
         "sinon": "^15.0.1",
+        "striptags": "^3.2.0",
         "stylelint": "^15.0.0",
         "stylelint-config-standard-scss": "^10.0.0",
         "webpack": "^5.76.3"
@@ -30978,6 +30979,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/striptags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==",
+      "dev": true
+    },
     "node_modules/style-loader": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
@@ -58684,6 +58691,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "striptags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==",
       "dev": true
     },
     "style-loader": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -110,6 +110,7 @@
     "qunit-dom": "^2.0.0",
     "sass": "^1.57.1",
     "sinon": "^15.0.1",
+    "striptags": "^3.2.0",
     "stylelint": "^15.0.0",
     "stylelint-config-standard-scss": "^10.0.0",
     "webpack": "^5.76.3"

--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -345,7 +345,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
           });
 
           module('when resetting students password', function () {
-            test('resets students password', async function (assert) {
+            test('resets students password and displays a success notification', async function (assert) {
               // given
               const screen = await visit('/eleves');
               await clickByName(this.intl.t('pages.sco-organization-participants.table.column.mainCheckbox'));
@@ -358,6 +358,11 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
               // then
               const resetPasswordsModal = await screen.queryByRole('dialog');
               assert.dom(resetPasswordsModal).isNotVisible();
+
+              const successNotification = await screen.getByText(
+                this.intl.t('pages.sco-organization-participants.messages.password-reset-success'),
+              );
+              assert.dom(successNotification).exists();
             });
           });
         });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -34,6 +34,11 @@
       "student-number-format": "Row {line} : The field “{field}” must not contain any special characters.",
       "student-number-unique": "Row {line} : The field “{field}” must be unique within the file."
     },
+    "student-password-reset": {
+      "organization-learner-does-not-belong-to-organization-error": "Some of the selected students are no longer part of this organisation.",
+      "organization-learner-without-username-error": "Some of the selected students no longer have a username. Please refresh this page.",
+      "user-does-not-belong-to-organization-error": "You no longer have the rights for this organisation."
+    },
     "student-xml-import": {
       "birth-city-code-required-for-french-student": "The field birth city code is mandatory for each student born in France.",
       "empty": "Each student must have an INE and a class.",
@@ -982,11 +987,14 @@
           }
         }
       },
+      "messages": {
+        "password-reset-success": "The password reset of the selected students has been done successfuly."
+      },
       "no-participants": "No students yet!",
       "no-participants-action": "The administrator must import the students database by clicking on the import button.",
       "page-title": "Students",
       "reset-password-modal": {
-        "title": "Réinitialisation de mot de passe des élèves avec identifiants",
+        "title": "Réinitialisation des <strong>mots de passe</strong> des élèves avec <strong>identifiant</strong>",
         "content-message-1": "Sur {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} élève</strong>} other {<strong>{totalSelectedStudents} élèves</strong>}} que vous avez sélectionné, {totalAffectedStudents, plural, =0 {<strong>aucun mot de passe</strong> sera réinitialisé} =1 {le mot de passe de <strong>{totalAffectedStudents} élève</strong> va être réinitialisé.} other {les mots de passe de <strong>{totalAffectedStudents} élèves</strong> vont être réinitialisé.}}",
         "content-message-2": "Un fichier CSV sera généré contenant les identifiants ainsi que les mots de passe à usage unique.",
         "content-message-3": "Communiquez ces nouveaux mots de passe à usage unique aux élèves. Lorsqu'ils se connecteront avec ce mot de passe, Pix leur demandera d'en saisir un nouveau.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -34,6 +34,11 @@
       "student-number-format": "Ligne {line} : Le champ “{field}” ne doit pas avoir de caractères spéciaux.",
       "student-number-unique": "Ligne {line} : Le champ “{field}” doit être unique au sein du fichier."
     },
+    "student-password-reset": {
+      "organization-learner-does-not-belong-to-organization-error": "Certains des élèves sélectionnés ne figurent plus dans cette organisation.",
+      "organization-learner-without-username-error": "Certains des élèves sélectionnés n'ont plus d'identifiant. Veuillez rafraichir la page.",
+      "user-does-not-belong-to-organization-error": "Vous n'avez plus les droits pour cette organisation."
+    },
     "student-xml-import": {
       "birth-city-code-required-for-french-student": "Le champ code commune de naissance est obligatoire pour chaque élève née en France.",
       "empty": "Les élèves doivent posséder un INE ainsi qu'une classe.",
@@ -985,13 +990,16 @@
           }
         }
       },
+      "messages": {
+        "password-reset-success": "La réinitialisation des mots de passe des élèves sélectionnés a été effectuée."
+      },
       "no-participants": "Aucun élève pour l’instant !",
       "no-participants-action": "L’administrateur doit importer la base élèves en cliquant sur le bouton importer.",
       "page-title": "Élèves",
       "reset-password-modal": {
-        "title": "Réinitialisation de mot de passe des élèves avec identifiant",
+        "title": "Réinitialisation des <strong>mots de passe</strong> des élèves avec <strong>identifiant</strong>",
         "content-message-1": "Sur {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} élève</strong> sélectionné} other {<strong>{totalSelectedStudents} élèves</strong> sélectionnés}}, {totalAffectedStudents, plural, =0 {<strong>aucun mot de passe</strong> ne sera réinitialisé} =1 {le mot de passe de <strong>{totalAffectedStudents} élève</strong> va être réinitialisé} other {les mots de passe de <strong>{totalAffectedStudents} élèves</strong> vont être réinitialisés}}.",
-        "content-message-2": "Un fichier CSV sera généré contenant les identifiants ainsi que les mots de passe à usage unique.",
+        "content-message-2": "Un fichier CSV contenant les identifiants ainsi que les mots de passe à usage unique sera généré.",
         "content-message-3": "Communiquez ces nouveaux mots de passe à usage unique aux élèves. Lorsqu'ils se connecteront avec ce mot de passe, Pix leur demandera d'en saisir un nouveau.",
         "warning-message": "Seuls les mots de passe des accès par identifiant peuvent être réinitialisés. Les accès par adresse email et Mediacentre ne sont pas impactés."
       },


### PR DESCRIPTION
## :unicorn: Problème

Il n'y a pas de notification pour l'utilisateur lorsque l'opération réussie ou est en erreur.

## :robot: Proposition

Ajouter cette notification.

## :rainbow: Remarques

RAS

## :100: Pour tester

#### Succès

- Se connecter à Pix Orga avec le compte `allorga@example.net`
- Choisir l'organisation `Collège The Night Watch`
- Cliquer sur l'onglet Élèves
- Sélectionner tous les élèves
- Cliquer sur le bouton Réinitialiser ....
- À l'affichage de la modale, cliquer sur le bouton Confirmer
- Constater l'affiche d'une notification de succès
- Constater le téléchargement d'un fichier CSV, la fermeture de la modale et la désélection des élèves
- Ouvrir le fichier CSV
- Vérifier que le contenu est ok

#### Erreurs

##### Élève ne faisant pas partie de l'organisation

- En l'état on ne sait pas tester ce cas sans intervention en base de données et donc pas faisable facilement uniquement à partir des RA

##### Élève n'ayant pas d'identifiant

- Se connecter à Pix Orga avec le compte `allorga@example.net`
- Choisir l'organisation `Collège The Night Watch`
- Cliquer sur l'onglet Élèves
- Sélectionner tous les élèves
- Cliquer sur le bouton Réinitialiser ....
- Ouvrir un nouvel onglet et se connecter sur Pix Admin avec le compte `superadmin@example.net`
- Afficher la page de détails d'un élève, ayant une méthode d'authentification avec identifiant, se trouvant dans la liste que vous avez sélectionné sur Pix Orga
- Supprimer la méthode d'authentification identifiant de cet élève
- Revenir sur l'onglet Pix Orga
- Cliquer sur le bouton Confirmer
- Constater l'affiche d'une notification d'erreur
