### PR TITLE
[TECH] Supprime la dépendance ember-export-application-global

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -46,7 +46,6 @@
         "ember-dayjs": "^0.12.0",
         "ember-decorators": "^6.1.1",
         "ember-exam": "^8.0.0",
-        "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^8.0.0",
         "ember-flatpickr": "^4.0.0",
@@ -16304,15 +16303,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/ember-export-application-global": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
-      "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/ember-factory-for-polyfill": {
       "version": "1.3.1",
@@ -46850,12 +46840,6 @@
           "dev": true
         }
       }
-    },
-    "ember-export-application-global": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
-      "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
-      "dev": true
     },
     "ember-factory-for-polyfill": {
       "version": "1.3.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -78,7 +78,6 @@
     "ember-dayjs": "^0.12.0",
     "ember-decorators": "^6.1.1",
     "ember-exam": "^8.0.0",
-    "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^8.0.0",
     "ember-flatpickr": "^4.0.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -47,7 +47,6 @@
         "ember-cookies": "^0.5.2",
         "ember-data": "~4.0.2",
         "ember-dayjs": "^0.12.0",
-        "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^8.0.0",
         "ember-flatpickr": "^4.0.0",
@@ -16818,15 +16817,6 @@
       },
       "engines": {
         "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-export-application-global": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
-      "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/ember-factory-for-polyfill": {
@@ -48861,12 +48851,6 @@
         "ember-cli-version-checker": "^5.1.1",
         "ember-compatibility-helpers": "^1.2.1"
       }
-    },
-    "ember-export-application-global": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
-      "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
-      "dev": true
     },
     "ember-factory-for-polyfill": {
       "version": "1.3.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -79,7 +79,6 @@
     "ember-cookies": "^0.5.2",
     "ember-data": "~4.0.2",
     "ember-dayjs": "^0.12.0",
-    "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^8.0.0",
     "ember-flatpickr": "^4.0.0",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -56,7 +56,6 @@
         "ember-dayjs": "^0.12.0",
         "ember-decorators": "^6.1.1",
         "ember-exam": "^8.0.0",
-        "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.2",
         "ember-intl": "^5.7.2",
         "ember-keyboard": "^8.0.0",
@@ -17360,15 +17359,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/ember-export-application-global": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
-      "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/ember-factory-for-polyfill": {
       "version": "1.3.1",
@@ -49032,12 +49022,6 @@
           "dev": true
         }
       }
-    },
-    "ember-export-application-global": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
-      "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
-      "dev": true
     },
     "ember-factory-for-polyfill": {
       "version": "1.3.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -88,7 +88,6 @@
     "ember-dayjs": "^0.12.0",
     "ember-decorators": "^6.1.1",
     "ember-exam": "^8.0.0",
-    "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.2",
     "ember-intl": "^5.7.2",
     "ember-keyboard": "^8.0.0",


### PR DESCRIPTION
## :unicorn: Problème
[ember-export-application-global](https://github.com/ember-cli/ember-export-application-global) est déprécié, et n'est de toute façon pas utilisé.

## :robot: Proposition
Supprimer cette dépendance de nos applications

## :100: Pour tester
:green_circle: tests
