### PR TITLE
[CLEANUP] Supprime de l'ancienne config sur certif

### DIFF
--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-const environment = process.env.environment;
-const pluginsToBlacklist = environment === 'production' ? ['ember-freestyle'] : [];
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
@@ -13,9 +11,6 @@ module.exports = function (defaults) {
     babel: {
       sourceMaps: 'inline',
       plugins: [require.resolve('ember-auto-import/babel-plugin')],
-    },
-    addons: {
-      blacklist: pluginsToBlacklist,
     },
     flatpickr: {
       locales: ['fr'],


### PR DESCRIPTION
## :unicorn: Problème
De la config pour exclure l'addon `ember-freestyle` de la construction de production est présente alors que ember-freestyle n'est plus utilisé. Voir https://github.com/1024pix/pix/pull/1669.

## :robot: Proposition
Supprimer la config.

## :100: Pour tester
:green_circle: tests
