### PR TITLE
[BUGFIX] Vérifier si l'épreuve est en autoReply (Pix-8737)

### DIFF
--- a/1d/app/pods/challenge/model.js
+++ b/1d/app/pods/challenge/model.js
@@ -35,18 +35,18 @@ export default class Challenge extends Model {
   }
 
   get isQROC() {
-    return this.type === 'QROC';
+    return this.autoReply === false && this.type === 'QROC';
   }
 
   get isQROCM() {
-    return this.type === 'QROCM-dep' || this.type === 'QROCM-ind';
+    return this.autoReply === false && (this.type === 'QROCM-dep' || this.type === 'QROCM-ind');
   }
 
   get isQCU() {
-    return this.type === 'QCU';
+    return this.autoReply === false && this.type === 'QCU';
   }
 
   get isQCM() {
-    return this.type === 'QCM' || this.type === 'QCMIMG';
+    return this.autoReply === false && (this.type === 'QCM' || this.type === 'QCMIMG');
   }
 }

--- a/1d/mirage/factories/challenge.js
+++ b/1d/mirage/factories/challenge.js
@@ -20,6 +20,9 @@ export default Factory.extend({
   proposals() {
     return 'Rue de : ${Rue#}';
   },
+  autoReply() {
+    return false;
+  },
   QROCWithTextArea: trait({
     format: 'paragraphe',
   }),

--- a/1d/tests/unit/models/challenge_test.js
+++ b/1d/tests/unit/models/challenge_test.js
@@ -1,0 +1,132 @@
+import { module, test } from 'qunit';
+import { setupTest } from '../../helpers/index';
+
+module('Unit | Model | Challenge', function (hooks) {
+  setupTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#isQROC', function () {
+    test('should be true if challenge type is QROC', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QROC',
+        autoReply: false,
+      });
+      assert.true(challenge.isQROC);
+    });
+
+    test('should be false if challenge type is not QROC', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QROCM-dep',
+        autoReply: false,
+      });
+      assert.false(challenge.isQROC);
+    });
+
+    test('should be false if challenge type is QROC and autoReply set to true', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QROC',
+        autoReply: true,
+      });
+      assert.false(challenge.isQROC);
+    });
+  });
+
+  module('#isQROCM', function () {
+    test('should be true if challenge type is QROCM-dep', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QROCM-dep',
+        autoReply: false,
+      });
+      assert.true(challenge.isQROCM);
+    });
+
+    test('should be true if challenge type is QROCM-ind', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QROCM-ind',
+        autoReply: false,
+      });
+      assert.true(challenge.isQROCM);
+    });
+
+    test('should be false if challenge type is not QROCM', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCM',
+        autoReply: false,
+      });
+      assert.false(challenge.isQROCM);
+    });
+
+    test('should be false if challenge type is QROCM and autoReply set to true', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QROCM-dep',
+        autoReply: true,
+      });
+      assert.false(challenge.isQROCM);
+    });
+  });
+
+  module('#isQCU', function () {
+    test('should be true if challenge type is QCU', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCU',
+        autoReply: false,
+      });
+      assert.true(challenge.isQCU);
+    });
+
+    test('should be false if challenge type is not QCU', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCM',
+        autoReply: false,
+      });
+      assert.false(challenge.isQCU);
+    });
+
+    test('should be false if challenge type is QCU and autoReply set to true', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCU',
+        autoReply: true,
+      });
+      assert.false(challenge.isQCU);
+    });
+  });
+
+  module('#isQCM', function () {
+    test('should be true if challenge type is QCM', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCM',
+        autoReply: false,
+      });
+      assert.true(challenge.isQCM);
+    });
+
+    test('should be true if challenge type is QCMIMG', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCMIMG',
+        autoReply: false,
+      });
+      assert.true(challenge.isQCM);
+    });
+
+    test('should be false if challenge type is not QCM', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCU',
+        autoReply: false,
+      });
+      assert.false(challenge.isQCM);
+    });
+
+    test('should be false if challenge type is QCM and autoReply set to true', async function (assert) {
+      const challenge = store.createRecord('challenge', {
+        type: 'QCM',
+        autoReply: true,
+      });
+      assert.false(challenge.isQCM);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Les boutons en bas de l'écran ne s'affichent plus (« je passe » et « je continue »).

## :robot: Proposition

C'est lié à la détection des modalités « embed ». Nous ajoutons donc une vérification supplémentaire pour détecter les embed.

## :rainbow: Remarques

## :100: Pour tester

Aller sur la _review app_ et essayer le parcours de moteur de recherche. La première épreuve est un embed justement. Si les boutons s'affichent, c'est que tout va bien.
