### PR TITLE
[BUMP] Monte la version minimale de Node.js en v16.17

### DIFF
--- a/1d/package-lock.json
+++ b/1d/package-lock.json
@@ -69,8 +69,7 @@
         "xss": "^1.0.14"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/1d/package.json
+++ b/1d/package.json
@@ -10,8 +10,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "directories": {
     "doc": "doc",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -82,8 +82,7 @@
         "webpack": "^5.65.0"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -6,8 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "ember": {
     "edition": "octane"

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -82,8 +82,7 @@
         "webpack": "^5.76.2"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -6,8 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "repository": {
     "type": "git",

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -24,8 +24,7 @@
         "npm-run-all": "4.1.5"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -5,8 +5,7 @@
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "license": "AGPL-3.0",
   "repository": {

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -26,8 +26,7 @@
         "sinon-chai": "^3.7.0"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@artilleryio/int-commons": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -5,8 +5,7 @@
   "homepage": "https://github.com/1024pix/pix/tree/dev/high-level-tests/load-testing#readme",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "license": "ISC",
   "repository": {

--- a/high-level-tests/test-algo/package-lock.json
+++ b/high-level-tests/test-algo/package-lock.json
@@ -26,8 +26,7 @@
         "sinon-chai": "^3.7.0"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/high-level-tests/test-algo/package.json
+++ b/high-level-tests/test-algo/package.json
@@ -4,8 +4,7 @@
   "description": "Application permettant de tester l'algorithme adaptatif de choix d'épreuve pour le positionnement.",
   "main": "index.js",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "scripts": {
     "start": "node index.js",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -94,8 +94,7 @@
         "xss": "^1.0.13"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -6,8 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "ember": {
     "edition": "octane"

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -86,8 +86,7 @@
         "webpack": "^5.76.3"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -6,8 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "ember": {
     "edition": "octane"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
         "mocha": "^10.0.0"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       },
       "peerDependencies": {
         "markdown-link-check": "^3.8.6"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :unicorn: Problème
L'API ne supporte pas les versions de Node <= 16.14 et Pix UI les versions de npm <= 8.13.2. Lors d'une montée de version inévitable en [v18.14.0](https://nodejs.org/en/blog/release/v18.14.0) ou supérieure qui package npm en version 9, on risque d'avoir des soucis de compatibilité car on ne permet pour l'instant pas de l'utiliser.

## :robot: Proposition

Pour simplifier les choses, on propose avec l'équipe Tech Days UP de montée la version minimum de Node.js qui embarque une version suffisante de npm (8.15.0), c'est à dire la v16.17.0.

Il est aussi possible d'utiliser la version de npm de son choix, par exemple si on veut essayer des montées de version.

C'est la même proposition que ce qu'on a implémenté sur Pix UI https://github.com/1024pix/pix-ui/pull/428.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la CI et la RA fonctionne toujours.
