### PR TITLE
[TECH] Ajouter un test d'acceptance pour fiabiliser la route /api/admin/target-profiles/{id} (PIX-8748)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -28,7 +28,6 @@ const serialize = function (targetProfiles) {
       'badges',
       'stageCollection',
       'areas',
-      'maxLevel',
     ],
     badges: {
       ref: 'id',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -188,7 +188,6 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             'is-public': true,
             'is-simplified-access': true,
             'are-knowledge-elements-resettable': false,
-            'max-level': 7,
             name: 'Mon Super profil cible',
             outdated: true,
             'owner-organization-id': 12,


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle propriété est renvoyée par la route GET /api/admin/target-profiles/{id} [PR-6627](https://github.com/1024pix/pix/pull/6627), mais aucun test d'acceptance ne couvre ce cas.

## :robot: Proposition
Ajouter un test d'acceptance

## :rainbow: Remarques

## :100: Pour tester
Vérifier que la CI est ✅