### PR TITLE
[FEATURE] Ajouter le filtre sur la certificabilité dans la page de résultat d'une collecte de profil dans Pix Orga (PIX-2431)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-campaigns.js
+++ b/api/db/seeds/data/team-prescription/build-campaigns.js
@@ -18,7 +18,7 @@ async function _createScoCampaigns(databaseBuilder) {
     name: 'Campagne de collecte de profil SCO - envoi simple',
     type: 'PROFILES_COLLECTION',
     title: null,
-    configCampaign: { participantCount: 10, profileDistribution: { beginner: 1, perfect: 1 } },
+    configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
   });
 
   await createProfilesCollectionCampaign({
@@ -29,7 +29,8 @@ async function _createScoCampaigns(databaseBuilder) {
     type: 'PROFILES_COLLECTION',
     title: null,
     multipleSendings: true,
-    configCampaign: { participantCount: 2, profileDistribution: { beginner: 1, perfect: 1 } },
+    sharedAt: new Date('2022-05-18'),
+    configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1 } },
   });
 }
 

--- a/api/db/seeds/data/team-prescription/build-organization.js
+++ b/api/db/seeds/data/team-prescription/build-organization.js
@@ -5,7 +5,7 @@ function _createScoOrganization(databaseBuilder) {
     id: SCO_ORGANIZATION_ID,
     type: 'SCO',
     name: 'Sco Orga team prescription',
-    isManagingStudents: false,
+    isManagingStudents: true,
     externalId: 'PRESCRIPTION',
   });
   databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -16,7 +16,7 @@ import * as groupSerializer from '../../infrastructure/serializers/jsonapi/group
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import { escapeFileName, extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
 import { ForbiddenAccess } from '../../domain/errors.js';
-import { mapCertificabilityByLabel } from '../organizations/helpers.js';
+import { certificabilityByLabel } from '../organizations/helpers.js';
 
 const { PassThrough } = stream;
 
@@ -67,7 +67,7 @@ const getById = async function (
   dependencies = {
     campaignReportSerializer,
     tokenService,
-  }
+  },
 ) {
   const { userId } = request.auth.credentials;
   const campaignId = request.params.id;
@@ -194,7 +194,7 @@ const findProfilesCollectionParticipations = async function (request) {
     filters.groups = [filters.groups];
   }
   if (filters.certificability) {
-    filters.certificability = mapCertificabilityByLabel(filters.certificability);
+    filters.certificability = certificabilityByLabel[filters.certificability];
   }
   const results = await usecases.findCampaignProfilesCollectionParticipationSummaries({
     userId,
@@ -208,7 +208,7 @@ const findProfilesCollectionParticipations = async function (request) {
 const findParticipantsActivity = async function (
   request,
   h,
-  dependencies = { campaignParticipantsActivitySerializer }
+  dependencies = { campaignParticipantsActivitySerializer },
 ) {
   const campaignId = request.params.id;
 

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -1,8 +1,5 @@
 import _ from 'lodash';
 import stream from 'stream';
-
-const { PassThrough } = stream;
-
 import { MissingQueryParamError } from '../http-errors.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { tokenService } from '../../../lib/domain/services/token-service.js';
@@ -19,6 +16,9 @@ import * as groupSerializer from '../../infrastructure/serializers/jsonapi/group
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import { escapeFileName, extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
 import { ForbiddenAccess } from '../../domain/errors.js';
+import { mapCertificabilityByLabel } from '../organizations/helpers.js';
+
+const { PassThrough } = stream;
 
 const save = async function (request, h, dependencies = { campaignReportSerializer }) {
   const { userId: creatorId } = request.auth.credentials;
@@ -67,7 +67,7 @@ const getById = async function (
   dependencies = {
     campaignReportSerializer,
     tokenService,
-  },
+  }
 ) {
   const { userId } = request.auth.credentials;
   const campaignId = request.params.id;
@@ -193,6 +193,9 @@ const findProfilesCollectionParticipations = async function (request) {
   if (filters.groups && !Array.isArray(filters.groups)) {
     filters.groups = [filters.groups];
   }
+  if (filters.certificability) {
+    filters.certificability = mapCertificabilityByLabel(filters.certificability);
+  }
   const results = await usecases.findCampaignProfilesCollectionParticipationSummaries({
     userId,
     campaignId,
@@ -205,7 +208,7 @@ const findProfilesCollectionParticipations = async function (request) {
 const findParticipantsActivity = async function (
   request,
   h,
-  dependencies = { campaignParticipantsActivitySerializer },
+  dependencies = { campaignParticipantsActivitySerializer }
 ) {
   const campaignId = request.params.id;
 

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -304,6 +304,7 @@ const register = async function (server) {
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[search]': Joi.string().empty(''),
+            'filter[certificability]': Joi.string().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'page[size]': Joi.number().integer().empty(''),
           }),

--- a/api/lib/application/organizations/helpers.js
+++ b/api/lib/application/organizations/helpers.js
@@ -12,4 +12,4 @@ function mapCertificabilityByLabel(certificabilityFilter) {
   return result.map((value) => certificabilityByLabel[value]);
 }
 
-export { mapCertificabilityByLabel };
+export { mapCertificabilityByLabel, certificabilityByLabel };

--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -1,6 +1,5 @@
-import lodash from 'lodash';
-
-const { chunk } = lodash;
+import chunk from 'lodash/chunk.js';
+import isBoolean from 'lodash/isBoolean.js';
 
 import bluebird from 'bluebird';
 import { knex } from '../../../db/knex-database-connection.js';
@@ -100,6 +99,9 @@ function _filterQuery(queryBuilder, filters) {
       'view-active-organization-learners.firstName',
       'view-active-organization-learners.lastName',
     );
+  }
+  if (isBoolean(filters.certificability)) {
+    queryBuilder.where('campaign-participations.isCertifiable', filters.certificability);
   }
 }
 

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -1,9 +1,6 @@
 import jwt from 'jsonwebtoken';
 
 import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
-
-const { STARTED } = CampaignParticipationStatuses;
-
 import {
   databaseBuilder,
   expect,
@@ -16,6 +13,8 @@ import {
 import { config as settings } from '../../../../lib/config.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { createServer } from '../../../../server.js';
+
+const { STARTED } = CampaignParticipationStatuses;
 
 describe('Acceptance | API | Campaign Controller', function () {
   let campaign;
@@ -199,7 +198,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           campaign_id: campaignId,
         },
         settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs },
+        { expiresIn: settings.authentication.accessTokenLifespanMs }
       );
     }
 
@@ -289,7 +288,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           campaign_id: campaignId,
         },
         settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs },
+        { expiresIn: settings.authentication.accessTokenLifespanMs }
       );
     }
 
@@ -726,7 +725,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
           payload,
         },
-        payload,
+        payload
       );
 
       // then
@@ -775,7 +774,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
           payload,
         },
-        payload,
+        payload
       );
 
       // then
@@ -850,7 +849,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           headers: { authorization: generateValidRequestAuthorizationHeader(anotherUserId) },
           payload,
         },
-        payload,
+        payload
       );
 
       // then
@@ -912,7 +911,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -924,7 +923,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           await databaseBuilder.commit();
@@ -970,7 +969,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -982,7 +981,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -994,7 +993,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           await databaseBuilder.commit();
@@ -1043,7 +1042,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1055,7 +1054,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           await databaseBuilder.commit();
@@ -1101,7 +1100,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1113,7 +1112,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1125,7 +1124,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            },
+            }
           );
 
           await databaseBuilder.commit();
@@ -1173,7 +1172,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           },
           {
             campaignId: campaign.id,
-          },
+          }
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1185,7 +1184,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           },
           {
             campaignId: campaign.id,
-          },
+          }
         );
 
         await databaseBuilder.commit();
@@ -1207,6 +1206,66 @@ describe('Acceptance | API | Campaign Controller', function () {
     });
   });
 
+  context('Search certificability filter', function () {
+    it('should returns profiles who are certifiable', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organization = databaseBuilder.factory.buildOrganization();
+
+      databaseBuilder.factory.buildMembership({
+        userId,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.MEMBER,
+      });
+      const campaign = databaseBuilder.factory.buildCampaign({
+        name: 'Campagne de Test N°3',
+        organizationId: organization.id,
+      });
+
+      databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+        {
+          firstName: 'Barry',
+          lastName: 'White',
+          organizationId: organization.id,
+          group: 'L1',
+        },
+        {
+          campaignId: campaign.id,
+          isCertifiable: true,
+        }
+      );
+
+      databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+        {
+          firstName: 'Marvin',
+          lastName: 'Gaye',
+          organizationId: organization.id,
+          group: 'L2',
+        },
+        {
+          campaignId: campaign.id,
+          isCertifiable: false,
+        }
+      );
+
+      await databaseBuilder.commit();
+
+      // when
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/profiles-collection-participations?filter[certificability]=eligible`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.have.lengthOf(1);
+      expect(response.result.data[0].attributes['last-name']).to.equal('White');
+    });
+  });
+
   describe('GET /api/campaigns/{id}/divisions', function () {
     it('should return the campaign participants division', async function () {
       const division = '3emeA';
@@ -1214,7 +1273,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const user = databaseBuilder.factory.buildUser.withMembership({ organizationId: campaign.organizationId });
       databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
         { organizationId: campaign.organizationId, division: division },
-        { campaignId: campaign.id },
+        { campaignId: campaign.id }
       );
       await databaseBuilder.commit();
 
@@ -1238,7 +1297,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const user = databaseBuilder.factory.buildUser.withMembership({ organizationId: campaign.organizationId });
       databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
         { organizationId: campaign.organizationId, group: group },
-        { campaignId: campaign.id },
+        { campaignId: campaign.id }
       );
       await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -198,7 +198,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           campaign_id: campaignId,
         },
         settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs }
+        { expiresIn: settings.authentication.accessTokenLifespanMs },
       );
     }
 
@@ -288,7 +288,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           campaign_id: campaignId,
         },
         settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs }
+        { expiresIn: settings.authentication.accessTokenLifespanMs },
       );
     }
 
@@ -725,7 +725,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
           payload,
         },
-        payload
+        payload,
       );
 
       // then
@@ -774,7 +774,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
           payload,
         },
-        payload
+        payload,
       );
 
       // then
@@ -849,7 +849,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           headers: { authorization: generateValidRequestAuthorizationHeader(anotherUserId) },
           payload,
         },
-        payload
+        payload,
       );
 
       // then
@@ -911,7 +911,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -923,7 +923,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           await databaseBuilder.commit();
@@ -969,7 +969,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -981,7 +981,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -993,7 +993,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           await databaseBuilder.commit();
@@ -1042,7 +1042,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1054,7 +1054,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           await databaseBuilder.commit();
@@ -1100,7 +1100,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1112,7 +1112,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1124,7 +1124,7 @@ describe('Acceptance | API | Campaign Controller', function () {
             },
             {
               campaignId: campaign.id,
-            }
+            },
           );
 
           await databaseBuilder.commit();
@@ -1172,7 +1172,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           },
           {
             campaignId: campaign.id,
-          }
+          },
         );
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1184,7 +1184,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           },
           {
             campaignId: campaign.id,
-          }
+          },
         );
 
         await databaseBuilder.commit();
@@ -1204,65 +1204,65 @@ describe('Acceptance | API | Campaign Controller', function () {
         expect(response.result.data[0].attributes['last-name']).to.equal('Gaye');
       });
     });
-  });
 
-  context('Search certificability filter', function () {
-    it('should returns profiles who are certifiable', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organization = databaseBuilder.factory.buildOrganization();
+    context('Search certificability filter', function () {
+      it('should returns profiles who are certifiable', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization();
 
-      databaseBuilder.factory.buildMembership({
-        userId,
-        organizationId: organization.id,
-        organizationRole: Membership.roles.MEMBER,
-      });
-      const campaign = databaseBuilder.factory.buildCampaign({
-        name: 'Campagne de Test N°3',
-        organizationId: organization.id,
-      });
-
-      databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-        {
-          firstName: 'Barry',
-          lastName: 'White',
+        databaseBuilder.factory.buildMembership({
+          userId,
           organizationId: organization.id,
-          group: 'L1',
-        },
-        {
-          campaignId: campaign.id,
-          isCertifiable: true,
-        }
-      );
-
-      databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-        {
-          firstName: 'Marvin',
-          lastName: 'Gaye',
+          organizationRole: Membership.roles.MEMBER,
+        });
+        const campaign = databaseBuilder.factory.buildCampaign({
+          name: 'Campagne de Test N°3',
           organizationId: organization.id,
-          group: 'L2',
-        },
-        {
-          campaignId: campaign.id,
-          isCertifiable: false,
-        }
-      );
+        });
 
-      await databaseBuilder.commit();
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            firstName: 'Barry',
+            lastName: 'White',
+            organizationId: organization.id,
+            group: 'L1',
+          },
+          {
+            campaignId: campaign.id,
+            isCertifiable: true,
+          },
+        );
 
-      // when
-      const options = {
-        method: 'GET',
-        url: `/api/campaigns/${campaign.id}/profiles-collection-participations?filter[certificability]=eligible`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
-      };
-      // when
-      const response = await server.inject(options);
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            firstName: 'Marvin',
+            lastName: 'Gaye',
+            organizationId: organization.id,
+            group: 'L2',
+          },
+          {
+            campaignId: campaign.id,
+            isCertifiable: false,
+          },
+        );
 
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result.data).to.have.lengthOf(1);
-      expect(response.result.data[0].attributes['last-name']).to.equal('White');
+        await databaseBuilder.commit();
+
+        // when
+        const options = {
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/profiles-collection-participations?filter[certificability]=eligible`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.have.lengthOf(1);
+        expect(response.result.data[0].attributes['last-name']).to.equal('White');
+      });
     });
   });
 
@@ -1273,7 +1273,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const user = databaseBuilder.factory.buildUser.withMembership({ organizationId: campaign.organizationId });
       databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
         { organizationId: campaign.organizationId, division: division },
-        { campaignId: campaign.id }
+        { campaignId: campaign.id },
       );
       await databaseBuilder.commit();
 
@@ -1297,7 +1297,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const user = databaseBuilder.factory.buildUser.withMembership({ organizationId: campaign.organizationId });
       databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
         { organizationId: campaign.organizationId, group: group },
-        { campaignId: campaign.id }
+        { campaignId: campaign.id },
       );
       await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -607,6 +607,62 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         expect(results.data[1].firstName).to.equal('Laa-Laa');
       });
     });
+
+    describe('when there is a filter on certificability', function () {
+      it('returns certifiable participants', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId },
+          { participantExternalId: 'Certifiable', campaignId, isCertifiable: true },
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId },
+          { participantExternalId: 'Not certifiable', campaignId, isCertifiable: false },
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { certificability: true },
+        );
+
+        const participantExternalIds = results.data.map((result) => result.participantExternalId);
+
+        // then
+        expect(participantExternalIds).to.deep.equal(['Certifiable']);
+      });
+
+      it('returns not certifiable participants', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId },
+          { participantExternalId: 'Certifiable', campaignId, isCertifiable: true },
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId },
+          { participantExternalId: 'Not certifiable', campaignId, isCertifiable: false },
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { certificability: false },
+        );
+
+        const participantExternalIds = results.data.map((result) => result.participantExternalId);
+
+        // then
+        expect(participantExternalIds).to.deep.equal(['Not certifiable']);
+      });
+    });
   });
 });
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -581,6 +581,22 @@ describe('Unit | Application | Router | campaign-router ', function () {
       expect(result.statusCode).to.equal(200);
     });
 
+    it('should return 200 with a string of certificability filter', async function () {
+      // given
+      sinon.stub(campaignController, 'findProfilesCollectionParticipations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const result = await httpTestServer.request(
+        'GET',
+        '/api/campaigns/1/profiles-collection-participations?filter[certificability]="eligibile"',
+      );
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
     it('should return 400 with unexpected filters', async function () {
       // given
       const httpTestServer = new HttpTestServer();

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -7,6 +7,7 @@
   @rowCount={{@rowCount}}
   @isHiddenStages={{true}}
   @isHiddenBadges={{true}}
+  @isHiddenCertificability={{true}}
   @onFilter={{@onFilter}}
   @onResetFilter={{@onResetFilter}}
 />

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -73,5 +73,15 @@
         {{badge.label}}
       </PixMultiSelect>
     {{/if}}
+    {{#if this.displayCertificabilityFilter}}
+      <PixSelect
+        @options={{this.certificabilityOptions}}
+        @value={{@selectedCertificability}}
+        @onChange={{this.onSelectCertificability}}
+        @screenReaderOnly={{true}}
+        @label={{t "pages.sco-organization-participants.filter.certificability.label"}}
+        @placeholder={{t "components.certificability.placeholder-select"}}
+      />
+    {{/if}}
   </PixFilterBanner>
 {{/if}}

--- a/orga/app/components/campaign/filter/participation-filters.js
+++ b/orga/app/components/campaign/filter/participation-filters.js
@@ -6,6 +6,19 @@ export default class ParticipationFilters extends Component {
   @service intl;
   @service currentUser;
 
+  get certificabilityOptions() {
+    return [
+      {
+        value: 'eligible',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'),
+      },
+      {
+        value: 'non-eligible',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.non-eligible'),
+      },
+    ];
+  }
+
   get isClearFiltersButtonDisabled() {
     return (
       !this.args.selectedStatus &&
@@ -13,7 +26,8 @@ export default class ParticipationFilters extends Component {
       (!this.displayDivisionFilter || this.args.selectedDivisions.length === 0) &&
       (!this.displayGroupsFilter || this.args.selectedGroups.length === 0) &&
       (!this.displayStagesFilter || this.args.selectedStages.length === 0) &&
-      (!this.displayBadgesFilter || this.args.selectedBadges.length === 0)
+      (!this.displayBadgesFilter || this.args.selectedBadges.length === 0) &&
+      (!this.displayCertificabilityFilter || !this.args.selectedCertificability)
     );
   }
 
@@ -24,8 +38,14 @@ export default class ParticipationFilters extends Component {
       this.displayDivisionFilter ||
       this.displayStatusFilter ||
       this.displayGroupsFilter ||
+      this.displayCertificabilityFilter ||
       this.displaySearchFilter
     );
+  }
+
+  get displayCertificabilityFilter() {
+    const { isTypeAssessment } = this.args.campaign;
+    return !isTypeAssessment && !this.args.isHiddenCertificability;
   }
 
   get displayStagesFilter() {
@@ -101,5 +121,10 @@ export default class ParticipationFilters extends Component {
   @action
   onSelectDivision(divisions) {
     this.args.onFilter('divisions', divisions);
+  }
+
+  @action
+  onSelectCertificability(certificability) {
+    this.args.onFilter('certificability', certificability);
   }
 }

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -5,6 +5,7 @@
     @campaign={{@campaign}}
     @selectedDivisions={{@selectedDivisions}}
     @selectedGroups={{@selectedGroups}}
+    @selectedCertificability={{@selectedCertificability}}
     @rowCount={{@profiles.meta.rowCount}}
     @searchFilter={{@searchFilter}}
     @onFilter={{@onFilter}}

--- a/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-
 export default class ProfilesController extends Controller {
+  @service router;
   @tracked pageNumber = 1;
   @tracked pageSize = 50;
   @tracked divisions = [];
@@ -13,7 +14,7 @@ export default class ProfilesController extends Controller {
   goToProfilePage(campaignId, campaignParticipationId, event) {
     event.stopPropagation();
     event.preventDefault();
-    this.transitionToRoute('authenticated.campaigns.participant-profile', campaignId, campaignParticipationId);
+    this.router.transitionTo('authenticated.campaigns.participant-profile', campaignId, campaignParticipationId);
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
@@ -9,6 +9,7 @@ export default class ProfilesController extends Controller {
   @tracked divisions = [];
   @tracked groups = [];
   @tracked search = null;
+  @tracked certificability = null;
 
   @action
   goToProfilePage(campaignId, campaignParticipationId, event) {
@@ -29,5 +30,6 @@ export default class ProfilesController extends Controller {
     this.divisions = [];
     this.groups = [];
     this.search = null;
+    this.certificability = null;
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -56,11 +56,11 @@ export default class ProfilesRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.pageNumber = 1;
-      controller.pageSize = 50;
-      controller.divisions = [];
-      controller.groups = [];
-      controller.search = null;
+      controller.set('pageNumber', 1);
+      controller.set('pageSize', 50);
+      controller.set('divisions', []);
+      controller.set('groups', []);
+      controller.set('search', null);
     }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -22,6 +22,9 @@ export default class ProfilesRoute extends Route {
     search: {
       refreshModel: true,
     },
+    certificability: {
+      refreshModel: true,
+    },
   };
 
   @action
@@ -46,6 +49,7 @@ export default class ProfilesRoute extends Route {
         divisions: params.divisions,
         groups: params.groups,
         search: params.search,
+        certificability: params.certificability,
       },
       page: {
         number: params.pageNumber,
@@ -61,6 +65,7 @@ export default class ProfilesRoute extends Route {
       controller.set('divisions', []);
       controller.set('groups', []);
       controller.set('search', null);
+      controller.set('certificability', null);
     }
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/profile-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profile-results.hbs
@@ -8,6 +8,7 @@
     @searchFilter={{this.search}}
     @selectedDivisions={{this.divisions}}
     @selectedGroups={{this.groups}}
+    @selectedCertificability={{this.certificability}}
     @onClickParticipant={{this.goToProfilePage}}
     @onFilter={{this.triggerFiltering}}
     @onReset={{this.resetFiltering}}

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
@@ -59,13 +59,15 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
 
   module('#goToProfilePage', function () {
     test('it should call transitionToRoute with appropriate arguments', function (assert) {
+      const routerService = this.owner.lookup('service:router');
       // given
       const event = {
         stopPropagation: sinon.stub(),
         preventDefault: sinon.stub(),
       };
 
-      controller.transitionToRoute = sinon.stub();
+      routerService.transitionTo = sinon.stub();
+
 
       // when
       controller.send('goToProfilePage', 123, 345, event);
@@ -73,7 +75,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
       // then
       assert.true(event.stopPropagation.called);
       assert.true(event.preventDefault.called);
-      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.participant-profile', 123, 345));
+      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.participant-profile', 123, 345));
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
@@ -68,7 +68,6 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
 
       routerService.transitionTo = sinon.stub();
 
-
       // when
       controller.send('goToProfilePage', 123, 345, event);
 

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
@@ -42,6 +42,7 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
             groups: params.groups,
             campaignId: params.campaignId,
             search: params.search,
+            certificability: params.certificability,
           },
         })
         .returns(expectedSummaries);
@@ -78,6 +79,21 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
 
         assert.strictEqual(route.loading(transition), undefined);
       });
+    });
+  });
+
+  module('resetController', function () {
+    test('should reset filter to default value when isExiting true', function (assert) {
+      const controller = { set: sinon.stub() };
+
+      route.resetController(controller, true);
+
+      assert.ok(controller.set.calledWith('certificability', null));
+      assert.ok(controller.set.calledWith('pageNumber', 1));
+      assert.ok(controller.set.calledWith('pageSize', 50));
+      assert.ok(controller.set.calledWith('divisions', []));
+      assert.ok(controller.set.calledWith('groups', []));
+      assert.ok(controller.set.calledWith('search', null));
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -204,6 +204,9 @@
     }
   },
   "components": {
+    "certificability": {
+      "placeholder-select": "Eligible / Non-eligible"
+    },
     "date": {
       "no-date": "No date yet"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -207,6 +207,9 @@
     }
   },
   "components": {
+    "certificability": {
+      "placeholder-select": "Certifiable / Non certifiable"
+    },
     "date": {
       "no-date": "Pas encore de date"
     },


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs ont besoin de pouvoir filtrer sur les participants qui sont certifiables/non certifiables à partir d'une campagne de collecte de profil

## :robot: Proposition
Ajouter la possibilité de filtrer sur la page de résultat d'une collecte de profil

## :rainbow: Remarques
Ajout d'un bsr pour tester le cas `disabled` du bouton Effacer les filtres

## :100: Pour tester
Se connecter sur la RA avec le compte prescription-sco@example.net et vérifier que sur la page de résultat d'une collecte de profil le filtre certificabilité apparaît et fonctionnel.