### PR TITLE
[FEATURE] Modifier le texte légal sur la page de récupération d'accès à Pix Orga (PIX-8559)

### DIFF
--- a/orga/app/components/auth/join-request-form.hbs
+++ b/orga/app/components/auth/join-request-form.hbs
@@ -57,11 +57,9 @@
   </form>
 
   <p class="join-request-form__legal-information">
-    Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre
-    à votre établissement scolaire d'accéder à son espace Pix Orga. Elles sont conservées pendant un an. Elles sont
-    destinées à Pix et ne sont pas communiquées à des tiers en dehors d’un envoi par mail à l'adresse électronique du
-    chef de l'établissement dont vous avez saisi l'identifiant UAI/RNE. Conformément à la loi « informatique et libertés
-    », vous pouvez exercer votre droit d’accès aux données vous concernant et les faire rectifier en envoyant un mail à
-    <a href="mailto:dpo@pix.fr">dpo@pix.fr</a>
+    {{t "pages.join-request-form.legal-information.text"}}
+    <a href={{t "pages.join-request-form.legal-information.hyperlink"}} target="_blank" rel="noopener noreferrer">
+      {{t "pages.join-request-form.legal-information.link"}}
+    </a>
   </p>
 </div>

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -631,6 +631,13 @@
       "no-students-imported-yet": "In this tab, you will find the certification results and certificates of the students. You will first need to import the students database of your school.",
       "select-label": "Class"
     },
+    "join-request-form": {
+      "legal-information": {
+        "link-text": "En savoir plus sur mes droits.",
+        "link-url": "https://pix.fr/dp-formulaire-recuperation-pixorga-sco",
+        "text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par le GIP Pix pour le compte du ministère de l’Éducation nationale en tant que responsable de traitement, pour permettre à votre établissement scolaire d’accéder à son espace Pix Orga en lui envoyant une invitation à rejoindre cet espace."
+      }
+    },
     "login": {
       "title": "Log in",
       "choose-language-aria-label": "Select a language"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -634,6 +634,13 @@
       "no-students-imported-yet": "Dans cet onglet, vous retrouverez les résultats et les attestations de certification des élèves. Vous devez, dans un premier temps, importer la base élèves de votre établissement. ",
       "select-label": "Classe"
     },
+    "join-request-form": {
+      "legal-information": {
+        "link-text": "En savoir plus sur mes droits.",
+        "link-url": "https://pix.fr/dp-formulaire-recuperation-pixorga-sco",
+        "text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par le GIP Pix pour le compte du ministère de l’Éducation nationale en tant que responsable de traitement, pour permettre à votre établissement scolaire d’accéder à son espace Pix Orga en lui envoyant une invitation à rejoindre cet espace."
+      }
+    },
     "login": {
       "title": "Connectez-vous",
       "choose-language-aria-label": "Sélectionnez une langue"


### PR DESCRIPTION
## :unicorn: Problème
Le texte légal sur la page de récupération d'accès à Pix Orga a été modifié. Il faut donc le mettre à jour.

## :robot: Proposition
Changer le texte légal sous le formulaire.

## :rainbow: Remarques
Le texte était auparavant écrit en dur dans le composant. Il a été déplacé dans des clés de traduction.

## :100: Pour tester

1. Se rendre sur Pix Orga (domaine fr)
2. Aller sur la page `/demande-administration-sco`
3. Vérifier que le nouveau est bien présent et que le lien contenu dans celui-ci fonctionne bien
