### PR TITLE
[TECH] Ajouter un script pour mettre à jour le département d'une liste d'organisations (PIX-6970)

### DIFF
--- a/api/lib/domain/usecases/organizations-administration/update-organization-province-code.js
+++ b/api/lib/domain/usecases/organizations-administration/update-organization-province-code.js
@@ -1,0 +1,13 @@
+import { OrganizationNotFoundError } from '../../errors.js';
+
+async function updateOrganizationProvinceCode({ organizationId, provinceCode, organizationForAdminRepository }) {
+  const organization = await organizationForAdminRepository.get(organizationId);
+
+  if (!organization) {
+    throw new OrganizationNotFoundError();
+  }
+
+  return await organizationForAdminRepository.update({ id: organization.id, provinceCode });
+}
+
+export { updateOrganizationProvinceCode };

--- a/api/scripts/organization/update-organizations-province-code.js
+++ b/api/scripts/organization/update-organizations-province-code.js
@@ -1,0 +1,91 @@
+import { fileURLToPath } from 'node:url';
+
+import _ from 'lodash';
+import bluebird from 'bluebird';
+
+import { checkCsvHeader, parseCsvWithHeader } from '../helpers/csvHelpers.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+import { updateOrganizationProvinceCode } from '../../lib/domain/usecases/organizations-administration/update-organization-province-code.js';
+import * as organizationForAdminRepository from '../../lib/infrastructure/repositories/organization-for-admin-repository.js';
+
+const modulePath = fileURLToPath(import.meta.url);
+const IS_LAUNCHED_FROM_CLI = process.argv[1] === modulePath;
+
+async function main() {
+  console.time('Organisations province code updated');
+  console.log('Starting updating organisation province code...');
+
+  const filePath = process.argv[2];
+  await _updateOrganizationsProvinceCode(filePath);
+
+  console.timeEnd('Organisations province code updated');
+}
+
+async function _updateOrganizationsProvinceCode(filePath) {
+  const errors = [];
+  const requiredFieldNames = ['organizationId', 'provinceCode'];
+  const csvParsingOptions = {
+    skipEmptyLines: true,
+    header: true,
+    transform: (value, columnName) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (!_.isEmpty(value)) {
+        if (columnName === 'organizationId') {
+          value = Number(value);
+        }
+      } else {
+        value = null;
+      }
+
+      return value;
+    },
+  };
+
+  console.log('Checking CSV header...');
+  await checkCsvHeader({ filePath, requiredFieldNames });
+  console.log('CSV header checked');
+
+  console.log('Parsing CSV data...');
+  const organizationsDTO = await parseCsvWithHeader(filePath, csvParsingOptions);
+  console.log('CSV data parsed');
+
+  console.log('Updating data...');
+  await bluebird.mapSeries(organizationsDTO, async (organizationDTO) => {
+    const { organizationId, provinceCode } = organizationDTO;
+
+    try {
+      await updateOrganizationProvinceCode({
+        organizationId,
+        provinceCode,
+        organizationForAdminRepository,
+      });
+    } catch (error) {
+      errors.push({ organizationDTO, error });
+    }
+  });
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.log(`Errors occurs on ${errors.length} element!`);
+  errors.forEach((error) => {
+    console.log(JSON.stringify(error.organizationDTO));
+    console.error(error.error?.message);
+  });
+
+  throw new Error('Process done with errors');
+}
+
+if (IS_LAUNCHED_FROM_CLI) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}

--- a/api/tests/unit/domain/usecases/organizations-administration/update-organization-province-code_test.js
+++ b/api/tests/unit/domain/usecases/organizations-administration/update-organization-province-code_test.js
@@ -1,0 +1,49 @@
+import { expect, catchErr, sinon } from '../../../../test-helper.js';
+import { updateOrganizationProvinceCode } from '../../../../../lib/domain/usecases/organizations-administration/update-organization-province-code.js';
+import { OrganizationNotFoundError } from '../../../../../lib/domain/errors.js';
+
+describe('Unit | UseCases | Organizations administration | Update organization province code', function () {
+  context('when organization exists', function () {
+    it('updates organization department', async function () {
+      // given
+      const organizationForAdminRepository = { get: sinon.stub().resolves({ id: 1 }), update: sinon.stub().resolves() };
+      const organizationId = 1;
+      const provinceCode = 12;
+
+      // when
+      await updateOrganizationProvinceCode({
+        organizationId,
+        provinceCode,
+        organizationForAdminRepository,
+      });
+
+      // then
+      expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organizationId);
+      expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
+        id: organizationId,
+        provinceCode,
+      });
+    });
+  });
+
+  context('when organization does not exists', function () {
+    it('throws an OrganizationNotFoundError', async function () {
+      // given
+      const organizationForAdminRepository = { get: sinon.stub().resolves(), update: sinon.stub().resolves() };
+      const organizationId = 1;
+      const provinceCode = 14;
+
+      // when
+      const error = await catchErr(updateOrganizationProvinceCode)({
+        organizationId,
+        provinceCode,
+        organizationForAdminRepository,
+      });
+
+      // then
+      expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organizationId);
+      expect(organizationForAdminRepository.update).to.not.have.been.called;
+      expect(error).to.be.an.instanceOf(OrganizationNotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous avons besoin d'un script pour mettre à jour le département d'une liste d'organisations.

## :robot: Proposition

Créer un script pour mettre à jour le département (provinceCode) d'une liste d'organisations.

## :rainbow: Remarques

⚠️ Le fonctionnement de ce script est de continuer sur erreur, c'est à dire même s'il y a des erreurs pour certaines organisations. Aussi l'exécution du script ne doit pas être stoppée si une ou plusieurs erreurs surviennent durant l’exécution. La liste des erreurs est affichée à la fin de l’exécution du script de manière à pouvoir les corriger avant de lancer le script une nouvelle fois.

## :100: Pour tester

```csv
organizationId,provinceCode
1,31
2,54
3,50
4,50
5,50
```

- Récupérer la branche `pix-6970`
- Ouvrir un terminal
- Se déplacer dans le dossier `/api/scripts/organization`
- Créer un fichier CSV de test avec les données ci-dessus (il faudra peut être modifier l'identifiant des organisations)
- Exécuter le script avec la commande `node update-organizations-province-code.js <votre-fichier-de-test>.csv`
- Constater que le script se termine avec succès
- Vérifier en base de données que les organisations ont bien une nouvelle valeur dans la colonne `provinceCode`
