### PR TITLE
[BUGFIX] Corrige la largeur du bouton "Je me connecte" de Pix Orga(PIX-8750).

### DIFF
--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -58,5 +58,9 @@
     display: flex;
     flex-direction: column;
     gap: $pix-spacing-s;
+
+    button[type="submit"] {
+      width: 100%;
+    }
   }
 }


### PR DESCRIPTION
In latest PixUI release, PixButton component now set its width to fit
content, to avoid having very large buttons.
For the login page, the desired behavior is different as we want it to
have its width to 100% of the enclosed container.

## :unicorn: Problème

Avec la dernière version de PixUI, le composant `PixButton` définit sa largeur en fonction de son contenu.
Ce comportement n'est pas celui désiré pour le bouton "Je me connecte" de la page de connexion.
Avec la montée de version sur Pix Orga, le bouton s'affiche désormais moins large que prévu.

## :robot: Proposition

On définit localement un style `width: 100%` pour le bouton de la page de connexion de Pix Orga.

## :rainbow: Remarques

Pix Certif aura surement le même soucis lors de la montée de version de PixUI.

## :100: Pour tester

Se rendre sur la review app de Pix Orga.
Constater que le bouton "Je me connecte" occupe toute la largeur du panneau (ie. même largeur que les champs identifiant / mot de passe).
Apprécier la fin de sa journée 🌞 
