### PR TITLE
[BUGFIX] Réparer le design de la page de récupération d'accès à Pix Orga (PIX-8315).

### DIFF
--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -16,6 +16,7 @@
   &__back {
     font-size: 1rem;
     text-align: left;
+    margin-top: $pix-spacing-s;
 
     a {
       color: $pix-communication-dark;

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -10,6 +10,10 @@
     box-sizing: border-box;
     margin-bottom: 24px;
   }
+
+  &__image {
+    margin: auto;
+  }
 }
 
 .panel-header__headline {

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -8,11 +8,7 @@
   justify-content: center;
 
   a {
-    color: $pix-communication-dark;
-
-    &:visited {
-      color: $pix-communication-dark;
-    }
+    text-decoration: underline;
   }
 
   &__panel {
@@ -49,6 +45,7 @@
 
   &__error-message {
     max-width: 497px;
+    margin-top: $pix-spacing-m;
     margin-bottom: 24px;
     font-size: 0.875rem;
     text-align: center;
@@ -60,5 +57,9 @@
     letter-spacing: 0.15px;
     margin-top: 54px;
     margin-bottom: 24px;
+  }
+
+  .pix-button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Le design de la page de récupération d'accès a Pix Orga était cassé

## :robot: Proposition
Réparer grace a des `margin`

## :rainbow: Remarques
Utilisation des design-tokens

## :100: Pour tester
- Se rendre sur la page `/demande-administration-sco`
- Constater que le logo est bien aligné
- Constater que le message d'erreur concernant UAI/RNE est bien espacé
- Constater que le lien `Revenir à la page de connexion` est bien espacé
