### PR TITLE
[FEATURE] Mettre à jour le prénom et le nom reçus du GAR quand le samlID change pour un même user (PIX-4771)

### DIFF
--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -58,7 +58,7 @@ async function findMatchingSupOrganizationLearnerIdForGivenOrganizationIdAndUser
   return organizationLearner;
 }
 
-async function findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
+async function findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo({
   organizationId,
   reconciliationInfo: { firstName, lastName, birthdate },
   organizationLearnerRepository,
@@ -233,6 +233,6 @@ export {
   createUsernameByUser,
   findMatchingCandidateIdForGivenUser,
   findMatchingSupOrganizationLearnerIdForGivenOrganizationIdAndUser,
-  findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser,
+  findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo,
   assertStudentHasAnAlreadyReconciledAccount,
 };

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -44,12 +44,12 @@ async function findMatchingSupOrganizationLearnerIdForGivenOrganizationIdAndUser
   });
 
   if (!organizationLearner) {
-    throw new NotFoundError('There are no organization learners found');
+    throw new NotFoundError('Found no organization learner matching organization, student number and birthdate');
   }
 
   const organizationLearnerId = findMatchingCandidateIdForGivenUser([organizationLearner], { firstName, lastName });
   if (!organizationLearnerId) {
-    throw new NotFoundError('There were no organizationLearners matching with names');
+    throw new NotFoundError('Found no organization learner matching organization and names');
   }
 
   if (!lodash.isNil(organizationLearner.userId)) {
@@ -69,12 +69,12 @@ async function findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
   });
 
   if (lodash.isEmpty(organizationLearners)) {
-    throw new NotFoundError('There are no organization learners found');
+    throw new NotFoundError('Found no organization learners matching organization and birthdate');
   }
 
   const organizationLearnerId = findMatchingCandidateIdForGivenUser(organizationLearners, { firstName, lastName });
   if (!organizationLearnerId) {
-    throw new NotFoundError('There were no organizationLearners matching with names');
+    throw new NotFoundError('Found no organization learner matching names');
   }
 
   return lodash.find(organizationLearners, { id: organizationLearnerId });

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -80,7 +80,7 @@ async function findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
   return lodash.find(organizationLearners, { id: organizationLearnerId });
 }
 
-async function checkIfStudentHasAnAlreadyReconciledAccount(
+async function assertStudentHasAnAlreadyReconciledAccount(
   organizationLearner,
   userRepository,
   obfuscationService,
@@ -234,5 +234,5 @@ export {
   findMatchingCandidateIdForGivenUser,
   findMatchingSupOrganizationLearnerIdForGivenOrganizationIdAndUser,
   findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser,
-  checkIfStudentHasAnAlreadyReconciledAccount,
+  assertStudentHasAnAlreadyReconciledAccount,
 };

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -3,29 +3,6 @@ import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.j
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { UserToCreate } from '../models/UserToCreate.js';
 
-function _buildPasswordAuthenticationMethod({ userId, hashedPassword }) {
-  return new AuthenticationMethod({
-    userId,
-    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
-    authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
-      password: hashedPassword,
-      shouldChangePassword: false,
-    }),
-  });
-}
-
-function _buildGARAuthenticationMethod({ externalIdentifier, user }) {
-  return new AuthenticationMethod({
-    externalIdentifier,
-    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
-    userId: user.id,
-    authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
-      firstName: user.firstName,
-      lastName: user.lastName,
-    }),
-  });
-}
-
 async function createUserWithPassword({
   user,
   hashedPassword,
@@ -115,4 +92,27 @@ async function createAndReconcileUserToOrganizationLearner({
   });
 }
 
-export { createAndReconcileUserToOrganizationLearner, createUserWithPassword, updateUsernameAndAddPassword };
+function _buildPasswordAuthenticationMethod({ userId, hashedPassword }) {
+  return new AuthenticationMethod({
+    userId,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    authenticationComplement: new AuthenticationMethod.PixAuthenticationComplement({
+      password: hashedPassword,
+      shouldChangePassword: false,
+    }),
+  });
+}
+
+function _buildGARAuthenticationMethod({ externalIdentifier, user }) {
+  return new AuthenticationMethod({
+    externalIdentifier,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    userId: user.id,
+    authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
+      firstName: user.firstName,
+      lastName: user.lastName,
+    }),
+  });
+}
+
+export { createUserWithPassword, updateUsernameAndAddPassword, createAndReconcileUserToOrganizationLearner };

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -1,5 +1,4 @@
 import lodash from 'lodash';
-
 const { isNil } = lodash;
 
 import {
@@ -9,10 +8,83 @@ import {
   EntityValidationError,
   OrganizationLearnerAlreadyLinkedToUserError,
 } from '../errors.js';
-
 import { User } from '../models/User.js';
 import { getCampaignUrl } from '../../infrastructure/utils/url-builder.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../constants.js';
+
+const createAndReconcileUserToOrganizationLearner = async function ({
+  campaignCode,
+  locale,
+  password,
+  userAttributes,
+  authenticationMethodRepository,
+  campaignRepository,
+  organizationLearnerRepository,
+  userRepository,
+  userToCreateRepository,
+  encryptionService,
+  mailService,
+  obfuscationService,
+  userReconciliationService,
+  userService,
+  passwordValidator,
+  userValidator,
+}) {
+  const campaign = await campaignRepository.getByCode(campaignCode);
+  if (!campaign) {
+    throw new CampaignCodeError();
+  }
+
+  const matchedOrganizationLearner =
+    await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
+      organizationId: campaign.organizationId,
+      reconciliationInfo: userAttributes,
+      organizationLearnerRepository,
+      userRepository,
+      obfuscationService,
+    });
+
+  const organizationLearnerFound = !isNil(matchedOrganizationLearner.userId);
+  if (organizationLearnerFound) {
+    const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
+    const error = STUDENT_RECONCILIATION_ERRORS.LOGIN_OR_REGISTER.IN_SAME_ORGANIZATION.username;
+    const meta = {
+      shortCode: error.shortCode,
+    };
+    throw new OrganizationLearnerAlreadyLinkedToUserError(detail, error.code, meta);
+  }
+
+  const isUsernameMode = userAttributes.withUsername;
+  const cleanedUserAttributes = _emptyOtherMode(isUsernameMode, userAttributes);
+
+  await _validateData({
+    isUsernameMode,
+    password,
+    userAttributes: cleanedUserAttributes,
+    userRepository,
+    passwordValidator,
+    userValidator,
+  });
+
+  const hashedPassword = await _encryptPassword(password, encryptionService);
+  const domainUser = _createDomainUser(cleanedUserAttributes);
+
+  const userId = await userService.createAndReconcileUserToOrganizationLearner({
+    hashedPassword,
+    organizationLearnerId: matchedOrganizationLearner.id,
+    user: domainUser,
+    authenticationMethodRepository,
+    organizationLearnerRepository,
+    userToCreateRepository,
+  });
+
+  const createdUser = await userRepository.get(userId);
+  if (!isUsernameMode) {
+    const redirectionUrl = getCampaignUrl(locale, campaignCode);
+    await mailService.sendAccountCreationEmail(createdUser.email, locale, redirectionUrl);
+  }
+  return createdUser;
+};
 
 function _encryptPassword(userPassword, encryptionService) {
   const encryptedPassword = encryptionService.hashPassword(userPassword);
@@ -112,79 +184,5 @@ async function _validateData({
     throw EntityValidationError.fromMultipleEntityValidationErrors(relevantErrors);
   }
 }
-
-const createAndReconcileUserToOrganizationLearner = async function ({
-  campaignCode,
-  locale,
-  password,
-  userAttributes,
-  authenticationMethodRepository,
-  campaignRepository,
-  organizationLearnerRepository,
-  userRepository,
-  userToCreateRepository,
-  encryptionService,
-  mailService,
-  obfuscationService,
-  userReconciliationService,
-  userService,
-  passwordValidator,
-  userValidator,
-}) {
-  const campaign = await campaignRepository.getByCode(campaignCode);
-  if (!campaign) {
-    throw new CampaignCodeError();
-  }
-
-  const matchedOrganizationLearner =
-    await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
-      organizationId: campaign.organizationId,
-      reconciliationInfo: userAttributes,
-      organizationLearnerRepository,
-      userRepository,
-      obfuscationService,
-    });
-
-  const organizationLearnerFound = !isNil(matchedOrganizationLearner.userId);
-  if (organizationLearnerFound) {
-    const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
-    const error = STUDENT_RECONCILIATION_ERRORS.LOGIN_OR_REGISTER.IN_SAME_ORGANIZATION.username;
-    const meta = {
-      shortCode: error.shortCode,
-    };
-    throw new OrganizationLearnerAlreadyLinkedToUserError(detail, error.code, meta);
-  }
-
-  const isUsernameMode = userAttributes.withUsername;
-  const cleanedUserAttributes = _emptyOtherMode(isUsernameMode, userAttributes);
-
-  await _validateData({
-    isUsernameMode,
-    password,
-    userAttributes: cleanedUserAttributes,
-    userRepository,
-    passwordValidator,
-    userValidator,
-  });
-
-  const hashedPassword = await _encryptPassword(password, encryptionService);
-  const domainUser = _createDomainUser(cleanedUserAttributes);
-
-  const userId = await userService.createAndReconcileUserToOrganizationLearner({
-    hashedPassword,
-    organizationLearnerId: matchedOrganizationLearner.id,
-    user: domainUser,
-    authenticationMethodRepository,
-    organizationLearnerRepository,
-    userToCreateRepository,
-  });
-
-  const createdUser = await userRepository.get(userId);
-  if (!isUsernameMode) {
-    const redirectionUrl = getCampaignUrl(locale, campaignCode);
-    await mailService.sendAccountCreationEmail(createdUser.email, locale, redirectionUrl);
-  }
-  return createdUser;
-};
 
 export { createAndReconcileUserToOrganizationLearner };

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -36,7 +36,7 @@ const createAndReconcileUserToOrganizationLearner = async function ({
   }
 
   const matchedOrganizationLearner =
-    await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
+    await userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo({
       organizationId: campaign.organizationId,
       reconciliationInfo: userAttributes,
       organizationLearnerRepository,

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -1,5 +1,6 @@
 import { CampaignCodeError, ObjectValidationError } from '../errors.js';
 import { User } from '../models/User.js';
+import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../constants.js';
 
@@ -90,6 +91,15 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
         identityProvider,
       });
 
+      const authenticationComplement = new AuthenticationMethod.GARAuthenticationComplement({
+        firstName,
+        lastName,
+      });
+      await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
+        authenticationComplement,
+        userId: reconciliationUserId,
+        identityProvider,
+      });
       const organizationLearner = await organizationLearnerRepository.reconcileUserToOrganizationLearner({
         userId: reconciliationUserId,
         organizationLearnerId: matchedOrganizationLearner.id,

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -51,8 +51,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
 
   try {
     matchedOrganizationLearner =
-      // TODO: Rename findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser→findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo
-      await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
+      await userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo({
         organizationId: campaign.organizationId,
         reconciliationInfo,
         organizationLearnerRepository,

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -58,7 +58,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
         organizationLearnerRepository,
       });
 
-    await userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount(
+    await userReconciliationService.assertStudentHasAnAlreadyReconciledAccount(
       matchedOrganizationLearner,
       userRepository,
       obfuscationService,

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -52,6 +52,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
 
   try {
     matchedOrganizationLearner =
+      // TODO: Rename findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser→findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo
       await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
         organizationId: campaign.organizationId,
         reconciliationInfo,

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -3,6 +3,11 @@ import { User } from '../models/User.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../constants.js';
 
+const existingUserReconciliationErrors = [
+  STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION.samlId.code,
+  STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION.samlId.code,
+];
+
 const createUserAndReconcileToOrganizationLearnerFromExternalUser = async function ({
   birthdate,
   campaignCode,
@@ -44,10 +49,6 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   let matchedOrganizationLearner;
   let userWithSamlId;
   let userId;
-  const reconciliationErrors = [
-    STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION.samlId.code,
-    STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION.samlId.code,
-  ];
 
   try {
     matchedOrganizationLearner =
@@ -76,7 +77,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
       });
     }
   } catch (error) {
-    if (reconciliationErrors.includes(error.code)) {
+    if (existingUserReconciliationErrors.includes(error.code)) {
       await authenticationMethodRepository.updateExternalIdentifierByUserIdAndIdentityProvider({
         externalIdentifier: externalUser.samlId,
         userId: error.meta.userId,

--- a/api/lib/domain/usecases/reconcile-sco-organization-learner-manually.js
+++ b/api/lib/domain/usecases/reconcile-sco-organization-learner-manually.js
@@ -32,7 +32,7 @@ const reconcileScoOrganizationLearnerManually = async function ({
       organizationLearnerRepository,
     });
 
-  await userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount(
+  await userReconciliationService.assertStudentHasAnAlreadyReconciledAccount(
     organizationLearnerOfUserAccessingCampaign,
     userRepository,
     obfuscationService,

--- a/api/lib/domain/usecases/reconcile-sco-organization-learner-manually.js
+++ b/api/lib/domain/usecases/reconcile-sco-organization-learner-manually.js
@@ -26,7 +26,7 @@ const reconcileScoOrganizationLearnerManually = async function ({
   }
 
   const organizationLearnerOfUserAccessingCampaign =
-    await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser({
+    await userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo({
       organizationId: campaign.organizationId,
       reconciliationInfo,
       organizationLearnerRepository,

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -211,8 +211,10 @@ const updateExternalIdentifierByUserIdAndIdentityProvider = async function ({
   externalIdentifier,
   userId,
   identityProvider,
+  domainTransaction = DomainTransaction.emptyTransaction(),
 }) {
-  const [authenticationMethodDTO] = await knex(AUTHENTICATION_METHODS_TABLE)
+  const knexConn = domainTransaction.knexTransaction ?? knex;
+  const [authenticationMethodDTO] = await knexConn(AUTHENTICATION_METHODS_TABLE)
     .where({ userId, identityProvider })
     .update({ externalIdentifier, updatedAt: new Date() })
     .returning(COLUMNS);
@@ -229,8 +231,10 @@ const updateAuthenticationComplementByUserIdAndIdentityProvider = async function
   authenticationComplement,
   userId,
   identityProvider,
+  domainTransaction = DomainTransaction.emptyTransaction(),
 }) {
-  const [authenticationMethodDTO] = await knex(AUTHENTICATION_METHODS_TABLE)
+  const knexConn = domainTransaction.knexTransaction ?? knex;
+  const [authenticationMethodDTO] = await knexConn(AUTHENTICATION_METHODS_TABLE)
     .where({ userId, identityProvider })
     .update({ authenticationComplement, updatedAt: new Date() })
     .returning(COLUMNS);

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -7,42 +7,6 @@ import { AuthenticationMethod } from '../../domain/models/AuthenticationMethod.j
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
 
-function _toDomain(authenticationMethodDTO) {
-  if (authenticationMethodDTO.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
-    authenticationMethodDTO.externalIdentifier = undefined;
-  }
-  const authenticationComplement = _toAuthenticationComplement(
-    authenticationMethodDTO.identityProvider,
-    authenticationMethodDTO.authenticationComplement,
-  );
-  return new AuthenticationMethod({
-    ...authenticationMethodDTO,
-    externalIdentifier: authenticationMethodDTO.externalIdentifier,
-    authenticationComplement,
-  });
-}
-
-function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationComplement) {
-  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
-    return new AuthenticationMethod.PixAuthenticationComplement(bookshelfAuthenticationComplement);
-  }
-
-  if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.code) {
-    return new AuthenticationMethod.OidcAuthenticationComplement(bookshelfAuthenticationComplement);
-  }
-
-  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.GAR.code) {
-    const methodWasCreatedWithoutUserFirstAndLastName = bookshelfAuthenticationComplement === null;
-    if (methodWasCreatedWithoutUserFirstAndLastName) {
-      return undefined;
-    }
-
-    return new AuthenticationMethod.GARAuthenticationComplement(bookshelfAuthenticationComplement);
-  }
-
-  return undefined;
-}
-
 const AUTHENTICATION_METHODS_TABLE = 'authentication-methods';
 const COLUMNS = Object.freeze([
   'id',
@@ -299,6 +263,42 @@ const batchUpdatePasswordThatShouldBeChanged = function ({
     ),
   );
 };
+
+function _toDomain(authenticationMethodDTO) {
+  if (authenticationMethodDTO.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
+    authenticationMethodDTO.externalIdentifier = undefined;
+  }
+  const authenticationComplement = _toAuthenticationComplement(
+    authenticationMethodDTO.identityProvider,
+    authenticationMethodDTO.authenticationComplement,
+  );
+  return new AuthenticationMethod({
+    ...authenticationMethodDTO,
+    externalIdentifier: authenticationMethodDTO.externalIdentifier,
+    authenticationComplement,
+  });
+}
+
+function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationComplement) {
+  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code) {
+    return new AuthenticationMethod.PixAuthenticationComplement(bookshelfAuthenticationComplement);
+  }
+
+  if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.code) {
+    return new AuthenticationMethod.OidcAuthenticationComplement(bookshelfAuthenticationComplement);
+  }
+
+  if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.GAR.code) {
+    const methodWasCreatedWithoutUserFirstAndLastName = bookshelfAuthenticationComplement === null;
+    if (methodWasCreatedWithoutUserFirstAndLastName) {
+      return undefined;
+    }
+
+    return new AuthenticationMethod.GARAuthenticationComplement(bookshelfAuthenticationComplement);
+  }
+
+  return undefined;
+}
 
 export {
   batchUpdatePasswordThatShouldBeChanged,

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -7,7 +7,6 @@ import {
   UserCouldNotBeReconciledError,
   UserNotFoundError,
 } from '../../domain/errors.js';
-
 import { OrganizationLearner } from '../../domain/models/OrganizationLearner.js';
 import { OrganizationLearnerForAdmin } from '../../domain/read-models/OrganizationLearnerForAdmin.js';
 import * as studentRepository from './student-repository.js';
@@ -193,9 +192,14 @@ const findByOrganizationIdAndBirthdate = async function ({ organizationId, birth
   return rawOrganizationLearners.map((rawOrganizationLearner) => new OrganizationLearner(rawOrganizationLearner));
 };
 
-const reconcileUserToOrganizationLearner = async function ({ userId, organizationLearnerId }) {
+const reconcileUserToOrganizationLearner = async function ({
+  userId,
+  organizationLearnerId,
+  domainTransaction = DomainTransaction.emptyTransaction(),
+}) {
   try {
-    const [rawOrganizationLearner] = await knex('organization-learners')
+    const knexConn = domainTransaction.knexTransaction ?? knex;
+    const [rawOrganizationLearner] = await knexConn('organization-learners')
       .where({ id: organizationLearnerId })
       .where('isDisabled', false)
       .update({ userId, updatedAt: knex.fn.now() })

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -58,7 +58,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
     });
   });
 
-  context('When no organizationLearner found', function () {
+  context('When no organizationLearner is found', function () {
     beforeEach(async function () {
       campaignCode = databaseBuilder.factory.buildCampaign().code;
       await databaseBuilder.commit();
@@ -95,7 +95,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
     });
   });
 
-  context('When one organizationLearner matched on names', function () {
+  context('When an organizationLearner matches on names', function () {
     beforeEach(async function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
       campaignCode = databaseBuilder.factory.buildCampaign({

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -91,7 +91,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
       // then
       expect(error).to.be.instanceof(NotFoundError);
-      expect(error.message).to.equal('There are no organization learners found');
+      expect(error.message).to.equal('Found no organization learners matching organization and birthdate');
     });
   });
 

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -146,7 +146,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
       // then
       expect(error).to.be.instanceof(NotFoundError);
-      expect(error.message).to.equal('There are no organization learners found');
+      expect(error.message).to.equal('Found no organization learners matching organization and birthdate');
     });
   });
 

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -212,9 +212,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);
     });
 
-    context(
-      'When the external user is already linked to another account without samlId authentication method',
-      function () {
+    context('When the external user is already linked to another account', function () {
+      context('without samlId authentication method', function () {
         it('throws an OrganizationLearnerAlreadyLinkedToUserError', async function () {
           // given
           const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
@@ -240,12 +239,9 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
           // then
           expect(error).to.be.instanceOf(OrganizationLearnerAlreadyLinkedToUserError);
         });
-      },
-    );
+      });
 
-    context(
-      'When the external user is already linked to another account with samlId authentication method',
-      function () {
+      context('with samlId authentication method', function () {
         context('When reconciled in other organization', function () {
           it('updates existing account with the new samlId, firstName and lastName', async function () {
             // given
@@ -358,8 +354,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);
           });
         });
-      },
-    );
+      });
+    });
 
     context('When the external user is already created', function () {
       it('does not create again the user', async function () {

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -150,7 +150,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     });
   });
 
-  context('When an organizationLearner match the token data and birthdate', function () {
+  context('When an organizationLearner matches on birthdate and on token firstName and lastName', function () {
     const firstName = 'Saml';
     const lastName = 'Jackson';
     const samlId = 'SamlId';
@@ -175,7 +175,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       await knex('users').delete();
     });
 
-    it('should create the external user, reconcile it and create GAR authentication method', async function () {
+    it('creates the external user, reconciles it and creates GAR authentication method', async function () {
       // given
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         firstName,
@@ -213,9 +213,9 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     });
 
     context(
-      'When the external user is already reconciled by another account without samlId authentication method',
+      'When the external user is already linked to another account without samlId authentication method',
       function () {
-        it('should throw a OrganizationLearnerAlreadyLinkedToUserError', async function () {
+        it('throws an OrganizationLearnerAlreadyLinkedToUserError', async function () {
           // given
           const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
             firstName,
@@ -244,10 +244,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     );
 
     context(
-      'When the external user is already reconciled by another account with samlId authentication method',
+      'When the external user is already linked to another account with samlId authentication method',
       function () {
         context('When reconciled in other organization', function () {
-          it('should update existing account with the new samlId', async function () {
+          it('updates existing account with the new samlId, firstName and lastName', async function () {
             // given
             const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
               firstName,
@@ -307,7 +307,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
         });
 
         context('When reconciled in the same organization', function () {
-          it('should update existing account with the new samlId', async function () {
+          it('updates existing account with the new samlId, firstName and lastName', async function () {
             // given
             const birthdate = '10-10-2010';
             const otherAccount = databaseBuilder.factory.buildUser({
@@ -362,7 +362,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     );
 
     context('When the external user is already created', function () {
-      it('should not create again the user', async function () {
+      it('does not create again the user', async function () {
         // given
         const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
           firstName,

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -209,7 +209,12 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       expect(usersBefore.length + 1).to.equal(usersAfter.length);
 
       const authenticationMethodInDB = await knex('authentication-methods');
-      expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);
+      const authenticationMethod = authenticationMethodInDB[0];
+      expect(authenticationMethod.externalIdentifier).to.equal(samlId);
+      expect(authenticationMethod.authenticationComplement).to.deep.equal({
+        firstName: 'Saml',
+        lastName: 'Jackson',
+      });
     });
 
     context('When the external user is already linked to another account', function () {
@@ -259,6 +264,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
               externalIdentifier: '12345678',
               userId: otherAccount.id,
+              firstName: 'John',
+              lastName: 'Travolta',
             });
 
             const otherOrganization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
@@ -298,7 +305,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
               identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
               userId: otherAccount.id,
             });
-            expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);
+            const authenticationMethod = authenticationMethodInDB[0];
+            expect(authenticationMethod.externalIdentifier).to.equal(samlId);
+            expect(authenticationMethod.authenticationComplement.firstName).not.to.equal('Saml');
+            expect(authenticationMethod.authenticationComplement.lastName).not.to.equal('Jackson');
           });
         });
 
@@ -314,6 +324,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
               externalIdentifier: '12345678',
               userId: otherAccount.id,
+              firstName: 'John',
+              lastName: 'Travolta',
             });
 
             const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
@@ -351,7 +363,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
               identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
               userId: otherAccount.id,
             });
-            expect(authenticationMethodInDB[0].externalIdentifier).to.equal(samlId);
+            const authenticationMethod = authenticationMethodInDB[0];
+            expect(authenticationMethod.externalIdentifier).to.equal(samlId);
+            expect(authenticationMethod.authenticationComplement.firstName).not.to.equal('Saml');
+            expect(authenticationMethod.authenticationComplement.lastName).not.to.equal('Jackson');
           });
         });
       });

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -151,8 +151,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
   });
 
   context('When an organizationLearner matches on birthdate and on token firstName and lastName', function () {
-    const firstName = 'Saml';
-    const lastName = 'Jackson';
+    const firstName = 'Julie';
+    const lastName = 'Dumoulin-Lemarchand';
     const samlId = 'SamlId';
 
     let campaignCode;
@@ -212,8 +212,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       const authenticationMethod = authenticationMethodInDB[0];
       expect(authenticationMethod.externalIdentifier).to.equal(samlId);
       expect(authenticationMethod.authenticationComplement).to.deep.equal({
-        firstName: 'Saml',
-        lastName: 'Jackson',
+        firstName: 'Julie',
+        lastName: 'Dumoulin-Lemarchand',
       });
     });
 
@@ -264,8 +264,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
               externalIdentifier: '12345678',
               userId: otherAccount.id,
-              firstName: 'John',
-              lastName: 'Travolta',
+              firstName: 'Juliette',
+              lastName: 'Dumoulin',
             });
 
             const otherOrganization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
@@ -307,8 +307,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             });
             const authenticationMethod = authenticationMethodInDB[0];
             expect(authenticationMethod.externalIdentifier).to.equal(samlId);
-            expect(authenticationMethod.authenticationComplement.firstName).not.to.equal('Saml');
-            expect(authenticationMethod.authenticationComplement.lastName).not.to.equal('Jackson');
+            expect(authenticationMethod.authenticationComplement).to.deep.equal({
+              firstName: 'Julie',
+              lastName: 'Dumoulin-Lemarchand',
+            });
           });
         });
 
@@ -324,8 +326,8 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
               externalIdentifier: '12345678',
               userId: otherAccount.id,
-              firstName: 'John',
-              lastName: 'Travolta',
+              firstName: 'Juliette',
+              lastName: 'Dumoulin',
             });
 
             const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
@@ -365,8 +367,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             });
             const authenticationMethod = authenticationMethodInDB[0];
             expect(authenticationMethod.externalIdentifier).to.equal(samlId);
-            expect(authenticationMethod.authenticationComplement.firstName).not.to.equal('Saml');
-            expect(authenticationMethod.authenticationComplement.lastName).not.to.equal('Jackson');
+            expect(authenticationMethod.authenticationComplement).to.deep.equal({
+              firstName: 'Julie',
+              lastName: 'Dumoulin-Lemarchand',
+            });
           });
         });
       });

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -363,7 +363,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
     });
   });
 
-  describe('#findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser', function () {
+  describe('#findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo', function () {
     let user;
     let organizationId;
     let organizationLearnerRepositoryStub;
@@ -390,7 +390,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
           // when
           const result = await catchErr(
-            userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser,
+            userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo,
           )({
             organizationId,
             reconciliationInfo: user,
@@ -413,13 +413,12 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
         it('should return matched OrganizationLearner', async function () {
           // when
-          const result = await userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser(
-            {
+          const result =
+            await userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo({
               organizationId,
               reconciliationInfo: user,
               organizationLearnerRepository: organizationLearnerRepositoryStub,
-            },
-          );
+            });
 
           // then
           expect(result).to.equal(organizationLearners[0]);
@@ -441,7 +440,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
         // when
         const result = await catchErr(
-          userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser,
+          userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo,
         )({
           organizationId,
           reconciliationInfo: user,

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -665,7 +665,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
     });
   });
 
-  describe('#checkIfStudentHasAnAlreadyReconciledAccount', function () {
+  describe('#assertStudentHasAnAlreadyReconciledAccount', function () {
     let userRepositoryStub;
     let obfuscationServiceStub;
     let studentRepositoryStub;
@@ -697,7 +697,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
           });
 
           // when
-          const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+          const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
             organizationLearner,
             userRepositoryStub,
             obfuscationServiceStub,
@@ -728,7 +728,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
           });
 
           // when
-          const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+          const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
             organizationLearner,
             userRepositoryStub,
             obfuscationServiceStub,
@@ -760,7 +760,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
           });
 
           // when
-          const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+          const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
             organizationLearner,
             userRepositoryStub,
             obfuscationServiceStub,
@@ -797,7 +797,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
           });
 
           // when
-          const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+          const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
             organizationLearner,
             userRepositoryStub,
             obfuscationServiceStub,
@@ -831,7 +831,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
           });
 
           // when
-          const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+          const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
             organizationLearner,
             userRepositoryStub,
             obfuscationServiceStub,
@@ -866,7 +866,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
           });
 
           // when
-          const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+          const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
             organizationLearner,
             userRepositoryStub,
             obfuscationServiceStub,
@@ -903,7 +903,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
         obfuscationServiceStub.getUserAuthenticationMethodWithObfuscation.withArgs(user).rejects(new NotFoundError());
 
         // when
-        const error = await catchErr(userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount)(
+        const error = await catchErr(userReconciliationService.assertStudentHasAnAlreadyReconciledAccount)(
           organizationLearner,
           userRepositoryStub,
           obfuscationServiceStub,

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -399,7 +399,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
           // then
           expect(result).to.be.instanceOf(NotFoundError);
-          expect(result.message).to.equal('There were no organizationLearners matching with names');
+          expect(result.message).to.equal('Found no organization learner matching names');
         });
       });
 
@@ -450,7 +450,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
         // then
         expect(result).to.be.instanceOf(NotFoundError);
-        expect(result.message).to.equal('There are no organization learners found');
+        expect(result.message).to.equal('Found no organization learners matching organization and birthdate');
       });
     });
   });

--- a/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -61,7 +61,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
       sendAccountCreationEmail: sinon.stub(),
     };
     userReconciliationService = {
-      findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser: sinon.stub(),
+      findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo: sinon.stub(),
     };
     userService = {
       createAndReconcileUserToOrganizationLearner: sinon.stub(),
@@ -118,7 +118,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
   context('When no organizationLearner found', function () {
     it('should throw a Not Found error', async function () {
       // given
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.throws(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.throws(
         new NotFoundError('Error message'),
       );
 
@@ -154,7 +154,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
     beforeEach(function () {
       createdUser = domainBuilder.buildUser();
 
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearnerId,
       );
       encryptionService.hashPassword.resolves(encryptedPassword);

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
     };
     userReconciliationService = {
       findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser: sinon.stub(),
-      checkIfStudentHasAnAlreadyReconciledAccount: sinon.stub(),
+      assertStudentHasAnAlreadyReconciledAccount: sinon.stub(),
     };
     userRepository = {
       getBySamlId: sinon.stub(),

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       createAccessTokenForSaml: sinon.stub(),
     };
     userReconciliationService = {
-      findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser: sinon.stub(),
+      findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo: sinon.stub(),
       assertStudentHasAnAlreadyReconciledAccount: sinon.stub(),
     };
     userRepository = {
@@ -42,7 +42,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
 
       campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userRepository.getBySamlId.resolves(user);
@@ -76,7 +76,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
 
       campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userRepository.getBySamlId.resolves(user);
@@ -112,7 +112,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
 
       campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userRepository.getBySamlId.resolves(null);
@@ -147,7 +147,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
 
       campaignRepository.getByCode.resolves('ABCDE');
       tokenService.extractExternalUserFromIdToken.resolves(externalUser);
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userRepository.getBySamlId.resolves(null);

--- a/api/tests/unit/domain/usecases/reconcile-sco-organization-learner-manually_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-sco-organization-learner-manually_test.js
@@ -41,7 +41,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
     };
     userReconciliationService = {
       findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser: sinon.stub(),
-      checkIfStudentHasAnAlreadyReconciledAccount: sinon.stub(),
+      assertStudentHasAnAlreadyReconciledAccount: sinon.stub(),
     };
   });
 
@@ -95,7 +95,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
         organizationLearner,
       );
-      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.throws(
+      userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.throws(
         new OrganizationLearnerAlreadyLinkedToUserError(),
       );
 
@@ -132,7 +132,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
         organizationLearner,
       );
-      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+      userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
       organizationLearnerRepository.findOneByUserIdAndOrganizationId
         .withArgs({
           userId: user.id,
@@ -188,7 +188,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
           userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
             currentOrganizationLearner,
           );
-          userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+          userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
           organizationLearnerRepository.findOneByUserIdAndOrganizationId.resolves();
           organizationLearnerRepository.findByUserId.withArgs({ userId: 1 }).resolves([previousOrganizationLearner]);
           organizationLearnerRepository.reconcileUserToOrganizationLearner.resolves(currentOrganizationLearner);
@@ -242,7 +242,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
           userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
             currentOrganizationLearner,
           );
-          userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+          userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
           organizationLearnerRepository.findOneByUserIdAndOrganizationId.resolves();
           organizationLearnerRepository.findByUserId.withArgs({ userId: 1 }).resolves([previousOrganizationLearner]);
 
@@ -296,7 +296,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
         userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
           currentOrganizationLearner,
         );
-        userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+        userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
         organizationLearnerRepository.findOneByUserIdAndOrganizationId.resolves();
         organizationLearnerRepository.findByUserId.withArgs({ userId: 1 }).resolves([previousOrganizationLearner]);
         organizationLearnerRepository.reconcileUserToOrganizationLearner.resolves(currentOrganizationLearner);
@@ -350,7 +350,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
         userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
           currentOrganizationLearner,
         );
-        userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+        userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
         organizationLearnerRepository.findOneByUserIdAndOrganizationId.resolves();
         organizationLearnerRepository.findByUserId.withArgs({ userId: 1 }).resolves([previousOrganizationLearner]);
         organizationLearnerRepository.reconcileUserToOrganizationLearner.resolves(currentOrganizationLearner);
@@ -414,7 +414,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
             userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
               currentOrganizationLearner,
             );
-            userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+            userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
             organizationLearnerRepository.findOneByUserIdAndOrganizationId.resolves();
             organizationLearnerRepository.findByUserId
               .withArgs({ userId: 1 })
@@ -473,7 +473,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
             userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
               currentOrganizationLearner,
             );
-            userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+            userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
             organizationLearnerRepository.findOneByUserIdAndOrganizationId.resolves();
             organizationLearnerRepository.findByUserId
               .withArgs({ userId: 1 })
@@ -515,7 +515,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
         organizationLearner,
       );
-      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+      userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
       organizationLearnerRepository.reconcileUserToOrganizationLearner
         .withArgs({
           userId: user.id,
@@ -554,7 +554,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
         organizationLearner,
       );
       organizationLearnerRepository.findByUserId.resolves([organizationLearner]);
-      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
+      userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
 
       // when
       const result = await usecases.reconcileScoOrganizationLearnerManually({

--- a/api/tests/unit/domain/usecases/reconcile-sco-organization-learner-manually_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-sco-organization-learner-manually_test.js
@@ -40,7 +40,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       findByUserId: sinon.stub(),
     };
     userReconciliationService = {
-      findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser: sinon.stub(),
+      findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo: sinon.stub(),
       assertStudentHasAnAlreadyReconciledAccount: sinon.stub(),
     };
   });
@@ -68,7 +68,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       campaignRepository.getByCode
         .withArgs(campaignCode)
         .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.throws(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.throws(
         new NotFoundError('Error message'),
       );
 
@@ -92,7 +92,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       campaignRepository.getByCode
         .withArgs(campaignCode)
         .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.throws(
@@ -129,7 +129,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       campaignRepository.getByCode
         .withArgs(campaignCode)
         .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -185,7 +185,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
           });
 
           campaignRepository.getByCode.resolves(campaign);
-          userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+          userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
             currentOrganizationLearner,
           );
           userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -239,7 +239,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
           });
 
           campaignRepository.getByCode.resolves(campaign);
-          userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+          userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
             currentOrganizationLearner,
           );
           userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -293,7 +293,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
         });
 
         campaignRepository.getByCode.resolves(campaign);
-        userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+        userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
           currentOrganizationLearner,
         );
         userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -347,7 +347,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
         });
 
         campaignRepository.getByCode.resolves(campaign);
-        userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+        userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
           currentOrganizationLearner,
         );
         userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -411,7 +411,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
             });
 
             campaignRepository.getByCode.resolves(campaign);
-            userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+            userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
               currentOrganizationLearner,
             );
             userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -470,7 +470,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
             });
 
             campaignRepository.getByCode.resolves(campaign);
-            userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+            userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
               currentOrganizationLearner,
             );
             userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -512,7 +512,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       campaignRepository.getByCode
         .withArgs(campaignCode)
         .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       userReconciliationService.assertStudentHasAnAlreadyReconciledAccount.resolves();
@@ -550,7 +550,7 @@ describe('Unit | UseCase | reconcile-sco-organization-learner-manually', functio
       campaignRepository.getByCode
         .withArgs(campaignCode)
         .resolves(domainBuilder.buildCampaign({ organization: { id: organizationId } }));
-      userReconciliationService.findMatchingOrganizationLearnerIdForGivenOrganizationIdAndUser.resolves(
+      userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
       organizationLearnerRepository.findByUserId.resolves([organizationLearner]);


### PR DESCRIPTION
## :unicorn: Problème

Le prénom et le nom reçus du GAR ne sont pas mis à jour quand le samlID change pour un même user.

## :robot: Proposition

Mettre à jour le prénom et le nom reçus du GAR quand le samlID change pour un même user.

## :rainbow: Remarques

RAS

## :100: Pour tester

On ne peut pas tester cette PR en RA.

Pour tester la PR il faut tester en local avec un _faux GAR_ à installer en local : 
https://github.com/1024pix/pix-saml-idp

En recette on pourra tester avec le _faux GAR_ suivant : 
https://test-idp.integration.pix.fr/

---

[fichiers-import-siecle.zip](https://github.com/1024pix/pix/files/12196004/fichiers-import-siecle.zip) d'exemple pour faire les tests ci-dessous, à utiliser pour faire les imports dans Pix Orga suivants les consignes ci-dessous.

---

1. Créer ou s'assurer que dans une organisation il existe un _organization learner_ avec un nom, prénom et date de naissance (par exemple `Juliette`, `Dumoulin`, `11/11/2011`). On pourra utiliser le fichier `siecle-julie-1.xml` du fichier ZIP en pièce jointe de ce ticket.
2. En utilisant un _faux GAR_, se générer un faux token d'authentification avec les mêmes nom et prénom que ceux de l'_organization learner_ et avec un _Saml ID_ (qui est le `externalIdentifier`) ayant une valeur particulière au choix (par exemple `abc123`)
3. Après la redirection automatique effectuée par le _faux GAR_ (_« Commencez votre parcours Pix, 
Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test, Je commence »_), participer à une campagne de cette organisation en entrant le code de campagne associé (par exemple `SCOBADGE1`)
4. Faire une réconciliation avec les mêmes nom, prénom (par exemple `Juliette`, `Dumoulin`) et date de naissance (par exemple  `11/11/2011`) que ceux de l'_organization learner_
5. Constater que les champs `authentication-methods.externalIdentifier` et `authentication-methods.authenticationComplement` ont respectivement les valeurs suivantes :

   ```
   abc123
   ```

   ```json
   {"firstName": "Juliette", "lastName": "Dumoulin"}
   ```
6. Modifier dans l'organisation le nom, prénom de l'_organization learner_ pour leur donner de nouvelles valeurs (par exemple `Julie`, `Dumoulin-Lemarchand`). On pourra utiliser le fichier `siecle-julie-2.xml` du fichier ZIP en pièce jointe de ce ticket.
7. En utilisant un faux GAR, se générer à nouveau un faux token d'authentification avec les mêmes valeurs pour le nom et le prénom que les nouvelles valeurs de ceux de l'_organization learner_ (par exemple `Julie`, `Dumoulin-Lemarchand`) et avec un _Saml ID_ (qui est le `externalIdentifier`) ayant une nouvelle valeur particulière au choix (par exemple `xyz789`)
8. Après la redirection automatique effectuée par le _faux GAR_ (_« Commencez votre parcours Pix, 
Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test, Je commence »_), participer à nouveau à une campagne de cette organisation en entrant le code de campagne associé (par exemple `SCOBADGE1`)
9. Faire à nouveau une réconciliation avec les nouvelles valeurs des nom et prénom de l'_organization learner_ (par exemple `Julie`, `Dumoulin-Lemarchand`) et toujours la même date de naissance  (par exemple  `11/11/2011`)
10. Constater que les champs `authentication-methods.externalIdentifier` et `authentication-methods.authenticationComplement` ont été mis à jour avec respectivement les valeurs suivantes :
   ```
   xyz789
   ```
   
   ```json
   {"firstName": "Julie", "lastName": "Dumoulin-Lemarchand"}
   ```
