### PR TITLE
[BUGFIX] Corriger la largeur du bouton "Je me connecte" de Pix Certif (PIX-8754).

### DIFF
--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -51,7 +51,7 @@
         </div>
       {{/if}}
 
-      <PixButton @type="submit">
+      <PixButton @type="submit" class="login-main-form__button">
         {{t "pages.login.actions.login.label"}}
       </PixButton>
 

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -8,7 +8,7 @@
     padding: 40px 60px;
   }
 
-  &__header { 
+  &__header {
     text-align: center;
   }
 
@@ -60,8 +60,7 @@
   }
 
   &__button {
-    margin-top: 8px;
-    font-size: 0.875rem;
+    width: 100%;
   }
 
   &__forgotten-password {


### PR DESCRIPTION
## :unicorn: Problème
Avec la dernière version de PixUI, le composant PixButton définit sa largeur en fonction de son contenu.
Ce comportement n'est pas celui désiré pour le bouton "Je me connecte" de la page de connexion.
Avec la montée de version sur Pix Certif, le bouton s'affiche désormais moins large que prévu.

## :robot: Proposition
On définit localement un style width: 100% pour le bouton de la page de connexion.

merci @HEYGUL pour l'info !


## :100: Pour tester
Aller sur Pix certif.
Constater que le bouton "Je me connecte" occupe toute la largeur du panneau.