### PR TITLE
[TECH] :sparkles: Détecter les  version de node dans les executors CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ executors:
   node-docker:
     parameters:
       node-version:
+        # renovate datasource=node-version depName=node
         default: 16.20.1
         type: string
     docker:
@@ -36,6 +37,7 @@ executors:
   node-redis-postgres-docker:
     parameters:
       node-version:
+        # renovate datasource=node-version depName=node
         default: 16.20.1
         type: string
     docker:
@@ -49,6 +51,7 @@ executors:
   node-browsers-docker:
     parameters:
       node-version:
+        # renovate datasource=node-version depName=node
         default: 16.20.1
         type: string
     docker:
@@ -59,6 +62,7 @@ executors:
   node-browsers-redis-postgres-docker:
     parameters:
       node-version:
+        # renovate datasource=node-version depName=node
         default: 16.20.1
         type: string
     docker:


### PR DESCRIPTION
## :unicorn: Problème

Avec la mise en place des executors, nous avons volontairement variabilisé les versions des images `cimg/node` dans des paramètres CircleCI. Renovate ne détecte donc plus la présence de ces dépendances dans le fichier 

## :robot: Proposition

Ajouter une configuration pour que renovate puisse détecter les versions de node (cf [configuration Renovate](https://github.com/1024pix/renovate-config/pull/24))

## :100: Pour tester

La configuration CircleCI a été testée ici : 
https://github.com/1024pix/pix-renovate-test/blob/d4f015f76e9fc88fdd260a1fe17f06a1da61b4e1/.circleci/config.yml#L31
Les PR crées sont : 
- https://github.com/1024pix/pix-renovate-test/pull/65
- https://github.com/1024pix/pix-renovate-test/pull/66
