### PR TITLE
[TECH] Refactoring des seeds certif (PIX-8547)

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -38,8 +38,8 @@ const buildCampaign = function ({
   }
 
   organizationId = _.isNil(organizationId) ? buildOrganization().id : organizationId;
-  creatorId = _.isUndefined(creatorId) ? buildUser().id : creatorId;
-  ownerId = _.isUndefined(ownerId) ? buildUser().id : ownerId;
+  creatorId = _.isUndefined(creatorId) ? buildUser({ firstName: 'campaignCreator' }).id : creatorId;
+  ownerId = _.isUndefined(ownerId) ? buildUser({ firstName: 'campaignOwner' }).id : ownerId;
   // Because of unicity constraint if no code is given we set the unique id as campaign code.
   code = _.isUndefined(code) ? id.toString() : code;
 

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -591,7 +591,7 @@ function _createDroit(databaseBuilder) {
     label: 'Pix+ Droit Expert',
     certificateMessage: null,
     temporaryCertificateMessage: null,
-    stickerUrl: 'https://images.pix.fr/stickers/macaron_PIX_DROIT_expert.pdf',
+    stickerUrl: 'https://images.pix.fr/stickers/macaron_droit_expert.pdf',
   });
 
   databaseBuilder.factory.buildBadge({
@@ -669,7 +669,7 @@ function _createDroit(databaseBuilder) {
     label: 'Pix+ Droit Initié',
     certificateMessage: null,
     temporaryCertificateMessage: null,
-    stickerUrl: 'https://images.pix.fr/stickers/macaron_PIX_DROIT_initie.pdf',
+    stickerUrl: 'https://images.pix.fr/stickers/macaron_droit_initie.pdf',
   });
 }
 

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -46,9 +46,10 @@ const PIX_EDU_1ER_DEGRE_FI_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 73;
 const PIX_EDU_1ER_DEGRE_FC_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 83;
 const PIX_EDU_2ND_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 74;
 const PIX_EDU_2ND_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 75;
-
+const COLLEGE_TAG_ID = 8;
 export {
   commonBuilder,
+  COLLEGE_TAG_ID,
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
@@ -107,7 +108,7 @@ function _createTags(databaseBuilder) {
   databaseBuilder.factory.buildTag({ id: 5, name: 'CFA' });
   databaseBuilder.factory.buildTag({ id: 6, name: 'AEFE' });
   databaseBuilder.factory.buildTag({ id: 7, name: 'MEDNUM' });
-  databaseBuilder.factory.buildTag({ id: 8, name: 'COLLEGE' });
+  databaseBuilder.factory.buildTag({ id: COLLEGE_TAG_ID, name: 'COLLEGE' });
   databaseBuilder.factory.buildTag({ id: 9, name: 'LYCEE' });
 }
 

--- a/api/db/seeds/data/common/tooling/organization-tooling.js
+++ b/api/db/seeds/data/common/tooling/organization-tooling.js
@@ -79,10 +79,6 @@ async function createOrganization({
     archivedBy,
     archivedAt,
     identityProviderForCampaigns,
-    adminUserId,
-    memberIds,
-    tagIds,
-    featureIds,
   });
 
   _buildMemberships({

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -590,7 +590,7 @@ async function _registerCandidatesToSession({
         userId = databaseBuilder.factory.buildUser.withRawPassword({
           firstName: `firstname${i}-${sessionId}`,
           lastName: `lastname${i}-${sessionId}`,
-          email: `firstname${i}-${sessionId}-lastname${i}-${sessionId}@example.net`,
+          email: _generateEmail({ sessionId, index: i }),
         }).id;
       }
 
@@ -608,7 +608,7 @@ async function _registerCandidatesToSession({
         birthINSEECode: '75115',
         birthCity: 'PARIS 15',
         birthCountry: 'France',
-        email: `firstname${i}-${sessionId}-lastname${i}-${sessionId}@example.net`,
+        email: _generateEmail({ sessionId, index: i }),
         birthdate: '2000-01-04',
         sessionId,
         createdAt: new Date(),
@@ -674,7 +674,7 @@ async function _registerSomeCandidatesToSession({ databaseBuilder, sessionId, co
       const userId = databaseBuilder.factory.buildUser.withRawPassword({
         firstName: `firstname${i}-${sessionId}`,
         lastName: `lastname${i}-${sessionId}`,
-        email: `firstname${i}-${sessionId}@example.net`,
+        email: _generateEmail({ sessionId, index: i }),
       }).id;
 
       const { billingMode: randomBillingMode, prepaymentCode: randomPrepaymentCode } =
@@ -691,7 +691,7 @@ async function _registerSomeCandidatesToSession({ databaseBuilder, sessionId, co
         birthINSEECode: '75115',
         birthCity: 'PARIS 15',
         birthCountry: 'France',
-        email: `firstname${i}-${sessionId}-lastname${i}-${sessionId}@example.net`,
+        email: _generateEmail({ sessionId, index: i }),
         birthdate: '2000-01-04',
         sessionId,
         createdAt: new Date(),
@@ -791,6 +791,10 @@ function _buildSession({
     supervisorPassword,
     version,
   });
+}
+
+function _generateEmail({ sessionId, index }) {
+  return `user-${index}-${sessionId}@example.net`;
 }
 
 async function _makeCandidatesCertifiable({ databaseBuilder, certificationCandidates, maxLevel = 7 }) {

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -1,4 +1,5 @@
 import * as tooling from '../common/tooling/index.js';
+import * as campaignTooling from '../common/tooling/campaign-tooling.js';
 
 import {
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
@@ -33,12 +34,19 @@ const DRAFT_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
 const PUBLISHED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 3;
 const V3_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 4;
 const PRO_STARTED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 5;
+const complementaryCertificationIds = [
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+];
 
 async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createScoOrganization({ databaseBuilder });
   await _createScoCertificationCenter({ databaseBuilder });
   await _createProOrganization({ databaseBuilder });
   await _createProCertificationCenter({ databaseBuilder });
+  await _createComplementaryCertificationCampaign({ databaseBuilder });
   await _createV3PilotCertificationCenter({ databaseBuilder });
   await _createSuccessCertifiableUser({ databaseBuilder });
   await _createScoSession({ databaseBuilder });
@@ -141,12 +149,7 @@ async function _createProCertificationCenter({ databaseBuilder }) {
     createdAt: new Date(),
     updatedAt: new Date(),
     memberIds: [PRO_CERTIFICATION_CENTER_USER_ID],
-    complementaryCertificationIds: [
-      CLEA_COMPLEMENTARY_CERTIFICATION_ID,
-      PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
-      PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-      PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    ],
+    complementaryCertificationIds,
   });
 }
 
@@ -381,4 +384,30 @@ async function _createProStartedSession({ databaseBuilder }) {
       hasComplementaryCertificationsToRegister: true,
     },
   });
+}
+
+async function _createComplementaryCertificationCampaign({ databaseBuilder }) {
+  for (const complementaryCertificationId of complementaryCertificationIds) {
+    const [targetProfileId] = await databaseBuilder
+      .knex('complementary-certification-badges')
+      .pluck('badges.targetProfileId')
+      .join('badges', 'badges.id', 'complementary-certification-badges.badgeId')
+      .where({ complementaryCertificationId });
+    const campaignCode = _createCodeCampaign(complementaryCertificationId);
+    await campaignTooling.createAssessmentCampaign({
+      databaseBuilder,
+      targetProfileId,
+      name: 'Campagne evaluation team-certif',
+      code: campaignCode,
+      title: 'Campagne evaluation team-certif',
+      configCampaign: {
+        participantCount: 0,
+      },
+    });
+  }
+}
+
+function _createCodeCampaign(complementaryCertificationId) {
+  const campaignCode = `${complementaryCertificationId}`.padStart(9, 'CERTIF_');
+  return campaignCode;
 }

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -3,6 +3,7 @@ import * as campaignTooling from '../common/tooling/campaign-tooling.js';
 
 import {
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  COLLEGE_TAG_ID,
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
@@ -181,6 +182,7 @@ async function _createScoOrganization({ databaseBuilder }) {
     configOrganization: {
       learnerCount: 8,
     },
+    tagIds: [COLLEGE_TAG_ID],
   });
 }
 

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -32,7 +32,7 @@ const SCO_PUBLISHED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 1;
 const DRAFT_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
 const PUBLISHED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 3;
 const V3_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 4;
-const STARTED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 5;
+const PRO_STARTED_SESSION_ID = TEAM_CERTIFICATION_OFFSET_ID + 5;
 
 async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createScoOrganization({ databaseBuilder });
@@ -46,7 +46,7 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createSession({ databaseBuilder });
   await _createV3Session({ databaseBuilder });
   await _createPublishedSession({ databaseBuilder });
-  await _createStartedSession({ databaseBuilder });
+  await _createProStartedSession({ databaseBuilder });
 }
 
 export { teamCertificationDataBuilder };
@@ -361,13 +361,13 @@ async function _createPublishedSession({ databaseBuilder }) {
   });
 }
 
-async function _createStartedSession({ databaseBuilder }) {
+async function _createProStartedSession({ databaseBuilder }) {
   await tooling.session.createStartedSession({
     databaseBuilder,
-    sessionId: STARTED_SESSION_ID,
-    accessCode: 'SCOS78',
-    address: '1 rue Certification pro',
-    certificationCenter: 'Centre de certification pro',
+    sessionId: PRO_STARTED_SESSION_ID,
+    accessCode: `PROS78`,
+    address: `1 rue Certification PRO`,
+    certificationCenter: `Centre de certification PRO`,
     certificationCenterId: PRO_CERTIFICATION_CENTER_ID,
     date: new Date(),
     description: 'une description',

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -265,6 +265,7 @@ async function _createPublishedScoSession({ databaseBuilder }) {
     juryCommentedAt: new Date(),
     configSession: {
       learnersToRegisterCount: 8,
+      maxLevel: 3,
     },
   });
 }
@@ -362,6 +363,7 @@ async function _createPublishedSession({ databaseBuilder }) {
     configSession: {
       candidatesToRegisterCount: 12,
       hasComplementaryCertificationsToRegister: true,
+      maxLevel: 3,
     },
   });
 }
@@ -384,6 +386,7 @@ async function _createProStartedSession({ databaseBuilder }) {
     configSession: {
       candidatesToRegisterCount: 12,
       hasComplementaryCertificationsToRegister: true,
+      maxLevel: 3,
     },
   });
 }

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -361,7 +361,7 @@ async function _createPublishedSession({ databaseBuilder }) {
     juryCommentAuthorId: null,
     juryCommentedAt: new Date(),
     configSession: {
-      candidatesToRegisterCount: 12,
+      candidatesToRegisterCount: 4,
       hasComplementaryCertificationsToRegister: true,
       maxLevel: 3,
     },
@@ -384,7 +384,7 @@ async function _createProStartedSession({ databaseBuilder }) {
     hasJoiningIssue: false,
     createdAt: new Date(),
     configSession: {
-      candidatesToRegisterCount: 12,
+      candidatesToRegisterCount: 6,
       hasComplementaryCertificationsToRegister: true,
       maxLevel: 3,
     },

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -112,7 +112,7 @@ async function _createAssessmentCampaign(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_PIX_ID,
     customResultPageText: 'customResultPageText',
     customResultPageButtonText: 'customResultPageButtonText',
-    customResultPageButtonUrl: 'customResultPageButtonUrl',
+    customResultPageButtonUrl: 'https://pix.fr/',
     multipleSendings: false,
     assessmentMethod: 'SMART_RANDOM',
     configCampaign: {

--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -142,7 +142,7 @@ async function createAssessmentCampaign(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_PIX_ID,
     customResultPageText: 'customResultPageText',
     customResultPageButtonText: 'customResultPageButtonText',
-    customResultPageButtonUrl: 'customResultPageButtonUrl',
+    customResultPageButtonUrl: 'https://pix.fr/',
     multipleSendings: false,
     assessmentMethod: 'SMART_RANDOM',
     configCampaign: {


### PR DESCRIPTION
## :unicorn: Problème
Les seeds certifs sont relativement et certaines données sont incorrectes

## :robot: Proposition
Reduire le nombre de donnees crees et corriger les problemes

## :rainbow: Remarques
- correction des liens pdf incorrectes des badges
- creation de 4 orga learners au lieu de 12
- MAJ des labels données pour etre plus explicites
- Relier les campagnes participation avec l'assessment
- vide customResultPageButtonUrl pour ne pas casser la page de fin de parcours
- Creer les campagnes de certification complementaire en amont (plutot qu'a chaque nouveau candidat)
- Ajoute le tag COLLEGE pour l'orga sco
- Ajoute un filtre pour un niveau max lors de la creation des competence utilisateurs

Avant (2 runs): 
- certif: 1:26.737 (m:ss.mmm)
-  certif: 1:20.541 (m:ss.mmm)

Apres (2 runs):
- certif: 26.052s
- certif: 27.171s

On passe d'environ 80 secondes à 30 secondes 🚀


## :100: Pour tester
Lancer les seeds, voir que ca tourne bien et jouer un peu avec les données pour s'assurer que rien n'est cassé 🥸
