### PR TITLE
[TECH] Ajouter un script pour mettre à jour l'attribut "identityProviderForCampaigns" d'une liste d'organisations (PIX-8433)

### DIFF
--- a/api/lib/domain/usecases/update-organization.js
+++ b/api/lib/domain/usecases/update-organization.js
@@ -1,0 +1,13 @@
+import { OrganizationNotFoundError } from '../errors.js';
+
+async function updateOrganization({ organization, organizationForAdminRepository }) {
+  const existingOrganization = await organizationForAdminRepository.get(organization.id);
+
+  if (!existingOrganization) {
+    throw new OrganizationNotFoundError();
+  }
+
+  return await organizationForAdminRepository.update(organization);
+}
+
+export { updateOrganization };

--- a/api/scripts/organization/update-organizations-identity-provider-for-campaigns.js
+++ b/api/scripts/organization/update-organizations-identity-provider-for-campaigns.js
@@ -1,0 +1,93 @@
+import { fileURLToPath } from 'node:url';
+
+import _ from 'lodash';
+import bluebird from 'bluebird';
+
+import { checkCsvHeader, parseCsvWithHeader } from '../helpers/csvHelpers.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+import { updateOrganization } from '../../lib/domain/usecases/update-organization.js';
+import * as organizationForAdminRepository from '../../lib/infrastructure/repositories/organization-for-admin-repository.js';
+
+const modulePath = fileURLToPath(import.meta.url);
+const IS_LAUNCHED_FROM_CLI = process.argv[1] === modulePath;
+
+async function main() {
+  console.time('Organisations identityProviderForCampaigns updated');
+  console.log('Starting updating organisation identityProviderForCampaigns...');
+
+  const filePath = process.argv[2];
+  await _updateOrganizationsProvinceCode(filePath);
+
+  console.timeEnd('Organisations identityProviderForCampaigns updated');
+}
+
+async function _updateOrganizationsProvinceCode(filePath) {
+  const errors = [];
+  const requiredFieldNames = ['organizationId', 'identityProviderForCampaigns'];
+  const csvParsingOptions = {
+    skipEmptyLines: true,
+    header: true,
+    transform: (value, columnName) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (!_.isEmpty(value)) {
+        if (columnName === 'organizationId') {
+          value = Number(value);
+        }
+      } else {
+        value = null;
+      }
+
+      return value;
+    },
+  };
+
+  console.log('Checking CSV header...');
+  await checkCsvHeader({ filePath, requiredFieldNames });
+  console.log('CSV header checked');
+
+  console.log('Parsing CSV data...');
+  const organizationsDTO = await parseCsvWithHeader(filePath, csvParsingOptions);
+  console.log('CSV data parsed');
+
+  console.log('Updating data...');
+  await bluebird.mapSeries(organizationsDTO, async (organizationDTO) => {
+    const organization = {
+      id: organizationDTO.organizationId,
+      identityProviderForCampaigns: organizationDTO.identityProviderForCampaigns,
+    };
+
+    try {
+      await updateOrganization({
+        organization,
+        organizationForAdminRepository,
+      });
+    } catch (error) {
+      errors.push({ organizationDTO, error });
+    }
+  });
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.log(`Errors occurs on ${errors.length} element!`);
+  errors.forEach((error) => {
+    console.log(JSON.stringify(error.organizationDTO));
+    console.error(error.error?.message);
+  });
+
+  throw new Error('Process done with errors');
+}
+
+if (IS_LAUNCHED_FROM_CLI) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}

--- a/api/tests/unit/domain/usecases/update-organization_test.js
+++ b/api/tests/unit/domain/usecases/update-organization_test.js
@@ -1,0 +1,45 @@
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { updateOrganization } from '../../../../lib/domain/usecases/update-organization.js';
+import { OrganizationNotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | UseCase | Update organization', function () {
+  context('when organization exists', function () {
+    context('when updating only "identityProviderForCampaigns" property', function () {
+      it('updates only "identityProviderForCampaigns" property and returns updated organization domain object', async function () {
+        // given
+        const organization = domainBuilder.buildOrganization();
+        const organizationForAdminRepository = {
+          get: sinon.stub().resolves({ ...organization }),
+          update: sinon.stub().resolves(),
+        };
+
+        // when
+        organization.identityProviderForCampaigns = 'NEW_IDENTITY_PROVIDER';
+        await updateOrganization({ organization, organizationForAdminRepository });
+
+        // then
+        expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organization.id);
+        expect(organizationForAdminRepository.update).to.have.been.calledWithMatch(organization);
+      });
+    });
+  });
+
+  context('when organization does not exists', function () {
+    it('throws an OrganizationNotFoundError', async function () {
+      // given
+      const organizationForAdminRepository = { get: sinon.stub().resolves(), update: sinon.stub().resolves() };
+      const organization = domainBuilder.buildOrganization();
+
+      // when
+      const error = await catchErr(updateOrganization)({
+        organization,
+        organizationForAdminRepository,
+      });
+
+      // then
+      expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organization.id);
+      expect(organizationForAdminRepository.update).to.not.have.been.called;
+      expect(error).to.be.an.instanceOf(OrganizationNotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous avons besoin d'un script pour mettre à jour l'attribut `identityProviderForCampaigns` d'une liste d'organisations.

## :robot: Proposition

Créer un script pour mettre à jour l'attribut `identityProviderForCampaigns` d'une liste d'organisations.

## :rainbow: Remarques

⚠️ Le fonctionnement de ce script est de continuer sur erreur, c'est à dire même s'il y a des erreurs pour certaines organisations. Aussi l'exécution du script ne doit pas être stoppée si une ou plusieurs erreurs surviennent durant l’exécution. La liste des erreurs est affichée à la fin de l’exécution du script de manière à pouvoir les corriger avant de lancer le script une nouvelle fois.

## :100: Pour tester

```csv
organizationId,identityProviderForCampaigns
1,GAR
2,GAR
3,GAR
4,GAR
5,GAR

```

- Récupérer la branche `pix-8433`
- Ouvrir un terminal
- Se déplacer dans le dossier `/api/scripts/organization`
- Créer un fichier CSV de test avec les données ci-dessus (il faudra peut être modifier l'identifiant des organisations)
- Exécuter le script avec la commande `node update-organizations-identity-provider-for-campaigns.js <votre-fichier-de-test>.csv`
- Constater que le script se termine avec succès
- Vérifier en base de données que les organisations ont bien une nouvelle valeur dans la colonne `identityProviderForCampaigns`
