### PR TITLE
[BUGFIX] Dans Pix Orga réparer le design cassé de l'affichage de la connexion Médiacentre dans la pop-up du compte de l'élève (PIX-8632)

### DIFF
--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.hbs
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.hbs
@@ -13,7 +13,7 @@
       <div>
         {{#if @student.isAuthenticatedFromGar}}
           <div class="manage-authentication-window__box">
-            <div class="manage-authentication-window__subTitle">
+            <div class="manage-authentication-window__subTitle manage-authentication-window__subTitle--mediacentre">
               <span>
                 {{t "pages.sco-organization-participants.manage-authentication-method-modal.section.mediacentre.label"}}
               </span>

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -108,7 +108,12 @@
   &__subTitle {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     margin-bottom: 16px;
+
+    &--mediacentre {
+      margin-bottom: 0;
+    }
 
     .green-icon {
       color: $pix-success-70;

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -8,7 +8,7 @@
     font-size: 1.125rem;
     font-weight: normal;
     color: $pix-neutral-90;
-    margin: 0px;
+    margin: 0;
   }
 
   label {
@@ -101,7 +101,7 @@
     }
 
     > .input-container {
-      margin-bottom: 0px;
+      margin-bottom: 0;
     }
   }
 

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   background-color: $pix-neutral-10;
-  padding: 24px;
+  padding: $pix-spacing-m;
 
   h6 {
     font-size: 1.125rem;
@@ -66,22 +66,22 @@
     color: $pix-neutral-0;
     flex-direction: column;
     font-size: .875rem;
-    padding-left: 16px;
+    padding-left: $pix-spacing-s;
 
     li {
-      margin: 4px 0;
+      margin: $pix-spacing-xxs 0;
     }
   }
 
   &__footer {
     background-color: $pix-neutral-70;
-    border-radius: 8px;
-    padding: 16px 24px;
-    margin-top: 16px;
+    border-radius: $pix-spacing-xs;
+    padding: $pix-spacing-s $pix-spacing-m;
+    margin-top: $pix-spacing-s;
 
     button {
       font-weight: 600;
-      margin-bottom: 16px;
+      margin-bottom: $pix-spacing-s;
     }
 
     label {
@@ -92,12 +92,12 @@
   &__box {
     background-color: $pix-neutral-0;
     border-radius: 8px;
-    margin-top: 16px;
-    padding: 16px 24px 16px 24px;
+    margin-top: $pix-spacing-s;
+    padding: $pix-spacing-s $pix-spacing-m;
 
     hr {
       color: $pix-neutral-22;
-      margin-bottom: 16px;
+      margin-bottom: $pix-spacing-s;
     }
 
     > .input-container {
@@ -109,7 +109,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 16px;
+    margin-bottom: $pix-spacing-s;
 
     &--mediacentre {
       margin-bottom: 0;


### PR DESCRIPTION
## :unicorn: Problème
Dans la pop-up de gestion du compte d'un élève, le texte de la connexion “Médiacentre” n’est plus centré à la verticale.

## :robot: Proposition
Utilisation d'un [sélecteur parent (&)](https://sass-lang.com/documentation/style-rules/parent-selector/#adding-suffixes) dans la class du sous-titre, pour ajouter un suffixe afin de suivre la convention BEM.

## :rainbow: Remarques
Petit refactor avec l'utilisation des espacements issus des design tokens de Pix.

## :100: Pour tester

1. **Se rendre sur Pix Orga (domaine fr)**
2. Se connecter avec un utilisateur administrateur d'une organisation, par exemple l'utilisateur `allorga@example.net`
3. Sélectionner une orga, par exemple le `Collège The Night Watch`
4. Se rendre dans l'onglet `Elèves`
5. Sélectionner un élève ayant, dans la colonne `Méthode(s) de connexion`, la valeur `Médiacentre` comme seule méthode de connexion
6. Cliquer sur les 3 petits points dans la colonne `Actions` de cet élève
7. Vérifier que `Médiacentre` est centré à la verticale
8. Retourner dans la liste des élèves
9. Cliquer sur les 3 petits points dans la colonne `Actions` d'un élève avec comme méthode de connexion `Adresse e-mail`
10. Vérifier qu'il n'y a pas de régressions
