### PR TITLE
[FEATURE] Créer les colonnes detachedAt et createdBy pour la table complementary-certification-badges (PIX-8745).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/history.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/history.hbs
@@ -25,7 +25,9 @@
                 </LinkTo>
               </td>
               <td>{{dayjs-format targetProfileHistory.attachedAt "DD/MM/YYYY"}}</td>
-              <td>TODO</td>
+              <td>
+                {{if targetProfileHistory.detachedAt (dayjs-format targetProfileHistory.detachedAt "DD/MM/YYYY") "-"}}
+              </td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/history_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/history_test.js
@@ -12,8 +12,13 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::H
     const store = this.owner.lookup('service:store');
     const complementaryCertification = store.createRecord('complementary-certification', {
       targetProfilesHistory: [
-        { id: 1023, name: 'Target Cascade', attachedAt: dayjs('2023-10-10T10:50:00Z') },
-        { id: 1025, name: 'Target Volcan', attachedAt: dayjs('2019-10-08T10:50:00Z') },
+        { id: 1023, name: 'Target Cascade', attachedAt: dayjs('2023-10-10T10:50:00Z'), detachedAt: null },
+        {
+          id: 1025,
+          name: 'Target Volcan',
+          attachedAt: dayjs('2019-10-08T10:50:00Z'),
+          detachedAt: dayjs('2020-10-08T10:50:00Z'),
+        },
       ],
     });
     this.targetProfilesHistory = complementaryCertification.targetProfilesHistory;
@@ -27,8 +32,8 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::H
     assert.dom(screen.getByRole('columnheader', { name: 'Nom du profil cible' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Date de rattachement' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Date de détachement' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Target Cascade 10/10/2023 TODO' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Target Volcan 08/10/2019 TODO' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Target Cascade 10/10/2023 -' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Target Volcan 08/10/2019 08/10/2020' })).exists();
     assert.dom(screen.getByRole('link', { name: 'Target Cascade' })).exists();
     assert.dom(screen.getByRole('link', { name: 'Target Volcan' })).exists();
   });

--- a/api/db/database-builder/factory/build-complementary-certification-badge.js
+++ b/api/db/database-builder/factory/build-complementary-certification-badge.js
@@ -14,6 +14,8 @@ const buildComplementaryCertificationBadge = function ({
   certificateMessage,
   temporaryCertificateMessage,
   stickerUrl = 'http://stiker-url.fr',
+  detachedAt = null,
+  createdBy,
 } = {}) {
   complementaryCertificationId = _.isNull(complementaryCertificationId)
     ? buildComplementaryCertification().id
@@ -31,6 +33,8 @@ const buildComplementaryCertificationBadge = function ({
     certificateMessage,
     temporaryCertificateMessage,
     stickerUrl,
+    detachedAt,
+    createdBy,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'complementary-certification-badges',

--- a/api/db/migrations/20230725115718_add_created_by_and_detached_at_in_complementary_certification_badges.js
+++ b/api/db/migrations/20230725115718_add_created_by_and_detached_at_in_complementary_certification_badges.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'complementary-certification-badges';
+const CREATED_BY_COLUMN = 'createdBy';
+const DETACHED_AT_COLUMN = 'detachedAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dateTime(DETACHED_AT_COLUMN).nullable();
+    table.integer(CREATED_BY_COLUMN).references('users.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(CREATED_BY_COLUMN);
+    table.dropColumn(DETACHED_AT_COLUMN);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -15,29 +15,35 @@ const PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 55;
 const REAL_PIX_SUPER_ADMIN_ID = 90000;
 
 // TARGET PROFILES
-const CLEA_TARGET_PROFILE_ID = 56;
+const CLEA_V1_TARGET_PROFILE_ID = 56;
+const CLEA_V2_TARGET_PROFILE_ID = 78;
 const PIX_DROIT_TARGET_PROFILE_ID = 59;
-const PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID = 66;
+const PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID = 66;
+const PIX_EDU_1ER_DEGRE_FC_TARGET_PROFILE_ID = 81;
 const PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID = 67;
 const PIX_PUBLIC_TARGET_PROFILE_ID = 76;
 
 // CERTIFIABLE BADGES
-const CLEA_CERTIFIABLE_BADGE_ID = 57;
+const CLEA_V1_CERTIFIABLE_BADGE_ID = 57;
+const CLEA_V2_CERTIFIABLE_BADGE_ID = 79;
 const PIX_DROIT_INITIE_CERTIFIABLE_BADGE_ID = 60;
 const PIX_DROIT_AVANCE_CERTIFIABLE_BADGE_ID = 61;
 const PIX_DROIT_EXPERT_CERTIFIABLE_BADGE_ID = 62;
-const PIX_EDU_1ER_DEGRE_INITIE_CERTIFIABLE_BADGE_ID = 68;
-const PIX_EDU_1ER_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID = 69;
+const PIX_EDU_1ER_DEGRE_FI_INITIE_CERTIFIABLE_BADGE_ID = 68;
+const PIX_EDU_1ER_DEGRE_FI_CONFIRME_CERTIFIABLE_BADGE_ID = 69;
+const PIX_EDU_1ER_DEGRE_FC_CONFIRME_CERTIFIABLE_BADGE_ID = 82;
 const PIX_EDU_2ND_DEGRE_INITIE_CERTIFIABLE_BADGE_ID = 70;
 const PIX_EDU_2ND_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID = 71;
 
 // COMPLEMENTARY CERTIFICATION BADGES
-const CLEA_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 58;
+const CLEA_V1_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 58;
+const CLEA_V2_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 80;
 const PIX_DROIT_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 63;
 const PIX_DROIT_AVANCE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 64;
 const PIX_DROIT_EXPERT_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 65;
-const PIX_EDU_1ER_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 72;
-const PIX_EDU_1ER_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 73;
+const PIX_EDU_1ER_DEGRE_FI_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 72;
+const PIX_EDU_1ER_DEGRE_FI_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 73;
+const PIX_EDU_1ER_DEGRE_FC_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 83;
 const PIX_EDU_2ND_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 74;
 const PIX_EDU_2ND_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID = 75;
 
@@ -47,24 +53,27 @@ export {
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-  CLEA_TARGET_PROFILE_ID,
+  CLEA_V1_TARGET_PROFILE_ID,
   PIX_DROIT_TARGET_PROFILE_ID,
-  PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID,
+  PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID,
+  PIX_EDU_1ER_DEGRE_FC_TARGET_PROFILE_ID,
   PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID,
-  CLEA_CERTIFIABLE_BADGE_ID,
+  CLEA_V1_CERTIFIABLE_BADGE_ID,
   PIX_DROIT_INITIE_CERTIFIABLE_BADGE_ID,
   PIX_DROIT_AVANCE_CERTIFIABLE_BADGE_ID,
   PIX_DROIT_EXPERT_CERTIFIABLE_BADGE_ID,
-  PIX_EDU_1ER_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
-  PIX_EDU_1ER_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
+  PIX_EDU_1ER_DEGRE_FI_INITIE_CERTIFIABLE_BADGE_ID,
+  PIX_EDU_1ER_DEGRE_FI_CONFIRME_CERTIFIABLE_BADGE_ID,
+  PIX_EDU_1ER_DEGRE_FC_CONFIRME_CERTIFIABLE_BADGE_ID,
   PIX_EDU_2ND_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
   PIX_EDU_2ND_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
-  CLEA_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+  CLEA_V1_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_DROIT_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_DROIT_AVANCE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_DROIT_EXPERT_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-  PIX_EDU_1ER_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-  PIX_EDU_1ER_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+  PIX_EDU_1ER_DEGRE_FI_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+  PIX_EDU_1ER_DEGRE_FI_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+  PIX_EDU_1ER_DEGRE_FC_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_2ND_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_2ND_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
 };
@@ -114,10 +123,20 @@ function _createClea(databaseBuilder) {
     id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildTargetProfile({
-    id: CLEA_TARGET_PROFILE_ID,
+    id: CLEA_V1_TARGET_PROFILE_ID,
     imageUrl: 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
     description: null,
-    name: 'Parcours complet CléA numérique',
+    name: 'Parcours complet CléA numérique V1',
+    isSimplifiedAccess: false,
+    category: 'PREDEFINED',
+    isPublic: true,
+  });
+
+  databaseBuilder.factory.buildTargetProfile({
+    id: CLEA_V2_TARGET_PROFILE_ID,
+    imageUrl: 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
+    description: null,
+    name: 'Parcours complet CléA numérique V2',
     isSimplifiedAccess: false,
     category: 'PREDEFINED',
     isPublic: true,
@@ -185,18 +204,31 @@ function _createClea(databaseBuilder) {
     { tubeId: 'recInPPTW79jkUbEY', level: 3 },
     { tubeId: 'rec6Ic2FdcxSRYkdn', level: 2 },
   ].map(({ tubeId, level }) => {
-    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: CLEA_TARGET_PROFILE_ID, tubeId, level });
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: CLEA_V1_TARGET_PROFILE_ID, tubeId, level });
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: CLEA_V2_TARGET_PROFILE_ID, tubeId, level });
   });
 
   databaseBuilder.factory.buildBadge({
-    id: CLEA_CERTIFIABLE_BADGE_ID,
-    targetProfileId: CLEA_TARGET_PROFILE_ID,
+    id: CLEA_V1_CERTIFIABLE_BADGE_ID,
+    targetProfileId: CLEA_V1_TARGET_PROFILE_ID,
     message:
       'Bravo ! Vous maîtrisez les compétences indispensables pour utiliser le numérique en milieu professionnel. Pour valoriser vos compétences avec une double certification Pix-CléA numérique, renseignez-vous auprès de votre conseiller ou de votre formateur.',
     altMessage: 'Prêt pour le CléA numérique',
-    key: badges.keys.PIX_EMPLOI_CLEA_V3,
+    key: badges.keys.PIX_EMPLOI_CLEA_V1,
     imageUrl: 'https://images.pix.fr/badges/Logos_badge_Prêt-CléA_Num NEW 2020.svg',
-    title: 'Prêt pour le CléA numérique',
+    title: 'Prêt pour le CléA numérique V1',
+    isCertifiable: true,
+    isAlwaysVisible: true,
+  });
+  databaseBuilder.factory.buildBadge({
+    id: CLEA_V2_CERTIFIABLE_BADGE_ID,
+    targetProfileId: CLEA_V2_TARGET_PROFILE_ID,
+    message:
+      'Bravo ! Vous maîtrisez les compétences indispensables pour utiliser le numérique en milieu professionnel. Pour valoriser vos compétences avec une double certification Pix-CléA numérique, renseignez-vous auprès de votre conseiller ou de votre formateur.',
+    altMessage: 'Prêt pour le CléA numérique',
+    key: badges.keys.PIX_EMPLOI_CLEA_V2,
+    imageUrl: 'https://images.pix.fr/badges/Logos_badge_Prêt-CléA_Num NEW 2020.svg',
+    title: 'Prêt pour le CléA numérique V2',
     isCertifiable: true,
     isAlwaysVisible: true,
   });
@@ -232,7 +264,14 @@ function _createClea(databaseBuilder) {
     },
   ].map(({ scope, threshold, cappedTubes, name }) => {
     databaseBuilder.factory.buildBadgeCriterion({
-      badgeId: CLEA_CERTIFIABLE_BADGE_ID,
+      badgeId: CLEA_V1_CERTIFIABLE_BADGE_ID,
+      scope,
+      threshold,
+      cappedTubes,
+      name,
+    });
+    databaseBuilder.factory.buildBadgeCriterion({
+      badgeId: CLEA_V2_CERTIFIABLE_BADGE_ID,
       scope,
       threshold,
       cappedTubes,
@@ -240,15 +279,31 @@ function _createClea(databaseBuilder) {
     });
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
-    id: CLEA_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-    badgeId: CLEA_CERTIFIABLE_BADGE_ID,
+    id: CLEA_V1_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+    badgeId: CLEA_V1_CERTIFIABLE_BADGE_ID,
     complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
     level: 4,
     imageUrl: 'https://images.pix.fr/badges/CleA_Num_certif.svg',
-    label: 'CléA Numérique',
+    label: 'CléA Numérique V1',
     certificateMessage: null,
     temporaryCertificateMessage: null,
     stickerUrl: 'https://images.pix.fr/stickers/macaron_clea.pdf',
+    createdAt: new Date('2020-01-01'),
+    detachedAt: new Date('2021-01-01'),
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
+  });
+  databaseBuilder.factory.buildComplementaryCertificationBadge({
+    id: CLEA_V2_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+    badgeId: CLEA_V2_CERTIFIABLE_BADGE_ID,
+    complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+    level: 4,
+    imageUrl: 'https://images.pix.fr/badges/CleA_Num_certif.svg',
+    label: 'CléA Numérique V2',
+    certificateMessage: null,
+    temporaryCertificateMessage: null,
+    stickerUrl: 'https://images.pix.fr/stickers/macaron_clea.pdf',
+    createdAt: new Date('2021-01-01'),
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 }
 
@@ -623,10 +678,19 @@ function _createPixEdu1erDegre(databaseBuilder) {
     id: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildTargetProfile({
-    id: PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID,
+    id: PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID,
     imageUrl: null,
     description: null,
-    name: '[Pix+Édu 1D FI] Prêt pour la certification du volet 1 (CRCN et CRCNÉ) 20 04 2023',
+    name: '[Pix+Édu 1D FI] Prêt pour la certification du volet 1',
+    isSimplifiedAccess: false,
+    category: 'PREDEFINED',
+    isPublic: true,
+  });
+  databaseBuilder.factory.buildTargetProfile({
+    id: PIX_EDU_1ER_DEGRE_FC_TARGET_PROFILE_ID,
+    imageUrl: null,
+    description: null,
+    name: '[Pix+Édu 1D FC] Prêt pour la certification du volet 1',
     isSimplifiedAccess: false,
     category: 'PREDEFINED',
     isPublic: true,
@@ -756,21 +820,39 @@ function _createPixEdu1erDegre(databaseBuilder) {
     { tubeId: 'tube26F5w4J602048x', level: 1 },
   ].map(({ tubeId, level }) => {
     databaseBuilder.factory.buildTargetProfileTube({
-      targetProfileId: PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID,
+      targetProfileId: PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID,
+      tubeId,
+      level,
+    });
+    databaseBuilder.factory.buildTargetProfileTube({
+      targetProfileId: PIX_EDU_1ER_DEGRE_FC_TARGET_PROFILE_ID,
       tubeId,
       level,
     });
   });
 
   databaseBuilder.factory.buildBadge({
-    id: PIX_EDU_1ER_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
-    targetProfileId: PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID,
+    id: PIX_EDU_1ER_DEGRE_FI_INITIE_CERTIFIABLE_BADGE_ID,
+    targetProfileId: PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID,
     message:
       'Félicitations ! Votre profil est prêt pour vous présenter à une certification Pix+Édu de niveau Initié (entrée dans le métier).',
-    altMessage: 'Pix+Édu niveau Initié (entrée dans le métier)',
+    altMessage: 'Pix+Édu FI niveau Initié (entrée dans le métier)',
     key: badges.keys.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
     imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-Initie-PREMIER-DEGRE.svg',
-    title: 'Pix+Édu niveau Initié (entrée dans le métier)',
+    title: 'Pix+Édu niveau Initié FI (entrée dans le métier)',
+    isCertifiable: true,
+    isAlwaysVisible: false,
+  });
+
+  databaseBuilder.factory.buildBadge({
+    id: PIX_EDU_1ER_DEGRE_FC_CONFIRME_CERTIFIABLE_BADGE_ID,
+    targetProfileId: PIX_EDU_1ER_DEGRE_FC_TARGET_PROFILE_ID,
+    message:
+      'Félicitations ! Votre profil est prêt pour vous présenter à une certification Pix+Édu de niveau Confirmé.',
+    altMessage: 'Pix+Édu FC niveau Confirmé',
+    key: badges.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
+    title: 'Pix+Édu FC niveau Confirmé',
     isCertifiable: true,
     isAlwaysVisible: false,
   });
@@ -792,7 +874,14 @@ function _createPixEdu1erDegre(databaseBuilder) {
     },
   ].map(({ scope, threshold, cappedTubes, name }) => {
     databaseBuilder.factory.buildBadgeCriterion({
-      badgeId: PIX_EDU_1ER_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
+      badgeId: PIX_EDU_1ER_DEGRE_FI_INITIE_CERTIFIABLE_BADGE_ID,
+      scope,
+      threshold,
+      cappedTubes,
+      name,
+    });
+    databaseBuilder.factory.buildBadgeCriterion({
+      badgeId: PIX_EDU_1ER_DEGRE_FC_CONFIRME_CERTIFIABLE_BADGE_ID,
       scope,
       threshold,
       cappedTubes,
@@ -801,24 +890,39 @@ function _createPixEdu1erDegre(databaseBuilder) {
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({
-    id: PIX_EDU_1ER_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-    badgeId: PIX_EDU_1ER_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
+    id: PIX_EDU_1ER_DEGRE_FI_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+    badgeId: PIX_EDU_1ER_DEGRE_FI_INITIE_CERTIFIABLE_BADGE_ID,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
     level: 1,
     imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Autonome_PREMIER-DEGRE.svg',
-    label: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
+    label: 'Pix+ Édu FI 1er degré Initié (entrée dans le métier)',
     certificateMessage: 'Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”',
     temporaryCertificateMessage:
       'Vous avez obtenu le niveau “Initié (entrée dans le métier)” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
     stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_1er_initie.pdf',
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
+  });
+
+  databaseBuilder.factory.buildComplementaryCertificationBadge({
+    id: PIX_EDU_1ER_DEGRE_FC_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+    badgeId: PIX_EDU_1ER_DEGRE_FC_CONFIRME_CERTIFIABLE_BADGE_ID,
+    complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    level: 1,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
+    label: 'Pix+ Édu FC 1er degré Confirmé',
+    certificateMessage: 'Vous avez obtenu la certification Pix+Édu niveau “Confirmé”',
+    temporaryCertificateMessage:
+      'Vous avez obtenu le niveau “Confirmé” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
+    stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_1er_confirme.pdf',
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 
   databaseBuilder.factory.buildBadge({
-    id: PIX_EDU_1ER_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
-    targetProfileId: PIX_EDU_1ER_DEGRE_TARGET_PROFILE_ID,
+    id: PIX_EDU_1ER_DEGRE_FI_CONFIRME_CERTIFIABLE_BADGE_ID,
+    targetProfileId: PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID,
     message:
       'Félicitations ! Votre profil est prêt pour vous présenter à une certification Pix+Édu de niveau Confirmé.',
-    altMessage: 'Pix+Édu niveau Confirmé',
+    altMessage: 'Pix+Édu FI niveau Confirmé',
     key: badges.keys.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
     imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-Confirme-PREMIER-DEGRE.svg',
     title: 'Pix+Édu niveau Confirmé',
@@ -843,7 +947,7 @@ function _createPixEdu1erDegre(databaseBuilder) {
     },
   ].map(({ scope, threshold, cappedTubes, name }) => {
     databaseBuilder.factory.buildBadgeCriterion({
-      badgeId: PIX_EDU_1ER_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
+      badgeId: PIX_EDU_1ER_DEGRE_FI_CONFIRME_CERTIFIABLE_BADGE_ID,
       scope,
       threshold,
       cappedTubes,
@@ -852,16 +956,17 @@ function _createPixEdu1erDegre(databaseBuilder) {
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({
-    id: PIX_EDU_1ER_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-    badgeId: PIX_EDU_1ER_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
+    id: PIX_EDU_1ER_DEGRE_FI_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+    badgeId: PIX_EDU_1ER_DEGRE_FI_CONFIRME_CERTIFIABLE_BADGE_ID,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
     level: 2,
     imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
-    label: 'Pix+ Édu 1er degré Confirmé',
+    label: 'Pix+ Édu FI 1er degré Confirmé',
     certificateMessage: 'Vous avez obtenu la certification Pix+Édu niveau “Confirmé”',
     temporaryCertificateMessage:
       'Vous avez obtenu le niveau “Confirmé” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
     stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_1er_confirme.pdf',
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 }
 
@@ -1056,6 +1161,7 @@ function _createPixEdu2ndDegre(databaseBuilder) {
     temporaryCertificateMessage:
       'Vous avez obtenu le niveau “Initié (entrée dans le métier)” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
     stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_2nd_initie.pdf',
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 
   databaseBuilder.factory.buildBadge({
@@ -1107,6 +1213,7 @@ function _createPixEdu2ndDegre(databaseBuilder) {
     temporaryCertificateMessage:
       'Vous avez obtenu le niveau “Confirmé” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
     stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_2nd_confirme.pdf',
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 }
 

--- a/api/lib/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
@@ -8,6 +8,7 @@ const getByComplementaryCertificationId = async function ({ complementaryCertifi
       name: 'target-profiles.name',
     })
     .max('complementary-certification-badges.createdAt', { as: 'attachedAt' })
+    .max('complementary-certification-badges.detachedAt', { as: 'detachedAt' })
     .leftJoin('badges', 'badges.id', 'complementary-certification-badges.badgeId')
     .leftJoin('target-profiles', 'target-profiles.id', 'badges.targetProfileId')
     .groupBy('target-profiles.id')

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -151,6 +151,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
                 id: 999,
                 name: 'Target',
                 attachedAt,
+                detachedAt: null,
               },
             ],
           },

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-target-profile-history-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-target-profile-history-repository_test.js
@@ -42,6 +42,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
         createdAt: new Date('2020-10-10'),
         label: 'oldBadge',
         level: 1,
+        detachedAt: new Date('2021-10-10'),
       });
 
       await databaseBuilder.commit();
@@ -58,8 +59,8 @@ describe('Integration | Repository | complementary-certification-target-profile-
           key: 'EDU_2ND_DEGRE',
           label: 'Pix+ Édu 2nd degré',
           targetProfilesHistory: [
-            { id: 999, name: 'currentTarget', attachedAt: new Date('2023-10-10') },
-            { id: 222, name: 'oldTarget', attachedAt: new Date('2020-10-10') },
+            { id: 999, name: 'currentTarget', attachedAt: new Date('2023-10-10'), detachedAt: null },
+            { id: 222, name: 'oldTarget', attachedAt: new Date('2020-10-10'), detachedAt: new Date('2021-10-10') },
           ],
           currentTargetProfileBadges: [
             {
@@ -83,6 +84,7 @@ function _createComplementaryCertificationBadge({
   targetProfileId,
   complementaryCertificationId,
   createdAt,
+  detachedAt,
   label,
   level,
 }) {
@@ -95,6 +97,7 @@ function _createComplementaryCertificationBadge({
     badgeId,
     complementaryCertificationId,
     createdAt,
+    detachedAt,
     label,
     level,
   });


### PR DESCRIPTION
## :unicorn: Problème
Le versioning des profils cibles et des résultats thématiques certifiants doit permettre d’assurer la pérennité des certifications complémentaires Pix en conservant un historique des différentes versions de profil cible et de RT certifiants sur lesquels elles sont basées.

Or elle n'existe pas pour le moment sur Pix Admin.

L'implémentation est pour le moment protégée par un feature toggle (implémenté par https://github.com/1024pix/pix/pull/6573).

## :robot: Proposition
Création des colonnes `detachedAt` et `createdBy` pour la table `complementary-certification-badges`
Afficher de la date de détachement dans l'historique des profil cibles.

## :rainbow: Remarques
Les seeds ont été mis à jour pour que chaque certif complémentaire ai un target profile courant et que les autres soient détachés (A potentiellement re modifier suite à l'échange de ce matin (1 complementary certification =/= 1 target profile)

## :100: Pour tester

- Sur PixAdmin avec le compte superadmin@example.net
- Cliquer sur l'icône dans le menu latéral nommé "certifications complémentaire" (icône tampon)
- Cliquer sur un des liens
- Constater que le troisième bloc contient les dates de détachement, le courant n'en à pas.
- (Exemple du CLEA, la V2 est la courante, les autres sont détachés (V1))

