### PR TITLE
[TECH] Utiliser le référentiel pour définir le statut d'une compétence (PIX-8747) 

### DIFF
--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -163,10 +163,28 @@ function _getScorecardStatus(knowledgeElements, skills) {
   if (_.isEmpty(knowledgeElements)) {
     return statuses.NOT_STARTED;
   }
-  const skillIds = skills.map((skill) => skill.id);
-  const knowledgeElementSkillIds = knowledgeElements.map((ke) => ke.skillId);
-  const remainingSkillIds = _.differenceBy(skillIds, knowledgeElementSkillIds);
-  return _.isEmpty(remainingSkillIds) ? statuses.COMPLETED : statuses.STARTED;
+
+  const knowledgeElementActiveSkillIds = [];
+  const remainingSkillIds = [];
+
+  skills.forEach((skill) => {
+    const isSkillAcquired = knowledgeElements.find((ke) => ke.skillId === skill.id);
+
+    isSkillAcquired ? knowledgeElementActiveSkillIds.push(skill) : remainingSkillIds.push(skill);
+  });
+
+  if (_.isEmpty(knowledgeElementActiveSkillIds)) {
+    return statuses.STARTED;
+  }
+
+  if (!_.isEmpty(remainingSkillIds)) {
+    const { difficulty: maxDifficultyReached } = _.maxBy(knowledgeElementActiveSkillIds, 'difficulty');
+    const { difficulty: maxDifficultyRemaining } = _.maxBy(remainingSkillIds, 'difficulty');
+
+    return maxDifficultyReached > maxDifficultyRemaining ? statuses.COMPLETED : statuses.STARTED;
+  }
+
+  return statuses.COMPLETED;
 }
 
 Scorecard.statuses = statuses;

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -59,7 +59,7 @@ class Scorecard {
     knowledgeElements,
     competence,
     area,
-    skills,
+    hasAssessmentEnded,
     allowExcessPix = false,
     allowExcessLevel = false,
   }) {
@@ -82,7 +82,7 @@ class Scorecard {
       exactlyEarnedPix: realTotalPixScoreForCompetence,
       level: currentLevel,
       pixScoreAheadOfNextLevel: pixAheadForNextLevel,
-      status: _getScorecardStatus(knowledgeElements, skills),
+      status: _getScorecardStatus(knowledgeElements, hasAssessmentEnded),
       remainingDaysBeforeReset,
       remainingDaysBeforeImproving,
     });
@@ -159,32 +159,12 @@ class Scorecard {
   }
 }
 
-function _getScorecardStatus(knowledgeElements, skills) {
+function _getScorecardStatus(knowledgeElements, hasAssessmentEnded) {
   if (_.isEmpty(knowledgeElements)) {
     return statuses.NOT_STARTED;
   }
 
-  const knowledgeElementActiveSkillIds = [];
-  const remainingSkillIds = [];
-
-  skills.forEach((skill) => {
-    const isSkillAcquired = knowledgeElements.find((ke) => ke.skillId === skill.id);
-
-    isSkillAcquired ? knowledgeElementActiveSkillIds.push(skill) : remainingSkillIds.push(skill);
-  });
-
-  if (_.isEmpty(knowledgeElementActiveSkillIds)) {
-    return statuses.STARTED;
-  }
-
-  if (!_.isEmpty(remainingSkillIds)) {
-    const { difficulty: maxDifficultyReached } = _.maxBy(knowledgeElementActiveSkillIds, 'difficulty');
-    const { difficulty: maxDifficultyRemaining } = _.maxBy(remainingSkillIds, 'difficulty');
-
-    return maxDifficultyReached > maxDifficultyRemaining ? statuses.COMPLETED : statuses.STARTED;
-  }
-
-  return statuses.COMPLETED;
+  return hasAssessmentEnded ? statuses.COMPLETED : statuses.STARTED;
 }
 
 Scorecard.statuses = statuses;

--- a/api/lib/domain/read-models/SharedProfileForCampaign.js
+++ b/api/lib/domain/read-models/SharedProfileForCampaign.js
@@ -15,11 +15,18 @@ class SharedProfileForCampaign {
     allAreas,
     maxReachableLevel,
     maxReachablePixScore,
+    allSkills,
   }) {
     this.id = campaignParticipation?.id;
     this.sharedAt = campaignParticipation?.sharedAt;
     this.pixScore = campaignParticipation?.pixScore || 0;
-    this.scorecards = this._buildScorecards(userId, competences, allAreas, knowledgeElementsGroupedByCompetenceId);
+    this.scorecards = this._buildScorecards(
+      userId,
+      competences,
+      allAreas,
+      knowledgeElementsGroupedByCompetenceId,
+      allSkills,
+    );
     this.canRetry = this._computeCanRetry(
       campaignAllowsRetry,
       this.sharedAt,
@@ -30,18 +37,20 @@ class SharedProfileForCampaign {
     this.maxReachablePixScore = maxReachablePixScore;
   }
 
-  _buildScorecards(userId, competences, allAreas, knowledgeElementsGroupedByCompetenceId) {
+  _buildScorecards(userId, competences, allAreas, knowledgeElementsGroupedByCompetenceId, allSkills) {
     if (isEmpty(knowledgeElementsGroupedByCompetenceId)) return [];
     return map(competences, (competence) => {
       const competenceId = competence.id;
       const area = allAreas.find((area) => area.id === competence.areaId);
       const knowledgeElements = knowledgeElementsGroupedByCompetenceId[competenceId];
+      const skills = allSkills.filter((skill) => skill.competenceId === competenceId);
 
       return Scorecard.buildFrom({
         userId,
         knowledgeElements,
         competence,
         area,
+        skills,
       });
     });
   }

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -76,6 +76,31 @@ async function fetchForCompetenceEvaluations({
   };
 }
 
+async function fetchForCompetenceEvaluationsByCompetenceId({
+  competenceId,
+  answerRepository,
+  challengeRepository,
+  knowledgeElementRepository,
+  skillRepository,
+  improvementService,
+}) {
+  const [allAnswers, targetSkills, challenges] = await Promise.all([
+    answerRepository.findByCompetenceId(competenceId),
+    skillRepository.findActiveByCompetenceId(competenceId),
+    challengeRepository.findValidatedByCompetenceId(competenceId),
+  ]);
+
+  const ke = await _fetchKnowledgeElements({ assessment, knowledgeElementRepository, improvementService });
+
+  return {
+    allAnswers,
+    lastAnswer: _.isEmpty(allAnswers) ? null : _.last(allAnswers),
+    targetSkills,
+    challenges,
+    knowledgeElements,
+  };
+}
+
 async function fetchForFlashCampaigns({
   assessmentId,
   answerRepository,

--- a/api/lib/domain/services/algorithm-methods/smart-random.js
+++ b/api/lib/domain/services/algorithm-methods/smart-random.js
@@ -3,7 +3,7 @@ import * as catAlgorithm from './cat-algorithm.js';
 import { getFilteredSkillsForNextChallenge, getFilteredSkillsForFirstChallenge } from './skills-filter.js';
 import { computeTubesFromSkills } from './../tube-service.js';
 
-export { getPossibleSkillsForNextChallenge };
+export { getPossibleSkillsForNextChallenge, findAnyChallenge };
 
 function getPossibleSkillsForNextChallenge({
   knowledgeElements,
@@ -25,7 +25,7 @@ function getPossibleSkillsForNextChallenge({
   // First challenge has specific rules
   const { possibleSkillsForNextChallenge, levelEstimated } = isUserStartingTheTest
     ? _findFirstChallenge({ knowledgeElements: knowledgeElementsOfTargetSkills, targetSkills, tubes })
-    : _findAnyChallenge({
+    : findAnyChallenge({
         knowledgeElements: knowledgeElementsOfTargetSkills,
         targetSkills,
         tubes,
@@ -54,7 +54,7 @@ function _filterSkillsByChallenges(skills, challenges) {
   return skillsWithChallenges;
 }
 
-function _findAnyChallenge({ knowledgeElements, targetSkills, tubes, isLastChallengeTimed }) {
+function findAnyChallenge({ knowledgeElements, targetSkills, tubes, isLastChallengeTimed }) {
   const predictedLevel = catAlgorithm.getPredictedLevel(knowledgeElements, targetSkills);
   const availableSkills = getFilteredSkillsForNextChallenge({
     knowledgeElements,

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -11,6 +11,8 @@ async function computeScorecard({
   areaRepository,
   skillRepository,
   knowledgeElementRepository,
+  smartRandom,
+  tubeRepository,
   allowExcessPix = false,
   allowExcessLevel = false,
   locale,
@@ -20,11 +22,22 @@ async function computeScorecard({
     competenceRepository.get({ id: competenceId, locale }),
     skillRepository.findOperativeByCompetenceId(competenceId),
   ]);
+
+  const tubeIds = skills.map((skill) => skill.tubeId);
+  const tubes = await tubeRepository.findByRecordIds(_.uniq(tubeIds), locale);
+
+  const { possibleSkillsForNextChallenge } = smartRandom.findAnyChallenge({
+    knowledgeElements,
+    targetSkills: skills,
+    tubes,
+    isLastChallengeTimed: false,
+  });
+
   const area = await areaRepository.get({ id: competence.areaId, locale });
   return Scorecard.buildFrom({
     userId,
     knowledgeElements,
-    skills,
+    hasAssessmentEnded: _.isEmpty(possibleSkillsForNextChallenge),
     competence,
     area,
     allowExcessPix,

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -9,23 +9,22 @@ async function computeScorecard({
   competenceId,
   competenceRepository,
   areaRepository,
-  competenceEvaluationRepository,
+  skillRepository,
   knowledgeElementRepository,
   allowExcessPix = false,
   allowExcessLevel = false,
   locale,
 }) {
-  const [knowledgeElements, competence, competenceEvaluations] = await Promise.all([
+  const [knowledgeElements, competence, skills] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId }),
     competenceRepository.get({ id: competenceId, locale }),
-    competenceEvaluationRepository.findByUserId(userId),
+    skillRepository.findOperativeByCompetenceId(competenceId),
   ]);
-  const competenceEvaluation = _.find(competenceEvaluations, { competenceId: competence.id });
   const area = await areaRepository.get({ id: competence.areaId, locale });
   return Scorecard.buildFrom({
     userId,
     knowledgeElements,
-    competenceEvaluation,
+    skills,
     competence,
     area,
     allowExcessPix,

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,8 +1,8 @@
 import {
-  ForbiddenAccess,
-  ChallengeNotAskedError,
-  CertificationEndedBySupervisorError,
   CertificationEndedByFinalizationError,
+  CertificationEndedBySupervisorError,
+  ChallengeNotAskedError,
+  ForbiddenAccess,
 } from '../errors.js';
 
 import { Examiner } from '../models/Examiner.js';
@@ -19,7 +19,6 @@ const correctAnswerThenUpdateAssessment = async function ({
   challengeRepository,
   scorecardService,
   competenceRepository,
-  competenceEvaluationRepository,
   skillRepository,
   campaignRepository,
   knowledgeElementRepository,
@@ -56,7 +55,7 @@ const correctAnswerThenUpdateAssessment = async function ({
       competenceId: challenge.competenceId,
       areaRepository,
       competenceRepository,
-      competenceEvaluationRepository,
+      skillRepository,
       knowledgeElementRepository,
       locale,
     });
@@ -92,7 +91,7 @@ const correctAnswerThenUpdateAssessment = async function ({
     competenceId: challenge.competenceId,
     areaRepository,
     competenceRepository,
-    competenceEvaluationRepository,
+    skillRepository,
     knowledgeElementRepository,
     scorecardBeforeAnswer,
     locale,
@@ -187,7 +186,7 @@ async function _addLevelUpInformation({
   competenceId,
   competenceRepository,
   areaRepository,
-  competenceEvaluationRepository,
+  skillRepository,
   knowledgeElementRepository,
   scorecardBeforeAnswer,
   locale,
@@ -203,7 +202,7 @@ async function _addLevelUpInformation({
     competenceId,
     competenceRepository,
     areaRepository,
-    competenceEvaluationRepository,
+    skillRepository,
     knowledgeElementRepository,
     locale,
   });

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -8,6 +8,8 @@ const getScorecard = async function ({
   competenceRepository,
   areaRepository,
   skillRepository,
+  tubeRepository,
+  smartRandom,
   knowledgeElementRepository,
   locale,
 }) {
@@ -23,6 +25,8 @@ const getScorecard = async function ({
     competenceRepository,
     areaRepository,
     skillRepository,
+    tubeRepository,
+    smartRandom,
     knowledgeElementRepository,
     locale,
   });

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -7,7 +7,7 @@ const getScorecard = async function ({
   scorecardService,
   competenceRepository,
   areaRepository,
-  competenceEvaluationRepository,
+  skillRepository,
   knowledgeElementRepository,
   locale,
 }) {
@@ -22,7 +22,7 @@ const getScorecard = async function ({
     competenceId,
     competenceRepository,
     areaRepository,
-    competenceEvaluationRepository,
+    skillRepository,
     knowledgeElementRepository,
     locale,
   });

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -11,6 +11,7 @@ const getUserProfileSharedForCampaign = async function ({
   competenceRepository,
   areaRepository,
   organizationLearnerRepository,
+  skillRepository,
   locale,
 }) {
   const campaignParticipation = await campaignParticipationRepository.findOneByCampaignIdAndUserId({
@@ -26,6 +27,7 @@ const getUserProfileSharedForCampaign = async function ({
     { multipleSendings: campaignAllowsRetry },
     isOrganizationLearnerActive,
     knowledgeElementsGroupedByCompetenceId,
+    allSkills,
   ] = await Promise.all([
     campaignRepository.get(campaignId),
     organizationLearnerRepository.isActive({ campaignId, userId }),
@@ -33,6 +35,7 @@ const getUserProfileSharedForCampaign = async function ({
       userId,
       limitDate: campaignParticipation.sharedAt,
     }),
+    skillRepository.list(),
   ]);
   const competences = await competenceRepository.listPixCompetencesOnly({ locale });
   const allAreas = await areaRepository.list({ locale });
@@ -47,6 +50,7 @@ const getUserProfileSharedForCampaign = async function ({
     knowledgeElementsGroupedByCompetenceId,
     userId,
     allAreas,
+    allSkills,
     maxReachableLevel,
     maxReachablePixScore,
   });

--- a/api/lib/domain/usecases/get-user-profile.js
+++ b/api/lib/domain/usecases/get-user-profile.js
@@ -6,28 +6,28 @@ const getUserProfile = async function ({
   userId,
   competenceRepository,
   areaRepository,
-  competenceEvaluationRepository,
+  skillRepository,
   knowledgeElementRepository,
   locale,
 }) {
-  const [knowledgeElementsGroupedByCompetenceId, competences, competenceEvaluations] = await Promise.all([
+  const [knowledgeElementsGroupedByCompetenceId, competences, skills] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId }),
     competenceRepository.listPixCompetencesOnly({ locale }),
-    competenceEvaluationRepository.findByUserId(userId),
+    skillRepository.list(),
   ]);
   const allAreas = await areaRepository.list({ locale });
 
   const scorecards = _.map(competences, (competence) => {
     const competenceId = competence.id;
     const knowledgeElementsForCompetence = knowledgeElementsGroupedByCompetenceId[competenceId];
-    const competenceEvaluation = _.find(competenceEvaluations, { competenceId });
+    const competenceSkills = skills.filter((skill) => skill.competenceId === competenceId);
     const area = allAreas.find((area) => area.id === competence.areaId);
     return Scorecard.buildFrom({
       userId,
       knowledgeElements: knowledgeElementsForCompetence,
       competence,
       area,
-      competenceEvaluation,
+      skills: competenceSkills,
     });
   });
 

--- a/api/lib/domain/usecases/reset-scorecard.js
+++ b/api/lib/domain/usecases/reset-scorecard.js
@@ -13,6 +13,7 @@ const resetScorecard = async function ({
   assessmentRepository,
   campaignParticipationRepository,
   campaignRepository,
+  skillRepository,
   locale,
 }) {
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
@@ -52,7 +53,7 @@ const resetScorecard = async function ({
     competenceId,
     competenceRepository,
     areaRepository,
-    competenceEvaluationRepository,
+    skillRepository,
     knowledgeElementRepository,
     locale,
   });

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -38,14 +38,14 @@ function _toDomainArray(answerDTOs) {
 }
 
 const COLUMNS = Object.freeze([
-  'id',
-  'result',
-  'resultDetails',
-  'timeout',
-  'value',
-  'assessmentId',
-  'challengeId',
-  'timeSpent',
+  'answers.id',
+  'answers.result',
+  'answers.resultDetails',
+  'answers.timeout',
+  'answers.value',
+  'answers.assessmentId',
+  'answers.challengeId',
+  'answers.timeSpent',
 ]);
 
 const get = async function (id) {
@@ -81,6 +81,21 @@ const findByChallengeAndAssessment = async function ({ challengeId, assessmentId
 
 const findByAssessment = async function (assessmentId) {
   const answerDTOs = await knex.select(COLUMNS).from('answers').where({ assessmentId }).orderBy('createdAt');
+  const answerDTOsWithoutDuplicate = _.uniqBy(answerDTOs, 'challengeId');
+
+  return _toDomainArray(answerDTOsWithoutDuplicate);
+};
+
+const findByCompetenceId = async function (competenceId) {
+  const answerDTOs = await knex
+    .select(COLUMNS)
+    .from('answers')
+    .join('assessments', function () {
+      this.on('assessments.id', 'answers.assessmentId')
+        .andOn('assessments.competenceId', competenceId)
+        .andOn('assessments.type', 'COMPETENCE_EVALUATION');
+    })
+    .orderBy('createdAt');
   const answerDTOsWithoutDuplicate = _.uniqBy(answerDTOs, 'challengeId');
 
   return _toDomainArray(answerDTOsWithoutDuplicate);
@@ -131,6 +146,7 @@ export {
   findByIds,
   findByChallengeAndAssessment,
   findByAssessment,
+  findByCompetenceId,
   findLastByAssessment,
   findChallengeIdsFromAnswerIds,
   saveWithKnowledgeElements,

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
@@ -16,6 +16,8 @@ describe('Acceptance | Controller | users-controller-get-user-profile-for-admin'
 
   const skillWeb1Id = 'recAcquisWeb1';
   const skillWeb1Name = '@web1';
+  const skillWeb2Id = 'recAcquisWeb2';
+  const skillWeb2Name = '@web2';
 
   const competenceId = 'recCompetence';
 
@@ -50,7 +52,13 @@ describe('Acceptance | Controller | users-controller-get-user-profile-for-admin'
         id: skillWeb1Id,
         name: skillWeb1Name,
         status: 'actif',
-        competenceId: competenceId,
+        competenceId,
+      },
+      {
+        id: skillWeb2Id,
+        name: skillWeb2Name,
+        status: 'actif',
+        competenceId,
       },
     ],
   };
@@ -103,15 +111,11 @@ describe('Acceptance | Controller | users-controller-get-user-profile-for-admin'
 
         knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
           userId,
-          competenceId: competenceId,
+          competenceId,
+          skillId: skillWeb1Id,
         });
 
-        const assessmentId = databaseBuilder.factory.buildAssessment({ state: 'started' }).id;
-        databaseBuilder.factory.buildCompetenceEvaluation({
-          userId,
-          assessmentId,
-          competenceId: competenceId,
-        });
+        databaseBuilder.factory.buildAssessment({ state: 'started' });
 
         await databaseBuilder.commit();
       });

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
@@ -53,12 +53,14 @@ describe('Acceptance | Controller | users-controller-get-user-profile-for-admin'
         name: skillWeb1Name,
         status: 'actif',
         competenceId,
+        level: 1,
       },
       {
         id: skillWeb2Id,
         name: skillWeb2Name,
         status: 'actif',
         competenceId,
+        level: 2,
       },
     ],
   };

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -45,6 +45,12 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
         areaId: 'recvoGdo7z2z7pXWa',
       },
     ],
+    skills: [
+      {
+        id: 'skillId',
+        competenceId,
+      },
+    ],
   };
 
   beforeEach(async function () {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -12,6 +12,8 @@ describe('Unit | Domain | Models | Scorecard', function () {
 
   describe('#buildFrom', function () {
     let actualScorecard;
+    let skills;
+    let knowledgeElements;
 
     const userId = '123';
     const area = { id: 'area' };
@@ -26,8 +28,8 @@ describe('Unit | Domain | Models | Scorecard', function () {
       // given
       const firstSkillId = Symbol('first skill id');
       const secondSkillId = Symbol('second skill id');
-      const skills = [{ id: firstSkillId }, { id: secondSkillId }];
-      const knowledgeElements = [
+      skills = [{ id: firstSkillId }, { id: secondSkillId }];
+      knowledgeElements = [
         { earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId },
         {
           earnedPix: 3.6,
@@ -36,152 +38,218 @@ describe('Unit | Domain | Models | Scorecard', function () {
         },
       ];
       computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-      // when
-      actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
     });
-    // then
-    it('should build an object of Scorecard type', function () {
-      expect(actualScorecard).to.be.instanceOf(Scorecard);
-    });
-    it('should build a scorecard id from a combination of userId and competenceId', function () {
-      expect(actualScorecard.id).to.equal(userId + '_' + competence.id);
-    });
-    it('should competence datas to the scorecard object', function () {
-      expect(actualScorecard.name).to.equal(competence.name);
-      expect(actualScorecard.competenceId).to.equal(competence.id);
-      expect(actualScorecard.area).to.deep.equal(area);
-      expect(actualScorecard.index).to.equal(competence.index);
-      expect(actualScorecard.description).to.equal(competence.description);
-    });
-    it('should have earned pix as a rounded sum of all knowledge elements earned pixes', function () {
-      expect(actualScorecard.earnedPix).to.equal(9);
-    });
-
-    it('should have exactly earned pix as a sum of all knowledge elements earned pixes', function () {
-      expect(actualScorecard.exactlyEarnedPix).to.equal(9.1);
-    });
-
-    it('should have a level computed from the number of pixes', function () {
-      expect(actualScorecard.earnedPix).to.equal(9);
-    });
-    it('should have set the number of pix ahead of the next level', function () {
-      expect(actualScorecard.pixScoreAheadOfNextLevel).to.equal(1);
-    });
-    it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', function () {
-      expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
-    });
-    it('should have set the scorecard remainingDaysBeforeImproving based on last knowledge element date', function () {
-      expect(actualScorecard.remainingDaysBeforeImproving).to.equal(4);
-    });
-
-    it('should return STARTED when some skills correspond to the knowledge elements', function () {
-      const firstSkillId = Symbol('first skill id');
-      const secondSkillId = Symbol('second skill id');
-      const skills = [{ id: firstSkillId }, { id: secondSkillId }];
-      const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId }];
-
-      //when
-      actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
-
-      //then
-      expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
-    });
-
-    it('should return COMPLETED when all the skills correspond to the knowledge elements', function () {
-      const firstSkillId = Symbol('first skill id');
-      const secondSkillId = Symbol('second skill id');
-      const thirdSkillId = Symbol('third skill id');
-      const skills = [{ id: firstSkillId }, { id: secondSkillId }];
-      const knowledgeElements = [
-        { earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId },
-        { earnedPix: 5.5, createdAt: new Date(), skillId: secondSkillId },
-        { earnedPix: 5.5, createdAt: new Date(), skillId: thirdSkillId },
-      ];
-
-      //when
-      actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
-
-      //then
-      expect(actualScorecard.status).to.equal(Scorecard.statuses.COMPLETED);
-    });
-
-    context('when the user level is beyond the upper limit allowed', function () {
-      let skills;
-      let knowledgeElements;
-      beforeEach(function () {
-        // given
-        const firstSkillId = Symbol('first skill id');
-        const secondSkillId = Symbol('second skill id');
-        skills = [{ id: firstSkillId }, { id: secondSkillId }];
-        knowledgeElements = [
-          { earnedPix: 50, skillId: firstSkillId },
-          { earnedPix: 70, skillId: secondSkillId },
-        ];
-
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
+    context('when there is knowledge elements', function () {
+      it('should build an object of Scorecard type', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard).to.be.instanceOf(Scorecard);
       });
-      // then
-      it('should have the competence level capped at the maximum value', function () {
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
-
-        expect(actualScorecard.level).to.equal(MAX_REACHABLE_LEVEL);
-        expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
+      it('should build a scorecard id from a combination of userId and competenceId', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.id).to.equal(userId + '_' + competence.id);
+      });
+      it('should competence datas to the scorecard object', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.name).to.equal(competence.name);
+        expect(actualScorecard.competenceId).to.equal(competence.id);
+        expect(actualScorecard.area).to.deep.equal(area);
+        expect(actualScorecard.index).to.equal(competence.index);
+        expect(actualScorecard.description).to.equal(competence.description);
+      });
+      it('should have earned pix as a rounded sum of all knowledge elements earned pixes', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.earnedPix).to.equal(9);
       });
 
-      it('should have the competence level not capped at the maximum value if we allow it', function () {
-        //when
-        actualScorecard = Scorecard.buildFrom({
-          userId,
-          knowledgeElements,
-          skills,
-          competence,
-          allowExcessLevel: true,
+      it('should have exactly earned pix as a sum of all knowledge elements earned pixes', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.exactlyEarnedPix).to.equal(9.1);
+      });
+
+      it('should have a level computed from the number of pixes', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.earnedPix).to.equal(9);
+      });
+      it('should have set the number of pix ahead of the next level', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.pixScoreAheadOfNextLevel).to.equal(1);
+      });
+      it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
+      });
+      it('should have set the scorecard remainingDaysBeforeImproving based on last knowledge element date', function () {
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+        // then
+        expect(actualScorecard.remainingDaysBeforeImproving).to.equal(4);
+      });
+
+      context('#status', function () {
+        it('should return STARTED when some skills does not correspond to the knowledge elements', function () {
+          const firstSkillId = Symbol('first skill id');
+          const secondSkillId = Symbol('second skill id');
+
+          const skills = [{ id: firstSkillId, difficulty: 1 }];
+          const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date(), skillId: secondSkillId }];
+
+          //when
+          actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+          //then
+          expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
         });
 
-        expect(actualScorecard.level).to.equal(15);
-        expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
-      });
-    });
+        it('should return STARTED when some skills correspond to the knowledge elements', function () {
+          const firstSkillId = Symbol('first skill id');
+          const secondSkillId = Symbol('second skill id');
+          const skills = [
+            { id: firstSkillId, difficulty: 1 },
+            { id: secondSkillId, difficulty: 2 },
+          ];
+          const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId }];
 
-    context('when the user pix score is higher than the max', function () {
-      let knowledgeElements;
-      let skills;
-      beforeEach(function () {
-        // given
-        const firstSkillId = Symbol('first skill id');
-        const secondSkillId = Symbol('second skill id');
-        skills = [{ id: firstSkillId }, { id: secondSkillId }];
-        knowledgeElements = [
-          { earnedPix: 50, skillId: firstSkillId },
-          { earnedPix: 70, skillId: secondSkillId },
-        ];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
+          //when
+          actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+          //then
+          expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
+        });
+
+        it('should return COMPLETED when all the skills correspond to the knowledge elements', function () {
+          const firstSkillId = Symbol('first skill id');
+          const secondSkillId = Symbol('second skill id');
+          const thirdSkillId = Symbol('third skill id');
+          const skills = [{ id: firstSkillId }, { id: secondSkillId }];
+          const knowledgeElements = [
+            { earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId },
+            { earnedPix: 5.5, createdAt: new Date(), skillId: secondSkillId },
+            { earnedPix: 5.5, createdAt: new Date(), skillId: thirdSkillId },
+          ];
+
+          //when
+          actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+          //then
+          expect(actualScorecard.status).to.equal(Scorecard.statuses.COMPLETED);
+        });
+
+        it('should return COMPLETED when max validated skills is higher than missing skills', function () {
+          const firstSkillId = Symbol('first skill id');
+          const secondSkillId = Symbol('second skill id');
+          const thirdSkillId = Symbol('third skill id');
+          const skills = [
+            { id: firstSkillId, difficulty: 3 },
+            { id: secondSkillId, difficulty: 6 },
+            { id: thirdSkillId, difficulty: 3 },
+          ];
+          const knowledgeElements = [
+            { earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId },
+            { earnedPix: 5.5, createdAt: new Date(), skillId: secondSkillId },
+          ];
+
+          //when
+          actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+          //then
+          expect(actualScorecard.status).to.equal(Scorecard.statuses.COMPLETED);
+        });
       });
 
-      it('should have the number of pix blocked', function () {
-        //when
-        actualScorecard = Scorecard.buildFrom({
-          userId,
-          knowledgeElements,
-          skills,
-          competence,
+      context('when the user level is beyond the upper limit allowed', function () {
+        let skills;
+        let knowledgeElements;
+        beforeEach(function () {
+          // given
+          const firstSkillId = Symbol('first skill id');
+          const secondSkillId = Symbol('second skill id');
+          skills = [{ id: firstSkillId }, { id: secondSkillId }];
+          knowledgeElements = [
+            { earnedPix: 50, skillId: firstSkillId },
+            { earnedPix: 70, skillId: secondSkillId },
+          ];
+
+          computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
         });
         // then
-        expect(actualScorecard.earnedPix).to.equal(constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+        it('should have the competence level capped at the maximum value', function () {
+          //when
+          actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+          expect(actualScorecard.level).to.equal(MAX_REACHABLE_LEVEL);
+          expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
+        });
+
+        it('should have the competence level not capped at the maximum value if we allow it', function () {
+          //when
+          actualScorecard = Scorecard.buildFrom({
+            userId,
+            knowledgeElements,
+            skills,
+            competence,
+            allowExcessLevel: true,
+          });
+
+          expect(actualScorecard.level).to.equal(15);
+          expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
+        });
       });
 
-      it('should have the same number of pix if we allow it', function () {
-        //when
-        actualScorecard = Scorecard.buildFrom({
-          userId,
-          knowledgeElements,
-          skills,
-          competence,
-          allowExcessPix: true,
+      context('when the user pix score is higher than the max', function () {
+        let knowledgeElements;
+        let skills;
+        beforeEach(function () {
+          // given
+          const firstSkillId = Symbol('first skill id');
+          const secondSkillId = Symbol('second skill id');
+          skills = [{ id: firstSkillId }, { id: secondSkillId }];
+          knowledgeElements = [
+            { earnedPix: 50, skillId: firstSkillId },
+            { earnedPix: 70, skillId: secondSkillId },
+          ];
+          computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
         });
-        // then
-        expect(actualScorecard.earnedPix).to.equal(120);
+
+        it('should have the number of pix blocked', function () {
+          //when
+          actualScorecard = Scorecard.buildFrom({
+            userId,
+            knowledgeElements,
+            skills,
+            competence,
+          });
+          // then
+          expect(actualScorecard.earnedPix).to.equal(constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+        });
+
+        it('should have the same number of pix if we allow it', function () {
+          //when
+          actualScorecard = Scorecard.buildFrom({
+            userId,
+            knowledgeElements,
+            skills,
+            competence,
+            allowExcessPix: true,
+          });
+          // then
+          expect(actualScorecard.earnedPix).to.equal(120);
+        });
       });
     });
 

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -11,7 +11,6 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#buildFrom', function () {
-    let competenceEvaluation;
     let actualScorecard;
 
     const userId = '123';
@@ -23,166 +22,108 @@ describe('Unit | Domain | Models | Scorecard', function () {
       index: 'index',
     };
 
-    context('with existing competence evaluation and assessment', function () {
-      beforeEach(function () {
-        // given
-        competenceEvaluation = {
-          status: 'started',
-          assessment: { state: 'started' },
-        };
-        const knowledgeElements = [
-          { earnedPix: 5.5, createdAt: new Date() },
-          {
-            earnedPix: 3.6,
-            createdAt: new Date(),
-          },
-        ];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        // when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, area });
-      });
-      // then
-      it('should build an object of Scorecard type', function () {
-        expect(actualScorecard).to.be.instanceOf(Scorecard);
-      });
-      it('should build a scorecard id from a combination of userId and competenceId', function () {
-        expect(actualScorecard.id).to.equal(userId + '_' + competence.id);
-      });
-      it('should competence datas to the scorecard object', function () {
-        expect(actualScorecard.name).to.equal(competence.name);
-        expect(actualScorecard.competenceId).to.equal(competence.id);
-        expect(actualScorecard.area).to.deep.equal(area);
-        expect(actualScorecard.index).to.equal(competence.index);
-        expect(actualScorecard.description).to.equal(competence.description);
-      });
-      it('should have earned pix as a rounded sum of all knowledge elements earned pixes', function () {
-        expect(actualScorecard.earnedPix).to.equal(9);
-      });
-
-      it('should have exactly earned pix as a sum of all knowledge elements earned pixes', function () {
-        expect(actualScorecard.exactlyEarnedPix).to.equal(9.1);
-      });
-
-      it('should have a level computed from the number of pixes', function () {
-        expect(actualScorecard.earnedPix).to.equal(9);
-      });
-      it('should have set the number of pix ahead of the next level', function () {
-        expect(actualScorecard.pixScoreAheadOfNextLevel).to.equal(1);
-      });
-      it('should have set the scorecard status based on the competence evaluation status', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
-      });
-      it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', function () {
-        expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
-      });
-      it('should have set the scorecard remainingDaysBeforeImproving based on last knowledge element date', function () {
-        expect(actualScorecard.remainingDaysBeforeImproving).to.equal(4);
-      });
+    beforeEach(function () {
+      // given
+      const firstSkillId = Symbol('first skill id');
+      const secondSkillId = Symbol('second skill id');
+      const skills = [{ id: firstSkillId }, { id: secondSkillId }];
+      const knowledgeElements = [
+        { earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId },
+        {
+          earnedPix: 3.6,
+          createdAt: new Date(),
+          skillId: secondSkillId,
+        },
+      ];
+      computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
+      // when
+      actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence, area });
+    });
+    // then
+    it('should build an object of Scorecard type', function () {
+      expect(actualScorecard).to.be.instanceOf(Scorecard);
+    });
+    it('should build a scorecard id from a combination of userId and competenceId', function () {
+      expect(actualScorecard.id).to.equal(userId + '_' + competence.id);
+    });
+    it('should competence datas to the scorecard object', function () {
+      expect(actualScorecard.name).to.equal(competence.name);
+      expect(actualScorecard.competenceId).to.equal(competence.id);
+      expect(actualScorecard.area).to.deep.equal(area);
+      expect(actualScorecard.index).to.equal(competence.index);
+      expect(actualScorecard.description).to.equal(competence.description);
+    });
+    it('should have earned pix as a rounded sum of all knowledge elements earned pixes', function () {
+      expect(actualScorecard.earnedPix).to.equal(9);
     });
 
-    context('when the competence evaluation has never been started', function () {
-      beforeEach(function () {
-        // given
-        competenceEvaluation = undefined;
-        const knowledgeElements = [];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
-      });
-      // then
-      it('should have set the scorecard status NOT_STARTED', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.NOT_STARTED);
-      });
+    it('should have exactly earned pix as a sum of all knowledge elements earned pixes', function () {
+      expect(actualScorecard.exactlyEarnedPix).to.equal(9.1);
     });
 
-    context('when the competence evaluation has never been started and some knowledgeElements exist', function () {
-      beforeEach(function () {
-        // given
-        competenceEvaluation = undefined;
-        const knowledgeElements = [
-          { earnedPix: 5.5, createdAt: new Date() },
-          {
-            earnedPix: 3.6,
-            createdAt: new Date(),
-          },
-        ];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
-      });
-      // then
-      it('should have set the scorecard status STARTED', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
-      });
+    it('should have a level computed from the number of pixes', function () {
+      expect(actualScorecard.earnedPix).to.equal(9);
+    });
+    it('should have set the number of pix ahead of the next level', function () {
+      expect(actualScorecard.pixScoreAheadOfNextLevel).to.equal(1);
+    });
+    it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', function () {
+      expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
+    });
+    it('should have set the scorecard remainingDaysBeforeImproving based on last knowledge element date', function () {
+      expect(actualScorecard.remainingDaysBeforeImproving).to.equal(4);
     });
 
-    context('when the competence evaluation has been reset but no knowledgeElements exist', function () {
-      beforeEach(function () {
-        // given
-        const knowledgeElements = [];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        competenceEvaluation = { status: 'reset' };
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
-      });
-      // then
-      it('should have set the scorecard status based on the competence evaluation status', function () {
-        expect(actualScorecard.status).to.equal('NOT_STARTED');
-      });
+    it('should return STARTED when some skills correspond to the knowledge elements', function () {
+      const firstSkillId = Symbol('first skill id');
+      const secondSkillId = Symbol('second skill id');
+      const skills = [{ id: firstSkillId }, { id: secondSkillId }];
+      const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId }];
+
+      //when
+      actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+      //then
+      expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
     });
 
-    context('when the competence evaluation has been reset and some knowledgeElements exist', function () {
-      beforeEach(function () {
-        // given
-        const knowledgeElements = [
-          { earnedPix: 5.5, createdAt: new Date() },
-          {
-            earnedPix: 3.6,
-            createdAt: new Date(),
-          },
-        ];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        competenceEvaluation = { status: 'reset' };
+    it('should return COMPLETED when all the skills correspond to the knowledge elements', function () {
+      const firstSkillId = Symbol('first skill id');
+      const secondSkillId = Symbol('second skill id');
+      const thirdSkillId = Symbol('third skill id');
+      const skills = [{ id: firstSkillId }, { id: secondSkillId }];
+      const knowledgeElements = [
+        { earnedPix: 5.5, createdAt: new Date(), skillId: firstSkillId },
+        { earnedPix: 5.5, createdAt: new Date(), skillId: secondSkillId },
+        { earnedPix: 5.5, createdAt: new Date(), skillId: thirdSkillId },
+      ];
 
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
-      });
-      // then
-      it('should have set the scorecard status STARTED', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
-      });
-    });
+      //when
+      actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
 
-    context('when the user has no knowledge elements for the competence', function () {
-      beforeEach(function () {
-        // given
-        const knowledgeElements = [];
-        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        competenceEvaluation = { status: 'reset' };
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements: [], competenceEvaluation, competence });
-      });
-      // then
-      it('should have a dayBeforeReset at null', function () {
-        expect(actualScorecard.remainingDaysBeforeReset).to.be.null;
-      });
-
-      it('should have a dayBeforeImproving at null', function () {
-        expect(actualScorecard.remainingDaysBeforeImproving).to.be.null;
-      });
+      //then
+      expect(actualScorecard.status).to.equal(Scorecard.statuses.COMPLETED);
     });
 
     context('when the user level is beyond the upper limit allowed', function () {
+      let skills;
       let knowledgeElements;
       beforeEach(function () {
         // given
-        knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
+        const firstSkillId = Symbol('first skill id');
+        const secondSkillId = Symbol('second skill id');
+        skills = [{ id: firstSkillId }, { id: secondSkillId }];
+        knowledgeElements = [
+          { earnedPix: 50, skillId: firstSkillId },
+          { earnedPix: 70, skillId: secondSkillId },
+        ];
+
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
       });
       // then
       it('should have the competence level capped at the maximum value', function () {
         //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
 
         expect(actualScorecard.level).to.equal(MAX_REACHABLE_LEVEL);
         expect(actualScorecard.earnedPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
@@ -193,7 +134,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
         actualScorecard = Scorecard.buildFrom({
           userId,
           knowledgeElements,
-          competenceEvaluation,
+          skills,
           competence,
           allowExcessLevel: true,
         });
@@ -205,9 +146,16 @@ describe('Unit | Domain | Models | Scorecard', function () {
 
     context('when the user pix score is higher than the max', function () {
       let knowledgeElements;
+      let skills;
       beforeEach(function () {
         // given
-        knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
+        const firstSkillId = Symbol('first skill id');
+        const secondSkillId = Symbol('second skill id');
+        skills = [{ id: firstSkillId }, { id: secondSkillId }];
+        knowledgeElements = [
+          { earnedPix: 50, skillId: firstSkillId },
+          { earnedPix: 70, skillId: secondSkillId },
+        ];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
       });
 
@@ -216,7 +164,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
         actualScorecard = Scorecard.buildFrom({
           userId,
           knowledgeElements,
-          competenceEvaluation,
+          skills,
           competence,
         });
         // then
@@ -228,7 +176,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
         actualScorecard = Scorecard.buildFrom({
           userId,
           knowledgeElements,
-          competenceEvaluation,
+          skills,
           competence,
           allowExcessPix: true,
         });
@@ -238,11 +186,19 @@ describe('Unit | Domain | Models | Scorecard', function () {
     });
 
     context('when there is no knowledge elements', function () {
+      let skills;
+      beforeEach(function () {
+        // given
+        const firstSkillId = Symbol('first skill id');
+        const secondSkillId = Symbol('second skill id');
+        skills = [{ id: firstSkillId }, { id: secondSkillId }];
+      });
+
       it('should return null when looking for remainingDaysBeforeReset', function () {
         const knowledgeElements = [];
 
         // when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
 
         // then
         expect(actualScorecard.remainingDaysBeforeReset).to.equal(null);
@@ -252,10 +208,20 @@ describe('Unit | Domain | Models | Scorecard', function () {
         const knowledgeElements = [];
 
         // when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
 
         // then
         expect(actualScorecard.remainingDaysBeforeImproving).to.equal(null);
+      });
+
+      it('should return status NOT_STARTED', function () {
+        const knowledgeElements = [];
+
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, skills, competence });
+
+        // then
+        expect(actualScorecard.status).to.equal(Scorecard.statuses.NOT_STARTED);
       });
     });
   });

--- a/api/tests/unit/domain/read-models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/read-models/SharedProfileForCampaign_test.js
@@ -9,8 +9,9 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
         const userId = 1;
         const competence = { id: 1, name: 'Useful competence', areaId: 'area' };
         const area = { id: 'area' };
+        const skills = [domainBuilder.buildSkill()];
         const knowledgeElements = [domainBuilder.buildKnowledgeElement({ competenceId: competence.id })];
-        const expectedScorecard = Scorecard.buildFrom({ userId, competence, knowledgeElements });
+        const expectedScorecard = Scorecard.buildFrom({ userId, competence, knowledgeElements, skills });
 
         const sharedProfileForCampaign = new SharedProfileForCampaign({
           userId,
@@ -22,6 +23,7 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
           knowledgeElementsGroupedByCompetenceId: {
             [competence.id]: knowledgeElements,
           },
+          allSkills: skills,
         });
 
         expect(sharedProfileForCampaign.scorecards[0]).to.deep.include({

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -1,15 +1,15 @@
-import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { Assessment } from '../../../../lib/domain/models/Assessment.js';
 import { AnswerStatus } from '../../../../lib/domain/models/AnswerStatus.js';
 import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
 import { correctAnswerThenUpdateAssessment } from '../../../../lib/domain/usecases/correct-answer-then-update-assessment.js';
 
 import {
-  ChallengeNotAskedError,
-  NotFoundError,
-  ForbiddenAccess,
-  CertificationEndedBySupervisorError,
   CertificationEndedByFinalizationError,
+  CertificationEndedBySupervisorError,
+  ChallengeNotAskedError,
+  ForbiddenAccess,
+  NotFoundError,
 } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', function () {
@@ -30,7 +30,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   };
   const assessmentRepository = { get: () => undefined };
   const challengeRepository = { get: () => undefined };
-  const competenceEvaluationRepository = {};
   const campaignRepository = { findSkillsByCampaignParticipationId: () => undefined };
   const skillRepository = { findActiveByCompetenceId: () => undefined };
   const flashAssessmentResultRepository = { save: () => undefined };
@@ -38,6 +37,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   const knowledgeElementRepository = {
     findUniqByUserIdAndAssessmentId: () => undefined,
   };
+  const competenceRepository = {};
+  const areaRepository = {};
+  const locale = 'fr';
   const flashAlgorithmService = { getEstimatedLevelAndErrorRate: () => undefined };
   const algorithmDataFetcherService = { fetchForFlashLevelEstimation: () => undefined };
   const nowDate = new Date('2021-03-11T11:00:04Z');
@@ -81,11 +83,13 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       answerRepository,
       assessmentRepository,
       challengeRepository,
-      competenceEvaluationRepository,
       skillRepository,
       campaignRepository,
       knowledgeElementRepository,
       flashAssessmentResultRepository,
+      areaRepository,
+      locale,
+      competenceRepository,
       scorecardService,
       flashAlgorithmService,
       algorithmDataFetcherService,
@@ -282,6 +286,15 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           });
 
           // then
+          sinon.assert.alwaysCalledWith(scorecardService.computeScorecard, {
+            userId,
+            competenceId: challenge.competenceId,
+            competenceRepository,
+            areaRepository,
+            skillRepository,
+            knowledgeElementRepository,
+            locale,
+          });
           expect(result.levelup).to.deep.equal({});
         });
       });

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -1,4 +1,4 @@
-import { sinon, expect } from '../../../test-helper.js';
+import { expect, sinon } from '../../../test-helper.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
 import { Scorecard } from '../../../../lib/domain/models/Scorecard.js';
 import { getScorecard } from '../../../../lib/domain/usecases/get-scorecard.js';
@@ -6,8 +6,9 @@ import { getScorecard } from '../../../../lib/domain/usecases/get-scorecard.js';
 describe('Unit | UseCase | get-scorecard', function () {
   let scorecardService;
   let competenceRepository;
-  let competenceEvaluationRepository;
+  let skillRepository;
   let knowledgeElementRepository;
+  let areaRepository;
   let scorecardId;
   let competenceId;
   let authenticatedUserId;
@@ -21,8 +22,9 @@ describe('Unit | UseCase | get-scorecard', function () {
     scorecardService = { computeScorecard: sinon.stub() };
     parseIdStub = sinon.stub(Scorecard, 'parseId');
     competenceRepository = {};
-    competenceEvaluationRepository = {};
+    skillRepository = {};
     knowledgeElementRepository = {};
+    areaRepository = {};
   });
 
   context('When user is authenticated', function () {
@@ -31,37 +33,9 @@ describe('Unit | UseCase | get-scorecard', function () {
     });
 
     context('And user asks for his own scorecard', function () {
-      it('should resolve', function () {
-        // given
-        scorecardService.computeScorecard
-          .withArgs({
-            userId: authenticatedUserId,
-            competenceRepository,
-            competenceEvaluationRepository,
-            knowledgeElementRepository,
-            locale,
-          })
-          .resolves({});
-
-        // when
-        const promise = getScorecard({
-          authenticatedUserId,
-          scorecardId,
-          scorecardService,
-          competenceRepository,
-          competenceEvaluationRepository,
-          knowledgeElementRepository,
-          locale,
-        });
-
-        // then
-        return expect(promise).to.be.fulfilled;
-      });
-
-      it('should return the user scorecard', async function () {
+      it('should resolve', async function () {
         // given
         const scorecard = Symbol('Scorecard');
-
         scorecardService.computeScorecard.resolves(scorecard);
 
         // when
@@ -69,9 +43,24 @@ describe('Unit | UseCase | get-scorecard', function () {
           authenticatedUserId,
           scorecardId,
           scorecardService,
+          competenceRepository,
+          skillRepository,
+          knowledgeElementRepository,
+          areaRepository,
+          locale,
         });
 
-        //then
+        // then
+        expect(scorecardService.computeScorecard).to.have.been.calledWith({
+          userId: authenticatedUserId,
+          competenceId,
+          competenceRepository,
+          areaRepository,
+          skillRepository,
+          knowledgeElementRepository,
+          locale,
+        });
+
         expect(userScorecard).to.deep.equal(scorecard);
       });
     });

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
   let areaRepository;
   let campaignRepository;
   let organizationLearnerRepository;
+  let skillRepository;
   let userId;
   let campaignId;
   let expectedMaxReachableLevel;
@@ -35,12 +36,17 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
       areaRepository = { list: sinon.stub() };
       campaignRepository = { get: sinon.stub() };
       organizationLearnerRepository = { isActive: sinon.stub() };
+      skillRepository = { list: sinon.stub() };
       sinon.stub(Scorecard, 'buildFrom');
       sinon.stub(constants, 'MAX_REACHABLE_LEVEL').value(expectedMaxReachableLevel);
       sinon.stub(constants, 'MAX_REACHABLE_PIX_SCORE').value(expectedMaxReachablePixScore);
     });
 
     it('should return the shared profile for campaign', async function () {
+      const skills = [
+        { id: 'skill1', competenceId: 'competence1' },
+        { id: 'skill2', competenceId: 'competence2' },
+      ];
       const knowledgeElements = { competence1: [], competence2: [] };
       const competences = [
         { id: 'competence1', areaId: 'area' },
@@ -59,11 +65,24 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
       areaRepository.list.withArgs({ locale: 'fr' }).resolves([area]);
       campaignRepository.get.withArgs(campaignId).resolves(campaign);
       organizationLearnerRepository.isActive.withArgs({ campaignId, userId }).resolves(false);
+      skillRepository.list.resolves(skills);
       Scorecard.buildFrom
-        .withArgs({ userId, knowledgeElements: knowledgeElements['competence1'], competence: competences[0], area })
+        .withArgs({
+          userId,
+          knowledgeElements: knowledgeElements['competence1'],
+          competence: competences[0],
+          area,
+          skills: [skills[0]],
+        })
         .returns({ id: 'Score1', earnedPix: 10 });
       Scorecard.buildFrom
-        .withArgs({ userId, knowledgeElements: knowledgeElements['competence2'], competence: competences[1], area })
+        .withArgs({
+          userId,
+          knowledgeElements: knowledgeElements['competence2'],
+          competence: competences[1],
+          area,
+          skills: [skills[1]],
+        })
         .returns({ id: 'Score2', earnedPix: 5 });
 
       // when
@@ -76,6 +95,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
         areaRepository,
         campaignRepository,
         organizationLearnerRepository,
+        skillRepository,
         locale,
       });
 

--- a/api/tests/unit/domain/usecases/get-user-profile_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile_test.js
@@ -12,18 +12,18 @@ function assertScorecard(userScorecard, expectedUserScorecard) {
 }
 
 describe('Unit | UseCase | get-user-profile', function () {
-  let competenceRepository;
+  let skillRepository;
   let areaRepository;
   let knowledgeElementRepository;
-  let competenceEvaluationRepository;
+  let competenceRepository;
   const scorecard = { id: 'foo' };
   const locale = 'fr';
 
   beforeEach(function () {
-    competenceRepository = { listPixCompetencesOnly: sinon.stub() };
+    skillRepository = { list: sinon.stub() };
     areaRepository = { list: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
-    competenceEvaluationRepository = { findByUserId: sinon.stub() };
+    competenceRepository = { listPixCompetencesOnly: sinon.stub() };
     sinon.stub(Scorecard, 'buildFrom').returns(scorecard);
   });
 
@@ -45,8 +45,14 @@ describe('Unit | UseCase | get-user-profile', function () {
           domainBuilder.buildCompetence({ id: 2, areaId: 'area' }),
           domainBuilder.buildCompetence({ id: 3, areaId: 'area' }),
         ];
+        const skills = [
+          domainBuilder.buildSkill({ competenceId: competenceList[0].id }),
+          domainBuilder.buildSkill({ competenceId: competenceList[1].id }),
+          domainBuilder.buildSkill({ competenceId: competenceList[2].id }),
+        ];
         const area = domainBuilder.buildArea({ id: 'area' });
         competenceRepository.listPixCompetencesOnly.resolves(competenceList);
+        skillRepository.list.resolves(skills);
         areaRepository.list.resolves([area]);
 
         const assessmentFinishedOfCompetence1 = domainBuilder.buildAssessment({
@@ -57,10 +63,6 @@ describe('Unit | UseCase | get-user-profile', function () {
         const assessmentStartedOfCompetence2 = domainBuilder.buildAssessment({
           type: 'CAMPAIGN',
           state: 'started',
-        });
-        const competenceEvaluationOfCompetence1 = domainBuilder.buildCompetenceEvaluation({
-          competenceId: 1,
-          assessment: assessmentFinishedOfCompetence1,
         });
 
         const knowledgeElementList = [
@@ -111,14 +113,13 @@ describe('Unit | UseCase | get-user-profile', function () {
         knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves(
           knowledgeElementGroupedByCompetenceId,
         );
-        competenceEvaluationRepository.findByUserId.resolves([competenceEvaluationOfCompetence1]);
 
         Scorecard.buildFrom
           .withArgs({
             userId,
             knowledgeElements: knowledgeElementGroupedByCompetenceId[1],
             competence: competenceList[0],
-            competenceEvaluation: competenceEvaluationOfCompetence1,
+            skills: [skills[0]],
             area,
           })
           .returns(expectedUserScorecard[0]);
@@ -128,7 +129,7 @@ describe('Unit | UseCase | get-user-profile', function () {
             userId,
             knowledgeElements: knowledgeElementGroupedByCompetenceId[2],
             competence: competenceList[1],
-            competenceEvaluation: undefined,
+            skills: [skills[1]],
             area,
           })
           .returns(expectedUserScorecard[1]);
@@ -138,7 +139,7 @@ describe('Unit | UseCase | get-user-profile', function () {
             userId,
             knowledgeElements: undefined,
             competence: competenceList[2],
-            competenceEvaluation: undefined,
+            skills: [skills[2]],
             area,
           })
           .returns(expectedUserScorecard[2]);
@@ -156,7 +157,7 @@ describe('Unit | UseCase | get-user-profile', function () {
           knowledgeElementRepository,
           competenceRepository,
           areaRepository,
-          competenceEvaluationRepository,
+          skillRepository,
           locale,
         });
 

--- a/api/tests/unit/domain/usecases/reset-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/reset-scorecard_test.js
@@ -17,6 +17,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
   const campaignParticipationRepository = {};
   const campaignRepository = {};
   const scorecardService = {};
+  const skillRepository = {};
   let getRemainingDaysBeforeResetStub;
 
   beforeEach(function () {
@@ -24,6 +25,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
     scorecard = Symbol('Scorecard');
     competenceEvaluationRepository.existsByCompetenceIdAndUserId = sinon.stub();
     knowledgeElementRepository.findUniqByUserIdAndCompetenceId = sinon.stub();
+    skillRepository.findOperativeByCompetenceId = sinon.stub();
     scorecardService.resetScorecard = sinon.stub();
     scorecardService.computeScorecard = sinon.stub();
     getRemainingDaysBeforeResetStub = sinon.stub(Scorecard, 'computeRemainingDaysBeforeReset');
@@ -56,7 +58,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
           competenceId,
           competenceRepository,
           areaRepository,
-          competenceEvaluationRepository,
+          skillRepository,
           knowledgeElementRepository,
           locale,
         })
@@ -80,6 +82,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
         competenceEvaluationRepository,
         knowledgeElementRepository,
         campaignRepository,
+        skillRepository,
         locale,
       });
 
@@ -124,7 +127,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
           competenceId,
           competenceRepository,
           areaRepository,
-          competenceEvaluationRepository,
+          skillRepository,
           knowledgeElementRepository,
           locale,
         })
@@ -141,6 +144,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
         areaRepository,
         competenceEvaluationRepository,
         knowledgeElementRepository,
+        skillRepository,
         locale,
       });
 
@@ -167,6 +171,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
         competenceRepository,
         competenceEvaluationRepository,
         knowledgeElementRepository,
+        skillRepository,
         locale,
       });
 
@@ -190,6 +195,7 @@ describe('Unit | UseCase | reset-scorecard', function () {
         competenceRepository,
         competenceEvaluationRepository,
         knowledgeElementRepository,
+        skillRepository,
         locale,
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -33,6 +33,10 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
         domainBuilder.buildCompetence({ id: 'rec1', areaId: '1' }),
         domainBuilder.buildCompetence({ id: 'rec2', areaId: '2' }),
       ];
+      const skills = [
+        domainBuilder.buildSkill({ competenceId: 'rec1' }),
+        domainBuilder.buildSkill({ competenceId: 'rec2' }),
+      ];
       const knowledgeElementsGroupedByCompetenceId = {
         rec1: [domainBuilder.buildKnowledgeElement()],
         rec2: [domainBuilder.buildKnowledgeElement()],
@@ -52,6 +56,7 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
         knowledgeElementsGroupedByCompetenceId,
         maxReachableLevel: 8,
         maxReachablePixScore: 768,
+        allSkills: skills,
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour effectuer la remise à zéro des compétences sur les campagnes, nous avons besoin de connaître les skills utilisés lors de celle ci. Actuellement le reset de card ne se base que sur les compétences évaluation qui est déduite des knowledge elements.

## :robot: Proposition
Utiliser les skills et les knowledge elements pour définir le statut d'une scorecard et ne plus dépendre des compétences évaluation.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter à Pix App
- Vérifier la cohérence entre les cartes et le total des pix obtenus
- Vérifier le statut des cartes par rapport aux compétences obtenus
- Tester le reset d'une carte (complète/non complète)
- :cat:

