### PR TITLE
[FEATURE][ORGA] Permettre à un admin d'une organisation de quitter une organisation (PIX-8380)

### DIFF
--- a/api/db/seeds/data/team-acces/build-organization-users.js
+++ b/api/db/seeds/data/team-acces/build-organization-users.js
@@ -1,16 +1,36 @@
 import { DEFAULT_PASSWORD } from '../../../constants.js';
 
 export const PIX_ORGA_ALL_ORGA_ID = 10001;
+export const PIX_ORGA_ADMIN_LEAVING_ID = 10002;
 
 export function buildOrganizationUsers(databaseBuilder) {
-  databaseBuilder.factory.buildUser.withRawPassword({
-    id: PIX_ORGA_ALL_ORGA_ID,
-    firstName: 'Rhaenyra',
-    lastName: 'Targaryen',
-    email: 'allorga@example.net',
-    rawPassword: DEFAULT_PASSWORD,
-    cgu: true,
-    pixOrgaTermsOfServiceAccepted: true,
-    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
-  });
+  [
+    {
+      id: PIX_ORGA_ALL_ORGA_ID,
+      firstName: 'Rhaenyra',
+      lastName: 'Targaryen',
+      email: 'allorga@example.net',
+    },
+    {
+      id: PIX_ORGA_ADMIN_LEAVING_ID,
+      firstName: 'Admin',
+      lastName: 'Leaving',
+      email: 'admin.leaving@example.net',
+    },
+  ].forEach(_buildUser(databaseBuilder));
+}
+
+function _buildUser(databaseBuilder) {
+  return function ({ id, firstName, lastName, email, rawPassword = DEFAULT_PASSWORD }) {
+    databaseBuilder.factory.buildUser.withRawPassword({
+      id,
+      firstName,
+      lastName,
+      email,
+      rawPassword,
+      cgu: true,
+      pixOrgaTermsOfServiceAccepted: true,
+      lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    });
+  };
 }

--- a/api/db/seeds/data/team-acces/build-sco-organizations.js
+++ b/api/db/seeds/data/team-acces/build-sco-organizations.js
@@ -1,7 +1,7 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { PIX_PUBLIC_TARGET_PROFILE_ID, REAL_PIX_SUPER_ADMIN_ID } from '../common/common-builder.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
-import { PIX_ORGA_ALL_ORGA_ID } from './build-organization-users.js';
+import { PIX_ORGA_ADMIN_LEAVING_ID, PIX_ORGA_ALL_ORGA_ID } from './build-organization-users.js';
 import { SCO_ORGANIZATION_ID } from './constants.js';
 
 export function buildScoOrganizations(databaseBuilder) {
@@ -22,11 +22,18 @@ function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
     createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 
-  databaseBuilder.factory.buildMembership({
-    userId: PIX_ORGA_ALL_ORGA_ID,
-    organizationId: organization.id,
-    organizationRole: Membership.roles.ADMIN,
-  });
+  [
+    {
+      userId: PIX_ORGA_ALL_ORGA_ID,
+      organizationId: organization.id,
+      organizationRole: Membership.roles.ADMIN,
+    },
+    {
+      userId: PIX_ORGA_ADMIN_LEAVING_ID,
+      organizationId: organization.id,
+      organizationRole: Membership.roles.ADMIN,
+    },
+  ].forEach(_buildAdminMembership(databaseBuilder));
 
   databaseBuilder.factory.buildCampaign({
     name: 'ACCES Sco - Collège - Campagne d’évaluation Badges',
@@ -42,4 +49,14 @@ function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
     idPixLabel: null,
     createdAt: new Date('2023-07-27'),
   });
+}
+
+function _buildAdminMembership(databaseBuilder) {
+  return function ({ userId, organizationId, organizationRole }) {
+    databaseBuilder.factory.buildMembership({
+      userId,
+      organizationId,
+      organizationRole,
+    });
+  };
 }

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -5,7 +5,7 @@ import { membershipController } from './membership-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {
-  server.route([
+  const adminRoutes = [
     {
       method: 'POST',
       path: '/api/admin/memberships',
@@ -30,36 +30,6 @@ const register = async function (server) {
           'hapi-swagger': {
             payloadType: 'form',
             order: 1,
-          },
-        },
-        tags: ['api', 'memberships'],
-      },
-    },
-    {
-      method: 'PATCH',
-      path: '/api/memberships/{id}',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkUserIsAdminInOrganization,
-            assign: 'isAdminInOrganization',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.membershipId,
-          }),
-        },
-        handler: membershipController.update,
-        description: 'Update organization role by admin for a organization members',
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation**\n" +
-            "- Elle permet de modifier le rôle d'un membre de l'organisation",
-        ],
-        plugins: {
-          'hapi-swagger': {
-            payloadType: 'form',
-            order: 2,
           },
         },
         tags: ['api', 'memberships'],
@@ -102,28 +72,6 @@ const register = async function (server) {
     },
     {
       method: 'POST',
-      path: '/api/memberships/{id}/disable',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkUserIsAdminInOrganization,
-            assign: 'isAdminInOrganization',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.membershipId,
-          }),
-        },
-        handler: membershipController.disable,
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation\n" +
-            "- Elle permet la désactivation d'un membre",
-        ],
-      },
-    },
-    {
-      method: 'POST',
       path: '/api/admin/memberships/{id}/disable',
       config: {
         pre: [
@@ -145,6 +93,62 @@ const register = async function (server) {
         handler: membershipController.disable,
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet la désactivation d'un membre",
+        ],
+      },
+    },
+  ];
+
+  server.route([
+    ...adminRoutes,
+    {
+      method: 'PATCH',
+      path: '/api/memberships/{id}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.membershipId,
+          }),
+        },
+        handler: membershipController.update,
+        description: 'Update organization role by admin for a organization members',
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation**\n" +
+            "- Elle permet de modifier le rôle d'un membre de l'organisation",
+        ],
+        plugins: {
+          'hapi-swagger': {
+            payloadType: 'form',
+            order: 2,
+          },
+        },
+        tags: ['api', 'memberships'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/memberships/{id}/disable',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.membershipId,
+          }),
+        },
+        handler: membershipController.disable,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation\n" +
             "- Elle permet la désactivation d'un membre",
         ],
       },

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -133,6 +133,32 @@ const register = async function (server) {
     },
     {
       method: 'POST',
+      path: '/api/memberships/me/disable',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+          {
+            method: securityPreHandlers.checkUserCanDisableHisOrganizationMembership,
+            assign: 'canDisableHisOrganizationMembership',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: membershipController.disableOwnOrganizationMembership,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'administrateur de l'organisation\n" +
+            "- Elle permet de se retirer d'une organisation",
+        ],
+      },
+    },
+    {
+      method: 'POST',
       path: '/api/memberships/{id}/disable',
       config: {
         pre: [

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -38,6 +38,15 @@ const disable = async function (request, h) {
   return h.response().code(204);
 };
 
-const membershipController = { create, update, disable };
+const disableOwnOrganizationMembership = async function (request, h) {
+  const organizationId = request.payload.organizationId;
+  const userId = requestResponseUtils.extractUserIdFromRequest(request);
+
+  await usecases.disableOwnOrganizationMembership({ organizationId, userId });
+
+  return h.response().code(204);
+};
+
+const membershipController = { create, update, disable, disableOwnOrganizationMembership };
 
 export { membershipController };

--- a/api/lib/application/usecases/checkUserCanDisableHisOrganizationMembership.js
+++ b/api/lib/application/usecases/checkUserCanDisableHisOrganizationMembership.js
@@ -1,0 +1,12 @@
+import * as membershipRepository from '../../infrastructure/repositories/membership-repository.js';
+
+async function execute({ organizationId, userId, dependencies = { membershipRepository } }) {
+  const currentActiveAdmins = await dependencies.membershipRepository.findAdminsByOrganizationId({ organizationId });
+  const activeAdminsLeftAfterDisablingCurrentUser = currentActiveAdmins.filter(
+    (currentActiveAdmin) => currentActiveAdmin.user.id !== userId,
+  );
+
+  return activeAdminsLeftAfterDisablingCurrentUser.length > 0;
+}
+
+export { execute };

--- a/api/lib/domain/usecases/disable-own-organization-membership.js
+++ b/api/lib/domain/usecases/disable-own-organization-membership.js
@@ -1,0 +1,9 @@
+async function disableOwnOrganizationMembership({ organizationId, userId, membershipRepository }) {
+  const [membership] = await membershipRepository.findByUserIdAndOrganizationId({ organizationId, userId });
+  return membershipRepository.updateById({
+    id: membership.id,
+    membership: { disabledAt: new Date(), updatedByUserId: userId },
+  });
+}
+
+export { disableOwnOrganizationMembership };

--- a/api/tests/acceptance/application/memberships/membership-controller_test.js
+++ b/api/tests/acceptance/application/memberships/membership-controller_test.js
@@ -329,4 +329,43 @@ describe('Acceptance | Controller | membership-controller', function () {
       });
     });
   });
+
+  describe('POST /api/memberships/me/disable', function () {
+    context('when user is one of the admins of the organization', function () {
+      it('disables user membership and returns a 204', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const organizationAdminUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildMembership({
+          userId: organizationAdminUserId,
+          organizationId,
+          organizationRole: Membership.roles.ADMIN,
+        });
+        databaseBuilder.factory.buildMembership({
+          userId: databaseBuilder.factory.buildUser().id,
+          organizationId,
+          organizationRole: Membership.roles.ADMIN,
+        });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'POST',
+          url: '/api/memberships/me/disable',
+          payload: {
+            organizationId,
+          },
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(organizationAdminUserId),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+  });
 });

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -350,4 +350,35 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
       expect(response.result).to.deep.equal(jsonApiError403);
     });
   });
+
+  describe('#checkUserCanDisableHisOrganizationMembership', function () {
+    context('when user cannot disable his organization membership', function () {
+      it('returns a well formed JSON API error', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({
+          userId,
+          organizationId,
+          organizationRole: Membership.roles.ADMIN,
+        });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          method: 'POST',
+          url: '/api/memberships/me/disable',
+          payload: { organizationId },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.result).to.deep.equal(jsonApiError403);
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/usecases/checkUserCanDisableHisOrganizationMembership_test.js
+++ b/api/tests/unit/application/usecases/checkUserCanDisableHisOrganizationMembership_test.js
@@ -1,0 +1,66 @@
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import * as checkUserCanDisableHisOrganizationMembership from '../../../../lib/application/usecases/checkUserCanDisableHisOrganizationMembership.js';
+import { Membership } from '../../../../lib/domain/models/Membership.js';
+
+describe('Unit | Application | UseCases | checkUserCanDisableHisOrganizationMembership', function () {
+  let membershipRepository;
+
+  beforeEach(function () {
+    membershipRepository = {
+      findAdminsByOrganizationId: sinon.stub(),
+    };
+  });
+
+  context('when there is at least one administrator left', function () {
+    it('returns "true"', async function () {
+      // given
+      const userId = 1;
+      const organizationId = 1;
+      const firstAdmin = domainBuilder.buildMembership({
+        id: 1,
+        organizationRole: Membership.roles.ADMIN,
+        user: domainBuilder.buildUser({ id: 1 }),
+      });
+      const secondAdmin = domainBuilder.buildMembership({
+        id: 2,
+        organizationRole: Membership.roles.ADMIN,
+        user: domainBuilder.buildUser({ id: 2 }),
+      });
+      membershipRepository.findAdminsByOrganizationId.resolves([firstAdmin, secondAdmin]);
+
+      // when
+      const canDisableHisOrganizationMembership = await checkUserCanDisableHisOrganizationMembership.execute({
+        organizationId,
+        userId,
+        dependencies: { membershipRepository },
+      });
+
+      // then
+      expect(canDisableHisOrganizationMembership).to.be.true;
+    });
+  });
+
+  context('when there is no administrator left', function () {
+    it('returns "false"', async function () {
+      // given
+      const userId = 1;
+      const organizationId = 1;
+      const admin = domainBuilder.buildMembership({
+        id: 1,
+        organizationRole: Membership.roles.ADMIN,
+        user: domainBuilder.buildUser({ id: 1 }),
+      });
+      membershipRepository.findAdminsByOrganizationId.resolves([admin]);
+
+      // when
+      const canDisableHisOrganizationMembership = await checkUserCanDisableHisOrganizationMembership.execute({
+        organizationId,
+        userId,
+        dependencies: { membershipRepository },
+      });
+
+      // then
+      expect(canDisableHisOrganizationMembership).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/disable-own-organization-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-own-organization-membership_test.js
@@ -1,0 +1,47 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { disableOwnOrganizationMembership } from '../../../../lib/domain/usecases/disable-own-organization-membership.js';
+
+describe('Unit | UseCase | disable-own-membership', function () {
+  let membershipRepository;
+  let clock;
+  const now = new Date('2023-08-01T11:15:00Z');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now });
+    membershipRepository = {
+      findByUserIdAndOrganizationId: sinon.stub(),
+      updateById: sinon.stub(),
+    };
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('success', function () {
+    it('disables membership', async function () {
+      // given
+      const membershipId = 1;
+      const organizationId = 10;
+      const userId = 100;
+      membershipRepository.findByUserIdAndOrganizationId.resolves([{ id: membershipId }]);
+      membershipRepository.updateById.resolves();
+
+      // when
+      await disableOwnOrganizationMembership({ organizationId, userId, membershipRepository });
+
+      // then
+      expect(membershipRepository.findByUserIdAndOrganizationId).to.have.been.calledWithExactly({
+        organizationId,
+        userId,
+      });
+      expect(membershipRepository.updateById).to.has.been.calledWithExactly({
+        id: membershipId,
+        membership: {
+          disabledAt: now,
+          updatedByUserId: userId,
+        },
+      });
+    });
+  });
+});

--- a/orga/app/adapters/membership.js
+++ b/orga/app/adapters/membership.js
@@ -19,4 +19,9 @@ export default class MembershipAdapter extends ApplicationAdapter {
     }
     return super.updateRecord(...arguments);
   }
+
+  leaveOrganization(organizationId) {
+    const url = `${this.host}/${this.namespace}/memberships/me/disable`;
+    return this.ajax(url, 'POST', { data: { organizationId } });
+  }
 }

--- a/orga/app/components/team/leave-organization-modal.hbs
+++ b/orga/app/components/team/leave-organization-modal.hbs
@@ -1,0 +1,28 @@
+<PixModal
+  @title="{{t 'pages.team-members.modals.leave-organization.title'}}"
+  @showModal={{@isOpen}}
+  @onCloseButtonClick={{@onClose}}
+>
+  <:content>
+    <p class="leave-organization-modal">
+      {{t "pages.team-members.modals.leave-organization.message" organizationName=@organizationName htmlSafe=true}}
+    </p>
+  </:content>
+  <:footer>
+    <div class="leave-organization-modal__action-buttons--container">
+      <ul class="leave-organization-modal__action-buttons--list">
+        <li>
+          <PixButton @triggerAction={{@onClose}} @backgroundColor="grey">
+            {{t "common.actions.cancel"}}
+          </PixButton>
+        </li>
+
+        <li>
+          <PixButton @triggerAction={{@onSubmit}} @backgroundColor="red">
+            {{t "common.actions.confirm"}}
+          </PixButton>
+        </li>
+      </ul>
+    </div>
+  </:footer>
+</PixModal>

--- a/orga/app/components/team/members-list-item.hbs
+++ b/orga/app/components/team/members-list-item.hbs
@@ -83,3 +83,9 @@
   @onSubmit={{this.onRemoveButtonClicked}}
   @onClose={{this.closeRemoveMembershipModal}}
 />
+<Team::LeaveOrganizationModal
+  @organizationName={{this.currentUserOrganizationName}}
+  @isOpen={{this.isLeaveOrganizationModalDisplayed}}
+  @onSubmit={{this.onLeaveButtonClicked}}
+  @onClose={{this.closeLeaveOrganizationModal}}
+/>

--- a/orga/app/components/team/members-list-item.hbs
+++ b/orga/app/components/team/members-list-item.hbs
@@ -5,8 +5,8 @@
   {{#unless this.isEditionMode}}
     <td>{{this.displayRole}}</td>
     {{#if this.currentUser.isAdminInOrganization}}
-      {{#if this.isNotCurrentUserMembership}}
-        <td class="zone-edit-role hide-on-mobile">
+      <td class="zone-edit-role hide-on-mobile">
+        {{#if this.isNotCurrentUserMembership}}
           <Dropdown::IconTrigger
             @icon="ellipsis-vertical"
             @dropdownButtonClass="zone-edit-role__dropdown-button"
@@ -20,10 +20,21 @@
               {{t "pages.team-members.actions.remove-membership"}}
             </Dropdown::Item>
           </Dropdown::IconTrigger>
-        </td>
-      {{else}}
-        <td class="hide-on-mobile"></td>
-      {{/if}}
+        {{else}}
+          {{#if @isMultipleAdminsAvailable}}
+            <Dropdown::IconTrigger
+              @icon="ellipsis-vertical"
+              @dropdownButtonClass="zone-edit-role__dropdown-button"
+              @dropdownContentClass="zone-edit-role__dropdown-content"
+              @ariaLabel={{t "pages.team-members.actions.manage"}}
+            >
+              <Dropdown::Item @onClick={{fn this.displayLeaveOrganizationModal @membership}}>
+                {{t "pages.team-members.actions.leave-organization"}}
+              </Dropdown::Item>
+            </Dropdown::IconTrigger>
+          {{/if}}
+        {{/if}}
+      </td>
     {{/if}}
   {{/unless}}
 

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -125,8 +125,15 @@ export default class MembersListItem extends Component {
     try {
       const membership = this.args.membership;
       await this.args.onLeaveOrganization(membership);
+      this.notifications.sendSuccess(
+        this.intl.t('pages.team-members.notifications.leave-organization.success', {
+          organizationName: this.currentUserOrganizationName,
+        }),
+      );
+      await this.session.waitBeforeInvalidation(5000);
       this.session.invalidate();
     } catch (_) {
+      this.notifications.sendError(this.intl.t('pages.team-members.notifications.leave-organization.error'));
     } finally {
       this.closeLeaveOrganizationModal();
     }

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -10,6 +10,7 @@ export default class MembersListItem extends Component {
   @service currentUser;
   @service notifications;
   @service intl;
+  @service session;
 
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
@@ -44,6 +45,10 @@ export default class MembersListItem extends Component {
 
   get isNotCurrentUserMembership() {
     return this.currentUser.prescriber.id !== this.args.membership.user.get('id');
+  }
+
+  get currentUserOrganizationName() {
+    return this.currentUser.organization.name;
   }
 
   @action
@@ -112,6 +117,18 @@ export default class MembersListItem extends Component {
       this.notifications.sendError(this.intl.t('pages.team-members.notifications.remove-membership.error'));
     } finally {
       this.closeRemoveMembershipModal();
+    }
+  }
+
+  @action
+  async onLeaveButtonClicked() {
+    try {
+      const membership = this.args.membership;
+      await this.args.onLeaveOrganization(membership);
+      this.session.invalidate();
+    } catch (_) {
+    } finally {
+      this.closeLeaveOrganizationModal();
     }
   }
 }

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -14,6 +14,7 @@ export default class MembersListItem extends Component {
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
   @tracked isRemoveMembershipModalDisplayed = false;
+  @tracked isLeaveOrganizationModalDisplayed = false;
 
   adminOption = {
     value: 'ADMIN',
@@ -82,8 +83,18 @@ export default class MembersListItem extends Component {
   }
 
   @action
+  displayLeaveOrganizationModal() {
+    this.isLeaveOrganizationModalDisplayed = true;
+  }
+
+  @action
   closeRemoveMembershipModal() {
     this.isRemoveMembershipModalDisplayed = false;
+  }
+
+  @action
+  closeLeaveOrganizationModal() {
+    this.isLeaveOrganizationModalDisplayed = false;
   }
 
   @action

--- a/orga/app/components/team/members-list.hbs
+++ b/orga/app/components/team/members-list.hbs
@@ -18,11 +18,11 @@
       {{#if @members}}
         <tbody>
           {{#each @members as |membership|}}
-            <Team::MembersListItem @membership={{membership}} @onRemoveMember={{@onRemoveMember}} />
             <Team::MembersListItem
               @membership={{membership}}
               @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}}
               @onRemoveMember={{@onRemoveMember}}
+              @onLeaveOrganization={{@onLeaveOrganization}}
             />
           {{/each}}
         </tbody>

--- a/orga/app/components/team/members-list.hbs
+++ b/orga/app/components/team/members-list.hbs
@@ -19,6 +19,11 @@
         <tbody>
           {{#each @members as |membership|}}
             <Team::MembersListItem @membership={{membership}} @onRemoveMember={{@onRemoveMember}} />
+            <Team::MembersListItem
+              @membership={{membership}}
+              @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}}
+              @onRemoveMember={{@onRemoveMember}}
+            />
           {{/each}}
         </tbody>
       {{/if}}

--- a/orga/app/components/team/members-list.js
+++ b/orga/app/components/team/members-list.js
@@ -7,4 +7,8 @@ export default class MembersList extends Component {
   get displayManagingColumn() {
     return this.currentUser.isAdminInOrganization;
   }
+
+  get isMultipleAdminsAvailable() {
+    return this.args.members?.filter((member) => member.isAdmin).length > 1;
+  }
 }

--- a/orga/app/controllers/authenticated/team/list/members.js
+++ b/orga/app/controllers/authenticated/team/list/members.js
@@ -4,11 +4,17 @@ import { service } from '@ember/service';
 
 export default class MembersController extends Controller {
   @service currentUser;
+  @service store;
 
   @action
   async removeMembership(membership) {
     membership.organization = this.currentUser.organization;
     await membership.save({ adapterOptions: { disable: true } });
     this.send('refreshModel');
+  }
+
+  @action
+  async leaveOrganization() {
+    await this.store.adapterFor('membership').leaveOrganization(this.currentUser.organization.id);
   }
 }

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -49,6 +49,12 @@ export default class CurrentSessionService extends SessionService {
     this.locale.setLocale(locale);
   }
 
+  waitBeforeInvalidation(millisecondsToWait) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(), millisecondsToWait);
+    });
+  }
+
   _getRouteAfterInvalidation() {
     const alternativeRootURL = this.alternativeRootURL;
     this.alternativeRootURL = null;

--- a/orga/app/styles/components/team/index.scss
+++ b/orga/app/styles/components/team/index.scss
@@ -1,1 +1,2 @@
+@import 'leave-organization-modal';
 @import 'remove-member-modal';

--- a/orga/app/styles/components/team/leave-organization-modal.scss
+++ b/orga/app/styles/components/team/leave-organization-modal.scss
@@ -1,0 +1,18 @@
+.leave-organization-modal {
+  color: $pix-neutral-90;
+  font-size: 1rem;
+  line-height: $pix-spacing-m;
+
+  &__action-buttons {
+
+    &--list {
+      display: flex;
+      gap: $pix-spacing-s;
+      justify-content: flex-end;
+    }
+
+    &--container {
+      margin-bottom: $pix-spacing-s;
+    }
+  }
+}

--- a/orga/app/templates/authenticated/team/list/members.hbs
+++ b/orga/app/templates/authenticated/team/list/members.hbs
@@ -1,2 +1,6 @@
 {{page-title (t "pages.team-members.title")}}
-<Team::MembersList @members={{@model}} @onRemoveMember={{this.removeMembership}} />
+<Team::MembersList
+  @members={{@model}}
+  @onRemoveMember={{this.removeMembership}}
+  @onLeaveOrganization={{this.leaveOrganization}}
+/>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -505,6 +505,16 @@ function routes() {
     return new Response(204);
   });
 
+  this.post('/memberships/me/disable', (schema, request) => {
+    const { requestHeaders } = request;
+    const token = requestHeaders['Authorization'];
+    const decodedToken = JSON.parse(atob(token.replace('Bearer aaa.', '').replace('.bbb', '')));
+    const membership = schema.memberships.findBy({ userId: decodedToken.user_id });
+    membership.destroy();
+
+    return new Response(204);
+  });
+
   this.get('/frameworks/for-target-profile-submission', (schema) => {
     return schema.frameworks.all();
   });

--- a/orga/tests/integration/components/team/leave-organization-modal_test.js
+++ b/orga/tests/integration/components/team/leave-organization-modal_test.js
@@ -1,0 +1,40 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Components | Team::LeaveOrganizationModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('displays modal content', async function (assert) {
+    // given
+    this.set('currentUserOrganizationName', 'Cola Corp');
+    this.set('isLeaveOrganizationModalDisplayed', true);
+    this.set('noop', sinon.stub());
+
+    // when
+    const screen = await render(
+      hbs`<Team::LeaveOrganizationModal
+  @organizationName={{this.currentUserOrganizationName}}
+  @isOpen={{this.isLeaveOrganizationModalDisplayed}}
+  @onSubmit={{this.noop}}
+  @onClose={{this.noop}}
+/>`,
+    );
+
+    // then
+    const modalTitleElement = screen.getByRole('heading', { level: 1, name: 'Quitter cet espace Pix Orga' });
+    assert.dom(modalTitleElement).exists();
+
+    const modalContentElement = screen.getByText('Cola Corp');
+    assert.dom(modalContentElement).exists();
+
+    const cancelButtonElement = screen.getByRole('button', { name: 'Annuler' });
+    assert.dom(cancelButtonElement).exists();
+
+    const confirmButtonElement = screen.getByRole('button', { name: 'Confirmer' });
+    assert.dom(confirmButtonElement).exists();
+  });
+});

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -27,9 +27,12 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
   setupIntlRenderingTest(hooks);
   let adminMembership;
   let memberMembership;
+  let store;
 
   hooks.beforeEach(function () {
-    const store = this.owner.lookup('service:store');
+    this.set('noop', sinon.stub());
+
+    store = this.owner.lookup('service:store');
     adminMembership = store.createRecord('membership', {
       id: 1,
       displayRole: 'Administrateur',
@@ -278,6 +281,63 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         // then
         sinon.assert.calledWith(removeMembershipStub, memberMembership);
         assert.notContains("Supprimer de l'équipe");
+      });
+    });
+  });
+
+  module('when there is multiple administrators', function () {
+    module('when current admin wants to leave the organization', function () {
+      class CurrentLeavingUserAdminStub extends Service {
+        isAdminInOrganization = true;
+        prescriber = {
+          id: '113',
+        };
+        organization = {
+          credit: 10000,
+        };
+      }
+
+      test('removes current administrator access to the organization, displays a success notification and invalidate the current session', async function (assert) {
+        // given
+        this.owner.register('service:current-user', CurrentLeavingUserAdminStub);
+        const sessionService = this.owner.lookup('service:session');
+
+        const leavingAdminMembership = store.createRecord('membership', {
+          id: 3,
+          displayRole: 'Administrateur',
+          organizationRole: 'ADMIN',
+          user: store.createRecord('user', {
+            id: 113,
+            firstName: 'Dimi',
+            lastName: 'Trie',
+          }),
+        });
+        const onLeaveOrganizationStub = sinon.stub().resolves();
+
+        this.set('membership', leavingAdminMembership);
+        this.set('isMultipleAdminsAvailable', true);
+        this.set('onLeaveOrganization', onLeaveOrganizationStub);
+
+        sinon.stub(sessionService, 'invalidate');
+
+        // when
+        const screen = await render(
+          hbs`<Team::MembersListItem
+  @membership={{this.membership}}
+  @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}}
+  @onRemoveMember={{this.noop}}
+  @onLeaveOrganization={{this.onLeaveOrganization}}
+/>`,
+        );
+        await clickByName('Gérer');
+        await click(screen.getByRole('button', { name: 'Quitter cet espace Pix Orga' }));
+        await screen.findByRole('dialog');
+        await click(screen.getByRole('button', { name: 'Confirmer' }));
+
+        // then
+        sinon.assert.calledWith(onLeaveOrganizationStub, leavingAdminMembership);
+        sinon.assert.called(sessionService.invalidate);
+        assert.ok(true);
       });
     });
   });

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -300,6 +300,7 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
       test('removes current administrator access to the organization, displays a success notification and invalidate the current session', async function (assert) {
         // given
         this.owner.register('service:current-user', CurrentLeavingUserAdminStub);
+        const notificationsService = this.owner.lookup('service:notifications');
         const sessionService = this.owner.lookup('service:session');
 
         const leavingAdminMembership = store.createRecord('membership', {
@@ -318,6 +319,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         this.set('isMultipleAdminsAvailable', true);
         this.set('onLeaveOrganization', onLeaveOrganizationStub);
 
+        sinon.stub(notificationsService, 'sendSuccess');
+        sinon.stub(sessionService, 'waitBeforeInvalidation');
         sinon.stub(sessionService, 'invalidate');
 
         // when
@@ -336,6 +339,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
 
         // then
         sinon.assert.calledWith(onLeaveOrganizationStub, leavingAdminMembership);
+        sinon.assert.called(notificationsService.sendSuccess);
+        sinon.assert.called(sessionService.waitBeforeInvalidation);
         sinon.assert.called(sessionService.invalidate);
         assert.ok(true);
       });

--- a/orga/tests/integration/components/team/members-list_test.js
+++ b/orga/tests/integration/components/team/members-list_test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
+import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -9,6 +10,15 @@ module('Integration | Component | Team::MembersList', function (hooks) {
 
   test('it should list the team members', async function (assert) {
     //given
+    class CurrentUserMemberStub extends Service {
+      isAdminInOrganization = false;
+      organization = {
+        credit: 10000,
+        name: 'Super Orga',
+      };
+    }
+    this.owner.register('service:current-user', CurrentUserMemberStub);
+
     const members = [
       {
         id: 1,

--- a/orga/tests/unit/components/team/members-list_test.js
+++ b/orga/tests/unit/components/team/members-list_test.js
@@ -1,0 +1,71 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Components | Team | members-list', function (hooks) {
+  setupTest(hooks);
+
+  let onRemoveMember;
+  let onLeaveOrganization;
+
+  hooks.beforeEach(function () {
+    this.set('noop', sinon.stub());
+
+    onRemoveMember = this.noop;
+    onLeaveOrganization = this.noop;
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('#isMultipleAdminsAvailable', function () {
+    module('when there is multiple admins', function () {
+      test('returns "true"', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const members = [
+          store.createRecord('membership', { organizationRole: 'ADMIN' }),
+          store.createRecord('membership', { organizationRole: 'ADMIN' }),
+          store.createRecord('membership', { organizationRole: 'MEMBER' }),
+        ];
+        const component = await createGlimmerComponent('component:team/members-list', {
+          members,
+          onRemoveMember,
+          onLeaveOrganization,
+        });
+
+        // when
+        const result = component.isMultipleAdminsAvailable;
+
+        // then
+        assert.true(result);
+      });
+    });
+
+    module('when there is only one admin', function () {
+      test('returns "false"', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const members = [
+          store.createRecord('membership', { organizationRole: 'ADMIN' }),
+          store.createRecord('membership', { organizationRole: 'MEMBER' }),
+          store.createRecord('membership', { organizationRole: 'MEMBER' }),
+        ];
+        const component = await createGlimmerComponent('component:team/members-list', {
+          members,
+          onRemoveMember,
+          onLeaveOrganization,
+        });
+
+        // when
+        const result = component.isMultipleAdminsAvailable;
+
+        // then
+        assert.false(result);
+      });
+    });
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/team/list/members_test.js
+++ b/orga/tests/unit/controllers/authenticated/team/list/members_test.js
@@ -59,4 +59,20 @@ module('Unit | Controller | authenticated/team/list/members', function (hooks) {
       assert.ok(true);
     });
   });
+
+  module('#leaveOrganization', function () {
+    test('disables current user membership', async function (assert) {
+      // given
+      const adapter = { leaveOrganization: sinon.stub().resolves() };
+      const store = this.owner.lookup('service:store');
+      sinon.stub(store, 'adapterFor').returns(adapter);
+
+      // when
+      await controller.leaveOrganization();
+
+      // then
+      sinon.assert.calledWith(adapter.leaveOrganization, currentUser.organization.id);
+      assert.ok(true);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1202,6 +1202,12 @@
           }
         }
       },
+      "modals": {
+        "leave-organization": {
+          "title": "Leave this Pix Orga space",
+          "message": "Are you sure you want to leave this Pix Orga space? You will no longer have access to <strong>{organizationName}</strong>.<br/><br/>Your campaigns remain accessible to the rest of the team and will not be archived.<br/><br/>Your access to other Pix Orga spaces will not be affected.<br/><br/>You'll be disconnected."
+        }
+      },
       "notifications": {
         "change-member-role": {
           "error": "An error occurred while changing this member's role.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1191,6 +1191,7 @@
       "title": "Team members",
       "actions": {
         "edit-organization-membership-role": "Change role",
+        "leave-organization": "Leave this Pix Orga space",
         "manage": "Manage",
         "remove-membership": "Remove",
         "save": "Save",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1214,6 +1214,10 @@
           "error": "An error occurred while changing this member's role.",
           "success": "The role has been changed."
         },
+        "leave-organization": {
+          "error": "An error has occurred while deactivating the member.",
+          "success": "You have been successfully removed from the organisation {organizationName}. You will be disconnected from Pix Orga..."
+        },
         "remove-membership": {
           "error": "An error occurred while removing this member.",
           "success": "{memberFirstName} {memberLastName} has successfully been removed from your Pix Orga team."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1217,6 +1217,10 @@
           "error": "Une erreur est survenue lors de la modification du rôle du membre.",
           "success": "Le rôle a bien été changé."
         },
+        "leave-organization": {
+          "error": "Une erreur est survenue lors de la désactivation du membre.",
+          "success": "Vous avez été supprimé avec succès de l'organisation {organizationName}. Vous allez être déconnecté de Pix Orga..."
+        },
         "remove-membership": {
           "error": "Une erreur est survenue lors de la désactivation du membre.",
           "success": "{memberFirstName} {memberLastName} a été supprimé avec succès de votre équipe Pix Orga."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1205,6 +1205,12 @@
           }
         }
       },
+      "modals": {
+        "leave-organization": {
+          "title": "Quitter cet espace Pix Orga",
+          "message": "Êtes-vous sûr de vouloir quitter cet espace Pix Orga ? Vous n’aurez plus accès à <strong>{organizationName}</strong>.<br/><br/>Vos campagnes restent accessibles au reste de l'équipe, elles ne seront pas archivées.<br/><br/>Vos accès à d’autres espaces Pix Orga ne seront pas impactés.<br/><br/>Vous allez être déconnecté."
+        }
+      },
       "notifications": {
         "change-member-role": {
           "error": "Une erreur est survenue lors de la modification du rôle du membre.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1194,6 +1194,7 @@
       "title": "Membres",
       "actions": {
         "edit-organization-membership-role": "Modifier le rôle",
+        "leave-organization": "Quitter cet espace Pix Orga",
         "manage": "Gérer",
         "remove-membership": "Supprimer",
         "save": "Enregistrer",


### PR DESCRIPTION
## :unicorn: Problème

En tant qu'administrateur d'une organisation, on souhaite avoir l'option de quitter une organisation. Actuellement ce n'est pas le cas. Pour y arriver, un autre administrateur doit faire une action `Supprimer un membre`.

## :robot: Proposition

Permettre à un administrateur d'une organisation de quitter cette dernière. Cette action ne sera possible que si l'organisation à plusieurs administrateurs.

## :rainbow: Remarques

- Pour réduire la complexité de la fonctionnalité, l'utilisateur ayant quitté l'organisation sera déconnecté de l'application.
- Un `cherry-pick` a été fait sur cette PR #6776 pour avoir les nouvelles seeds

## :100: Pour tester

- Se connecter sur https://orga-pr6742.review.pix.fr/ avec le compte `admin.leaving@example.net`
- Se rendre sur la page `Équipe`
- Constater l'affichage d'un tableau contenant 2 administrateurs
- Cliquer sur le bouton d'action de l'administrateur `Leaving Admin`
- Cliquer sur l'action `Quitter cet espace Pix Orga`
- Constater l'affichage d'une modale
- Cliquer sur le bouton `Confirmer`
- Constater l'affichage rapide d'une notification de succès
- Constater que l'utilisateur a été automatique déconnecté de l'application
- Se connecter de nouveau avec le compte `admin.leaving@example.net`
- Constater l'affichage d'un message d'erreur, car l'utilisateur n'avait qu'une seule organisation gérée
