### PR TITLE
[TECH] Simplifier `cpfCertificationResultRepository.markCertificationToExport`

### DIFF
--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -37,7 +37,7 @@ const markCertificationCoursesAsExported = async function ({ certificationCourse
     .whereIn('id', certificationCourseIds);
 };
 
-const markCertificationToExport = async function ({ startDate, endDate, limit = 'ALL', offset = 0, batchId }) {
+const markCertificationToExport = async function ({ startDate, endDate, limit, offset, batchId }) {
   const now = new Date();
 
   return knex

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -282,57 +282,6 @@ describe('Integration | Repository | CpfCertificationResult', function () {
   });
 
   describe('#markCertificationToExport', function () {
-    context('when there is no offset, limit', function () {
-      it('should save batchId in cpfFilename', async function () {
-        // given
-        const startDate = new Date('2022-01-01');
-        const endDate = new Date('2022-01-10');
-
-        const firstPublishedSessionId = databaseBuilder.factory.buildSession({
-          publishedAt: new Date('2022-01-04'),
-        }).id;
-        createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 123,
-          sessionId: firstPublishedSessionId,
-        });
-        createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 456,
-          sessionId: firstPublishedSessionId,
-        });
-        const secondPublishedSessionId = databaseBuilder.factory.buildSession({
-          publishedAt: new Date('2023-01-09'),
-        }).id;
-        createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 789,
-          sessionId: secondPublishedSessionId,
-        });
-        createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 101112,
-          sessionId: secondPublishedSessionId,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        await cpfCertificationResultRepository.markCertificationToExport({
-          startDate,
-          endDate,
-          batchId: 'toto#1',
-        });
-
-        // then
-        const certificationCourses = await knex('certification-courses')
-          .select('id', 'cpfImportStatus', 'cpfFilename')
-          .orderBy('id');
-        expect(certificationCourses).to.deep.equal([
-          { id: 123, cpfImportStatus: 'PENDING', cpfFilename: 'toto#1' },
-          { id: 456, cpfImportStatus: 'PENDING', cpfFilename: 'toto#1' },
-          { id: 789, cpfImportStatus: null, cpfFilename: null },
-          { id: 101112, cpfImportStatus: null, cpfFilename: null },
-        ]);
-      });
-    });
-
     context('when there are pending certification courses', function () {
       context('when there are offset/limit', function () {
         it('should save partially batchId in cpfFilename', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans l'appel de `knex.limit`, `ALL` n'est pas un integer et ça cause un log dans le test d'intégration correspondant :

```
A valid integer must be provided to limit
```

## :robot: Proposition
Les valeurs `limit` et `offset` étant toujours fournies par [le planner](https://github.com/1024pix/pix/blob/663eedd596c4119582e3f35eaaef7db3d1527c5f/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js#L24C71-L24C71), ne plus supporter leur absence.

## :rainbow: Remarques
RAS

## :100: Pour tester
CI 🟢 
