### PR TITLE
[TECH] Corrige le test du csv parser pour ne plus avoir de warning dans la console (PIX-8761)

### DIFF
--- a/api/tests/unit/infrastructure/serializers/csv/csv-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-parser_test.js
@@ -16,7 +16,9 @@ describe('Unit | Infrastructure | CsvParser', function () {
 
         const input = `Column 1;Column 2
         John;Mc Lane`;
-        const parser = new CsvParser(input, header);
+        const encodedInput = iconv.encode(input, 'utf8');
+
+        const parser = new CsvParser(encodedInput, header);
         const [result] = parser.parse();
 
         expect(result.col1).to.equal('John');
@@ -30,7 +32,9 @@ describe('Unit | Infrastructure | CsvParser', function () {
         const input = `Column 1
         GodZilla
         Gidora`;
-        const parser = new CsvParser(input, header);
+        const encodedInput = iconv.encode(input, 'utf8');
+
+        const parser = new CsvParser(encodedInput, header);
 
         const [result1, result2] = parser.parse();
 


### PR DESCRIPTION
## :unicorn: Problème
Dans les deux premiers tests du csv parser c'est des strings qui étaient passés en input du parser. 
Quand on lançait les tests on avait donc un warning : 
`Iconv-lite warning: decode()-ing strings is deprecated. Refer to https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding`.

## :robot: Proposition
Encoder la string en utf8 avec iconv.encode avant de la passer en input.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Lancer le test du fichier `api/tests/unit/infrastructure/serializers/csv/csv-parser_test.js`
- Vérifier qu'il passe et qu'aucun warning n'est affiché dans la console
- 🐱 
