### PR TITLE
[BUGFIX] Aligner le comportement de la sidebar par rapport au Breadcrumb de la page participant d'une campagne (PIX-8762)

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -20,30 +20,12 @@
         {{t "navigation.main.certifications"}}
       </LinkTo>
     {{/if}}
-    {{#if this.currentUser.isSCOManagingStudents}}
-      <LinkTo @route="authenticated.sco-organization-participants" class="sidebar-nav__item">
-        <span class="sidebar-nav__item-icon">
-          <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
-        </span>
-        {{t "navigation.main.sco-organization-participants"}}
-      </LinkTo>
-    {{/if}}
-    {{#if this.isNotManagingStudents}}
-      <LinkTo @route="authenticated.organization-participants" class="sidebar-nav__item">
-        <span class="sidebar-nav__item-icon">
-          <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
-        </span>
-        {{t "navigation.main.organization-participants"}}
-      </LinkTo>
-    {{/if}}
-    {{#if this.currentUser.isSUPManagingStudents}}
-      <LinkTo @route="authenticated.sup-organization-participants" class="sidebar-nav__item">
-        <span class="sidebar-nav__item-icon">
-          <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
-        </span>
-        {{t "navigation.main.sup-organization-participants"}}
-      </LinkTo>
-    {{/if}}
+    <LinkTo @route={{this.organizationLearnersList.route}} class="sidebar-nav__item">
+      <span class="sidebar-nav__item-icon">
+        <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
+      </span>
+      {{t this.organizationLearnersList.label}}
+    </LinkTo>
     <LinkTo @route="authenticated.team" class="sidebar-nav__item">
       <span class="sidebar-nav__item-icon">
         <img src="{{this.rootURL}}/icons/users-light.svg" alt="" role="none" />

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -13,7 +13,22 @@ export default class SidebarMenu extends Component {
     return this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents;
   }
 
-  get isNotManagingStudents() {
-    return !this.currentUser.isSCOManagingStudents && !this.currentUser.isSUPManagingStudents;
+  get organizationLearnersList() {
+    if (this.currentUser.isSCOManagingStudents) {
+      return {
+        route: 'authenticated.sco-organization-participants',
+        label: 'navigation.main.sco-organization-participants',
+      };
+    } else if (this.currentUser.isSUPManagingStudents) {
+      return {
+        route: 'authenticated.sup-organization-participants',
+        label: 'navigation.main.sup-organization-participants',
+      };
+    } else {
+      return {
+        route: 'authenticated.organization-participants',
+        label: 'navigation.main.organization-participants',
+      };
+    }
   }
 }

--- a/orga/app/components/participant/link-to.js
+++ b/orga/app/components/participant/link-to.js
@@ -5,9 +5,9 @@ export default class LinkTo extends Component {
   @service currentUser;
 
   get route() {
-    if (this.currentUser.organization.isSco) {
+    if (this.currentUser.isSCOManagingStudents) {
       return 'authenticated.sco-organization-participants.sco-organization-participant';
-    } else if (this.currentUser.organization.isSup) {
+    } else if (this.currentUser.isSUPManagingStudents) {
       return 'authenticated.sup-organization-participants.sup-organization-participant';
     }
     return 'authenticated.organization-participants.organization-participant';

--- a/orga/tests/unit/components/participant/link-to_test.js
+++ b/orga/tests/unit/components/participant/link-to_test.js
@@ -5,51 +5,96 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Component | Participant::LinkTo', function (hooks) {
   setupTest(hooks);
 
-  test('should return route to sco participant details', async function (assert) {
-    // given
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.organization = {
-      isSco: true,
-      isSup: false,
-    };
-    const component = await createGlimmerComponent('component:participant/link-to');
+  module('organization is managing student', function () {
+    test('should return route to sco participant details', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.organization = {
+        isSco: true,
+        isSup: false,
+      };
+      currentUser.isSCOManagingStudents = true;
 
-    // when
-    const route = component.route;
+      const component = await createGlimmerComponent('component:participant/link-to');
 
-    // then
-    assert.strictEqual(route, 'authenticated.sco-organization-participants.sco-organization-participant');
+      // when
+      const route = component.route;
+
+      // then
+      assert.strictEqual(route, 'authenticated.sco-organization-participants.sco-organization-participant');
+    });
+
+    test('should return route to sup participant details', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.organization = {
+        isSco: false,
+        isSup: true,
+      };
+      currentUser.isSUPManagingStudents = true;
+
+      const component = await createGlimmerComponent('component:participant/link-to');
+
+      // when
+      const route = component.route;
+
+      // then
+      assert.strictEqual(route, 'authenticated.sup-organization-participants.sup-organization-participant');
+    });
   });
 
-  test('should return route to sup participant details', async function (assert) {
-    // given
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.organization = {
-      isSco: false,
-      isSup: true,
-    };
-    const component = await createGlimmerComponent('component:participant/link-to');
+  module('organization is not managing student', function () {
+    test('should return route to participant details for sco', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.organization = {
+        isSco: true,
+        isSup: false,
+      };
+      currentUser.isSCOManagingStudents = false;
 
-    // when
-    const route = component.route;
+      const component = await createGlimmerComponent('component:participant/link-to');
 
-    // then
-    assert.strictEqual(route, 'authenticated.sup-organization-participants.sup-organization-participant');
-  });
+      // when
+      const route = component.route;
 
-  test('should return route to participant details', async function (assert) {
-    // given
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.organization = {
-      isSco: false,
-      isSup: false,
-    };
-    const component = await createGlimmerComponent('component:participant/link-to');
+      // then
+      assert.strictEqual(route, 'authenticated.organization-participants.organization-participant');
+    });
 
-    // when
-    const route = component.route;
+    test('should return route to participant details for sup', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.organization = {
+        isSco: false,
+        isSup: true,
+      };
+      currentUser.isSUPManagingStudents = false;
 
-    // then
-    assert.strictEqual(route, 'authenticated.organization-participants.organization-participant');
+      const component = await createGlimmerComponent('component:participant/link-to');
+
+      // when
+      const route = component.route;
+
+      // then
+      assert.strictEqual(route, 'authenticated.organization-participants.organization-participant');
+    });
+
+    test('should return route to participant details for pro', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.organization = {
+        isSco: false,
+        isSup: false,
+      };
+
+      const component = await createGlimmerComponent('component:participant/link-to');
+
+      // when
+      const route = component.route;
+
+      // then
+      assert.strictEqual(route, 'authenticated.organization-participants.organization-participant');
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le breadcrumb retourne pour une orga sco sup vers eleves/etudiants sans tenir compte du isManagingStudent.
La sidebar prend en compte cette différenciation

## :robot: Proposition
Prendre en compte le isManagingStudent pour définir le lien à afficher

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur PixOrga et vérifier que les liens Eleve participant etudiants sont bien contextualisé en fonction du isManagingStudent SCO SUP