### PR TITLE
[BUGFIX] Créer les acquis de la campagne au moment de la création en masse (PIX-8735)

### DIFF
--- a/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
+++ b/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
@@ -2,7 +2,6 @@ import { CampaignTypes } from '../../models/CampaignTypes.js';
 
 const createCampaigns = async function ({
   campaignsToCreate,
-  campaignAdministrationRepository,
   membershipRepository,
   campaignRepository,
   campaignCodeGenerator,
@@ -22,7 +21,7 @@ const createCampaigns = async function ({
     }),
   );
 
-  return campaignAdministrationRepository.createCampaigns(enrichedCampaignsData);
+  return campaignRepository.save(enrichedCampaignsData);
 };
 
 export { createCampaigns };

--- a/api/lib/infrastructure/repositories/campaigns-administration/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaigns-administration/campaign-repository.js
@@ -7,14 +7,4 @@ const archiveCampaigns = function (campaignIds, userId) {
   });
 };
 
-const createCampaigns = function (campaignsToCreate) {
-  return knex.batchInsert(
-    'campaigns',
-    campaignsToCreate.map((campaignToCreate) => ({
-      ...campaignToCreate,
-      createdAt: new Date(),
-    })),
-  );
-};
-
-export { archiveCampaigns, createCampaigns };
+export { archiveCampaigns };

--- a/api/tests/integration/infrastructure/repositories/campaigns-administration/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaigns-administration/campaign-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, knex, databaseBuilder, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaigns-administration/campaign-repository.js';
 
 describe('Integration | Infrastructure | Repository | Campaign Administration | campaign-repository', function () {
@@ -70,55 +70,6 @@ describe('Integration | Infrastructure | Repository | Campaign Administration | 
 
       // when
       expect(call).to.not.throw();
-    });
-  });
-
-  describe('#createCampaigns', function () {
-    afterEach(function () {
-      return knex('campaigns').delete();
-    });
-
-    it('creates campaigns', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-
-      await databaseBuilder.commit();
-
-      const campaignsToCreate = [
-        {
-          targetProfileId,
-          name: 'CampaignToCreate',
-          organizationId,
-          title: 'CampaignToCreate',
-          customLandingPageText: 'CampaignToCreate',
-          ownerId: userId,
-          creatorId: userId,
-          type: 'ASSESSMENT',
-        },
-      ];
-
-      // when
-      await campaignRepository.createCampaigns(campaignsToCreate);
-
-      const createdCampaign = await knex('campaigns')
-        .select(
-          'targetProfileId',
-          'name',
-          'organizationId',
-          'title',
-          'customLandingPageText',
-          'creatorId',
-          'createdAt',
-          'ownerId',
-          'type',
-        )
-        .where('name', campaignsToCreate[0].name)
-        .first();
-
-      // then
-      expect(createdCampaign).to.deep.equal({ ...campaignsToCreate[0], createdAt: now });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
@@ -3,8 +3,8 @@ import { createCampaigns } from '../../../../../lib/domain/usecases/campaigns-ad
 
 describe('Unit | UseCase | campaign-administration | create-campaign', function () {
   it('should create campaigns', async function () {
-    const campaignAdministrationRepository = {
-      createCampaigns: sinon.stub(),
+    const campaignRepository = {
+      save: sinon.stub(),
     };
     const code1 = Symbol('code1');
     const code2 = Symbol('code2');
@@ -15,7 +15,6 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
       organization,
       organizationRole: 'ADMIN',
     });
-    const campaignRepository = Symbol('campaignRepository');
     const campaignCodeGeneratorStub = {
       generate: sinon.stub().withArgs(campaignRepository).onFirstCall().resolves(code1).onSecondCall().resolves(code2),
     };
@@ -56,7 +55,7 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
       },
     ];
 
-    campaignAdministrationRepository.createCampaigns.withArgs(campaignsWithAllData).resolves();
+    campaignRepository.save.withArgs(campaignsWithAllData).resolves();
 
     const membershipRepository = {
       findAdminsByOrganizationId: sinon.stub(),
@@ -67,13 +66,12 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
 
     await createCampaigns({
       campaignsToCreate,
-      campaignAdministrationRepository,
       membershipRepository,
       campaignRepository,
       campaignCodeGenerator: campaignCodeGeneratorStub,
     });
 
-    expect(campaignAdministrationRepository.createCampaigns).to.have.been.calledWith(campaignsWithAllData);
+    expect(campaignRepository.save).to.have.been.calledWith(campaignsWithAllData);
     expect(membershipRepository.findAdminsByOrganizationId).to.have.been.calledTwice;
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans pix orga lorsque je souhaite afficher ma campagne, j’ai une erreur de chargement côté analyse et aussi lors de l’upload du fichier csv des résultats.

## :robot: Proposition
Actuellement nous n’avons pas créé les tubes d’acquis (nouvelle méthode pour le versionning des profils cibles fait par l'équipe contenu), donc ma campagne ne comporte pas d’acquis. 

On adapte la fonction de creation d'une campaign pour créer plusieurs campaigns.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Aller sur Pix Admin et creer des campaigns via import csv
Aller sur Pix App et participer a une campaign et partarger les resultats
Aller sur Pix Orga pour voir les resultats

