### PR TITLE
[BUGFIX] Réparer la selection des niveaux sur les paliers par niveaux

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -28,6 +28,7 @@ const serialize = function (targetProfiles) {
       'badges',
       'stageCollection',
       'areas',
+      'maxLevel',
     ],
     badges: {
       ref: 'id',

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -186,6 +186,7 @@ describe('Acceptance | Route | target-profiles', function () {
         name: 'Savoir tout faire',
         outdated: false,
         'owner-organization-id': targetProfile.ownerOrganizationId,
+        'max-level': -Infinity,
       };
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -188,6 +188,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             'is-public': true,
             'is-simplified-access': true,
             'are-knowledge-elements-resettable': false,
+            'max-level': 7,
             name: 'Mon Super profil cible',
             outdated: true,
             'owner-organization-id': 12,


### PR DESCRIPTION
## :unicorn: Problème
La suppression d'un attribut a causé une régression

## :robot: Proposition
Le remettre pour rétablir le bon fonctionnement de la sélection des paliers par niveau dans Pix Admin.

## :rainbow: Remarques

## :100: Pour tester
Aller sur Pix Admin
Créer un target profile
Ajouter un palier par niveau 
Vérifier qu'on peut sélectionner les niveaux