### PR TITLE
[BUGFIX] Corriger l'affichage du lien sur la page de récupération d'accès à Pix Orga (PIX-8782)

### DIFF
--- a/orga/app/components/auth/join-request-form.hbs
+++ b/orga/app/components/auth/join-request-form.hbs
@@ -58,8 +58,8 @@
 
   <p class="join-request-form__legal-information">
     {{t "pages.join-request-form.legal-information.text"}}
-    <a href={{t "pages.join-request-form.legal-information.hyperlink"}} target="_blank" rel="noopener noreferrer">
-      {{t "pages.join-request-form.legal-information.link"}}
+    <a href={{t "pages.join-request-form.legal-information.link-url"}} target="_blank" rel="noopener noreferrer">
+      {{t "pages.join-request-form.legal-information.link-text"}}
     </a>
   </p>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Lors de la dernière MER, nous avons remarqué que le lien sur la page de récupération d'accès à Pix Orga était cassé.

## :robot: Proposition
Corriger le nommage des clés de traduction utilisées dans le composant.

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Aller sur Pix Orga (domaine fr)
2. Se rendre sur la page `demande-administration-sco`
3. Vérifier que le lien présent dans le texte sous le bouton `Envoyer` s'affiche bien et qu'il renvoie bien vers https://pix.fr/dp-formulaire-recuperation-pixorga-sco
