### PR TITLE
[TECH] Ajout d'un helper pour la création de tests paramétrisés.

### DIFF
--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -115,6 +115,17 @@ async function insertUserWithRoleCertif() {
   return user;
 }
 
+function buildParameterizedTests(params, title, callee) {
+  describe('parameterized test', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    params.forEach((test) => {
+      it(title(test), function () {
+        return callee(test);
+      });
+    });
+  });
+}
+
 async function insertOrganizationUserWithRoleAdmin() {
   const adminUser = databaseBuilder.factory.buildUser();
   const organization = databaseBuilder.factory.buildOrganization();
@@ -289,4 +300,5 @@ export {
   learningContentBuilder,
   createTempFile,
   removeTempFile,
+  buildParameterizedTests,
 };

--- a/api/tests/test-helper_test.js
+++ b/api/tests/test-helper_test.js
@@ -1,4 +1,4 @@
-import { expect, catchErr } from './test-helper.js';
+import { expect, catchErr, buildParameterizedTests } from './test-helper.js';
 
 describe('Test helpers', function () {
   describe('#catchErr', function () {
@@ -27,6 +27,19 @@ describe('Test helpers', function () {
 
       // then
       await expect(promise).to.be.rejectedWith('Expected an error, but none was thrown.');
+    });
+  });
+
+  describe('#buildParameterizedTests', function () {
+    it('should call all passed functions', function () {
+      buildParameterizedTests(
+        ['hello', 'hello'],
+        (data) => `should do ${data}`,
+        function (data) {
+          // Then
+          expect(data).to.equal('hello');
+        },
+      );
     });
   });
 });

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -1,4 +1,4 @@
-import { expect } from '../../../test-helper.js';
+import { buildParameterizedTests, expect } from '../../../test-helper.js';
 
 import {
   isNumeric,
@@ -59,20 +59,24 @@ describe('Unit | Utils | string-utils', function () {
   });
 
   describe('#splitIntoWordsAndRemoveBackspaces', function () {
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    [
-      { case: 'abc', expectedResult: ['abc'] },
-      { case: 'qvak\nqwak\nanything\n', expectedResult: ['qvak', 'qwak', 'anything'] },
-      { case: 'wîth àccénts êêê', expectedResult: ['wîth àccénts êêê'] },
-      { case: ',.!p-u-n-c-t', expectedResult: [',.!p-u-n-c-t'] },
-      { case: 'variant 1\nvariant 2\nvariant 3\n', expectedResult: ['variant 1', 'variant 2', 'variant 3'] },
-    ].forEach((data) => {
-      it(`should return ${data.expectedResult} with ${data.case}`, function () {
-        // When
-        const result = splitIntoWordsAndRemoveBackspaces(data.case);
-        // Then
-        expect(result).to.be.deep.equal(data.expectedResult);
-      });
+    it('should call all passed functions', function () {
+      buildParameterizedTests(
+        [
+          { case: 'abc', expectedResult: ['abc'] },
+          { case: 'qvak\nqwak\nanything\n', expectedResult: ['qvak', 'qwak', 'anything'] },
+          { case: 'wîth àccénts êêê', expectedResult: ['wîth àccénts êêê'] },
+          { case: ',.!p-u-n-c-t', expectedResult: [',.!p-u-n-c-t'] },
+          { case: 'variant 1\nvariant 2\nvariant 3\n', expectedResult: ['variant 1', 'variant 2', 'variant 3'] },
+        ],
+        (data) => `should return ${data.expectedResult} with ${data.case}`,
+        function (data) {
+          // When
+          const result = splitIntoWordsAndRemoveBackspaces(data.case);
+
+          // Then
+          expect(result).to.be.deep.equal(data.expectedResult);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Lors de la création de tests paramétrisés, nous utilisons actuellement le schéma suivant : 

```
describe('some context', function() {
  //eslint-disable-next-line mocha/no-setup-in-describe
  [{key, otherKey}, {key, otherKey}].forEach(({key, otherKey}) => {
    it(`should do something with ${key} and ${otherKey}`, function() {
       ...
    });
  });
});

```

Le problème étant ici l'utilisation de `// eslint-disable-next-line mocha/no-setup-in-describe` afin de pouvoir utiliser le tableau de données dans le cadre du test.
Cette utilisation se retrouve donc à de nombreuses reprises dans la base de code.

## :robot: Proposition

Création d'un nouveau helper permettant la création de fonctions paramétrisées ayant la forme suivante : 

```
function buildParameterizedTests(params, title, callee) {
  describe('parameterized test', function () {
    // eslint-disable-next-line mocha/no-setup-in-describe
    params.forEach((test) => {
      it(title(test), function () {
        return callee(test);
      });
    });
  });
}
```

Où :
- `params` réprésente le tableau de données
- `title` le titre de la fonction `it()`
- `callee` la fonction contenant la structure du test (given/when/then)

## :rainbow: Remarques

Les stubs ne fonctionnent pas encore

L'ajout de cette fonction fait perdre le contexte initial pour revenir en début de ligne dans le cas de l'utilisation du `--reporter=spec`

## :100: Pour tester

CI verte.
