### PR TITLE
[TECH] Ajouter un test sur le bouton retour (PIX-8776)

### DIFF
--- a/1d/app/pods/assessment/results/route.js
+++ b/1d/app/pods/assessment/results/route.js
@@ -7,8 +7,6 @@ export default class ResultRoute extends Route {
 
   async model() {
     const assessment = await this.modelFor('assessment');
-    const mission = this.store.findRecord('mission', assessment.missionId);
-
-    return mission;
+    return this.store.findRecord('mission', assessment.missionId);
   }
 }

--- a/1d/tests/acceptance/end-mission_test.js
+++ b/1d/tests/acceptance/end-mission_test.js
@@ -1,0 +1,23 @@
+import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { currentURL } from '@ember/test-helpers';
+
+module('Acceptance | Challenge', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('redirect to home page after clicking on return button', async function (assert) {
+    // given
+    const mission = this.server.create('mission');
+    const assessment = this.server.create('assessment', { missionId: mission.id });
+
+    // when
+    await visit(`/assessments/${assessment.id}/results`);
+    await clickByText('Retour aux missions');
+
+    // then
+    assert.strictEqual(currentURL(), '/');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de fin de parcours il y a un bouton qui permet de revenir à la page d'accueil. Ce bouton de redirection n'est pas testé

## :robot: Proposition
Ajout du test sur la redirection du bouton.

## :rainbow: Remarques


## :100: Pour tester
Faire tourner les tests