### PR TITLE
[TECH] Trier les data pour la génération du timeSeries chart des tech-days api arboresence

### DIFF
--- a/api/scripts/arborescence-monitoring/add-metrics-to-gist.js
+++ b/api/scripts/arborescence-monitoring/add-metrics-to-gist.js
@@ -6,13 +6,18 @@ async function parseTimeSeriesMetrics({ metricsFilepath }) {
   return JSON.parse(currentRawMetrics);
 }
 
+function sortTimeSeriesMetrics(existingTimeSeriesMetrics) {
+  return existingTimeSeriesMetrics.sort((a, b) => new Date(a.x).getTime() - new Date(b.x).getTime());
+}
+
 async function main() {
   const metricsFilepath = process.argv[2];
   const existingTimeSeriesMetrics = await parseTimeSeriesMetrics({ metricsFilepath });
 
   const updatedTimeSeriesMetrics = await _addOrUpdateTodayValue(existingTimeSeriesMetrics);
+  const sortedTimeSeriesMetrics = sortTimeSeriesMetrics(updatedTimeSeriesMetrics);
 
-  const stringifiedMetrics = JSON.stringify(updatedTimeSeriesMetrics);
+  const stringifiedMetrics = JSON.stringify(sortedTimeSeriesMetrics);
   await writeFile(metricsFilepath, stringifiedMetrics);
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre des tech-days appi arborescnce, nous avons créé des indicateurs pour suivre la migration vers la nouvelle arborescence. L'un de ces indicateur est un timeSeries chart, et il ressemble actuellement à ca : 

<img width="639" alt="image" src="https://github.com/1024pix/pix/assets/26234185/83b0215b-4c1c-4bef-a619-d871100aefba">

## :robot: Proposition
Ajouter une méthode qui trie les data avant de générer le chart.

## :rainbow: Remarques


## :100: Pour tester
- Récupérer les data du gist en local : https://gist.githubusercontent.com/pix-service/62aad2c4b2fbfddd519dc86413e14b7b/raw/tech_days_api_arbo.json
- Créer un fichier json contenant ces data.
- Lancer le script `npm run monitoring:arborescence -- ./path-to-json-file.json`
- cliquer sur le troisième lien envoyé par le script
- constater que les data sont affichées dans l'ordre