### PR TITLE
[TECH] Revue de la fonction shuffle pour 1d (pix-8784)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-item-qcm/component.js
+++ b/1d/app/pods/components/challenge/challenge-item-qcm/component.js
@@ -13,7 +13,7 @@ export default class ChallengeItemQcm extends Component {
     const arrayOfBoolean = valueAsArrayOfBoolean();
     const labeledCheckboxesList = labeledCheckboxes(arrayOfProposals, arrayOfBoolean);
     if (this.args.challenge.shuffled) {
-      pshuffle(labeledCheckboxesList);
+      pshuffle(labeledCheckboxesList, this.args.assessment?.id);
     }
     return labeledCheckboxesList;
   }

--- a/1d/app/pods/components/challenge/challenge-item-qcu/component.js
+++ b/1d/app/pods/components/challenge/challenge-item-qcu/component.js
@@ -9,8 +9,8 @@ export default class QcuProposals extends Component {
   get labeledRadios() {
     const arrayOfProposals = proposalsAsArray(this.args.challenge.proposals);
     const labeledCheckboxesList = labeledCheckboxes(arrayOfProposals, valueAsArrayOfBoolean());
-    if (this.args.shuffled) {
-      pshuffle(labeledCheckboxesList, this.args.assessment.id);
+    if (this.args.challenge.shuffled) {
+      pshuffle(labeledCheckboxesList, this.args.assessment?.id);
     }
     return labeledCheckboxesList;
   }

--- a/1d/app/pods/components/challenge/item/template.hbs
+++ b/1d/app/pods/components/challenge/item/template.hbs
@@ -34,12 +34,20 @@
         {{/if}}
         {{#if @challenge.isQCU}}
           <div class="challenge-item__qcu">
-            <Challenge::ChallengeItemQcu @challenge={{@challenge}} @setAnswerValue={{this.setAnswerValue}} />
+            <Challenge::ChallengeItemQcu
+              @challenge={{@challenge}}
+              @setAnswerValue={{this.setAnswerValue}}
+              @assessment={{@assessment}}
+            />
           </div>
         {{/if}}
         {{#if @challenge.isQCM}}
           <div class="challenge-item__qcm">
-            <Challenge::ChallengeItemQcm @challenge={{@challenge}} @setAnswerValue={{this.setAnswerValue}} />
+            <Challenge::ChallengeItemQcm
+              @challenge={{@challenge}}
+              @setAnswerValue={{this.setAnswerValue}}
+              @assessment={{@assessment}}
+            />
           </div>
         {{/if}}
       </div>

--- a/1d/app/utils/pshuffle.js
+++ b/1d/app/utils/pshuffle.js
@@ -1,19 +1,29 @@
 /**
  * Pseudo randomly shuffle arr based on seed (same seed gives same order).
- * @param {any[]} arr
+ * @param {any[]} array
+ * @param {int} seed (optional) used as based of shuffle, must be between 0 and 1
  */
-export function pshuffle(arr) {
-  let m = arr.length;
-  const random = Math.floor(Math.random() * 100000);
-
-  // While there remain elements to shuffle...
-  while (m) {
-    // Pick a remaining element...
-    const i = random % m--;
-
-    // And swap it with the current element.
-    const t = arr[m];
-    arr[m] = arr[i];
-    arr[i] = t;
+export function pshuffle(array, seed = Math.random()) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = _randomIndexFrom0ToI(i, seed);
+    _permuteJValueToIValue(array, i, j);
   }
+}
+
+function _randomIndexFrom0ToI(i, seed) {
+  return Math.floor(_ensureSeedIsBetween0And1(seed) * (i + 1));
+}
+
+function _permuteJValueToIValue(array, i, j) {
+  [array[i], array[j]] = [array[j], array[i]];
+}
+
+function _ensureSeedIsBetween0And1(seed) {
+  if (seed === 0) {
+    return 1;
+  }
+  if (seed > 1 || seed < 0) {
+    return Number.parseFloat('0.' + Math.abs(seed).toString());
+  }
+  return seed;
 }

--- a/1d/tests/unit/utils/pshuffle_test.js
+++ b/1d/tests/unit/utils/pshuffle_test.js
@@ -1,0 +1,77 @@
+import { module, test } from 'qunit';
+import { setupTest } from '../../helpers/index';
+import { pshuffle } from '1d/utils/pshuffle';
+
+module('Unit | Utils | PShuffle', function (hooks) {
+  setupTest(hooks);
+
+  test('shuffles keep all elements of given array', function (assert) {
+    const array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    pshuffle(array);
+
+    assert.deepEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], array.sort());
+  });
+
+  test('shuffles the given array', function (assert) {
+    const array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    pshuffle(array);
+
+    assert.notDeepEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], array);
+  });
+
+  test('shuffles stably with the same seed', function (assert) {
+    const arr1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const arr2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(arr1, 456);
+    pshuffle(arr2, 456);
+
+    assert.deepEqual(arr1, arr2);
+  });
+
+  test('shuffles differently with a different seed', function (assert) {
+    const arr1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const arr2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(arr1, 789);
+    pshuffle(arr2, 987);
+
+    assert.notDeepEqual(arr1, arr2);
+  });
+
+  test('shuffles works with null', function (assert) {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(arr, null);
+
+    assert.notDeepEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], arr);
+  });
+
+  test('shuffles works with undefined', function (assert) {
+    const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(arr, undefined);
+
+    assert.notDeepEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], arr);
+  });
+
+  test('shuffles works with an negative seed', function (assert) {
+    const arr1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const arr2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(arr1, 456);
+    pshuffle(arr2, -456);
+
+    assert.deepEqual(arr1, arr2);
+  });
+
+  test('wheen seed equals to 0 should shuffle with 1', function (assert) {
+    const arr1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const arr2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(arr1, 1);
+    pshuffle(arr2, 0);
+
+    assert.deepEqual(arr1, arr2);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous trouvions la fonction shuffle un peu complexe. Nous l'avions déjà détérioré pour ne plus prendre en compte l'`assessmentId`.

## :robot: Proposition

Reprendre la fonction en reprenant les contraintes existante : pouvoir mélanger à partir d'un seed et pouvoir mélange SANS le seed.

## :rainbow: Remarques

:warning: attention, ce n'est pas une fonction, l'appel à `pshuffle(array)` modifie le tableau passé en paramètre.

## :100: Pour tester

:shrug: 
