### PR TITLE
[FEATURE] Afficher la page de rattachement pour un nouveau profil cible à une certification complémentaire (PIX-8739).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.hbs
@@ -1,0 +1,20 @@
+<div class="card">
+  <div class="card__title">1. Renseigner le nouveau profil cible à rattacher</div>
+  <div class="card__content">
+    <form class="complementary-certification-attach-target-profile__form">
+      <PixSelect
+        class=""
+        @label="ID du profil cible"
+        @emptyMessage="Aucun résultat"
+        @searchPlaceholder="Exemple: 3"
+        @searchLabel="Rechercher un profile cible à rattacher à la certification complémentaire"
+        @isSearchable={{true}}
+        @value={{this.targetProfileToAttach}}
+        @options={{this.targetProfiles}}
+        @onChange={{this.onChange}}
+        @hideDefaultOption={{true}}
+      />
+      <PixButton class="complementary-certification-attach-target-profile-form__submit-button">Valider</PixButton>
+    </form>
+  </div>
+</div>

--- a/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.js
+++ b/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class AttachTargetProfile extends Component {
+  @tracked targetProfileToAttach = this.targetProfiles[0].value;
+
+  get targetProfiles() {
+    return [
+      {
+        label: 'Profil cible 1',
+        value: 'coucou',
+      },
+    ];
+  }
+
+  @action
+  onChange(value) {
+    this.targetProfileToAttach = value;
+  }
+}

--- a/admin/app/components/complementary-certifications/target-profiles/header.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/header.hbs
@@ -1,0 +1,7 @@
+<header class="page-header">
+  <div class="page-title">
+    <LinkTo @route="authenticated.complementary-certifications.list">Toutes les certifications complémentaires</LinkTo>
+    <span class="wire">&nbsp;>&nbsp;</span>
+    <h1>{{@complementaryCertificationLabel}}</h1>
+  </div>
+</header>

--- a/admin/app/components/complementary-certifications/target-profiles/information.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.hbs
@@ -12,8 +12,10 @@
         {{this.currentTargetProfile.name}}
       </LinkTo>
     </span>
-
-    <PixButton>Rattacher un nouveau profil cible</PixButton>
+    <PixButtonLink
+      @route="authenticated.complementary-certifications.complementary-certification.attach-target-profile"
+    >Rattacher un nouveau profil cible
+    </PixButtonLink>
 
   </div>
 </section>

--- a/admin/app/components/complementary-certifications/target-profiles/information.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.hbs
@@ -12,10 +12,12 @@
         {{this.currentTargetProfile.name}}
       </LinkTo>
     </span>
-    <PixButtonLink
-      @route="authenticated.complementary-certifications.complementary-certification.attach-target-profile"
-    >Rattacher un nouveau profil cible
-    </PixButtonLink>
-
+    <div class="complementary-certification-details-target-profile__attach-button">
+      <PixButtonLink
+        @route="authenticated.complementary-certifications.complementary-certification.attach-target-profile"
+        @model={{this.currentTargetProfile.id}}
+      >Rattacher un nouveau profil cible
+      </PixButtonLink>
+    </div>
   </div>
 </section>

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -1,0 +1,12 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class AttachTargetProfileController extends Controller {
+  @service router;
+
+  @action
+  async cancel() {
+    this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -94,7 +94,7 @@ Router.map(function () {
       this.route('list');
       this.route('complementary-certification', { path: '/:complementary_certification_id' }, function () {
         this.route('details');
-        this.route('attach-target-profile');
+        this.route('attach-target-profile', { path: '/attach-target-profile/:target_profile_id' });
       });
     });
 

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -94,6 +94,7 @@ Router.map(function () {
       this.route('list');
       this.route('complementary-certification', { path: '/:complementary_certification_id' }, function () {
         this.route('details');
+        this.route('attach-target-profile');
       });
     });
 

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification.js
@@ -5,6 +5,8 @@ export default class ComplementaryCertificationRoute extends Route {
   @service store;
 
   model(params) {
-    return this.store.findRecord('complementary-certification', params.complementary_certification_id);
+    return this.store.findRecord('complementary-certification', params.complementary_certification_id, {
+      reload: true,
+    });
   }
 }

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -1,14 +1,22 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class ComplementaryCertificationAttachRoute extends Route {
+export default class AttachTargetProfileRoute extends Route {
   @service accessControl;
 
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier', 'isSupport'], 'authenticated');
   }
 
-  async model() {
-    return this.modelFor('authenticated.complementary-certifications.complementary-certification');
+  model(params) {
+    const targetProfileId = parseInt(params.target_profile_id);
+    const complementaryCertification = this.modelFor(
+      'authenticated.complementary-certifications.complementary-certification',
+    );
+
+    return {
+      complementaryCertification,
+      currentTargetProfile: complementaryCertification.currentTargetProfiles.find(({ id }) => id === targetProfileId),
+    };
   }
 }

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ComplementaryCertificationAttachRoute extends Route {
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier', 'isSupport'], 'authenticated');
+  }
+
+  async model() {
+    return this.modelFor('authenticated.complementary-certifications.complementary-certification');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -44,6 +44,7 @@
 @import 'components/certification-issue-reports';
 @import 'components/certification-center-invitations';
 @import 'components/complementary-certifications/details';
+@import 'components/complementary-certifications/attach-target-profile';
 @import 'components/profile';
 @import 'components/certified-profile';
 @import 'components/confirm-popup';

--- a/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
@@ -1,0 +1,25 @@
+.complementary-certification-attach-target-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+
+  &__header {
+    @extend %pix-title-s;
+
+    color: $pix-neutral-90;
+    line-height: 36px;
+  }
+
+  &__form {
+    display: flex;
+    gap: 10px;
+    align-items: flex-end;
+    padding: $pix-spacing-s 0;
+  }
+}
+
+.complementary-certification-attach-target-profile-form {
+  &__submit-button {
+    height: 2.25rem;
+  }
+}

--- a/admin/app/styles/components/complementary-certifications/details.scss
+++ b/admin/app/styles/components/complementary-certifications/details.scss
@@ -47,4 +47,8 @@
       text-decoration: underline;
     }
   }
+
+  &__attach-button {
+    width:  fit-content;
+  }
 }

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -1,12 +1,6 @@
 {{page-title "Certification complémentaire " @model.id " | Pix Admin" replace=true}}
 
-<header class="page-header">
-  <div class="page-title">
-    <LinkTo @route="authenticated.complementary-certifications.list">Toutes les certification complémentaires</LinkTo>
-    <span class="wire">&nbsp;>&nbsp;</span>
-    <h1>{{@model.label}}</h1>
-  </div>
-</header>
+<ComplementaryCertifications::TargetProfiles::Header @complementaryCertificationLabel={{@model.label}} />
 
 <main class="page-body">
   <h1>Rattacher un nouveau profil cible à la certification {{@model.label}}</h1>

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -1,0 +1,13 @@
+{{page-title "Certification complémentaire " @model.id " | Pix Admin" replace=true}}
+
+<header class="page-header">
+  <div class="page-title">
+    <LinkTo @route="authenticated.complementary-certifications.list">Toutes les certification complémentaires</LinkTo>
+    <span class="wire">&nbsp;>&nbsp;</span>
+    <h1>{{@model.label}}</h1>
+  </div>
+</header>
+
+<main class="page-body">
+  <h1>Rattacher un nouveau profil cible à la certification {{@model.label}}</h1>
+</main>

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -1,7 +1,34 @@
-{{page-title "Certification complémentaire " @model.id " | Pix Admin" replace=true}}
+{{page-title "Certification complémentaire " @model.complementaryCertification.id " | Pix Admin" replace=true}}
 
-<ComplementaryCertifications::TargetProfiles::Header @complementaryCertificationLabel={{@model.label}} />
+<ComplementaryCertifications::TargetProfiles::Header
+  @complementaryCertificationLabel={{@model.complementaryCertification.label}}
+/>
 
 <main class="page-body">
-  <h1>Rattacher un nouveau profil cible à la certification {{@model.label}}</h1>
+  <div class="page-section complementary-certification-attach-target-profile">
+    <h1 class="complementary-certification-attach-target-profile__header">
+      Rattacher un nouveau profil cible à la certification
+      {{@model.complementaryCertification.label}}
+    </h1>
+    <span class="complementary-certification-details__target-profile">Profile cible actuel:
+      <LinkTo
+        @route="authenticated.target-profiles.target-profile"
+        @model={{@model.currentTargetProfile.id}}
+        class="complementary-certification-details-target-profile__link"
+      >
+        {{@model.currentTargetProfile.name}}
+      </LinkTo>
+    </span>
+
+    <ComplementaryCertifications::TargetProfiles::AttachTargetProfile />
+    <div>
+      <PixButton
+        @size="small"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{this.cancel}}
+      >Annuler
+      </PixButton>
+    </div>
+  </div>
 </main>

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
@@ -1,12 +1,6 @@
 {{page-title "Certification complémentaire " @model.id " | Pix Admin" replace=true}}
 
-<header class="page-header">
-  <div class="page-title">
-    <LinkTo @route="authenticated.complementary-certifications.list">Toutes les certification complémentaires</LinkTo>
-    <span class="wire">&nbsp;>&nbsp;</span>
-    <h1>{{@model.label}}</h1>
-  </div>
-</header>
+<ComplementaryCertifications::TargetProfiles::Header @complementaryCertificationLabel={{@model.label}} />
 
 <main class="page-body">
   <ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{@model}} />

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import dayjs from 'dayjs';
+
+module(
+  'Acceptance | Complementary certifications | Complementary certification | attach-target-profile',
+  function (hooks) {
+    setupApplicationTest(hooks);
+    setupMirage(hooks);
+
+    module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
+      module('on information section', function () {
+        test('it should display current target profile link and redirect to details page on click', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('complementary-certification', {
+            id: 1,
+            key: 'KEY',
+            label: 'MARIANNE CERTIF',
+            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+          });
+          server.create('target-profile', {
+            id: 3,
+            name: 'ALEX TARGET',
+          });
+          const screen = await visit('/complementary-certifications/1/attach-target-profile');
+          const currentTargetProfileLinks = screen.getAllByRole('link', { name: 'ALEX TARGET' });
+
+          // when
+          await click(currentTargetProfileLinks[0]);
+
+          // then
+          assert.strictEqual(currentURL(), '/target-profiles/3/details');
+        });
+      });
+    });
+  },
+);

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list_test.js
@@ -59,7 +59,18 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
 
       test('it should redirect to complementary certification details on click ', async function (assert) {
         // given
-        server.create('complementary-certification', { id: 1, key: 'AN', label: 'TOINE' });
+        server.create('complementary-certification', {
+          id: 1,
+          key: 'AN',
+          label: 'TOINE',
+          targetProfilesHistory: [
+            {
+              id: 52,
+              name: 'Stephen target',
+              badges: [],
+            },
+          ],
+        });
         const screen = await visit('/complementary-certifications/list');
 
         // when

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/information_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/information_test.js
@@ -21,7 +21,7 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::I
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Certification complémentaire' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Rattacher un nouveau profil cible' })).exists();
+    assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
     assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
     assert.dom(screen.getByText('MARIANNE CERTIF')).exists();
   });


### PR DESCRIPTION
## :unicorn: Problème
Le versioning des profils cibles et des résultats thématiques certifiants doit permettre d’assurer la pérennité des certifications complémentaires Pix en conservant un historique des différentes versions de profil cible et de RT certifiants sur lesquels elles sont basées. L'implémentation est pour le moment protégée par un feature toggle.

Actuellement la page pour rattacher un nouveau profile cible n'existe pas.

## :robot: Proposition
Créer la page de rattachement pour un nouveau profil cible à une certification complémentaire
Pas de select car notre cas de figure nécessite de créer un nouveau composant sur Pix UI

## :100: Pour tester

- Sur PixAdmin avec le compte [superadmin@example.net](mailto:superadmin@example.net)
- Cliquer sur l'icône dans le menu latéral nommé "certifications complémentaire" (icône tampon)
- Cliquer sur un des liens
- Cliquer sur le bouton pour rattacher un profile cible
