### PR TITLE
[TECH] Ajoute la nouvelle feature de remontée de certificabilité auto dans la table features (PIX-8788)

### DIFF
--- a/api/db/migrations/20230407090348_add-multiple-sending-feature.js
+++ b/api/db/migrations/20230407090348_add-multiple-sending-feature.js
@@ -1,15 +1,15 @@
 const TABLE_NAME = 'features';
-const MULTIPLE_SENDING_KEY = 'MULTIPLE_SENDING_ASSESSMENT';
+import { ORGANIZATION_FEATURE } from '../../lib/domain/constants.js';
 
 const up = function (knex) {
   return knex(TABLE_NAME).insert({
-    key: MULTIPLE_SENDING_KEY,
-    description: "Permet d'activer l'envoi multiple sur les campagnes d'évaluation",
+    key: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+    description: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.description,
   });
 };
 
 const down = function (knex) {
-  return knex(TABLE_NAME).where({ key: MULTIPLE_SENDING_KEY }).delete();
+  return knex(TABLE_NAME).where({ key: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key }).delete();
 };
 
 export { up, down };

--- a/api/db/migrations/20230731095207_add-auto-certificability-feature-on-features-table.js
+++ b/api/db/migrations/20230731095207_add-auto-certificability-feature-on-features-table.js
@@ -1,0 +1,27 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+
+import { ORGANIZATION_FEATURE } from '../../lib/domain/constants.js';
+const TABLE_NAME = 'features';
+
+const up = function (knex) {
+  return knex(TABLE_NAME).insert({
+    key: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+    description: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.description,
+  });
+};
+
+const down = function (knex) {
+  return knex(TABLE_NAME)
+    .where({ key: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key })
+    .delete();
+};
+
+export { up, down };

--- a/api/db/migrations/20230731122538_add-columns-certifiable-at-and-is-certifiable-on-organization-learners.js
+++ b/api/db/migrations/20230731122538_add-columns-certifiable-at-and-is-certifiable-on-organization-learners.js
@@ -1,0 +1,28 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-learners';
+const IS_CERTIFIABLE_COLUMN = 'isCertifiable';
+const CERTIFIABLE_AT_COLUMN = 'certifiableAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.date(CERTIFIABLE_AT_COLUMN).defaultTo(null);
+    table.boolean(IS_CERTIFIABLE_COLUMN).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(CERTIFIABLE_AT_COLUMN);
+    table.dropColumn(IS_CERTIFIABLE_COLUMN);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/feature/feature-builder.js
+++ b/api/db/seeds/data/feature/feature-builder.js
@@ -1,8 +1,13 @@
-import * as apps from '../../../../lib/domain/constants.js';
+import { ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
 
 const featuresBuilder = function ({ databaseBuilder }) {
   databaseBuilder.factory.buildFeature({
-    key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
+    key: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+    description: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.description,
+  });
+  databaseBuilder.factory.buildFeature({
+    key: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+    description: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.description,
   });
 };
 

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -51,6 +51,8 @@ import { teamAccesDataBuilder } from './data/team-acces/data-builder.js';
 const seed = async function (knex) {
   const shouldUseNewSeeds = process.env.USE_NEW_SEEDS === 'true';
   const databaseBuilder = new DatabaseBuilder({ knex });
+  // Feature list
+  featuresBuilder({ databaseBuilder });
   if (shouldUseNewSeeds) {
     await commonBuilder({ databaseBuilder });
     await teamAccesDataBuilder(databaseBuilder);
@@ -62,9 +64,6 @@ const seed = async function (knex) {
     await databaseBuilder.commit();
     await databaseBuilder.fixSequences();
   } else {
-    // Feature list
-    featuresBuilder({ databaseBuilder });
-
     // cities
     certificationCpfCityBuilder({ databaseBuilder });
 

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -108,7 +108,14 @@ const CERTIFICATION_CENTER_TYPES = {
 };
 
 const ORGANIZATION_FEATURE = {
-  MULTIPLE_SENDING_ASSESSMENT: 'MULTIPLE_SENDING_ASSESSMENT',
+  MULTIPLE_SENDING_ASSESSMENT: {
+    key: 'MULTIPLE_SENDING_ASSESSMENT',
+    description: "Permet d'activer l'envoi multiple sur les campagnes d'évaluation",
+  },
+  COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: {
+    key: 'COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
+    description: "Permet d'activer la remontée automatique de la certificabilité des prescrits",
+  },
 };
 
 const constants = {

--- a/api/lib/domain/usecases/organizations-administration/update-organization.js
+++ b/api/lib/domain/usecases/organizations-administration/update-organization.js
@@ -53,11 +53,13 @@ async function _addOrUpdateDataProtectionOfficer({ organization, dataProtectionO
 
 async function _enablingOrganizationFeature(organization, organizationFeatureRepository) {
   const availableFeatures = await organizationFeatureRepository.getFeaturesListFromOrganization(organization.id);
-  const isAssessmentFeatureEnable = availableFeatures.includes(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
+  const isAssessmentFeatureEnable = availableFeatures.includes(
+    apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+  );
 
   const organizationFeatureData = {
     organizationId: organization.id,
-    featureKey: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
+    featureKey: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
   };
 
   if (isAssessmentFeatureEnable && !organization.enableMultipleSendingAssessment) {

--- a/api/lib/infrastructure/repositories/prescriber-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-repository.js
@@ -76,7 +76,7 @@ async function _isMultipleSendingAssessmentEnabled(prescriber) {
     .pluck('key');
 
   prescriber.enableMultipleSendingAssessment = availableFeatures.includes(
-    apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
+    apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
   );
 }
 

--- a/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
@@ -21,7 +21,7 @@ describe('Integration | Application | Controller | organization-administration-c
       identityProviderForCampaigns: 'POLE_EMPLOI',
     });
 
-    featureId = databaseBuilder.factory.buildFeature({ key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT }).id;
+    featureId = databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
 
     await databaseBuilder.commit();
   });
@@ -171,7 +171,7 @@ describe('Integration | Application | Controller | organization-administration-c
       .where('organizationId', organization.id);
 
     expect(organizationFeature.length).to.equal(1);
-    expect(organizationFeature[0].key).to.equal(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
+    expect(organizationFeature[0].key).to.equal(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key);
     expect(response.source.data.attributes['enable-multiple-sending-assessment']).to.equal(true);
   });
 

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -330,9 +330,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
         it('should return activated feature for current organization', async function () {
           // given
           expectedPrescriber.userOrgaSettings = userOrgaSettings;
-          const feature = databaseBuilder.factory.buildFeature({
-            key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
-          });
+          const feature = databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
           databaseBuilder.factory.buildOrganizationFeature({ featureId: feature.id, organizationId: organization.id });
           await databaseBuilder.commit();
 
@@ -346,9 +344,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
         it('should return deactivated feature for current organization', async function () {
           // given
           expectedPrescriber.userOrgaSettings = userOrgaSettings;
-          databaseBuilder.factory.buildFeature({
-            key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT,
-          });
+          databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
           await databaseBuilder.commit();
 
           // when


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'epix de remontée automatique de la certificabilité nous avons besoin d'ajouter à la table features la nouvelle feature "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY"

## :robot: Proposition
Creer la migration et un seed qui ajoute cette feature dans la table features.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Lancer les migrations et/ou seeds
- Verifier que dans la table features la nouvelle fonctionnalité existe
- 🐱 
