### PR TITLE
[TECH] Ajoute les colonnes certifiableAt et isCertifiable sur la table organization-learners (PIX-8789).

### DIFF
--- a/api/db/migrations/20230731122538_add-columns-certifiable-at-and-is-certifiable-on-organization-learners.js
+++ b/api/db/migrations/20230731122538_add-columns-certifiable-at-and-is-certifiable-on-organization-learners.js
@@ -1,0 +1,28 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-learners';
+const IS_CERTIFIABLE_COLUMN = 'isCertifiable';
+const CERTIFIABLE_AT_COLUMN = 'certifiableAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.date(CERTIFIABLE_AT_COLUMN).defaultTo(null);
+    table.boolean(IS_CERTIFIABLE_COLUMN).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(CERTIFIABLE_AT_COLUMN);
+    table.dropColumn(IS_CERTIFIABLE_COLUMN);
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de le fonctionnalité de remontée automatique de la certificabilité pour les organisations SCO, on a besoin de stocker l'information de la certificabilité autre part que la table campaign-participations qui continue à être le fonctionnement normal pour les autres organisations.

## :robot: Proposition
On a ajoute les colonnes certifiableAt et isCertifiable sur la table organization-learners. Elle ne seront remplis que pour les organisations ayant la feature COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY d'activer.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
En local lancer "npm run db:reset" et vérifier que les deux colonnes ont bien été ajoutés dans la organization-learners.
