### PR TITLE
[BUMP] Mise à jour de Pix UI sur Pix Orga et Pix admin.

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.7.0",
-        "@1024pix/pix-ui": "38.2.0",
+        "@1024pix/pix-ui": "^39.0.1",
         "@1024pix/stylelint-config": "^4.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "38.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-38.2.0.tgz",
-      "integrity": "sha512-2FseshI7fA5EAfXBbZDv+zJ8gQhsodm2scZxjzE75JzMkGjKbtpeCSvCtZtdBdfNxLx4wwcySdhmR4fOZf4xww==",
+      "version": "39.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-39.0.1.tgz",
+      "integrity": "sha512-Yag0egqtHURMHItiZxGPLT7OlGc9s37/rOK7buwrgi9GRyhCyBuy8PAHCw/ZEAFs/47HNMy3KwKXCZwdmOsaZA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -121,8 +121,7 @@
         "lodash.debounce": "^4.0.8"
       },
       "engines": {
-        "node": "16 || 18",
-        "npm": "8 || 9"
+        "node": "^16.17 || ^18"
       }
     },
     "node_modules/@1024pix/stylelint-config": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.7.0",
-    "@1024pix/pix-ui": "38.2.0",
+    "@1024pix/pix-ui": "^39.0.1",
     "@1024pix/stylelint-config": "^4.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.7.0",
-        "@1024pix/pix-ui": "^38.0.0",
+        "@1024pix/pix-ui": "^39.0.1",
         "@1024pix/stylelint-config": "^4.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "38.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-38.2.0.tgz",
-      "integrity": "sha512-2FseshI7fA5EAfXBbZDv+zJ8gQhsodm2scZxjzE75JzMkGjKbtpeCSvCtZtdBdfNxLx4wwcySdhmR4fOZf4xww==",
+      "version": "39.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-39.0.1.tgz",
+      "integrity": "sha512-Yag0egqtHURMHItiZxGPLT7OlGc9s37/rOK7buwrgi9GRyhCyBuy8PAHCw/ZEAFs/47HNMy3KwKXCZwdmOsaZA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -123,8 +123,7 @@
         "lodash.debounce": "^4.0.8"
       },
       "engines": {
-        "node": "16 || 18",
-        "npm": "8 || 9"
+        "node": "^16.17 || ^18"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -34832,9 +34831,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "38.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-38.2.0.tgz",
-      "integrity": "sha512-2FseshI7fA5EAfXBbZDv+zJ8gQhsodm2scZxjzE75JzMkGjKbtpeCSvCtZtdBdfNxLx4wwcySdhmR4fOZf4xww==",
+      "version": "39.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-39.0.1.tgz",
+      "integrity": "sha512-Yag0egqtHURMHItiZxGPLT7OlGc9s37/rOK7buwrgi9GRyhCyBuy8PAHCw/ZEAFs/47HNMy3KwKXCZwdmOsaZA==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/orga/package.json
+++ b/orga/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.7.0",
-    "@1024pix/pix-ui": "^38.0.0",
+    "@1024pix/pix-ui": "^39.0.1",
     "@1024pix/stylelint-config": "^4.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",


### PR DESCRIPTION
## :unicorn: Problème

Les largeurs du bouton de base avaient été fixées pour s'adapter à leur contenu dans une précédente version de Pix UI.
Ce changement de comportement entraine des régressions sur certains écrans (notamment le login).

## :robot: Proposition

Le bouton retrouve une largeur qui s'adapte à celle de son conteneur dans la version 39.0.1 de Pix UI.
On met donc à jour Pix UI pour les applications Pix Orga et Pix Admin qui étaient impactées.

## :rainbow: Remarques

RAS.

## :100: Pour tester

Se rendre sur la page de connexion et constater que le bouton occupe toute la largeur du conteneur.

