### PR TITLE
[BUGFIX] Refacto la méthode shuffle pour corriger les tests flaky(PIX-8808)

### DIFF
--- a/1d/app/utils/pshuffle.js
+++ b/1d/app/utils/pshuffle.js
@@ -3,7 +3,9 @@
  * @param {any[]} array
  * @param {int} seed (optional) used as based of shuffle, must be between 0 and 1
  */
-export function pshuffle(array, seed = Math.random()) {
+
+const SEED_OFFSET = 7;
+export function pshuffle(array, seed = Math.random() * 10000) {
   for (let i = array.length - 1; i > 0; i--) {
     const j = _randomIndexFrom0ToI(i, seed);
     _permuteJValueToIValue(array, i, j);
@@ -11,19 +13,17 @@ export function pshuffle(array, seed = Math.random()) {
 }
 
 function _randomIndexFrom0ToI(i, seed) {
-  return Math.floor(_ensureSeedIsBetween0And1(seed) * (i + 1));
+  return (_ensureSeedCanShuffle(seed) * (i + 1)) % i;
+}
+
+function _ensureSeedCanShuffle(seed) {
+  let newSeed = Math.floor(Math.abs(seed));
+  if (newSeed <= 1) {
+    newSeed += SEED_OFFSET;
+  }
+  return newSeed;
 }
 
 function _permuteJValueToIValue(array, i, j) {
   [array[i], array[j]] = [array[j], array[i]];
-}
-
-function _ensureSeedIsBetween0And1(seed) {
-  if (seed === 0) {
-    return 1;
-  }
-  if (seed > 1 || seed < 0) {
-    return Number.parseFloat('0.' + Math.abs(seed).toString());
-  }
-  return seed;
 }

--- a/1d/tests/unit/utils/pshuffle_test.js
+++ b/1d/tests/unit/utils/pshuffle_test.js
@@ -65,13 +65,21 @@ module('Unit | Utils | PShuffle', function (hooks) {
     assert.deepEqual(arr1, arr2);
   });
 
-  test('wheen seed equals to 0 should shuffle with 1', function (assert) {
-    const arr1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    const arr2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  test('shuffles works with a seed equal 0', function (assert) {
+    const shuffledArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const notShuffledArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-    pshuffle(arr1, 1);
-    pshuffle(arr2, 0);
+    pshuffle(shuffledArray, 0);
 
-    assert.deepEqual(arr1, arr2);
+    assert.notDeepEqual(shuffledArray, notShuffledArray);
+  });
+
+  test('shuffles works with a seed equal 1', function (assert) {
+    const shuffledArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const notShuffledArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    pshuffle(shuffledArray, 1);
+
+    assert.notDeepEqual(shuffledArray, notShuffledArray);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Avec notre refacto de la méthode shuffle dans [cette PR](https://github.com/1024pix/pix/pull/6782), on pouvait avoir des tests flakys notamment quand le seed était égal à 0

## :robot: Proposition
Retravailler la fonction shuffle pour corriger les cas flaky.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer les tests pour check si il y en pas des flakys.
