### PR TITLE
[CLEANUP] Corrige des messages de dépréciations sur les fronts sur miragejs

### DIFF
--- a/1d/mirage/config.js
+++ b/1d/mirage/config.js
@@ -1,5 +1,20 @@
-export default function () {
-  this.urlPrefix = 'http://localhost:3000';
+import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
+import { createServer } from 'miragejs';
+
+export default function makeServer(config) {
+  const finalConfig = {
+    ...config,
+    models: { ...discoverEmberDataModels(), ...config.models },
+    serializers: applyEmberDataSerializers(config.serializers),
+    routes,
+    logging: true,
+    urlPrefix: 'http://localhost:3000',
+  };
+
+  return createServer(finalConfig);
+}
+
+function routes() {
   this.namespace = 'api/pix1d';
   this.timing = 0; // response delay
 

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -1,4 +1,5 @@
-import { Response } from 'miragejs';
+import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
+import { Response, createServer } from 'miragejs';
 import { findPaginatedStudents } from './handlers/find-paginated-students';
 import { findPaginatedSessionSummaries } from './handlers/find-paginated-session-summaries';
 
@@ -11,9 +12,20 @@ function parseQueryString(queryString) {
   return result;
 }
 
-export default function () {
-  this.logging = true;
-  this.urlPrefix = 'http://localhost:3000';
+export default function makeServer(config) {
+  const finalConfig = {
+    ...config,
+    models: { ...discoverEmberDataModels(), ...config.models },
+    serializers: applyEmberDataSerializers(config.serializers),
+    routes,
+    logging: true,
+    urlPrefix: 'http://localhost:3000',
+  };
+
+  return createServer(finalConfig);
+}
+
+function routes() {
   this.namespace = 'api';
   this.timing = 0;
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -1,3 +1,6 @@
+import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
+import { createServer } from 'miragejs';
+
 import getAreas from './routes/get-areas';
 import getCampaigns from './routes/get-campaigns';
 import getCertificationCandidatesSubscriptions from './routes/get-certification-candidates-subscriptions';
@@ -31,10 +34,21 @@ import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import postSharedCertifications from './routes/post-shared-certifications';
 import loadUserTutorialsRoutes from './routes/get-user-tutorials';
 
+export default function makeServer(config) {
+  const finalConfig = {
+    ...config,
+    models: { ...discoverEmberDataModels(), ...config.models },
+    serializers: applyEmberDataSerializers(config.serializers),
+    routes,
+    logging: true,
+    urlPrefix: 'http://localhost:3000',
+  };
+
+  return createServer(finalConfig);
+}
+
 /* eslint max-statements: off */
-export default function () {
-  this.logging = true;
-  this.urlPrefix = 'http://localhost:3000';
+function routes() {
   this.namespace = 'api';
   this.timing = 0; // response delay
 

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -1,4 +1,5 @@
-import Response from 'ember-cli-mirage/response';
+import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
+import { Response, createServer } from 'miragejs';
 import { findPaginatedCampaignProfilesCollectionParticipationSummaries } from './handlers/find-paginated-campaign-participation-summaries';
 import { findPaginatedOrganizationMemberships } from './handlers/find-paginated-organization-memberships';
 import { findFilteredPaginatedScoOrganizationParticipants } from './handlers/find-filtered-paginated-sco-organization-participants';
@@ -21,10 +22,21 @@ function parseQueryString(queryString) {
   return result;
 }
 
+export default function makeServer(config) {
+  const finalConfig = {
+    ...config,
+    models: { ...discoverEmberDataModels(), ...config.models },
+    serializers: applyEmberDataSerializers(config.serializers),
+    routes,
+    logging: true,
+    urlPrefix: 'http://localhost:3000',
+  };
+
+  return createServer(finalConfig);
+}
+
 /* eslint ember/no-get: off */
-export default function () {
-  this.logging = true;
-  this.urlPrefix = 'http://localhost:3000';
+function routes() {
   this.namespace = 'api';
   this.timing = 0;
 


### PR DESCRIPTION
## :unicorn: Problème
L'export default de la configuration mirage qui exporte les routes est déprécié. Cela déclenche de très nombreux warnings dans les tests.

## :robot: Proposition
Utiliser la fonction `createServer`  avec la config spécial de ember-cli-mirage comme recommandé et qui sera nécessaire dans la prochaine version de ember-cli-mirage: https://www.ember-cli-mirage.com/docs/advanced/server-configuration

## :100: Pour tester
:green_circle:  tests + regarder les warnings dans la console et constater que le warning suivant n'existe plus
> DEPRECATION: The routes only function has been deprecated. Please use the make server version your default export in the config. [deprecation id: ember-cli-mirage-config-routes-only-export] This will be removed in ember-cli-mirage 3.0.0.
