### PR TITLE
[CLEANUP] Suppression de messages de dépréciations sur les méthodes de routes

### DIFF
--- a/admin/app/routes/authenticated/campaigns/campaign/index.js
+++ b/admin/app/routes/authenticated/campaigns/campaign/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.replaceWith('authenticated.campaigns.campaign.participations');
+    this.router.replaceWith('authenticated.campaigns.campaign.participations');
   }
 }

--- a/admin/app/routes/authenticated/organizations/get/index.js
+++ b/admin/app/routes/authenticated/organizations/get/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.replaceWith('authenticated.organizations.get.team');
+    this.router.replaceWith('authenticated.organizations.get.team');
   }
 }

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
   @service currentUser;
   @service store;
+  @service router;
 
   queryParams = {
     pageNumber: { refreshModel: true },
@@ -58,7 +59,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
 
     // eslint-disable-next-line ember/no-controller-access-in-routes
     this.controllerFor('authenticated.sessions.add-student').set('returnToSessionCandidates', (sessionId) =>
-      this.transitionTo('authenticated.sessions.details.certification-candidates', sessionId),
+      this.router.transitionTo('authenticated.sessions.details.certification-candidates', sessionId),
     );
   }
 

--- a/certif/app/routes/not-found.js
+++ b/certif/app/routes/not-found.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class NotFoundRoute extends Route {
+  @service router;
+
   afterModel() {
-    this.transitionTo('application');
+    this.router.transitionTo('application');
   }
 }

--- a/certif/tests/unit/routes/not-found_test.js
+++ b/certif/tests/unit/routes/not-found_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | not-found', function (hooks) {
   setupTest(hooks);
@@ -9,14 +10,11 @@ module('Unit | Route | not-found', function (hooks) {
     const route = this.owner.lookup('route:not-found');
     const expectedRedirection = 'application';
 
-    route.transitionTo = (redirection) => {
-      assert.strictEqual(
-        redirection,
-        expectedRedirection,
-        `expect transition to ${expectedRedirection}, got ${redirection}`,
-      );
-    };
+    sinon.stub(route.router, 'transitionTo');
+    route.router.transitionTo.resolves();
 
     route.afterModel();
+
+    assert.ok(route.router.transitionTo.calledWith(expectedRedirection));
   });
 });

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -1,8 +1,11 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 export default class AssessmentResultsController extends Controller {
+  @service router;
+
   @tracked pageNumber = 1;
   @tracked pageSize = 50;
   @tracked divisions = [];
@@ -15,7 +18,7 @@ export default class AssessmentResultsController extends Controller {
   goToAssessmentPage(campaignId, participantId, event) {
     event.stopPropagation();
     event.preventDefault();
-    this.transitionToRoute('authenticated.campaigns.participant-assessment', campaignId, participantId);
+    this.router.transitionTo('authenticated.campaigns.participant-assessment', campaignId, participantId);
   }
 
   @action

--- a/orga/app/controllers/authenticated/sup-organization-participants/import.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/import.js
@@ -14,6 +14,7 @@ export default class ImportController extends Controller {
   @service notifications;
   @service errorMessages;
   @service store;
+  @service router;
 
   @tracked isLoading = false;
 
@@ -27,7 +28,7 @@ export default class ImportController extends Controller {
     try {
       const response = await adapter.addStudentsCsv(organizationId, files);
       this._sendNotifications(response);
-      this.transitionToRoute('authenticated.sup-organization-participants.list');
+      this.router.transitionTo('authenticated.sup-organization-participants.list');
     } catch (errorResponse) {
       this._sendErrorNotifications(errorResponse);
     } finally {
@@ -45,7 +46,7 @@ export default class ImportController extends Controller {
     try {
       const response = await adapter.replaceStudentsCsv(organizationId, files);
       this._sendNotifications(response);
-      this.transitionToRoute('authenticated.sup-organization-participants.list');
+      this.router.transitionTo('authenticated.sup-organization-participants.list');
     } catch (errorResponse) {
       this._sendErrorNotifications(errorResponse);
     } finally {

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -8,6 +8,7 @@ export default class NewController extends Controller {
   @service notifications;
   @service store;
   @service currentUser;
+  @service router;
 
   @tracked isLoading = false;
 
@@ -26,7 +27,7 @@ export default class NewController extends Controller {
       });
       const organization = this.currentUser.organization;
       await organization.organizationInvitations.reload();
-      this.transitionToRoute('authenticated.team.list.invitations');
+      this.router.transitionTo('authenticated.team.list.invitations');
 
       const message =
         emails.length > 1
@@ -46,7 +47,7 @@ export default class NewController extends Controller {
 
   @action
   cancel() {
-    this.transitionToRoute('authenticated.team.list.invitations');
+    this.router.transitionTo('authenticated.team.list.invitations');
   }
 
   _handleResponseError({ errors }) {

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -8,6 +8,7 @@ const ENGLISH_LOCALE = 'en';
 export default class TermOfServiceController extends Controller {
   @service currentUser;
   @service intl;
+  @service router;
 
   @tracked isEnglishLocale = this.intl.primaryLocale === ENGLISH_LOCALE;
 
@@ -15,6 +16,6 @@ export default class TermOfServiceController extends Controller {
   async submit() {
     await this.currentUser.prescriber.save({ adapterOptions: { acceptPixOrgaTermsOfService: true } });
     this.currentUser.prescriber.pixOrgaTermsOfServiceAccepted = true;
-    this.transitionToRoute('application');
+    this.router.transitionTo('application');
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign.js
+++ b/orga/app/routes/authenticated/campaigns/campaign.js
@@ -3,13 +3,14 @@ import { service } from '@ember/service';
 
 export default class CampaignRoute extends Route {
   @service store;
+  @service router;
 
   async model(params) {
     try {
       const campaign = await this.store.findRecord('campaign', params.campaign_id);
       return campaign;
     } catch (error) {
-      this.send('error', error, this.replaceWith('not-found', params.campaign_id));
+      this.send('error', error, this.router.replaceWith('not-found', params.campaign_id));
     }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/index.js
+++ b/orga/app/routes/authenticated/campaigns/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    return this.replaceWith('authenticated.campaigns.list.my-campaigns');
+    return this.router.replaceWith('authenticated.campaigns.list.my-campaigns');
   }
 }

--- a/orga/app/routes/authenticated/campaigns/list/index.js
+++ b/orga/app/routes/authenticated/campaigns/list/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    return this.replaceWith('authenticated.campaigns.list.my-campaigns');
+    return this.router.replaceWith('authenticated.campaigns.list.my-campaigns');
   }
 }

--- a/orga/app/routes/authenticated/campaigns/participant-assessment/index.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   redirect() {
-    this.replaceWith('authenticated.campaigns.participant-assessment.results');
+    this.router.replaceWith('authenticated.campaigns.participant-assessment.results');
   }
 }

--- a/orga/app/routes/authenticated/campaigns/update.js
+++ b/orga/app/routes/authenticated/campaigns/update.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 export default class UpdateRoute extends Route {
   @service currentUser;
   @service store;
+  @service router;
 
   async model(params) {
     const organization = this.currentUser.organization;
@@ -21,7 +22,7 @@ export default class UpdateRoute extends Route {
     const isCurrentUserOwnerOfTheCampaign = parseInt(this.currentUser.prescriber.id) === model.campaign.ownerId;
     if (!isCurrentUserAdmin && !isCurrentUserOwnerOfTheCampaign) {
       transition.abort();
-      this.transitionTo('authenticated.campaigns');
+      this.router.transitionTo('authenticated.campaigns');
     }
   }
 

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -3,10 +3,11 @@ import { service } from '@ember/service';
 
 export default class AuthenticatedCertificationsRoute extends Route {
   @service currentUser;
+  @service router;
 
   beforeModel() {
     if (!(this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents)) {
-      this.replaceWith('application');
+      this.router.replaceWith('application');
     }
   }
 

--- a/orga/app/routes/authenticated/index.js
+++ b/orga/app/routes/authenticated/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    return this.replaceWith('authenticated.campaigns');
+    return this.router.replaceWith('authenticated.campaigns');
   }
 }

--- a/orga/app/routes/authenticated/sco-organization-participants.js
+++ b/orga/app/routes/authenticated/sco-organization-participants.js
@@ -3,11 +3,12 @@ import Route from '@ember/routing/route';
 
 export default class ScoOrganizationParticipantsRoute extends Route {
   @service currentUser;
+  @service router;
 
   beforeModel() {
     super.beforeModel(...arguments);
     if (!this.currentUser.isSCOManagingStudents) {
-      return this.replaceWith('application');
+      return this.router.replaceWith('application');
     }
   }
 }

--- a/orga/app/routes/authenticated/sup-organization-participants.js
+++ b/orga/app/routes/authenticated/sup-organization-participants.js
@@ -3,10 +3,11 @@ import Route from '@ember/routing/route';
 
 export default class SupOrganizationParticipantsRoute extends Route {
   @service currentUser;
+  @service router;
 
   beforeModel() {
     if (!this.currentUser.isSUPManagingStudents) {
-      return this.replaceWith('application');
+      return this.router.replaceWith('application');
     }
   }
 }

--- a/orga/app/routes/authenticated/sup-organization-participants/import.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/import.js
@@ -3,11 +3,12 @@ import Route from '@ember/routing/route';
 
 export default class ImportRoute extends Route {
   @service currentUser;
+  @service router;
 
   beforeModel() {
     super.beforeModel(...arguments);
     if (!this.currentUser.isAdminInOrganization) {
-      return this.replaceWith('application');
+      return this.router.replaceWith('application');
     }
   }
 }

--- a/orga/app/routes/authenticated/team/list/index.js
+++ b/orga/app/routes/authenticated/team/list/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.replaceWith('authenticated.team.list.members');
+    this.router.replaceWith('authenticated.team.list.members');
   }
 }

--- a/orga/app/routes/authenticated/team/new.js
+++ b/orga/app/routes/authenticated/team/new.js
@@ -4,11 +4,12 @@ import Route from '@ember/routing/route';
 export default class NewRoute extends Route {
   @service store;
   @service currentUser;
+  @service router;
 
   beforeModel() {
     super.beforeModel(...arguments);
     if (!this.currentUser.isAdminInOrganization) {
-      return this.replaceWith('application');
+      return this.router.replaceWith('application');
     }
   }
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results_test.js
@@ -70,14 +70,14 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
   });
 
   module('#goToAssessmentPage', function () {
-    test('it should call transitionToRoute with appropriate arguments', function (assert) {
+    test('it should call transitionTo with appropriate arguments', function (assert) {
       // given
       const event = {
         stopPropagation: sinon.stub(),
         preventDefault: sinon.stub(),
       };
 
-      controller.transitionToRoute = sinon.stub();
+      controller.router.transitionTo = sinon.stub();
 
       // when
       controller.send('goToAssessmentPage', 123, 345, event);
@@ -85,7 +85,9 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       // then
       assert.true(event.stopPropagation.called);
       assert.true(event.preventDefault.called);
-      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.participant-assessment', 123, 345));
+      assert.true(
+        controller.router.transitionTo.calledWith('authenticated.campaigns.participant-assessment', 123, 345),
+      );
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
@@ -58,7 +58,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
   });
 
   module('#goToProfilePage', function () {
-    test('it should call transitionToRoute with appropriate arguments', function (assert) {
+    test('it should call transitionTo with appropriate arguments', function (assert) {
       const routerService = this.owner.lookup('service:router');
       // given
       const event = {

--- a/orga/tests/unit/controllers/authenticated/campaigns/list/all-campaigns_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list/all-campaigns_test.js
@@ -16,7 +16,7 @@ module('Unit | Controller | authenticated/campaigns/list/all-campaigns', functio
   });
 
   module('#action goToCampaignPage', function () {
-    test('it should call transitionToRoute with appropriate arguments', function (assert) {
+    test('it should call transitionTo with appropriate arguments', function (assert) {
       // given
       controller.router = { transitionTo: sinon.stub() };
 

--- a/orga/tests/unit/controllers/authenticated/sup-organization-participants/import_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-organization-participants/import_test.js
@@ -14,7 +14,7 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
     this.owner.lookup('service:intl').setLocale('fr');
     controller = this.owner.lookup('controller:authenticated/sup-organization-participants/import');
     controller.send = sinon.stub();
-    controller.transitionToRoute = sinon.stub();
+    controller.router.transitionTo = sinon.stub();
     controller.currentUser = currentUser;
 
     const store = this.owner.lookup('service:store');

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
@@ -10,21 +10,16 @@ module('Unit | Route | authenticated/campaigns/campaign', function (hooks) {
     const route = this.owner.lookup('route:authenticated/campaigns/campaign');
     const store = this.owner.lookup('service:store');
     const params = { campaign_id: 'liste' };
+    const expectedRedirection = 'not-found';
 
     sinon.stub(store, 'findRecord');
     store.findRecord.rejects({ errors: [{ status: '400' }] });
-
-    // then
-    const expectedRedirection = 'not-found';
-    route.replaceWith = (redirection) => {
-      assert.strictEqual(
-        redirection,
-        expectedRedirection,
-        `expect transition to ${expectedRedirection}, got ${redirection}`,
-      );
-    };
+    sinon.stub(route.router, 'replaceWith');
 
     // when
     await route.model(params);
+
+    // then
+    assert.ok(route.router.replaceWith.calledWith(expectedRedirection));
   });
 });

--- a/orga/tests/unit/routes/authenticated/certifications_test.js
+++ b/orga/tests/unit/routes/authenticated/certifications_test.js
@@ -19,7 +19,7 @@ module('Unit | Route | authenticated/certifications', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
-      route.replaceWith = replaceWithStub;
+      route.router.replaceWith = replaceWithStub;
 
       // when
       route.beforeModel();
@@ -39,7 +39,7 @@ module('Unit | Route | authenticated/certifications', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
-      route.replaceWith = replaceWithStub;
+      route.router.replaceWith = replaceWithStub;
 
       // when
       route.beforeModel();
@@ -59,7 +59,7 @@ module('Unit | Route | authenticated/certifications', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const route = this.owner.lookup('route:authenticated.certifications');
       const replaceWithStub = sinon.stub();
-      route.replaceWith = replaceWithStub;
+      route.router.replaceWith = replaceWithStub;
 
       // when
       route.beforeModel();


### PR DESCRIPTION
## :unicorn: Problème
Certaines méthodes des routes et controllers sont dépréciées: Voir: https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods

## :robot: Proposition
Utiliser le service `router` pour utiliser les méthodes comme indiqué dans la documentation.


## :100: Pour tester
:green_circle: + Voir dans la console js l'absence de warnings similaire a: 
> DEPRECATION: Calling replaceWith on a route is deprecated. Use the RouterService instead. [deprecation id: routing.transition-methods] This will be removed in ember-source 5.0.0.
