### PR TITLE
[FEATURE] Le champ de description d'un signalement des épreuves n'est plus requis (PIX-7976).

### DIFF
--- a/api/lib/application/feedbacks/feedback-controller.js
+++ b/api/lib/application/feedbacks/feedback-controller.js
@@ -1,14 +1,8 @@
-import { BadRequestError } from '../http-errors.js';
-import { _ } from '../../infrastructure/utils/lodash-utils.js';
 import * as serializer from '../../infrastructure/serializers/jsonapi/feedback-serializer.js';
 
 const save = async function (request, h) {
   const newUserAgent = request.headers['user-agent'].slice(0, 255);
   const feedback = await serializer.deserialize(request.payload, newUserAgent);
-
-  if (_.isBlank(feedback.get('content'))) {
-    throw new BadRequestError('Feedback content must not be blank');
-  }
 
   const persistedFeedback = await feedback.save();
 

--- a/api/lib/application/feedbacks/index.js
+++ b/api/lib/application/feedbacks/index.js
@@ -15,7 +15,7 @@ const register = async function (server) {
             data: Joi.object({
               type: Joi.string().valid('feedbacks'),
               attributes: Joi.object({
-                content: Joi.string().min(1).required(),
+                content: Joi.string().allow('').required(),
               }),
               relationships: Joi.object({
                 assessment: Joi.object({

--- a/api/tests/acceptance/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedbacks/feedback-controller_test.js
@@ -1,6 +1,9 @@
+import lodash from 'lodash';
 import { expect, knex, databaseBuilder } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { Feedback } from '../../../../lib/infrastructure/orm-models/Feedback.js';
+
+const { cloneDeep } = lodash;
 
 describe('Acceptance | Controller | feedback-controller', function () {
   let server;
@@ -53,6 +56,18 @@ describe('Acceptance | Controller | feedback-controller', function () {
 
     it('should return 201 HTTP status code', function () {
       // when
+      const promise = server.inject(options);
+
+      // then
+      return promise.then((response) => {
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+
+    it('should return 201 HTTP status code with empty content', function () {
+      // when
+      const optionsWithEmptyContent = cloneDeep(options);
+      optionsWithEmptyContent.payload.data.attributes.content = '';
       const promise = server.inject(options);
 
       // then

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -51,9 +51,21 @@ describe('Unit | Controller | feedback-controller', function () {
       sinon.stub(Feedback.prototype, 'save').resolves(persistedFeedback);
     });
 
-    it('should return a successful response with HTTP code 201 when feedback was saved', async function () {
+    it('should return a successful response with HTTP code 201 when feedback was saved with some text content', async function () {
       // given
       const payload = jsonFeedback;
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+
+    it('should return a successful response with HTTP code 201 when feedback was saved with blank content', async function () {
+      // given
+      const payload = cloneDeep(jsonFeedback);
+      payload.data.attributes.content = '';
 
       // when
       const response = await httpTestServer.request(method, url, payload);

--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -75,8 +75,6 @@
                     placeholder={{t
                       "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
                     }}
-                    @errorMessage={{this.emptyTextBoxMessageError}}
-                    required
                     {{on "change" this.setContent}}
                   />
                 </div>

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { service } from '@ember/service';
-import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
@@ -16,7 +15,6 @@ export default class FeedbackPanel extends Component {
   @tracked content = null;
   @tracked displayQuestionDropdown = false;
   @tracked displayTextBox = false;
-  @tracked emptyTextBoxMessageError = null;
   @tracked isFormSubmitted = false;
   @tracked nextCategory = null;
   @tracked quickHelpInstructions = null;
@@ -88,21 +86,15 @@ export default class FeedbackPanel extends Component {
       return;
     }
     this._sendButtonStatus = buttonStatusTypes.pending;
-    const content = this.content;
-
-    if (isEmpty(content) || isEmpty(content.trim())) {
-      this._sendButtonStatus = buttonStatusTypes.unrecorded;
-      this.emptyTextBoxMessageError = this.intl.t('pages.challenge.feedback-panel.form.status.error.empty-message');
-      return;
-    }
 
     const category = this._category
       ? this.intl.t(this._category)
       : this.intl.t(
           'pages.challenge.feedback-panel.form.fields.category-selection.options.' + this._currentMajorCategory,
         );
+
     const feedback = this.store.createRecord('feedback', {
-      content: this.content,
+      content: this.content || '',
       category,
       assessment: this.args.assessment,
       challenge: this.args.challenge,
@@ -123,7 +115,6 @@ export default class FeedbackPanel extends Component {
   displayCategoryOptions(value) {
     this.displayTextBox = false;
     this.quickHelpInstructions = null;
-    this.emptyTextBoxMessageError = null;
     this.displayQuestionDropdown = false;
     this._category = null;
     this._currentNextCategory = null;
@@ -147,13 +138,11 @@ export default class FeedbackPanel extends Component {
     if (value === '') {
       this.displayTextBox = false;
       this.quickHelpInstructions = null;
-      this.emptyTextBoxMessageError = null;
       this._currentNextCategory = null;
       return;
     }
 
     this._currentNextCategory = value;
-    this.emptyTextBoxMessageError = null;
     this._category = this.nextCategory[value - 1] ? this.nextCategory[value - 1].name : null;
     if (this._category != null) {
       this._showFeedbackActionBasedOnCategoryType(this.nextCategory[value - 1]);
@@ -162,7 +151,6 @@ export default class FeedbackPanel extends Component {
 
   _resetPanel() {
     this.isFormSubmitted = false;
-    this.emptyTextBoxMessageError = null;
     this._resetForm();
     if (this.args.alwaysOpenForm) {
       this.isExpanded = true;

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -41,32 +41,53 @@ module('Integration | Component | feedback-panel', function (hooks) {
         .doesNotExist();
     });
 
-    test('should display the "mercix" view when clicking on send button', async function (assert) {
-      // given
-      const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
+    module('when clicking on send button', function (hooks) {
+      let screen;
 
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      hooks.beforeEach(async function () {
+        screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
 
-      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
-      await screen.findByRole('listbox');
-      await click(
-        screen.getByRole('option', {
-          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
-        }),
-      );
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
-      const contentValue = 'Prêtes-moi ta plume, pour écrire un mot';
-      await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), contentValue);
+        await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
+        await screen.findByRole('listbox');
+        await click(
+          screen.getByRole('option', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+          }),
+        );
+      });
 
-      // when
-      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
+      test('should display the "mercix" view without content value', async function (assert) {
+        // when
+        await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
-      // then
-      assert
-        .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
-        .doesNotExist();
-      assert.dom(screen.getByText('Votre commentaire a bien été transmis à l’équipe du projet Pix.')).exists();
-      assert.dom(screen.getByText('Mercix !')).exists();
+        // then
+        assert
+          .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+          .doesNotExist();
+        assert.dom(screen.getByText('Votre commentaire a bien été transmis à l’équipe du projet Pix.')).exists();
+        assert.dom(screen.getByText('Mercix !')).exists();
+      });
+
+      test('should display the "mercix" view when content value is filled', async function (assert) {
+        // given
+        const contentValue = 'Prêtes-moi ta plume, pour écrire un mot';
+        await fillIn(
+          screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }),
+          contentValue,
+        );
+
+        // when
+        await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
+
+        // then
+        assert
+          .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+          .doesNotExist();
+        assert.dom(screen.getByText('Votre commentaire a bien été transmis à l’équipe du projet Pix.')).exists();
+        assert.dom(screen.getByText('Mercix !')).exists();
+      });
     });
 
     module('when selecting a category', function () {
@@ -384,47 +405,6 @@ module('Integration | Component | feedback-panel', function (hooks) {
   });
 
   module('Error management', function () {
-    test('should display error if "content" is empty', async function (assert) {
-      // given
-      const screen = await render(hbs`<FeedbackPanel />`);
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
-
-      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
-      await screen.findByRole('listbox');
-      await click(
-        screen.getByRole('option', {
-          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
-        }),
-      );
-
-      // when
-      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
-
-      // then
-      assert.dom(screen.getByText('Vous devez saisir un message.')).exists();
-    });
-
-    test('should display error if "content" is blank', async function (assert) {
-      // given
-      const screen = await render(hbs`<FeedbackPanel />`);
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
-
-      await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
-      await screen.findByRole('listbox');
-      await click(
-        screen.getByRole('option', {
-          name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
-        }),
-      );
-      await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '');
-
-      // when
-      await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
-
-      // then
-      assert.dom(screen.getByText('Vous devez saisir un message.')).exists();
-    });
-
     test('should not display error if "form" view (with error) was closed and re-opened', async function (assert) {
       // given
       const screen = await render(hbs`<FeedbackPanel />`);

--- a/mon-pix/tests/unit/components/feedback-panel_test.js
+++ b/mon-pix/tests/unit/components/feedback-panel_test.js
@@ -25,7 +25,6 @@ module('Unit | Component | feedback-panel', function (hooks) {
     test('should close and reset form', function (assert) {
       // given
       component.isExpanded = true;
-      component.emptyTextBoxMessageError = '10, 9, 8, ...';
       component.isFormSubmitted = true;
 
       // when
@@ -34,7 +33,6 @@ module('Unit | Component | feedback-panel', function (hooks) {
       // then
       assert.false(component.isExpanded);
       assert.false(component.isFormSubmitted);
-      assert.notOk(component.emptyTextBoxMessageError);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

On souhaite recevoir moins de signalements d'épreuve hasardeux.
Jusqu'à présent, on obligeait aux utilisateurs de rentrer une description écrite d'un potentiel problème rencontré.
Ce champ n'était pas toujours très bien rempli.

## :robot: Proposition

Cette tâche est la **première étape** d'un chantier de restructuration du bloc de signalement d'épreuve.
On ne souhaite plus que le champ de texte de description soit requis pour l'envoi d'un signalement d'épreuve.

## :100: Pour tester

- Se rendre sur [PixApp en RA](https://app-pr6799.review.pix.fr/)
- Visiter une épreuve
- Ouvrir le bloc de signalement d'épreuve
- Choisir dans le premier sélecteur "L'accessibilité de l'épreuve"
- Cliquer sur "Envoyer" sans remplir le textarea
- Constater que le formulaire a bien été soumis
