### PR TITLE
[FEATURE] Activer ou désactiver la fonctionnalité de remontée de la certificabilité à l'édition de l'organisation (PIX-8795).

### DIFF
--- a/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
+++ b/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
@@ -62,7 +62,6 @@ class OrganizationForAdmin {
     this.enableMultipleSendingAssessment = enableMultipleSendingAssessment;
     this.tags = tags;
     this.features = features;
-
     this.tagsToAdd = [];
     this.tagsToRemove = [];
   }
@@ -98,9 +97,12 @@ class OrganizationForAdmin {
     this.showSkills = organization.showSkills;
     this.updateIdentityProviderForCampaigns(organization.identityProviderForCampaigns);
     this.dataProtectionOfficer.updateInformation(dataProtectionOfficer);
-
     this.features[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] =
       organization.enableMultipleSendingAssessment;
+    if (this.type === 'SCO') {
+      this.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] =
+        this.isManagingStudents;
+    }
     this.tagsToAdd = differenceBy(tags, this.tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
   }

--- a/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
+++ b/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
@@ -204,6 +204,69 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
       expect(givenOrganization.isManagingStudents).to.equal(true);
     });
 
+    it('should enable compute organization learner certificability when updating SCO organization isManagingStudents to true', function () {
+      // given
+      const givenOrganization = new OrganizationForAdmin({
+        isManagingStudents: false,
+        type: 'SCO',
+        features: {
+          [apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+        },
+      });
+
+      // when
+      givenOrganization.updateWithDataProtectionOfficerAndTags({
+        isManagingStudents: true,
+      });
+
+      // then
+      expect(
+        givenOrganization.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+      ).to.equal(true);
+    });
+
+    it('should disable compute organization learner certificability when updating SCO organization isManagingStudents to false', function () {
+      // given
+      const givenOrganization = new OrganizationForAdmin({
+        isManagingStudents: true,
+        type: 'SCO',
+        features: {
+          [apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+        },
+      });
+
+      // when
+      givenOrganization.updateWithDataProtectionOfficerAndTags({
+        isManagingStudents: false,
+      });
+
+      // then
+      expect(
+        givenOrganization.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+      ).to.equal(false);
+    });
+
+    it('should not enable compute organization learner certificability when updating SUP organization isManagingStudents to true', function () {
+      // given
+      const givenOrganization = new OrganizationForAdmin({
+        isManagingStudents: false,
+        type: 'SUP',
+        features: {
+          [apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+        },
+      });
+
+      // when
+      givenOrganization.updateWithDataProtectionOfficerAndTags({
+        isManagingStudents: true,
+      });
+
+      // then
+      expect(
+        givenOrganization.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+      ).to.equal(false);
+    });
+
     it('should update organization email even if empty value', function () {
       // given
       const documentationUrl = 'initial@email.fr';


### PR DESCRIPTION
## :unicorn: Problème
La fonctionnalité de remontée de la certificabilité à l'édition de l'organisation doit être activée/désactivée selon l'état de isManagingStudent

## :robot: Proposition
Faire ça 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter à Pix Admin
- se placer sur une orga Sco
- décocher isManagingStudent
- vérifier l'état de la feature en base
- faire la même chose en réactivant le isManagingStudent
- 🎉 