### PR TITLE
[TECH] PixAdmin : montée de version de pix-ui en 39.0.3 (PIX-8787).

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.7.0",
-        "@1024pix/pix-ui": "^39.0.1",
+        "@1024pix/pix-ui": "^39.0.3",
         "@1024pix/stylelint-config": "^4.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "39.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-39.0.1.tgz",
-      "integrity": "sha512-Yag0egqtHURMHItiZxGPLT7OlGc9s37/rOK7buwrgi9GRyhCyBuy8PAHCw/ZEAFs/47HNMy3KwKXCZwdmOsaZA==",
+      "version": "39.0.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-39.0.3.tgz",
+      "integrity": "sha512-L1ve5iTGtSS+WPgKVDJ/LQ5EbzYu5Zy4v6P2iJe4TIScmsg1j8cL+J9c5cs81cSpA5H4QVc8fIDj1PHJfWlPow==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.7.0",
-    "@1024pix/pix-ui": "^39.0.1",
+    "@1024pix/pix-ui": "^39.0.3",
     "@1024pix/stylelint-config": "^4.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème

Le composant PixInput en mode `readonly` n'avait pas de style spécifique avant la [version 39.0.3](https://ui.pix.fr/?path=/docs/changelog--docs#v3903-02082023) de Pix-UI.

## :robot: Proposition

Monter la version de Pix-UI dans PixAdmin en 39.0.3.

## :100: Pour tester

- CI OK ✅
