### PR TITLE
[FEATURE] Filtrer liste des sessions de certification par version (PIX-8340).

### DIFF
--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -10,7 +10,6 @@
         <th id="session-status">Statut</th>
         <th id="session-finalization-date">Date de finalisation</th>
         <th id="session-publication-date">Date de publication</th>
-        <th id="session-results-sent-to-prescriber">Date de diffusion au prescripteur</th>
       </tr>
       <tr>
         <td class="table__column table__column--id">
@@ -63,16 +62,6 @@
         </td>
         <td></td>
         <td></td>
-        <td>
-          <PixSelect
-            @label="Filtrer les sessions par leurs résultats diffusés ou non diffusés"
-            @screenReaderOnly={{true}}
-            class="sessions-list-items__select"
-            @options={{this.sessionResultsSentToPrescriberOptions}}
-            @onChange={{this.selectSessionResultsSentToPrescriber}}
-            @value={{@resultsSentToPrescriberAt}}
-          />
-        </td>
       </tr>
     </thead>
 
@@ -98,7 +87,6 @@
             <td headers="session-status">{{session.displayStatus}}</td>
             <td headers="session-finalization-date">{{format-date session.finalizedAt}}</td>
             <td headers="session-publication-date">{{format-date session.publishedAt}}</td>
-            <td headers="session-results-sent-to-prescriber">{{format-date session.resultsSentToPrescriberAt}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -10,6 +10,7 @@
         <th id="session-status">Statut</th>
         <th id="session-finalization-date">Date de finalisation</th>
         <th id="session-publication-date">Date de publication</th>
+        <th id="session-version">Version de la session</th>
       </tr>
       <tr>
         <td class="table__column table__column--id">
@@ -62,6 +63,16 @@
         </td>
         <td></td>
         <td></td>
+        <td>
+          <PixSelect
+            @label="Filtrer les sessions par leur version"
+            @screenReaderOnly={{true}}
+            class="sessions-list-items__select"
+            @options={{this.sessionVersionOptions}}
+            @onChange={{this.selectSessionVersion}}
+            @value={{@version}}
+          />
+        </td>
       </tr>
     </thead>
 
@@ -87,6 +98,7 @@
             <td headers="session-status">{{session.displayStatus}}</td>
             <td headers="session-finalization-date">{{format-date session.finalizedAt}}</td>
             <td headers="session-publication-date">{{format-date session.publishedAt}}</td>
+            <td headers="session-version">{{session.version}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/admin/app/components/sessions/list-items.js
+++ b/admin/app/components/sessions/list-items.js
@@ -8,6 +8,7 @@ export default class ListItems extends Component {
   @tracked selectedCertificationCenterTypeOption = null;
   @tracked selectedSessionResultsSentToPrescriberOption = null;
   @tracked selectedSessionStatusOption = null;
+  @tracked selectedSessionVersionOption = null;
 
   constructor() {
     super(...arguments);
@@ -29,6 +30,14 @@ export default class ListItems extends Component {
       ...map(statusToDisplayName, (label, status) => ({ value: status, label })),
     ];
     this.selectedSessionStatusOption = this.getSessionStatusOptionByValue(this.args.sessionStatus);
+
+    // session version
+    this.sessionVersionOptions = [
+      { value: 'all', label: 'Tous' },
+      { value: '2', label: 'Sessions V2' },
+      { value: '3', label: 'Sessions V3' },
+    ];
+    this.selectedSessionVersionOption = this.getSessionVersionOptionByValue();
   }
 
   @action
@@ -55,5 +64,18 @@ export default class ListItems extends Component {
       return find(this.sessionStatusOptions, { value });
     }
     return this.sessionStatusOptions[0];
+  }
+
+  @action
+  selectSessionVersion(newValue) {
+    this.selectedSessionVersionOption = this.getSessionVersionOptionByValue(newValue);
+    this.args.onChangeSessionVersion(newValue);
+  }
+
+  getSessionVersionOptionByValue(value) {
+    if (value) {
+      return find(this.sessionVersionOptions, { value });
+    }
+    return this.sessionVersionOptions[0];
   }
 }

--- a/admin/app/components/sessions/list-items.js
+++ b/admin/app/components/sessions/list-items.js
@@ -29,16 +29,6 @@ export default class ListItems extends Component {
       ...map(statusToDisplayName, (label, status) => ({ value: status, label })),
     ];
     this.selectedSessionStatusOption = this.getSessionStatusOptionByValue(this.args.sessionStatus);
-
-    // "certification center type" filter
-    this.sessionResultsSentToPrescriberOptions = [
-      { value: 'all', label: 'Tous' },
-      { value: 'true', label: 'Résultats diffusés' },
-      { value: 'false', label: 'Résultats non diffusés' },
-    ];
-    this.selectedSessionResultsSentToPrescriberOption = this.getSessionResultsSentToPrescriberOptionByValue(
-      this.args.resultsSentToPrescriberAt,
-    );
   }
 
   @action
@@ -65,18 +55,5 @@ export default class ListItems extends Component {
       return find(this.sessionStatusOptions, { value });
     }
     return this.sessionStatusOptions[0];
-  }
-
-  @action
-  selectSessionResultsSentToPrescriber(newValue) {
-    this.selectedSessionResultsSentToPrescriberOption = this.getSessionResultsSentToPrescriberOptionByValue(newValue);
-    this.args.onChangeSessionResultsSent(newValue);
-  }
-
-  getSessionResultsSentToPrescriberOptionByValue(value) {
-    if (value) {
-      return find(this.sessionResultsSentToPrescriberOptions, { value });
-    }
-    return this.sessionResultsSentToPrescriberOptions[0];
   }
 }

--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -7,7 +7,15 @@ import { action } from '@ember/object';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedSessionsListAllController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'id', 'certificationCenterName', 'certificationCenterExternalId', 'status'];
+  queryParams = [
+    'pageNumber',
+    'pageSize',
+    'id',
+    'certificationCenterName',
+    'certificationCenterExternalId',
+    'status',
+    'version',
+  ];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
@@ -17,6 +25,7 @@ export default class AuthenticatedSessionsListAllController extends Controller {
   @tracked certificationCenterExternalId = null;
   @tracked certificationCenterType = null;
   @tracked status = null;
+  @tracked version = null;
 
   pendingFilters = {};
 
@@ -30,6 +39,7 @@ export default class AuthenticatedSessionsListAllController extends Controller {
         value = param.target.value; // param is an InputEvent
         break;
       case 'status':
+      case 'version':
       case 'certificationCenterType':
         debounceDuration = 0;
         value = param;
@@ -50,6 +60,12 @@ export default class AuthenticatedSessionsListAllController extends Controller {
   @action
   updateCertificationCenterTypeFilter(newValue) {
     this.certificationCenterType = this._getOrNullForOptionAll(newValue);
+    this.triggerFiltering.perform();
+  }
+
+  @action
+  updateSessionVersionFilter(newValue) {
+    this.version = this._getOrNullForOptionAll(newValue);
     this.triggerFiltering.perform();
   }
 

--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -7,15 +7,7 @@ import { action } from '@ember/object';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedSessionsListAllController extends Controller {
-  queryParams = [
-    'pageNumber',
-    'pageSize',
-    'id',
-    'certificationCenterName',
-    'certificationCenterExternalId',
-    'status',
-    'resultsSentToPrescriberAt',
-  ];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'certificationCenterName', 'certificationCenterExternalId', 'status'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
@@ -25,7 +17,6 @@ export default class AuthenticatedSessionsListAllController extends Controller {
   @tracked certificationCenterExternalId = null;
   @tracked certificationCenterType = null;
   @tracked status = null;
-  @tracked resultsSentToPrescriberAt = null;
 
   pendingFilters = {};
 
@@ -40,7 +31,6 @@ export default class AuthenticatedSessionsListAllController extends Controller {
         break;
       case 'status':
       case 'certificationCenterType':
-      case 'resultsSentToPrescriberAt':
         debounceDuration = 0;
         value = param;
         break;
@@ -66,12 +56,6 @@ export default class AuthenticatedSessionsListAllController extends Controller {
   @action
   updateSessionStatusFilter(newValue) {
     this.status = this._getOrNullForOptionAll(newValue);
-    this.triggerFiltering.perform();
-  }
-
-  @action
-  updateSessionResultsSentToPrescriberFilter(newValue) {
-    this.resultsSentToPrescriberAt = this._getOrNullForOptionAll(newValue);
     this.triggerFiltering.perform();
   }
 

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -47,6 +47,7 @@ export default class Session extends Model {
   @attr('boolean') hasIncident;
   @attr('boolean') hasJoiningIssue;
   @attr('boolean') hasSupervisorAccess;
+  @attr() version;
 
   @hasMany('jury-certification-summary') juryCertificationSummaries;
   @belongsTo('user') assignedCertificationOfficer;

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -14,6 +14,7 @@ export default class AuthenticatedSessionsAllRoute extends Route {
     certificationCenterExternalId: { refreshModel: true },
     certificationCenterType: { refreshModel: true },
     status: { refreshModel: true },
+    version: { refreshModel: true },
   };
 
   async model(params) {
@@ -26,6 +27,7 @@ export default class AuthenticatedSessionsAllRoute extends Route {
           certificationCenterExternalId: trim(params.certificationCenterExternalId) || undefined,
           certificationCenterType: params.certificationCenterType || undefined,
           status: params.status || undefined,
+          version: params.version || undefined,
         },
         page: {
           number: params.pageNumber,
@@ -48,6 +50,7 @@ export default class AuthenticatedSessionsAllRoute extends Route {
       controller.certificationCenterExternalId = null;
       controller.certificationCenterType = null;
       controller.status = FINALIZED;
+      controller.version = null;
     }
   }
 }

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -14,7 +14,6 @@ export default class AuthenticatedSessionsAllRoute extends Route {
     certificationCenterExternalId: { refreshModel: true },
     certificationCenterType: { refreshModel: true },
     status: { refreshModel: true },
-    resultsSentToPrescriberAt: { refreshModel: true },
   };
 
   async model(params) {
@@ -27,7 +26,6 @@ export default class AuthenticatedSessionsAllRoute extends Route {
           certificationCenterExternalId: trim(params.certificationCenterExternalId) || undefined,
           certificationCenterType: params.certificationCenterType || undefined,
           status: params.status || undefined,
-          resultsSentToPrescriberAt: params.resultsSentToPrescriberAt || undefined,
         },
         page: {
           number: params.pageNumber,
@@ -50,7 +48,6 @@ export default class AuthenticatedSessionsAllRoute extends Route {
       controller.certificationCenterExternalId = null;
       controller.certificationCenterType = null;
       controller.status = FINALIZED;
-      controller.resultsSentToPrescriberAt = null;
     }
   }
 }

--- a/admin/app/templates/authenticated/sessions/list/all.hbs
+++ b/admin/app/templates/authenticated/sessions/list/all.hbs
@@ -6,5 +6,7 @@
   @onChangeSessionStatus={{this.updateSessionStatusFilter}}
   @certificationCenterType={{this.certificationCenterType}}
   @onChangeCertificationCenterType={{this.updateCertificationCenterTypeFilter}}
+  @onChangeSessionVersion={{this.updateSessionVersionFilter}}
+  @version={{this.version}}
   @triggerFiltering={{this.triggerFiltering}}
 />

--- a/admin/app/templates/authenticated/sessions/list/all.hbs
+++ b/admin/app/templates/authenticated/sessions/list/all.hbs
@@ -6,7 +6,5 @@
   @onChangeSessionStatus={{this.updateSessionStatusFilter}}
   @certificationCenterType={{this.certificationCenterType}}
   @onChangeCertificationCenterType={{this.updateCertificationCenterTypeFilter}}
-  @resultsSentToPrescriberAt={{this.resultsSentToPrescriberAt}}
-  @onChangeSessionResultsSent={{this.updateSessionResultsSentToPrescriberFilter}}
   @triggerFiltering={{this.triggerFiltering}}
 />

--- a/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -56,9 +56,9 @@ function _getFiltersFromQueryParams(queryParams) {
       ? queryParams['filter[status]'].trim() || null
       : null
     : null;
-  const resultsSentToPrescriberAtFilter = queryParams
-    ? queryParams['filter[resultsSentToPrescriberAt]']
-      ? queryParams['filter[resultsSentToPrescriberAt]'].trim() || null
+  const versionFilter = queryParams
+    ? queryParams['filter[version]']
+      ? queryParams['filter[version]'].trim() || null
       : null
     : null;
   return {
@@ -66,7 +66,7 @@ function _getFiltersFromQueryParams(queryParams) {
     certificationCenterNameFilter,
     certificationCenterExternalIdFilter,
     statusFilter,
-    resultsSentToPrescriberAtFilter,
+    versionFilter,
   };
 }
 
@@ -81,13 +81,7 @@ function _areFiltersValid({ idFilter }) {
 
 function _applyFilters(
   sessions,
-  {
-    idFilter,
-    certificationCenterNameFilter,
-    certificationCenterExternalIdFilter,
-    statusFilter,
-    resultsSentToPrescriberAtFilter,
-  },
+  { idFilter, certificationCenterNameFilter, certificationCenterExternalIdFilter, statusFilter, versionFilter },
 ) {
   let filteredSessions = sessions;
   if (idFilter) {
@@ -112,17 +106,10 @@ function _applyFilters(
   if (statusFilter) {
     filteredSessions = filter(filteredSessions, { status: statusFilter });
   }
-  if (resultsSentToPrescriberAtFilter) {
-    if (resultsSentToPrescriberAtFilter === 'true') {
-      filteredSessions = filter(filteredSessions, (session) => {
-        return Boolean(session.resultsSentToPrescriberAt);
-      });
-    }
-    if (resultsSentToPrescriberAtFilter === 'false') {
-      filteredSessions = filter(filteredSessions, (session) => {
-        return !session.resultsSentToPrescriberAt;
-      });
-    }
+
+  if (versionFilter) {
+    filteredSessions = filter(filteredSessions, { version: +versionFilter });
+    console.log(filteredSessions);
   }
 
   return filteredSessions;

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -184,68 +184,6 @@ module('Acceptance | Session List', function (hooks) {
           assert.strictEqual(sessionProcessedCount, 5);
         });
       });
-
-      module('#resultsSentToPrescriberAt', function (hooks) {
-        hooks.beforeEach(function () {
-          server.createList('session', 5, 'withResultsSentToPrescriber', 'finalized');
-          server.createList('session', 3, 'finalized');
-        });
-
-        test('it should display sessions regardless the results have been sent or not', async function (assert) {
-          // when
-          const screen = await visit('/sessions/list');
-
-          // then
-          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
-            exact: false,
-          }).length;
-          assert.strictEqual(sessionCount, 8);
-        });
-
-        test('it should only display sessions which results have been sent', async function (assert) {
-          // when
-          const screen = await visit('/sessions/list');
-          await click(
-            screen.getByRole('button', {
-              name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
-            }),
-          );
-          await screen.findByRole('listbox');
-          await click(
-            screen.getByRole('option', {
-              name: 'Résultats diffusés',
-            }),
-          );
-
-          // then
-          const sessionWithResultSentCount = screen.getAllByLabelText('Informations de la session de certification', {
-            exact: false,
-          }).length;
-          assert.strictEqual(sessionWithResultSentCount, 5);
-        });
-
-        test('it should only display sessions which results have not been sent', async function (assert) {
-          // when
-          const screen = await visit('/sessions/list');
-          await click(
-            screen.getByRole('button', {
-              name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
-            }),
-          );
-          await screen.findByRole('listbox');
-          await click(
-            screen.getByRole('option', {
-              name: 'Résultats non diffusés',
-            }),
-          );
-
-          // then
-          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
-            exact: false,
-          }).length;
-          assert.strictEqual(sessionCount, 3);
-        });
-      });
     });
   });
 });

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -184,6 +184,68 @@ module('Acceptance | Session List', function (hooks) {
           assert.strictEqual(sessionProcessedCount, 5);
         });
       });
+
+      module('#version', function (hooks) {
+        hooks.beforeEach(function () {
+          server.createList('session', 5, { version: 2 });
+          server.createList('session', 3, { version: 3 });
+        });
+
+        test('it should display sessions regardless of the version', async function (assert) {
+          // when
+          const screen = await visit('/sessions/list');
+
+          // then
+          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionCount, 8);
+        });
+
+        test('it should only display V2 sessions', async function (assert) {
+          // when
+          const screen = await visit('/sessions/list');
+          await click(
+            screen.getByRole('button', {
+              name: 'Filtrer les sessions par leur version',
+            }),
+          );
+          await screen.findByRole('listbox');
+          await click(
+            screen.getByRole('option', {
+              name: 'Sessions V2',
+            }),
+          );
+
+          // then
+          const v2Sessions = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(v2Sessions, 5);
+        });
+
+        test('it should only display V3 sessions', async function (assert) {
+          // when
+          const screen = await visit('/sessions/list');
+          await click(
+            screen.getByRole('button', {
+              name: 'Filtrer les sessions par leur version',
+            }),
+          );
+          await screen.findByRole('listbox');
+          await click(
+            screen.getByRole('option', {
+              name: 'Sessions V3',
+            }),
+          );
+
+          // then
+          const v3Sessions = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(v3Sessions, 3);
+        });
+      });
     });
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -190,4 +190,45 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       assert.strictEqual(this.status, 'created');
     });
   });
+
+  module('Dropdown menu for version filtering', function () {
+    test('it should render a dropdown menu to filter sessions on their status', async function (assert) {
+      // given
+      const screen = await render(hbs`<Sessions::ListItems />`);
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions par leur version',
+        }),
+      );
+      await screen.findByRole('listbox');
+
+      // then
+      assert.dom(screen.getByRole('option', { name: 'Tous' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Sessions V2' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Sessions V3' })).exists();
+    });
+
+    test('it should filter sessions on (session) "version" when it has changed', async function (assert) {
+      // given
+      this.set('version', 2);
+      this.set('updateSessionVersionFilter', (newValue) => this.set('version', newValue));
+      const screen = await render(
+        hbs`<Sessions::ListItems @version={{this.version}} @onChangeSessionVersion={{this.updateSessionVersionFilter}} />`,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions par leur version',
+        }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Sessions V3' }));
+
+      // then
+      assert.strictEqual(this.version, '3');
+    });
+  });
 });

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -51,11 +51,6 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       month: 'numeric',
       year: 'numeric',
     });
-    const displayedResultsSentToPrescriberAt = resultsSentToPrescriberAt.toLocaleString('fr-FR', {
-      day: 'numeric',
-      month: 'numeric',
-      year: 'numeric',
-    });
 
     sessions.meta = { rowCount: 2 };
     this.set('sessions', sessions);
@@ -78,13 +73,6 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       assert
         .dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(8)`)
         .hasText(sessions[i].publishedAt ? displayedPublishedAt : sessions[i].publishedAt);
-      assert
-        .dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(9)`)
-        .hasText(
-          sessions[i].resultsSentToPrescriberAt
-            ? displayedResultsSentToPrescriberAt
-            : sessions[i].resultsSentToPrescriberAt,
-        );
     }
     // Colonne : Centre de certification
     assert.dom('table tbody tr:nth-child(1) td:nth-child(3)').hasText(sessions[0].certificationCenterExternalId);
@@ -200,52 +188,6 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
       // then
       assert.strictEqual(this.status, 'created');
-    });
-  });
-
-  module('Dropdown menu for resultsSentToPrescriberAt filtering', function () {
-    test('it should render a dropdown menu to filter sessions on their results sending', async function (assert) {
-      // given
-      const screen = await render(hbs`<Sessions::ListItems />`);
-
-      // when
-      await click(
-        screen.getByRole('button', {
-          name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
-        }),
-      );
-      await screen.findByRole('listbox');
-
-      // then
-      assert.dom(screen.getByRole('option', { name: 'Tous' })).exists();
-      assert.dom(screen.getByRole('option', { name: 'Résultats diffusés' })).exists();
-      assert.dom(screen.getByRole('option', { name: 'Résultats non diffusés' })).exists();
-    });
-
-    test('it should filter sessions on results sending status when it has changed', async function (assert) {
-      // given
-      this.set('resultsSentToPrescriberAt', 'true');
-      this.set('updateSessionResultsSentToPrescriberFilter', (newValue) =>
-        this.set('resultsSentToPrescriberAt', newValue),
-      );
-      const screen = await render(
-        hbs`<Sessions::ListItems
-  @resultsSentToPrescriberAt={{this.resultsSentToPrescriberAt}}
-  @onChangeSessionResultsSent={{this.updateSessionResultsSentToPrescriberFilter}}
-/>`,
-      );
-
-      // when
-      await click(
-        screen.getByRole('button', {
-          name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
-        }),
-      );
-      await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Résultats non diffusés' }));
-
-      // then
-      assert.strictEqual(this.resultsSentToPrescriberAt, 'false');
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/all_test.js
@@ -52,20 +52,6 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
       });
     });
 
-    module('when fieldName is resultsSentToPrescriberAt', function () {
-      test('it should update controller resultsSentToPrescriberAt field', async function (assert) {
-        // given
-        controller.resultsSentToPrescriberAt = 'someValue';
-
-        // when
-        const expectedValue = 'someOtherValue';
-        await controller.triggerFiltering.perform('resultsSentToPrescriberAt', expectedValue);
-
-        // then
-        assert.strictEqual(controller.resultsSentToPrescriberAt, expectedValue);
-      });
-    });
-
     module('when fieldName is certificationCenterType', function () {
       test('should update controller certificationCenterType field', async function (assert) {
         // given

--- a/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
@@ -35,7 +35,6 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: undefined,
-          resultsSentToPrescriberAt: undefined,
         };
 
         // then
@@ -54,7 +53,6 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: undefined,
-          resultsSentToPrescriberAt: undefined,
         };
 
         // when
@@ -76,7 +74,6 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: undefined,
-          resultsSentToPrescriberAt: undefined,
         };
 
         // when
@@ -98,7 +95,6 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: 'SCO',
           certificationCenterExternalId: undefined,
           status: undefined,
-          resultsSentToPrescriberAt: undefined,
         };
 
         // when
@@ -120,7 +116,6 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: 'EXTID',
           status: undefined,
-          resultsSentToPrescriberAt: undefined,
         };
 
         // when
@@ -142,29 +137,6 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: 'someStatus',
-          resultsSentToPrescriberAt: undefined,
-        };
-
-        // when
-        await route.model(params);
-
-        // then
-        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
-        assert.ok(true);
-      });
-    });
-
-    module('when queryParams resultsSentToPrescriberAt is true', function () {
-      test('it should call store.query with a filter with true resultsSentToPrescriberAt', async function (assert) {
-        // given
-        params.resultsSentToPrescriberAt = true;
-        expectedQueryArgs.filter = {
-          id: undefined,
-          certificationCenterName: undefined,
-          certificationCenterType: undefined,
-          certificationCenterExternalId: undefined,
-          status: undefined,
-          resultsSentToPrescriberAt: true,
         };
 
         // when

--- a/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
@@ -35,6 +35,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: undefined,
+          version: undefined,
         };
 
         // then
@@ -53,6 +54,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: undefined,
+          version: undefined,
         };
 
         // when
@@ -74,6 +76,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: undefined,
+          version: undefined,
         };
 
         // when
@@ -95,6 +98,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: 'SCO',
           certificationCenterExternalId: undefined,
           status: undefined,
+          version: undefined,
         };
 
         // when
@@ -116,6 +120,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: 'EXTID',
           status: undefined,
+          version: undefined,
         };
 
         // when
@@ -137,6 +142,29 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
           certificationCenterType: undefined,
           certificationCenterExternalId: undefined,
           status: 'someStatus',
+          version: undefined,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams version is 3', function () {
+      test('it should call store.query with a filter with version', async function (assert) {
+        // given
+        params.version = 3;
+        expectedQueryArgs.filter = {
+          id: undefined,
+          certificationCenterName: undefined,
+          certificationCenterType: undefined,
+          certificationCenterExternalId: undefined,
+          status: undefined,
+          version: 3,
         };
 
         // when
@@ -186,7 +214,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         certificationCenterName: 'someName',
         certificationCenterType: 'someType',
         status: 'someStatus',
-        resultsSentToPrescriberAt: 'someValue',
+        version: 'someVersion',
       };
     });
 
@@ -202,7 +230,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         assert.deepEqual(controller.certificationCenterName, null);
         assert.deepEqual(controller.certificationCenterType, null);
         assert.deepEqual(controller.status, 'finalized');
-        assert.deepEqual(controller.resultsSentToPrescriberAt, null);
+        assert.deepEqual(controller.version, null);
       });
     });
 
@@ -218,7 +246,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         assert.deepEqual(controller.certificationCenterName, 'someName');
         assert.deepEqual(controller.status, 'someStatus');
         assert.deepEqual(controller.certificationCenterType, 'someType');
-        assert.deepEqual(controller.resultsSentToPrescriberAt, 'someValue');
+        assert.deepEqual(controller.version, 'someVersion');
       });
     });
   });

--- a/api/lib/domain/models/JurySession.js
+++ b/api/lib/domain/models/JurySession.js
@@ -24,6 +24,7 @@ class JurySession {
     juryCommentAuthor,
     hasIncident,
     hasJoiningIssue,
+    version = 2,
   } = {}) {
     this.id = id;
     this.certificationCenterName = certificationCenterName;
@@ -47,6 +48,7 @@ class JurySession {
     this.juryCommentAuthor = juryCommentAuthor;
     this.hasIncident = hasIncident;
     this.hasJoiningIssue = hasJoiningIssue;
+    this.version = version;
   }
 
   get status() {

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -6,6 +6,7 @@ import { types } from '../models/CertificationCenter.js';
 import { CERTIFICATION_SESSIONS_ERRORS } from '../constants/sessions-errors.js';
 import { EntityValidationError } from '../errors.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { CertificationVersion } from '../models/CertificationVersion.js';
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
 
@@ -80,6 +81,7 @@ const sessionFiltersValidationSchema = Joi.object({
   certificationCenterName: Joi.string().trim().optional(),
   certificationCenterExternalId: Joi.string().trim().optional(),
   certificationCenterType: Joi.string().trim().valid(types.SUP, types.SCO, types.PRO).optional(),
+  version: Joi.number().valid(CertificationVersion.V2, CertificationVersion.V3).optional(),
 });
 
 const validate = function (session) {

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -77,7 +77,6 @@ const sessionFiltersValidationSchema = Joi.object({
     .trim()
     .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED)
     .optional(),
-  resultsSentToPrescriberAt: Joi.boolean().optional(),
   certificationCenterName: Joi.string().trim().optional(),
   certificationCenterExternalId: Joi.string().trim().optional(),
   certificationCenterType: Joi.string().trim().valid(types.SUP, types.SCO, types.PRO).optional(),

--- a/api/lib/infrastructure/repositories/sessions/jury-session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/jury-session-repository.js
@@ -101,14 +101,8 @@ function _toDomain(jurySessionFromDB) {
 }
 
 function _setupFilters(query, filters) {
-  const {
-    id,
-    certificationCenterName,
-    status,
-    resultsSentToPrescriberAt,
-    certificationCenterExternalId,
-    certificationCenterType,
-  } = filters;
+  const { id, certificationCenterName, status, certificationCenterExternalId, certificationCenterType, version } =
+    filters;
 
   if (id) {
     query.where('sessions.id', id);
@@ -129,12 +123,10 @@ function _setupFilters(query, filters) {
     ]);
   }
 
-  if (resultsSentToPrescriberAt === true) {
-    query.whereNotNull('resultsSentToPrescriberAt');
+  if (version) {
+    query.where('sessions.version', version);
   }
-  if (resultsSentToPrescriberAt === false) {
-    query.whereNull('resultsSentToPrescriberAt');
-  }
+
   if (status === statuses.CREATED) {
     query.whereNull('finalizedAt');
     query.whereNull('publishedAt');

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -27,6 +27,7 @@ const serialize = function (jurySessions, hasSupervisorAccess, meta) {
       'hasSupervisorAccess',
       'hasJoiningIssue',
       'hasIncident',
+      'version',
       // included
       'assignedCertificationOfficer',
       'juryCommentAuthor',

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -83,6 +83,7 @@ describe('Acceptance | Controller | session-controller-get-jury-session', functi
               'has-supervisor-access': true,
               'has-joining-issue': false,
               'has-incident': false,
+              version: 2,
             },
             relationships: {
               'assigned-certification-officer': { data: { type: 'user', id: '100002' } },

--- a/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
@@ -532,22 +532,22 @@ describe('Integration | Repository | JurySession', function () {
         });
       });
 
-      context('when there is a filter regarding resultsSentToPrescriberAt state', function () {
-        context('when there is a filter on sessions which results have been sent to prescriber', function () {
+      context('when there is a filter on the version', function () {
+        context('when there is a filter on sessions version', function () {
           let expectedSessionId;
 
           beforeEach(function () {
             expectedSessionId = databaseBuilder.factory.buildSession({
-              resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z'),
+              version: 3,
             }).id;
-            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null });
+            databaseBuilder.factory.buildSession();
 
             return databaseBuilder.commit();
           });
 
           it('should apply the strict filter and return the appropriate results', async function () {
             // given
-            const filters = { resultsSentToPrescriberAt: true };
+            const filters = { version: 3 };
             const page = { number: 1, size: 10 };
 
             // when
@@ -559,34 +559,10 @@ describe('Integration | Repository | JurySession', function () {
           });
         });
 
-        context('when there is a filter on sessions which results have not been sent to prescriber', function () {
-          let expectedSessionId;
-
+        context('when there is no filter on the version', function () {
           beforeEach(function () {
-            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z') });
-            expectedSessionId = databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null }).id;
-
-            return databaseBuilder.commit();
-          });
-
-          it('should apply the strict filter and return the appropriate results', async function () {
-            // given
-            const filters = { resultsSentToPrescriberAt: false };
-            const page = { number: 1, size: 10 };
-
-            // when
-            const { jurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
-
-            // then
-            expect(jurySessions).to.have.length(1);
-            expect(jurySessions[0].id).to.equal(expectedSessionId);
-          });
-        });
-
-        context('when there is no filter on whether session results has been sent to prescriber or not', function () {
-          beforeEach(function () {
-            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z') });
-            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null });
+            databaseBuilder.factory.buildSession();
+            databaseBuilder.factory.buildSession();
 
             return databaseBuilder.commit();
           });

--- a/api/tests/tooling/domain-builder/factory/build-jury-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-session.js
@@ -25,6 +25,7 @@ const buildJurySession = function ({
   juryCommentAuthor = null,
   hasIncident = false,
   hasJoiningIssue = false,
+  version = 2,
 } = {}) {
   if (_.isUndefined(certificationCenterId)) {
     const certificationCenter = domainBuilder.buildCertificationCenter();
@@ -57,6 +58,7 @@ const buildJurySession = function ({
     juryCommentAuthor,
     hasIncident,
     hasJoiningIssue,
+    version,
   });
 };
 

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -356,5 +356,40 @@ describe('Unit | Domain | Validators | session-validator', function () {
         });
       });
     });
+
+    context('when validating version', function () {
+      context('when version not in submitted filters', function () {
+        it('should not throw any error', function () {
+          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
+        });
+      });
+
+      context('when version is in submitted filters', function () {
+        context('when version is not a number', function () {
+          it('should throw an error', async function () {
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({
+              version: 'ok',
+            });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when version is not in the versions allowed list', function () {
+          it('should throw an error', async function () {
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({
+              version: 4,
+            });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when resultsSentToPrescriberAt is a number in the allowed list', function () {
+          it('should not throw an error', async function () {
+            expect(sessionValidator.validateAndNormalizeFilters({ version: 2 })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ version: 3 })).to.not.throw;
+          });
+        });
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -356,40 +356,5 @@ describe('Unit | Domain | Validators | session-validator', function () {
         });
       });
     });
-
-    context('when validating resultsSentToPrescriberAt', function () {
-      context('when resultsSentToPrescriberAt not in submitted filters', function () {
-        it('should not throw any error', function () {
-          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
-        });
-      });
-
-      context('when resultsSentToPrescriberAt is in submitted filters', function () {
-        context('when resultsSentToPrescriberAt is not a boolean', function () {
-          it('should throw an error', async function () {
-            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({
-              resultsSentToPrescriberAt: 123,
-            });
-            expect(error).to.be.instanceOf(EntityValidationError);
-          });
-        });
-
-        context('when resultsSentToPrescriberAt is not in the resultsSentToPrescriberAt list', function () {
-          it('should throw an error', async function () {
-            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({
-              resultsSentToPrescriberAt: 'SomeOtherValue',
-            });
-            expect(error).to.be.instanceOf(EntityValidationError);
-          });
-        });
-
-        context('when resultsSentToPrescriberAt is a boolean', function () {
-          it('should not throw an error', async function () {
-            expect(sessionValidator.validateAndNormalizeFilters({ resultsSentToPrescriberAt: true })).to.not.throw;
-            expect(sessionValidator.validateAndNormalizeFilters({ resultsSentToPrescriberAt: false })).to.not.throw;
-          });
-        });
-      });
-    });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -45,6 +45,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
           assignedCertificationOfficer,
           hasJoiningIssue: true,
           hasIncident: true,
+          version: 2,
         });
 
         // when
@@ -76,6 +77,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'jury-commented-at': null,
               'has-incident': true,
               'has-joining-issue': true,
+              version: 2,
             },
             relationships: {
               'jury-certification-summaries': {
@@ -129,6 +131,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
           juryComment: 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
           juryCommentedAt: new Date('2021-02-21T14:23:56Z'),
           juryCommentAuthor,
+          version: 3,
         });
 
         // when
@@ -160,6 +163,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'jury-commented-at': new Date('2021-02-21T14:23:56Z'),
               'has-incident': false,
               'has-joining-issue': false,
+              version: 3,
             },
             relationships: {
               'jury-certification-summaries': {
@@ -208,6 +212,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
           finalizedAt: new Date('2020-02-17T14:23:56Z'),
           resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
           publishedAt: new Date('2020-02-21T14:23:56Z'),
+          version: 2,
         });
 
         // when
@@ -238,9 +243,9 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'jury-comment': null,
               'jury-commented-at': null,
               'has-supervisor-access': true,
-
               'has-incident': false,
               'has-joining-issue': false,
+              version: 2,
             },
             relationships: {
               'jury-certification-summaries': {
@@ -281,6 +286,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
           finalizedAt: new Date('2020-02-17T14:23:56Z'),
           resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
           publishedAt: new Date('2020-02-21T14:23:56Z'),
+          version: 3,
         });
 
         // when
@@ -312,6 +318,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'jury-commented-at': null,
               'has-incident': false,
               'has-joining-issue': false,
+              version: 3,
             },
             relationships: {
               'jury-certification-summaries': {


### PR DESCRIPTION
## :unicorn: Problème

Une phase pilote pour la certification nextGen va être organisée auprès de quelques centres sélectionnés. Lors de cette phase, le pôle certif devra traiter à la fois les certifs actuelles, et les certifs nextGen. 

Pour faciliter le traitement pendant cette phase de transition, le pôle certif doit pouvoir identifier simplement le type de session.

## :robot: Proposition

Dans Pix Admin > menu “Sessions de certification” > onglet “Toutes les sessions” : 
Ajout d'une colonne “Type de session”
Afficher un filtre sous forme de liste déroulante avec les options suivantes : `Tous, sessions V2, sessions V3`

## :rainbow: Remarques

Nous supprimons dans cette PR la colonne permettant le filtre sur l'envoi des résultats aux prescripteurs, car inutilisée.

## :100: Pour tester

• Dans Pix Admin > “Sessions de certification”, cliquer sur l’onglet “Toutes les sessions”
• Vérifier que la colonne “Date de diffusion au prescripteur” n’est plus affichée
• Vérifier que  la colonne “Type de session” est affichée avec par défaut l’option “Tous” sélectionnée dans le filtre correspondant
• Sélectionner l’option “sessions v2” dans la liste déroulante
Résultat : toutes les sessions sauf celle avec des certif nextGen sont affichées

• Sélectionner l’option “sessions v3”
Résultat : toutes les sessions avec des certifs nextGen sont affichée
