### PR TITLE
[TECH] Corriger les alertes de lint dans le dossier api/ (PIX-8822)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -3,9 +3,8 @@ import lodash from 'lodash';
 const { isUndefined, isNil } = lodash;
 
 import { databaseBuffer } from '../database-buffer.js';
-import { AuthenticationMethod } from '../../../lib/domain/models/index.js';
+import { AuthenticationMethod, Membership } from '../../../lib/domain/models/index.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
-import { Membership } from '../../../lib/domain/models/index.js';
 
 import * as encrypt from '../../../lib/domain/services/encryption-service.js';
 

--- a/api/scripts/database/restore-dump/helpers/scalingo/scalingo-client.js
+++ b/api/scripts/database/restore-dump/helpers/scalingo/scalingo-client.js
@@ -1,4 +1,4 @@
-import scalingo from 'scalingo';
+import { clientFromToken } from 'scalingo';
 import { ScalingoDBClient } from './db-client.js';
 
 class ScalingoClient {
@@ -10,7 +10,7 @@ class ScalingoClient {
 
   static async getInstance({ application, token, region }) {
     const apiUrl = `https://api.${region}.scalingo.com`;
-    const client = await scalingo.clientFromToken(token, { apiUrl });
+    const client = await clientFromToken(token, { apiUrl });
 
     return new ScalingoClient({ client, application, region });
   }

--- a/api/tests/.eslintrc.cjs
+++ b/api/tests/.eslintrc.cjs
@@ -7,6 +7,6 @@ module.exports = {
   },
   rules: {
     'no-console': ['error'],
-    'mocha/no-setup-in-describe': ['warn'],
+    'mocha/no-setup-in-describe': ['error'],
   },
 };

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -13,7 +13,7 @@ import MockDate from 'mockdate';
 import chai from 'chai';
 
 const expect = chai.expect;
-import sinon from 'sinon';
+import sinon, { restore } from 'sinon';
 import chaiAsPromised from 'chai-as-promised';
 import chaiSorted from 'chai-sorted';
 import sinonChai from 'sinon-chai';
@@ -41,7 +41,7 @@ nock.disableNetConnect();
 import { buildLearningContent as learningContentBuilder } from './tooling/learning-content-builder/index.js';
 
 import * as tokenService from '../lib/domain/services/token-service.js';
-import { Membership } from '../lib/domain/models/Membership.js';
+import { Membership } from '../lib/domain/models/index.js';
 
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
 
@@ -52,7 +52,7 @@ import { createTempFile, removeTempFile } from './tooling/temporary-file.js';
 
 /* eslint-disable mocha/no-top-level-hooks */
 afterEach(function () {
-  sinon.restore();
+  restore();
   learningContentCache.flushAll();
   nock.cleanAll();
   return databaseBuilder.clean();

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -76,11 +76,12 @@ describe('Unit | Controller | assessment-controller', function () {
   });
 
   describe('#getCurrentActivity', function () {
+    let activity;
     const assessmentId = 104974;
-    const activity = { assessmentId, level: Activity.levels.TUTORIAL };
     let activitySerializerStub;
 
     beforeEach(function () {
+      activity = { assessmentId, level: Activity.levels.TUTORIAL };
       sinon.stub(usecases, 'getCurrentActivity').withArgs({ assessmentId }).resolves(activity);
       activitySerializerStub = { serialize: sinon.stub() };
       activitySerializerStub.serialize.resolvesArg(0);

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -6,6 +6,10 @@ import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-id
 import * as moduleUnderTest from '../../../../lib/application/users/index.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 
+const CODE_IDENTITY_PROVIDER_GAR = NON_OIDC_IDENTITY_PROVIDERS.GAR.code;
+const CODE_IDENTITY_PROVIDER_POLE_EMPLOI = OidcIdentityProviders.POLE_EMPLOI.code;
+const CODE_IDENTITY_PROVIDER_CNAV = OidcIdentityProviders.CNAV.code;
+
 describe('Unit | Router | user-router', function () {
   describe('POST /api/users', function () {
     const method = 'POST';
@@ -934,13 +938,11 @@ describe('Unit | Router | user-router', function () {
     describe('POST /api/admin/users/{id}/remove-authentication', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
-        NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        CODE_IDENTITY_PROVIDER_GAR,
         'EMAIL',
         'USERNAME',
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        OidcIdentityProviders.POLE_EMPLOI.code,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        OidcIdentityProviders.CNAV.code,
+        CODE_IDENTITY_PROVIDER_POLE_EMPLOI,
+        CODE_IDENTITY_PROVIDER_CNAV,
       ].forEach((type) => {
         it(`should return 200 when user is "SUPER_ADMIN" and type is ${type}`, async function () {
           // given
@@ -1064,81 +1066,81 @@ describe('Unit | Router | user-router', function () {
 
     describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
-      [
-        NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
-        OidcIdentityProviders.POLE_EMPLOI.code,
-        OidcIdentityProviders.CNAV.code,
-      ].forEach((identityProvider) => {
-        it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
-          // given
-          sinon
-            .stub(userController, 'reassignAuthenticationMethods')
-            .callsFake((request, h) => h.response({}).code(204));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response(true));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-          const payload = {
-            data: {
-              attributes: {
-                'user-id': 2,
-                'identity-provider': identityProvider,
+      [CODE_IDENTITY_PROVIDER_GAR, CODE_IDENTITY_PROVIDER_POLE_EMPLOI, CODE_IDENTITY_PROVIDER_CNAV].forEach(
+        (identityProvider) => {
+          it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
+            // given
+            sinon
+              .stub(userController, 'reassignAuthenticationMethods')
+              .callsFake((request, h) => h.response({}).code(204));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+              .callsFake((request, h) => h.response(true));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
+            const payload = {
+              data: {
+                attributes: {
+                  'user-id': 2,
+                  'identity-provider': identityProvider,
+                },
               },
-            },
-          };
+            };
 
-          // when
-          const { statusCode } = await httpTestServer.request(
-            'POST',
-            '/api/admin/users/1/authentication-methods/1',
-            payload,
-          );
+            // when
+            const { statusCode } = await httpTestServer.request(
+              'POST',
+              '/api/admin/users/1/authentication-methods/1',
+              payload,
+            );
 
-          // then
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
-          expect(statusCode).to.equal(204);
-        });
+            // then
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+            sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+            expect(statusCode).to.equal(204);
+          });
 
-        it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
-          // given
-          sinon
-            .stub(userController, 'reassignAuthenticationMethods')
-            .callsFake((request, h) => h.response({}).code(204));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(true));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-          const payload = {
-            data: {
-              attributes: {
-                'user-id': 3,
-                'identity-provider': identityProvider,
+          it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
+            // given
+            sinon
+              .stub(userController, 'reassignAuthenticationMethods')
+              .callsFake((request, h) => h.response({}).code(204));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+              .callsFake((request, h) => h.response(true));
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
+            const payload = {
+              data: {
+                attributes: {
+                  'user-id': 3,
+                  'identity-provider': identityProvider,
+                },
               },
-            },
-          };
+            };
 
-          // when
-          const { statusCode } = await httpTestServer.request(
-            'POST',
-            '/api/admin/users/1/authentication-methods/1',
-            payload,
-          );
+            // when
+            const { statusCode } = await httpTestServer.request(
+              'POST',
+              '/api/admin/users/1/authentication-methods/1',
+              payload,
+            );
 
-          // then
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
-          expect(statusCode).to.equal(204);
-        });
-      });
+            // then
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+            sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+            expect(statusCode).to.equal(204);
+          });
+        },
+      );
 
       it('returns 400 when "userId" is not a number', async function () {
         // given

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -334,6 +334,7 @@ describe('Unit | Domain | Errors', function () {
         expect(error.key).to.equal(joiErrorDetail.context.key);
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
         { type: 'any.required', why: 'required' },

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -388,6 +388,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     expect(assessmentResultRepository.save).to.have.been.calledOnce;
   });
 
+  // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
   // eslint-disable-next-line mocha/no-setup-in-describe
   [
     {

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -4,10 +4,11 @@ const { handleCertificationRescoring } = _forTestOnly.handlers;
 import { ChallengeNeutralized } from '../../../../lib/domain/events/ChallengeNeutralized.js';
 import { ChallengeDeneutralized } from '../../../../lib/domain/events/ChallengeDeneutralized.js';
 import { CertificationJuryDone } from '../../../../lib/domain/events/CertificationJuryDone.js';
-import { CertificationAssessment } from '../../../../lib/domain/models/CertificationAssessment.js';
-import { CertificationResult } from '../../../../lib/domain/models/CertificationResult.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
+import { CertificationAssessment, CertificationResult, AssessmentResult } from '../../../../lib/domain/models/index.js';
 import { CertificationComputeError } from '../../../../lib/domain/errors.js';
+
+const CERTIFICATION_RESULT_EMITTER_AUTOJURY = CertificationResult.emitters.PIX_ALGO_AUTO_JURY;
+const CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION = CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION;
 
 describe('Unit | Domain | Events | handle-certification-rescoring', function () {
   it('computes and persists the assessment result and competence marks when computation succeeds', async function () {
@@ -391,18 +392,15 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
   [
     {
       eventType: CertificationJuryDone,
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      emitter: CertificationResult.emitters.PIX_ALGO_AUTO_JURY,
+      emitter: CERTIFICATION_RESULT_EMITTER_AUTOJURY,
     },
     {
       eventType: ChallengeNeutralized,
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      emitter: CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION,
+      emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
     },
     {
       eventType: ChallengeDeneutralized,
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      emitter: CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION,
+      emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
     },
   ].forEach(({ eventType, emitter }) => {
     context(`when event is of type ${eventType}`, function () {

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -459,6 +459,7 @@ describe('Unit | Domain | Models | Assessment', function () {
   });
 
   describe('#computeMethod', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { assessmentType: 'PREVIEW', expectedMethod: 'CHOSEN' },

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -66,6 +66,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       );
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     _.forIn(CertificationAssessment.states, (value) => {
       it(`should not throw an ObjectValidationError when state is ${value}`, function () {

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -66,7 +66,6 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       );
     });
 
-    // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line mocha/no-setup-in-describe
     _.forIn(CertificationAssessment.states, (value) => {
       it(`should not throw an ObjectValidationError when state is ${value}`, function () {

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -81,6 +81,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { name: 'firstName', code: 'CANDIDATE_FIRST_NAME_MUST_BE_A_STRING' },
@@ -350,6 +351,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         expect(error).to.deepEqualInstanceOmitting(certificationCandidatesError, ['message', 'stack']);
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
         it(`should not throw if billing mode is an expected value ${billingMode}`, async function () {
@@ -442,6 +444,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { field: 'firstName', expectedCode: FIRST_NAME_ERROR_CODE },
@@ -620,6 +623,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         context('when billing mode is in the expected values', function () {
+          // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
           // eslint-disable-next-line mocha/no-setup-in-describe
           ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
             it(`should return nothing for ${billingMode}`, async function () {
@@ -867,6 +871,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       }
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
       it(`should not throw if billing mode is expected value ${billingMode}`, async function () {
@@ -977,6 +982,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
   });
 
   describe('parseBillingMode', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { value: 'Gratuite', expectedTranslation: 'FREE' },
@@ -992,6 +998,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
   });
 
   describe('translateBillingMode', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { value: 'FREE', expectedTranslation: 'Gratuite' },

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -1,5 +1,5 @@
 import { catchErr, domainBuilder, expect } from '../../../test-helper.js';
-import { CertificationCandidate } from '../../../../lib/domain/models/CertificationCandidate.js';
+import { CertificationCandidate } from '../../../../lib/domain/models/index.js';
 
 import {
   CertificationCandidatePersonalInfoFieldMissingError,
@@ -10,9 +10,14 @@ import {
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../lib/domain/constants/certification-candidates-errors.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 
-const i18n = getI18n();
+const FIRST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code;
+const LAST_NAME_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code;
+const BIRTHDATE_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code;
+const SEX_ERROR_CODE = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code;
 
+const i18n = getI18n();
 const translate = i18n.__;
+
 describe('Unit | Domain | Models | Certification Candidate', function () {
   describe('constructor', function () {
     it('should build a Certification Candidate from JSON', function () {
@@ -437,15 +442,15 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
     });
 
-    /* eslint-disable mocha/no-setup-in-describe */
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { field: 'firstName', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code },
-      { field: 'lastName', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code },
-      { field: 'birthdate', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code },
+      { field: 'firstName', expectedCode: FIRST_NAME_ERROR_CODE },
+      { field: 'lastName', expectedCode: LAST_NAME_ERROR_CODE },
+      { field: 'birthdate', expectedCode: BIRTHDATE_ERROR_CODE },
       {
         field: 'sex',
-        expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code,
-      } /* eslint-enable mocha/no-setup-in-describe */,
+        expectedCode: SEX_ERROR_CODE,
+      },
     ].forEach(({ field, expectedCode }) => {
       it(`should return a report when field ${field} is not present`, async function () {
         // given
@@ -489,7 +494,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const report = certificationCandidate.validateForMassSessionImport();
 
       // then
-      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code]);
+      expect(report).to.deep.equal([BIRTHDATE_ERROR_CODE]);
     });
 
     context('when extraTimePercentage field is presents', function () {
@@ -539,7 +544,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const report = certificationCandidate.validateForMassSessionImport();
 
       // then
-      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code]);
+      expect(report).to.deep.equal([SEX_ERROR_CODE]);
     });
 
     context('when billing mode field is presents', function () {
@@ -703,10 +708,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const report = certificationCandidate.validateForMassSessionImport();
 
         // then
-        expect(report).to.deep.equal([
-          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code,
-          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code,
-        ]);
+        expect(report).to.deep.equal([FIRST_NAME_ERROR_CODE, BIRTHDATE_ERROR_CODE]);
       });
     });
   });

--- a/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
+++ b/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
@@ -1,14 +1,11 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
-import { CertificationChallengeWithType } from '../../../../lib/domain/models/CertificationChallengeWithType.js';
+import { CertificationChallengeWithType } from '../../../../lib/domain/models/index.js';
 import { Type } from '../../../../lib/domain/models/Challenge.js';
 
 describe('Unit | Domain | Models | CertificationChallengeWithType', function () {
   describe('#constructor', function () {
-    // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line mocha/no-setup-in-describe
-    const validTypes = Object.values(Type);
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    validTypes.forEach((validType) => {
+    Object.values(Type).forEach((validType) => {
       it(`should initialize CertificationChallengeWithType with type ${validType}`, function () {
         // when
         const certificationChallengeWithType = new CertificationChallengeWithType({ type: validType });

--- a/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
+++ b/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
@@ -4,6 +4,7 @@ import { Type } from '../../../../lib/domain/models/Challenge.js';
 
 describe('Unit | Domain | Models | CertificationChallengeWithType', function () {
   describe('#constructor', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     Object.values(Type).forEach((validType) => {
       it(`should initialize CertificationChallengeWithType with type ${validType}`, function () {

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -107,6 +107,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
   });
 
   describe('#correctBirthdate', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['2000-13-01', null, undefined, '', 'invalid'].forEach((invalidDate) => {
       it(`throws if date is invalid : ${invalidDate}`, function () {
@@ -135,6 +136,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
   });
 
   describe('#correctFirstName', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [null, undefined, '', '   '].forEach((invalidFirstName) => {
       it(`throws if first name is invalid : ${invalidFirstName}`, function () {
@@ -163,6 +165,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
   });
 
   describe('#correctLastName', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [null, undefined, '', '   '].forEach((invalidLastName) => {
       it(`throws if last name is invalid : ${invalidLastName}`, function () {
@@ -191,6 +194,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
   });
 
   describe('#correctBirthplace', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [null, undefined, '', '   '].forEach((invalidBirthPlace) => {
       it(`does not modify if birthplace is invalid : ${invalidBirthPlace}`, function () {
@@ -254,6 +258,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
       expect(() => certificationCourse.correctSex(sex)).not.to.throw(EntityValidationError);
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['M', 'F'].forEach((validSex) => {
       it(`modifies the sex when value is ${validSex}`, function () {

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -3,7 +3,7 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../lib/domain/models/CertificationIssueReportCategory.js';
-import { CertificationIssueReportResolutionAttempt } from '../../../../lib/domain/models/CertificationIssueReportResolutionAttempt.js';
+import { CertificationIssueReportResolutionAttempt } from '../../../../lib/domain/models/index.js';
 import {
   CertificationIssueReportResolutionStrategies,
   neutralizeWithoutCheckingStrategy,
@@ -13,6 +13,23 @@ import {
   neutralizeOrValidateIfFocusedChallengeStrategy,
   doNotResolveStrategy,
 } from '../../../../lib/domain/models/CertificationIssueReportResolutionStrategies.js';
+
+const ISSUE_REPORT_SUBCATEGORY_NAME_OR_BIRTHDATE = CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE;
+const ISSUE_REPORT_SUBCATEGORY_LEFT_EXAM_ROOM = CertificationIssueReportSubcategories.LEFT_EXAM_ROOM;
+const ISSUE_REPORT_SUBCATEGORY_ACCESSIBILITY_ISSUE = CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE;
+const ISSUE_REPORT_SUBCATEGORY_OTHER = CertificationIssueReportSubcategories.OTHER;
+const ISSUE_REPORT_SUBCATEGORY_EMBED_NOT_WORKING = CertificationIssueReportSubcategories.EMBED_NOT_WORKING;
+const ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING = CertificationIssueReportSubcategories.FILE_NOT_OPENING;
+const ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING = CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING;
+const ISSUE_REPORT_SUBCATEGORY_WEBSITE_UNAVAILABLE = CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE;
+const ISSUE_REPORT_SUBCATEGORY_WEBSITE_BLOCKED = CertificationIssueReportSubcategories.WEBSITE_BLOCKED;
+const ISSUE_REPORT_SUBCATEGORY_LINK_NOT_WORKING = CertificationIssueReportSubcategories.LINK_NOT_WORKING;
+const ISSUE_REPORT_SUBCATEGORY_IMAGE_NOT_DISPLAYING = CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING;
+const ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_PERCENTAGE = CertificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE;
+const ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED = CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED;
+const ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT = CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT;
+const ISSUE_REPORT_SUBCATEGORY_SKIP_ON_OOPS = CertificationIssueReportSubcategories.SKIP_ON_OOPS;
+const ISSUE_REPORT_SUBCATEGORY_UNKNOWN = CertificationIssueReportSubcategories.SIGNATURE_ISSUE;
 
 describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies', function () {
   context('#NEUTRALIZE_WITHOUT_CHECKING', function () {
@@ -26,7 +43,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -56,7 +73,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -87,7 +104,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -117,7 +134,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -151,7 +168,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -186,7 +203,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -223,7 +240,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -258,7 +275,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -290,7 +307,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -318,7 +335,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -347,7 +364,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -387,7 +404,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -428,7 +445,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -463,7 +480,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -501,7 +518,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -538,7 +555,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -573,7 +590,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -601,7 +618,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -630,7 +647,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -664,7 +681,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -705,7 +722,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -742,7 +759,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -782,7 +799,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -819,7 +836,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -854,7 +871,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -882,7 +899,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -911,7 +928,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -945,7 +962,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -986,7 +1003,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -1023,7 +1040,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -1066,7 +1083,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -1103,7 +1120,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -1147,7 +1164,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -1184,7 +1201,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
             certificationAnswersByDate: [certificationAnswer],
           });
           const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-            subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+            subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
             category: CertificationIssueReportCategory.IN_CHALLENGE,
             questionNumber: 1,
           });
@@ -1221,7 +1238,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -1249,7 +1266,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -1279,7 +1296,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -1313,7 +1330,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       it('resolves the certification issue report anyway', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+          subcategory: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
           category: CertificationIssueReportCategory.IN_CHALLENGE,
           questionNumber: 1,
         });
@@ -1352,7 +1369,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     it('returns an unresolved resolution attempt', async function () {
       // given
       const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-        subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+        subcategory: ISSUE_REPORT_SUBCATEGORY_EMBED_NOT_WORKING,
         category: CertificationIssueReportCategory.IN_CHALLENGE,
         questionNumber: 1,
       });
@@ -1372,7 +1389,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     it('does not resolve the certification issue report', async function () {
       // given
       const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-        subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+        subcategory: ISSUE_REPORT_SUBCATEGORY_EMBED_NOT_WORKING,
         category: CertificationIssueReportCategory.IN_CHALLENGE,
         questionNumber: 1,
       });
@@ -1394,96 +1411,80 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_NAME_OR_BIRTHDATE,
         strategyToBeApplied: 'doNotResolve',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_PERCENTAGE,
         strategyToBeApplied: 'doNotResolve',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_LEFT_EXAM_ROOM,
         strategyToBeApplied: 'doNotResolve',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_UNKNOWN,
         strategyToBeApplied: 'doNotResolve',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_IMAGE_NOT_DISPLAYING,
         strategyToBeApplied: 'neutralizeIfImageOrEmbed',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.LINK_NOT_WORKING,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_LINK_NOT_WORKING,
         strategyToBeApplied: 'doNotResolve',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_EMBED_NOT_WORKING,
         strategyToBeApplied: 'neutralizeIfImageOrEmbed',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_FILE_NOT_OPENING,
         strategyToBeApplied: 'neutralizeIfAttachment',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_WEBSITE_UNAVAILABLE,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_WEBSITE_BLOCKED,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_EXTRA_TIME_EXCEEDED,
         strategyToBeApplied: 'neutralizeIfTimedChallenge',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_SOFTWARE_NOT_WORKING,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.OTHER,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_OTHER,
         strategyToBeApplied: 'doNotResolve',
       },
 
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_UNINTENTIONAL_FOCUS_OUT,
         strategyToBeApplied: 'neutralizeOrValidateIfFocusedChallenge',
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.SKIP_ON_OOPS,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_SKIP_ON_OOPS,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        subCategoryToBeResolved: CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
+        subCategoryToBeResolved: ISSUE_REPORT_SUBCATEGORY_ACCESSIBILITY_ISSUE,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
     ].forEach(({ subCategoryToBeResolved, strategyToBeApplied }) => {

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1408,6 +1408,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
   });
 
   context('#resolve', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -35,6 +35,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         );
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE, WHITESPACES_VALUE].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, function () {
@@ -45,6 +46,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         });
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE].forEach((emptyValue) => {
         it(`should create a NON_BLOCKING_TECHNICAL_ISSUE CertificationIssueReport when subcategory is empty with value ${emptyValue}`, function () {
@@ -73,6 +75,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         );
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE, WHITESPACES_VALUE].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value "${emptyValue}"`, function () {
@@ -83,6 +86,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         });
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE].forEach((emptyValue) => {
         it(`should create a NON_BLOCKING_CANDIDATE_ISSUE CertificationIssueReport when subcategory is empty with value "${emptyValue}"`, function () {
@@ -111,6 +115,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         );
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE, WHITESPACES_VALUE].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, function () {
@@ -140,6 +145,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         );
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE, WHITESPACES_VALUE].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, function () {
@@ -150,7 +156,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         });
       });
 
-      // Test dynamically all subcategories
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [...Object.values(CertificationIssueReportSubcategories)].forEach((subcategory) => {
         if (
@@ -194,7 +200,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         );
       });
 
-      // Test dynamically all subcategories
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [...Object.values(CertificationIssueReportSubcategories)].forEach((subcategory) => {
         if (
@@ -249,6 +255,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         }
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when questionNumber is empty with value ${emptyValue}`, function () {
@@ -302,6 +309,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
         );
       });
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [MISSING_VALUE, EMPTY_VALUE, UNDEFINED_VALUE, WHITESPACES_VALUE].forEach((emptyValue) => {
         it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, function () {
@@ -316,6 +324,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
     context(
       'Adds isImpactful boolean to certif issue report when the category or subcategory is impactful',
       function () {
+        // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
         // eslint-disable-next-line mocha/no-setup-in-describe
         [
           { certificationCourseId: 42, category: 'OTHER', subcategory: undefined, description: 'toto' },
@@ -381,6 +390,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
           });
         });
 
+        // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
         // eslint-disable-next-line mocha/no-setup-in-describe
         [
           {

--- a/api/tests/unit/domain/models/CertificationReport_test.js
+++ b/api/tests/unit/domain/models/CertificationReport_test.js
@@ -6,6 +6,7 @@ import lodash from 'lodash';
 const { keys } = lodash;
 describe('Unit | Domain | Models | CertificationReport', function () {
   describe('#constructor', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     EMPTY_BLANK_AND_NULL.forEach((examinerComment) => {
       it(`should return no examiner comment if comment is "${examinerComment}"`, function () {
@@ -34,6 +35,7 @@ describe('Unit | Domain | Models | CertificationReport', function () {
       certificationReport.validateForFinalization();
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -104,6 +104,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     });
 
     context('status', function () {
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
         {
@@ -167,6 +168,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       expect(cancelledCertificationResult.isCancelled()).to.be.true;
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { statusName: 'validated', status: CERTIFICATION_RESULT_STATUS_VALIDATED },
@@ -206,6 +208,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       expect(isValidated).to.be.true;
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
@@ -245,6 +248,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       expect(isRejected).to.be.true;
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
@@ -284,6 +288,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       expect(isInError).to.be.true;
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
@@ -323,6 +328,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       expect(isStarted).to.be.true;
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
@@ -346,6 +352,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
   });
 
   context('#hasBeenRejectedAutomatically', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -1,5 +1,14 @@
-import { CertificationResult } from '../../../../lib/domain/models/CertificationResult.js';
+import { CertificationResult } from '../../../../lib/domain/models/index.js';
 import { expect, domainBuilder } from '../../../test-helper.js';
+
+const CERTIFICATION_RESULT_STATUS_CANCELLED = CertificationResult.status.CANCELLED;
+const CERTIFICATION_RESULT_STATUS_ERROR = CertificationResult.status.ERROR;
+const CERTIFICATION_RESULT_STATUS_REJECTED = CertificationResult.status.REJECTED;
+const CERTIFICATION_RESULT_STATUS_STARTED = CertificationResult.status.STARTED;
+const CERTIFICATION_RESULT_STATUS_VALIDATED = CertificationResult.status.VALIDATED;
+const CERTIFICATION_RESULT_EMITTER_PIXALGO = CertificationResult.emitters.PIX_ALGO;
+const CERTIFICATION_RESULT_EMITTER_AUTOJURY = CertificationResult.emitters.PIX_ALGO_AUTO_JURY;
+const CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION = CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION;
 
 describe('Unit | Domain | Models | CertificationResult', function () {
   context('#static from', function () {
@@ -22,7 +31,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
         assessmentId: 789,
         resultCreatedAt: new Date('2020-01-03'),
         pixScore: 123,
-        emitter: CertificationResult.emitters.PIX_ALGO,
+        emitter: CERTIFICATION_RESULT_EMITTER_PIXALGO,
         commentForCandidate: 'Un commentaire candidat 1',
         commentForJury: 'Un commentaire jury 1',
         commentForOrganization: 'Un commentaire orga 1',
@@ -47,7 +56,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
       const certificationResultDTO = {
         ...certificationResultData,
         isCancelled: false,
-        assessmentResultStatus: CertificationResult.status.VALIDATED,
+        assessmentResultStatus: CERTIFICATION_RESULT_STATUS_VALIDATED,
       };
 
       // when
@@ -72,8 +81,8 @@ describe('Unit | Domain | Models | CertificationResult', function () {
         assessmentId: 789,
         resultCreatedAt: new Date('2020-01-03'),
         pixScore: 123,
-        status: CertificationResult.status.VALIDATED,
-        emitter: CertificationResult.emitters.PIX_ALGO,
+        status: CERTIFICATION_RESULT_STATUS_VALIDATED,
+        emitter: CERTIFICATION_RESULT_EMITTER_PIXALGO,
         commentForCandidate: 'Un commentaire candidat 1',
         commentForJury: 'Un commentaire jury 1',
         commentForOrganization: 'Un commentaire orga 1',
@@ -100,29 +109,29 @@ describe('Unit | Domain | Models | CertificationResult', function () {
         {
           statusName: 'cancelled',
           isCancelled: true,
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          assessmentResultStatus: CertificationResult.status.VALIDATED,
+
+          assessmentResultStatus: CERTIFICATION_RESULT_STATUS_VALIDATED,
           validationFunction: 'isCancelled',
         },
         {
           statusName: 'validated',
           isCancelled: false,
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          assessmentResultStatus: CertificationResult.status.VALIDATED,
+
+          assessmentResultStatus: CERTIFICATION_RESULT_STATUS_VALIDATED,
           validationFunction: 'isValidated',
         },
         {
           statusName: 'rejected',
           isCancelled: false,
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          assessmentResultStatus: CertificationResult.status.REJECTED,
+
+          assessmentResultStatus: CERTIFICATION_RESULT_STATUS_REJECTED,
           validationFunction: 'isRejected',
         },
         {
           statusName: 'error',
           isCancelled: false,
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          assessmentResultStatus: CertificationResult.status.ERROR,
+
+          assessmentResultStatus: CERTIFICATION_RESULT_STATUS_ERROR,
           validationFunction: 'isInError',
         },
 
@@ -151,7 +160,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('returns true if status is "cancelled"', function () {
       // given
       const cancelledCertificationResult = domainBuilder.buildCertificationResult({
-        status: CertificationResult.status.CANCELLED,
+        status: CERTIFICATION_RESULT_STATUS_CANCELLED,
       });
 
       // when / then
@@ -160,14 +169,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'validated', status: CertificationResult.status.VALIDATED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'rejected', status: CertificationResult.status.REJECTED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'error', status: CertificationResult.status.ERROR },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'started', status: CertificationResult.status.STARTED },
+      { statusName: 'validated', status: CERTIFICATION_RESULT_STATUS_VALIDATED },
+
+      { statusName: 'rejected', status: CERTIFICATION_RESULT_STATUS_REJECTED },
+
+      { statusName: 'error', status: CERTIFICATION_RESULT_STATUS_ERROR },
+
+      { statusName: 'started', status: CERTIFICATION_RESULT_STATUS_STARTED },
     ].forEach(function (testCase) {
       it(`should return false when status is ${testCase.statusName}`, async function () {
         // given
@@ -188,7 +196,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('returns true if status is "validated"', function () {
       // given
       const validatedCertificationResult = domainBuilder.buildCertificationResult({
-        status: CertificationResult.status.VALIDATED,
+        status: CERTIFICATION_RESULT_STATUS_VALIDATED,
       });
 
       // when
@@ -200,14 +208,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'cancelled', status: CertificationResult.status.CANCELLED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'rejected', status: CertificationResult.status.REJECTED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'error', status: CertificationResult.status.ERROR },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'started', status: CertificationResult.status.STARTED },
+      { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
+
+      { statusName: 'rejected', status: CERTIFICATION_RESULT_STATUS_REJECTED },
+
+      { statusName: 'error', status: CERTIFICATION_RESULT_STATUS_ERROR },
+
+      { statusName: 'started', status: CERTIFICATION_RESULT_STATUS_STARTED },
     ].forEach(function (testCase) {
       it(`should return false when status is ${testCase.statusName}`, async function () {
         // given
@@ -228,7 +235,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('returns true if status is "rejected"', function () {
       // given
       const rejectedCertificationResult = domainBuilder.buildCertificationResult({
-        status: CertificationResult.status.REJECTED,
+        status: CERTIFICATION_RESULT_STATUS_REJECTED,
       });
 
       // when
@@ -240,14 +247,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'cancelled', status: CertificationResult.status.CANCELLED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'validated', status: CertificationResult.status.VALIDATED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'error', status: CertificationResult.status.ERROR },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'started', status: CertificationResult.status.STARTED },
+      { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
+
+      { statusName: 'validated', status: CERTIFICATION_RESULT_STATUS_VALIDATED },
+
+      { statusName: 'error', status: CERTIFICATION_RESULT_STATUS_ERROR },
+
+      { statusName: 'started', status: CERTIFICATION_RESULT_STATUS_STARTED },
     ].forEach(function (testCase) {
       it(`should return false when status is ${testCase.statusName}`, async function () {
         // given
@@ -268,7 +274,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('returns true if status is "error"', function () {
       // given
       const errorCertificationResult = domainBuilder.buildCertificationResult({
-        status: CertificationResult.status.ERROR,
+        status: CERTIFICATION_RESULT_STATUS_ERROR,
       });
 
       // when
@@ -280,14 +286,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'cancelled', status: CertificationResult.status.CANCELLED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'validated', status: CertificationResult.status.VALIDATED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'rejected', status: CertificationResult.status.REJECTED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'started', status: CertificationResult.status.STARTED },
+      { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
+
+      { statusName: 'validated', status: CERTIFICATION_RESULT_STATUS_VALIDATED },
+
+      { statusName: 'rejected', status: CERTIFICATION_RESULT_STATUS_REJECTED },
+
+      { statusName: 'started', status: CERTIFICATION_RESULT_STATUS_STARTED },
     ].forEach(function (testCase) {
       it(`should return false when status is ${testCase.statusName}`, async function () {
         // given
@@ -308,7 +313,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     it('returns true if status is "started"', function () {
       // given
       const startedCertificationResult = domainBuilder.buildCertificationResult({
-        status: CertificationResult.status.STARTED,
+        status: CERTIFICATION_RESULT_STATUS_STARTED,
       });
 
       // when
@@ -320,14 +325,10 @@ describe('Unit | Domain | Models | CertificationResult', function () {
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'cancelled', status: CertificationResult.status.CANCELLED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'validated', status: CertificationResult.status.VALIDATED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'rejected', status: CertificationResult.status.REJECTED },
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      { statusName: 'error', status: CertificationResult.status.ERROR },
+      { statusName: 'cancelled', status: CERTIFICATION_RESULT_STATUS_CANCELLED },
+      { statusName: 'validated', status: CERTIFICATION_RESULT_STATUS_VALIDATED },
+      { statusName: 'rejected', status: CERTIFICATION_RESULT_STATUS_REJECTED },
+      { statusName: 'error', status: CERTIFICATION_RESULT_STATUS_ERROR },
     ].forEach(function (testCase) {
       it(`should return false when status is ${testCase.statusName}`, async function () {
         // given
@@ -348,45 +349,34 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        emitter: CertificationResult.emitters.PIX_ALGO,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: CertificationResult.status.REJECTED,
+        emitter: CERTIFICATION_RESULT_EMITTER_PIXALGO,
+        status: CERTIFICATION_RESULT_STATUS_REJECTED,
         expectedResult: true,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        emitter: CertificationResult.emitters.PIX_ALGO_AUTO_JURY,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: CertificationResult.status.REJECTED,
+        emitter: CERTIFICATION_RESULT_EMITTER_AUTOJURY,
+        status: CERTIFICATION_RESULT_STATUS_REJECTED,
         expectedResult: true,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        emitter: CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: CertificationResult.status.REJECTED,
+        emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
+        status: CERTIFICATION_RESULT_STATUS_REJECTED,
         expectedResult: false,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        emitter: CertificationResult.emitters.PIX_ALGO,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: CertificationResult.status.STARTED,
+        emitter: CERTIFICATION_RESULT_EMITTER_PIXALGO,
+        status: CERTIFICATION_RESULT_STATUS_STARTED,
         expectedResult: false,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        emitter: CertificationResult.emitters.PIX_ALGO_AUTO_JURY,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: CertificationResult.status.STARTED,
+        emitter: CERTIFICATION_RESULT_EMITTER_AUTOJURY,
+        status: CERTIFICATION_RESULT_STATUS_STARTED,
         expectedResult: false,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        emitter: CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: CertificationResult.status.STARTED,
+        emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
+
+        status: CERTIFICATION_RESULT_STATUS_STARTED,
         expectedResult: false,
       },
     ].forEach(function ({ expectedResult, emitter, status }) {

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -150,6 +150,7 @@ describe('Unit | Domain | Models | Challenge', function () {
       other: Validator,
     };
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     Object.entries(challengeTypeAndValidators).forEach(([challengeType, associatedValidatorClass]) => {
       context(`when challenge of type: ${challengeType} exists`, function () {

--- a/api/tests/unit/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential_test.js
@@ -5,6 +5,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationScoringWithoutCompl
     context('reproducibility rate is equal or greater than minimum reproducibility rate', function () {
       const minimumReproducibilityRate = 70;
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [70, 80, 90].forEach((reproducibilityRate) => {
         context('pix score is equal or greater than minimum earned pix', function () {
@@ -50,6 +51,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationScoringWithoutCompl
     context('reproducibility rate is lower than minimum reproducibility rate', function () {
       const minimumReproducibilityRate = 70;
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       [1, 50, 69].forEach((reproducibilityRate) => {
         context('pix score is equal or greater than minimum earned pix', function () {

--- a/api/tests/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/unit/domain/models/KnowledgeElement_test.js
@@ -37,6 +37,7 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
   });
 
   describe('#isDirectlyValidated', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
@@ -331,6 +332,7 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
       sinon.useFakeTimers(testCurrentDate.getTime());
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { daysBefore: 0, hoursBefore: 2, expectedDaysSinceLastKnowledgeElement: 0.0833 },

--- a/api/tests/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/unit/domain/models/KnowledgeElement_test.js
@@ -1,14 +1,18 @@
 import { expect, sinon, domainBuilder } from '../../../test-helper.js';
-import { AnswerStatus } from '../../../../lib/domain/models/AnswerStatus.js';
-import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
+import { AnswerStatus, KnowledgeElement } from '../../../../lib/domain/models/index.js';
 import dayjs from 'dayjs';
+
+const KE_STATUS_VALIDATED = KnowledgeElement.StatusType.VALIDATED;
+const KE_STATUS_INVALIDATED = KnowledgeElement.StatusType.INVALIDATED;
+const KE_SOURCE_DIRECT = KnowledgeElement.SourceType.DIRECT;
+const KE_SOURCE_INFERRED = KnowledgeElement.SourceType.INFERRED;
 
 describe('Unit | Domain | Models | KnowledgeElement', function () {
   describe('#isValidated', function () {
     it('should be true if status validated', function () {
       // given
       const knowledgeElement = domainBuilder.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.VALIDATED,
+        status: KE_STATUS_VALIDATED,
       });
 
       // when
@@ -21,7 +25,7 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
     it('should be false if status not validated', function () {
       // given
       const knowledgeElement = domainBuilder.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.INVALIDATED,
+        status: KE_STATUS_INVALIDATED,
       });
 
       // when
@@ -36,31 +40,23 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: KnowledgeElement.StatusType.VALIDATED,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        source: KnowledgeElement.SourceType.DIRECT,
+        status: KE_STATUS_VALIDATED,
+        source: KE_SOURCE_DIRECT,
         expected: true,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: KnowledgeElement.StatusType.INVALIDATED,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        source: KnowledgeElement.SourceType.DIRECT,
+        status: KE_STATUS_INVALIDATED,
+        source: KE_SOURCE_DIRECT,
         expected: false,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: KnowledgeElement.StatusType.VALIDATED,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        source: KnowledgeElement.SourceType.INFERRED,
+        status: KE_STATUS_VALIDATED,
+        source: KE_SOURCE_INFERRED,
         expected: false,
       },
       {
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        status: KnowledgeElement.StatusType.INVALIDATED,
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        source: KnowledgeElement.SourceType.INFERRED,
+        status: KE_STATUS_INVALIDATED,
+        source: KE_SOURCE_INFERRED,
         expected: false,
       },
     ].forEach(({ status, source, expected }) => {
@@ -81,7 +77,7 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
     it('should be true if status invalidated', function () {
       // given
       const knowledgeElement = domainBuilder.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.INVALIDATED,
+        status: KE_STATUS_INVALIDATED,
       });
 
       // when
@@ -94,7 +90,7 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
     it('should be false if status not invalidated', function () {
       // given
       const knowledgeElement = domainBuilder.buildKnowledgeElement({
-        status: KnowledgeElement.StatusType.VALIDATED,
+        status: KE_STATUS_VALIDATED,
       });
 
       // when
@@ -175,8 +171,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
       it('should create a knowledge element', function () {
         // then
         const directKnowledgeElement = domainBuilder.buildKnowledgeElement({
-          source: KnowledgeElement.SourceType.DIRECT,
-          status: KnowledgeElement.StatusType.VALIDATED,
+          source: KE_SOURCE_DIRECT,
+          status: KE_STATUS_VALIDATED,
           earnedPix: skill.pixValue,
           answerId: validAnswer.id,
           assessmentId: validAnswer.assessmentId,
@@ -217,8 +213,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
         it('should create one direct knowledge element and two inferred validated for easier skills', function () {
           // then
           const directKnowledgeElement = domainBuilder.buildKnowledgeElement({
-            source: KnowledgeElement.SourceType.DIRECT,
-            status: KnowledgeElement.StatusType.VALIDATED,
+            source: KE_SOURCE_DIRECT,
+            status: KE_STATUS_VALIDATED,
             earnedPix: skill.pixValue,
             answerId: validAnswer.id,
             assessmentId: validAnswer.assessmentId,
@@ -229,8 +225,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
           });
           directKnowledgeElement.id = undefined;
           const inferredKnowledgeElementForEasierSkill = domainBuilder.buildKnowledgeElement({
-            source: KnowledgeElement.SourceType.INFERRED,
-            status: KnowledgeElement.StatusType.VALIDATED,
+            source: KE_SOURCE_INFERRED,
+            status: KE_STATUS_VALIDATED,
             earnedPix: easierSkill.pixValue,
             answerId: validAnswer.id,
             assessmentId: validAnswer.assessmentId,
@@ -241,8 +237,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
           });
           inferredKnowledgeElementForEasierSkill.id = undefined;
           const inferredKnowledgeElementForMuchEasierSkill = domainBuilder.buildKnowledgeElement({
-            source: KnowledgeElement.SourceType.INFERRED,
-            status: KnowledgeElement.StatusType.VALIDATED,
+            source: KE_SOURCE_INFERRED,
+            status: KE_STATUS_VALIDATED,
             earnedPix: muchEasierSkill.pixValue,
             answerId: validAnswer.id,
             assessmentId: validAnswer.assessmentId,
@@ -281,8 +277,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
         it('should create one direct knowledge element and two inferred invalidated for harder skills', function () {
           // then
           const directKnowledgeElement = domainBuilder.buildKnowledgeElement({
-            source: KnowledgeElement.SourceType.DIRECT,
-            status: KnowledgeElement.StatusType.INVALIDATED,
+            source: KE_SOURCE_DIRECT,
+            status: KE_STATUS_INVALIDATED,
             earnedPix: 0,
             answerId: invalidAnswer.id,
             assessmentId: invalidAnswer.assessmentId,
@@ -292,8 +288,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
           });
           directKnowledgeElement.id = undefined;
           const inferredKnowledgeElementForHarderSkill = domainBuilder.buildKnowledgeElement({
-            source: KnowledgeElement.SourceType.INFERRED,
-            status: KnowledgeElement.StatusType.INVALIDATED,
+            source: KE_SOURCE_INFERRED,
+            status: KE_STATUS_INVALIDATED,
             earnedPix: 0,
             answerId: invalidAnswer.id,
             assessmentId: invalidAnswer.assessmentId,
@@ -303,8 +299,8 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
           });
           inferredKnowledgeElementForHarderSkill.id = undefined;
           const inferredKnowledgeElementForMuchHarderSkill = domainBuilder.buildKnowledgeElement({
-            source: KnowledgeElement.SourceType.INFERRED,
-            status: KnowledgeElement.StatusType.INVALIDATED,
+            source: KE_SOURCE_INFERRED,
+            status: KE_STATUS_INVALIDATED,
             earnedPix: 0,
             answerId: invalidAnswer.id,
             assessmentId: invalidAnswer.assessmentId,

--- a/api/tests/unit/domain/models/OrganizationPlacesLot_test.js
+++ b/api/tests/unit/domain/models/OrganizationPlacesLot_test.js
@@ -434,6 +434,7 @@ describe('Unit | Domain | Models | OrganizationPlaces', function () {
           ]);
         });
 
+        // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
         // eslint-disable-next-line mocha/no-setup-in-describe
         [
           { code: CODE_CATEGORY_T0, category: CATEGORY_FREE_RATE },

--- a/api/tests/unit/domain/models/OrganizationPlacesLot_test.js
+++ b/api/tests/unit/domain/models/OrganizationPlacesLot_test.js
@@ -1,7 +1,18 @@
 import { expect } from '../../../test-helper.js';
 import * as categories from '../../../../lib/domain/constants/organization-places-categories.js';
-import { OrganizationPlacesLot } from '../../../../lib/domain/models/OrganizationPlacesLot.js';
+import { OrganizationPlacesLot } from '../../../../lib/domain/models/index.js';
 import { EntityValidationError } from '../../../../lib/domain/errors.js';
+
+const CODE_CATEGORY_T0 = categories.T0;
+const CODE_CATEGORY_T1 = categories.T1;
+const CODE_CATEGORY_T2 = categories.T2;
+const CODE_CATEGORY_T2BIS = categories.T2bis;
+const CODE_CATEGORY_T3 = categories.T3;
+const CATEGORY_FREE_RATE = categories.FREE_RATE;
+const CATEGORY_PUBLIC_RATE = categories.PUBLIC_RATE;
+const CATEGORY_REDUCE_RATE = categories.REDUCE_RATE;
+const CATEGORY_SPECIAL_REDUCE_RATE = categories.SPECIAL_REDUCE_RATE;
+const CATEGORY_FULL_RATE = categories.FULL_RATE;
 
 describe('Unit | Domain | Models | OrganizationPlaces', function () {
   describe('#constructor', function () {
@@ -26,7 +37,7 @@ describe('Unit | Domain | Models | OrganizationPlaces', function () {
       expect(organizationPlacesLot.activationDate).to.equal('2022-01-02');
       expect(organizationPlacesLot.expirationDate).to.equal('2023-01-02');
       expect(organizationPlacesLot.reference).to.equal('abc123');
-      expect(organizationPlacesLot.category).to.equal(categories.T0);
+      expect(organizationPlacesLot.category).to.equal(CODE_CATEGORY_T0);
       expect(organizationPlacesLot.createdBy).to.equal(888);
     });
 
@@ -422,12 +433,14 @@ describe('Unit | Domain | Models | OrganizationPlaces', function () {
             },
           ]);
         });
+
+        // eslint-disable-next-line mocha/no-setup-in-describe
         [
-          { code: categories.T0, category: categories.FREE_RATE },
-          { code: categories.T1, category: categories.PUBLIC_RATE },
-          { code: categories.T2, category: categories.REDUCE_RATE },
-          { code: categories.T2bis, category: categories.SPECIAL_REDUCE_RATE },
-          { code: categories.T3, category: categories.FULL_RATE },
+          { code: CODE_CATEGORY_T0, category: CATEGORY_FREE_RATE },
+          { code: CODE_CATEGORY_T1, category: CATEGORY_PUBLIC_RATE },
+          { code: CODE_CATEGORY_T2, category: CATEGORY_REDUCE_RATE },
+          { code: CODE_CATEGORY_T2BIS, category: CATEGORY_SPECIAL_REDUCE_RATE },
+          { code: CODE_CATEGORY_T3, category: CATEGORY_FULL_RATE },
         ].forEach((data) => {
           it(`it returns ${data.code} when category is ${data.category}`, function () {
             //given

--- a/api/tests/unit/domain/models/Progression_test.js
+++ b/api/tests/unit/domain/models/Progression_test.js
@@ -1,10 +1,11 @@
-import { Progression } from '../../../../lib/domain/models/Progression.js';
+import { Progression } from '../../../../lib/domain/models/index.js';
 import { expect, domainBuilder } from '../../../test-helper.js';
 
 describe('Unit | Domain | Models | Progression', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const [skillLevel1, skillLevel2, skillLevel3] = domainBuilder.buildSkillCollection();
+  let skillLevel1, skillLevel2, skillLevel3;
+  beforeEach(function () {
+    [skillLevel1, skillLevel2, skillLevel3] = domainBuilder.buildSkillCollection();
+  });
 
   describe('#completionRate', function () {
     context('when the profile is not fully evaluated', function () {

--- a/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/SCOCertificationCandidate_test.js
@@ -25,6 +25,7 @@ describe('Unit | Domain | Models | SCO Certification Candidate', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['firstName', 'lastName'].forEach((field) => {
       it(`should throw an error when field ${field} is not a string`, async function () {
@@ -52,6 +53,7 @@ describe('Unit | Domain | Models | SCO Certification Candidate', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['sex', 'birthINSEECode'].forEach((field) => {
       it(`should throw an error when field ${field} is not a string`, async function () {
@@ -63,6 +65,7 @@ describe('Unit | Domain | Models | SCO Certification Candidate', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['sessionId', 'organizationLearnerId'].forEach((field) => {
       it(`should throw an error when field ${field} is not a number`, async function () {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -1,7 +1,12 @@
 import { expect, sinon } from '../../../test-helper.js';
-import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
-import { Scorecard } from '../../../../lib/domain/models/Scorecard.js';
+import { KnowledgeElement, Scorecard } from '../../../../lib/domain/models/index.js';
 import { constants, MAX_REACHABLE_LEVEL, MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../../lib/domain/constants.js';
+
+const MINIMUM_DELAY_IN_DAYS_FOR_RESET = constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET;
+const MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
+const SCORECARD_STATUS_STARTED = Scorecard.statuses.STARTED;
+const SCORECARD_STATUS_NOT_STARTED = Scorecard.statuses.NOT_STARTED;
+const SCORECARD_STATUS_COMPLETED = Scorecard.statuses.COMPLETED;
 
 describe('Unit | Domain | Models | Scorecard', function () {
   let computeDaysSinceLastKnowledgeElementStub;
@@ -70,7 +75,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
         expect(actualScorecard.pixScoreAheadOfNextLevel).to.equal(1);
       });
       it('should have set the scorecard status based on the competence evaluation status', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
+        expect(actualScorecard.status).to.equal(SCORECARD_STATUS_STARTED);
       });
       it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', function () {
         expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
@@ -91,7 +96,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       });
       // then
       it('should have set the scorecard status NOT_STARTED', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.NOT_STARTED);
+        expect(actualScorecard.status).to.equal(SCORECARD_STATUS_NOT_STARTED);
       });
     });
 
@@ -112,7 +117,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       });
       // then
       it('should have set the scorecard status STARTED', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
+        expect(actualScorecard.status).to.equal(SCORECARD_STATUS_STARTED);
       });
     });
 
@@ -149,7 +154,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       });
       // then
       it('should have set the scorecard status STARTED', function () {
-        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
+        expect(actualScorecard.status).to.equal(SCORECARD_STATUS_STARTED);
       });
     });
 
@@ -262,7 +267,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
 
   describe('#computeRemainingDaysBeforeReset', function () {
     let testCurrentDate;
-    const originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET;
+    const originalConstantValue = MINIMUM_DELAY_IN_DAYS_FOR_RESET;
 
     beforeEach(function () {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
@@ -277,6 +282,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_FOR_RESET').value(originalConstantValue);
     });
 
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { daysSinceLastKnowledgeElement: 0.0833, expectedDaysBeforeReset: 7 },
       { daysSinceLastKnowledgeElement: 1, expectedDaysBeforeReset: 6 },
@@ -305,7 +311,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
 
   describe('#computeRemainingDaysBeforeImproving', function () {
     let testCurrentDate;
-    const originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
+    const originalConstantValue = MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
 
     beforeEach(function () {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
@@ -320,6 +326,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING').value(originalConstantValue);
     });
 
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { daysSinceLastKnowledgeElement: 0.0833, expectedDaysBeforeImproving: 4 },
       { daysSinceLastKnowledgeElement: 0, expectedDaysBeforeImproving: 4 },
@@ -363,7 +370,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   describe('#isFinished', function () {
     it('should return true when status is completed', function () {
       // given
-      const scorecard = new Scorecard({ status: Scorecard.statuses.COMPLETED });
+      const scorecard = new Scorecard({ status: SCORECARD_STATUS_COMPLETED });
 
       // when
       const result = scorecard.isFinished;
@@ -372,7 +379,8 @@ describe('Unit | Domain | Models | Scorecard', function () {
       expect(result).to.be.true;
     });
 
-    [Scorecard.statuses.STARTED, Scorecard.statuses.NOT_STARTED].forEach((status) => {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [SCORECARD_STATUS_STARTED, SCORECARD_STATUS_NOT_STARTED].forEach((status) => {
       it('should return false when status is not completed', function () {
         // given
         const scorecard = new Scorecard({ status });
@@ -430,16 +438,17 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isFinishedWithMaxLevel', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { level: 2, status: Scorecard.statuses.NOT_STARTED, expectedResult: false },
-      { level: 2, status: Scorecard.statuses.STARTED, expectedResult: false },
-      { level: 2, status: Scorecard.statuses.COMPLETED, expectedResult: true },
-      { level: 1, status: Scorecard.statuses.NOT_STARTED, expectedResult: false },
-      { level: 1, status: Scorecard.statuses.STARTED, expectedResult: false },
-      { level: 1, status: Scorecard.statuses.COMPLETED, expectedResult: false },
-      { level: 3, status: Scorecard.statuses.NOT_STARTED, expectedResult: false },
-      { level: 3, status: Scorecard.statuses.STARTED, expectedResult: false },
-      { level: 3, status: Scorecard.statuses.COMPLETED, expectedResult: true },
+      { level: 2, status: SCORECARD_STATUS_NOT_STARTED, expectedResult: false },
+      { level: 2, status: SCORECARD_STATUS_STARTED, expectedResult: false },
+      { level: 2, status: SCORECARD_STATUS_COMPLETED, expectedResult: true },
+      { level: 1, status: SCORECARD_STATUS_NOT_STARTED, expectedResult: false },
+      { level: 1, status: SCORECARD_STATUS_STARTED, expectedResult: false },
+      { level: 1, status: SCORECARD_STATUS_COMPLETED, expectedResult: false },
+      { level: 3, status: SCORECARD_STATUS_NOT_STARTED, expectedResult: false },
+      { level: 3, status: SCORECARD_STATUS_STARTED, expectedResult: false },
+      { level: 3, status: SCORECARD_STATUS_COMPLETED, expectedResult: true },
     ].forEach((testCase) => {
       it(`should return ${testCase.expectedResult} when level is ${testCase.level} and status ${testCase.status}`, function () {
         // given
@@ -456,10 +465,11 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isNotStarted', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { status: Scorecard.statuses.NOT_STARTED, expectedResult: true },
-      { status: Scorecard.statuses.STARTED, expectedResult: false },
-      { status: Scorecard.statuses.COMPLETED, expectedResult: false },
+      { status: SCORECARD_STATUS_NOT_STARTED, expectedResult: true },
+      { status: SCORECARD_STATUS_STARTED, expectedResult: false },
+      { status: SCORECARD_STATUS_COMPLETED, expectedResult: false },
     ].forEach((testCase) => {
       it(`should return ${testCase.expectedResult} when status is ${testCase.status}`, function () {
         // given
@@ -475,10 +485,11 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isStarted', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { status: Scorecard.statuses.NOT_STARTED, expectedResult: false },
-      { status: Scorecard.statuses.STARTED, expectedResult: true },
-      { status: Scorecard.statuses.COMPLETED, expectedResult: false },
+      { status: SCORECARD_STATUS_NOT_STARTED, expectedResult: false },
+      { status: SCORECARD_STATUS_STARTED, expectedResult: true },
+      { status: SCORECARD_STATUS_COMPLETED, expectedResult: false },
     ].forEach((testCase) => {
       it(`should return ${testCase.expectedResult} when status is ${testCase.status}`, function () {
         // given
@@ -494,12 +505,13 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isProgressable', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { status: Scorecard.statuses.NOT_STARTED, level: 0, expectedResult: false },
-      { status: Scorecard.statuses.COMPLETED, level: 1, expectedResult: false },
-      { status: Scorecard.statuses.STARTED, level: 1, expectedResult: true },
-      { status: Scorecard.statuses.STARTED, level: 2, expectedResult: false },
-      { status: Scorecard.statuses.STARTED, level: 3, expectedResult: false },
+      { status: SCORECARD_STATUS_NOT_STARTED, level: 0, expectedResult: false },
+      { status: SCORECARD_STATUS_COMPLETED, level: 1, expectedResult: false },
+      { status: SCORECARD_STATUS_STARTED, level: 1, expectedResult: true },
+      { status: SCORECARD_STATUS_STARTED, level: 2, expectedResult: false },
+      { status: SCORECARD_STATUS_STARTED, level: 3, expectedResult: false },
     ].forEach((testCase) => {
       it(`should return ${testCase.expectedResult} when status is ${testCase.status}, level is ${testCase.level}`, function () {
         // given
@@ -516,6 +528,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isImprovable', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { isFinished: false, isFinishedWithMaxLevel: true, remainingDaysBeforeImproving: 5, expectedResult: false },
       { isFinished: false, isFinishedWithMaxLevel: true, remainingDaysBeforeImproving: 0, expectedResult: false },
@@ -542,6 +555,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#shouldWaitBeforeImproving', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { isFinished: false, isFinishedWithMaxLevel: true, remainingDaysBeforeImproving: 5, expectedResult: false },
       { isFinished: false, isFinishedWithMaxLevel: true, remainingDaysBeforeImproving: 0, expectedResult: false },
@@ -568,6 +582,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isResettable', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { isFinished: false, isStarted: true, remainingDaysBeforeReset: 5, expectedResult: false },
       { isFinished: false, isStarted: true, remainingDaysBeforeReset: 0, expectedResult: true },
@@ -688,6 +703,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#percentageAheadOfNextLevel', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { pixScoreAheadOfNextLevel: 0, expectedPercentageAheadOfNextLevel: 0 },
       { pixScoreAheadOfNextLevel: 4, expectedPercentageAheadOfNextLevel: 50 },

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -282,6 +282,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_FOR_RESET').value(originalConstantValue);
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { daysSinceLastKnowledgeElement: 0.0833, expectedDaysBeforeReset: 7 },
@@ -326,6 +327,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING').value(originalConstantValue);
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { daysSinceLastKnowledgeElement: 0.0833, expectedDaysBeforeImproving: 4 },
@@ -379,6 +381,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       expect(result).to.be.true;
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [SCORECARD_STATUS_STARTED, SCORECARD_STATUS_NOT_STARTED].forEach((status) => {
       it('should return false when status is not completed', function () {
@@ -438,6 +441,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isFinishedWithMaxLevel', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { level: 2, status: SCORECARD_STATUS_NOT_STARTED, expectedResult: false },
@@ -465,6 +469,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isNotStarted', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { status: SCORECARD_STATUS_NOT_STARTED, expectedResult: true },
@@ -485,6 +490,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isStarted', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { status: SCORECARD_STATUS_NOT_STARTED, expectedResult: false },
@@ -505,6 +511,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isProgressable', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { status: SCORECARD_STATUS_NOT_STARTED, level: 0, expectedResult: false },
@@ -528,6 +535,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isImprovable', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { isFinished: false, isFinishedWithMaxLevel: true, remainingDaysBeforeImproving: 5, expectedResult: false },
@@ -555,6 +563,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#shouldWaitBeforeImproving', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { isFinished: false, isFinishedWithMaxLevel: true, remainingDaysBeforeImproving: 5, expectedResult: false },
@@ -582,6 +591,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#isResettable', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { isFinished: false, isStarted: true, remainingDaysBeforeReset: 5, expectedResult: false },
@@ -703,6 +713,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
   });
 
   describe('#percentageAheadOfNextLevel', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { pixScoreAheadOfNextLevel: 0, expectedPercentageAheadOfNextLevel: 0 },

--- a/api/tests/unit/domain/models/SupOrganizationLearner_test.js
+++ b/api/tests/unit/domain/models/SupOrganizationLearner_test.js
@@ -23,6 +23,7 @@ describe('Unit | Domain | Models | SupOrganizationLearner', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     ['firstName', 'lastName', 'birthdate', 'studentNumber'].forEach((field) => {
       it(`throw an error when ${field} is required`, async function () {
@@ -33,6 +34,7 @@ describe('Unit | Domain | Models | SupOrganizationLearner', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       'studentNumber',
@@ -57,6 +59,7 @@ describe('Unit | Domain | Models | SupOrganizationLearner', function () {
       });
     });
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       'studentNumber',
@@ -125,6 +128,7 @@ describe('Unit | Domain | Models | SupOrganizationLearner', function () {
 
     context('student number', function () {
       context('when student number is not correctly formed', function () {
+        // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
         // eslint-disable-next-line mocha/no-setup-in-describe
         ['#123457', '1 23457', '1.23457', '1,23457E+11', 'gégé'].forEach((value) => {
           it(`throw an error when student number is ${value}`, async function () {
@@ -137,6 +141,7 @@ describe('Unit | Domain | Models | SupOrganizationLearner', function () {
       });
 
       context('when student number is correctly formed', function () {
+        // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
         // eslint-disable-next-line mocha/no-setup-in-describe
         ['123456', '1234aA', '1-a-B', '1_a_B'].forEach((value) => {
           it(`throw an error when student number is ${value}`, async function () {

--- a/api/tests/unit/domain/services/email-validator_test.js
+++ b/api/tests/unit/domain/services/email-validator_test.js
@@ -6,6 +6,7 @@ describe('Unit | Service | email-validator', function () {
     expect(service.emailIsValid()).to.be.false;
   });
 
+  // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
   // eslint-disable-next-line mocha/no-setup-in-describe
   [
     '',
@@ -23,6 +24,7 @@ describe('Unit | Service | email-validator', function () {
     });
   });
 
+  // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
   // eslint-disable-next-line mocha/no-setup-in-describe
   [
     'follower@pix.fr',

--- a/api/tests/unit/domain/services/get-competence-level_test.js
+++ b/api/tests/unit/domain/services/get-competence-level_test.js
@@ -4,20 +4,19 @@ import { getCompetenceLevel } from '../../../../lib/domain/services/get-competen
 describe('Unit | Domain | Service | Get Competence Level', function () {
   describe('#getCompetenceLevel', function () {
     const userId = 'userId';
-    const competenceId = 'competenceId';
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const knowledgeElements = Symbol('knowledgeElements');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const domainTransaction = Symbol('domainTransaction');
     const level = 3;
     let competenceLevel;
     let knowledgeElementRepository;
+    let competenceId;
+    let knowledgeElements;
+    let domainTransaction;
     let scoringService;
 
     beforeEach(async function () {
       // given
+      competenceId = 'competenceId';
+      knowledgeElements = Symbol('knowledgeElements');
+      domainTransaction = Symbol('domainTransaction');
       knowledgeElementRepository = {
         findUniqByUserIdAndCompetenceId: sinon.stub().resolves(knowledgeElements),
       };

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -8,26 +8,23 @@ import _ from 'lodash';
 
 describe('Unit | Service | PickChallengeService', function () {
   describe('#pickChallenge', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const englishSpokenChallenge = domainBuilder.buildChallenge({ locales: [ENGLISH_SPOKEN] });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const frenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const frenchChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_FRANCE] });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const validatedChallenge = domainBuilder.buildChallenge({ status: 'validé' });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const archivedChallenge = domainBuilder.buildChallenge({ status: 'archivé' });
+    let englishSpokenChallenge,
+      frenchSpokenChallenge,
+      otherFrenchSpokenChallenge,
+      frenchChallenge,
+      validatedChallenge,
+      archivedChallenge;
 
     const randomSeed = 'some-random-seed';
+
+    beforeEach(function () {
+      englishSpokenChallenge = domainBuilder.buildChallenge({ locales: [ENGLISH_SPOKEN] });
+      frenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
+      otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
+      frenchChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_FRANCE] });
+      validatedChallenge = domainBuilder.buildChallenge({ status: 'validé' });
+      archivedChallenge = domainBuilder.buildChallenge({ status: 'archivé' });
+    });
 
     context('when challenge in selected locale exists', function () {
       it('should return challenge in selected locale', function () {

--- a/api/tests/unit/domain/services/pole-emploi-service_test.js
+++ b/api/tests/unit/domain/services/pole-emploi-service_test.js
@@ -2,18 +2,16 @@ import { expect } from '../../../test-helper.js';
 import * as poleEmploiService from '../../../../lib/domain/services/pole-emploi-service.js';
 import { config as settings } from '../../../../lib/config.js';
 
+const ORIGINAL_ENV = settings.apiManager.url;
+
 describe('Unit | Service | Pole Emploi Service', function () {
   describe('#generateLink', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const originalEnv = settings.apiManager.url;
-
     before(function () {
       settings.apiManager.url = 'https://url-externe';
     });
 
     after(function () {
-      settings.apiManager.url = originalEnv;
+      settings.apiManager.url = ORIGINAL_ENV;
     });
 
     it('should generate a link', function () {

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -1,9 +1,11 @@
 import { expect, sinon, domainBuilder } from '../../../test-helper.js';
-import { Assessment } from '../../../../lib/domain/models/Assessment.js';
-import { Scorecard } from '../../../../lib/domain/models/Scorecard.js';
-import { CompetenceEvaluation } from '../../../../lib/domain/models/CompetenceEvaluation.js';
+import {
+  Assessment,
+  CompetenceEvaluation,
+  Scorecard,
+  CampaignParticipationStatuses,
+} from '../../../../lib/domain/models/index.js';
 import * as scorecardService from '../../../../lib/domain/services/scorecard-service.js';
-import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;
 
@@ -102,19 +104,17 @@ describe('Unit | Service | ScorecardService', function () {
     let campaignRepository;
     let resetKnowledgeElement1;
     let resetKnowledgeElement2;
+    let updatedCompetenceEvaluation;
 
     const userId = 1;
     const competenceId = 2;
     const knowledgeElements = [{ id: 1 }, { id: 2 }];
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const updatedCompetenceEvaluation = Symbol('updated competence evaluation');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    resetKnowledgeElement2 = Symbol('reset knowledge element 2');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    resetKnowledgeElement1 = Symbol('reset knowledge element 1');
+
+    beforeEach(function () {
+      updatedCompetenceEvaluation = Symbol('updated competence evaluation');
+      resetKnowledgeElement2 = Symbol('reset knowledge element 2');
+      resetKnowledgeElement1 = Symbol('reset knowledge element 1');
+    });
 
     context('when competence evaluation exists', function () {
       beforeEach(async function () {
@@ -232,19 +232,17 @@ describe('Unit | Service | ScorecardService', function () {
       let newAssessment2Saved;
       let campaignParticipation1;
       let campaignParticipation2;
+      let campaignParticipation1Updated;
+      let campaignParticipation2Updated;
       let campaign;
       const assessmentId1 = 12345;
       const assessmentId2 = 56789;
       const skillId = 'recmoustache';
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const campaignParticipation1Updated = Symbol('campaign participation 1 updated');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const campaignParticipation2Updated = Symbol('campaign participation 2 updated');
       const shouldResetCompetenceEvaluation = false;
 
       beforeEach(async function () {
+        campaignParticipation1Updated = Symbol('campaign participation 1 updated');
+        campaignParticipation2Updated = Symbol('campaign participation 2 updated');
         const skill = domainBuilder.buildSkill({ id: skillId });
         const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
         campaign = domainBuilder.buildCampaign.ofTypeAssessment({ targetProfileId: targetProfile.id, targetProfile });

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -1,6 +1,6 @@
 import { domainBuilder, sinon, expect, catchErr } from '../../../test-helper.js';
 import { publishSession } from '../../../../lib/domain/services/session-publication-service.js';
-import { FinalizedSession } from '../../../../lib/domain/models/FinalizedSession.js';
+import { FinalizedSession, EmailingAttempt } from '../../../../lib/domain/models/index.js';
 
 import {
   SendingEmailToResultRecipientError,
@@ -8,7 +8,6 @@ import {
   SendingEmailToRefererError,
 } from '../../../../lib/domain/errors.js';
 
-import { EmailingAttempt } from '../../../../lib/domain/models/EmailingAttempt.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 
 describe('Unit | UseCase | session-publication-service', function () {
@@ -56,41 +55,37 @@ describe('Unit | UseCase | session-publication-service', function () {
     const recipient1 = 'email1@example.net';
     const recipient2 = 'email2@example.net';
     const certificationCenter = 'certificationCenter';
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const candidateWithRecipient1 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient1,
-    });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const candidateWithRecipient2 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient2,
-    });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const candidate2WithRecipient2 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient2,
-    });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: null,
-    });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const originalSession = domainBuilder.buildSession({
-      id: sessionId,
-      certificationCenter,
-      date: sessionDate,
-      certificationCandidates: [
-        candidateWithRecipient1,
-        candidateWithRecipient2,
-        candidate2WithRecipient2,
-        candidateWithNoRecipient,
-      ],
-      publishedAt: null,
-    });
+    let candidateWithRecipient1,
+      candidateWithRecipient2,
+      candidate2WithRecipient2,
+      candidateWithNoRecipient,
+      originalSession;
+
     beforeEach(function () {
+      candidateWithRecipient1 = domainBuilder.buildCertificationCandidate({
+        resultRecipientEmail: recipient1,
+      });
+      candidateWithRecipient2 = domainBuilder.buildCertificationCandidate({
+        resultRecipientEmail: recipient2,
+      });
+      candidate2WithRecipient2 = domainBuilder.buildCertificationCandidate({
+        resultRecipientEmail: recipient2,
+      });
+      candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({
+        resultRecipientEmail: null,
+      });
+      originalSession = domainBuilder.buildSession({
+        id: sessionId,
+        certificationCenter,
+        date: sessionDate,
+        certificationCandidates: [
+          candidateWithRecipient1,
+          candidateWithRecipient2,
+          candidate2WithRecipient2,
+          candidateWithNoRecipient,
+        ],
+        publishedAt: null,
+      });
       sessionRepository.getWithCertificationCandidates.withArgs(sessionId).resolves(originalSession);
     });
 

--- a/api/tests/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcm_test.js
@@ -15,6 +15,7 @@ describe('Unit | Service | SolutionServiceQCM ', function () {
       { answerValue: '1, 2, 3', solutionValue: '1, 2, 3' },
     ];
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     successfulCases.forEach(({ answerValue, solutionValue }) => {
       it(
@@ -33,6 +34,7 @@ describe('Unit | Service | SolutionServiceQCM ', function () {
       { answerValue: '3, 1', solutionValue: '1, 2' },
     ];
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     failedCases.forEach(({ answerValue, solutionValue }) => {
       it(

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -9,6 +9,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
   describe('match, with numerical answers and solutions', function () {
     const challengeFormat = 'nombre';
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
@@ -160,7 +161,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         solution: 'qvak\nqwak\nanything\n',
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     successfulCases.forEach(function (data) {
       it(
@@ -196,7 +197,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         solution: 'qvakes\nqwakes\nanything\n',
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     failingCases.forEach(function (data) {
       it(
@@ -302,7 +303,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: {},
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(
@@ -416,7 +417,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: { t1: true },
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(
@@ -530,7 +531,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: { t2: true },
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(
@@ -644,7 +645,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: { t3: true },
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(
@@ -758,7 +759,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: { t1: true, t2: true },
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(
@@ -872,7 +873,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: { t1: true, t3: true },
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(
@@ -986,7 +987,7 @@ describe('Unit | Service | SolutionServiceQROC ', function () {
         deactivations: { t2: true, t3: true },
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     allCases.forEach(function (data) {
       it(

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -64,6 +64,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     failedCases.forEach((testCase) => {
       it(`should return "ko" when ${testCase.when}`, function () {
@@ -147,6 +148,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
       },
     ];
 
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     maximalScoreCases.forEach(function (testCase) {
       it(`Should return "ok" when ${testCase.when}`, function () {
@@ -222,6 +224,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       maximalScoreCases.forEach(function (testCase) {
         it(`should return "ok" when ${testCase.context}`, function () {
@@ -285,6 +288,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       partialScoreCases.forEach(function (testCase) {
         it(`should return "partially" when ${testCase.when}`, function () {
@@ -357,6 +361,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       failedCases.forEach(function (testCase) {
         it(`should return "ko" when ${testCase.context}`, function () {
@@ -487,6 +492,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function (testCase) {
         it(`${testCase.when}, should return ${testCase.output} when answer is "${testCase.answer}" and solution is "${testCase.solution}"`, function () {
@@ -665,6 +671,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function (testCase) {
         it(
@@ -808,6 +815,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function (testCase) {
         it(
@@ -951,6 +959,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function (testCase) {
         it(
@@ -988,8 +997,8 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
           deactivations: { t1: true, t2: true, t3: true },
         },
       ];
-      // It is recommended to disable 'no-setup-in-describe' for dynamically
-      // generated tests. cf: https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md
+
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function ({ when, output, answer, solution, scoring, deactivations }) {
         it(`${when} should return ${output} when answer is "${answer}" and solution is "${solution}"`, function () {
@@ -1183,7 +1192,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
           deactivations: { t1: true, t2: true },
         },
       ];
-
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function (testCase) {
         it(
@@ -1384,7 +1393,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
           deactivations: { t1: true, t3: true },
         },
       ];
-
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       allCases.forEach(function (testCase) {
         it(

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -222,6 +222,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // eslint-disable-next-line mocha/no-setup-in-describe
       maximalScoreCases.forEach(function (testCase) {
         it(`should return "ok" when ${testCase.context}`, function () {
           // given
@@ -284,6 +285,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // eslint-disable-next-line mocha/no-setup-in-describe
       partialScoreCases.forEach(function (testCase) {
         it(`should return "partially" when ${testCase.when}`, function () {
           // given
@@ -355,6 +357,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function () {
         },
       ];
 
+      // eslint-disable-next-line mocha/no-setup-in-describe
       failedCases.forEach(function (testCase) {
         it(`should return "ko" when ${testCase.context}`, function () {
           // given

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -225,7 +225,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
         enabledTreatments: ['t1', 't2', 't3'],
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     successfulCases.forEach(function (testCase) {
       it(
@@ -300,7 +300,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function () {
         enabledTreatments: ['t1', 't2', 't3'],
       },
     ];
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     failingCases.forEach(function (testCase) {
       it(

--- a/api/tests/unit/domain/services/string-comparison-service_test.js
+++ b/api/tests/unit/domain/services/string-comparison-service_test.js
@@ -129,13 +129,9 @@ describe('Unit | Service | Validation Comparison', function () {
       const inputString = 'aaaaaa';
       const referenceString = '12KBKHBHB65';
 
-      // when
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const actual = areTwoStringsCloseEnough(inputString, referenceString, MAX_ACCEPTABLE_RATIO);
-
       // then
       it('should return false', function () {
+        const actual = areTwoStringsCloseEnough(inputString, referenceString, MAX_ACCEPTABLE_RATIO);
         expect(actual).to.be.false;
       });
     });
@@ -146,13 +142,9 @@ describe('Unit | Service | Validation Comparison', function () {
       const inputString = 'aaaaaa';
       const referenceString = 'àaaaaa';
 
-      // when
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const actual = areTwoStringsCloseEnough(inputString, referenceString, MAX_ACCEPTABLE_RATIO);
-
       // then
       it('should return true', function () {
+        const actual = areTwoStringsCloseEnough(inputString, referenceString, MAX_ACCEPTABLE_RATIO);
         expect(actual).to.be.true;
       });
     });
@@ -167,13 +159,9 @@ describe('Unit | Service | Validation Comparison', function () {
         const inputString = 'aaaaaa';
         const references = ['12KBKHBHB65', 'Jacques'];
 
-        // when
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        const actual = isOneStringCloseEnoughFromMultipleStrings(inputString, references, MAX_ACCEPTABLE_RATIO);
-
         // then
         it('should return false', function () {
+          const actual = isOneStringCloseEnoughFromMultipleStrings(inputString, references, MAX_ACCEPTABLE_RATIO);
           expect(actual).to.be.false;
         });
       },
@@ -187,13 +175,9 @@ describe('Unit | Service | Validation Comparison', function () {
         const inputString = 'aaaaaa';
         const references = ['àaaaaa', 'bbbbbbb', 'aaaaab'];
 
-        // when
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        const actual = isOneStringCloseEnoughFromMultipleStrings(inputString, references, MAX_ACCEPTABLE_RATIO);
-
         // then
         it('should return true', function () {
+          const actual = isOneStringCloseEnoughFromMultipleStrings(inputString, references, MAX_ACCEPTABLE_RATIO);
           expect(actual).to.be.true;
         });
       },

--- a/api/tests/unit/domain/services/string-comparison-service_test.js
+++ b/api/tests/unit/domain/services/string-comparison-service_test.js
@@ -17,7 +17,7 @@ describe('Unit | Service | Validation Comparison', function () {
         { should: 'If they have one different character', arg1: 'a', arg2: ['ab'], output: 1 },
         { should: 'If they have two different characters', arg1: 'book', arg2: ['back'], output: 2 },
       ];
-
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       successfulCases.forEach(function (testCase) {
         it(`${testCase.should} for example arg1 ${JSON.stringify(testCase.arg1)} and arg2 ${JSON.stringify(
@@ -52,7 +52,7 @@ describe('Unit | Service | Validation Comparison', function () {
         },
         { should: 'If the difference is 2 for all elements', arg1: 'book', arg2: ['back', 'buck'], output: 2 },
       ];
-
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       successfulCases.forEach(function (testCase) {
         it(`${testCase.should} for example arg1 ${JSON.stringify(testCase.arg1)} and arg2 ${JSON.stringify(
@@ -65,6 +65,7 @@ describe('Unit | Service | Validation Comparison', function () {
   });
 
   describe('getSmallestLevenshteinRatio', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { scenario: 'the inputString is the only reference', inputString: 'a1', references: ['a1'], expected: 0 },
@@ -97,6 +98,7 @@ describe('Unit | Service | Validation Comparison', function () {
   });
 
   describe('getLevenshteinRatio', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { scenario: 'the inputString is the reference', inputString: 'a1', reference: 'a1', expected: 0 },

--- a/api/tests/unit/domain/services/validation-treatments_test.js
+++ b/api/tests/unit/domain/services/validation-treatments_test.js
@@ -9,6 +9,7 @@ import {
 
 describe('Unit | Service | Validation Treatments', function () {
   describe('#normalizeAndRemoveAccents', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { description: 'white spaces', input: '  foo  bar  ', expected: 'foobar' },
@@ -32,6 +33,7 @@ describe('Unit | Service | Validation Treatments', function () {
   });
 
   describe('#removeSpecialCharacters', function () {
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { description: 'all point types', input: '?Allo?,:;.', expected: 'Allo' },

--- a/api/tests/unit/domain/services/verify-certificate-code-service_test.js
+++ b/api/tests/unit/domain/services/verify-certificate-code-service_test.js
@@ -5,7 +5,7 @@ import { CertificateVerificationCodeGenerationTooManyTrials } from '../../../../
 
 describe('Unit | Service | VerifyCertificateCode', function () {
   describe('#generateCertificateVerificationCode', function () {
-    // TODO: Fix this the next time the file is edited.
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
     _.times(100, () =>
       it('should return a certification code containing 8 digits/letters except 0, 1 and vowels', async function () {

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -1,9 +1,10 @@
 import _ from 'lodash';
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import { completeAssessment } from '../../../../lib/domain/usecases/complete-assessment.js';
-import { Assessment, CampaignParticipationStatuses } from '../../../../lib/domain/models/index.js';
+import { Assessment } from '../../../../lib/domain/models/Assessment.js';
 import { AlreadyRatedAssessmentError } from '../../../../lib/domain/errors.js';
 import { AssessmentCompleted } from '../../../../lib/domain/events/AssessmentCompleted.js';
+import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
 
 describe('Unit | UseCase | complete-assessment', function () {
   let assessmentRepository;
@@ -57,16 +58,16 @@ describe('Unit | UseCase | complete-assessment', function () {
   });
 
   context('when assessment is not yet completed', function () {
-    let competenceEvaluationAssessment, campaignAssessment, certificationAssessment;
-
-    beforeEach(function () {
-      competenceEvaluationAssessment = _buildCompetenceEvaluationAssessment();
-      campaignAssessment = _buildCampaignAssessment();
-      certificationAssessment = _buildCertificationAssessment();
-    });
-
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
-    [competenceEvaluationAssessment, campaignAssessment, certificationAssessment].forEach((assessment) => {
+    [
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      _buildCompetenceEvaluationAssessment(),
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      _buildCampaignAssessment(),
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      _buildCertificationAssessment(),
+    ].forEach((assessment) => {
       // eslint-disable-next-line mocha/no-setup-in-describe
       context(`common behavior when assessment is of type ${assessment.type}`, function () {
         beforeEach(function () {

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import { completeAssessment } from '../../../../lib/domain/usecases/complete-assessment.js';
-import { Assessment } from '../../../../lib/domain/models/Assessment.js';
+import { Assessment, CampaignParticipationStatuses } from '../../../../lib/domain/models/index.js';
 import { AlreadyRatedAssessmentError } from '../../../../lib/domain/errors.js';
 import { AssessmentCompleted } from '../../../../lib/domain/events/AssessmentCompleted.js';
-import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
 
 describe('Unit | UseCase | complete-assessment', function () {
   let assessmentRepository;
@@ -58,16 +57,16 @@ describe('Unit | UseCase | complete-assessment', function () {
   });
 
   context('when assessment is not yet completed', function () {
+    let competenceEvaluationAssessment, campaignAssessment, certificationAssessment;
+
+    beforeEach(function () {
+      competenceEvaluationAssessment = _buildCompetenceEvaluationAssessment();
+      campaignAssessment = _buildCampaignAssessment();
+      certificationAssessment = _buildCertificationAssessment();
+    });
+
     // eslint-disable-next-line mocha/no-setup-in-describe
-    [
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      _buildCompetenceEvaluationAssessment(),
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      _buildCampaignAssessment(),
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      _buildCertificationAssessment(),
-    ].forEach((assessment) => {
-      // TODO: Fix this the next time the file is edited.
+    [competenceEvaluationAssessment, campaignAssessment, certificationAssessment].forEach((assessment) => {
       // eslint-disable-next-line mocha/no-setup-in-describe
       context(`common behavior when assessment is of type ${assessment.type}`, function () {
         beforeEach(function () {

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -1,7 +1,5 @@
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
-import { Assessment } from '../../../../lib/domain/models/Assessment.js';
-import { AnswerStatus } from '../../../../lib/domain/models/AnswerStatus.js';
-import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
+import { Assessment, AnswerStatus, KnowledgeElement } from '../../../../lib/domain/models/index.js';
 import { correctAnswerThenUpdateAssessment } from '../../../../lib/domain/usecases/correct-answer-then-update-assessment.js';
 
 import {
@@ -11,6 +9,9 @@ import {
   CertificationEndedBySupervisorError,
   CertificationEndedByFinalizationError,
 } from '../../../../lib/domain/errors.js';
+
+const ANSWER_STATUS_FOCUSEDOUT = AnswerStatus.FOCUSEDOUT;
+const ANSWER_STATUS_OK = AnswerStatus.OK;
 
 describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', function () {
   const userId = 1;
@@ -41,13 +42,11 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   const flashAlgorithmService = { getEstimatedLevelAndErrorRate: () => undefined };
   const algorithmDataFetcherService = { fetchForFlashLevelEstimation: () => undefined };
   const nowDate = new Date('2021-03-11T11:00:04Z');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  nowDate.setMilliseconds(1);
 
   let dependencies;
 
   beforeEach(function () {
+    nowDate.setMilliseconds(1);
     sinon.stub(answerRepository, 'saveWithKnowledgeElements');
     sinon.stub(assessmentRepository, 'get');
     sinon.stub(challengeRepository, 'get');
@@ -907,27 +906,28 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       assessmentRepository.get.resolves(assessment);
     });
 
-    /* eslint-disable mocha/no-setup-in-describe */
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
         isFocusedOut: true,
         lastQuestionState: 'focusedout',
-        expected: { result: AnswerStatus.FOCUSEDOUT, isFocusedOut: true },
+        expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
       },
       {
         isFocusedOut: false,
         lastQuestionState: 'asked',
-        expected: { result: AnswerStatus.OK, isFocusedOut: false },
+        expected: { result: ANSWER_STATUS_OK, isFocusedOut: false },
       },
       {
         isFocusedOut: false,
         lastQuestionState: 'focusedout',
-        expected: { result: AnswerStatus.FOCUSEDOUT, isFocusedOut: true },
+        expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
       },
       {
         isFocusedOut: true,
         lastQuestionState: 'asked',
-        expected: { result: AnswerStatus.FOCUSEDOUT, isFocusedOut: true },
+        expected: { result: ANSWER_STATUS_FOCUSEDOUT, isFocusedOut: true },
       },
     ].forEach(({ isFocusedOut, lastQuestionState, expected }) => {
       context(`when answer.isFocusedOut=${isFocusedOut} and lastQuestionState=${lastQuestionState}`, function () {
@@ -949,6 +949,5 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         });
       });
     });
-    /* eslint-enable mocha/no-setup-in-describe */
   });
 });

--- a/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -4,18 +4,8 @@ import { CampaignProfilesCollectionParticipationSummary } from '../../../../lib/
 import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | UseCase | find-campaign-profiles-collection-participation-summaries', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const userId = Symbol('user id');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const campaignId = Symbol('campaign id');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const campaignProfilesCollectionParticipationSummaryRepository = { findPaginatedByCampaignId: sinon.stub() };
+  let userId, campaignId;
+  let campaignRepository, campaignProfilesCollectionParticipationSummaryRepository;
 
   const campaignProfilesCollectionParticipationSummaries = [
     new CampaignProfilesCollectionParticipationSummary({
@@ -24,6 +14,13 @@ describe('Unit | UseCase | find-campaign-profiles-collection-participation-summa
       lastName: 'World',
     }),
   ];
+
+  beforeEach(function () {
+    userId = Symbol('user id');
+    campaignId = Symbol('campaign id');
+    campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
+    campaignProfilesCollectionParticipationSummaryRepository = { findPaginatedByCampaignId: sinon.stub() };
+  });
 
   context('the user belongs to the organization of the campaign', function () {
     let participationSummaries;

--- a/api/tests/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
@@ -6,14 +6,11 @@ import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/err
 describe('Unit | UseCase | find-competence-evaluations-by-assessment', function () {
   const userId = 1;
   const assessmentId = 2;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessmentRepository = { ownedByUser: _.noop() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const competenceEvaluationRepository = { findByAssessmentId: _.noop() };
+  let assessmentRepository, competenceEvaluationRepository;
 
   beforeEach(function () {
+    assessmentRepository = { ownedByUser: _.noop() };
+    competenceEvaluationRepository = { findByAssessmentId: _.noop() };
     assessmentRepository.ownedByUser = sinon.stub();
     competenceEvaluationRepository.findByAssessmentId = sinon.stub();
   });

--- a/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
@@ -8,25 +8,18 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
   const certificationCenterId = 1;
   const userId = 'userId';
   let organization;
-
-  const organizationRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getIdByCertificationCenterId: sinon.stub(),
-  };
-  const organizationLearnerRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findByOrganizationIdAndUpdatedAtOrderByDivision: sinon.stub(),
-  };
-
-  const certificationCandidateRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findBySessionId: sinon.stub(),
-  };
+  let organizationRepository, organizationLearnerRepository, certificationCandidateRepository;
 
   beforeEach(async function () {
+    organizationRepository = {
+      getIdByCertificationCenterId: sinon.stub(),
+    };
+    organizationLearnerRepository = {
+      findByOrganizationIdAndUpdatedAtOrderByDivision: sinon.stub(),
+    };
+    certificationCandidateRepository = {
+      findBySessionId: sinon.stub(),
+    };
     const externalId = 'AAA111';
     const certificationCenter = domainBuilder.buildCertificationCenter({ id: certificationCenterId, externalId });
     organization = domainBuilder.buildOrganization({ externalId });

--- a/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
@@ -49,14 +49,12 @@ describe('Unit | UseCase | flag-session-results-as-sent-to-prescriber', function
     });
 
     context('when results are not flagged as sent yet', function () {
-      let notFlaggedSession;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const updatedSession = Symbol('updatedSession');
+      let notFlaggedSession, updatedSession;
       const now = new Date('2019-01-01T05:06:07Z');
       let clock;
 
       beforeEach(function () {
+        updatedSession = Symbol('updatedSession');
         clock = sinon.useFakeTimers(now);
         notFlaggedSession = new Session({ resultsSentToPrescriberAt: null });
         sessionRepository.get.withArgs(sessionId).resolves(notFlaggedSession);

--- a/api/tests/unit/domain/usecases/get-organization-learners-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-learners-csv-template_test.js
@@ -5,18 +5,14 @@ import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/err
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 
 describe('Unit | UseCase | get-organization-learners-csv-template', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const userId = Symbol('userId');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const organizationId = Symbol('organizationId');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const membershipRepository = { findByUserIdAndOrganizationId: _.noop };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const i18n = getI18n();
+  let userId, organizationId, membershipRepository, i18n;
+
+  beforeEach(function () {
+    userId = Symbol('userId');
+    organizationId = Symbol('organizationId');
+    membershipRepository = { findByUserIdAndOrganizationId: _.noop };
+    i18n = getI18n();
+  });
 
   context('When user is ADMIN in a SUP organization managing students', function () {
     it('should return headers line', async function () {

--- a/api/tests/unit/domain/usecases/get-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/get-prescriber_test.js
@@ -4,14 +4,13 @@ import { UserNotMemberOfOrganizationError } from '../../../../lib/domain/errors.
 
 describe('Unit | UseCase | get-prescriber', function () {
   const userId = 1;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const expectedResult = Symbol('prescriber');
   let prescriberRepository;
   let membershipRepository;
   let userOrgaSettingsRepository;
+  let expectedResult;
 
   beforeEach(function () {
+    expectedResult = Symbol('prescriber');
     prescriberRepository = { getPrescriber: sinon.stub() };
     membershipRepository = { findByUserId: sinon.stub() };
     userOrgaSettingsRepository = { findOneByUserId: sinon.stub(), create: sinon.stub(), update: sinon.stub() };

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -1,6 +1,5 @@
 import { expect, sinon, catchErr } from '../../../test-helper.js';
-import { Assessment } from '../../../../lib/domain/models/Assessment.js';
-import { CompetenceEvaluation } from '../../../../lib/domain/models/CompetenceEvaluation.js';
+import { Assessment, CompetenceEvaluation } from '../../../../lib/domain/models/index.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import _ from 'lodash';
@@ -11,31 +10,18 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', function () {
   const newAssessmentId = 789;
   const competenceId = 'recABC123';
   const competenceEvaluation = { userId, competenceId, assessmentId };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const competenceRepository = { get: _.noop };
-  const competenceEvaluationRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    save: _.noop,
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    getByCompetenceIdAndUserId: _.noop,
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    updateStatusByUserIdAndCompetenceId: _.noop,
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    updateAssessmentId: _.noop,
-  };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const assessmentRepository = { save: _.noop };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const updatedCompetenceEvaluation = Symbol('updated competence evaluation');
+  let competenceRepository, competenceEvaluationRepository, assessmentRepository, updatedCompetenceEvaluation;
 
   beforeEach(function () {
+    competenceRepository = { get: _.noop };
+    competenceEvaluationRepository = {
+      save: _.noop,
+      getByCompetenceIdAndUserId: _.noop,
+      updateStatusByUserIdAndCompetenceId: _.noop,
+      updateAssessmentId: _.noop,
+    };
+    assessmentRepository = { save: _.noop };
+    updatedCompetenceEvaluation = Symbol('updated competence evaluation');
     sinon.stub(competenceRepository, 'get');
     sinon.stub(competenceEvaluationRepository, 'save');
     sinon.stub(competenceEvaluationRepository, 'getByCompetenceIdAndUserId');

--- a/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -8,7 +8,7 @@ import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '.
 import { CampaignProfilesCollectionExport } from '../../../../lib/infrastructure/serializers/csv/campaign-profiles-collection-export.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 
-describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', function () {
+describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', function () {
   const campaignRepository = { get: () => undefined };
   const userRepository = { getWithMemberships: () => undefined };
   const competenceRepository = { listPixCompetencesOnly: () => undefined };
@@ -16,14 +16,12 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
   const campaignParticipationRepository = { findProfilesCollectionResultDataByCampaignId: () => undefined };
   let writableStream;
   let csvPromise;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const placementProfileService = Symbol('placementProfileService');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const i18n = getI18n();
+  let placementProfileService;
+  let i18n;
 
   beforeEach(function () {
+    placementProfileService = Symbol('placementProfileService');
+    i18n = getI18n();
     sinon.stub(campaignRepository, 'get').rejects('error for campaignRepository.get');
     sinon.stub(userRepository, 'getWithMemberships').rejects('error for userRepository.getWithMemberships');
     sinon

--- a/api/tests/unit/domain/usecases/update-student-number_test.js
+++ b/api/tests/unit/domain/usecases/update-student-number_test.js
@@ -8,15 +8,14 @@ describe('Unit | UseCase | update-student-number', function () {
   const organizationLearnerId = 1234;
 
   let organizationLearner;
+  let supOrganizationLearnerRepository;
 
-  const supOrganizationLearnerRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findOneByStudentNumber: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    updateStudentNumber: sinon.stub(),
-  };
+  beforeEach(function () {
+    supOrganizationLearnerRepository = {
+      findOneByStudentNumber: sinon.stub(),
+      updateStudentNumber: sinon.stub(),
+    };
+  });
 
   context('When there is an organization learner with the same student number', function () {
     beforeEach(function () {


### PR DESCRIPTION
## :unicorn: Problème
Petits warnings de lint, souvent liés au fait de faire du "code" en dehors des blocs dédiés.
Après, vu qu'on fait du test dynamique (structure style `[].forEach(() => it('should etc...')`), il est recommandé de mettre le commentaire pour désactiver la règle de lint associée.
![disable_rule](https://github.com/1024pix/pix/assets/48727874/0b26d01f-d4db-44c6-af95-ff0e2138395e)


## :robot: Proposition
Fix des warnings, ou bien par un vrai fix, ou bien en désactivant la règle quand c'est à propos.
Avant : 100 warnings
Après : 0 warning.
✋🏿 🎤 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Faire un `npm run lint:js` et constater qu'il n'y a plus de warning
