### PR TITLE
[FEATURE] Ajout d'une modale de confirmation de soumission de signalement d'épreuve (PIX-8649).

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -29,7 +29,7 @@
         {{else}}
           <p>{{t "pages.challenge.feedback-panel.description"}}</p>
           <div class="feedback-panel__form-wrapper">
-            <form class="feedback-panel__form" {{on "submit" this.sendFeedback}} novalidate>
+            <form id="feedback-form" class="feedback-panel__form" {{on "submit" this.sendFeedback}} novalidate>
               <div class="feedback-panel__group">
                 <div class="feedback-panel__category-selection">
                   <PixSelect
@@ -79,7 +79,7 @@
                   />
                 </div>
                 <PixButton
-                  @type="submit"
+                  @triggerAction={{this.toggleModalVisibility}}
                   @backgroundColor="grey"
                   aria-label={{t "pages.challenge.feedback-panel.form.actions.submit-aria-label"}}
                   @isDisabled={{this.isSendButtonDisabled}}
@@ -95,8 +95,28 @@
             {{t "pages.challenge.feedback-panel.information.data-usage" htmlSafe=true}}
           </div>
         {{/if}}
-
       </div>
     {{/if}}
   {{/if}}
 </div>
+
+<PixModal
+  class="feedback-panel__submit-modal"
+  @title={{t "pages.challenge.feedback-panel.modal.title"}}
+  @showModal={{this.isModalVisible}}
+  @onCloseButtonClick={{this.toggleModalVisibility}}
+>
+  <:content>
+    {{t "pages.challenge.feedback-panel.modal.content" htmlSafe=true}}
+  </:content>
+  <:footer>
+    <PixButton
+      @triggerAction={{this.toggleModalVisibility}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+    >
+      {{t "common.actions.cancel"}}
+    </PixButton>
+    <PixButton @type="submit" form="feedback-form">{{t "common.actions.validate"}}</PixButton>
+  </:footer>
+</PixModal>

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -19,6 +19,7 @@ export default class FeedbackPanel extends Component {
   @tracked nextCategory = null;
   @tracked quickHelpInstructions = null;
   @tracked isExpanded = false;
+  @tracked isModalVisible = false;
   @tracked _currentMajorCategory = null;
   @tracked _currentNextCategory = null;
   _category = null;
@@ -106,6 +107,7 @@ export default class FeedbackPanel extends Component {
       this.isFormSubmitted = true;
       this._sendButtonStatus = buttonStatusTypes.recorded;
       this._resetForm();
+      this.toggleModalVisibility();
     } catch (error) {
       this._sendButtonStatus = buttonStatusTypes.unrecorded;
     }
@@ -147,6 +149,11 @@ export default class FeedbackPanel extends Component {
     if (this._category != null) {
       this._showFeedbackActionBasedOnCategoryType(this.nextCategory[value - 1]);
     }
+  }
+
+  @action
+  toggleModalVisibility() {
+    this.isModalVisible = !this.isModalVisible;
   }
 
   _resetPanel() {

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -174,3 +174,16 @@
 .feedback-panel__alert {
   margin: 4px 0;
 }
+
+/* Submit modal
+–––––––––––––––––––––––––––––––––––––––––––––––––– */
+
+.feedback-panel__submit-modal > [class$='__footer'] {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: $pix-spacing-s;
+
+  & > :not(:first-child) {
+    margin-left: $pix-spacing-xs;
+  }
+}

--- a/mon-pix/tests/acceptance/compare-answer-solution-qroc_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution-qroc_test.js
@@ -49,8 +49,8 @@ module('Acceptance | Compare answers and solutions for QROC questions', function
       await click(screen.getByRole('button', { name: 'Réponses et tutos' }));
 
       // then
-      assert.dom('.pix-modal__overlay--hidden').doesNotExist();
-      assert.dom('.pix-modal__overlay').exists();
+      assert.dom('.pix-modal__overlay--hidden .comparison-window').doesNotExist();
+      assert.dom('.pix-modal__overlay .comparison-window').exists();
     });
 
     test('should contain an instruction', async function (assert) {

--- a/mon-pix/tests/acceptance/compare-answer-solution_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution_test.js
@@ -73,8 +73,8 @@ module('Compare answers and solutions for QCM questions', function (hooks) {
 
       await click('.result-item__correction-button');
 
-      assert.dom('.pix-modal__overlay--hidden').doesNotExist();
-      assert.dom('.pix-modal__overlay').exists();
+      assert.dom('.pix-modal__overlay--hidden .comparison-window').doesNotExist();
+      assert.dom('.pix-modal__overlay .comparison-window').exists();
     });
   });
 

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -58,14 +58,43 @@ module('Integration | Component | feedback-panel', function (hooks) {
         );
       });
 
-      test('should display the "mercix" view without content value', async function (assert) {
+      test('should display a confirmation modal', async function (assert) {
+        // given
+        const modalTitle = screen.getByText('Confirmation du signalement');
+
         // when
         await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
         // then
-        assert
-          .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
-          .doesNotExist();
+        assert.notOk(
+          modalTitle.closest('.pix-modal__overlay').classList.toString().includes('pix-modal__overlay--hidden'),
+        );
+      });
+
+      test('should be able to close the modal', async function (assert) {
+        // given
+        const modalTitle = screen.getByText('Confirmation du signalement');
+
+        // when
+        await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
+        await click(screen.getByText(this.intl.t('common.actions.cancel')));
+
+        // then
+        assert.ok(
+          modalTitle.closest('.pix-modal__overlay').classList.toString().includes('pix-modal__overlay--hidden'),
+        );
+      });
+
+      test('should display the "mercix" view without content value', async function (assert) {
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.actions.submit-aria-label'),
+          }),
+        );
+        await click(screen.getByText(this.intl.t('common.actions.validate')));
+
+        // then
         assert.dom(screen.getByText('Votre commentaire a bien été transmis à l’équipe du projet Pix.')).exists();
         assert.dom(screen.getByText('Mercix !')).exists();
       });
@@ -80,6 +109,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
         // when
         await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
+        await click(screen.getByText(this.intl.t('common.actions.validate')));
 
         // then
         assert

--- a/mon-pix/tests/unit/components/feedback-panel_test.js
+++ b/mon-pix/tests/unit/components/feedback-panel_test.js
@@ -71,6 +71,30 @@ module('Unit | Component | feedback-panel', function (hooks) {
     });
   });
 
+  module('#toggleModalVisibility', function () {
+    test('should set isModalVisible from false to true', function (assert) {
+      // given
+      component.isModalVisible = false;
+
+      // when
+      component.toggleModalVisibility();
+
+      // then
+      assert.true(component.isModalVisible);
+    });
+
+    test('should set isModalVisible from true to false', function (assert) {
+      // given
+      component.isModalVisible = true;
+
+      // when
+      component.toggleModalVisibility();
+
+      // then
+      assert.false(component.isModalVisible);
+    });
+  });
+
   module('#sendFeedback', function (hooks) {
     let feedback;
     let store;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -42,7 +42,8 @@
       "close": "Close",
       "quit": "Exit",
       "sign-out": "Sign out",
-      "stay": "Stay"
+      "stay": "Stay",
+      "validate": "Validate"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -653,6 +654,10 @@
         "information": {
           "data-usage": "'<p>'Pix processes the data from this area to manage and analyse the difficulty encountered and benefit from your feedback. You have rights over your data which can be exercised via: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.org/en-gb/personal-data-reporting-test\" target=\"_blank\" class=\"link\">'To find out more about protecting your data and your rights.'</a></p>'",
           "guidance": "'<p>'*Make sure you write in this zone: for your benefit and the benefit of others, please stay objective and keep to the facts.'</p><p>'Do not enter any information about yourself or third parties, or any information related to health; religion; political, or philosophical opinions; trade union affiliation; ethnic origins; or penalties and convictions.'</p>'"
+        },
+        "modal": {
+          "title": "Report confirmation",
+          "content": "'<p><strong>'Do you confirm this problem report?'</strong></p><p>'Thank you for this problem report, our team will review it soon. Every feedback helps us improve our services and the experience of all Pix users. Please note that we will not reach out to you on this topic. Thank you for your help.'</p>'"
         }
       },
       "has-focused-out-of-window": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -42,7 +42,8 @@
       "close": "Fermer",
       "quit": "Quitter",
       "sign-out": "Se déconnecter",
-      "stay": "Rester"
+      "stay": "Rester",
+      "validate": "Valider"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -653,6 +654,10 @@
         "information": {
           "data-usage": "'<p>'Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de : <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Pour en savoir plus sur la protection de vos données et sur vos droits.'</a></p>'",
           "guidance": "'<p>'* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.'</p><p>'Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.'</p>'"
+        },
+        "modal": {
+          "title": "Confirmation du signalement",
+          "content": "'<p><strong>'Êtes-vous certain(e) de vouloir signaler ce problème ?'</strong></p><p>'Nous vous remercions pour votre signalement qui sera examiné attentivement par l'équipe de Pix. Nous prenons en compte tous vos commentaires pour améliorer continuellement nos services et l'expérience utilisateur. Nous ne pourrons pas vous donner de réponse personnalisée. Merci pour votre collaboration.'</p>'"
         }
       },
       "has-focused-out-of-window": {


### PR DESCRIPTION
## :unicorn: Problème

Sur une épreuve, on souhaite recevoir moins de signalements hasardeux.

## :robot: Proposition

**🆙 Suite de la PR #6799** 

Ajouter une modale après la soumission du formulaire de signalement de problème sur une épreuve.
Elle demande à l'utilisateur s'il souhaite vraiment soumettre ce signalement.
On profite de cette modale pour indiquer à l’utilisateur de ne pas attendre de retours de la part de Pix. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Aller sur [PixApp en RA](https://app-pr6811.review.pix.fr/)
- Visiter une épreuve
- Soumettre un signalement de problème
- ✅ Attester de la présence de la modale de confirmation
- Fermer cette modale
- ✅ Le formulaire ne devrait pas avoir changé d'état
- Re-soumettre et, cette fois, confirmer la décision
- ✅ Attester de l'affichage de fin de soumission

🔄 Faire de même à partir de la modale "Réponses et tuto" d'une page de checkpoint.
