### PR TITLE
[FEATURE] Pouvoir choisir de rechercher sur les orgas archivés ou non dans Pix Admin (PIX-6109).

### DIFF
--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -10,7 +10,7 @@ const DEFAULT_PAGE_NUMBER = 1;
 export default class ListController extends Controller {
   @service accessControl;
 
-  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId', 'hideArchived'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
@@ -19,6 +19,7 @@ export default class ListController extends Controller {
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;
+  @tracked hideArchived = false;
 
   updateFilters(filters) {
     Object.keys(filters).forEach((filterKey) => (this[filterKey] = filters[filterKey]));

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -11,6 +11,7 @@ export default class ListRoute extends Route {
     name: { refreshModel: true },
     type: { refreshModel: true },
     externalId: { refreshModel: true },
+    hideArchived: { refreshModel: true },
   };
 
   model(params) {
@@ -20,6 +21,7 @@ export default class ListRoute extends Route {
         name: params.name ? params.name.trim() : '',
         type: params.type ? params.type.trim() : '',
         externalId: params.externalId ? params.externalId.trim() : '',
+        hideArchived: params.hideArchived,
       },
       page: {
         number: params.pageNumber,
@@ -36,6 +38,7 @@ export default class ListRoute extends Route {
       controller.name = null;
       controller.type = null;
       controller.externalId = null;
+      controller.hideArchived = false;
     }
   }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -53,6 +53,7 @@
 @import 'components/organizations/all-tags';
 @import 'components/organizations/archiving-confirmation-modal';
 @import 'components/organizations/campaigns-section';
+@import 'components/organizations/list-items';
 @import 'components/organizations/places';
 @import 'components/organizations/places-lot-creation-form';
 @import 'components/organization-information-section';

--- a/admin/app/styles/components/organizations/list-items.scss
+++ b/admin/app/styles/components/organizations/list-items.scss
@@ -1,0 +1,11 @@
+.organization-list {
+  &__archived-organizations-toggle {
+    display: flex;
+    justify-content: flex-end;
+    padding-bottom: $pix-spacing-s;
+
+    p {
+      margin: 0;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -17,6 +17,10 @@
 
 <main class="page-body">
   <section class="page-section">
+    <span class="organization-list__archived-organizations-toggle">
+      <p>Masquer les organisations archivées</p>
+      <XToggle @size="small" @theme="light" @value={{this.hideArchived}} @onToggle={{fn (mut this.hideArchived)}} />
+    </span>
     <Organizations::ListItems
       @organizations={{@model}}
       @id={{this.id}}

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -102,6 +102,17 @@ module('Acceptance | Organizations | List', function (hooks) {
         // then
         assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).hasValue('1234567A');
       });
+
+      test('it displays non archived organizations', async function (assert) {
+        // given
+        const screen = await visit('/organizations/list');
+
+        // when
+        await click(screen.getByRole('checkbox'));
+
+        // then
+        assert.strictEqual(currentURL(), '/organizations/list?hideArchived=true');
+      });
     });
 
     test('it should redirect to organization details on click', async function (assert) {

--- a/admin/tests/unit/routes/authenticated/organizations/list_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list_test.js
@@ -33,6 +33,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
           name: '',
           type: '',
           externalId: '',
+          hideArchived: undefined,
         };
 
         // then
@@ -48,11 +49,13 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         params.name = ' someName';
         params.type = 'someType ';
         params.externalId = 'someExternalId';
+        params.hideArchived = true;
         expectedQueryArgs.filter = {
           id: 'someId',
           name: 'someName',
           type: 'someType',
           externalId: 'someExternalId',
+          hideArchived: true,
         };
 
         // when
@@ -76,6 +79,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         name: 'someName',
         type: 'someType',
         externalId: 'someExternalId',
+        hideArchived: false,
       };
     });
 
@@ -91,6 +95,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         assert.strictEqual(controller.name, null);
         assert.strictEqual(controller.type, null);
         assert.strictEqual(controller.externalId, null);
+        assert.false(controller.hideArchived);
       });
     });
 
@@ -106,6 +111,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         assert.strictEqual(controller.name, 'someName');
         assert.strictEqual(controller.type, 'someType');
         assert.strictEqual(controller.externalId, 'someExternalId');
+        assert.false(controller.hideArchived);
       });
     });
   });

--- a/api/db/seeds/data/team-acces/build-archived-organizations.js
+++ b/api/db/seeds/data/team-acces/build-archived-organizations.js
@@ -1,0 +1,9 @@
+import { REAL_PIX_SUPER_ADMIN_ID } from '../common/common-builder.js';
+
+export function buildArchivedOrganizations(databaseBuilder) {
+  databaseBuilder.factory.buildOrganization({
+    name: 'Organisation archivée',
+    archivedAt: new Date('2023-08-04'),
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
+  });
+}

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -4,6 +4,7 @@ import { buildScoOrganizations } from './build-sco-organizations.js';
 import { buildTemporaryBlockedUsers } from './build-temporary-blocked-user.js';
 import { buildUsers } from './build-users.js';
 import { buildOrganizationUsers } from './build-organization-users.js';
+import { buildArchivedOrganizations } from './build-archived-organizations.js';
 import { buildScoOrganizationLearners } from './build-sco-organization-learners.js';
 
 async function teamAccesDataBuilder(databaseBuilder) {
@@ -13,6 +14,7 @@ async function teamAccesDataBuilder(databaseBuilder) {
   buildTemporaryBlockedUsers(databaseBuilder);
   buildOrganizationUsers(databaseBuilder);
   buildScoOrganizations(databaseBuilder);
+  buildArchivedOrganizations(databaseBuilder);
   buildScoOrganizationLearners(databaseBuilder);
 }
 

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -97,6 +97,7 @@ const register = async function (server) {
           query: Joi.object({
             'filter[id]': identifiersType.organizationId.empty('').allow(null).optional(),
             'filter[name]': Joi.string().empty('').allow(null).optional(),
+            'filter[hideArchived]': Joi.boolean().optional(),
             'page[number]': Joi.number().integer().empty('').allow(null).optional(),
             'page[size]': Joi.number().integer().empty('').allow(null).optional(),
           }),

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -33,7 +33,7 @@ function _toDomain(rawOrganization) {
 }
 
 function _setSearchFiltersForQueryBuilder(qb, filter) {
-  const { id, name, type, externalId } = filter;
+  const { id, name, type, externalId, hideArchived } = filter;
   if (id) {
     qb.where('organizations.id', id);
   }
@@ -45,6 +45,9 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
   }
   if (externalId) {
     qb.whereILike('externalId', `%${externalId}%`);
+  }
+  if (hideArchived) {
+    qb.whereNull('archivedAt');
   }
 }
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -706,6 +706,32 @@ describe('Integration | Repository | Organization', function () {
         expect(pagination).to.deep.equal(expectedPagination);
       });
     });
+
+    context('when there are organizations matching the "hideArchived" filter', function () {
+      beforeEach(function () {
+        databaseBuilder.factory.buildOrganization({ archivedAt: null });
+        databaseBuilder.factory.buildOrganization({ archivedAt: new Date('2023-08-04') });
+
+        return databaseBuilder.commit();
+      });
+
+      it('return only Organizations matching "hideArchived" if given in filters', async function () {
+        // given
+        const filter = { hideArchived: true };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
+
+        // when
+        const { models: matchingOrganizations, pagination } = await organizationRepository.findPaginatedFiltered({
+          filter,
+          page,
+        });
+
+        // then
+        expect(_.map(matchingOrganizations, 'archivedAt')).to.have.members([null]);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+    });
   });
 
   describe('#findPaginatedFilteredByTargetProfile', function () {


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas cacher les organisations archivées 

## :robot: Proposition
Ajouter un bouton toggle afin de cacher les organisations archivées

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre sur https://admin-pr6812.review.pix.fr/
- Se connecter avec l'utilisateur `superadmin@example.net`
- Se rendre sur la liste des organisations
- Aller jusqu'a la page 3
- Constater la présence de l'organisation qui a pour nom `Organisation archivée` dans la liste
- Cliquer sur le toggle `Masquer les organisations archivés`
- Constater que l'organisation n'est plus dans la liste
