### PR TITLE
[TECH] Remplacer le modèle bookshelf `competenceEvaluation` par l'utilisation de knex

### DIFF
--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -1,5 +1,3 @@
-import * as bookshelfToDomainConverter from '../utils/bookshelf-to-domain-converter.js';
-import { BookshelfCompetenceEvaluation } from '../orm-models/CompetenceEvaluation.js';
 import _ from 'lodash';
 import { NotFoundError } from '../../domain/errors.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
@@ -36,12 +34,13 @@ const updateStatusByAssessmentId = async function ({ assessmentId, status }) {
   return _toDomain({ competenceEvaluation, assessment: null });
 };
 
-const updateStatusByUserIdAndCompetenceId = function ({ userId, competenceId, status }) {
-  return BookshelfCompetenceEvaluation.where({ userId, competenceId })
-    .save({ status }, { require: true, patch: true })
-    .then((updatedCompetenceEvaluation) =>
-      bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation),
-    );
+const updateStatusByUserIdAndCompetenceId = async function ({ userId, competenceId, status }) {
+  const [competenceEvaluation] = await knex('competence-evaluations')
+    .where({ userId, competenceId })
+    .update({ status })
+    .returning('*');
+
+  return _toDomain({ competenceEvaluation, assessment: null });
 };
 
 const updateAssessmentId = async function ({

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -112,8 +112,13 @@ const findByAssessmentId = async function (assessmentId) {
   return competenceEvaluations.map((competenceEvaluation) => _toDomain({ competenceEvaluation, assessment: null }));
 };
 
-const existsByCompetenceIdAndUserId = async function ({ competenceId, userId }) {
-  const competenceEvaluation = await _getByCompetenceIdAndUserId({ competenceId, userId });
+const existsByCompetenceIdAndUserId = async function ({
+  competenceId,
+  userId,
+  domainTransaction = DomainTransaction.emptyTransaction(),
+}) {
+  const knexConn = domainTransaction.knexTransaction || knex;
+  const competenceEvaluation = await _getByCompetenceIdAndUserId({ competenceId, userId, knexConn });
   return competenceEvaluation ? true : false;
 };
 

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -105,11 +105,12 @@ const findByUserId = async function (userId) {
   return _selectOnlyOneCompetenceEvaluationByCompetence(domainCompetenceEvaluations);
 };
 
-const findByAssessmentId = function (assessmentId) {
-  return BookshelfCompetenceEvaluation.where({ assessmentId })
-    .orderBy('createdAt', 'asc')
-    .fetchAll()
-    .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfCompetenceEvaluation, results));
+const findByAssessmentId = async function (assessmentId) {
+  const competenceEvaluations = await knex('competence-evaluations')
+    .where({ assessmentId })
+    .orderBy('createdAt', 'asc');
+
+  return competenceEvaluations.map((competenceEvaluation) => _toDomain({ competenceEvaluation, assessment: null }));
 };
 
 const existsByCompetenceIdAndUserId = async function ({ competenceId, userId }) {

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -27,12 +27,13 @@ const save = async function ({ competenceEvaluation, domainTransaction = DomainT
   return _toDomain({ competenceEvaluation: competenceEvaluationCreated, assessment: null });
 };
 
-const updateStatusByAssessmentId = function ({ assessmentId, status }) {
-  return BookshelfCompetenceEvaluation.where({ assessmentId })
-    .save({ status }, { require: true, patch: true })
-    .then((updatedCompetenceEvaluation) =>
-      bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation),
-    );
+const updateStatusByAssessmentId = async function ({ assessmentId, status }) {
+  const [competenceEvaluation] = await knex('competence-evaluations')
+    .where({ assessmentId })
+    .update({ status })
+    .returning('*');
+
+  return _toDomain({ competenceEvaluation, assessment: null });
 };
 
 const updateStatusByUserIdAndCompetenceId = function ({ userId, competenceId, status }) {

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -75,10 +75,11 @@ const getByCompetenceIdAndUserId = async function ({
   domainTransaction = DomainTransaction.emptyTransaction(),
   forUpdate = false,
 }) {
+  const knexConn = domainTransaction.knexTransaction || knex;
   const competenceEvaluation = await _getByCompetenceIdAndUserId({
     competenceId,
     userId,
-    domainTransaction,
+    knexConn,
     forUpdate,
   });
   if (competenceEvaluation === null) {

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -58,17 +58,15 @@ const updateAssessmentId = function ({
     );
 };
 
-const getByAssessmentId = function (assessmentId) {
-  return BookshelfCompetenceEvaluation.where({ assessmentId })
-    .orderBy('createdAt', 'asc')
-    .fetch({ withRelated: ['assessment'] })
-    .then((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, result))
-    .catch((bookshelfError) => {
-      if (bookshelfError instanceof BookshelfCompetenceEvaluation.NotFoundError) {
-        throw new NotFoundError();
-      }
-      throw bookshelfError;
-    });
+const getByAssessmentId = async function (assessmentId) {
+  const competenceEvaluation = await knex('competence-evaluations').where({ assessmentId }).first();
+  if (!competenceEvaluation) {
+    throw new NotFoundError();
+  }
+
+  const assessment = await knex('assessments').where({ id: competenceEvaluation.assessmentId }).first();
+
+  return _toDomain({ competenceEvaluation, assessment });
 };
 
 const getByCompetenceIdAndUserId = async function ({

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -327,6 +327,50 @@ describe('Integration | Repository | Competence Evaluation', function () {
     });
   });
 
+  describe('#existsByCompetenceIdAndUserId', function () {
+    let userId;
+
+    beforeEach(async function () {
+      // given
+      userId = databaseBuilder.factory.buildUser({}).id;
+
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId,
+        competenceId: '1',
+        status: STARTED,
+      });
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId,
+        competenceId: '2',
+        status: STARTED,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return true where there is a a competence evaluation', async function () {
+      // when
+      const result = await competenceEvaluationRepository.existsByCompetenceIdAndUserId({
+        competenceId: 1,
+        userId,
+      });
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should return false when there is no competence evaluation', async function () {
+      // when
+      const result = await competenceEvaluationRepository.existsByCompetenceIdAndUserId({
+        competenceId: 'fakeId',
+        userId,
+      });
+
+      // then
+      expect(result).to.equal(false);
+    });
+  });
+
   describe('#updateStatusByAssessmentId', function () {
     let assessment;
 


### PR DESCRIPTION
## :unicorn: Problème
Un ADR existe concernant la suppression de l'ORM bookshelf de l'API. Cependant, le repository `competenceEvaluation` l'utilise encore.

## :robot: Proposition
Remplacer l'utilisation de bookshelf par knex.

## :rainbow: Remarques
Dans la même veine que #6251, #5901...

## :100: Pour tester
Vérifier que les cartes compétences fonctionnent toujours (reprendre une compétence, la terminer, la reset...).
