### PR TITLE
[FEATURE] Mise en place de la V0 de l'oralisation des instructions (PIX-8801)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-instruction/component.js
+++ b/1d/app/pods/components/challenge/challenge-instruction/component.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class ChallengeInstruction extends Component {
+  @action
+  readTheInstruction() {
+    if (!window.speechSynthesis.speaking) {
+      const utterance = new SpeechSynthesisUtterance();
+
+      utterance.text = document.getElementsByClassName('challenge-instruction')[0].innerText;
+      utterance.lang = 'fr-FR';
+
+      window.speechSynthesis.speak(utterance);
+    }
+  }
+}

--- a/1d/app/pods/components/challenge/challenge-instruction/component.js
+++ b/1d/app/pods/components/challenge/challenge-instruction/component.js
@@ -1,13 +1,16 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import * as markdownConverter from '1d/utils/markdown-converter';
 
 export default class ChallengeInstruction extends Component {
   @action
-  readTheInstruction() {
+  readTheInstruction(text) {
     if (!window.speechSynthesis.speaking) {
       const utterance = new SpeechSynthesisUtterance();
 
-      utterance.text = document.getElementsByClassName('challenge-instruction')[0].innerText;
+      const parser = new DOMParser();
+      const parsedText = parser.parseFromString(markdownConverter.toHTML(text), 'text/html').body.innerText;
+      utterance.text = parsedText;
       utterance.lang = 'fr-FR';
 
       window.speechSynthesis.speak(utterance);

--- a/1d/app/pods/components/challenge/challenge-instruction/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-instruction/template.hbs
@@ -4,6 +4,6 @@
     @ariaLabel="Lire la consigne à haute voix"
     @withBackground="true"
     @icon="volume-high"
-    @triggerAction={{this.readTheInstruction}}
+    @triggerAction={{fn this.readTheInstruction @instruction}}
   />
 </div>

--- a/1d/app/pods/components/challenge/challenge-instruction/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-instruction/template.hbs
@@ -1,3 +1,9 @@
 <div class="challenge-instruction">
   <Markdown::MarkdownToHtmlUnsafe @markdown={{@instruction}} />
+  <PixIconButton
+    @ariaLabel="Lire la consigne à haute voix"
+    @withBackground="true"
+    @icon="volume-high"
+    @triggerAction={{this.readTheInstruction}}
+  />
 </div>

--- a/1d/app/pods/components/markdown/markdown-to-html-unsafe/component.js
+++ b/1d/app/pods/components/markdown/markdown-to-html-unsafe/component.js
@@ -4,7 +4,7 @@ import { htmlSafe } from '@ember/template';
 
 export default class MarkdownToHtmlUnsafe extends Component {
   get html() {
-    const unsafeHtml = markdownConverter.toHTML(this.args.markdown)
+    const unsafeHtml = markdownConverter.toHTML(this.args.markdown);
     return htmlSafe(unsafeHtml);
   }
 }

--- a/1d/app/pods/components/markdown/markdown-to-html-unsafe/component.js
+++ b/1d/app/pods/components/markdown/markdown-to-html-unsafe/component.js
@@ -1,19 +1,10 @@
 import Component from '@glimmer/component';
-import showdown from 'showdown';
+import * as markdownConverter from '1d/utils/markdown-converter.js';
 import { htmlSafe } from '@ember/template';
 
 export default class MarkdownToHtmlUnsafe extends Component {
-  get options() {
-    return {
-      openLinksInNewWindow: true,
-      strikethrough: true,
-      extensions: this.args.extensions ? this.args.extensions.split(' ') : [],
-    };
-  }
-
   get html() {
-    const converter = new showdown.Converter(this.options);
-    const unsafeHtml = converter.makeHtml(this.args.markdown);
+    const unsafeHtml = markdownConverter.toHTML(this.args.markdown)
     return htmlSafe(unsafeHtml);
   }
 }

--- a/1d/app/router.js
+++ b/1d/app/router.js
@@ -4,6 +4,16 @@ import config from './config/environment';
 export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
+
+  constructor() {
+    super(...arguments);
+    this.on('routeDidChange', () => {
+      if (window.speechSynthesis?.speaking) {
+        window.speechSynthesis.cancel();
+      }
+      window.scrollTo(0, 0);
+    });
+  }
 }
 
 Router.map(function () {

--- a/1d/app/utils/markdown-converter.js
+++ b/1d/app/utils/markdown-converter.js
@@ -1,0 +1,13 @@
+import showdown from 'showdown';
+
+const DEFAULT_OPTIONS = {
+  openLinksInNewWindow: true,
+  strikethrough: true,
+  extensions: [],
+}
+
+export function toHTML(text, options = {}) {
+  const converter = new showdown.Converter({...DEFAULT_OPTIONS, ...options});
+  return converter.makeHtml(text);
+}
+

--- a/1d/app/utils/markdown-converter.js
+++ b/1d/app/utils/markdown-converter.js
@@ -4,10 +4,9 @@ const DEFAULT_OPTIONS = {
   openLinksInNewWindow: true,
   strikethrough: true,
   extensions: [],
-}
+};
 
 export function toHTML(text, options = {}) {
-  const converter = new showdown.Converter({...DEFAULT_OPTIONS, ...options});
+  const converter = new showdown.Converter({ ...DEFAULT_OPTIONS, ...options });
   return converter.makeHtml(text);
 }
-

--- a/1d/tests/integration/components/challenge-instruction_test.js
+++ b/1d/tests/integration/components/challenge-instruction_test.js
@@ -18,5 +18,19 @@ module('Integration | Component | ChallengeInstruction', (hooks) => {
       sinon.mock(window.speechSynthesis.speak).once;
       assert.ok(true);
     });
+
+    test('should oralize given text without markdown symbols', async function (assert) {
+      const text = "blabla même s'il y a du **gras**";
+      const expectedText = "blabla même s'il y a du gras";
+
+      this.set('instruction', text);
+      const screen = await render(hbs`<Challenge::ChallengeInstruction @instruction={{this.instruction}} />`);
+
+      sinon.spy(window.speechSynthesis, 'speak');
+      await click(screen.getByLabelText('Lire la consigne à haute voix'));
+
+      const spyCall = await window.speechSynthesis.speak.getCall(0);
+      assert.equal(expectedText, spyCall.args[0].text);
+    });
   });
 });

--- a/1d/tests/integration/components/challenge-instruction_test.js
+++ b/1d/tests/integration/components/challenge-instruction_test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import { click } from '@ember/test-helpers';
+
+module('Integration | Component | ChallengeInstruction', (hooks) => {
+  setupRenderingTest(hooks);
+
+  module('oralization', function () {
+    test('should call the method speechSynthesis', async function (assert) {
+      this.set('instruction', 'Trouve les drapeaux');
+      const screen = await render(hbs`<Challenge::ChallengeInstruction @instruction={{this.instruction}} />`);
+
+      await click(screen.getByLabelText('Lire la consigne à haute voix'));
+
+      sinon.mock(window.speechSynthesis.speak).once;
+      assert.ok(true);
+    });
+  });
+});

--- a/1d/tests/unit/utils/markdown-converter_test.js
+++ b/1d/tests/unit/utils/markdown-converter_test.js
@@ -6,21 +6,20 @@ module('Unit | Utils | MarkdownConverter', function (hooks) {
   setupTest(hooks);
 
   test('keep text without markdown symbols', function (assert) {
-    const text = "un simple texte"
-    const expectedText = "<p>un simple texte</p>"
+    const text = 'un simple texte';
+    const expectedText = '<p>un simple texte</p>';
 
-    const resultText = markdownConverter.toHTML(text)
+    const resultText = markdownConverter.toHTML(text);
 
     assert.equal(expectedText, resultText);
   });
 
   test('text with bold', function (assert) {
-    const text = "un texte **gras**"
-    const expectedText = "<p>un texte <strong>gras</strong></p>"
+    const text = 'un texte **gras**';
+    const expectedText = '<p>un texte <strong>gras</strong></p>';
 
-    const resultText = markdownConverter.toHTML(text)
+    const resultText = markdownConverter.toHTML(text);
 
     assert.equal(expectedText, resultText);
   });
-
 });

--- a/1d/tests/unit/utils/markdown-converter_test.js
+++ b/1d/tests/unit/utils/markdown-converter_test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupTest } from '../../helpers/index';
+import * as markdownConverter from '1d/utils/markdown-converter';
+
+module('Unit | Utils | MarkdownConverter', function (hooks) {
+  setupTest(hooks);
+
+  test('keep text without markdown symbols', function (assert) {
+    const text = "un simple texte"
+    const expectedText = "<p>un simple texte</p>"
+
+    const resultText = markdownConverter.toHTML(text)
+
+    assert.equal(expectedText, resultText);
+  });
+
+  test('text with bold', function (assert) {
+    const text = "un texte **gras**"
+    const expectedText = "<p>un texte <strong>gras</strong></p>"
+
+    const resultText = markdownConverter.toHTML(text)
+
+    assert.equal(expectedText, resultText);
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour les élèves avec des difficultés de lecture, on a besoin d'une solution pour leur permettre de lire la consigne.

## :robot: Proposition
Ajouter l'oralisation

## :rainbow: Remarques
textContent vs innerText
Nous avons utiliser `innerText` car il contient seulement le texte visible alors que `textContent` contient tous les textes y compris les textes en display none
cf [la doc MDN de textContext](https://developer.mozilla.org/fr/docs/Web/API/Node/textContent)

## :100: Pour tester
- aller sur pix1d et commencer une mission
- cliquer sur le bouton pour entendre la vocalisation.