### PR TITLE
[BUGFIX] Rendre accessible les habilitations d'un centre de certif aux rôles CERTIF (PIX-8830).

### DIFF
--- a/api/lib/application/complementary-certifications/index.js
+++ b/api/lib/application/complementary-certifications/index.js
@@ -13,6 +13,7 @@ const register = async function (server) {
               securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
@@ -21,7 +22,7 @@ const register = async function (server) {
         handler: complementaryCertificationController.findComplementaryCertifications,
         tags: ['api', 'admin'],
         notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin, Support et Métier',
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin, Support, Certif et Métier',
           'Elle renvoie la liste des certifications complémentaires existantes.',
         ],
       },

--- a/api/tests/unit/application/complementary-certifications/index_test.js
+++ b/api/tests/unit/application/complementary-certifications/index_test.js
@@ -5,23 +5,6 @@ import * as moduleUnderTest from '../../../../lib/application/complementary-cert
 
 describe('Unit | Application | Router | complementary-certifications-router', function () {
   describe('GET /api/admin/complementary-certifications', function () {
-    describe('when the user authenticated has certif role', function () {
-      it('should return 403 HTTP status code', async function () {
-        // given
-        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleCertif').callsFake((request, h) => h.response(true));
-        sinon.stub(complementaryCertificationController, 'findComplementaryCertifications').returns('ok');
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const response = await httpTestServer.request('GET', '/api/admin/complementary-certifications');
-
-        // then
-        expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(complementaryCertificationController.findComplementaryCertifications);
-      });
-    });
-
     describe('when the user authenticated has no role', function () {
       it('should return 403 HTTP status code', async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
[La PR](https://github.com/1024pix/pix/pull/6674) introduit un bug qui enlève aux rôle CERTIF la possibilité d’accéder aux certifications complémentaire. 
Ainsi lorsqu'ils se rendent dans la page de détails d'un centre de certification, Ember retourne une page blanche.

## :robot: Proposition
Rendre accessible les habilitations d'un centre de certif aux rôles CERTIF

## :rainbow: Remarques
Un refacto de la route /api/admin/complementary-certifications à introduit ce bug

## :100: Pour tester

- Se connecter à pix admin avec l'utilisateur pixcertif@example.net (rôle certif)
- aller dans le détails d'un centre de certification
- Constater que l'on accède bien à tous les éléments de la page
