### PR TITLE
[FEATURE]  Ajouter le bouton pour permettre la remise à zéro des compétences d'une campagne (PIX-8823)

### DIFF
--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -687,6 +687,7 @@ function _createPixEdu1erDegre(databaseBuilder) {
     description: null,
     name: '[Pix+Édu 1D FI] Prêt pour la certification du volet 1',
     isSimplifiedAccess: false,
+    areKnowledgeElementsResettable: true,
     category: 'PREDEFINED',
     isPublic: true,
   });

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -1,8 +1,8 @@
 import { BadgeResult } from './BadgeResult.js';
 import { CompetenceResult } from './CompetenceResult.js';
 import {
-  MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING,
   MAX_MASTERY_RATE,
+  MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING,
   MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING,
 } from '../../constants.js';
 import moment from 'moment';
@@ -12,6 +12,7 @@ class AssessmentResult {
     participationResults,
     isCampaignMultipleSendings,
     isOrganizationLearnerActive,
+    isTargetProfileResetAllowed,
     isCampaignArchived,
     competences,
     badgeResultsDTO,
@@ -69,6 +70,13 @@ class AssessmentResult {
       this.masteryRate,
       this.isDisabled,
     );
+    this.canReset = this._computeCanReset({
+      isTargetProfileResetAllowed,
+      isCampaignMultipleSendings,
+      isOrganizationLearnerActive,
+      isDisabled: this.isDisabled,
+      sharedAt,
+    });
 
     if (flashScoringResults) {
       this.estimatedFlashLevel = flashScoringResults.estimatedLevel;
@@ -115,6 +123,22 @@ class AssessmentResult {
       masteryRate < MAX_MASTERY_RATE &&
       isOrganizationLearnerActive &&
       !isDisabled
+    );
+  }
+
+  _computeCanReset({
+    isTargetProfileResetAllowed,
+    isOrganizationLearnerActive,
+    isCampaignMultipleSendings,
+    isDisabled,
+    sharedAt,
+  }) {
+    return (
+      isTargetProfileResetAllowed &&
+      isOrganizationLearnerActive &&
+      isCampaignMultipleSendings &&
+      !isDisabled &&
+      this._timeBeforeRetryingPassed(sharedAt)
     );
   }
 

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -26,6 +26,7 @@ const getByUserIdAndCampaignId = async function ({ userId, campaignId, badges, l
   const competences = await _findTargetedCompetences(campaignId, locale);
   const badgeResultsDTO = await _getBadgeResults(badges);
   const stageCollection = await _getStageCollection(campaignId);
+  const isTargetProfileResetAllowed = await _getTargetProfileResetAllowed(campaignId);
 
   return new AssessmentResult({
     participationResults,
@@ -36,6 +37,7 @@ const getByUserIdAndCampaignId = async function ({ userId, campaignId, badges, l
     isOrganizationLearnerActive,
     isCampaignArchived,
     flashScoringResults,
+    isTargetProfileResetAllowed,
   });
 };
 
@@ -171,6 +173,15 @@ async function _getAcquiredBadgeIds(userId, campaignParticipationId) {
 
 function _getStageCollection(campaignId) {
   return stageCollectionRepository.findStageCollection({ campaignId });
+}
+
+async function _getTargetProfileResetAllowed(campaignId) {
+  const targetProfile = await knex('target-profiles')
+    .join('campaigns', 'campaigns.targetProfileId', 'target-profiles.id')
+    .where('campaigns.id', campaignId)
+    .first('areKnowledgeElementsResettable');
+
+  return targetProfile ? targetProfile.areKnowledgeElementsResettable : false;
 }
 
 async function _getBadgeResults(badges) {

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -19,6 +19,7 @@ const serialize = function (results) {
       'competenceResults',
       'reachedStage',
       'canRetry',
+      'canReset',
       'canImprove',
       'isDisabled',
     ],

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -238,6 +238,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
             'is-completed': true,
             'is-shared': true,
             'can-retry': false,
+            'can-reset': false,
             'can-improve': false,
             'is-disabled': false,
             'participant-external-id': 'participantExternalId',

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -555,6 +555,32 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       });
     });
 
+    context('when time before retrying is not passed', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-04T05:06:07Z'),
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canRetry).to.be.false;
+      });
+    });
+
     context(
       'when the participation has been shared less than MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING days ago',
       function () {
@@ -670,6 +696,214 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         });
       },
     );
+  });
+
+  describe('#canReset', function () {
+    let clock, originalConstantValue, now;
+
+    beforeEach(function () {
+      originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+      now = new Date('2020-01-05T05:06:07Z');
+      clock = sinon.useFakeTimers(now);
+      sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(4);
+    });
+
+    afterEach(function () {
+      clock.restore();
+      sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(originalConstantValue);
+    });
+
+    context('when the campaign does not allow multiple sendings', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = false;
+        const isTargetProfileResetAllowed = true;
+        const isOrganizationLearnerActive = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isTargetProfileResetAllowed,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+    });
+
+    context('when is disabled', function () {
+      it('returns false on participant disabled', function () {
+        const isCampaignMultipleSendings = true;
+        const isTargetProfileResetAllowed = true;
+        const isOrganizationLearnerActive = false;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isTargetProfileResetAllowed,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+
+      it('returns false on campaign archive', function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isTargetProfileResetAllowed = true;
+        const isCampaignArchived = true;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isTargetProfileResetAllowed,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+    });
+
+    context('when the participation is not shared', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isTargetProfileResetAllowed = true;
+        const isOrganizationLearnerActive = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: null,
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isTargetProfileResetAllowed,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+    });
+
+    context('when the participation is deleted', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isTargetProfileResetAllowed = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: true,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isTargetProfileResetAllowed,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+    });
+
+    context('when time before retrying is not passed', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isTargetProfileResetAllowed = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-04T05:06:07Z'),
+          isDeleted: false,
+        };
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stageCollection: [],
+          badgeResultsDTO: [],
+          isTargetProfileResetAllowed,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
+
+        expect(assessmentResult.canReset).to.be.false;
+      });
+    });
+
+    it('returns true', function () {
+      const isCampaignMultipleSendings = true;
+      const isOrganizationLearnerActive = true;
+      const isTargetProfileResetAllowed = true;
+      const isCampaignArchived = false;
+      const participationResults = {
+        knowledgeElements: [],
+        acquiredBadgeIds: [],
+        masteryRate: '0.34',
+        sharedAt: new Date('2020-01-01T05:06:07Z'),
+        isDeleted: false,
+      };
+      const assessmentResult = new AssessmentResult({
+        participationResults,
+        competences: [],
+        stageCollection: [],
+        badgeResultsDTO: [],
+        isTargetProfileResetAllowed,
+        isCampaignMultipleSendings,
+        isOrganizationLearnerActive,
+        isCampaignArchived,
+      });
+
+      expect(assessmentResult.canReset).to.be.true;
+    });
   });
 
   describe('#canImprove', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/participant-result-serializer.js';
 import { AssessmentResult } from '../../../../../lib/domain/read-models/participant-results/AssessmentResult.js';
 import { KnowledgeElement } from '../../../../../lib/domain/models/KnowledgeElement.js';
@@ -7,6 +7,7 @@ import { StageCollection } from '../../../../../lib/domain/models/user-campaign-
 describe('Unit | Serializer | JSON API | participant-result-serializer', function () {
   context('#serialize', function () {
     const isCampaignMultipleSendings = true;
+    const isTargetProfileResetAllowed = true;
     const isOrganizationLearnerActive = true;
     const isCampaignArchived = false;
     let participationResults;
@@ -90,6 +91,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         isCampaignMultipleSendings,
         isOrganizationLearnerActive,
         isCampaignArchived,
+        isTargetProfileResetAllowed,
       });
 
       const expectedSerializedCampaignParticipationResult = {
@@ -102,6 +104,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'total-skills-count': 2,
             'validated-skills-count': 1,
             'can-retry': true,
+            'can-reset': true,
             'can-improve': false,
             'is-disabled': false,
             'participant-external-id': 'greg@lafleche.fr',
@@ -275,6 +278,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           isOrganizationLearnerActive,
           isCampaignArchived,
           flashScoringResults,
+          isTargetProfileResetAllowed,
         });
 
         // when

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -189,7 +189,7 @@
               >
                 <:content>
                   <PixBanner @type="warning">{{t "pages.skill-review.reset.modal.warning-text"}}</PixBanner>
-                  <p class="reset-ke-modal__text">
+                  <p class="reset-campaign-participation-modal__text">
 
                     {{t
                       "pages.skill-review.reset.modal.text"
@@ -199,7 +199,7 @@
                   </p>
                 </:content>
                 <:footer>
-                  <div class="reset-ke-modal__footer">
+                  <div class="reset-campaign-participation-modal__footer">
                     <PixButton
                       @backgroundColor="transparent-light"
                       @isBorderVisible={{true}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -150,28 +150,37 @@
           </div>
         </div>
       </div>
-      {{#if @model.campaignParticipationResult.canRetry}}
+      {{#if this.displayRetryOrResetActions}}
         <div class="skill-review__retry">
           <p class="skill-review-retry__message">{{t
               "pages.skill-review.retry.message"
               organizationName=@model.campaign.organizationName
             }}</p>
           <div class="skill-review__actions">
-            <PixButtonLink
-              @route="campaigns.entry-point"
-              @model={{@model.campaign.code}}
-              @query={{this.retryQuery}}
-              @size="small"
-              @shape="rounded"
-            >{{t "pages.skill-review.retry.button"}}</PixButtonLink>
-            <PixButtonLink
-              @route="campaigns.entry-point"
-              @model={{@model.campaign.code}}
-              @query={{this.resetQuery}}
-              @size="small"
-              @shape="rounded"
-              @backgroundColor="transparent"
-            >{{t "pages.skill-review.reset.button"}}</PixButtonLink>
+            {{#if @model.campaignParticipationResult.canRetry}}
+              <PixButtonLink
+                @route="campaigns.entry-point"
+                @model={{@model.campaign.code}}
+                @query={{this.retryQuery}}
+                @size="small"
+                @shape="rounded"
+              >{{t "pages.skill-review.retry.button"}}</PixButtonLink>
+            {{/if}}
+
+            {{#if @model.campaignParticipationResult.canReset}}
+              <PixButtonLink
+                @route="campaigns.entry-point"
+                @model={{@model.campaign.code}}
+                @query={{this.resetQuery}}
+                @size="small"
+                @shape="rounded"
+                @backgroundColor="transparent"
+              >{{t "pages.skill-review.reset.button"}}</PixButtonLink>
+
+              <PixBanner @type="default" class="skill-review__action-banner">{{t
+                  "pages.skill-review.reset.notifications"
+                }}</PixBanner>
+            {{/if}}
           </div>
         </div>
       {{/if}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -159,6 +159,7 @@
           <div class="skill-review__actions">
             {{#if @model.campaignParticipationResult.canRetry}}
               <PixButtonLink
+                class="skill-review__actions__pix-button"
                 @route="campaigns.entry-point"
                 @model={{@model.campaign.code}}
                 @query={{this.retryQuery}}
@@ -168,18 +169,57 @@
             {{/if}}
 
             {{#if @model.campaignParticipationResult.canReset}}
-              <PixButtonLink
-                @route="campaigns.entry-point"
-                @model={{@model.campaign.code}}
-                @query={{this.resetQuery}}
+              <PixButton
+                class="skill-review__actions__pix-button"
                 @size="small"
                 @shape="rounded"
                 @backgroundColor="transparent"
-              >{{t "pages.skill-review.reset.button"}}</PixButtonLink>
+                @isBorderVisible={{true}}
+                @triggerAction={{this.showResetModal}}
+              >{{t "pages.skill-review.reset.button"}}</PixButton>
 
               <PixBanner @type="default" class="skill-review__action-banner">{{t
                   "pages.skill-review.reset.notifications"
                 }}</PixBanner>
+
+              <PixModal
+                @title={{t "pages.skill-review.reset.button"}}
+                @showModal={{this.displayResetCampaignParticipationModal}}
+                @onCloseButtonClick={{this.closeResetModal}}
+              >
+                <:content>
+                  <PixBanner @type="warning" class="skill-review__action-banner">{{t
+                      "pages.skill-review.reset.modal.warning-text"
+                    }}</PixBanner>
+                  <p class="reset-ke-modal__text">
+
+                    {{t
+                      "pages.skill-review.reset.modal.text"
+                      targetProfileName=@model.campaign.targetProfileName
+                      htmlSafe=true
+                    }}
+                  </p>
+                </:content>
+                <:footer>
+                  <div class="reset-ke-modal__footer">
+                    <PixButton
+                      @backgroundColor="transparent-light"
+                      @isBorderVisible={{true}}
+                      @triggerAction={{this.closeResetModal}}
+                    >
+                      {{t "common.actions.cancel"}}
+                    </PixButton>
+                    <PixButtonLink
+                      @route="campaigns.entry-point"
+                      @model={{@model.campaign.code}}
+                      @query={{this.resetQuery}}
+                      @size="big"
+                      @shape="squircle"
+                      @backgroundColor="red"
+                    >{{t "common.actions.confirm"}}</PixButtonLink>
+                  </div>
+                </:footer>
+              </PixModal>
             {{/if}}
           </div>
         </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -159,9 +159,15 @@
           <LinkTo
             @route="campaigns.entry-point"
             @model={{@model.campaign.code}}
-            @query={{this.query}}
+            @query={{this.retryQuery}}
             class="skill-review-retry__button button button--big button--link"
           >{{t "pages.skill-review.retry.button"}}</LinkTo>
+          <LinkTo
+            @route="campaigns.entry-point"
+            @model={{@model.campaign.code}}
+            @query={{this.resetQuery}}
+            class="skill-review-reset__button button button--big button--link"
+          >{{t "pages.skill-review.reset.button"}}</LinkTo>
         </div>
       {{/if}}
       {{#if @model.trainings}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -156,18 +156,23 @@
               "pages.skill-review.retry.message"
               organizationName=@model.campaign.organizationName
             }}</p>
-          <LinkTo
-            @route="campaigns.entry-point"
-            @model={{@model.campaign.code}}
-            @query={{this.retryQuery}}
-            class="skill-review-retry__button button button--big button--link"
-          >{{t "pages.skill-review.retry.button"}}</LinkTo>
-          <LinkTo
-            @route="campaigns.entry-point"
-            @model={{@model.campaign.code}}
-            @query={{this.resetQuery}}
-            class="skill-review-reset__button button button--big button--link"
-          >{{t "pages.skill-review.reset.button"}}</LinkTo>
+          <div class="skill-review__actions">
+            <PixButtonLink
+              @route="campaigns.entry-point"
+              @model={{@model.campaign.code}}
+              @query={{this.retryQuery}}
+              @size="small"
+              @shape="rounded"
+            >{{t "pages.skill-review.retry.button"}}</PixButtonLink>
+            <PixButtonLink
+              @route="campaigns.entry-point"
+              @model={{@model.campaign.code}}
+              @query={{this.resetQuery}}
+              @size="small"
+              @shape="rounded"
+              @backgroundColor="transparent"
+            >{{t "pages.skill-review.reset.button"}}</PixButtonLink>
+          </div>
         </div>
       {{/if}}
       {{#if @model.trainings}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -188,9 +188,7 @@
                 @onCloseButtonClick={{this.closeResetModal}}
               >
                 <:content>
-                  <PixBanner @type="warning" class="skill-review__action-banner">{{t
-                      "pages.skill-review.reset.modal.warning-text"
-                    }}</PixBanner>
+                  <PixBanner @type="warning">{{t "pages.skill-review.reset.modal.warning-text"}}</PixBanner>
                   <p class="reset-ke-modal__text">
 
                     {{t

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -16,7 +16,7 @@ export default class SkillReview extends Component {
   @tracked showNotFinishedYetMessage = false;
   @tracked showGlobalErrorMessage = false;
   @tracked isShareButtonClicked = false;
-  @tracked displayResetModal = false;
+  @tracked displayResetCampaignParticipationModal = false;
 
   get retryQuery() {
     return {
@@ -216,8 +216,13 @@ export default class SkillReview extends Component {
   }
 
   @action
-  toggleDisplayResetModal() {
-    this.displayResetKeModal = !this.displayResetKeModal;
+  showResetModal() {
+    this.displayResetCampaignParticipationModal = true;
+  }
+
+  @action
+  closeResetModal() {
+    this.displayResetCampaignParticipationModal = false;
   }
 
   @action

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -17,9 +17,15 @@ export default class SkillReview extends Component {
   @tracked showGlobalErrorMessage = false;
   @tracked isShareButtonClicked = false;
 
-  get query() {
+  get retryQuery() {
     return {
       retry: true,
+    };
+  }
+
+  get resetQuery() {
+    return {
+      reset: true,
     };
   }
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -16,6 +16,7 @@ export default class SkillReview extends Component {
   @tracked showNotFinishedYetMessage = false;
   @tracked showGlobalErrorMessage = false;
   @tracked isShareButtonClicked = false;
+  @tracked displayResetModal = false;
 
   get retryQuery() {
     return {
@@ -27,6 +28,10 @@ export default class SkillReview extends Component {
     return {
       reset: true,
     };
+  }
+
+  get displayRetryOrResetActions() {
+    return this.args.model.campaignParticipationResult.canRetry || this.args.model.campaignParticipationResult.canReset;
   }
 
   get title() {
@@ -208,6 +213,11 @@ export default class SkillReview extends Component {
     }
     Url.search = urlParams.toString();
     return Url.toString();
+  }
+
+  @action
+  toggleDisplayResetModal() {
+    this.displayResetKeModal = !this.displayResetKeModal;
   }
 
   @action

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -7,6 +7,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
   @attr('boolean') canRetry;
+  @attr('boolean') canReset;
   @attr('boolean') canImprove;
   @attr('boolean') isDisabled;
   @attr('boolean') isShared;

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -3,6 +3,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class CampaignParticipation extends Model {
   // attributes
   @attr('boolean') isShared;
+  @attr('boolean') isReset;
   @attr('date') createdAt;
   @attr('date') sharedAt;
   @attr('date') deletedAt;

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -40,9 +40,11 @@ export default class Entrance extends Route {
 
   async _beginCampaignParticipation(campaign) {
     const participantExternalId = this.campaignStorage.get(campaign.code, 'participantExternalId');
+    const reset = this.campaignStorage.get(campaign.code, 'reset');
     const campaignParticipation = this.store.createRecord('campaign-participation', {
       campaign,
       participantExternalId,
+      isReset: reset ? true : undefined,
     });
 
     try {
@@ -78,6 +80,7 @@ export default class Entrance extends Route {
     const hasParticipated = Boolean(ongoingCampaignParticipation);
     this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
     const retry = this.campaignStorage.get(campaign.code, 'retry');
-    return !hasParticipated || (campaign.multipleSendings && retry);
+    const reset = this.campaignStorage.get(campaign.code, 'reset');
+    return !hasParticipated || (campaign.multipleSendings && (retry || reset));
   }
 }

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -28,6 +28,9 @@ export default class EntryPoint extends Route {
     if (queryParams.retry) {
       this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
+    if (queryParams.reset) {
+      this.campaignStorage.set(campaign.code, 'reset', transition.to.queryParams.reset);
+    }
 
     let hasParticipated = false;
     if (this.session.isAuthenticated) {

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -40,6 +40,7 @@
 @import 'components/circle-chart';
 @import 'components/comparison-window';
 @import 'components/choice-chip';
+@import 'components/reset-ke-modal';
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -40,7 +40,7 @@
 @import 'components/circle-chart';
 @import 'components/comparison-window';
 @import 'components/choice-chip';
-@import 'components/reset-ke-modal';
+@import 'components/reset-campaign-participation-modal';
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/components/_reset-campaign-participation-modal.scss
+++ b/mon-pix/app/styles/components/_reset-campaign-participation-modal.scss
@@ -1,4 +1,4 @@
-.reset-ke-modal {
+.reset-campaign-participation-modal {
   &__text {
     margin: $pix-spacing-m;
   }
@@ -6,7 +6,7 @@
   &__footer {
     display: flex;
     gap: $pix-spacing-s;
-    align-items:center;
+    align-items: center;
     justify-content: end;
   }
 }

--- a/mon-pix/app/styles/components/_reset-ke-modal.scss
+++ b/mon-pix/app/styles/components/_reset-ke-modal.scss
@@ -1,0 +1,12 @@
+.reset-ke-modal {
+  &__text {
+    margin: $pix-spacing-m;
+  }
+
+  &__footer {
+    display: flex;
+    gap: $pix-spacing-s;
+    align-items:center;
+    justify-content: end;
+  }
+}

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -34,6 +34,16 @@
     }
   }
 
+  &__actions {
+    .pix-button {
+      margin: 0 auto;
+
+      &:first-child {
+        margin-bottom: $pix-spacing-xs;
+      }
+    }
+  }
+
   &__trainings {
     margin-top: $pix-spacing-xl;
     padding: $pix-spacing-l 0;
@@ -132,11 +142,6 @@
   &__message {
     margin: 1em 0;
   }
-
-  &__button {
-    padding: 10px;
-    font-size: 0.875rem;
-  }
 }
 
 .skill-review-trainings {
@@ -181,7 +186,9 @@
     transition: all 0.2s ease-in-out;
 
     &:hover {
-      box-shadow: 0 7px 14px 0 rgb(12 22 58 / 20%), 0 3px 6px 0 rgba($pix-neutral-110, 0.2);
+      box-shadow:
+        0 7px 14px 0 rgb(12 22 58 / 20%),
+        0 3px 6px 0 rgba($pix-neutral-110, 0.2);
     }
   }
 }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -37,7 +37,7 @@
   &__actions {
     text-align: initial;
 
-    .pix-button {
+    &__pix-button {
       margin: 0 auto ;
 
       &:first-child {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -35,13 +35,19 @@
   }
 
   &__actions {
+    text-align: initial;
+
     .pix-button {
-      margin: 0 auto;
+      margin: 0 auto ;
 
       &:first-child {
         margin-bottom: $pix-spacing-xs;
       }
     }
+  }
+
+  &__action-banner {
+    margin-top: $pix-spacing-s;
   }
 
   &__trainings {

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -2,32 +2,39 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import EmberObject from '@ember/object';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | Campaign | skill-review', function (hooks) {
   setupIntlRenderingTest(hooks);
+  let model;
 
-  test('it should display a list of competences and their scores', async function (assert) {
-    // given
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    this.owner.setupRouter();
+
     const competenceResults = [
-      {
+      store.createRecord('competence-result', {
         name: 'Faire des câlins',
         flashPixScore: 23,
         areaColor: 'jaffa',
-      },
-    ];
-    const model = {
-      campaign: EmberObject.create({
-        isFlash: true,
       }),
-      campaignParticipationResult: EmberObject.create({
+    ];
+    model = {
+      campaign: store.createRecord('campaign', {
+        isFlash: true,
+        code: 'CODECAMPAIGN',
+      }),
+      campaignParticipationResult: store.createRecord('campaign-participation-result', {
         id: 12345,
         flashPixScore: 122,
         competenceResults,
         campaignParticipationBadges: [],
       }),
     };
+  });
 
+  test('it should display a list of competences and their scores', async function (assert) {
+    // given
     this.set('model', model);
 
     // when
@@ -37,5 +44,63 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
     assert.dom(screen.getByText('Compétences testées')).exists();
     assert.dom(screen.getByRole('rowheader', { name: 'Faire des câlins' })).exists();
     assert.dom(screen.getByRole('cell', { name: '23 Pix' })).exists();
+  });
+
+  test('display retry button', async function (assert) {
+    model.campaignParticipationResult.set('canRetry', true);
+    model.campaignParticipationResult.set('isDisabled', false);
+    model.campaignParticipationResult.set('isShared', true);
+
+    this.set('model', model);
+
+    // when
+    const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+    const linkButton = screen.getByRole('link', { name: 'Repasser mon parcours' });
+    assert.dom(linkButton).exists();
+    assert.dom(linkButton).hasAttribute('href', '/campagnes/CODECAMPAIGN?retry=true');
+
+    assert.dom(screen.queryByRole('button', { name: 'Remettre à zéro et tout retenter' })).doesNotExist();
+  });
+
+  module('Reset button', function (hooks) {
+    hooks.beforeEach(function () {
+      model.campaignParticipationResult.set('canReset', true);
+      model.campaignParticipationResult.set('isDisabled', false);
+      model.campaignParticipationResult.set('isShared', true);
+
+      this.set('model', model);
+    });
+
+    test('display reset button', async function (assert) {
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.dom(screen.queryByRole('link', { name: 'Repasser mon parcours' })).doesNotExist();
+      assert.dom(screen.getByRole('button', { name: 'Remettre à zéro et tout retenter' })).exists();
+    });
+
+    test('open confirmation modal to reset skills', async function (assert) {
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      await click(screen.getByRole('button', { name: 'Remettre à zéro et tout retenter' }));
+
+      await screen.findByRole('dialog');
+
+      assert.dom(screen.getByRole('heading', { level: 1, name: 'Remettre à zéro et tout retenter' })).exists();
+      assert
+        .dom(
+          screen.getByText(
+            'Vos Pix, vos niveaux et votre certificabilité obtenus lors de ce parcours vont être supprimés.',
+          ),
+        )
+        .exists();
+
+      const linkButton = screen.getByRole('link', { name: 'Confirmer' });
+      assert.dom(linkButton).exists();
+      assert.dom(linkButton).hasAttribute('href', '/campagnes/CODECAMPAIGN?reset=true');
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+    });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -90,6 +90,31 @@ module('Unit | Route | Entrance', function (hooks) {
       assert.ok(true);
     });
 
+    test('should save another campaign participation when reset is allowed', async function (assert) {
+      // given
+      campaign = {
+        code: 'SOMECODE',
+        multipleSendings: true,
+      };
+
+      route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(true);
+      route.campaignStorage.get.withArgs(campaign.code, 'reset').returns(true);
+      route.currentUser.user.hasAssessmentParticipations = true;
+
+      // when
+      await route.afterModel(campaign);
+
+      // then
+      sinon.assert.calledWith(route.store.createRecord, 'campaign-participation', {
+        campaign,
+        isReset: true,
+        participantExternalId: undefined,
+      });
+      sinon.assert.called(campaignParticipationStub.save);
+      sinon.assert.notCalled(route.currentUser.load);
+      assert.ok(true);
+    });
+
     test('should resume and not create any new campaign participation when some is already existing', async function (assert) {
       //given
       campaign = EmberObject.create({

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1423,6 +1423,9 @@
         "button": "Retake my customised test",
         "message": "{organizationName} encourages you to retake your test to measure your progress."
       },
+      "reset": {
+        "button": "Reset"
+      },
       "send-results": "Don't forget to submit your results.",
       "send-status": {
         "in-progress": "Results are being shared..."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1423,10 +1423,10 @@
       "reset": {
         "button": "Reset and restart from the beginning",
         "modal": {
-          "text": "You are about to reset and restart your customized test <strong>{targetProfileName}</strong>, in order to improve your result. At the end of the customized test, you can resend your results.",
-          "warning-text": "Your Pix, levels and certifiability obtained during the customized test will be deleted."
+          "text": "You are about to reset and restart your customised test <strong>{targetProfileName}</strong>, in order to try to improve your results. At the end of this customised test, you can submit your results.",
+          "warning-text": "Your pix score, levels and eligibility for certification obtained during this customised test will be deleted."
         },
-        "notifications": "If you choose to retry the failed questions or reset and restart from the beginning, your organization will no longer be able to see your previously sent result. At the end of the campaign you will need to resend your results, so that it can be taken into account by the organizer."
+        "notifications": "If you choose to retry the failed questions or reset and restart from the beginning, your organisation will no longer be able to see your previously sent results. At the end of this customised test you will need to submit your results, so that it can be taken into account by the organiser."
       },
       "retry": {
         "button": "Retake my customised test",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -40,6 +40,7 @@
       "back": "Back",
       "cancel": "Cancel",
       "close": "Close",
+      "confirm": "Confirm",
       "quit": "Exit",
       "sign-out": "Sign out",
       "stay": "Stay",
@@ -1419,13 +1420,17 @@
       },
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
       "organization-message": "Message of your organization",
+      "reset": {
+        "button": "Reset and restart from the beginning",
+        "modal": {
+          "text": "You are about to reset and restart your customized test <strong>{targetProfileName}</strong>, in order to improve your result. At the end of the customized test, you can resend your results.",
+          "warning-text": "Your Pix, levels and certifiability obtained during the customized test will be deleted."
+        },
+        "notifications": "If you choose to retry the failed questions or reset and restart from the beginning, your organization will no longer be able to see your previously sent result. At the end of the campaign you will need to resend your results, so that it can be taken into account by the organizer."
+      },
       "retry": {
         "button": "Retake my customised test",
         "message": "{organizationName} encourages you to retake your test to measure your progress."
-      },
-      "reset": {
-        "button": "Reset",
-        "notifications": "waiting trad"
       },
       "send-results": "Don't forget to submit your results.",
       "send-status": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1424,7 +1424,8 @@
         "message": "{organizationName} encourages you to retake your test to measure your progress."
       },
       "reset": {
-        "button": "Reset"
+        "button": "Reset",
+        "notifications": "waiting trad"
       },
       "send-results": "Don't forget to submit your results.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -40,6 +40,7 @@
       "back": "Retour",
       "cancel": "Annuler",
       "close": "Fermer",
+      "confirm": "Confirmer",
       "quit": "Quitter",
       "sign-out": "Se déconnecter",
       "stay": "Rester",
@@ -1419,13 +1420,17 @@
       },
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "organization-message": "Message de votre organisation",
+      "reset": {
+        "button": "Remettre à zéro et tout retenter",
+        "modal": {
+          "text": "Vous êtes sur le point de remettre à zéro votre parcours <strong>{targetProfileName}</strong>, afin de tenter d’améliorer votre niveau. A la fin du parcours, vous pourrez à nouveau envoyer vos résultats.",
+          "warning-text": "Vos Pix, vos niveaux et votre certificabilité obtenus lors de ce parcours vont être supprimés."
+        },
+        "notifications": "Si vous retentez les questions échouées ou remettez à zéro pour tout retenter, votre organisation ne pourra plus voir votre dernier résultat. Pour que votre résultat soit comptabilisé par l'organisateur du test, vous devrez l'envoyer à nouveau."
+      },
       "retry": {
         "button": "Repasser mon parcours",
         "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser."
-      },
-      "reset": {
-        "button": "Remettre à zéro et tout retenter",
-        "notifications": "Si vous retentez les questions échouées ou remettez à zéro pour tout retenter, votre organisation ne pourra plus voir votre dernier résultat. Pour que votre résultat soit comptabilisé par l'organisateur du test, vous devrez l'envoyer à nouveau."
       },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1424,7 +1424,8 @@
         "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser."
       },
       "reset": {
-        "button": "Remettre à zéro et tout retenter"
+        "button": "Remettre à zéro et tout retenter",
+        "notifications": "Si vous retentez les questions échouées ou remettez à zéro pour tout retenter, votre organisation ne pourra plus voir votre dernier résultat. Pour que votre résultat soit comptabilisé par l'organisateur du test, vous devrez l'envoyer à nouveau."
       },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1423,6 +1423,9 @@
         "button": "Repasser mon parcours",
         "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser."
       },
+      "reset": {
+        "button": "Remettre à zéro et tout retenter"
+      },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {
         "in-progress": "Envoi en cours"


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre des Pix+Edu, en l'absence de card ne permettant pas de reset leur compétences il nous fallait un moyen de permettre aux utilisateurs de pouvoir repasser une campagne de 0.

## :robot: Proposition
Ajouter le bouton qui permet de faire l'appel au reset des sujets d'une campagnes

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter avec `prescription-sco@example.net` , cliquez sur j'ai un code `SCOMULTIP` . faire le campagne, Envoyer ces résultats, vérifier l'apparition des deux boutons `Repasser` et `Repasser et remettre à zéro`