### PR TITLE
[FEATURE] ETQ utilisateur Pix Orga, JV pouvoir filtrer sur les élèves n'ayant PAS de connexion MEDIACENTRE (PIX-8432)

### DIFF
--- a/api/db/seeds/data/team-acces/build-blocked-users.js
+++ b/api/db/seeds/data/team-acces/build-blocked-users.js
@@ -1,4 +1,4 @@
-import { DEFAULT_PASSWORD } from './constants.js';
+import { DEFAULT_PASSWORD } from '../../../constants.js';
 
 function _buildUserBeforeBeingBlocked(databaseBuilder) {
   const blockedUser = databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/db/seeds/data/team-acces/build-pix-admin-roles.js
+++ b/api/db/seeds/data/team-acces/build-pix-admin-roles.js
@@ -1,4 +1,4 @@
-import { DEFAULT_PASSWORD } from './constants.js';
+import { DEFAULT_PASSWORD } from '../../../constants.js';
 import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;

--- a/api/db/seeds/data/team-acces/build-sco-organization-learners.js
+++ b/api/db/seeds/data/team-acces/build-sco-organization-learners.js
@@ -1,0 +1,240 @@
+import { SCO_ORGANIZATION_ID } from './constants.js';
+import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
+import { DEFAULT_PASSWORD } from '../../../constants.js';
+
+export function buildScoOrganizationLearners(databaseBuilder) {
+  _buildScoOrganizationLearnerWithAllConnectionTypes(databaseBuilder);
+  _buildScoOrganizationLearnerWithUsernameAndMediacentre(databaseBuilder);
+  _buildScoOrganizationLearnerWithUsernameAndEmail(databaseBuilder);
+  _buildScoOrganizationLearnerWithEmailAndMediacentre(databaseBuilder);
+  _buildScoOrganizationLearnerWithEmail(databaseBuilder);
+  _buildScoOrganizationLearnerWithUsername(databaseBuilder);
+  _buildScoOrganizationLearnerWithMediacentre(databaseBuilder);
+  _buildScoOrganizationLearnersWithoutConnectionType(databaseBuilder);
+}
+
+function _buildScoOrganizationLearnerWithAllConnectionTypes(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Eliza',
+    lastName: 'Delajungle',
+    email: 'eliza-dlj@school.net',
+    username: 'eliza.delajungle.0101',
+  });
+
+  const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2011-01-01',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789ED',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+    userFirstName: organizationLearner.firstName,
+    userLastName: organizationLearner.lastName,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    externalIdentifier: 'externalED',
+    userId: user.id,
+  });
+}
+
+function _buildScoOrganizationLearnerWithUsernameAndMediacentre(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Bob',
+    lastName: 'Leponge',
+    email: null,
+    username: 'bob.leponge.0202',
+  });
+
+  const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2012-02-02',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789BL',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+    userFirstName: organizationLearner.firstName,
+    userLastName: organizationLearner.lastName,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    externalIdentifier: 'externalBL',
+    userId: user.id,
+  });
+}
+
+function _buildScoOrganizationLearnerWithUsernameAndEmail(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Naruto',
+    lastName: 'Uzumaki',
+    email: 'hokage@school.net',
+    username: 'naruto.uzumaki.0303',
+  });
+
+  const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2013-03-03',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789NU',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndPassword({
+    userFirstName: organizationLearner.firstName,
+    userLastName: organizationLearner.lastName,
+    password: DEFAULT_PASSWORD,
+    shouldChangePassword: false,
+    userId: user.id,
+  });
+}
+
+function _buildScoOrganizationLearnerWithEmailAndMediacentre(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Bart',
+    lastName: 'Simpson',
+    email: 'bart@school.net',
+    username: null,
+  });
+
+  const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2013-03-03',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789BS',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+    userFirstName: organizationLearner.firstName,
+    userLastName: organizationLearner.lastName,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    externalIdentifier: 'externalBS',
+    userId: user.id,
+  });
+}
+
+function _buildScoOrganizationLearnerWithEmail(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Hermione',
+    lastName: 'Granger',
+    email: 'hermione@school.net',
+    username: null,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2013-03-03',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789HG',
+  });
+}
+
+function _buildScoOrganizationLearnerWithUsername(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Kirua',
+    lastName: 'Zoldik',
+    email: null,
+    username: 'hunter.0202',
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2013-03-03',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789KZ',
+  });
+}
+
+function _buildScoOrganizationLearnerWithMediacentre(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Mikasa',
+    lastName: 'Ackerman',
+    email: null,
+    username: null,
+  });
+
+  const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: '2014-04-04',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: user.id,
+    nationalStudentId: '123456789MA',
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+    userFirstName: organizationLearner.firstName,
+    userLastName: organizationLearner.lastName,
+    identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    externalIdentifier: 'externalMA',
+    userId: user.id,
+  });
+}
+
+function _buildScoOrganizationLearnersWithoutConnectionType(databaseBuilder) {
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: 'Nico',
+    lastName: 'Robin',
+    birthdate: '2010-10-10',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: null,
+    nationalStudentId: '123456789NR',
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: 'Izuku',
+    lastName: 'Midoriya',
+    birthdate: '2012-12-12',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: null,
+    nationalStudentId: '123456789IZ',
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: 'Edward',
+    lastName: 'Elric',
+    birthdate: '2012-12-12',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: null,
+    nationalStudentId: '123456789EE',
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: 'Harry',
+    lastName: 'Potter',
+    birthdate: '2012-12-12',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: null,
+    nationalStudentId: '123456789HP',
+  });
+}

--- a/api/db/seeds/data/team-acces/build-sco-organizations.js
+++ b/api/db/seeds/data/team-acces/build-sco-organizations.js
@@ -2,6 +2,7 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/id
 import { PIX_PUBLIC_TARGET_PROFILE_ID, REAL_PIX_SUPER_ADMIN_ID } from '../common/common-builder.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { PIX_ORGA_ALL_ORGA_ID } from './build-organization-users.js';
+import { SCO_ORGANIZATION_ID } from './constants.js';
 
 export function buildScoOrganizations(databaseBuilder) {
   _buildCollegeTheNightWatchOrganization(databaseBuilder);
@@ -9,6 +10,7 @@ export function buildScoOrganizations(databaseBuilder) {
 
 function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
   const organization = databaseBuilder.factory.buildOrganization({
+    id: SCO_ORGANIZATION_ID,
     type: 'SCO',
     name: 'Collège House of The Dragon',
     isManagingStudents: true,
@@ -39,16 +41,5 @@ function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
     customLandingPageText: null,
     idPixLabel: null,
     createdAt: new Date('2023-07-27'),
-  });
-
-  databaseBuilder.factory.buildOrganizationLearner({
-    firstName: 'Bart',
-    lastName: 'Simpson',
-    birthdate: '2013-02-23',
-    division: '6B',
-    group: null,
-    organizationId: organization.id,
-    userId: null,
-    nationalStudentId: '123456789BS',
   });
 }

--- a/api/db/seeds/data/team-acces/build-temporary-blocked-user.js
+++ b/api/db/seeds/data/team-acces/build-temporary-blocked-user.js
@@ -1,4 +1,4 @@
-import { DEFAULT_PASSWORD } from './constants.js';
+import { DEFAULT_PASSWORD } from '../../../constants.js';
 
 function _buildUserBeforeBeingTemporarilyBlocked(databaseBuilder) {
   const temporaryBlockedUser = databaseBuilder.factory.buildUser.withRawPassword({

--- a/api/db/seeds/data/team-acces/constants.js
+++ b/api/db/seeds/data/team-acces/constants.js
@@ -1,3 +1,3 @@
-const DEFAULT_PASSWORD = 'pix123';
+const SCO_ORGANIZATION_ID = 2023;
 
-export { DEFAULT_PASSWORD };
+export { SCO_ORGANIZATION_ID };

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -4,6 +4,7 @@ import { buildScoOrganizations } from './build-sco-organizations.js';
 import { buildTemporaryBlockedUsers } from './build-temporary-blocked-user.js';
 import { buildUsers } from './build-users.js';
 import { buildOrganizationUsers } from './build-organization-users.js';
+import { buildScoOrganizationLearners } from './build-sco-organization-learners.js';
 
 async function teamAccesDataBuilder(databaseBuilder) {
   buildPixAdminRoles(databaseBuilder);
@@ -12,6 +13,7 @@ async function teamAccesDataBuilder(databaseBuilder) {
   buildTemporaryBlockedUsers(databaseBuilder);
   buildOrganizationUsers(databaseBuilder);
   buildScoOrganizations(databaseBuilder);
+  buildScoOrganizationLearners(databaseBuilder);
 }
 
 export { teamAccesDataBuilder };

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -39,6 +39,9 @@ function _setFilters(qb, { search, divisions, connectionTypes, certificability }
         // we only retrieve GAR authentication method in join clause
         this.orWhereRaw('"authentication-methods"."externalIdentifier" IS NOT NULL');
       }
+      if (connectionTypes.includes('without_mediacentre')) {
+        this.orWhereRaw('"authentication-methods"."externalIdentifier" IS NULL');
+      }
     });
   }
   if (certificability) {

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -305,6 +305,21 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           // then
           expect(lastName).to.equal('Norris');
         });
+
+        it('should return sco participants filtered by "without_mediacentre" user connexion', async function () {
+          // when
+          const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+            organizationId,
+            filter: { connectionTypes: ['without_mediacentre'] },
+          });
+
+          // then
+          expect(data.length).to.deep.equal(3);
+          expect(data[0].lastName).to.equal('Lee');
+          expect(data[1].lastName).to.equal('Rambo');
+          expect(data[2].lastName).to.equal('Willis');
+        });
+
         it('should return sco participants filtered by "none" & "mediacentre" user connexion', async function () {
           // when
           const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -50,6 +50,7 @@ export default class ScoList extends Component {
       { value: 'email', label: this.intl.t(CONNECTION_TYPES.email) },
       { value: 'identifiant', label: this.intl.t(CONNECTION_TYPES.identifiant) },
       { value: 'mediacentre', label: this.intl.t(CONNECTION_TYPES.mediacentre) },
+      { value: 'without_mediacentre', label: this.intl.t(CONNECTION_TYPES.without_mediacentre) },
     ];
   }
 

--- a/orga/app/helpers/connection-types.js
+++ b/orga/app/helpers/connection-types.js
@@ -4,4 +4,5 @@ export const CONNECTION_TYPES = {
   email: 'pages.sco-organization-participants.connection-types.email',
   identifiant: 'pages.sco-organization-participants.connection-types.identifiant',
   mediacentre: 'pages.sco-organization-participants.connection-types.mediacentre',
+  without_mediacentre: 'pages.sco-organization-participants.connection-types.without-mediacentre',
 };

--- a/orga/mirage/handlers/find-filtered-paginated-sco-organization-participants.js
+++ b/orga/mirage/handlers/find-filtered-paginated-sco-organization-participants.js
@@ -42,6 +42,8 @@ function _filtersFromQueryParams(schema, organizationId, queryParams) {
       if (connectionTypeFilter.includes('email') && scoOrganizationParticipant.hasEmail) return true;
       if (connectionTypeFilter.includes('mediacentre') && scoOrganizationParticipant.isAuthenticatedFromGar)
         return true;
+      if (connectionTypeFilter.includes('without_mediacentre') && !scoOrganizationParticipant.isAuthenticatedFromGar)
+        return true;
       return false;
     });
   }

--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -148,10 +148,61 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
               name: this.intl.t('pages.sco-organization-participants.connection-types.email'),
             }),
           );
+
           // then
           assert.strictEqual(currentURL(), '/eleves?connectionTypes=%5B%22email%22%5D');
           assert.contains('Rambo');
           assert.notContains('Norris');
+        });
+
+        module('when user select "Sans Mediacentre" in connection type filter', function () {
+          test('it displays a list of students without the "Mediacentre" connection type', async function (assert) {
+            // given
+            server.create('sco-organization-participant', {
+              organizationId,
+              firstName: 'Mikasa',
+              lastName: 'Ackerman',
+              email: 'mikasa@snk.net',
+              hasEmail: true,
+              isAuthenticatedFromGar: false,
+            });
+            server.create('sco-organization-participant', {
+              organizationId,
+              firstName: 'Eren',
+              lastName: 'Jager',
+              username: 'titan.0308',
+              hasUsername: true,
+              email: 'eren@symlink.net',
+              hasEmail: true,
+              isAuthenticatedFromGar: true,
+              isAssociated: true,
+            });
+            server.create('sco-organization-participant', {
+              organizationId,
+              firstName: 'Armin',
+              lastName: 'Arlett',
+              hasEmail: false,
+              hasUsername: false,
+              isAuthenticatedFromGar: true,
+            });
+
+            // when
+            const screen = await visit('/eleves');
+            await click(
+              screen.getByLabelText(this.intl.t('pages.sco-organization-participants.filter.login-method.aria-label')),
+            );
+            await click(
+              await screen.findByRole('checkbox', {
+                name: this.intl.t('pages.sco-organization-participants.connection-types.without-mediacentre'),
+              }),
+            );
+
+            // then
+            assert.strictEqual(currentURL(), '/eleves?connectionTypes=%5B%22without_mediacentre%22%5D');
+            assert.contains('Mikasa');
+            assert.notContains('Eren');
+            assert.notContains('Armin');
+          });
         });
 
         test('it should paginate the students list', async function (assert) {

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -238,6 +238,40 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
   });
 
+  module('filters', function () {
+    module('connection types', function () {
+      test('displays a list of options to filter the students', async function (assert) {
+        // given
+        this.set('students', []);
+        this.set('divisions', []);
+        this.set('connectionTypes', []);
+        this.set('certificability', []);
+        this.set('search', null);
+
+        const screen = await render(hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @searchFilter={{this.search}}
+  @divisionsFilter={{this.divisions}}
+  @connectionTypeFilter={{this.connectionTypes}}
+  @certificabilityFilter={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @onResetFilter={{this.noop}}
+/>`);
+
+        // when 
+        await click(screen.getByLabelText('Rechercher par méthode de connexion'));
+        await screen.findByRole('menu');
+
+        // then 
+        assert.dom(screen.getByRole('checkbox', { name: 'Aucune' })).exists();
+        assert.dom(screen.getByRole('checkbox', { name: 'Adresse e-mail' })).exists();
+        assert.dom(screen.getByRole('checkbox', { name: 'Identifiant' })).exists();
+        assert.dom(screen.getByRole('checkbox', { name: 'Mediacentre' })).exists();
+        assert.dom(screen.getByRole('checkbox', { name: 'Sans Mediacentre' })).exists();
+      });
+    });
+  });
   module('when user is filtering some users', function () {
     test('it should trigger filtering with search', async function (assert) {
       // given

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -259,11 +259,11 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @onResetFilter={{this.noop}}
 />`);
 
-        // when 
+        // when
         await click(screen.getByLabelText('Rechercher par méthode de connexion'));
         await screen.findByRole('menu');
 
-        // then 
+        // then
         assert.dom(screen.getByRole('checkbox', { name: 'Aucune' })).exists();
         assert.dom(screen.getByRole('checkbox', { name: 'Adresse e-mail' })).exists();
         assert.dom(screen.getByRole('checkbox', { name: 'Identifiant' })).exists();

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -920,7 +920,8 @@
         "empty": "–",
         "identifiant": "Username",
         "mediacentre": "Mediacentre",
-        "none": "None"
+        "none": "None",
+        "without-mediacentre": "Without Mediacentre"
       },
       "filter": {
         "title": "Filters",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -923,7 +923,8 @@
         "empty": "–",
         "identifiant": "Identifiant",
         "mediacentre": "Mediacentre",
-        "none": "Aucune"
+        "none": "Aucune",
+        "without-mediacentre": "Sans Mediacentre"
       },
       "filter": {
         "title": "Filtres",


### PR DESCRIPTION
## :unicorn: Problème
Si un professeur veut savoir quels élèves n’ont pas encore d’accès via Mediacentre, il n’a pas de moyen simple pour voir cette information. S’il clique sur "Identifiant", alors il va potentiellement avoir les **résultats des élèves qui ont identifiant ET Mediacentre.**   

## :robot: Proposition
Il faudrait ajouter la possibilité de lister les élèves qui ont une méthode de connexion mais qui n’est PAS MEDIACENTRE.

Ajouter une option dans la liste `Sans Mediacentre` à positionner en dernier.

## :rainbow: Remarques
De nouveaux seeds ont été ajoutés afin de tester la PR.

## :100: Pour tester
⚠️ En local, n'oubliez pas de faire un `USE_NEW_SEEDS=true npm run db:reset` pour voir les nouveaux seeds

1. Allez sur `Pix Orga` (domaine fr)
2. Connectez-vous avec l'utilisateur `allorga@example.net`
3. Sélectionnez le `Collège House of The Dragon (ACCES_SCO)`
4. Cliquez sur `Elèves`, vous devez voir une liste avec 11 élèves
5. Dans les filtres, cliquez sur `Méthodes de connexion` et choisissez `Sans Mediacentre`
6. Vous devez voir la **liste filtrée avec les élèves ne possédant pas de méthode de connexion Mediacentre** 


