### PR TITLE
[FEATURE] Afficher un toggle pour accéder aux deux profiles cibles d'une certification complémentaire (PIX-8811).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.js
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.js
@@ -2,6 +2,6 @@ import Component from '@glimmer/component';
 
 export default class BadgeList extends Component {
   get currentTargetProfileBadges() {
-    return this.args.currentTargetProfiles?.[0].badges;
+    return this.args.currentTargetProfile?.badges;
   }
 }

--- a/admin/app/components/complementary-certifications/target-profiles/information.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.hbs
@@ -6,16 +6,26 @@
     <span class="complementary-certification-details__target-profile">Profil cible actuel :
       <LinkTo
         @route="authenticated.target-profiles.target-profile"
-        @model={{this.currentTargetProfile.id}}
+        @model={{@currentTargetProfile.id}}
         class="complementary-certification-details-target-profile__link"
       >
-        {{this.currentTargetProfile.name}}
+        {{@currentTargetProfile.name}}
       </LinkTo>
     </span>
+    {{#if this.isMultipleCurrentTargetProfiles}}
+      <PixToggle
+        @label="Accéder aux détails des profils cibles courants"
+        @onLabel="Profil 1"
+        @offLabel="Profil 2"
+        @toggled={{this.isToggled}}
+        @onChange={{this.onChange}}
+        @screenReaderOnly={{true}}
+      />
+    {{/if}}
     <div class="complementary-certification-details-target-profile__attach-button">
       <PixButtonLink
         @route="authenticated.complementary-certifications.complementary-certification.attach-target-profile"
-        @model={{this.currentTargetProfile.id}}
+        @model={{@currentTargetProfile.id}}
       >Rattacher un nouveau profil cible
       </PixButtonLink>
     </div>

--- a/admin/app/components/complementary-certifications/target-profiles/information.js
+++ b/admin/app/components/complementary-certifications/target-profiles/information.js
@@ -1,7 +1,16 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class Information extends Component {
-  get currentTargetProfile() {
-    return this.args.complementaryCertification.targetProfilesHistory?.[0];
+  @tracked isToggled = true;
+
+  get isMultipleCurrentTargetProfiles() {
+    return this.args.complementaryCertification.currentTargetProfiles?.length > 1;
+  }
+
+  @action onChange() {
+    this.isToggled = !this.isToggled;
+    this.args.switchTargetProfile();
   }
 }

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/details.js
@@ -1,0 +1,20 @@
+import { action } from '@ember/object';
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class DetailsController extends Controller {
+  @tracked _targetProfileId;
+
+  get currentTargetProfile() {
+    return this.model.currentTargetProfiles?.find(({ id }) => id === this.targetProfileId);
+  }
+
+  get targetProfileId() {
+    return this._targetProfileId ?? this.model.currentTargetProfiles?.[0].id;
+  }
+
+  @action
+  switchTargetProfile() {
+    this._targetProfileId = this.model.currentTargetProfiles?.find(({ id }) => id !== this.targetProfileId).id;
+  }
+}

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
@@ -3,7 +3,11 @@
 <ComplementaryCertifications::TargetProfiles::Header @complementaryCertificationLabel={{@model.label}} />
 
 <main class="page-body">
-  <ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{@model}} />
-  <ComplementaryCertifications::TargetProfiles::BadgesList @currentTargetProfiles={{@model.currentTargetProfiles}} />
+  <ComplementaryCertifications::TargetProfiles::Information
+    @complementaryCertification={{@model}}
+    @currentTargetProfile={{this.currentTargetProfile}}
+    @switchTargetProfile={{this.switchTargetProfile}}
+  />
+  <ComplementaryCertifications::TargetProfiles::BadgesList @currentTargetProfile={{this.currentTargetProfile}} />
   <ComplementaryCertifications::TargetProfiles::History @targetProfilesHistory={{@model.targetProfilesHistory}} />
 </main>

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -23,11 +23,11 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::B
         },
       ],
     });
-    this.currentTargetProfiles = complementaryCertification.currentTargetProfiles;
+    this.currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
 
     // when
     const screen = await render(
-      hbs`<ComplementaryCertifications::TargetProfiles::BadgesList @currentTargetProfiles={{this.currentTargetProfiles}} />`,
+      hbs`<ComplementaryCertifications::TargetProfiles::BadgesList @currentTargetProfile={{this.currentTargetProfile}} />`,
     );
 
     // then

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/information_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/information_test.js
@@ -13,10 +13,11 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::I
       label: 'MARIANNE CERTIF',
       targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
     });
+    this.currentTargetProfile = this.complementaryCertification.currentTargetProfiles[0];
 
     // when
     const screen = await render(
-      hbs`<ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{this.complementaryCertification}} />`,
+      hbs`<ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{this.complementaryCertification}} @currentTargetProfile={{this.currentTargetProfile}}/>`,
     );
 
     // then
@@ -24,5 +25,50 @@ module('Integration | Component | ComplementaryCertifications::TargetProfiles::I
     assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
     assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
     assert.dom(screen.getByText('MARIANNE CERTIF')).exists();
+  });
+
+  module('when there is multiple current target profiles', function () {
+    test('it should display the target profile toggle', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.complementaryCertification = store.createRecord('complementary-certification', {
+        label: 'MARIANNE CERTIF',
+        targetProfilesHistory: [
+          { name: 'ALEX TARGET', id: 3 },
+          { name: 'JUDE TARGET', id: 4 },
+        ],
+      });
+      this.currentTargetProfile = this.complementaryCertification.currentTargetProfiles[0];
+
+      // when
+      const screen = await render(
+        hbs`<ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{this.complementaryCertification}} @currentTargetProfile={{this.currentTargetProfile}}/>`,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Accéder aux détails des profils cibles courants' })).exists();
+    });
+  });
+
+  module('when there is only one current target profile', function () {
+    test('it should not display the target profile toggle', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.complementaryCertification = store.createRecord('complementary-certification', {
+        label: 'MARIANNE CERTIF',
+        targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
+      });
+      this.currentTargetProfile = this.complementaryCertification.currentTargetProfiles[0];
+
+      // when
+      const screen = await render(
+        hbs`<ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{this.complementaryCertification}} @currentTargetProfile={{this.currentTargetProfile}}/>`,
+      );
+
+      // then
+      assert
+        .dom(screen.queryByRole('button', { name: 'Accéder aux détails des profils cibles courants' }))
+        .doesNotExist();
+    });
   });
 });

--- a/admin/tests/unit/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/unit/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -10,10 +10,7 @@ module('Unit | Component | complementary-certifications/target-profiles/badges-l
     const component = createGlimmerComponent('component:complementary-certifications/target-profiles/badges-list');
 
     component.args = {
-      currentTargetProfiles: [
-        { id: 1, name: 'current target', badges: [{ id: 1, level: 2, label: 'badge Pluie' }] },
-        { id: 2, name: 'old target', badges: [] },
-      ],
+      currentTargetProfile: { id: 1, name: 'current target', badges: [{ id: 1, level: 2, label: 'badge Pluie' }] },
     };
 
     // when & then

--- a/admin/tests/unit/components/complementary-certifications/target-profiles/information_test.js
+++ b/admin/tests/unit/components/complementary-certifications/target-profiles/information_test.js
@@ -1,24 +1,88 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
 
 module('Unit | Component | complementary-certifications/target-profiles/information', function (hooks) {
   setupTest(hooks);
 
-  test('it should display current target profile', async function (assert) {
-    // given
-    const component = createGlimmerComponent('component:complementary-certifications/target-profiles/information');
+  module('#isMultipleCurrentTargetProfiles', function () {
+    module('when there is multiple current target profiles', function () {
+      test('it should return true', async function (assert) {
+        // given
+        const component = createGlimmerComponent('component:complementary-certifications/target-profiles/information');
 
-    component.args = {
-      complementaryCertification: {
-        targetProfilesHistory: [
-          { id: 1, name: 'current target' },
-          { id: 2, name: 'old target' },
-        ],
-      },
-    };
+        component.args = {
+          complementaryCertification: {
+            currentTargetProfiles: [
+              { id: 1, name: 'current target' },
+              { id: 2, name: 'another current target' },
+            ],
+          },
+        };
 
-    // when & then
-    assert.deepEqual(component.currentTargetProfile, { id: 1, name: 'current target' });
+        // when & then
+        assert.true(component.isMultipleCurrentTargetProfiles);
+      });
+    });
+
+    module('when there is only one current target profiles', function () {
+      test('it should return false', async function (assert) {
+        // given
+        const component = createGlimmerComponent('component:complementary-certifications/target-profiles/information');
+
+        component.args = {
+          complementaryCertification: {
+            currentTargetProfiles: [{ id: 1, name: 'current target' }],
+          },
+        };
+
+        // when & then
+        assert.false(component.isMultipleCurrentTargetProfiles);
+      });
+    });
+
+    module('when there is no current target profiles', function () {
+      test('it should return false', async function (assert) {
+        // given
+        const component = createGlimmerComponent('component:complementary-certifications/target-profiles/information');
+
+        component.args = {
+          complementaryCertification: {
+            currentTargetProfiles: [],
+          },
+        };
+
+        // when & then
+        assert.false(component.isMultipleCurrentTargetProfiles);
+      });
+    });
+  });
+
+  module('#onChange', function () {
+    test('it should call switchTargetProfile method', async function (assert) {
+      // given
+      const component = createGlimmerComponent('component:complementary-certifications/target-profiles/information');
+
+      component.args = {
+        complementaryCertification: {
+          currentTargetProfiles: [
+            { id: 1, name: 'current target' },
+            { id: 2, name: 'another current target' },
+          ],
+        },
+        switchTargetProfile: sinon.stub(),
+      };
+
+      // when & then
+      assert.true(component.isToggled);
+
+      // when
+      component.onChange();
+
+      // then
+      assert.false(component.isToggled);
+      sinon.assert.called(component.args.switchTargetProfile);
+    });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | authenticated/complementary-centerifications/complementary-certification/details',
+  function (hooks) {
+    setupTest(hooks);
+
+    let controller;
+
+    hooks.beforeEach(function () {
+      controller = this.owner.lookup(
+        'controller:authenticated/complementary-certifications/complementary-certification/details',
+      );
+    });
+
+    module('#targetProfileId', function () {
+      module('when _targetProfileId is not defined', function () {
+        test('it should return the first current target profile id', function (assert) {
+          // given
+          controller.model = { currentTargetProfiles: [{ id: 55 }, { id: 66 }] };
+          controller._targetProfileId = undefined;
+
+          // when
+          const id = controller.targetProfileId;
+
+          // then
+          assert.strictEqual(id, 55);
+        });
+      });
+
+      module('when _targetProfileId is defined', function () {
+        test('it should return the current selected target profile id', function (assert) {
+          // given
+          controller.model = { currentTargetProfiles: [{ id: 55 }, { id: 66 }] };
+          controller._targetProfileId = 66;
+
+          // when
+          const id = controller.targetProfileId;
+
+          // then
+          assert.strictEqual(id, 66);
+        });
+      });
+    });
+
+    module('#currentTargetProfile', function () {
+      test('it should return the selected target profile', function (assert) {
+        // given
+        controller.model = { currentTargetProfiles: [{ id: 55 }, { id: 66 }] };
+        controller._targetProfileId = 66;
+
+        // when
+        const targetProfile = controller.currentTargetProfile;
+
+        // then
+        assert.deepEqual(targetProfile, { id: 66 });
+      });
+    });
+
+    module('#switchTargetProfile', function () {
+      test('it should return the selected target profile', function (assert) {
+        // given
+        controller.model = { currentTargetProfiles: [{ id: 55 }, { id: 66 }] };
+        controller._targetProfileId = 55;
+
+        // when
+        controller.switchTargetProfile();
+
+        // then
+        assert.strictEqual(controller.targetProfileId, 66);
+      });
+    });
+  },
+);


### PR DESCRIPTION
## :unicorn: Problème
On peut avoir plusieurs profil cibles rattachés à une certification complémentaires. Il n'est pour le moment pas possible d'en gérer une en particulier

## :robot: Proposition
Afficher un toggle pour accéder/sélectionner deux profiles cibles d'une certification complémentaire

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur pix-admin
Aller sur la page de la certification complémentaire pix+ Edu 1er degrés
Constater qu'il y a un toggle
Constater que lorsque l'on clique sur le toggle, le profil cible sélectionné est mis à jour

