### PR TITLE
[FEATURE] Améliorer l'accessibilité des formulaires sur Pix-App (PIX-8077)

### DIFF
--- a/mon-pix/app/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item-qcm.hbs
@@ -1,8 +1,8 @@
 <form {{on "submit" this.validateAnswer}}>
 
-  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+  <fieldset class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
     <h2 class="sr-only">{{t "pages.challenge.parts.answer-input"}}</h2>
-    <p class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcm"}}</p>
+    <legend class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcm"}}</legend>
     <div class="challenge-proposals">
       <QcmProposals
         @answer={{@answer}}
@@ -30,7 +30,7 @@
         />
       </div>
     {{/if}}
-  </div>
+  </fieldset>
 
   {{#if this.errorMessage}}
     <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>

--- a/mon-pix/app/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item-qcu.hbs
@@ -1,8 +1,8 @@
 <form {{on "submit" this.validateAnswer}}>
 
-  <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+  <fieldset class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
     <h2 class="sr-only">{{t "pages.challenge.parts.answer-input"}}</h2>
-    <p class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcu"}}</p>
+    <legend class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcu"}}</legend>
     <div class="challenge-proposals">
       <QcuProposals
         @answer={{@answer}}
@@ -30,7 +30,7 @@
         />
       </div>
     {{/if}}
-  </div>
+  </fieldset>
 
   {{#if this.errorMessage}}
     <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -12,6 +12,8 @@
 .challenge-response {
   @extend %pix-body-m;
 
+  display: flex;
+  flex-direction: column;
   margin: 4px;
   background-color: $pix-neutral-10;
 
@@ -98,6 +100,7 @@ form .challenge-response {
   .challenge-response__instructions {
     @extend %pix-body-s;
 
+    float: left;
     margin-top: 0;
     color: $pix-neutral-60;
 


### PR DESCRIPTION
## :unicorn: Problème
D'après l'audit, nos formulaires d'épreuves QCU et QCM doivent être regroupés dans un élément `fieldset`.

## :robot: Proposition
Remplacer le block par un élément `fieldset` et ajouter un élément `legend`.

## :rainbow: Remarques
Il faut également faire le travail pour le QCROm-dep à l'avenir mais cela demande un travail de refacto supplémentaire 

## :100: Pour tester
Aller sur une épreuve QCU et QCM et vérifier la présence d'un élément `fieldset` et `legend`.
- https://app-pr6824.review.pix.fr/challenges/recLt9uwa2dR3IYpi/preview
- https://app-pr6824.review.pix.fr/challenges/recT0Ks2EDgoDgEKc/preview
