### PR TITLE
[FEATURE] Publication en masse des sessions V3 (PIX-8313).

### DIFF
--- a/admin/app/routes/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/routes/authenticated/sessions/list/to-be-published.js
@@ -5,8 +5,23 @@ import { service } from '@ember/service';
 export default class AuthenticatedSessionsListToBePublishedRoute extends Route {
   @service store;
 
-  model() {
-    return this.store.query('to-be-published-session', {});
+  queryParams = {
+    version: { refreshModel: true },
+  };
+
+  model(_, transition) {
+    if (transition.to.queryParams.version === '3') {
+      return this.store.query('to-be-published-session', {
+        filter: {
+          version: 3,
+        },
+      });
+    }
+    return this.store.query('to-be-published-session', {
+      filter: {
+        version: 2,
+      },
+    });
   }
 
   @action

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -7,7 +7,7 @@
     <LinkTo @route="authenticated.sessions.list.with-required-action" @query={{hash version=2}} class="navbar-item">
       Sessions à traiter ({{this.sessionsWithRequiredActionCount}})
     </LinkTo>
-    <LinkTo @route="authenticated.sessions.list.to-be-published" class="navbar-item">
+    <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=2}} class="navbar-item">
       Sessions à publier
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
@@ -18,7 +18,10 @@
       @query={{hash version=3}}
       class="navbar-item navbar-item--right"
     >
-      Sessions à traiter nextgen ({{this.sessionsWithRequiredActionCountVersion3}})
+      Sessions à traiter V3 ({{this.sessionsWithRequiredActionCountVersion3}})
+    </LinkTo>
+    <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=3}} class="navbar-item">
+      Sessions à publier V3
     </LinkTo>
   </nav>
 </header>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -39,6 +39,7 @@ import {
 } from './handlers/trainings';
 import { findFrameworkAreas } from './handlers/frameworks';
 import { getWithRequiredActionSessions } from './handlers/get-with-required-action-sessions';
+import { getToBePublishedSessions } from './handlers/get-to-be-published-sessions';
 
 export default function makeServer(config) {
   const finalConfig = {
@@ -84,14 +85,7 @@ function routes() {
   this.put('/admin/admin-members/:id/deactivate', () => {});
 
   this.get('/admin/sessions', findPaginatedAndFilteredSessions);
-  this.get('/admin/sessions/to-publish', (schema) => {
-    const toBePublishedSessions = schema.toBePublishedSessions.all();
-    return toBePublishedSessions;
-  });
-  this.get('/admin/sessions/to-publish', (schema) => {
-    const toBePublishedSessions = schema.toBePublishedSessions.all();
-    return toBePublishedSessions;
-  });
+  this.get('/admin/sessions/to-publish', getToBePublishedSessions);
   this.get('/admin/sessions/with-required-action', getWithRequiredActionSessions);
   this.patch('/admin/sessions/:id/publish', () => {
     return new Response(204);

--- a/admin/mirage/handlers/get-to-be-published-sessions.js
+++ b/admin/mirage/handlers/get-to-be-published-sessions.js
@@ -1,0 +1,6 @@
+export function getToBePublishedSessions(schema, request) {
+  const queryParams = request.queryParams;
+  const toBePublishedSessions = schema.toBePublishedSessions.all();
+
+  return toBePublishedSessions.filter((session) => `${session.version}` === queryParams['filter[version]']);
+}

--- a/admin/tests/unit/routes/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/to-be-published_test.js
@@ -16,24 +16,66 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function (h
   });
 
   module('#model', function () {
-    test('it should fetch the list of sessions to be published', async function (assert) {
-      // given
-      const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');
-      const toBePublishedSessions = [
-        {
-          certificationCenterName: 'Centre SCO des Anne-Solo',
-          finalizedAt: '2020-04-15T15:00:34.000Z',
-        },
-      ];
-      const queryStub = sinon.stub();
-      queryStub.withArgs('to-be-published-session', {}).resolves(toBePublishedSessions);
-      store.query = queryStub;
+    module('when filtering on V2 sessions', function () {
+      test('it should fetch the list of sessions to be published', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');
+        const v2Sessions = [
+          {
+            certificationCenterName: 'Centre SCO des Anne-Solo',
+            finalizedAt: '2020-04-15T15:00:34.000Z',
+          },
+        ];
+        const queryStub = sinon.stub();
+        const _ = sinon.stub();
+        const transition = {
+          to: {
+            queryParams: {
+              version: '2',
+            },
+          },
+        };
 
-      // when
-      const result = await route.model();
+        queryStub.withArgs('to-be-published-session', { filter: { version: 2 } }).resolves(v2Sessions);
+        store.query = queryStub;
 
-      // then
-      assert.deepEqual(result, toBePublishedSessions);
+        // when
+        const result = await route.model(_, transition);
+        // then
+
+        assert.deepEqual(result, v2Sessions);
+      });
+    });
+
+    module('when filtering on V3 sessions', function () {
+      test('it should fetch the list of sessions to be published', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');
+        const v3Sessions = [
+          {
+            certificationCenterName: 'Centre V3',
+            finalizedAt: '2020-08-20T18:00:00.000Z',
+          },
+        ];
+        const queryStub = sinon.stub();
+        const _ = sinon.stub();
+        const transition = {
+          to: {
+            queryParams: {
+              version: '3',
+            },
+          },
+        };
+
+        queryStub.withArgs('to-be-published-session', { filter: { version: 3 } }).resolves(v3Sessions);
+        store.query = queryStub;
+
+        // when
+        const result = await route.model(_, transition);
+        // then
+
+        assert.deepEqual(result, v3Sessions);
+      });
     });
   });
 });

--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -4,7 +4,8 @@ import * as withRequiredActionSessionSerializer from '../../infrastructure/seria
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 
 const findFinalizedSessionsToPublish = async function (request, h, dependencies = { toBePublishedSessionSerializer }) {
-  const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
+  const { filter } = extractParameters(request.query);
+  const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish(filter);
   return dependencies.toBePublishedSessionSerializer.serialize(finalizedSessionsToPublish);
 };
 

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -86,6 +86,11 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/admin/sessions/to-publish',
       config: {
+        validate: {
+          query: Joi.object({
+            'filter[version]': Joi.number(),
+          }),
+        },
         pre: [
           {
             method: (request, h) =>

--- a/api/lib/domain/usecases/find-finalized-sessions-to-publish.js
+++ b/api/lib/domain/usecases/find-finalized-sessions-to-publish.js
@@ -1,5 +1,5 @@
-const findFinalizedSessionsToPublish = function ({ finalizedSessionRepository }) {
-  return finalizedSessionRepository.findFinalizedSessionsToPublish();
+const findFinalizedSessionsToPublish = function ({ finalizedSessionRepository, version }) {
+  return finalizedSessionRepository.findFinalizedSessionsToPublish({ version });
 };
 
 export { findFinalizedSessionsToPublish };

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | finalized-session-controller-find-finalized-
       };
 
       databaseBuilder.factory.buildSession({ id: 121 });
-      databaseBuilder.factory.buildSession({ id: 333 });
+      databaseBuilder.factory.buildSession({ id: 333, version: 3 });
       databaseBuilder.factory.buildSession({ id: 323 });
       databaseBuilder.factory.buildSession({ id: 423 });
 
@@ -48,6 +48,20 @@ describe('Acceptance | Controller | finalized-session-controller-find-finalized-
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.have.lengthOf(2);
         expect(response.result.data[0].type).to.equal('to-be-published-sessions');
+      });
+
+      context('When requesting only version 3', function () {
+        it('should return a 200 status code response with JSON API serialized', async function () {
+          options.url = '/api/admin/sessions/to-publish?filter[version]=3';
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.data).to.have.lengthOf(1);
+          expect(response.result.data[0].type).to.equal('to-be-published-sessions');
+        });
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
@@ -135,20 +135,29 @@ describe('Integration | Repository | Finalized-session', function () {
     context('when there are publishable sessions', function () {
       it('finds a list of publishable finalized session order by finalization date', async function () {
         // given
+        const session1 = databaseBuilder.factory.buildSession();
+        const session2 = databaseBuilder.factory.buildSession();
+        const session3 = databaseBuilder.factory.buildSession({ version: 3 });
+        const session4 = databaseBuilder.factory.buildSession();
+        const session5 = databaseBuilder.factory.buildSession();
+        const session6 = databaseBuilder.factory.buildSession({ version: 3 });
         const publishableFinalizedSession1 = databaseBuilder.factory.buildFinalizedSession({
           isPublishable: true,
           publishedAt: null,
           finalizedAt: new Date('2020-01-01'),
+          sessionId: session1.id,
         });
         const publishableFinalizedSession2 = databaseBuilder.factory.buildFinalizedSession({
           isPublishable: true,
           publishedAt: null,
           finalizedAt: new Date('2019-01-01'),
+          sessionId: session2.id,
         });
         const publishableFinalizedSession3 = databaseBuilder.factory.buildFinalizedSession({
           isPublishable: true,
           publishedAt: null,
           finalizedAt: new Date('2021-01-01'),
+          sessionId: session3.id,
         });
 
         databaseBuilder.factory.buildFinalizedSession({
@@ -156,9 +165,18 @@ describe('Integration | Repository | Finalized-session', function () {
           publishedAt: null,
           finalizedAt: new Date('2020-01-01'),
           assignedCertificationOfficerName: 'Ruppert Giles',
+          sessionId: session4.id,
         });
-        databaseBuilder.factory.buildFinalizedSession({ isPublishable: false, publishedAt: null });
-        databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: '2021-01-01' });
+        databaseBuilder.factory.buildFinalizedSession({
+          isPublishable: false,
+          publishedAt: null,
+          sessionId: session5.id,
+        });
+        databaseBuilder.factory.buildFinalizedSession({
+          isPublishable: true,
+          publishedAt: '2021-01-01',
+          sessionId: session6.id,
+        });
 
         await databaseBuilder.commit();
 

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -39,6 +39,43 @@ describe('Unit | Controller | finalized-session', function () {
         // then
         expect(response).to.deep.equal(serializedFinalizedSessions);
       });
+
+      context('When filtering on publishable version number', function () {
+        it('should find finalized publishable sessions', async function () {
+          // given
+          const version = 3;
+          request = {
+            payload: {},
+            query: {
+              'filter[version]': version,
+            },
+            auth: {
+              credentials: {
+                userId,
+              },
+            },
+          };
+
+          const foundFinalizedSessions = Symbol('foundSession');
+          usecases.findFinalizedSessionsToPublish.withArgs({ version }).resolves(foundFinalizedSessions);
+
+          const toBePublishedSessionSerializer = {
+            serialize: sinon.stub(),
+          };
+          const serializedFinalizedSessions = Symbol('serializedSession');
+          toBePublishedSessionSerializer.serialize
+            .withArgs(foundFinalizedSessions)
+            .resolves(serializedFinalizedSessions);
+
+          // when
+          const response = await finalizedSessionController.findFinalizedSessionsToPublish(request, hFake, {
+            toBePublishedSessionSerializer,
+          });
+
+          // then
+          expect(response).to.deep.equal(serializedFinalizedSessions);
+        });
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-finalized-sessions-to-publish_test.js
+++ b/api/tests/unit/domain/usecases/find-finalized-sessions-to-publish_test.js
@@ -39,4 +39,25 @@ describe('Unit | UseCase | findFinalizedSessionsToPublish', function () {
       expect(result).to.deep.equal([]);
     });
   });
+
+  context('when filtering on a specific version', function () {
+    it('should get a list of publishable sessions', async function () {
+      // given
+      const finalizedSessionRepository = {
+        findFinalizedSessionsToPublish: sinon.stub(),
+      };
+
+      const v3PublishableSession = {
+        ...domainBuilder.buildFinalizedSession({ isPublishable: true, publishedAt: null }),
+        version: 3,
+      };
+
+      finalizedSessionRepository.findFinalizedSessionsToPublish.withArgs({ version: 3 }).resolves(v3PublishableSession);
+      // when
+      const result = await findFinalizedSessionsToPublish({ finalizedSessionRepository, version: 3 });
+
+      // then
+      expect(result).to.deep.equal(v3PublishableSession);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Une phase pilote pour la certification nextGen va être organisée auprès de quelques centres sélectionnés. Lors de cette phase, le pôle certif et d’autres personnes chez Pix vont souhaiter observer les résultats/déroulé etc avant la publication des sessions nextGen, même celles qui ne nécessitent pas d’action manuelle du pôle certif.

⚠️ En ajoutant les certif nextGen à la liste des sessions à publier, elles vont se perdre dans un amas de sessions et être publiées sans qu’on ait le temps de jeter un oeil.

## :robot: Proposition

Séparer la publication en masse des sessions actuelles vs. celle des sessions nextGen. 
Dans Pix Admin > menu “Sessions de certification” : ajouter un onglet “Sessions à publier v3”
Onglet à placer APRES l’onglet “Toutes les sessions” (voir maquette)
Liste des sessions v3 “SANS problème” = qui ne nécessitent pas d’intervention manuelle du pôle certif
Bouton “Publier toutes les sessions v3” : permet de publier toutes les sessions nextGen de la liste en one shot
Pour chaque session, un bouton “Publier” : permet de publier une session unique dans cette liste
Même design que la liste des sessions à publier actuelle

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Dans pix certif, créer une session pour un centre taggué comme pilote nextGen
Inscrire un candidat à cette certif
Sur pix-app, rejoindre cette session et lancer le test de certification
Répondre à la dernière question du test (avec bouton magique ? ou tout passer c’est OK ce qui compte étant que la certif soit terminée)
Finaliser la session avec AUCUN signalement
Dans pix admin, cliquer sur le menu “Sessions de certification”
Résultat : un nouvel onglet “Sessions à publier v3” est affiché
Cliquer sur l’onglet 
Résultat : la session finalisée préalablement est affichée dans cette liste
Cliquer sur le bouton “Publier toutes les sessions v3”
Résultats : 
- la session passe au statut “Résultats transmis par Pix”
- le certificat “dans sa version actuelle” est visible sur le compte app du candidat
