### PR TITLE
[FEATURE] Ajouter une tâche asynchrone pour calculer la certificabilité pour un prescrit (PIX-8791)

### DIFF
--- a/api/lib/domain/models/OrganizationLearner.js
+++ b/api/lib/domain/models/OrganizationLearner.js
@@ -24,6 +24,8 @@ class OrganizationLearner {
     updatedAt,
     userId,
     organizationId,
+    isCertifiable,
+    certifiableAt,
   } = {}) {
     this.id = id;
     this.lastName = lastName;
@@ -45,6 +47,8 @@ class OrganizationLearner {
     this.updatedAt = updatedAt;
     this.userId = userId;
     this.organizationId = organizationId;
+    this.isCertifiable = isCertifiable;
+    this.certifiableAt = certifiableAt;
   }
 }
 

--- a/api/lib/domain/models/OrganizationLearner.js
+++ b/api/lib/domain/models/OrganizationLearner.js
@@ -50,6 +50,16 @@ class OrganizationLearner {
     this.isCertifiable = isCertifiable;
     this.certifiableAt = certifiableAt;
   }
+
+  updateCertificability(placementProfile) {
+    if (placementProfile.isCertifiable()) {
+      this.certifiableAt = placementProfile.profileDate;
+    } else {
+      this.certifiableAt = null;
+    }
+
+    this.isCertifiable = placementProfile.isCertifiable();
+  }
 }
 
 OrganizationLearner.STATUS = STATUS;

--- a/api/lib/domain/usecases/compute-organization-learner-certificability.js
+++ b/api/lib/domain/usecases/compute-organization-learner-certificability.js
@@ -1,0 +1,18 @@
+const computeOrganizationLearnerCertificability = async function ({
+  organizationLearnerId,
+  organizationLearnerRepository,
+  placementProfileService,
+}) {
+  const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
+
+  const placementProfile = await placementProfileService.getPlacementProfile({
+    userId: organizationLearner.userId,
+    limitDate: new Date().toISOString(),
+  });
+
+  await organizationLearner.updateCertificability(placementProfile);
+
+  await organizationLearnerRepository.updateCertificability(organizationLearner);
+};
+
+export { computeOrganizationLearnerCertificability };

--- a/api/lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJob.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJob.js
@@ -1,0 +1,9 @@
+import { JobPgBoss } from '../JobPgBoss.js';
+
+class ComputeCertificabilityJob extends JobPgBoss {
+  constructor(queryBuilder) {
+    super({ name: 'ComputeCertificabilityJob', retryLimit: 0 }, queryBuilder);
+  }
+}
+
+export { ComputeCertificabilityJob };

--- a/api/lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js
@@ -1,0 +1,16 @@
+import { ComputeCertificabilityJob } from './ComputeCertificabilityJob.js';
+import { usecases } from '../../../domain/usecases/index.js';
+
+class ComputeCertificabilityJobHandler {
+  async handle(event) {
+    const { organizationLearnerId } = event;
+
+    await usecases.computeOrganizationLearnerCertificability({ organizationLearnerId });
+  }
+
+  get name() {
+    return ComputeCertificabilityJob.name;
+  }
+}
+
+export { ComputeCertificabilityJobHandler };

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -351,7 +351,7 @@ const isActive = async function ({ userId, campaignId }) {
 async function updateCertificability(organizationLearner) {
   await knex('organization-learners').where({ id: organizationLearner.id }).update({
     isCertifiable: organizationLearner.isCertifiable,
-    certifiableAt: knex.fn.now(),
+    certifiableAt: organizationLearner.certifiableAt,
   });
 }
 

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -348,6 +348,13 @@ const isActive = async function ({ userId, campaignId }) {
   return !learner?.isDisabled;
 };
 
+async function updateCertificability(organizationLearner) {
+  await knex('organization-learners').where({ id: organizationLearner.id }).update({
+    isCertifiable: organizationLearner.isCertifiable,
+    certifiableAt: knex.fn.now(),
+  });
+}
+
 export {
   findByIds,
   findByOrganizationId,
@@ -368,4 +375,5 @@ export {
   getLatestOrganizationLearner,
   updateUserIdWhereNull,
   isActive,
+  updateCertificability,
 };

--- a/api/tests/integration/domain/services/organization-learners-csv-service_test.js
+++ b/api/tests/integration/domain/services/organization-learners-csv-service_test.js
@@ -56,7 +56,7 @@ describe('Integration | Services | organization-learners-csv-service', function 
 
       //then
       const actualResult = _.map(results, (result) =>
-        _.omit(result, ['id', 'organizationId', 'userId', 'updatedAt', 'isDisabled']),
+        _.omit(result, ['id', 'organizationId', 'userId', 'updatedAt', 'isDisabled', 'isCertifiable', 'certifiableAt']),
       );
       expect(actualResult).to.deep.equal(expectedOrganizationLearners);
     });

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2069,6 +2069,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
       // when
       organizationLearner.isCertifiable = true;
+      organizationLearner.certifiableAt = new Date('2023-01-01');
       await organizationLearnerRepository.updateCertificability(organizationLearner);
 
       // then
@@ -2076,7 +2077,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         .where({ id: organizationLearner.id })
         .first();
       expect(isCertifiable).to.be.true;
-      expect(certifiableAt).to.exists;
+      expect(new Date(certifiableAt)).to.deep.equal(organizationLearner.certifiableAt);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2059,4 +2059,24 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       expect(isActive).to.be.true;
     });
   });
+  describe('#updateCertificability', function () {
+    it('should update isCertifiable and certifiableAt', async function () {
+      // given
+      const organizationLearner = new OrganizationLearner(
+        databaseBuilder.factory.buildOrganizationLearner({ isCertifiable: null, certifiableAt: null }),
+      );
+      await databaseBuilder.commit();
+
+      // when
+      organizationLearner.isCertifiable = true;
+      await organizationLearnerRepository.updateCertificability(organizationLearner);
+
+      // then
+      const { isCertifiable, certifiableAt } = await knex('organization-learners')
+        .where({ id: organizationLearner.id })
+        .first();
+      expect(isCertifiable).to.be.true;
+      expect(certifiableAt).to.exists;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/unit/domain/models/OrganizationLearner_test.js
@@ -1,0 +1,47 @@
+import { expect, domainBuilder } from '../../../test-helper.js';
+import { OrganizationLearner, PlacementProfile } from '../../../../lib/domain/models/index.js';
+import { MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY } from '../../../../lib/domain/constants.js';
+import range from 'lodash/range.js';
+
+describe('Unit | Domain | Models | OrganizationLearner', function () {
+  describe('#updateCertificability', function () {
+    it('should update certificability', function () {
+      // given
+      const certifiableDate = new Date('2023-01-01');
+      const organizationLearner = new OrganizationLearner({ isCertifiable: false });
+      const userCompetences = range(MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY).map(() =>
+        domainBuilder.buildUserCompetence({ estimatedLevel: 1 }),
+      );
+      const placementProfile = new PlacementProfile({
+        userId: organizationLearner.userId,
+        profileDate: certifiableDate,
+        userCompetences,
+      });
+
+      // when
+      organizationLearner.updateCertificability(placementProfile);
+
+      //then
+      expect(organizationLearner.isCertifiable).to.be.true;
+      expect(new Date(organizationLearner.certifiableAt)).to.deep.equal(placementProfile.profileDate);
+    });
+
+    it('should not update certifiableAt if not certifiable', function () {
+      // given
+      const profileDate = new Date('2023-01-01');
+      const organizationLearner = new OrganizationLearner({ isCertifiable: false });
+      const placementProfile = new PlacementProfile({
+        userId: organizationLearner.userId,
+        profileDate: profileDate,
+        userCompetences: [],
+      });
+
+      // when
+      organizationLearner.updateCertificability(placementProfile);
+
+      //then
+      expect(organizationLearner.isCertifiable).to.be.false;
+      expect(organizationLearner.certifiableAt).to.be.null;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/compute-organization-learner-certificability_test.js
+++ b/api/tests/unit/domain/usecases/compute-organization-learner-certificability_test.js
@@ -1,0 +1,47 @@
+import { expect, sinon, domainBuilder } from '../../../test-helper.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | UseCase | compute-organization-learner-certificabilty', function () {
+  let clock;
+
+  beforeEach(async function () {
+    clock = sinon.useFakeTimers({
+      now: Date.now(),
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+  it('should update certificability for an organization learner', async function () {
+    // given
+    const organizationLearnerRepository = {
+      get: sinon.stub(),
+      updateCertificability: sinon.stub(),
+    };
+    const organizationLearnerId = 1;
+    const organizationLearner = domainBuilder.buildOrganizationLearner({ id: organizationLearnerId });
+    sinon.stub(organizationLearner, 'updateCertificability');
+    organizationLearnerRepository.get.withArgs(organizationLearner.id).returns(organizationLearner);
+    const placementProfileService = {
+      getPlacementProfile: sinon.stub(),
+    };
+
+    const placementProfile = domainBuilder.buildPlacementProfile({ userId: organizationLearner.userId });
+    placementProfileService.getPlacementProfile
+      .withArgs({ userId: organizationLearner.userId, limitDate: new Date().toISOString() })
+      .returns(placementProfile);
+
+    // when
+    await usecases.computeOrganizationLearnerCertificability({
+      organizationLearnerId,
+      organizationLearnerRepository,
+      placementProfileService,
+    });
+
+    // then
+    expect(organizationLearner.updateCertificability).to.have.been.calledWith(placementProfile);
+    expect(organizationLearnerRepository.updateCertificability).to.have.been.calledWith(organizationLearner);
+  });
+});

--- a/api/worker.js
+++ b/api/worker.js
@@ -10,6 +10,8 @@ import { ParticipationResultCalculationJob } from './lib/infrastructure/jobs/cam
 import { SendSharedParticipationResultsToPoleEmploiJob } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
 import { ParticipationResultCalculationJobHandler } from './lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js';
 import { SendSharedParticipationResultsToPoleEmploiHandler } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler.js';
+import { ComputeCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJob.js';
+import { ComputeCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js';
 import { scheduleCpfJobs } from './lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js';
 import { MonitoredJobQueue } from './lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js';
 import * as url from 'url';
@@ -44,6 +46,7 @@ async function runJobs() {
   });
 
   monitoredJobQueue.performJob(ParticipationResultCalculationJob.name, ParticipationResultCalculationJobHandler);
+  monitoredJobQueue.performJob(ComputeCertificabilityJob.name, ComputeCertificabilityJobHandler);
   monitoredJobQueue.performJob(
     SendSharedParticipationResultsToPoleEmploiJob.name,
     SendSharedParticipationResultsToPoleEmploiHandler,


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix de mise à jour de la certificabilité en automatique, nous avons besoin de calculer la certificabilité d'un prescrit et stocké l'information.

## :robot: Proposition
Dans cette PR, nous ajoutons un job qui sera traité par le worker PGBoss qui s'occupe de calculer la certificabilité d'un prescrit et stocké l'information sur la table organization-learners.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
En local : 
- Lancer le worker : npm run start:job
- Insérer une dans la table jobs de PGBoss { name: "ComputeCertificabilityJob", data: "{\"organizationLearnerId\": 100728}", on_complete: true }
- Constater que le job est bien pris en charge pas le worker et vérifier en base de données que le colonne isCertifiable et certifiableAt pour ce prescrit ont bien été mis à jour
