### PR TITLE
 [TECH] Création d'une migration pour mettre à jour view-active-organization-learner (PIX-8850)

### DIFF
--- a/api/db/database-builder/factory/build-organization-learner.js
+++ b/api/db/database-builder/factory/build-organization-learner.js
@@ -33,6 +33,8 @@ const buildOrganizationLearner = function ({
   userId,
   deletedBy = null,
   deletedAt = null,
+  isCertifiable = null,
+  certifiableAt = null,
 } = {}) {
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -67,6 +69,8 @@ const buildOrganizationLearner = function ({
     userId,
     deletedBy,
     deletedAt,
+    isCertifiable,
+    certifiableAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20230807122533_refresh-view-active-organization-learner.js
+++ b/api/db/migrations/20230807122533_refresh-view-active-organization-learner.js
@@ -1,0 +1,23 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const VIEW_NAME = 'view-active-organization-learners';
+const REFERENCE_TABLE_NAME = 'organization-learners';
+
+const up = async function (knex) {
+  await knex.schema.createViewOrReplace(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME).whereNull('deletedAt'));
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropView(VIEW_NAME);
+};
+
+export { up, down };

--- a/api/lib/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository.js
@@ -10,10 +10,10 @@ function _buildIsCertifiable(queryBuilder, organizationLearnerId) {
     .select(
       'view-active-organization-learners.id as organizationLearnerId',
       knex.raw(
-        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
+        'FIRST_VALUE("campaign-participations"."isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
       ),
       knex.raw(
-        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
+        'FIRST_VALUE("campaign-participations"."sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
       ),
     )
     .from('view-active-organization-learners')

--- a/api/lib/infrastructure/repositories/organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/organization-participant-repository.js
@@ -122,10 +122,10 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
     .select([
       'view-active-organization-learners.id as organizationLearnerId',
       knex.raw(
-        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
+        'FIRST_VALUE("campaign-participations"."isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
       ),
       knex.raw(
-        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
+        'FIRST_VALUE("campaign-participations"."sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
       ),
     ])
     .from('view-active-organization-learners')

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -60,10 +60,10 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
     .select([
       'view-active-organization-learners.id as organizationLearnerId',
       knex.raw(
-        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
+        'FIRST_VALUE("campaign-participations"."isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
       ),
       knex.raw(
-        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
+        'FIRST_VALUE("campaign-participations"."sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
       ),
     ])
     .from('view-active-organization-learners')

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -39,10 +39,10 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
     .select([
       'view-active-organization-learners.id as organizationLearnerId',
       knex.raw(
-        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
+        'FIRST_VALUE("campaign-participations"."isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
       ),
       knex.raw(
-        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
+        'FIRST_VALUE("campaign-participations"."sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
       ),
     ])
     .from('view-active-organization-learners')

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -788,9 +788,9 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
           organizationId,
         });
         expect(actualOrganizationLearners).to.have.length(1);
-        expect(_.omit(actualOrganizationLearners[0], ['updatedAt', 'id'])).to.deep.equal(
-          _.omit(firstOrganizationLearner, ['updatedAt', 'id']),
-        );
+        expect(
+          _.omit(actualOrganizationLearners[0], ['updatedAt', 'id', 'certifiableAt', 'isCertifiable']),
+        ).to.deep.equal(_.omit(firstOrganizationLearner, ['updatedAt', 'id', 'certifiableAt', 'isCertifiable']));
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-organization-learner.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-learner.js
@@ -22,6 +22,8 @@ function buildOrganizationLearner({
   userId,
   isDisabled = false,
   updatedAt = new Date('2020-01-01'),
+  certifiableAt = null,
+  isCertifiable = null,
 } = {}) {
   return new OrganizationLearner({
     id,
@@ -44,6 +46,8 @@ function buildOrganizationLearner({
     userId,
     isDisabled,
     organizationId: organization.id,
+    certifiableAt,
+    isCertifiable,
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à cette [PR](https://github.com/1024pix/pix/pull/6789), les colonnes `isCertifiable` et `CertifiableAt` ont été ajoutées à la table "organization-learners". Cependant, la vue `view-active-organization-learner`, qui se base dessus, ne se met pas à jour automatiquement.

## :robot: Proposition
Création d'une nouvelle migration pour mettre à jour la vue `view-active-organization-learner`.

## :rainbow: Remarques
Comme ce n'est pas une materializedView nous ne pouvons pas faire un refresh et avons besoin d'utiliser la méthode [`knex.createViewOrReplace`](https://knexjs.org/guide/schema-builder.html#createvieworreplace)

## :100: Pour tester
- Lancer les migrations
- Vérifier que les colonnes `isCertifiable` et `CertifiableAt` sont présentes sur la vue `view-active-organization-learner`
- 🎉 🐱 