### PR TITLE
[BUGFIX] afficher seulement les RT acquis et valides dans le bloc skill-review-share (PIX-8682).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.hbs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.hbs
@@ -1,0 +1,21 @@
+{{#if this.showBadgeIcons}}
+  <ul class="skill-review-share__badge-icons">
+    {{#each this.badgesToShow as |badge|}}
+      <li>
+        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
+          <:triggerElement>
+            <a href="#{{badge.title}}">
+              <img
+                aria-labelledby="tooltip-certifiable-{{badge.key}}"
+                class="skill-review-share-badge-icons__image"
+                src="{{badge.imageUrl}}"
+                alt="{{badge.altMessage}}"
+              />
+            </a>
+          </:triggerElement>
+          <:tooltip>{{badge.title}}</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/each}}
+  </ul>
+{{/if}}

--- a/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.js
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class SkillReviewCompetenceStagesResult extends Component {
+  get badgesToShow() {
+    return this.args.badges.filter((badge) => badge.isAcquired && badge.isValid);
+  }
+
+  get showBadgeIcons() {
+    return this.badgesToShow.length > 0;
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -105,46 +105,9 @@
                   @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
                   @isFlashCampaign={{this.isFlashCampaign}}
                 />
-                <div class="skill-review-share__badge-icons">
-                  {{#if this.showValidBadges}}
-                    <div class="skill-review-share-badge-icons skill-review-share-badge-icons--certifiable">
-                      {{#each this.validBadges as |badge|}}
-                        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
-                          <:triggerElement>
-                            <a href="#{{badge.title}}">
-                              <img
-                                aria-labelledby="tooltip-certifiable-{{badge.key}}"
-                                class="skill-review-share-badge-icons__image"
-                                src="{{badge.imageUrl}}"
-                                alt="{{badge.altMessage}}"
-                              />
-                            </a>
-                          </:triggerElement>
-                          <:tooltip>{{badge.title}}</:tooltip>
-                        </PixTooltip>
-                      {{/each}}
-                    </div>
-                  {{/if}}
-                  {{#if this.showNotCertifiableBadges}}
-                    <div class="skill-review-share-badge-icons skill-review-share-badge-icons--not-certifiable">
-                      {{#each this.notCertifiableBadges as |badge|}}
-                        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-{{badge.key}}">
-                          <:triggerElement>
-                            <a href="#{{badge.title}}">
-                              <img
-                                aria-labelledby="tooltip-{{badge.key}}"
-                                class="skill-review-share-badge-icons__image"
-                                src="{{badge.imageUrl}}"
-                                alt="{{badge.altMessage}}"
-                              />
-                            </a>
-                          </:triggerElement>
-                          <:tooltip>{{badge.title}}</:tooltip>
-                        </PixTooltip>
-                      {{/each}}
-                    </div>
-                  {{/if}}
-                </div>
+                <Campaigns::Assessment::SkillReview::ShareBadgeIcons
+                  @badges={{@model.campaignParticipationResult.campaignParticipationBadges}}
+                />
               {{/if}}
             {{/if}}
           </div>

--- a/mon-pix/tests/integration/components/campaign/skill-review/share-badge-icons_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review/share-badge-icons_test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import EmberObject from '@ember/object';
+
+const possibleBadgesCombinations = [
+  { id: 1, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+  { id: 2, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+  { id: 3, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+  { id: 4, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+  { id: 5, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+  { id: 6, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+  { id: 7, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+  { id: 8, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+  { id: 9, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+  { id: 10, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+  { id: 11, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+  { id: 12, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+  { id: 13, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+  { id: 14, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+  { id: 15, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+  { id: 16, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+];
+
+module('Integration | Component | Campaign | Skill Review | share-badge-icons', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a list of competences and their scores', async function (assert) {
+    // given
+    const model = {
+      campaignParticipationResult: EmberObject.create({ campaignParticipationBadges: possibleBadgesCombinations }),
+    };
+
+    this.set('model', model);
+
+    // when
+    const screen = await render(hbs`
+        <Campaigns::Assessment::SkillReview::ShareBadgeIcons
+          @badges={{this.model.campaignParticipationResult.campaignParticipationBadges}}
+        />
+      `);
+
+    // then
+    assert.strictEqual(screen.getAllByRole('listitem').length, 4);
+  });
+
+  test('it should not display the component', async function (assert) {
+    // given
+    const noAcquiredBadges = possibleBadgesCombinations.filter((badge) => !badge.isAcquired);
+
+    const model = {
+      campaignParticipationResult: EmberObject.create({ campaignParticipationBadges: noAcquiredBadges }),
+    };
+
+    this.set('model', model);
+
+    // when
+    const screen = await render(hbs`
+        <Campaigns::Assessment::SkillReview::ShareBadgeIcons
+          @badges={{this.model.campaignParticipationResult.campaignParticipationBadges}}
+        />
+      `);
+
+    // then
+    assert.strictEqual(screen.queryByRole('list'), null);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Les RT non obtenus s’affichent sous “J’envoie mes résultats” dans la page de résultat de campagne. 

## :robot: Proposition

Découper le fichier `skill-review.hbs` et créer un composant dédié à l'affichage de ces RT : `components/campaigns/assessment/skill-review/share-badge-icons.hbs`

## :rainbow: Remarques

Il faudrait continuer à découper le fichier `skill-review.hbs` car il est toujours trop gros.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
