### PR TITLE
[BUGFIX] afficher seulement les RT acquis et valides dans le bloc skill-review-share (PIX-8682).

### DIFF
--- a/api/db/seeds/data/common/tooling/index.js
+++ b/api/db/seeds/data/common/tooling/index.js
@@ -1,9 +1,10 @@
 import * as campaign from './campaign-tooling.js';
-import * as session from './session-tooling.js';
+import * as certificationCenter from './certification-center-tooling.js';
+import * as learningContent from './learning-content.js';
+import * as organization from './organization-tooling.js';
 import * as profile from './profile-tooling.js';
+import * as session from './session-tooling.js';
 import * as targetProfile from './target-profile-tooling.js';
 import * as training from './training-tooling.js';
-import * as organization from './organization-tooling.js';
-import * as certificationCenter from './certification-center-tooling.js';
 
-export { campaign, certificationCenter, organization, session, targetProfile, training, profile };
+export { campaign, certificationCenter, learningContent, organization, profile, session, targetProfile, training };

--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -1,4 +1,5 @@
 import * as tooling from '../common/tooling/index.js';
+import evalCampaignWithBadgesUser from './users/eval-campaign-with-badges.js';
 
 const TEAM_EVALUATION_OFFSET_ID = 1000000;
 /// USERS
@@ -17,6 +18,9 @@ export async function teamEvaluationDataBuilder({ databaseBuilder }) {
   createScoOrganization(databaseBuilder);
   await createCoreTargetProfile(databaseBuilder);
   await createAssessmentCampaign(databaseBuilder);
+
+  // Other users
+  await evalCampaignWithBadgesUser(TEAM_EVALUATION_OFFSET_ID, databaseBuilder);
 }
 
 function createScoOrganization(databaseBuilder) {

--- a/api/db/seeds/data/team-evaluation/users/eval-campaign-with-badges.js
+++ b/api/db/seeds/data/team-evaluation/users/eval-campaign-with-badges.js
@@ -1,0 +1,296 @@
+import * as tooling from '../../common/tooling/index.js';
+import dayjs from 'dayjs';
+
+export default async function initUser(teamOffset, databaseBuilder) {
+  const TEAM_OFFSET = teamOffset;
+  const ALL_PURPOSE_ID = teamOffset + 1;
+
+  /**
+   * User configuration
+   */
+  // 1. Build user
+  const user = databaseBuilder.factory.buildUser.withRawPassword({
+    id: ALL_PURPOSE_ID,
+    firstName: 'User campaign with badges',
+    lastName: 'Team Eval',
+    email: 'eval-campaign-with-badges@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+
+  // 2. Link user to organization
+  databaseBuilder.factory.buildMembership({
+    userId: user.id,
+    organizationId: TEAM_OFFSET,
+    organizationRole: 'ADMIN',
+  });
+
+  // 3. Transform it into an organization learner
+  const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+    userId: user.id,
+    organizationId: TEAM_OFFSET,
+  });
+
+  /**
+   * Target-profile configuration
+   */
+  // 1. Build target-profile
+  const { targetProfileId, cappedTubesDTO } = await tooling.targetProfile.createTargetProfile({
+    databaseBuilder,
+    targetProfileId: ALL_PURPOSE_ID,
+    name: 'Profil cible paliers et RT acquis',
+    isPublic: true,
+    ownerOrganizationId: TEAM_OFFSET,
+    isSimplifiedAccess: false,
+    description: 'Profil cible avec des paliers par niveaux et avec des RT acquis, certifiables et en lacune',
+    configTargetProfile: {
+      frameworks: [
+        {
+          chooseCoreFramework: true,
+          countTubes: 10,
+          minLevel: 5,
+          maxLevel: 6,
+        },
+      ],
+    },
+  });
+
+  // 2. Build target-profile badges
+  const commonBadgesProps = {
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+  };
+
+  const badgesToCreate = [
+    // Acquired + Not certifiable
+    {
+      altMessage: '1 RT non-certifiable, acquis et valide',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Droit- Pret-certif_Bronze--Initie.svg',
+      message: '1 RT non-certifiable, acquis et valide',
+      title: '1 RT non-certifiable, acquis et valide',
+      isCertifiable: false,
+      isAlwaysVisible: false,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 0,
+          },
+        ],
+      },
+    },
+    {
+      altMessage: '1 RT non-certifiable, acquis, valide et en lacune',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-Initie-PREMIER-DEGRE.svg',
+      message: '1 RT non-certifiable, acquis, valide et en lacune',
+      title: '1 RT non-certifiable, acquis, valide et en lacune',
+      isCertifiable: false,
+      isAlwaysVisible: true,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 10,
+          },
+        ],
+      },
+    },
+    // Acquired + Certifiables
+    {
+      altMessage: '1 RT certifiable, acquis et valide',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+      message: '1 RT certifiable, acquis et valide',
+      title: '1 RT certifiable, acquis et valide',
+      isCertifiable: true,
+      isAlwaysVisible: false,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 0,
+          },
+        ],
+      },
+    },
+    {
+      altMessage: '1 RT certifiable, acquis, valide et en lacune',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
+      message: '1 RT certifiable, acquis, valide et en lacune',
+      title: '1 RT certifiable, acquis, valide et en lacune',
+      isCertifiable: true,
+      isAlwaysVisible: true,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 10,
+          },
+        ],
+      },
+    },
+    // Not-acquired + Always visible (displayed)
+    {
+      altMessage: '1 RT certifiable, non-acquis et en lacune',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
+      message: '1 RT certifiable, non-acquis et en lacune',
+      title: '1 RT certifiable, non-acquis et en lacune',
+      isCertifiable: true,
+      isAlwaysVisible: true,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 100,
+          },
+        ],
+      },
+    },
+    {
+      altMessage: '1 RT non-certifiable, non-acquis et en lacune',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme.svg',
+      message: '1 RT non-certifiable, non-acquis et en lacune',
+      title: '1 RT non-certifiable, non-acquis et en lacune',
+      isCertifiable: false,
+      isAlwaysVisible: true,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 100,
+          },
+        ],
+      },
+    },
+    // Not-acquired + Not always visible (not displayed)
+    {
+      altMessage: '1 RT certifiable, non-acquis et pas en lacune',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
+      message: '1 RT certifiable, non-acquis et pas en lacune',
+      title: '1 RT certifiable, non-acquis et pas en lacune',
+      isCertifiable: true,
+      isAlwaysVisible: false,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 100,
+          },
+        ],
+      },
+    },
+    {
+      altMessage: '1 RT non-certifiable, non-acquis et pas en lacune',
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme.svg',
+      message: '1 RT non-certifiable, non-acquis et pas en lacune',
+      title: '1 RT non-certifiable, non-acquis et pas en lacune',
+      isCertifiable: false,
+      isAlwaysVisible: false,
+      configBadge: {
+        criteria: [
+          {
+            scope: 'CampaignParticipation',
+            threshold: 100,
+          },
+        ],
+      },
+    },
+  ];
+  const buildedBadges = [];
+  let badgeIndex = 0;
+
+  for await (const badge of badgesToCreate) {
+    const newBadge = await tooling.targetProfile.createBadge({
+      ...commonBadgesProps,
+      badgeId: ALL_PURPOSE_ID + badgeIndex,
+      key: `SOME_KEY_FOR_RT_${ALL_PURPOSE_ID + badgeIndex}`,
+      ...badge,
+    });
+
+    buildedBadges.push(newBadge);
+
+    badgeIndex++;
+  }
+
+  /**
+   * Campaign-participation configuration
+   */
+  // 1. Build campaign with a specific campaign code
+  const campaign = await tooling.campaign.createAssessmentCampaign({
+    databaseBuilder,
+    organizationId: TEAM_OFFSET,
+    ownerId: TEAM_OFFSET,
+    name: "Campagne d'évaluation SCO - envoi simple",
+    code: 'EVALBADGE',
+    targetProfileId: targetProfileId,
+    idPixLabel: null,
+    configCampaign: { participantCount: 0 },
+  });
+
+  // 2. Build campaign-participation
+  const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+    campaignId: campaign.campaignId,
+    userId: user.id,
+    organizationLearnerId: organizationLearner.id,
+    masteryRate: 0.5,
+    pixScore: 500,
+    validatedSkillsCount: 5,
+    isCertifiable: true,
+    status: 'SHARED',
+  });
+
+  // 3. Build wanted badges acquisitions
+  const acquiredBadges = badgesToCreate.filter((badge) => badge.configBadge.criteria[0].threshold < 100);
+
+  for (const badge of buildedBadges.slice(0, acquiredBadges.length)) {
+    databaseBuilder.factory.buildBadgeAcquisition({
+      badgeId: badge.badgeId,
+      userId: user.id,
+      campaignParticipationId: campaignParticipation.id,
+    });
+  }
+
+  /**
+   * Assesment-result configuration
+   */
+  // 1. Build assessment
+  const assessment = await databaseBuilder.factory.buildAssessment({
+    userId: user.id,
+    type: 'CAMPAIGN',
+    campaignParticipationId: campaignParticipation.id,
+  });
+
+  // 2. Build assessment result
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId: assessment.id,
+  });
+
+  /**
+   * Knowledge elements configuration
+   * (we need some acquired KEs to have valid badges)
+   */
+  const answersAndKEFromAdvancedProfile = await tooling.profile.getAnswersAndKnowledgeElementsForAdvancedProfile();
+
+  for (const { answerData, keData } of answersAndKEFromAdvancedProfile) {
+    const answer = databaseBuilder.factory.buildAnswer({
+      assessmentId: assessment.id,
+      answerData,
+    });
+
+    databaseBuilder.factory.buildKnowledgeElement({
+      assessmentId: assessment.id,
+      answerId: answer.id,
+      userId: user.id,
+      ...keData,
+      createdAt: dayjs().subtract(1, 'day'),
+    });
+  }
+}

--- a/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.hbs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.hbs
@@ -1,0 +1,27 @@
+{{#if this.showBadgeIcons}}
+  <ul class="skill-review-share__badge-icons">
+    {{#each this.acquiredAndValidBadges as |badge|}}
+      <li
+        class={{if
+          badge.isCertifiable
+          "skill-review-share-badge-icons__item--certifiable"
+          "skill-review-share-badge-icons__item--not-certifiable"
+        }}
+      >
+        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
+          <:triggerElement>
+            <a href="#{{badge.title}}">
+              <img
+                aria-labelledby="tooltip-certifiable-{{badge.key}}"
+                class="skill-review-share-badge-icons__image"
+                src="{{badge.imageUrl}}"
+                alt="{{badge.altMessage}}"
+              />
+            </a>
+          </:triggerElement>
+          <:tooltip>{{badge.title}}</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/each}}
+  </ul>
+{{/if}}

--- a/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.js
+++ b/mon-pix/app/components/campaigns/assessment/skill-review/share-badge-icons.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+
+export default class SkillReviewCompetenceStagesResult extends Component {
+  get acquiredAndValidBadges() {
+    const acquiredAndValidBadges = this.args.badges.filter((badge) => badge.isAcquired && badge.isValid);
+    const badgesCertifiableFirst = acquiredAndValidBadges.sort((a) => {
+      return a.isCertifiable ? -1 : 1;
+    });
+    return badgesCertifiableFirst;
+  }
+
+  get showBadgeIcons() {
+    return this.acquiredAndValidBadges.length > 0;
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -105,46 +105,9 @@
                   @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
                   @isFlashCampaign={{this.isFlashCampaign}}
                 />
-                <div class="skill-review-share__badge-icons">
-                  {{#if this.showValidBadges}}
-                    <div class="skill-review-share-badge-icons skill-review-share-badge-icons--certifiable">
-                      {{#each this.validBadges as |badge|}}
-                        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
-                          <:triggerElement>
-                            <a href="#{{badge.title}}">
-                              <img
-                                aria-labelledby="tooltip-certifiable-{{badge.key}}"
-                                class="skill-review-share-badge-icons__image"
-                                src="{{badge.imageUrl}}"
-                                alt="{{badge.altMessage}}"
-                              />
-                            </a>
-                          </:triggerElement>
-                          <:tooltip>{{badge.title}}</:tooltip>
-                        </PixTooltip>
-                      {{/each}}
-                    </div>
-                  {{/if}}
-                  {{#if this.showNotCertifiableBadges}}
-                    <div class="skill-review-share-badge-icons skill-review-share-badge-icons--not-certifiable">
-                      {{#each this.notCertifiableBadges as |badge|}}
-                        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-{{badge.key}}">
-                          <:triggerElement>
-                            <a href="#{{badge.title}}">
-                              <img
-                                aria-labelledby="tooltip-{{badge.key}}"
-                                class="skill-review-share-badge-icons__image"
-                                src="{{badge.imageUrl}}"
-                                alt="{{badge.altMessage}}"
-                              />
-                            </a>
-                          </:triggerElement>
-                          <:tooltip>{{badge.title}}</:tooltip>
-                        </PixTooltip>
-                      {{/each}}
-                    </div>
-                  {{/if}}
-                </div>
+                <Campaigns::Assessment::SkillReview::ShareBadgeIcons
+                  @badges={{@model.campaignParticipationResult.campaignParticipationBadges}}
+                />
               {{/if}}
             {{/if}}
           </div>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -108,6 +108,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/communication-banner';
 @import 'components/pix-toggle';
 @import 'components/skip-link';
+@import 'components/campaigns/assessment/skill-review/share-badge-icons';
 
 /* pages */
 @import 'pages/assessment-results';

--- a/mon-pix/app/styles/components/campaigns/assessment/skill-review/share-badge-icons.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/skill-review/share-badge-icons.scss
@@ -1,0 +1,56 @@
+.skill-review-share__badge-icons {
+  display: flex;
+}
+
+/*
+ * BADGES ITEMS
+ */
+[class*='skill-review-share-badge-icons__item'] {
+  position: relative;
+  padding: $pix-spacing-xs;
+  border-radius: 1rem;
+
+  & > * {
+    z-index: 1;
+  }
+
+  &::before {
+    position: absolute;
+    top: 0;
+    right: calc(100% - 1rem);
+    z-index: 0;
+    width: 2rem;
+    height: 100%;
+    content: '';
+  }
+}
+
+// Certifiable badge item
+.skill-review-share-badge-icons__item--certifiable {
+  background-color: $pix-success-5;
+
+  & + .skill-review-share-badge-icons__item--certifiable::before {
+    background-color: $pix-success-5;
+  }
+}
+
+// Not certifiable badge item
+.skill-review-share-badge-icons__item--not-certifiable {
+  background-color: $pix-neutral-10;
+
+  & + .skill-review-share-badge-icons__item--not-certifiable::before {
+    background-color: $pix-neutral-10;
+  }
+}
+
+.skill-review-share-badge-icons__item--certifiable + .skill-review-share-badge-icons__item--not-certifiable {
+  margin-left: $pix-spacing-xs;
+}
+
+/*
+ * ICON IMAGE
+ */
+.skill-review-share-badge-icons__image {
+  display: block;
+  width: 3rem;
+}

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -565,51 +565,12 @@
     text-align: center;
   }
 
-  &__badge-icons {
-    display: flex;
-    flex-basis: 100%;
-    flex-direction: column;
-    height: 89px;
-
-    @include device-is('tablet') {
-      flex-direction: row;
-    }
-  }
-
   &__button {
     max-width: fit-content;
     margin: 0 auto;
 
     @include device-is('tablet') {
       margin: 0;
-    }
-  }
-}
-
-.skill-review-share-badge-icons {
-  display: flex;
-  justify-content: center;
-  border-radius: 16px;
-
-  &__image {
-    max-width: 50px;
-    margin: 8px 0 8px 10px;
-
-    &:last-child {
-      margin-right: 10px;
-    }
-  }
-
-  &--certifiable {
-    background-color: $pix-success-5;
-  }
-
-  &--not-certifiable {
-    margin: 16px 0 0;
-    background-color: $pix-neutral-10;
-
-    @include device-is('tablet') {
-      margin: 0 0 0 16px;
     }
   }
 }

--- a/mon-pix/tests/integration/components/campaign/skill-review/share-badge-icons_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review/share-badge-icons_test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import EmberObject from '@ember/object';
+
+const possibleBadgesCombinations = [
+  { id: 1, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+  { id: 2, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+  { id: 3, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+  { id: 4, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+  { id: 5, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+  { id: 6, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+  { id: 7, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+  { id: 8, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+  { id: 9, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+  { id: 10, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+  { id: 11, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+  { id: 12, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+  { id: 13, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+  { id: 14, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+  { id: 15, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+  { id: 16, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+];
+
+module('Integration | Component | Campaign | Skill Review | share-badge-icons', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a list of competences and their scores', async function (assert) {
+    // given
+    const model = {
+      campaignParticipationResult: EmberObject.create({ campaignParticipationBadges: possibleBadgesCombinations }),
+    };
+
+    this.set('model', model);
+
+    // when
+    const screen = await render(hbs`
+        <Campaigns::Assessment::SkillReview::ShareBadgeIcons
+          @badges={{this.model.campaignParticipationResult.campaignParticipationBadges}}
+        />
+      `);
+
+    // then
+    assert.strictEqual(screen.getAllByRole('listitem').length, 4);
+  });
+
+  test('it should not display the component', async function (assert) {
+    // given
+    const noAcquiredBadges = possibleBadgesCombinations.filter((badge) => !badge.isAcquired);
+
+    const model = {
+      campaignParticipationResult: EmberObject.create({ campaignParticipationBadges: noAcquiredBadges }),
+    };
+
+    this.set('model', model);
+
+    // when
+    const screen = await render(hbs`
+        <Campaigns::Assessment::SkillReview::ShareBadgeIcons
+          @badges={{this.model.campaignParticipationResult.campaignParticipationBadges}}
+        />
+      `);
+
+    // then
+    assert.strictEqual(screen.queryByRole('list'), null);
+  });
+});

--- a/mon-pix/tests/unit/components/campaigns/assessment/skill-review/share-badge-icons_test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/skill-review/share-badge-icons_test.js
@@ -1,0 +1,96 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | campaigns | assessment | skill-review | share-badge-icons', function (hooks) {
+  setupTest(hooks);
+
+  const possibleBadgesCombinations = [
+    { id: 1, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+    { id: 2, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+    { id: 3, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+    { id: 4, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+    { id: 5, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+    { id: 6, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+    { id: 7, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+    { id: 8, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+    { id: 9, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+    { id: 10, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+    { id: 11, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+    { id: 12, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+    { id: 13, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+    { id: 14, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+    { id: 15, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+    { id: 16, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+  ];
+
+  module('#acquiredAndValidBadges', function () {
+    test('should return only acquired and valid badges', async function (assert) {
+      // given
+      const component = createGlimmerComponent('campaigns/assessment/skill-review/share-badge-icons');
+      component.args.badges = possibleBadgesCombinations;
+
+      // when
+      const acquiredAndValidBadges = component.acquiredAndValidBadges;
+
+      // then
+      assert.deepEqual(acquiredAndValidBadges.length, 4);
+      assert.true(acquiredAndValidBadges[0].isAcquired);
+      assert.true(acquiredAndValidBadges[0].isValid);
+    });
+
+    test('should sort certifiable badges first', async function (assert) {
+      // given
+      const component = createGlimmerComponent('campaigns/assessment/skill-review/share-badge-icons');
+      component.args.badges = possibleBadgesCombinations;
+
+      // when
+      const acquiredAndValidBadges = component.acquiredAndValidBadges;
+
+      // then
+      assert.deepEqual(acquiredAndValidBadges.length, 4);
+      assert.true(acquiredAndValidBadges[0].isCertifiable);
+      assert.true(acquiredAndValidBadges[1].isCertifiable);
+      assert.false(acquiredAndValidBadges[2].isCertifiable);
+      assert.false(acquiredAndValidBadges[3].isCertifiable);
+    });
+  });
+
+  module('#showBadgeIcons', function () {
+    test('should return true if it has at least one badge to show', async function (assert) {
+      // given
+      const component = createGlimmerComponent('campaigns/assessment/skill-review/share-badge-icons');
+      component.args.badges = possibleBadgesCombinations;
+
+      // when
+      const showBadgeIcons = component.showBadgeIcons;
+
+      // then
+      assert.true(showBadgeIcons);
+    });
+
+    test('should return false if it has no acquired badge', async function (assert) {
+      // given
+      const component = createGlimmerComponent('campaigns/assessment/skill-review/share-badge-icons');
+      component.args.badges = possibleBadgesCombinations.filter((badge) => !badge.isAcquired);
+
+      // when
+      const showBadgeIcons = component.showBadgeIcons;
+
+      // then
+      assert.false(showBadgeIcons);
+    });
+
+    test('should return false if it has no valid badge', async function (assert) {
+      // given
+      const component = createGlimmerComponent('campaigns/assessment/skill-review/share-badge-icons');
+      component.args.badges = possibleBadgesCombinations.filter((badge) => !badge.isValid);
+
+      // when
+      const showBadgeIcons = component.showBadgeIcons;
+
+      // then
+      assert.false(showBadgeIcons);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Les RT non obtenus s’affichent sous “J’envoie mes résultats” dans la page de résultat de campagne. 

## :robot: Proposition

Découper le fichier `skill-review.hbs` et créer un composant dédié à l'affichage de ces RT : `components/campaigns/assessment/skill-review/share-badge-icons.hbs`

## :rainbow: Remarques

- Un utilisateur spécifique, qui a déjà passé une campagne et qui a gagné des badges, a été créé dans les seeds
- Il faudrait continuer à découper le fichier `skill-review.hbs` car il est toujours trop gros.

## :100: Pour tester

- Se connecter sur [PixApp en RA](https://app-pr6837.review.pix.fr/) avec l'utilisateur `eval-campaign-with-badges@example.net`
- Aller sur la [page de fin de campagne](https://app-pr6837.review.pix.fr/campagnes/EVALBADGE/evaluation/resultats) `EVALBADGE` :

  - ✅ Vérifier la présence de 4 badges dans le bloc haut :
    - les 2 premiers avec des tooltips précisant qu'ils sont **certifiables**
    - les 2 suivants avec des tooltips précisants qu'ils ne sont **pas certifiables** 
  - ✅ Dans le bloc `Vos résultats thématiques`, 3 badges sont présents : 
    - **2 acquis**, qui sont censés être les mêmes que dans le bloc du haut 
    - **1 non-acquis** mais visible
  - ✅ Au-dessus, 2 badges sont affichés avec le design spécifique des badges certifiants