### PR TITLE
[BUGFIX] Les tests statiques créés via PixEditor ne se lancent pas sur PixApp (PIX-8866)

### DIFF
--- a/api/lib/domain/services/course-service.js
+++ b/api/lib/domain/services/course-service.js
@@ -1,7 +1,5 @@
 import _ from 'lodash';
 import { Course } from '../models/Course.js';
-import { NotFoundError } from '../../domain/errors.js';
-
 import * as courseRepository from '../../infrastructure/repositories/course-repository.js';
 
 const getCourse = async function ({ courseId, dependencies = { courseRepository } }) {
@@ -10,12 +8,7 @@ const getCourse = async function ({ courseId, dependencies = { courseRepository 
     return Promise.resolve(new Course({ id: courseId }));
   }
 
-  // TODO This repo switch should not be here because we make a technical discrimination on the course id
-  if (_.startsWith(courseId, 'rec')) {
-    return dependencies.courseRepository.get(courseId);
-  }
-
-  throw new NotFoundError();
+  return dependencies.courseRepository.get(courseId);
 };
 
 export { getCourse };


### PR DESCRIPTION
## :unicorn: Problème
Côté PixEditor, les nouveaux tests statiques créés via l'interface ne sont pas jouables depuis PixApp.
C'est à cause de leur id. L'id a maintenant la forme "course.......". Donc, la release contient des tests statiques ayant deux formes différentes d'ids : "course......." et "rec.......".
Malheureusement l'API pix n'est pas flexxx.

## :robot: Proposition
Corriger le code de récupération de test statique pour qu'il puisse jouer également les tests statiques avec un id différent de "rec....".

## :rainbow: Remarques
S'assurer que le comportement d'avant est toujours iso : à savoir les courseIds n'étant pas des tests statiques, soit c'est "campagne" et ça résoud un test statique vide, et pour le reste ca balance NotFound

## :100: Pour tester
vérifier que les tests statiques avec un id commencant par course sont joués. + vérifier que tous les types d'assessments fonctionnent.
