### PR TITLE
[BUGFIX] Changement d'avis lors de l'inscription individuelle d'un candidat concernant certif complémentaire (PIX-8880)

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -323,7 +323,6 @@
                   name="complementary-certifications"
                   id={{concat "no-complementaryCertification"}}
                   checked="checked"
-                  value="none"
                   {{on "input" this.updateComplementaryCertification}}
                 />
                 {{t "common.labels.candidate.none"}}

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -66,8 +66,10 @@ export default class NewCertificationCandidateModal extends Component {
 
   @action
   updateComplementaryCertification(complementaryCertification) {
-    if (complementaryCertification?.target?.value !== 'none') {
+    if (complementaryCertification?.key) {
       this.args.candidateData.complementaryCertification = complementaryCertification;
+    } else {
+      this.args.candidateData.complementaryCertification = undefined;
     }
   }
 

--- a/certif/tests/integration/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-modal_test.js
@@ -11,6 +11,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
 
   hooks.beforeEach(async function () {
     const store = this.owner.lookup('service:store');
+
     class CurrentUserStub extends Service {
       currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         habilitations: [
@@ -19,6 +20,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
         ],
       });
     }
+
     this.owner.register('service:current-user', CurrentUserStub);
   });
 

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -282,7 +282,9 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
       // given
       modal.args.candidateData = {};
       const complementaryCertification = {
-        label: 'complementaryCertification',
+        id: 0,
+        label: 'Certif complémentaire 1',
+        key: 'COMP_0',
       };
 
       // when
@@ -294,8 +296,16 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
 
     test('it should not be possible to select multiple complementary certifications', function (assert) {
       // given
-      const firstComplementaryCertification = { label: 'firstComplementaryCertification' };
-      const secondComplementaryCertification = { label: 'secondComplementaryCertification' };
+      const firstComplementaryCertification = {
+        id: 1,
+        label: 'firstComplementaryCertification',
+        key: 'COMP_1',
+      };
+      const secondComplementaryCertification = {
+        id: 2,
+        label: 'secondComplementaryCertification',
+        key: 'COMP_2',
+      };
       modal.args.candidateData = {
         complementaryCertification: firstComplementaryCertification,
       };
@@ -305,6 +315,27 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
 
       // then
       assert.deepEqual(modal.args.candidateData.complementaryCertification, secondComplementaryCertification);
+    });
+
+    test('it should remove the complementary when no complementary is selected', function (assert) {
+      // given
+      modal.args.candidateData = {
+        complementaryCertification: {
+          id: 0,
+          label: 'Certif complémentaire 1',
+          key: 'COMP_0',
+        },
+      };
+
+      const noneChoice = {
+        target: { value: 'none' },
+      };
+
+      // when
+      modal.updateComplementaryCertification(noneChoice);
+
+      // then
+      assert.strictEqual(typeof modal.args.candidateData.complementaryCertification, 'undefined');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Un utilisateur Pix Certif souhaite inscrire un candidat via la modale d'inscription individuelle.
Il rempli les premiers champs et clique sur une des certif complémentaires.
Il se ravise et clique sur “Aucune” dans les certif complémentaires.
Il valide l’inscription de ce candidat.
Le candidat est inscrit avec une certification complémentaire (celle qui avait été initialement sélectionnée)

## :robot: Proposition
Corriger la gestion des choix des certif complémentaire dans la modale d'inscription

## :100: Pour tester

https://github.com/1024pix/pix/assets/103997660/be165b2d-9df8-4db3-a2f2-4f7cfaf84559

