### PR TITLE
[FEATURE] Ne pas permettre le reset avant 4j (PIX-8829)

### DIFF
--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -32,6 +32,8 @@ const register = async function (server) {
               type: Joi.string(),
               attributes: Joi.object({
                 'participant-external-id': Joi.string().allow(null).max(255),
+                'is-retry': Joi.boolean().allow(null).default(false),
+                'is-reset': Joi.boolean().allow(null).default(false),
               }).required(),
             }).required(),
           }).required(),

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -115,6 +115,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CompetenceResetError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.NotEnoughDaysPassedBeforeResetCampaignParticipationError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.NoCampaignParticipationForUserAndCampaign) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -381,6 +381,7 @@ class InvalidCertificationIssueReportForSaving extends DomainError {
     super(message);
   }
 }
+
 class CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually extends DomainError {
   constructor(message = 'Le signalement ne peut pas être modifié manuellement') {
     super(message);
@@ -438,6 +439,12 @@ class SendingEmailToResultRecipientError extends DomainError {
 class CompetenceResetError extends DomainError {
   constructor(remainingDaysBeforeReset) {
     super(`Il reste ${remainingDaysBeforeReset} jours avant de pouvoir réinitiliser la compétence.`);
+  }
+}
+
+class NotEnoughDaysPassedBeforeResetCampaignParticipationError extends DomainError {
+  constructor() {
+    super(`Il n'est pas possible de remettre à zéro votre parcours pour le moment.`);
   }
 }
 
@@ -1388,6 +1395,7 @@ export {
   NoStagesForCampaign,
   NoOrganizationToAttach,
   NotEligibleCandidateError,
+  NotEnoughDaysPassedBeforeResetCampaignParticipationError,
   NotFoundError,
   DeletedError,
   NotImplementedError,

--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -1,4 +1,9 @@
-import { AlreadyExistingCampaignParticipationError, EntityValidationError, ForbiddenAccess } from '../errors.js';
+import {
+  AlreadyExistingCampaignParticipationError,
+  EntityValidationError,
+  ForbiddenAccess,
+  NotEnoughDaysPassedBeforeResetCampaignParticipationError,
+} from '../errors.js';
 
 import { CampaignParticipation } from './CampaignParticipation.js';
 import { Assessment } from './Assessment.js';
@@ -86,6 +91,10 @@ class CampaignParticipant {
 
     if (!isReset && this._canImproveResults()) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
+    }
+
+    if (isReset && this.previousCampaignParticipationForUser && !this.previousCampaignParticipationForUser.canReset) {
+      throw new NotEnoughDaysPassedBeforeResetCampaignParticipationError();
     }
 
     if (this._isMissingParticipantExternalId(participantExternalId)) {

--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -1,8 +1,9 @@
-import { EntityValidationError, ForbiddenAccess, AlreadyExistingCampaignParticipationError } from '../errors.js';
+import { AlreadyExistingCampaignParticipationError, EntityValidationError, ForbiddenAccess } from '../errors.js';
 
 import { CampaignParticipation } from './CampaignParticipation.js';
 import { Assessment } from './Assessment.js';
 import { OrganizationLearner } from './OrganizationLearner.js';
+
 const couldNotJoinCampaignErrorMessage = "Vous n'êtes pas autorisé à rejoindre la campagne";
 const couldNotImproveCampaignErrorMessage = 'Vous ne pouvez pas repasser la campagne';
 
@@ -20,8 +21,8 @@ class CampaignParticipant {
     this.organizationLearnerHasParticipatedForAnotherUser = organizationLearner.hasParticipated;
   }
 
-  start({ participantExternalId }) {
-    this._checkCanParticipateToCampaign(participantExternalId);
+  start({ participantExternalId, isReset }) {
+    this._checkCanParticipateToCampaign(participantExternalId, isReset);
 
     const participantExternalIdToUse =
       this.previousCampaignParticipationForUser?.participantExternalId || participantExternalId;
@@ -60,7 +61,7 @@ class CampaignParticipant {
     return !this.campaignToStartParticipation.isRestricted && !this.organizationLearnerId;
   }
 
-  _checkCanParticipateToCampaign(participantExternalId) {
+  _checkCanParticipateToCampaign(participantExternalId, isReset) {
     if (this.campaignToStartParticipation.isArchived) {
       throw new ForbiddenAccess(couldNotJoinCampaignErrorMessage);
     }
@@ -82,7 +83,8 @@ class CampaignParticipant {
     if (['STARTED', 'TO_SHARE'].includes(this.previousCampaignParticipationForUser?.status)) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
     }
-    if (this._canImproveResults()) {
+
+    if (!isReset && this._canImproveResults()) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
     }
 

--- a/api/lib/domain/read-models/PreviousCampaignParticipation.js
+++ b/api/lib/domain/read-models/PreviousCampaignParticipation.js
@@ -1,0 +1,44 @@
+import dayjs from 'dayjs';
+import { MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../constants.js';
+
+class PreviousCampaignParticipation {
+  constructor({
+    id,
+    participantExternalId,
+    validatedSkillsCount,
+    status,
+    isDeleted,
+    isTargetProfileResetAllowed,
+    isOrganizationLearnerActive,
+    isCampaignMultipleSendings,
+    sharedAt,
+  }) {
+    this.id = id;
+    this.participantExternalId = participantExternalId;
+    this.validatedSkillsCount = validatedSkillsCount;
+    this.status = status;
+    this.isDeleted = isDeleted;
+    this.isTargetProfileResetAllowed = isTargetProfileResetAllowed;
+    this.isOrganizationLearnerActive = isOrganizationLearnerActive;
+    this.isCampaignMultipleSendings = isCampaignMultipleSendings;
+    this.sharedAt = sharedAt;
+  }
+
+  get canReset() {
+    return (
+      this.isTargetProfileResetAllowed &&
+      this.isCampaignMultipleSendings &&
+      this.isOrganizationLearnerActive &&
+      this._isTimeBeforeRetryingPassed(this.sharedAt)
+    );
+  }
+
+  _isTimeBeforeRetryingPassed(sharedAt) {
+    const isShared = Boolean(sharedAt);
+    if (!isShared) return false;
+
+    return dayjs().diff(sharedAt, 'days') >= MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+  }
+}
+
+export { PreviousCampaignParticipation };

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -18,7 +18,10 @@ const startCampaignParticipation = async function ({
     domainTransaction,
   });
 
-  campaignParticipant.start({ participantExternalId: campaignParticipation.participantExternalId });
+  campaignParticipant.start({
+    participantExternalId: campaignParticipation.participantExternalId,
+    isReset: campaignParticipation.isReset,
+  });
 
   const campaignParticipationId = await campaignParticipantRepository.save(campaignParticipant, domainTransaction);
 

--- a/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -162,6 +162,12 @@ describe('Acceptance | API | Campaign Participations', function () {
         multipleSendings: true,
       }).id;
 
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: multipleSendingsCampaignId,
+        status: CampaignParticipationStatuses.SHARED,
+      });
+
       const framework = domainBuilder.buildFramework({ id: 'frameworkId', name: 'someFramework' });
       const skill1 = {
         id: 'recSK123',

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -1,12 +1,14 @@
-import { expect, databaseBuilder, mockLearningContent, catchErr } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../test-helper.js';
 import { knex } from '../../../../db/knex-database-connection.js';
 import * as campaignParticipantRepository from '../../../../lib/infrastructure/repositories/campaign-participant-repository.js';
 import { CampaignParticipant } from '../../../../lib/domain/models/CampaignParticipant.js';
 import { CampaignToStartParticipation } from '../../../../lib/domain/models/CampaignToStartParticipation.js';
 import lodash from 'lodash';
-const { pick } = lodash;
 import { AlreadyExistingCampaignParticipationError, NotFoundError } from '../../../../lib/domain/errors.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+
+const { pick } = lodash;
+
 const campaignParticipationDBAttributes = [
   'id',
   'campaignId',
@@ -592,12 +594,18 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           campaignId: campaignToStartParticipation.id,
           isImproved: true,
         });
+
+        const sharedAt = new Date('2020-01-01');
         const expectedAttributes = {
           id: 10,
           participantExternalId: 'something',
           validatedSkillsCount: 1,
           status: 'SHARED',
           isDeleted: true,
+          isTargetProfileResetAllowed: false,
+          isCampaignMultipleSendings: true,
+          isOrganizationLearnerActive: true,
+          sharedAt,
         };
         databaseBuilder.factory.buildCampaignParticipation({
           id: 10,
@@ -607,6 +615,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           deletedAt: new Date(),
           userId,
           campaignId: campaignToStartParticipation.id,
+          sharedAt,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -41,6 +41,7 @@ import {
   LocaleFormatError,
   LocaleNotSupportedError,
   CertificationCandidateNotFoundError,
+  NotEnoughDaysPassedBeforeResetCampaignParticipationError,
 } from '../../../lib/domain/errors.js';
 
 import { HttpErrors } from '../../../lib/application/http-errors.js';
@@ -364,6 +365,19 @@ describe('Unit | Application | ErrorManager', function () {
         SESSION_SUPERVISING.INCORRECT_DATA.getMessage(),
         SESSION_SUPERVISING.INCORRECT_DATA.code,
       );
+    });
+
+    it('should instantiate PreconditionFailedError when NotEnoughDaysPassedBeforeResetCampaignParticipationError', async function () {
+      // given
+      const error = new NotEnoughDaysPassedBeforeResetCampaignParticipationError();
+      sinon.stub(HttpErrors, 'PreconditionFailedError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.PreconditionFailedError).to.have.been.called;
     });
 
     it('should instantiate BadRequestError when OrganizationLearnerAlreadyLinkedToInvalidUserError', async function () {

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -1,5 +1,6 @@
 import { expect } from '../../test-helper.js';
 import * as errors from '../../../lib/domain/errors.js';
+import { NotEnoughDaysPassedBeforeResetCampaignParticipationError } from '../../../lib/domain/errors.js';
 
 describe('Unit | Domain | Errors', function () {
   it('should export a AdminMemberError', function () {
@@ -418,5 +419,16 @@ describe('Unit | Domain | Errors', function () {
 
   it('exports LocaleNotSupportedError', function () {
     expect(errors.LocaleNotSupportedError).to.exist;
+  });
+
+  it('NotEnoughDaysPassedBeforeResetCampaignParticipationError error should have the correct wording', function () {
+    // given
+    const expectedErrorMessage = `Il n'est pas possible de remettre à zéro votre parcours pour le moment.`;
+
+    // when
+    const error = new NotEnoughDaysPassedBeforeResetCampaignParticipationError();
+
+    // then
+    expect(error.message).to.equal(expectedErrorMessage);
   });
 });

--- a/api/tests/unit/domain/read-models/PreviousCampaignParticipation_test.js
+++ b/api/tests/unit/domain/read-models/PreviousCampaignParticipation_test.js
@@ -1,0 +1,203 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { PreviousCampaignParticipation } from '../../../../lib/domain/read-models/PreviousCampaignParticipation.js';
+import { constants } from '../../../../lib/domain/constants.js';
+
+describe('Unit | Domain | Read-Models | PreviousCampaignParticipation', function () {
+  describe('#constructor', function () {
+    it('should build a PreviousCampaignParticipant readmodel object from data', function () {
+      // given
+      const id = 1;
+      const participantExternalId = 1;
+      const validatedSkillsCount = 1;
+      const status = 'ENDED';
+      const isDeleted = true;
+      const isTargetProfileResetAllowed = true;
+      const isOrganizationLearnerActive = true;
+      const isCampaignMultipleSendings = false;
+      const sharedAt = new Date('2019-03-12T01:02:03Z');
+      const params = {
+        id,
+        participantExternalId,
+        validatedSkillsCount,
+        status,
+        isDeleted,
+        isTargetProfileResetAllowed,
+        isOrganizationLearnerActive,
+        isCampaignMultipleSendings,
+        sharedAt,
+      };
+
+      // when
+      const result = new PreviousCampaignParticipation({ ...params });
+
+      expect(result).to.be.instanceOf(PreviousCampaignParticipation);
+      expect(result).to.be.deep.equal({ ...params });
+    });
+  });
+
+  describe('#canReset', function () {
+    let clock, originalConstantValue, now, baseProps;
+
+    beforeEach(function () {
+      originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+      now = new Date('2020-01-07T05:06:07Z');
+      clock = sinon.useFakeTimers(now);
+      sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(4);
+
+      baseProps = {
+        id: 1,
+        participantExternalId: 1,
+        validatedSkillsCount: 1,
+        status: 'ENDED',
+        isDeleted: true,
+        isTargetProfileResetAllowed: true,
+        isCampaignMultipleSendings: true,
+        isOrganizationLearnerActive: true,
+        sharedAt: new Date('2020-01-01T01:02:03Z'),
+      };
+    });
+
+    afterEach(function () {
+      clock.restore();
+      sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(originalConstantValue);
+    });
+
+    describe('when isShared is not defined', function () {
+      it('should return false', function () {
+        // given
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          sharedAt: undefined,
+        });
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.false;
+      });
+    });
+
+    describe('when previous campaign participation does not respect minimum delay', function () {
+      it('should return false', function () {
+        // given
+        const sharedAt = new Date('2020-01-04T01:02:03Z');
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          sharedAt,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.false;
+      });
+    });
+
+    describe('when previous campaign participation has exact minimum delay', function () {
+      it('should return true', function () {
+        // given
+        const sharedAt = new Date('2020-01-03T01:02:03Z');
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          sharedAt,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
+      });
+    });
+
+    describe('when previous campaign participation respects minimum delay', function () {
+      it('should return true', function () {
+        // given
+        const sharedAt = new Date('2020-01-01T01:02:03Z');
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          sharedAt,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
+      });
+    });
+
+    describe('when isTargetProfileResetAllowed is true', function () {
+      it('should return true', function () {
+        // given
+        const isTargetProfileResetAllowed = true;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isTargetProfileResetAllowed,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
+      });
+    });
+
+    describe('when isTargetProfileResetAllowed is false', function () {
+      it('should return false', function () {
+        // given
+        const isTargetProfileResetAllowed = false;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isTargetProfileResetAllowed,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.false;
+      });
+    });
+
+    describe('when isCampaignMultipleSendings is true', function () {
+      it('should return true', function () {
+        // given
+        const isCampaignMultipleSendings = true;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isCampaignMultipleSendings,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
+      });
+    });
+
+    describe('when isCampaignMultipleSendings is false', function () {
+      it('should return false', function () {
+        // given
+        const isCampaignMultipleSendings = false;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isCampaignMultipleSendings,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.false;
+      });
+    });
+
+    describe('when isOrganizationLearnerActive is true', function () {
+      it('should return true', function () {
+        // given
+        const isOrganizationLearnerActive = true;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isOrganizationLearnerActive,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.true;
+      });
+    });
+
+    describe('when isOrganizationLearnerActive is false', function () {
+      it('should return false', function () {
+        // given
+        const isOrganizationLearnerActive = false;
+        const previousCampaignParticipation = new PreviousCampaignParticipation({
+          ...baseProps,
+          isOrganizationLearnerActive,
+        });
+
+        // when & then
+        expect(previousCampaignParticipation.canReset).to.be.false;
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -61,7 +61,10 @@ describe('Unit | UseCase | start-campaign-participation', function () {
     });
 
     // then
-    expect(campaignParticipant.start).to.have.been.calledWith({ participantExternalId: 'YvoLoL' });
+    expect(campaignParticipant.start).to.have.been.calledWith({
+      participantExternalId: 'YvoLoL',
+      isReset: campaignParticipationAttributes.isReset,
+    });
     expect(event).to.deep.equal(campaignParticipationStartedEvent);
     expect(campaignParticipation).to.deep.equal(expectedCampaignParticipation);
     expect(campaignRepository.areKnowledgeElementsResettable).to.have.been.calledWith({


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas de protection de délai sur le endpoint permettant de remettre à zéro un parcours.

## :robot: Proposition
Ajouter une protection calculant le `canReset` comme dans l'`AssessmentResult` dans le nouveau modèle `PreviousCampaignParticipation`

## :rainbow: Remarques


## :100: Pour tester
- Setter la var d'env `DAY_BEFORE_RETRYING` à plus que 0J
- Se connecter avec devcomp-sco@example.net
- Terminer la campagne `SCOMULTIP`
- Forcer un appel réseau au endpoint `POST /campaign-participations` avec `isReset` à `true`
- Recevoir une erreur 412, contrairement à avant où ça se faisait sans broncher
