### PR TITLE
[FEATURE] Sécuriser l'accès à l'API de journalisation (PIX-8836)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,7 @@ jobs:
           name: Test
           command: npm run test
           environment:
+            PIX_API_CLIENT_SECRET: $2a$04$vkPRiypzeVQVG92/dCll7.5brjDQZVZc750VwKBc01icXjVIQqRVq
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
           when: always
       - store_test_results:

--- a/audit-logger/package-lock.json
+++ b/audit-logger/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@hapi/basic": "^7.0.2",
         "@hapi/hapi": "~21.3.2",
         "dotenv": "^16.3.1",
         "joi": "^17.9.2",
@@ -514,6 +515,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.1.tgz",
       "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
       "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/basic": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/basic/-/basic-7.0.2.tgz",
+      "integrity": "sha512-kdpsmCEHVDlIYStRbszSyy/9+dq5KkfWLX5AjuHGPwtzuuZopZnhkVvMZV45hQ8hA8V/weCoMs0nzXJ7JCA2ow==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
     },

--- a/audit-logger/package-lock.json
+++ b/audit-logger/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@hapi/basic": "^7.0.2",
         "@hapi/hapi": "~21.3.2",
+        "bcrypt": "^5.1.0",
         "dotenv": "^16.3.1",
         "joi": "^17.9.2",
         "knex": "^2.5.1",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.0",
+        "@types/bcrypt": "^5.0.0",
         "@types/lodash": "^4.14.197",
         "@types/node": "^18.17.4",
         "@types/pg": "^8.10.2",
@@ -891,6 +893,61 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1010,6 +1067,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.0.tgz",
       "integrity": "sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==",
       "dev": true
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/chai": {
       "version": "4.3.5",
@@ -1641,8 +1707,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1685,6 +1750,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1705,7 +1781,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1736,6 +1811,36 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/arg": {
@@ -1899,6 +2004,19 @@
         }
       ]
     },
+    "node_modules/bcrypt": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.0.tgz",
+      "integrity": "sha512-RHBS7HI5N5tEnGTmtR/pppX0mmDSBpQ4aCBsj7CEQfYXDcO74A8sIBYcJMuCsis2E81zDxeENYhv66oZwLiA+Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.10",
+        "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -1933,7 +2051,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2119,6 +2236,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2137,6 +2262,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
@@ -2153,8 +2286,12 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2280,6 +2417,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2332,6 +2482,11 @@
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -3106,6 +3261,28 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3155,6 +3332,25 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-func-name": {
@@ -3226,7 +3422,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3408,6 +3603,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
     "node_modules/help-me": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
@@ -3472,6 +3672,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "4.3.1",
@@ -3691,6 +3903,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4149,7 +4369,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4239,7 +4458,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4253,6 +4471,48 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mlly": {
@@ -4301,6 +4561,30 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/nodemon": {
       "version": "3.0.1",
@@ -4409,6 +4693,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -4622,7 +4925,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5150,7 +5452,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5330,7 +5631,6 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
       "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5340,6 +5640,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5385,8 +5690,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -5463,6 +5767,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -5512,7 +5829,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5608,6 +5924,22 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
+    },
+    "node_modules/tar": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/tarn": {
       "version": "3.0.2",
@@ -5712,6 +6044,11 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -6105,6 +6442,20 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6172,6 +6523,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -6188,8 +6547,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -59,6 +59,7 @@
     "vitest": "^0.34.1"
   },
   "dependencies": {
+    "@hapi/basic": "^7.0.2",
     "@hapi/hapi": "~21.3.2",
     "dotenv": "^16.3.1",
     "joi": "^17.9.2",

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -39,6 +39,7 @@
   "type": "module",
   "devDependencies": {
     "@tsconfig/node18": "^18.2.0",
+    "@types/bcrypt": "^5.0.0",
     "@types/lodash": "^4.14.197",
     "@types/node": "^18.17.4",
     "@types/pg": "^8.10.2",
@@ -61,6 +62,7 @@
   "dependencies": {
     "@hapi/basic": "^7.0.2",
     "@hapi/hapi": "~21.3.2",
+    "bcrypt": "^5.1.0",
     "dotenv": "^16.3.1",
     "joi": "^17.9.2",
     "knex": "^2.5.1",

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -18,7 +18,7 @@
     "preinstall": "npx check-engine",
     "test": "NODE_ENV=test npm run db:prepare && vitest",
     "test:ci": "NODE_ENV=test npm run db:prepare && vitest",
-    "test:coverage": "vitest --coverage.enabled",
+    "test:coverage": "NODE_ENV=test vitest --coverage.enabled",
     "test:watch": "NODE_ENV=test npm run db:prepare && vitest --watch",
     "start": "node dist/lib/index.js",
     "start:watch": "nodemon src/lib/index.ts"

--- a/audit-logger/sample.env
+++ b/audit-logger/sample.env
@@ -55,3 +55,14 @@ DATABASE_CONNECTION_POOL_MAX_SIZE=10
 # default: 1
 # sample: DATABASE_CONNECTION_POOL_MIN_SIZE=2
 DATABASE_CONNECTION_POOL_MIN_SIZE=2
+
+# ========
+# SECURITY
+# ========
+
+# Pix API client credentials
+#
+# presence: required
+# type: string
+# sample: PIX_API_CLIENT_SECRET=pixApiClientSecretDev
+PIX_API_CLIENT_SECRET=pixApiClientSecretDev

--- a/audit-logger/sample.env
+++ b/audit-logger/sample.env
@@ -64,5 +64,5 @@ DATABASE_CONNECTION_POOL_MIN_SIZE=2
 #
 # presence: required
 # type: string
-# sample: PIX_API_CLIENT_SECRET=pixApiClientSecretDev
-PIX_API_CLIENT_SECRET=pixApiClientSecretDev
+# sample: PIX_API_CLIENT_SECRET=bcrypt(pixApiClientSecretTest)
+PIX_API_CLIENT_SECRET=$2a$04$vkPRiypzeVQVG92/dCll7.5brjDQZVZc750VwKBc01icXjVIQqRVq

--- a/audit-logger/scripts/scalingo-post-ra-creation.sh
+++ b/audit-logger/scripts/scalingo-post-ra-creation.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 npm run postdeploy
-npm run db:seed

--- a/audit-logger/src/lib/config.ts
+++ b/audit-logger/src/lib/config.ts
@@ -13,6 +13,7 @@ type Configuration = {
     logForHumans: boolean;
   };
   port: number;
+  pixApiClientSecret: string;
 };
 
 const config: Configuration = {
@@ -23,6 +24,7 @@ const config: Configuration = {
     logForHumans: _getLogForHumans(),
   },
   port: parseInt(process.env.PORT as string, 10) || 3001,
+  pixApiClientSecret: process.env.PIX_API_CLIENT_SECRET as string,
 };
 
 switch (config.environment) {
@@ -31,7 +33,12 @@ switch (config.environment) {
     break;
   case 'test':
     config.logging.enabled = _isBooleanFeatureEnabledElseDefault(process.env.TEST_LOG_ENABLED as BooleanType, false);
+    config.pixApiClientSecret = 'pixApiClientSecretTest';
     break;
+}
+
+if (config.pixApiClientSecret === undefined) {
+  throw new Error('Environment variable PIX_API_CLIENT_SECRET must be defined');
 }
 
 export { config };

--- a/audit-logger/src/lib/config.ts
+++ b/audit-logger/src/lib/config.ts
@@ -33,7 +33,6 @@ switch (config.environment) {
     break;
   case 'test':
     config.logging.enabled = _isBooleanFeatureEnabledElseDefault(process.env.TEST_LOG_ENABLED as BooleanType, false);
-    config.pixApiClientSecret = 'pixApiClientSecretTest';
     break;
 }
 

--- a/audit-logger/src/lib/controllers/create-audit-log.controller.ts
+++ b/audit-logger/src/lib/controllers/create-audit-log.controller.ts
@@ -24,6 +24,7 @@ export const CREATE_AUDIT_LOG_ROUTE: ServerRoute = {
   method: 'POST',
   path: '/api/audit-logs',
   options: {
+    auth: 'simple',
     handler: createAuditLogController.handle.bind(createAuditLogController),
     validate: {
       payload: Joi.object({

--- a/audit-logger/src/lib/index.ts
+++ b/audit-logger/src/lib/index.ts
@@ -9,7 +9,7 @@ process.on('SIGINT', () => {
   _exitOnSignal('SIGINT').then(() => {}, () => {});
 });
 
-const hapiServer: HapiServer = new HapiServer();
+const hapiServer: HapiServer = await HapiServer.createServer();
 
 try {
   await hapiServer.start();

--- a/audit-logger/src/lib/infrastructure/services/authentication.service.ts
+++ b/audit-logger/src/lib/infrastructure/services/authentication.service.ts
@@ -2,16 +2,16 @@ import bcrypt from 'bcrypt';
 
 import { config } from '../../config.js';
 
-export const validate = async (username: string, password: string): Promise<object> => {
+export const areCredentialsValid = async (username: string, password: string): Promise<boolean> => {
   if (username !== 'pix-api') {
-    return { isValid: false, credentials: null };
+    return false;
   }
 
   const isPasswordValid = await bcrypt.compare(password, config.pixApiClientSecret);
 
   if (!isPasswordValid) {
-    return { isValid: false, credentials: null };
+    return false;
   }
 
-  return { isValid: true, credentials: {} };
+  return true;
 };

--- a/audit-logger/src/lib/infrastructure/services/authentication.service.ts
+++ b/audit-logger/src/lib/infrastructure/services/authentication.service.ts
@@ -1,9 +1,11 @@
+import { config } from '../../config.js';
+
 export const validate = (username: string, password: string): object => {
   if (username !== 'pix-api') {
     return { isValid: false, credentials: null };
   }
 
-  if (password !== 'password') {
+  if (password !== config.pixApiClientSecret) {
     return { isValid: false, credentials: null };
   }
 

--- a/audit-logger/src/lib/infrastructure/services/authentication.service.ts
+++ b/audit-logger/src/lib/infrastructure/services/authentication.service.ts
@@ -1,11 +1,15 @@
+import bcrypt from 'bcrypt';
+
 import { config } from '../../config.js';
 
-export const validate = (username: string, password: string): object => {
+export const validate = async (username: string, password: string): Promise<object> => {
   if (username !== 'pix-api') {
     return { isValid: false, credentials: null };
   }
 
-  if (password !== config.pixApiClientSecret) {
+  const isPasswordValid = await bcrypt.compare(password, config.pixApiClientSecret);
+
+  if (!isPasswordValid) {
     return { isValid: false, credentials: null };
   }
 

--- a/audit-logger/src/lib/infrastructure/services/authentication.service.ts
+++ b/audit-logger/src/lib/infrastructure/services/authentication.service.ts
@@ -1,0 +1,11 @@
+export const validate = (username: string, password: string): object => {
+  if (username !== 'pix-api') {
+    return { isValid: false, credentials: null };
+  }
+
+  if (password !== 'password') {
+    return { isValid: false, credentials: null };
+  }
+
+  return { isValid: true, credentials: {} };
+};

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -1,4 +1,4 @@
-import { Server } from '@hapi/hapi';
+import { Server, type ServerOptions } from '@hapi/hapi';
 import hapiBasicPlugin from '@hapi/basic';
 
 import { config } from './config.js';
@@ -12,9 +12,15 @@ export class HapiServer {
   private readonly _server: Server;
 
   constructor() {
+
+    const debugOptions: ServerOptions['debug'] = { request: false, log: false };
+    if (process.env.NODE_ENV !== 'production') {
+      debugOptions.request = ['error'];
+    }
+
     this._server = new Server({
       compression: false,
-      debug: { request: false, log: false },
+      debug: debugOptions,
       routes: {
         cors: {
           origin: ['*'],

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -5,6 +5,7 @@ import { config } from './config.js';
 import { ROUTES } from './routes.js';
 import { disconnect } from '../db/knex-database-connection.js';
 import { logger } from './infrastructure/logger.js';
+import { validate } from './infrastructure/services/authentication.service.js';
 
 const { port } = config;
 
@@ -58,21 +59,12 @@ export class HapiServer {
   {
     const hapiServer = new HapiServer();
     await hapiServer.server.register(hapiBasicPlugin);
-    hapiServer.server.auth.strategy('simple', 'basic', { validate });
+    hapiServer.server.auth.strategy('simple', 'basic', {
+      validate: async (_:Request, username: string, password: string) => validate(username, password)
+    });
     hapiServer.server.route(ROUTES);
 
     return hapiServer;
   }
 }
 
-const validate = async (_: Request, username: string, password: string): Promise<object> => {
-  if (username !== 'pix-api') {
-    return { isValid: false, credentials: null };
-  }
-
-  if (password !== 'password') {
-    return { isValid: false, credentials: null };
-  }
-
-  return { isValid: true, credentials: {} };
-};

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -1,4 +1,4 @@
-import { Server, type ServerOptions } from '@hapi/hapi';
+import { type Request, Server, type ServerOptions } from '@hapi/hapi';
 import hapiBasicPlugin from '@hapi/basic';
 
 import { config } from './config.js';
@@ -58,8 +58,21 @@ export class HapiServer {
   {
     const hapiServer = new HapiServer();
     await hapiServer.server.register(hapiBasicPlugin);
+    hapiServer.server.auth.strategy('simple', 'basic', { validate });
     hapiServer.server.route(ROUTES);
 
     return hapiServer;
   }
 }
+
+const validate = async (_: Request, username: string, password: string): Promise<object> => {
+  if (username !== 'pix-api') {
+    return { isValid: false, credentials: null };
+  }
+
+  if (password !== 'password') {
+    return { isValid: false, credentials: null };
+  }
+
+  return { isValid: true, credentials: {} };
+};

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -60,7 +60,7 @@ export class HapiServer {
     const hapiServer = new HapiServer();
     await hapiServer.server.register(hapiBasicPlugin);
     hapiServer.server.auth.strategy('simple', 'basic', {
-      validate: async (_:Request, username: string, password: string) => validate(username, password)
+      validate: async (_:Request, username: string, password: string) => await validate(username, password)
     });
     hapiServer.server.route(ROUTES);
 

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -29,7 +29,6 @@ export class HapiServer {
         stripTrailingSlash: true,
       },
     });
-   this._server.route(ROUTES);
   }
 
   get server(): Server {
@@ -46,5 +45,13 @@ export class HapiServer {
     logger.info('Closing connections to database...');
     await disconnect();
     logger.info('Exiting process...');
+  }
+
+  static async createServer(): Promise<HapiServer>
+  {
+    const hapiServer = new HapiServer();
+    hapiServer.server.route(ROUTES);
+
+    return hapiServer;
   }
 }

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -5,7 +5,7 @@ import { config } from './config.js';
 import { ROUTES } from './routes.js';
 import { disconnect } from '../db/knex-database-connection.js';
 import { logger } from './infrastructure/logger.js';
-import { validate } from './infrastructure/services/authentication.service.js';
+import { areCredentialsValid } from './infrastructure/services/authentication.service.js';
 
 const { port } = config;
 
@@ -60,7 +60,12 @@ export class HapiServer {
     const hapiServer = new HapiServer();
     await hapiServer.server.register(hapiBasicPlugin);
     hapiServer.server.auth.strategy('simple', 'basic', {
-      validate: async (_:Request, username: string, password: string) => await validate(username, password)
+      validate: async (_:Request, username: string, password: string) => {
+        if (await areCredentialsValid(username, password)) {
+          return { isValid: true, credentials: {} };
+        }
+        return { isValid: false, credentials: null };
+      }
     });
     hapiServer.server.route(ROUTES);
 

--- a/audit-logger/src/lib/server.ts
+++ b/audit-logger/src/lib/server.ts
@@ -1,4 +1,5 @@
 import { Server } from '@hapi/hapi';
+import hapiBasicPlugin from '@hapi/basic';
 
 import { config } from './config.js';
 import { ROUTES } from './routes.js';
@@ -50,6 +51,7 @@ export class HapiServer {
   static async createServer(): Promise<HapiServer>
   {
     const hapiServer = new HapiServer();
+    await hapiServer.server.register(hapiBasicPlugin);
     hapiServer.server.route(ROUTES);
 
     return hapiServer;

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -29,7 +29,7 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
   });
 
   describe('when request is valid', () => {
-    test('returns a created http status', async () => {
+    test('returns a no content http status', async () => {
       // when
       const response = await server.inject(options);
 

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -10,6 +10,8 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
     const hapiServer = await HapiServer.createServer();
     server = hapiServer.server;
 
+    const base64EncodedCredentials = btoa('pix-api:password');
+
     options = {
       method: 'POST',
       url: '/api/audit-logs',
@@ -21,11 +23,28 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
         role: 'SUPPORT',
         client: 'PIX_ADMIN',
       },
+      headers: {
+        Authorization: `Basic ${base64EncodedCredentials}`,
+      }
     };
   });
 
   afterEach(async function (): Promise<void> {
     await server.stop();
+  });
+
+  describe('when user credentials are invalid', () => {
+    test('returns a unauthorized http status', async() => {
+      // when
+      options = {
+        ...options,
+        headers: {}
+      }
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).toEqual(401);
+    });
   });
 
   describe('when request is valid', () => {

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -10,7 +10,7 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
     const hapiServer = await HapiServer.createServer();
     server = hapiServer.server;
 
-    const base64EncodedCredentials = btoa('pix-api:password');
+    const base64EncodedCredentials = btoa('pix-api:pixApiClientSecretTest');
 
     options = {
       method: 'POST',

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -7,7 +7,8 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
   let options: ServerInjectOptions;
 
   beforeEach(async function (): Promise<void> {
-    server = (new HapiServer()).server;
+    const hapiServer = await HapiServer.createServer();
+    server = hapiServer.server;
 
     options = {
       method: 'POST',

--- a/audit-logger/tests/functional/create-audit-log.http
+++ b/audit-logger/tests/functional/create-audit-log.http
@@ -1,4 +1,5 @@
 POST {{baseUrl}}/api/audit-logs
+Authorization: Basic pix-api pixApiClientSecretTest
 Content-Type: application/json
 
 {"targetUserId": "2", "userId": "3", "action": "ANONYMIZATION", "occurredAt": "2023-08-04T08:57:54.836Z", "role": "SUPPORT", "client": "PIX_ADMIN"}

--- a/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
+++ b/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { validate } from '../../../../src/lib/infrastructure/services/authentication.service.js'
+
+describe('Unit | Infrastructure | Services | authentication', () => {
+  describe('#validate', () => {
+    describe('when username is incorrect', function () {
+      test('returns false and null credentials', () => {
+        // given
+        const username = 'wrong-username';
+        const password = 'password';
+
+        // when
+        const result = validate(username, password);
+
+        // then
+        expect(result).toEqual({ isValid: false, credentials: null });
+      });
+    });
+
+    describe('when password is incorrect', function () {
+      test('returns false and null credentials', () => {
+        // given
+        const username = 'pix-api';
+        const password = 'wrong-password';
+
+        // when
+        const result = validate(username, password);
+
+        // then
+        expect(result).toEqual({ isValid: false, credentials: null });
+      });
+    });
+
+    describe('when username and password are correct', function () {
+      test('returns true and empty credentials object', () => {
+        // given
+        const username = 'pix-api';
+        const password = 'password';
+
+        // when
+        const result = validate(username, password);
+
+        // then
+        expect(result).toEqual({ isValid: true, credentials: {} });
+      });
+    });
+  });
+});

--- a/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
+++ b/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import { validate } from '../../../../src/lib/infrastructure/services/authentication.service.js'
+import { areCredentialsValid } from '../../../../src/lib/infrastructure/services/authentication.service.js'
 
 describe('Unit | Infrastructure | Services | authentication', () => {
-  describe('#validate', () => {
+  describe('#areCredentialsValid', () => {
     describe('when username is incorrect', function () {
       test('returns false and null credentials', async () => {
         // given
@@ -10,10 +10,10 @@ describe('Unit | Infrastructure | Services | authentication', () => {
         const password = 'pixApiClientSecretTest';
 
         // when
-        const result = await validate(username, password);
+        const result = await areCredentialsValid(username, password);
 
         // then
-        expect(result).toEqual({ isValid: false, credentials: null });
+        expect(result).toEqual(false);
       });
     });
 
@@ -24,10 +24,10 @@ describe('Unit | Infrastructure | Services | authentication', () => {
         const password = 'wrong-password';
 
         // when
-        const result = await validate(username, password);
+        const result = await areCredentialsValid(username, password);
 
         // then
-        expect(result).toEqual({ isValid: false, credentials: null });
+        expect(result).toEqual(false);
       });
     });
 
@@ -38,10 +38,10 @@ describe('Unit | Infrastructure | Services | authentication', () => {
         const password = 'pixApiClientSecretTest';
 
         // when
-        const result = await validate(username, password);
+        const result = await areCredentialsValid(username, password);
 
         // then
-        expect(result).toEqual({ isValid: true, credentials: {} });
+        expect(result).toEqual(true);
       });
     });
   });

--- a/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
+++ b/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { validate } from '../../../../src/lib/infrastructure/services/authentication.service.js'
+import { config } from '../../../../src/lib/config.js';
 
 describe('Unit | Infrastructure | Services | authentication', () => {
   describe('#validate', () => {
@@ -7,7 +8,7 @@ describe('Unit | Infrastructure | Services | authentication', () => {
       test('returns false and null credentials', () => {
         // given
         const username = 'wrong-username';
-        const password = 'password';
+        const password = config.pixApiClientSecret;
 
         // when
         const result = validate(username, password);
@@ -35,7 +36,7 @@ describe('Unit | Infrastructure | Services | authentication', () => {
       test('returns true and empty credentials object', () => {
         // given
         const username = 'pix-api';
-        const password = 'password';
+        const password = config.pixApiClientSecret;
 
         // when
         const result = validate(username, password);

--- a/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
+++ b/audit-logger/tests/unit/infrastructure/services/authentication.service.test.ts
@@ -1,17 +1,16 @@
 import { describe, expect, test } from 'vitest';
 import { validate } from '../../../../src/lib/infrastructure/services/authentication.service.js'
-import { config } from '../../../../src/lib/config.js';
 
 describe('Unit | Infrastructure | Services | authentication', () => {
   describe('#validate', () => {
     describe('when username is incorrect', function () {
-      test('returns false and null credentials', () => {
+      test('returns false and null credentials', async () => {
         // given
         const username = 'wrong-username';
-        const password = config.pixApiClientSecret;
+        const password = 'pixApiClientSecretTest';
 
         // when
-        const result = validate(username, password);
+        const result = await validate(username, password);
 
         // then
         expect(result).toEqual({ isValid: false, credentials: null });
@@ -19,13 +18,13 @@ describe('Unit | Infrastructure | Services | authentication', () => {
     });
 
     describe('when password is incorrect', function () {
-      test('returns false and null credentials', () => {
+      test('returns false and null credentials', async () => {
         // given
         const username = 'pix-api';
         const password = 'wrong-password';
 
         // when
-        const result = validate(username, password);
+        const result = await validate(username, password);
 
         // then
         expect(result).toEqual({ isValid: false, credentials: null });
@@ -33,13 +32,13 @@ describe('Unit | Infrastructure | Services | authentication', () => {
     });
 
     describe('when username and password are correct', function () {
-      test('returns true and empty credentials object', () => {
+      test('returns true and empty credentials object', async () => {
         // given
         const username = 'pix-api';
-        const password = config.pixApiClientSecret;
+        const password = 'pixApiClientSecretTest';
 
         // when
-        const result = validate(username, password);
+        const result = await validate(username, password);
 
         // then
         expect(result).toEqual({ isValid: true, credentials: {} });


### PR DESCRIPTION
## :unicorn: Problème

Aujourd’hui, n’importe quel client peut appeler l’API de l’application de journalisation et insérer des entrées. Nous voulons nous assurer que seuls les clients autorisé (aujourd’hui Pix API) soient autorisé à effectuer cette opération.

## :robot: Proposition

- Utiliser le plugin [@hapi/basic](https://hapi.dev/tutorials/auth/?lang=en_US#basic)
- Stocker la clé API dans les variables d’environment de l'application Pix Audit Logger

## :rainbow: Remarques

RAS

## :100: Pour tester

#### JSON de test pour le payload de la requête

```json
{
  "targetUserId": "2",
  "userId": "3",
  "action": "ANONYMIZATION",
  "occurredAt": "2023-07-05",
  "role": "SUPPORT",
  "client": "PIX_ADMIN"
}
```

####  Cas d'erreurs

##### Aucun header `Authorization`

- Faire une requête `POST https://pix-audit-logger-review-pr6849.osc-fr1.scalingo.io/api/audit-logs` sans fournir de headers `Authorization`
- Constater que le statut de la réponse est `401 Unauthorized`

##### Avec le header `Authorization` contenant des valeurs non valides

- Faire une requête `POST https://pix-audit-logger-review-pr6849.osc-fr1.scalingo.io/api/audit-logs` avec le header `Authorization: Basic <VALEUR_ENCODEE_BASE64>`. `VALEUR_ENCODEE_BASE64` étant la valeur en Base64 de `<username>:<password>`
- Constater que le statut de la réponse est `401 Unauthorized`

#### Cas OK

- Faire une requête `POST https://pix-audit-logger-review-pr6849.osc-fr1.scalingo.io/api/audit-logs` avec le header `Authorization: Basic <VALEUR_ENCODEE_BASE64>`. `VALEUR_ENCODEE_BASE64` étant la valeur en Base64 de `pix-api:pixApiClientSecretTest`
- Constater que le statut de la réponse est `204 NoContent`