### PR TITLE
[BUGFIX] Modifier le texte de la modale de signalement d'épreuve (PIX-8859).

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -658,7 +658,7 @@
         },
         "modal": {
           "title": "Confirmation du signalement",
-          "content": "'<p><strong>'Êtes-vous certain(e) de vouloir signaler ce problème ?'</strong></p><p>'Nous vous remercions pour votre signalement qui sera examiné attentivement par l'équipe de Pix. Nous prenons en compte tous vos commentaires pour améliorer continuellement nos services et l'expérience utilisateur. Nous ne pourrons pas vous donner de réponse personnalisée. Merci pour votre collaboration.'</p>'"
+          "content": "'<p><strong>'Êtes-vous certain de vouloir signaler ce problème ?'</strong></p><p>'Nous vous remercions pour votre signalement qui sera examiné attentivement par l'équipe de Pix. Nous prenons en compte tous vos commentaires pour améliorer continuellement nos services et l'expérience utilisateur. Nous ne pourrons pas vous donner de réponse personnalisée. Merci pour votre collaboration.'</p>'"
         }
       },
       "has-focused-out-of-window": {


### PR DESCRIPTION
## :unicorn: Problème

On avait introduit par erreur de l'écriture inclusive.

## :robot: Proposition

Supprimer l'écriture inclusive.

## :100: Pour tester

- Aller sur une page d'épreuve en RA et lancer un signalement.
