### PR TITLE
[FEATURE] Cacher l'ajout d'un commentaire sur les signalements sur Pix-App (PIX-8860)

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -59,25 +59,32 @@
                 </div>
               </div>
               {{#if this.displayTextBox}}
-                <div class="feedback-panel__group">
-                  <p class="feedback-panel__field-notice">
-                    {{t "pages.challenge.feedback-panel.form.status.error.max-characters"}}
-                  </p>
-                  <label class="screen-reader-only" for="feedback-panel__field">{{t
-                      "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
-                    }}</label>
-                  <PixTextarea
-                    class="feedback-panel__field--content"
-                    @value={{this.content}}
-                    @id="feedback-panel__field"
-                    @maxlength="10000"
-                    rows="5"
-                    placeholder={{t
-                      "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
-                    }}
-                    {{on "change" this.setContent}}
-                  />
-                </div>
+                {{#if this.displayAddCommentButton}}
+                  <button type="button" class="feedback-panel__comment" onClick={{this.addComment}}>
+                    <FaIcon @icon="pen" class="feedback-panel-comment__icon" />
+                    {{t "pages.challenge.feedback-panel.form.fields.detail-selection.add-comment"}}
+                  </button>
+                {{else}}
+                  <div>
+                    <p class="feedback-panel__field-notice">
+                      {{t "pages.challenge.feedback-panel.form.status.error.max-characters"}}
+                    </p>
+                    <label class="screen-reader-only" for="feedback-panel__field">{{t
+                        "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
+                      }}</label>
+                    <PixTextarea
+                      class="feedback-panel__field--content"
+                      @value={{this.content}}
+                      @id="feedback-panel__field"
+                      @maxlength="10000"
+                      rows="5"
+                      placeholder={{t
+                        "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
+                      }}
+                      {{on "change" this.setContent}}
+                    />
+                  </div>
+                {{/if}}
                 <PixButton
                   @triggerAction={{this.toggleModalVisibility}}
                   @backgroundColor="grey"

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -15,6 +15,7 @@ export default class FeedbackPanel extends Component {
   @tracked content = null;
   @tracked displayQuestionDropdown = false;
   @tracked displayTextBox = false;
+  @tracked displayAddCommentButton = true;
   @tracked isFormSubmitted = false;
   @tracked nextCategory = null;
   @tracked quickHelpInstructions = null;
@@ -156,6 +157,11 @@ export default class FeedbackPanel extends Component {
     this.isModalVisible = !this.isModalVisible;
   }
 
+  @action
+  addComment() {
+    this.displayAddCommentButton = false;
+  }
+
   _resetPanel() {
     this.isFormSubmitted = false;
     this._resetForm();
@@ -171,12 +177,14 @@ export default class FeedbackPanel extends Component {
     this.quickHelpInstructions = null;
     this._currentMajorCategory = null;
     this.displayTextBox = false;
+    this.displayAddCommentButton = true;
     this.displayQuestionDropdown = false;
   }
 
   _showFeedbackActionBasedOnCategoryType(category) {
     this.displayTextBox = false;
     this.quickHelpInstructions = null;
+    this.displayAddCommentButton = true;
 
     if (category.type === 'tutorial') {
       this.quickHelpInstructions = category.content;

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -70,8 +70,22 @@
   width: 100%;
 }
 
-.feedback-panel__group {
-  margin-bottom: $pix-spacing-xs;
+.feedback-panel__comment {
+  @extend %pix-body-s;
+
+  display: flex;
+  align-items: center;
+  margin: $pix-spacing-s 0;
+  color: $pix-neutral-70;
+  font-weight: 500;
+  text-decoration: underline;
+}
+
+.feedback-panel-comment {
+  &__icon {
+    margin-right: $pix-spacing-xxs;
+    padding: $pix-spacing-xxs;
+  }
 }
 
 .feedback-panel__field-notice {

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -26,6 +26,7 @@ module.exports = function () {
       'link',
       'lock',
       'minus',
+      'pen',
       'plus',
       'power-off',
       'right-from-bracket',

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -53,6 +53,11 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
               name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
             }),
           );
+          await click(
+            screen.getByRole('button', {
+              name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
+            }),
+          );
           const contentValue = 'Prêtes-moi ta plume, pour écrire un mot';
           await fillIn(
             screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }),
@@ -82,6 +87,11 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
                 name: this.intl.t(
                   'pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility',
                 ),
+              }),
+            );
+            await click(
+              screen.getByRole('button', {
+                name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
               }),
             );
 

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -101,6 +101,11 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       test('should display the "mercix" view when content value is filled', async function (assert) {
         // given
+        await click(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
+          }),
+        );
         const contentValue = 'Prêtes-moi ta plume, pour écrire un mot';
         await fillIn(
           screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }),
@@ -164,6 +169,11 @@ module('Integration | Component | feedback-panel', function (hooks) {
             name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
           }),
         );
+        await click(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
+          }),
+        );
 
         // then
         const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
@@ -219,6 +229,11 @@ module('Integration | Component | feedback-panel', function (hooks) {
             name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
           }),
         );
+        await click(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
+          }),
+        );
 
         // then
         assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
@@ -247,6 +262,11 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await click(
           screen.getByRole('option', {
             name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+          }),
+        );
+        await click(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
           }),
         );
 
@@ -280,6 +300,11 @@ module('Integration | Component | feedback-panel', function (hooks) {
             name: this.intl.t(
               'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-displayed-on-mobile-devices-with-problems.label',
             ),
+          }),
+        );
+        await click(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
           }),
         );
 
@@ -445,6 +470,11 @@ module('Integration | Component | feedback-panel', function (hooks) {
       await click(
         screen.getByRole('option', {
           name: this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.accessibility'),
+        }),
+      );
+      await click(
+        screen.getByRole('button', {
+          name: this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.add-comment'),
         }),
       );
 

--- a/mon-pix/tests/unit/components/feedback-panel_test.js
+++ b/mon-pix/tests/unit/components/feedback-panel_test.js
@@ -123,4 +123,17 @@ module('Unit | Component | feedback-panel', function (hooks) {
       assert.notOk(component.nextCategory);
     });
   });
+
+  module('#addComment', function () {
+    test('should display a comment input and hide button', async function (assert) {
+      // given
+      component.displayAddCommentButton = true;
+
+      // when
+      component.addComment();
+
+      // then
+      assert.false(component.displayAddCommentButton);
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -588,6 +588,7 @@
               }
             },
             "detail-selection": {
+              "add-comment": "Add a comment",
               "aria-first": "Select the category of the problem encountered",
               "aria-secondary": "Select an option to specify your problem",
               "label": "Select an option to specify your problem",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -588,6 +588,7 @@
               }
             },
             "detail-selection": {
+              "add-comment": "Ajouter un commentaire",
               "aria-first": "J'ai un problème avec",
               "aria-secondary": "Sélectionner une option pour préciser votre problème",
               "label": "Sélectionner une option pour préciser votre problème",


### PR DESCRIPTION
## :unicorn: Problème
On souhaite cacher l'ajout d'un commentaire sur les signalements pour éviter l'envoi de commentaires abusifs.

## :robot: Proposition
Ajouter un bouton permettant d'afficher un `textarea` pour compléter le signalement avec un commentaire.

## :rainbow: Remarques

## :100: Pour tester
Aller sur la [RA](https://app-pr6852.review.pix.fr/connexion)
Aller sur le panneau de signalements et vérifier l'utilisabilité du bouton.
