### PR TITLE
[FEATURE]  Barre de recherche pour rattacher des profils cibles à une complémentaire (PIX-8856)

### DIFF
--- a/admin/app/adapters/attachable-target-profile.js
+++ b/admin/app/adapters/attachable-target-profile.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class AttachableTargetProfile extends ApplicationAdapter {
+  namespace = 'api/admin/complementary-certifications';
+}

--- a/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.hbs
@@ -2,19 +2,34 @@
   <div class="card__title">1. Renseigner le nouveau profil cible à rattacher</div>
   <div class="card__content">
     <form class="complementary-certification-attach-target-profile__form">
-      <PixSelect
-        class=""
-        @label="ID du profil cible"
-        @emptyMessage="Aucun résultat"
-        @searchPlaceholder="Exemple: 3"
-        @searchLabel="Rechercher un profile cible à rattacher à la certification complémentaire"
-        @isSearchable={{true}}
-        @value={{this.targetProfileToAttach}}
-        @options={{this.targetProfiles}}
-        @onChange={{this.onChange}}
-        @hideDefaultOption={{true}}
-      />
-      <PixButton class="complementary-certification-attach-target-profile-form__submit-button">Valider</PixButton>
+      <div class="complementary-certification-attach-target-profile-form-search">
+        <PixSearchInput
+          @id="search-input"
+          @label="ID du profil cible"
+          @ariaLabel="Rechercher un profil cible à rattacher à la certification complémentaire"
+          @placeholder="Exemple: 3"
+          @debounceTimeInMs={{this.debounce}}
+          @triggerFiltering={{this.onSearchValueInput}}
+          autocomplete="off"
+        />
+        {{#if @options.length}}
+          <ul role="listbox" class="complementary-certification-attach-target-profile-form-search__results">
+            {{#each @options as |option|}}
+              <li
+                class="complementary-certification-attach-target-profile-form-search__results__option"
+                role="option"
+                aria-selected="false"
+                tabindex="0"
+                {{on "click" (fn this.onSelectTargetProfile option)}}
+                {{on-enter-action (fn this.onSelectTargetProfile option)}}
+                {{on-space-action (fn this.onSelectTargetProfile option)}}
+              >
+                {{option.label}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/if}}
+      </div>
     </form>
   </div>
 </div>

--- a/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.js
+++ b/admin/app/components/complementary-certifications/target-profiles/attach-target-profile.js
@@ -1,21 +1,18 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 export default class AttachTargetProfile extends Component {
-  @tracked targetProfileToAttach = this.targetProfiles[0].value;
-
-  get targetProfiles() {
-    return [
-      {
-        label: 'Profil cible 1',
-        value: 'coucou',
-      },
-    ];
+  get debounce() {
+    return 0;
   }
 
   @action
-  onChange(value) {
-    this.targetProfileToAttach = value;
+  async onSearchValueInput(_, value) {
+    this.args.onSearch(value);
+  }
+
+  @action
+  onSelectTargetProfile(option) {
+    this.args.onSelection(option);
   }
 }

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -1,12 +1,40 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
 
 export default class AttachTargetProfileController extends Controller {
   @service router;
+  @service store;
+
+  @tracked options = [];
 
   @action
   async cancel() {
     this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
+  }
+
+  @action
+  onSelection(selectedAttachableTargetProfile) {
+    // TODO: PIX-8858
+    console.log(selectedAttachableTargetProfile);
+  }
+
+  @action
+  async onSearch(value) {
+    const searchTerm = value?.trim();
+    const isSearchById = searchTerm && /^\d+$/.test(searchTerm);
+    const isSearchByName = searchTerm?.length >= 2;
+
+    if (isSearchById || isSearchByName) {
+      const attachableTargetProfiles = await this.store.query('attachable-target-profile', { searchTerm });
+
+      this.options = attachableTargetProfiles.map((attachableTargetProfile) => ({
+        label: `${attachableTargetProfile.id} - ${attachableTargetProfile.name}`,
+        value: attachableTargetProfile.id,
+      }));
+    } else {
+      this.options = [];
+    }
   }
 }

--- a/admin/app/models/attachable-target-profile.js
+++ b/admin/app/models/attachable-target-profile.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AttachableTargetProfile extends Model {
+  @attr('string') name;
+}

--- a/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
@@ -19,7 +19,55 @@
 }
 
 .complementary-certification-attach-target-profile-form {
+
   &__submit-button {
     height: 2.25rem;
+  }
+}
+
+.complementary-certification-attach-target-profile-form-search {
+  min-width: 40%;
+
+  &__results {
+    position: absolute;
+    z-index: 200;
+    width: inherit;
+    max-height: 12.5rem;
+    padding: $pix-spacing-xs $pix-spacing-s;
+    overflow-y: auto;
+    white-space: nowrap;
+    list-style-type: none;
+    background-color: $pix-neutral-0;
+    border-top: none;
+    border-radius: 0 0 $pix-spacing-xxs $pix-spacing-xxs;
+    box-shadow: 0 6px 12px rgb(7 20 46 / 8%);
+    transition: all 0.1s ease-in-out;
+
+    &__option:hover,
+    &__option:focus {
+      background-color: $pix-neutral-10;
+      outline: none;
+      cursor: pointer;
+    }
+
+    &::-webkit-scrollbar {
+      width: 0.5rem;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: $pix-neutral-20;
+      border: 1px solid $pix-neutral-20;
+      border-radius: $pix-spacing-xxs;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      width: 0.375rem;
+      background: $pix-neutral-30;
+      border-radius: $pix-spacing-xxs;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background: $pix-neutral-35;
+    }
   }
 }

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -20,7 +20,11 @@
       </LinkTo>
     </span>
 
-    <ComplementaryCertifications::TargetProfiles::AttachTargetProfile />
+    <ComplementaryCertifications::TargetProfiles::AttachTargetProfile
+      @onSelection={{this.onSelection}}
+      @onSearch={{this.onSearch}}
+      @options={{this.options}}
+    />
     <div>
       <PixButton
         @size="small"

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -412,6 +412,23 @@ function routes() {
     return schema.complementaryCertifications.find(request.params.id);
   });
 
+  this.get('admin/complementary-certifications/attachable-target-profiles', (schema, request) => {
+    const targetProfileId = parseInt(request.queryParams.searchTerm);
+    const targetProfile = schema.attachableTargetProfiles.find(targetProfileId);
+
+    return {
+      data: [
+        {
+          type: 'attachable-target-profile',
+          id: targetProfile.id,
+          attributes: {
+            name: targetProfile.name,
+          },
+        },
+      ],
+    };
+  });
+
   this.put('/admin/sessions/:id/comment', (schema, request) => {
     const sessionToUpdate = schema.sessions.find(request.params.id);
     const params = JSON.parse(request.requestBody);

--- a/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -109,7 +109,6 @@ function _applyFilters(
 
   if (versionFilter) {
     filteredSessions = filter(filteredSessions, { version: +versionFilter });
-    console.log(filteredSessions);
   }
 
   return filteredSessions;

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, waitFor } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import dayjs from 'dayjs';
@@ -68,6 +68,34 @@ module(
 
               // then
               assert.strictEqual(currentURL(), '/target-profiles/3/details');
+            });
+          });
+        });
+
+        module('when user type in the search bar', function () {
+          test('it should display the search results', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('complementary-certification', {
+              id: 1,
+              key: 'KEY',
+              label: 'MARIANNE CERTIF',
+              targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+            });
+            server.create('attachable-target-profile', {
+              id: 3,
+              name: 'ALEX TARGET',
+            });
+            const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+
+            // when
+            const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+            await fillIn(input, '3');
+
+            // then
+            await waitFor(async () => {
+              await screen.findByRole('listbox');
+              assert.dom(screen.getByRole('option', { name: '3 - ALEX TARGET' })).exists();
             });
           });
         });

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/attach-target-profile_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/attach-target-profile_test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { render, waitFor } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { fillIn } from '@ember/test-helpers';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import sinon from 'sinon';
+
+module('Integration | Component | ComplementaryCertifications::TargetProfiles::AttachTargetProfile', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it should display a search box', async function (assert) {
+    // given
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::TargetProfiles::AttachTargetProfile />`);
+
+    // then
+    assert.dom(screen.getByRole('searchbox', { name: 'ID du profil cible' })).exists();
+  });
+
+  test('it should display the provided search results', async function (assert) {
+    // given
+    const options = [{ label: '3 - ALEX TARGET' }];
+    this.set('options', options);
+
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::TargetProfiles::AttachTargetProfile
+      @options={{this.options}}
+    />`);
+
+    // then
+    const searchResult = await screen.findByRole('option', { name: '3 - ALEX TARGET' });
+    assert.dom(searchResult).exists();
+  });
+
+  test('it should trigger handler search function when the user is entering search terms', async function (assert) {
+    // given
+    const onSearchStub = sinon.stub();
+    this.set('onSearchStub', onSearchStub);
+
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::TargetProfiles::AttachTargetProfile
+      @onSearch={{this.onSearchStub}}
+    />`);
+    const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+    await fillIn(input, '3');
+
+    // then
+    sinon.assert.calledWithExactly(this.onSearchStub, '3');
+    assert.ok(true);
+  });
+
+  test('it should trigger handler function when a target profile is selected', async function (assert) {
+    // given
+    const options = [{ id: 3, label: '3 - ALEX TARGET' }];
+    this.set('options', options);
+    const onSelectionStub = sinon.stub();
+
+    this.set('onSelection', onSelectionStub);
+
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::TargetProfiles::AttachTargetProfile
+      @onSelection={{this.onSelection}}
+      @options={{this.options}}
+  />`);
+    await waitFor(async () => {
+      await screen.findByRole('listbox');
+    });
+    const targetProfileSelectable = screen.getByRole('option', { name: '3 - ALEX TARGET' });
+    await targetProfileSelectable.click();
+
+    // then
+    assert.ok(true);
+    sinon.assert.calledWithExactly(onSelectionStub, {
+      id: 3,
+      label: '3 - ALEX TARGET',
+    });
+  });
+});

--- a/admin/tests/unit/adapters/attachable-target-profile_test.js
+++ b/admin/tests/unit/adapters/attachable-target-profile_test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 module('Unit | Adapter | attachable-target-profile', function (hooks) {
   setupTest(hooks);
 
-  test.only('should send a GET request to search target profiles for complementary certification endpoint', async function (assert) {
+  test('should send a GET request to search target profiles for complementary certification endpoint', async function (assert) {
     // given
     const adapter = this.owner.lookup('adapter:attachable-target-profile');
     adapter.ajax = sinon.stub().resolves();
@@ -14,8 +14,6 @@ module('Unit | Adapter | attachable-target-profile', function (hooks) {
     const url = await adapter.urlForQuery(undefined, 'attachable-target-profile');
 
     // then
-    assert.ok(
-      url.endsWith('api/admin/complementary-certifications/attachable-target-profiles'),
-    );
+    assert.ok(url.endsWith('api/admin/complementary-certifications/attachable-target-profiles'));
   });
 });

--- a/admin/tests/unit/adapters/attachable-target-profile_test.js
+++ b/admin/tests/unit/adapters/attachable-target-profile_test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | attachable-target-profile', function (hooks) {
+  setupTest(hooks);
+
+  test.only('should send a GET request to search target profiles for complementary certification endpoint', async function (assert) {
+    // given
+    const adapter = this.owner.lookup('adapter:attachable-target-profile');
+    adapter.ajax = sinon.stub().resolves();
+
+    // when
+    const url = await adapter.urlForQuery(undefined, 'attachable-target-profile');
+
+    // then
+    assert.ok(
+      url.endsWith('api/admin/complementary-certifications/attachable-target-profiles'),
+    );
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -1,0 +1,109 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | attach-target-profile', function (hooks) {
+  setupTest(hooks);
+
+  module('#onSearch', function () {
+    module('when there is no searchTerm', function () {
+      test('it should update options with an empty array', async function (assert) {
+        const controller = this.owner.lookup(
+          'controller:authenticated/complementary-certifications.complementary-certification.attach-target-profile',
+        );
+
+        // when
+        controller.onSearch(null, '');
+
+        // then
+        assert.deepEqual(controller.options, []);
+      });
+    });
+
+    module('when there is a searchTerm', function () {
+      module('when there is a searchTerm with one number', function () {
+        test('it should update options with the list of attachable target profile', async function (assert) {
+          const store = this.owner.lookup('service:store');
+          const attachableTargetProfile = store.createRecord('attachable-target-profile', {
+            id: 12,
+            name: 'target-profile',
+          });
+          const expectedOption = {
+            label: '12 - target-profile',
+            value: '12',
+          };
+          store.query = sinon.stub().resolves([attachableTargetProfile]);
+          const controller = this.owner.lookup(
+            'controller:authenticated/complementary-certifications.complementary-certification.attach-target-profile',
+          );
+          // when
+          await controller.onSearch(' 1 ');
+
+          // then
+          assert.ok(store.query.calledWithExactly('attachable-target-profile', { searchTerm: '1' }));
+          assert.deepEqual(controller.options, [expectedOption]);
+        });
+      });
+      module('when there is a searchTerm with 2 or more characters', function () {
+        test('it should update options with the list of attachable target profile', async function (assert) {
+          const store = this.owner.lookup('service:store');
+          const attachableTargetProfile = store.createRecord('attachable-target-profile', {
+            id: 12,
+            name: 'target-profile',
+          });
+          const expectedOption = {
+            label: '12 - target-profile',
+            value: '12',
+          };
+          store.query = sinon.stub().resolves([attachableTargetProfile]);
+          const controller = this.owner.lookup(
+            'controller:authenticated/complementary-certifications.complementary-certification.attach-target-profile',
+          );
+          // when
+          await controller.onSearch('tar');
+
+          // then
+          assert.ok(store.query.calledWithExactly('attachable-target-profile', { searchTerm: 'tar' }));
+          assert.deepEqual(controller.options, [expectedOption]);
+        });
+      });
+      module('when there is a searchTerm with less than 2 characters other than number', function () {
+        test('it should update searchResults with the list of attachable target profile', async function (assert) {
+          const store = this.owner.lookup('service:store');
+          const controller = this.owner.lookup(
+            'controller:authenticated/complementary-certifications.complementary-certification.attach-target-profile',
+          );
+          store.query = sinon.stub();
+
+          // when
+          await controller.onSearch('t');
+
+          // then
+          assert.notOk(store.query.called);
+          assert.deepEqual(controller.options, []);
+        });
+      });
+    });
+  });
+
+  module('#onSelectTargetProfile', function () {
+    module('when a target profile is selected', function () {
+      test('it should update selectedTargetProfile and searchResults with an empty array', async function (assert) {
+        const store = this.owner.lookup('service:store');
+        const controller = this.owner.lookup(
+          'controller:authenticated/complementary-certifications.complementary-certification.attach-target-profile',
+        );
+        const targetProfile = store.createRecord('attachable-target-profile', {
+          id: 12,
+          name: 'target profile',
+        });
+
+        // when
+        controller.onSelection(targetProfile);
+
+        // then
+        assert.deepEqual(controller.options, []);
+      });
+    });
+  });
+});

--- a/api/lib/application/complementary-certifications/index.js
+++ b/api/lib/application/complementary-certifications/index.js
@@ -53,7 +53,7 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/admin/complementary-certifications/target-profiles/search',
+      path: '/api/admin/complementary-certifications/attachable-target-profiles',
       config: {
         validate: {
           query: Joi.object({

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -160,14 +160,14 @@ describe('Acceptance | API | complementary-certification-controller', function (
     });
   });
 
-  describe('GET /api/admin/complementary-certifications/target-profiles/search', function () {
+  describe('GET /api/admin/complementary-certifications/target-profiles/attachable-target-profiles', function () {
     context('when no search term provided', function () {
       it('should return 200 HTTP status code', async function () {
         // given
         const superAdmin = await insertUserWithRoleSuperAdmin();
         const options = {
           method: 'GET',
-          url: '/api/admin/complementary-certifications/target-profiles/search',
+          url: '/api/admin/complementary-certifications/attachable-target-profiles',
           headers: {
             authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
           },
@@ -205,7 +205,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
         const superAdmin = await insertUserWithRoleSuperAdmin();
         const options = {
           method: 'GET',
-          url: '/api/admin/complementary-certifications/target-profiles/search?searchTerm=that%20way',
+          url: '/api/admin/complementary-certifications/attachable-target-profiles?searchTerm=that%20way',
           headers: {
             authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
           },

--- a/api/tests/unit/application/complementary-certifications/index_test.js
+++ b/api/tests/unit/application/complementary-certifications/index_test.js
@@ -25,7 +25,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
     });
   });
 
-  describe('GET /api/admin/complementary-certifications/target-profiles/search', function () {
+  describe('GET /api/admin/complementary-certifications/attachable-target-profiles', function () {
     describe('when the user authenticated has certif role', function () {
       it('should return 403 HTTP status code', async function () {
         // given
@@ -39,7 +39,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
         // when
         const response = await httpTestServer.request(
           'GET',
-          '/api/admin/complementary-certifications/target-profiles/search',
+          '/api/admin/complementary-certifications/attachable-target-profiles',
         );
 
         // then
@@ -65,7 +65,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
         // when
         const response = await httpTestServer.request(
           'GET',
-          '/api/admin/complementary-certifications/target-profiles/search',
+          '/api/admin/complementary-certifications/attachable-target-profiles',
         );
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
L’utilisateur qui veut changer le PC rattaché à une certification complémentaire a besoin de pouvoir le retrouver facilement grâce à l’id qu’il a l’habitude d’utiliser mais aussi de vérifier le nom du nouveau PC sélectionné avant de valider la modification.

## :robot: Proposition

* Barre de recherche
  * La recherche se déclenche sur : 1..n chiffres remplis, sinon a minima 2 caractères 
* Au clic, cela renvoi le profil choisi

## :rainbow: Remarques
* Au clic il ne se passe rien actuellement car c'est implémenté dans PIX-8858

## :100: Pour tester
* Sur Pix Admin, avec `superadmin@example.net`
* Page `/complementary-certifications/list`
* Cliquer sur une complémentaire, puis sur "Rattacher un profil"
* Tenter une recherche avec un seul chiffre --> '1', la recherche doit apparaitre
* Effacer, Tenter une recherche avec 1 caractère --> 'n', la recherche de doit pas apparaitre
* Ajouter un caractère de plus --> 'nu', la recherche se déclenche
