### PR TITLE
[TECH] Gestion d'une page d'erreur pour 1d (PIX-8805)

### DIFF
--- a/1d/app/pods/assessment/challenge/route.js
+++ b/1d/app/pods/assessment/challenge/route.js
@@ -7,20 +7,18 @@ export default class ChallengeRoute extends Route {
 
   async model(params, transition) {
     const assessment = await this.modelFor('assessment');
-    try {
-      const challengeId = transition?.to.queryParams.challengeId;
-      if (assessment.type === 'PREVIEW' && challengeId) {
-        const challenge = await this.store.findRecord('challenge', challengeId);
-        return { assessment, challenge };
-      }
-      const challenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
-      const activity = await this.store.queryRecord('activity', { assessmentId: assessment.id });
-      return { assessment, challenge, activity };
-    } catch (err) {
-      //TODO manage error instead of says it's the end...
+    const challengeId = transition?.to.queryParams.challengeId;
+    if (assessment.type === 'PREVIEW' && challengeId) {
+      const challenge = await this.store.findRecord('challenge', challengeId);
+      return { assessment, challenge };
+    }
+    const challenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
+    if (challenge == null) {
       return this.router.replaceWith('assessment.resume', assessment.id, {
         queryParams: { assessmentHasNoMoreQuestions: true },
       });
     }
+    const activity = await this.store.queryRecord('activity', { assessmentId: assessment.id });
+    return { assessment, challenge, activity };
   }
 }

--- a/1d/app/pods/error/template.hbs
+++ b/1d/app/pods/error/template.hbs
@@ -1,0 +1,5 @@
+<div class="error">
+  <h1>{{t "pages.error.title"}}</h1>
+  <p>{{t "pages.error.message"}}</p>
+  <LinkTo class="pix1d-button pix1d-button--small not-found__button" @route="home">{{t "pages.error.backHome"}}</LinkTo>
+</div>

--- a/1d/app/pods/not-found/template.hbs
+++ b/1d/app/pods/not-found/template.hbs
@@ -1,0 +1,7 @@
+<div class="error">
+  <h1>{{t "pages.not-found.title"}}</h1>
+  <p>{{t "pages.not-found.message"}}</p>
+  <LinkTo class="pix1d-button pix1d-button--small not-found__button" @route="home">{{t
+      "pages.not-found.backHome"
+    }}</LinkTo>
+</div>

--- a/1d/app/router.js
+++ b/1d/app/router.js
@@ -19,4 +19,7 @@ Router.map(function () {
     this.route('results');
     this.route('challenge', { path: '/challenges' });
   });
+
+  // XXX: this route is used for any request that did not match any of the previous routes. SHOULD ALWAYS BE THE LAST ONE
+  this.route('not-found', { path: '/*path' });
 });

--- a/1d/app/styles/app.scss
+++ b/1d/app/styles/app.scss
@@ -15,6 +15,7 @@
 @import 'components/challenge-instruction';
 @import 'components/challenge-item';
 @import 'components/challenge-item-proposals';
+@import 'components/error';
 @import 'components/home';
 @import 'components/mission';
 @import 'components/warning';

--- a/1d/app/styles/components/error.scss
+++ b/1d/app/styles/components/error.scss
@@ -1,0 +1,21 @@
+.error {
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+  align-items: center;
+  height: 100vh;
+  background-color: var(--pix-color-secondary);
+
+  h1 {
+    margin-top: 50px;
+    font-size: 2.5rem;
+  }
+
+  p {
+    font-size: 1.5rem;
+  }
+
+  &__button {
+    width: fit-content;
+  }
+}

--- a/1d/tests/unit/routes/assessment-challenge_test.js
+++ b/1d/tests/unit/routes/assessment-challenge_test.js
@@ -47,7 +47,7 @@ module('Unit | Route | AssessmentChallengeRoute', function (hooks) {
         const assessment = { id: 2 };
         sinon.stub(route.router, 'replaceWith');
         sinon.stub(route, 'modelFor').returns(assessment);
-        sinon.stub(store, 'queryRecord').rejects();
+        sinon.stub(store, 'queryRecord').returns(null);
 
         await route.model();
 

--- a/1d/translations/fr.json
+++ b/1d/translations/fr.json
@@ -4,6 +4,16 @@
       "illustration": {
         "placeholder": "Chargement de l'image en cours"
       }
+    },
+    "not-found": {
+      "title": "Page non trouvée",
+      "message": "La page que tu cherches n'existe pas sur Pix1D.",
+      "backHome": "Retour à l'accueil"
+    },
+    "error": {
+      "title": "Erreur",
+      "message": "Oups, une erreur inattendue est survenue.",
+      "backHome": "Retour à l'accueil"
     }
   }
 }

--- a/api/lib/domain/usecases/get-next-challenge-for-pix1d.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-pix1d.js
@@ -95,6 +95,7 @@ async function _getNextActivityChallenge(
     });
   }
   assessmentRepository.completeByAssessmentId(assessmentId);
+  return null;
 }
 
 const status = {

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-pix1d_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-pix1d_test.js
@@ -161,7 +161,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-pix1d', function ()
       // when
       const result = await getNextChallengeForPix1d({ assessmentId, ...dependencies });
       // then
-      expect(result).to.equal(undefined);
+      expect(result).to.equal(null);
     });
 
     it('should update the activity with the status succeed', async function () {
@@ -280,7 +280,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-pix1d', function ()
       const result = await getNextChallengeForPix1d({ assessmentId, ...dependencies });
 
       // then
-      expect(result).to.equal(undefined);
+      expect(result).to.equal(null);
     });
     it('should update the activity with the status failed', async function () {
       // when
@@ -319,7 +319,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-pix1d', function ()
       const result = await getNextChallengeForPix1d({ assessmentId, ...dependencies });
 
       // then
-      expect(result).to.equal(undefined);
+      expect(result).to.equal(null);
     });
     it('should update the activity with the status skipped', async function () {
       // when


### PR DESCRIPTION
## :unicorn: Problème

En cas d'erreur, nous affichons une page blanche.

Lorsque nous avons un problème côté API sur la récupération du prochain challenge, nous avons un comportement qui consiste à dire que la mission est finie (au lieu d'afficher une erreur).

## :robot: Proposition

Ajouter une page d'erreur explicite que ce soit pour 
- l'accès a une ressource non disponible sur 1d
- un retour en erreur de l'API.

## :rainbow: Remarques

:unicorn: 

## :100: Pour tester

Sur la RA : 

- sur une URL qui n'existe pas (ex : https://1d-pr6855.review.pix.fr/missionsssss), la page "Page non trouvée" est affichée
- sur une URL qui charge une ressource inconnue (ex: https://1d-pr6855.review.pix.fr/missions/plop) , la page "Erreur" est affichée
