### PR TITLE
[TECH] Utiliser les repositories grâce au fichier index.

### DIFF
--- a/api/lib/domain/usecases/add-tutorial-evaluation.js
+++ b/api/lib/domain/usecases/add-tutorial-evaluation.js
@@ -5,7 +5,7 @@ const addTutorialEvaluation = async function ({
   tutorialId,
   status,
 } = {}) {
-  await tutorialRepository.get(tutorialId);
+  await tutorialRepository.get({ tutorialId });
 
   return tutorialEvaluationRepository.createOrUpdate({ userId, tutorialId, status });
 };

--- a/api/lib/domain/usecases/add-tutorial-to-user.js
+++ b/api/lib/domain/usecases/add-tutorial-to-user.js
@@ -6,7 +6,7 @@ const addTutorialToUser = async function ({
   tutorialId,
   skillId,
 } = {}) {
-  await tutorialRepository.get(tutorialId);
+  await tutorialRepository.get({ tutorialId });
   if (skillId != null) await skillRepository.get(skillId);
 
   return userSavedTutorialRepository.addTutorial({ userId, tutorialId, skillId });

--- a/api/lib/domain/usecases/get-current-user.js
+++ b/api/lib/domain/usecases/get-current-user.js
@@ -9,7 +9,7 @@ const getCurrentUser = async function ({
   const [hasAssessmentParticipations, codeForLastProfileToShare, hasRecommendedTrainings] = await Promise.all([
     campaignParticipationRepository.hasAssessmentParticipations(authenticatedUserId),
     campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(authenticatedUserId),
-    userRecommendedTrainingRepository.hasRecommendedTrainings(authenticatedUserId),
+    userRecommendedTrainingRepository.hasRecommendedTrainings({ userId: authenticatedUserId }),
   ]);
   const user = await userRepository.get(authenticatedUserId);
   const shouldSeeDataProtectionPolicyInformationBanner = user.shouldSeeDataProtectionPolicyInformationBanner;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -179,7 +179,6 @@ import * as targetProfileSummaryForAdminRepository from '../../infrastructure/re
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
 import * as temporarySessionsStorageForMassImportService from '../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js';
 import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';
-import * as trainingRepository from '../../infrastructure/repositories/training-repository.js';
 import * as trainingTriggerRepository from '../../infrastructure/repositories/training-trigger-repository.js';
 import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
 import * as tutorialEvaluationRepository from '../../infrastructure/repositories/tutorial-evaluation-repository.js';
@@ -401,7 +400,7 @@ const dependencies = {
   temporarySessionsStorageForMassImportService,
   thematicRepository,
   tokenService,
-  trainingRepository,
+  trainingRepository: repositories.trainingRepository,
   trainingTriggerRepository,
   tubeRepository,
   tutorialEvaluationRepository,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -179,7 +179,6 @@ import * as targetProfileSummaryForAdminRepository from '../../infrastructure/re
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
 import * as temporarySessionsStorageForMassImportService from '../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js';
 import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';
-import * as trainingTriggerRepository from '../../infrastructure/repositories/training-trigger-repository.js';
 import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
 import * as tutorialEvaluationRepository from '../../infrastructure/repositories/tutorial-evaluation-repository.js';
 import * as tutorialRepository from '../../infrastructure/repositories/tutorial-repository.js';
@@ -401,7 +400,7 @@ const dependencies = {
   thematicRepository,
   tokenService,
   trainingRepository: repositories.trainingRepository,
-  trainingTriggerRepository,
+  trainingTriggerRepository: repositories.trainingTriggerRepository,
   tubeRepository,
   tutorialEvaluationRepository,
   tutorialRepository,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -180,7 +180,6 @@ import * as targetProfileTrainingRepository from '../../infrastructure/repositor
 import * as temporarySessionsStorageForMassImportService from '../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js';
 import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
-import * as tutorialEvaluationRepository from '../../infrastructure/repositories/tutorial-evaluation-repository.js';
 import * as tutorialRepository from '../../infrastructure/repositories/tutorial-repository.js';
 import * as userEmailRepository from '../../infrastructure/repositories/user-email-repository.js';
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
@@ -402,7 +401,7 @@ const dependencies = {
   trainingRepository: repositories.trainingRepository,
   trainingTriggerRepository: repositories.trainingTriggerRepository,
   tubeRepository,
-  tutorialEvaluationRepository,
+  tutorialEvaluationRepository: repositories.tutorialEvaluationRepository,
   tutorialRepository,
   userEmailRepository,
   userLoginRepository,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -185,7 +185,6 @@ import * as userEmailRepository from '../../infrastructure/repositories/user-ema
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
 import * as userOrgaSettingsRepository from '../../infrastructure/repositories/user-orga-settings-repository.js';
 import * as userOrganizationsForAdminRepository from '../../infrastructure/repositories/user-organizations-for-admin-repository.js';
-import * as userRecommendedTrainingRepository from '../../infrastructure/repositories/user-recommended-training-repository.js';
 import * as userReconciliationService from '../services/user-reconciliation-service.js';
 import * as userRepository from '../../infrastructure/repositories/user-repository.js';
 import * as userSavedTutorialRepository from '../../infrastructure/repositories/user-saved-tutorial-repository.js';
@@ -407,7 +406,7 @@ const dependencies = {
   userLoginRepository,
   userOrgaSettingsRepository,
   userOrganizationsForAdminRepository,
-  userRecommendedTrainingRepository,
+  userRecommendedTrainingRepository: repositories.userRecommendedTrainingRepository,
   userReconciliationService,
   userRepository,
   userSavedTutorialRepository,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -180,7 +180,6 @@ import * as targetProfileTrainingRepository from '../../infrastructure/repositor
 import * as temporarySessionsStorageForMassImportService from '../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js';
 import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
-import * as tutorialRepository from '../../infrastructure/repositories/tutorial-repository.js';
 import * as userEmailRepository from '../../infrastructure/repositories/user-email-repository.js';
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
 import * as userOrgaSettingsRepository from '../../infrastructure/repositories/user-orga-settings-repository.js';
@@ -401,7 +400,7 @@ const dependencies = {
   trainingTriggerRepository: repositories.trainingTriggerRepository,
   tubeRepository,
   tutorialEvaluationRepository: repositories.tutorialEvaluationRepository,
-  tutorialRepository,
+  tutorialRepository: repositories.tutorialRepository,
   userEmailRepository,
   userLoginRepository,
   userOrgaSettingsRepository,

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -1,12 +1,14 @@
 import { injectDependencies } from '../utils/dependency-injection.js';
 
 import * as correctionRepository from './correction-repository.js';
+import * as trainingRepository from './training-repository.js';
 
 import { fromDatasourceObject } from '../adapters/solution-adapter.js';
 import * as tutorialRepository from './tutorial-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
   correctionRepository,
+  trainingRepository,
 };
 
 const dependencies = {

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -4,6 +4,7 @@ import * as correctionRepository from './correction-repository.js';
 import * as trainingRepository from './training-repository.js';
 import * as trainingTriggerRepository from './training-trigger-repository.js';
 import * as tutorialEvaluationRepository from './tutorial-evaluation-repository.js';
+import * as userRecommendedTrainingRepository from './user-recommended-training-repository.js';
 
 import { fromDatasourceObject } from '../adapters/solution-adapter.js';
 import * as tutorialRepository from './tutorial-repository.js';
@@ -13,6 +14,7 @@ const repositoriesWithoutInjectedDependencies = {
   trainingRepository,
   trainingTriggerRepository,
   tutorialEvaluationRepository,
+  userRecommendedTrainingRepository,
 };
 
 const dependencies = {

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -2,6 +2,7 @@ import { injectDependencies } from '../utils/dependency-injection.js';
 
 import * as correctionRepository from './correction-repository.js';
 import * as trainingRepository from './training-repository.js';
+import * as trainingTriggerRepository from './training-trigger-repository.js';
 
 import { fromDatasourceObject } from '../adapters/solution-adapter.js';
 import * as tutorialRepository from './tutorial-repository.js';
@@ -9,6 +10,7 @@ import * as tutorialRepository from './tutorial-repository.js';
 const repositoriesWithoutInjectedDependencies = {
   correctionRepository,
   trainingRepository,
+  trainingTriggerRepository,
 };
 
 const dependencies = {

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -4,16 +4,17 @@ import * as correctionRepository from './correction-repository.js';
 import * as trainingRepository from './training-repository.js';
 import * as trainingTriggerRepository from './training-trigger-repository.js';
 import * as tutorialEvaluationRepository from './tutorial-evaluation-repository.js';
+import * as tutorialRepository from './tutorial-repository.js';
 import * as userRecommendedTrainingRepository from './user-recommended-training-repository.js';
 
 import { fromDatasourceObject } from '../adapters/solution-adapter.js';
-import * as tutorialRepository from './tutorial-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
   correctionRepository,
   trainingRepository,
   trainingTriggerRepository,
   tutorialEvaluationRepository,
+  tutorialRepository,
   userRecommendedTrainingRepository,
 };
 

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -3,6 +3,7 @@ import { injectDependencies } from '../utils/dependency-injection.js';
 import * as correctionRepository from './correction-repository.js';
 import * as trainingRepository from './training-repository.js';
 import * as trainingTriggerRepository from './training-trigger-repository.js';
+import * as tutorialEvaluationRepository from './tutorial-evaluation-repository.js';
 
 import { fromDatasourceObject } from '../adapters/solution-adapter.js';
 import * as tutorialRepository from './tutorial-repository.js';
@@ -11,6 +12,7 @@ const repositoriesWithoutInjectedDependencies = {
   correctionRepository,
   trainingRepository,
   trainingTriggerRepository,
+  tutorialEvaluationRepository,
 };
 
 const dependencies = {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -6,12 +6,11 @@ import { tutorialDatasource } from '../datasources/learning-content/tutorial-dat
 import { NotFoundError } from '../../domain/errors.js';
 import { TutorialForUser } from '../../domain/read-models/TutorialForUser.js';
 import { LOCALE } from '../../domain/constants.js';
-
-const { FRENCH_FRANCE } = LOCALE;
-
 import * as knowledgeElementRepository from './knowledge-element-repository.js';
 import * as skillRepository from './skill-repository.js';
 import * as paginateModule from '../utils/paginate.js';
+
+const { FRENCH_FRANCE } = LOCALE;
 
 const findByRecordIdsForCurrentUser = async function ({ ids, userId, locale }) {
   const tutorials = await _findByRecordIds({ ids, locale });
@@ -52,9 +51,9 @@ const findPaginatedFilteredForCurrentUser = async function ({ userId, filters = 
   return { models, meta };
 };
 
-const get = async function (id) {
+const get = async function ({ tutorialId }) {
   try {
-    const tutorialData = await tutorialDatasource.get(id);
+    const tutorialData = await tutorialDatasource.get(tutorialId);
     return _toDomain(tutorialData);
   } catch (error) {
     throw new NotFoundError('Tutorial not found');

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -19,10 +19,6 @@ const findByRecordIdsForCurrentUser = async function ({ ids, userId, locale }) {
   return _toTutorialsForUser({ tutorials, tutorialEvaluations, userSavedTutorials });
 };
 
-const findByRecordIds = async function (ids) {
-  return _findByRecordIds({ ids });
-};
-
 const findPaginatedFilteredForCurrentUser = async function ({ userId, filters = {}, page }) {
   const userSavedTutorials = await userSavedTutorialRepository.find({ userId });
   const [tutorials, tutorialEvaluations] = await Promise.all([
@@ -106,7 +102,6 @@ const findPaginatedFilteredRecommendedByUserId = async function ({
 
 export {
   findByRecordIdsForCurrentUser,
-  findByRecordIds,
   findPaginatedFilteredForCurrentUser,
   get,
   list,

--- a/api/lib/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/lib/infrastructure/repositories/user-recommended-training-repository.js
@@ -31,7 +31,7 @@ const findByCampaignParticipationId = async function ({
   return trainings.map(_toDomain);
 };
 
-const hasRecommendedTrainings = async function (userId, domainTransaction = DomainTransaction.emptyTransaction()) {
+const hasRecommendedTrainings = async function ({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction?.knexTransaction || knex;
   const result = await knexConn(TABLE_NAME).select(1).where({ userId }).first();
   return Boolean(result);

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -106,40 +106,6 @@ describe('Integration | Repository | tutorial-repository', function () {
     });
   });
 
-  describe('#findByRecordIds', function () {
-    it('should find tutorials by ids', async function () {
-      // given
-      const tutorialsList = [
-        {
-          duration: '00:00:54',
-          format: 'video',
-          link: 'https://tuto.fr',
-          source: 'tuto.fr',
-          title: 'tuto0',
-          id: 'recTutorial0',
-        },
-        {
-          duration: '00:01:54',
-          format: 'page',
-          link: 'https://tuto.com',
-          source: 'tuto.com',
-          title: 'tuto1',
-          id: 'recTutorial1',
-        },
-      ];
-      const learningContent = { tutorials: tutorialsList };
-      mockLearningContent(learningContent);
-
-      // when
-      const tutorials = await tutorialRepository.findByRecordIds(['recTutorial0', 'recTutorial1']);
-
-      // then
-      expect(tutorials).to.have.lengthOf(2);
-      expect(tutorials[0]).to.be.instanceof(Tutorial);
-      expect(tutorials).to.deep.include.members(tutorialsList);
-    });
-  });
-
   describe('#findPaginatedFilteredForCurrentUser', function () {
     let userId;
 

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, mockLearningContent, databaseBuilder, catchErr, domainBuilder } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
 import { Tutorial } from '../../../../lib/domain/models/Tutorial.js';
 import { TutorialEvaluation } from '../../../../lib/domain/models/TutorialEvaluation.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
@@ -389,7 +389,7 @@ describe('Integration | Repository | tutorial-repository', function () {
     context('when tutorial does not exist', function () {
       it('should throw a NotFoundError', async function () {
         // when
-        const error = await catchErr(tutorialRepository.get)('recTutoImaginaire');
+        const error = await catchErr(tutorialRepository.get)({ tutorialId: 'recTutoImaginaire' });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
@@ -413,7 +413,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         mockLearningContent(learningContent);
 
         // when
-        const tutorial = await tutorialRepository.get('recTutorial0');
+        const tutorial = await tutorialRepository.get({ tutorialId: 'recTutorial0' });
 
         // then
         expect(tutorial).to.deep.equal(tutorials[0]);

--- a/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, knex } from '../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 import * as userRecommendedTrainingRepository from '../../../../lib/infrastructure/repositories/user-recommended-training-repository.js';
 import { UserRecommendedTraining } from '../../../../lib/domain/read-models/UserRecommendedTraining.js';
 
@@ -142,7 +142,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       await databaseBuilder.commit();
 
       // when
-      const result = await userRecommendedTrainingRepository.hasRecommendedTrainings(userId);
+      const result = await userRecommendedTrainingRepository.hasRecommendedTrainings({ userId });
 
       // then
       expect(result).to.equal(true);
@@ -156,7 +156,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       await databaseBuilder.commit();
 
       // when
-      const result = await userRecommendedTrainingRepository.hasRecommendedTrainings(userId);
+      const result = await userRecommendedTrainingRepository.hasRecommendedTrainings({ userId });
 
       // then
       expect(result).to.equal(false);

--- a/api/tests/unit/domain/usecases/get-current-user_test.js
+++ b/api/tests/unit/domain/usecases/get-current-user_test.js
@@ -24,7 +24,7 @@ describe('Unit | UseCase | get-current-user', function () {
     campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser
       .withArgs(1)
       .resolves('SOMECODE');
-    userRecommendedTrainingRepository.hasRecommendedTrainings.withArgs(1).resolves(false);
+    userRecommendedTrainingRepository.hasRecommendedTrainings.withArgs({ userId: 1 }).resolves(false);
 
     // when
     const result = await getCurrentUser({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il est possible de faire de l'injection de dépendance dans les repositories. Grâce à cela, nous avons un fichier index.js qui pourrait recenser tous les repositories et les exporter pour les utiliser ailleurs. Cependant, le fichier index ne contient qu'un seul repository.

## :robot: Proposition
Ajouter des repositories dans le fichier index, et s'en servir dans l'injection de dépendances pour les usecases.

## :rainbow: Remarques
Afin de faciliter une éventuelle injection de dépendance, les signatures de méthodes ont évoluées en prenant en paramètre un objet. (cf: https://github.com/1024pix/pix/pull/6332) 
Une méthode s'est avérée pas utilisée et a donc été supprimée. 

## :100: Pour tester
- CI OK 