### PR TITLE
[FEATURE] Active la remontée de la certificabilité automatique aux organizations SCO qui gère des élèves (PIX-8790)

### DIFF
--- a/api/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students.js
+++ b/api/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students.js
@@ -1,0 +1,40 @@
+import { knex, disconnect } from '../../db/knex-database-connection.js';
+import * as url from 'url';
+import * as apps from '../../lib/domain/constants.js';
+
+async function enableComputeCertificabilityOnScoOrganizationsThatManageStudents() {
+  const organizationIds = (
+    await knex('organizations').select('id').where({
+      type: 'SCO',
+      isManagingStudents: true,
+    })
+  ).map(({ id }) => id);
+
+  const { id: featureId } = await knex('features')
+    .select('id')
+    .where({ key: apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key })
+    .first();
+
+  await knex('organization-features')
+    .insert(organizationIds.map((organizationId) => ({ organizationId, featureId })))
+    .onConflict()
+    .ignore();
+}
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await enableComputeCertificabilityOnScoOrganizationsThatManageStudents();
+    } catch (error) {
+      console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+export { enableComputeCertificabilityOnScoOrganizationsThatManageStudents };

--- a/api/tests/integration/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students_test.js
+++ b/api/tests/integration/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students_test.js
@@ -1,0 +1,42 @@
+import { expect, databaseBuilder, knex } from '../../../test-helper.js';
+import { enableComputeCertificabilityOnScoOrganizationsThatManageStudents } from '../../../../scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students.js';
+import * as apps from '../../../../lib/domain/constants.js';
+
+describe('Integration | Scripts | enable-compute-certificability-on-sco-organizations-that-manages-students_test.js', function () {
+  afterEach(function () {
+    return knex('organization-features').delete();
+  });
+
+  it('should enable COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY feature on organizations of type SCO with isManagingStudents to true', async function () {
+    // given
+    databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
+    const organizationId = databaseBuilder.factory.buildOrganization({
+      type: 'SCO',
+      isManagingStudents: true,
+    }).id;
+    databaseBuilder.factory.buildOrganization({
+      type: 'SCO',
+      isManagingStudents: false,
+    });
+    databaseBuilder.factory.buildOrganization({
+      type: 'PRO',
+    });
+    databaseBuilder.factory.buildOrganization({
+      type: 'SUP',
+      isManagingStudents: true,
+    });
+    databaseBuilder.factory.buildOrganization({
+      type: 'SUP',
+      isManagingStudents: false,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await enableComputeCertificabilityOnScoOrganizationsThatManageStudents();
+
+    // then
+    const organizationFeatures = await knex('organization-features').where({ organizationId });
+    expect(organizationFeatures.length).to.equal(1);
+    expect(organizationFeatures[0].organizationId).to.equal(organizationId);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix qui met en place la remontée de la certificabilité automatique pour les organisations SCO qui gèrent des élèves, on a besoin d'activer la fonctionnalité sur toutes les organisations existantes.

## :robot: Proposition
On ajoute un script oneshot qui insère la feature dans la table organization-features pour toutes les organisations SCO qui gère des élèves.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- En local ou en RA lancer le script 
- Vérifier en base de données que des lignes ont été insérés dans la table organization-features
