### PR TITLE
[TECH] Désactiver l'execution de db:seed à la création des RA de audit-logger

### DIFF
--- a/audit-logger/scripts/scalingo-post-ra-creation.sh
+++ b/audit-logger/scripts/scalingo-post-ra-creation.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 npm run postdeploy
-npm run db:seed


### PR DESCRIPTION
## :unicorn: Problème

La tâche db:seed n'existe pas dans le package audit-logger. Des erreurs sont constatées lors de la tentative de son execution sur les RA 

## :robot: Proposition

Supprimer le lancement de db:seed

## :100: Pour tester

Vérifier que db:seed n'est pas exécuté sur la RA
