### PR TITLE
[TECH] Remets les features dans les seeds (PIX-8915).

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -108,7 +108,6 @@ class DatabaseBuilder {
   async _emptyDatabase() {
     const sortedTables = _.without(
       _.map(this.tablesOrderedByDependencyWithDirtinessMap, 'table'),
-      'features',
       'knex_migrations',
       'knex_migrations_lock',
       'view-active-organization-learners',

--- a/api/db/seeds/data/common/feature-builder.js
+++ b/api/db/seeds/data/common/feature-builder.js
@@ -1,0 +1,15 @@
+import { ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
+
+const featuresBuilder = async function ({ databaseBuilder }) {
+  databaseBuilder.factory.buildFeature({
+    key: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+    description: ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.description,
+  });
+  databaseBuilder.factory.buildFeature({
+    key: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+    description: ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.description,
+  });
+  await databaseBuilder.commit();
+};
+
+export { featuresBuilder };

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,5 +1,6 @@
 import { DatabaseBuilder } from '../database-builder/database-builder.js';
 import { commonBuilder } from './data/common/common-builder.js';
+import { featuresBuilder } from './data/common/feature-builder.js';
 import { team1dDataBuilder } from './data/team-1d/data-builder.js';
 import { teamContenuDataBuilder } from './data/team-contenu/data-builder.js';
 import { teamCertificationDataBuilder } from './data/team-certification/data-builder.js';
@@ -10,6 +11,9 @@ import { teamAccesDataBuilder } from './data/team-acces/data-builder.js';
 
 const seed = async function (knex) {
   const databaseBuilder = new DatabaseBuilder({ knex });
+  // This is needed when you have to re-seed database that is fully migrated (ex: on Scalingo you can't drop database)
+  await featuresBuilder({ databaseBuilder });
+
   await commonBuilder({ databaseBuilder });
   await teamAccesDataBuilder(databaseBuilder);
   await team1dDataBuilder({ databaseBuilder });

--- a/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
+++ b/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
@@ -4,6 +4,7 @@ import {
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
+import * as apps from '../../../../lib/domain/constants.js';
 
 import { createServer } from '../../../../server.js';
 
@@ -56,6 +57,7 @@ describe('Acceptance | Routes | organization-administration-controller', functio
         });
         const tag = databaseBuilder.factory.buildTag({ id: 7, name: 'AEFE' });
         databaseBuilder.factory.buildOrganizationTag({ tagId: tag.id, organizationId: organization.id });
+        databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
@@ -22,11 +22,7 @@ describe('Integration | Application | Controller | organization-administration-c
       identityProviderForCampaigns: 'POLE_EMPLOI',
     });
 
-    const feature = await knex('features')
-      .select('id')
-      .where({ key: apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key })
-      .first();
-    featureId = feature.id;
+    featureId = databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
 
     await databaseBuilder.commit();
   });


### PR DESCRIPTION
## :unicorn: Problème
Scalingo ne permet pas d'utiliser le script `db:reset` car il n'autorise pas le drop de base. Par conséquent pour re-seed une RA ou l'intégration il faut éxecuter les scripts suivants : 
- npm run db:empty
- npm run db:seed
Les features sont indispensables pour le bon fonctionnement de l'application. Vu que les migrations ont déjà été joué dans cette base, on est obligé d'ajouter dans les seeds pour qu'elle soit bien présentes en db.

## :robot: Proposition
On remet les features dans les seeds.

## :rainbow: Remarques
Une alternative consiste à supprimer l'addon pg dans la ra sur scalingo mais c'est plus fastidieux.

## :100: Pour tester
Lancer les scripts suivants sans erreur :
- npm run db:empty
- npm run db:seed