### PR TITLE
[BUGFIX] Ignorer les espaces dans les adresses emails saisies pour l'envoi d'invitation(s) depuis Pix Orga (PIX-7726)

### DIFF
--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -42,7 +42,7 @@ export default class NewController extends Controller {
 
   @action
   updateEmail(event) {
-    this.model.email = event.target.value;
+    this.model.email = event.target.value?.trim();
   }
 
   @action

--- a/orga/tests/unit/controllers/authenticated/team/new_test.js
+++ b/orga/tests/unit/controllers/authenticated/team/new_test.js
@@ -1,0 +1,23 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | Authenticated | Team | new', (hooks) => {
+  setupTest(hooks);
+
+  module('#updateEmail', () => {
+    test("removes email's spaces from input", function (assert) {
+      // given
+      const emailWithSpaces = '    user@example.net  ';
+      const controller = this.owner.lookup('controller:authenticated/team/new');
+      controller.model = {
+        email: null,
+      };
+
+      // when
+      controller.updateEmail({ target: { value: emailWithSpaces } });
+
+      // then
+      assert.strictEqual(controller.model.email, 'user@example.net');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un administrateur d'une organisation Pix souhaite inviter des personnes à rejoindre son équipe, si il met des espaces avant et/ou après l'adresse e-mail saisie, alors il reçoit une notification d'erreur lui indiquant que le format de l'e-mail saisi est incorrect.

## :robot: Proposition
Ajouter un `trim()` sur l'e-mail saisi de façon à ignorer ces espaces automatiquement.

## :rainbow: Remarques
RAS.

## :100: Pour tester

- Se rendre sur Pix Orga
- Se connecter avec le compte `allorga@exemple.net`
- Aller dans l'onglet `Equipe`
- Cliquer sur le bouton `Inviter un membre`
- Dans le champs `Adresse(s) e-mail`, saisissez une adresse e-mail avec plein d'espaces avant et après 
   - (ex: `'    naruto@konoha.net    '`)
- Cliquer sur le bouton `Inviter`
- Vérifier que vous recevez une notification de succès

