### PR TITLE
[FEATURE] Lire l'erreur de soumission d'épreuve à son apparition (PIX-8890).

### DIFF
--- a/mon-pix/app/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item-qcm.hbs
@@ -33,7 +33,7 @@
   </fieldset>
 
   {{#if this.errorMessage}}
-    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
+    <PixMessage role="alert" class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
     </PixMessage>
   {{/if}}

--- a/mon-pix/app/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item-qcu.hbs
@@ -33,7 +33,7 @@
   </fieldset>
 
   {{#if this.errorMessage}}
-    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
+    <PixMessage role="alert" class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
     </PixMessage>
   {{/if}}

--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -116,7 +116,7 @@
   {{/if}}
 
   {{#if this.errorMessage}}
-    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
+    <PixMessage role="alert" class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
     </PixMessage>
   {{/if}}

--- a/mon-pix/app/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/components/challenge-item-qrocm.hbs
@@ -32,7 +32,7 @@
   </div>
 
   {{#if this.errorMessage}}
-    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
+    <PixMessage role="alert" class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
     </PixMessage>
   {{/if}}

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -61,7 +61,7 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
       await click('.challenge-actions__action-validate');
 
       // then
-      assert.dom('.challenge-response__alert').exists();
+      assert.dom('.challenge-response__alert[role="alert"]').exists();
       assert.strictEqual(
         find('.challenge-response__alert').textContent.trim(),
         'Pour valider, sélectionnez une réponse. Sinon, passez.',

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -39,7 +39,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
         assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           '“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.',
@@ -110,7 +110,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
         assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.',
@@ -287,7 +287,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
         assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.',
@@ -411,7 +411,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         // given
         const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
         await click('.challenge-actions__action-validate');
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
 
         // when
         await click(screen.getByRole('button', { name: /Select:/ }));

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -49,7 +49,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
         await click(find('.challenge-actions__action-validate'));
 
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
         assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir tous les champs réponse. Sinon, passez.',
@@ -90,7 +90,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
         assert.ok(currentURL().includes(`/assessments/${assessment.id}/challenges/0`));
       });
 
@@ -105,7 +105,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        assert.dom('.challenge-response__alert').exists();
+        assert.dom('.challenge-response__alert[role="alert"]').exists();
         assert.ok(currentURL().includes(`/assessments/${assessment.id}/challenges/0`));
       });
 


### PR DESCRIPTION
## :unicorn: Problème

L'erreur qui s'affiche à la soumission d'une épreuve non remplie n'est pas lue par les lecteurs d'écran.

## :robot: Proposition

Ajouter un `role="alert"` sur ces blocs d'erreur.
> [En savoir plus sur ce role](https://a11y-guidelines.orange.com/fr/articles/aria-live-alert/#le-role-alert)

## :100: Pour tester

- Se connecter à [PixApp en RA](https://app-pr6864.review.pix.fr/)
- Démarrer un lecteur d'écran
- Visiter la page d'une épreuve
- Ne pas répondre et cliquer sur `Je valide`
- ✅ Le lecteur d'écran est censé lire le message d'erreur qui s'affiche
