### PR TITLE
[FEATURE] Activation de la remontée des certifs auto à la création en masse d'organisations (PIX-8794)

### DIFF
--- a/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
+++ b/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
@@ -1,5 +1,5 @@
 import { DataProtectionOfficer } from '../DataProtectionOfficer.js';
-import * as apps from '../../constants.js';
+import { ORGANIZATION_FEATURE } from '../../constants.js';
 import differenceBy from 'lodash/differenceBy.js';
 
 const CREDIT_DEFAULT_VALUE = 0;
@@ -64,6 +64,9 @@ class OrganizationForAdmin {
     this.enableMultipleSendingAssessment = enableMultipleSendingAssessment;
     this.tags = tags;
     this.features = features;
+    if (this.type === 'SCO' && this.isManagingStudents) {
+      this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = true;
+    }
     this.tagsToAdd = [];
     this.tagsToRemove = [];
   }
@@ -99,11 +102,9 @@ class OrganizationForAdmin {
     this.showSkills = organization.showSkills;
     this.updateIdentityProviderForCampaigns(organization.identityProviderForCampaigns);
     this.dataProtectionOfficer.updateInformation(dataProtectionOfficer);
-    this.features[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] =
-      organization.enableMultipleSendingAssessment;
+    this.features[ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] = organization.enableMultipleSendingAssessment;
     if (this.type === 'SCO') {
-      this.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] =
-        this.isManagingStudents;
+      this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = this.isManagingStudents;
     }
     this.tagsToAdd = differenceBy(tags, this.tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));

--- a/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
+++ b/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
@@ -2,6 +2,8 @@ import { DataProtectionOfficer } from '../DataProtectionOfficer.js';
 import * as apps from '../../constants.js';
 import differenceBy from 'lodash/differenceBy.js';
 
+const CREDIT_DEFAULT_VALUE = 0;
+
 class OrganizationForAdmin {
   constructor({
     id,
@@ -11,7 +13,7 @@ class OrganizationForAdmin {
     externalId,
     provinceCode,
     isManagingStudents,
-    credit,
+    credit = CREDIT_DEFAULT_VALUE,
     email,
     documentationUrl,
     createdBy,

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -1,11 +1,12 @@
+import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 const { isEmpty, uniqBy } = lodash;
 
-import bluebird from 'bluebird';
 import { Organization } from '../models/Organization.js';
 import { OrganizationTag } from '../models/OrganizationTag.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
+import { OrganizationForAdmin } from '../models/index.js';
 
 import {
   ManyOrganizationsFoundError,
@@ -158,7 +159,7 @@ function _mapOrganizationsData(organizations) {
   for (const organization of organizations) {
     const email = organization.type === Organization.types.SCO ? organization.emailForSCOActivation : undefined;
     mapOrganizationByExternalId.set(organization.externalId, {
-      organization: new Organization({
+      organization: new OrganizationForAdmin({
         ...organization,
         email,
       }),

--- a/api/scripts/create-organizations-with-tags-and-target-profiles.js
+++ b/api/scripts/create-organizations-with-tags-and-target-profiles.js
@@ -15,6 +15,7 @@ import * as dataProtectionOfficerRepository from '../lib/infrastructure/reposito
 import * as organizationTagRepository from '../lib/infrastructure/repositories/organization-tag-repository.js';
 import * as tagRepository from '../lib/infrastructure/repositories/tag-repository.js';
 import * as targetProfileShareRepository from '../lib/infrastructure/repositories/target-profile-share-repository.js';
+import * as organizationValidator from '../lib/domain/validators/organization-with-tags-and-target-profiles-script.js';
 import { disconnect } from '../db/knex-database-connection.js';
 import lodash from 'lodash';
 
@@ -99,6 +100,7 @@ async function createOrganizationWithTagsAndTargetProfiles(filePath) {
   const createdOrganizations = await createOrganizationsWithTagsAndTargetProfiles({
     organizations,
     domainTransaction,
+    organizationValidator,
     organizationRepository,
     tagRepository,
     targetProfileShareRepository,

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -18,6 +18,7 @@ import { OrganizationInvitation } from '../../../../lib/domain/models/Organizati
 import { Assessment } from '../../../../lib/domain/models/Assessment.js';
 import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
 import { CampaignTypes } from '../../../../lib/domain/models/CampaignTypes.js';
+import { ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
 
 describe('Acceptance | Application | organization-controller', function () {
   let server;
@@ -157,6 +158,7 @@ describe('Acceptance | Application | organization-controller', function () {
       await knex('target-profiles').delete();
       await knex('organization-tags').delete();
       await knex('tags').delete();
+      await knex('organization-features').delete();
       await knex('organizations').delete();
     });
 
@@ -166,6 +168,7 @@ describe('Acceptance | Application | organization-controller', function () {
       databaseBuilder.factory.buildTag({ name: 'GRAS' });
       databaseBuilder.factory.buildTag({ name: 'GARGOUILLE' });
       databaseBuilder.factory.buildTag({ name: 'GARBURE' });
+      databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
       await databaseBuilder.commit();

--- a/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
@@ -16,12 +16,12 @@ describe('Integration | Application | Controller | organization-administration-c
       credit: 200,
       externalId: 'itsme',
       provinceCode: 'FR',
-      isManagingStudents: true,
+      isManagingStudents: false,
       documentationUrl: 'overthere',
       showSkills: false,
       identityProviderForCampaigns: 'POLE_EMPLOI',
     });
-
+    databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
     featureId = databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
 
     await databaseBuilder.commit();

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -24,11 +24,13 @@ import {
 
 import { createOrganizationsWithTagsAndTargetProfiles } from '../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
+import { ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
 
 describe('Integration | UseCases | create-organizations-with-tags-and-target-profiles', function () {
   let userId;
 
   beforeEach(async function () {
+    databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
     userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();
   });

--- a/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
+++ b/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
@@ -1,8 +1,41 @@
-import { expect } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import { OrganizationForAdmin } from '../../../../../lib/domain/models/organizations-administration/OrganizationForAdmin.js';
-import * as apps from '../../../../../lib/domain/constants.js';
+import { ORGANIZATION_FEATURE } from '../../../../../lib/domain/constants.js';
 
 describe('Unit | Domain | Models | OrganizationForAdmin', function () {
+  context('for sco organizations', function () {
+    context('when organization isManagingStudent is true', function () {
+      it('should build an OrganizationForAdmin with compute organization learner certificability enabled', function () {
+        // given
+        const expectedOrganization = domainBuilder.buildOrganizationForAdmin({ type: 'SCO', isManagingStudents: true });
+
+        // when
+        const organization = new OrganizationForAdmin(expectedOrganization);
+
+        // then
+        expect(organization.features).to.includes({
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+        });
+      });
+    });
+
+    context('when organization isManagingStudent is false', function () {
+      it('should build an OrganizationForAdmin without compute organization learner certificability feature', function () {
+        // given
+        const expectedOrganization = domainBuilder.buildOrganizationForAdmin({
+          type: 'SCO',
+          isManagingStudents: false,
+        });
+
+        // when
+        const organization = new OrganizationForAdmin(expectedOrganization);
+
+        // then
+        expect(organization.features).to.deep.equal({});
+      });
+    });
+  });
+
   context('#archivistFullName', function () {
     it('should return the full name of user who archived the organization', function () {
       // given
@@ -210,7 +243,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
         isManagingStudents: false,
         type: 'SCO',
         features: {
-          [apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
         },
       });
 
@@ -221,7 +254,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
 
       // then
       expect(
-        givenOrganization.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
       ).to.equal(true);
     });
 
@@ -231,7 +264,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
         isManagingStudents: true,
         type: 'SCO',
         features: {
-          [apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
         },
       });
 
@@ -242,7 +275,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
 
       // then
       expect(
-        givenOrganization.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
       ).to.equal(false);
     });
 
@@ -252,7 +285,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
         isManagingStudents: false,
         type: 'SUP',
         features: {
-          [apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
         },
       });
 
@@ -263,7 +296,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
 
       // then
       expect(
-        givenOrganization.features[apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
       ).to.equal(false);
     });
 
@@ -392,7 +425,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
       // given
       const givenOrganization = new OrganizationForAdmin({
         features: {
-          [apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: false,
+          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: false,
         },
       });
 
@@ -401,7 +434,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
 
       // then
       expect(givenOrganization.features).to.includes({
-        [apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
+        [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
       });
     });
 
@@ -409,7 +442,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
       // given
       const givenOrganization = new OrganizationForAdmin({
         features: {
-          [apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
+          [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
         },
       });
 
@@ -418,7 +451,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
 
       // then
       expect(givenOrganization.features).to.includes({
-        [apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: false,
+        [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: false,
       });
     });
   });

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -1,6 +1,5 @@
 import { expect, catchErr, sinon, domainBuilder } from '../../../test-helper.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
-import { Organization } from '../../../../lib/domain/models/Organization.js';
 import { OrganizationTag } from '../../../../lib/domain/models/OrganizationTag.js';
 import { DomainTransaction as domainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from '../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js';
@@ -11,6 +10,7 @@ import {
   OrganizationAlreadyExistError,
   OrganizationTagNotFound,
 } from '../../../../lib/domain/errors.js';
+import { OrganizationForAdmin } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', function () {
   let organizationRepositoryStub;
@@ -193,8 +193,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       identityProviderForCampaigns: 'GAR',
       emailForSCOActivation: 'savedEmail@example.net',
     };
-    const organizationPROToCreate = new Organization(organizationPRO);
-    const organizationSCOToCreate = new Organization({
+    const organizationPROToCreate = new OrganizationForAdmin(organizationPRO);
+    const organizationSCOToCreate = new OrganizationForAdmin({
       ...organizationSCO,
       email: organizationSCO.emailForSCOActivation,
     });
@@ -217,7 +217,8 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     });
 
     // then
-    expect(organizationRepositoryStub.batchCreateOrganizations).to.be.calledWith(expectedProOrganizationToInsert);
+    const expectedOrganizationsToCreate = organizationRepositoryStub.batchCreateOrganizations.getCall(0).args[0];
+    expect(expectedOrganizationsToCreate).to.deep.equal(expectedProOrganizationToInsert);
   });
 
   it('should add organization tags when exists', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Pour notre Epix sur la remontée des certifs auto dans Pix Orga, nous avons besoin d'activer cette fonctionnalité des la création des organisations Sco avec gestion des élèves via la création d'organisation en masse sur Pix Admin.

## :robot: Proposition
Activer la fonctionnalité au moment de la création d'orga en masse pour celles ayant le type 'SCO' et isManagingStudent à true

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter en tant que SuperAdmin à PixAdmin
- Aller sur la page d'administration
- Importer un fichier .csv* pour créer des orgas en mass
- Vérifier sur la table 'organisation-features' que les orgas de type 'SCO' avec gestion des étudiants ont bien la fonctionnalité
- 🐱 

*Pour avoir des tests complets, ce fichier doit avoir : 
- Une orga Pro
- Une orga Sco avec isManagingStudents à true
- Une orga Sco avec isManagingStudents à false
- Une orga Sup avec isManagingStudents à true
- Une orga Sup avec isManagingStudents à false


