### PR TITLE
[FEATURE] Insérer en base les acquisitions de paliers (PIX-8604)

### DIFF
--- a/api/db/database-builder/factory/build-stage-acquisition.js
+++ b/api/db/database-builder/factory/build-stage-acquisition.js
@@ -1,0 +1,26 @@
+import { databaseBuffer } from '../database-buffer.js';
+import { buildCampaignParticipation } from './build-campaign-participation.js';
+import { buildStage } from './build-stage.js';
+import { buildUser } from './build-user.js';
+import { STAGE_ACQUISITIONS_TABLE_NAME } from '../../migrations/20230721114848_create-stage_acquisitions-table.js';
+
+const buildStageAcquisition = function ({
+  id = databaseBuffer.getNextId(),
+  stageId = buildStage().id,
+  userId = buildUser().id,
+  campaignParticipationId = buildCampaignParticipation().id,
+  createdAt = new Date('2000-01-01'),
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: STAGE_ACQUISITIONS_TABLE_NAME,
+    values: {
+      id,
+      stageId,
+      userId,
+      campaignParticipationId,
+      createdAt,
+    },
+  });
+};
+
+export { buildStageAcquisition };

--- a/api/db/migrations/20230721114848_create-stage_acquisitions-table.js
+++ b/api/db/migrations/20230721114848_create-stage_acquisitions-table.js
@@ -1,0 +1,20 @@
+export const STAGE_ACQUISITIONS_TABLE_NAME = 'stage-acquisitions';
+export const USER_ID_COLUMN = 'userId';
+export const STAGE_ID_COLUMN = 'stageId';
+export const CAMPAIGN_PARTICIPATION_ID_COLUMN = 'campaignParticipationId';
+
+const up = async function (knex) {
+  await knex.schema.createTable(STAGE_ACQUISITIONS_TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.integer(USER_ID_COLUMN).references('users.id');
+    table.integer(STAGE_ID_COLUMN).references('stages.id');
+    table.integer(CAMPAIGN_PARTICIPATION_ID_COLUMN).references('campaign-participations.id').index();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(STAGE_ACQUISITIONS_TABLE_NAME);
+};
+
+export { up, down };

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -114,11 +114,12 @@ const getCurrentActivity = async function (request, h, dependencies = { activity
 const completeAssessment = async function (request) {
   const assessmentId = request.params.id;
   const locale = extractLocaleFromRequest(request);
-
   let event;
+
   await DomainTransaction.execute(async (domainTransaction) => {
     const result = await usecases.completeAssessment({ assessmentId, domainTransaction });
     await usecases.handleBadgeAcquisition({ assessment: result.assessment, domainTransaction });
+    await usecases.handleStageAcquisition({ assessment: result.assessment, domainTransaction });
     await usecases.handleTrainingRecommendation({ assessment: result.assessment, locale, domainTransaction });
     event = result.event;
   });

--- a/api/lib/domain/models/BadgeCriterionForCalculation.js
+++ b/api/lib/domain/models/BadgeCriterionForCalculation.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { getMasteryPercentage } from '../services/get-mastery-percentage-service.js';
 
 export class BadgeCriterionForCalculation {
   constructor({ threshold, skillIds }) {
@@ -7,28 +7,12 @@ export class BadgeCriterionForCalculation {
   }
 
   getAcquisitionPercentage(knowledgeElements) {
-    const knowledgeElementsInSkills = _removeKnowledgeElementsNotInSkills(knowledgeElements, this.skillIds);
-    const validatedSkillsCount = knowledgeElementsInSkills.filter(
-      (knowledgeElement) => knowledgeElement.isValidated,
-    ).length;
-    const totalSkillsCount = this.skillIds.length;
-    const masteryPercentage = _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount);
-
+    const masteryPercentage = getMasteryPercentage(knowledgeElements, this.skillIds);
     const acquisitionPercentage = Math.round((masteryPercentage / this.threshold) * 100);
-
     return acquisitionPercentage > 100 ? 100 : acquisitionPercentage;
   }
 
   isFulfilled(knowledgeElements) {
     return this.getAcquisitionPercentage(knowledgeElements) === 100;
   }
-}
-
-function _removeKnowledgeElementsNotInSkills(knowledgeElements, skillIds) {
-  return _.filter(knowledgeElements, (knowledgeElement) => skillIds.some((id) => id === knowledgeElement.skillId));
-}
-
-function _computeMasteryPercentage(validatedSkillsCount, totalSkillsCount) {
-  if (totalSkillsCount === 0) return 0;
-  return Math.round((validatedSkillsCount * 100) / totalSkillsCount);
 }

--- a/api/lib/domain/models/Stage.js
+++ b/api/lib/domain/models/Stage.js
@@ -1,13 +1,61 @@
 class Stage {
-  constructor({ id, title, message, threshold, level, prescriberTitle, prescriberDescription, targetProfileId } = {}) {
+  /**
+   * @param {number} id
+   * @param {string} title
+   * @param {string} message
+   * @param {number|undefined} threshold
+   * @param {number|undefined} level
+   * @param {string} prescriberTitle
+   * @param {string} prescriberDescription
+   * @param {number} targetProfileId
+   * @param {boolean} isFirstSkill
+   */
+  constructor({
+    id,
+    isFirstSkill,
+    level,
+    message,
+    prescriberDescription,
+    prescriberTitle,
+    targetProfileId,
+    threshold,
+    title,
+  } = {}) {
     this.id = id;
-    this.title = title;
-    this.message = message;
-    this.threshold = threshold;
+    this.isFirstSkill = isFirstSkill;
     this.level = level;
-    this.prescriberTitle = prescriberTitle;
+    this.message = message;
     this.prescriberDescription = prescriberDescription;
+    this.prescriberTitle = prescriberTitle;
     this.targetProfileId = targetProfileId;
+    this.threshold = threshold;
+    this.title = title;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  get isZeroStage() {
+    return this.level === 0 || this.threshold === 0;
+  }
+
+  /**
+   * Stage can be defined by stage or threshold.
+   *
+   * @returns {boolean}
+   */
+  get isLevelStage() {
+    return Boolean(this.level);
+  }
+
+  /**
+   * Used to convert level into threshold.
+   *
+   * @param {number} value
+   */
+  setThreshold(value) {
+    this.level = undefined;
+    this.threshold = value;
   }
 }
 

--- a/api/lib/domain/models/StageAcquisition.js
+++ b/api/lib/domain/models/StageAcquisition.js
@@ -1,0 +1,17 @@
+class StageAcquisition {
+  /**
+   *
+   * @param {number} id
+   * @param {number} userId
+   * @param {number} stageId
+   * @param {number} campaignParticipationId
+   */
+  constructor({ id, userId, stageId, campaignParticipationId }) {
+    this.id = id;
+    this.userId = userId;
+    this.stageId = stageId;
+    this.campaignParticipationId = campaignParticipationId;
+  }
+}
+
+export { StageAcquisition };

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -119,6 +119,7 @@ import { Skill } from './Skill.js';
 import { SkillSet } from './SkillSet.js';
 import { Solution } from './Solution.js';
 import { Stage } from './Stage.js';
+import { StageAcquisition } from './StageAcquisition.js';
 import { Student } from './Student.js';
 import { SupOrganizationLearner } from './SupOrganizationLearner.js';
 import { SupOrganizationLearnerSet } from './SupOrganizationLearnerSet.js';
@@ -272,6 +273,7 @@ export {
   SkillSet,
   Solution,
   Stage,
+  StageAcquisition,
   Student,
   SupOrganizationLearner,
   SupOrganizationLearnerSet,

--- a/api/lib/domain/services/get-mastery-percentage-service.js
+++ b/api/lib/domain/services/get-mastery-percentage-service.js
@@ -1,0 +1,20 @@
+/**
+ * Returns mastery percentage based on user
+ * knowledge elements and skillIds.
+ *
+ * @param {KnowledgeElement[]} knowledgeElements
+ * @param {string[]} skillIds
+ *
+ * @returns {number}
+ */
+export const getMasteryPercentage = (knowledgeElements, skillIds) => {
+  if (!skillIds.length) return 0;
+
+  const validatedKnowledgeElements = knowledgeElements.filter(({ isValidated }) => isValidated);
+
+  const knowledgeElementsInSkills = validatedKnowledgeElements.filter((knowledgeElement) =>
+    skillIds.some((id) => String(id) === String(knowledgeElement.skillId)),
+  );
+
+  return Math.round((knowledgeElementsInSkills.length * 100) / skillIds.length);
+};

--- a/api/lib/domain/services/stages/convert-level-stages-into-thresholds-service.js
+++ b/api/lib/domain/services/stages/convert-level-stages-into-thresholds-service.js
@@ -1,0 +1,18 @@
+/**
+ * @param {Stage[]} stages
+ * @param {Skill[]} skills
+ *
+ * @returns {void}
+ */
+export const convertLevelStagesIntoThresholds = (stages, skills) => {
+  stages.forEach((stage) => {
+    if (stage.isZeroStage || stage.isFirstSkill || !stage.isLevelStage) return;
+
+    if (!skills.length) {
+      stage.setThreshold(100);
+    }
+
+    const stageSkillsCount = skills.filter((skill) => skill.difficulty <= stage.level).length;
+    stage.setThreshold(Math.round((stageSkillsCount / skills.length) * 100));
+  });
+};

--- a/api/lib/domain/services/stages/get-new-acquired-stages-service.js
+++ b/api/lib/domain/services/stages/get-new-acquired-stages-service.js
@@ -1,0 +1,19 @@
+/**
+ * Filter stages that should be acquired based on validatedSkillCount,
+ * alreadyAcquiredStages and masteryPercentage.
+ *
+ * @param {Stage[]} stages
+ * @param {number} validatedSkillCount
+ * @param {number[]} alreadyAcquiredStagesIds
+ * @param {number} masteryPercentage
+ *
+ * @returns {Stage[]}
+ */
+export const getNewAcquiredStages = (stages, validatedSkillCount, alreadyAcquiredStagesIds, masteryPercentage) =>
+  stages.filter((stage) => {
+    if (alreadyAcquiredStagesIds.includes(stage.id)) return false;
+    if (stage.isZeroStage) return true;
+    if (stage.isFirstSkill) return validatedSkillCount >= 1;
+
+    return stage.threshold <= masteryPercentage;
+  });

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -6,16 +6,15 @@ import { config } from '../../config.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 
 import * as accountRecoveryDemandRepository from '../../infrastructure/repositories/account-recovery-demand-repository.js';
-import * as adminMemberRepository from '../../infrastructure/repositories/admin-member-repository.js';
-
-import * as TargetProfileForSpecifierRepository from '../../infrastructure/repositories/campaign/target-profile-for-specifier-repository.js';
-import * as algorithmDataFetcherService from '../../domain/services/algorithm-methods/data-fetcher.js';
 import * as activityAnswerRepository from '../../infrastructure/repositories/activity-answer-repository.js';
-import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
 import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
+import * as adminMemberRepository from '../../infrastructure/repositories/admin-member-repository.js';
+import * as algorithmDataFetcherService from '../../domain/services/algorithm-methods/data-fetcher.js';
+import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
+import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method-repository.js';
 import * as authenticationServiceRegistry from '../services/authentication/authentication-service-registry.js';
 import * as authenticationSessionService from '../../domain/services/authentication/authentication-session-service.js';
@@ -124,9 +123,9 @@ import * as organizationParticipantRepository from '../../infrastructure/reposit
 import * as organizationPlacesCapacityRepository from '../../infrastructure/repositories/organization-places-capacity-repository.js';
 import * as organizationPlacesLotRepository from '../../infrastructure/repositories/organizations/organization-places-lot-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
+import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
 import * as organizationTagRepository from '../../infrastructure/repositories/organization-tag-repository.js';
 import * as organizationValidator from '../validators/organization-with-tags-and-target-profiles-script.js';
-import * as organizationsToAttachToTargetProfileRepository from '../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository.js';
 import * as participantResultRepository from '../../infrastructure/repositories/participant-result-repository.js';
 import * as participationsForCampaignManagementRepository from '../../infrastructure/repositories/participations-for-campaign-management-repository.js';
 import * as participationsForUserManagementRepository from '../../infrastructure/repositories/participations-for-user-management-repository.js';
@@ -155,22 +154,22 @@ import * as sessionForSupervisorKitRepository from '../../infrastructure/reposit
 import * as sessionJuryCommentRepository from '../../infrastructure/repositories/sessions/session-jury-comment-repository.js';
 import * as sessionPublicationService from '../../domain/services/session-publication-service.js';
 import * as sessionRepository from '../../infrastructure/repositories/sessions/session-repository.js';
+import * as sessionsImportValidationService from '../../domain/services/sessions-mass-import/sessions-import-validation-service.js';
 import * as sessionSummaryRepository from '../../infrastructure/repositories/sessions/session-summary-repository.js';
 import * as sessionValidator from '../validators/session-validator.js';
 import * as sessionXmlService from '../../domain/services/session-xml-service.js';
-import * as sessionsImportValidationService from '../../domain/services/sessions-mass-import/sessions-import-validation-service.js';
 import * as skillRepository from '../../infrastructure/repositories/skill-repository.js';
 import * as skillSetRepository from '../../infrastructure/repositories/skill-set-repository.js';
 import * as smartRandom from '../../domain/services/algorithm-methods/smart-random.js';
-import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as stageCollectionForTargetProfileRepository from '../../infrastructure/repositories/target-profile-management/stage-collection-repository.js';
+import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import * as studentRepository from '../../infrastructure/repositories/student-repository.js';
+import * as supervisorAccessRepository from '../../infrastructure/repositories/supervisor-access-repository.js';
 import * as supOrganizationLearnerRepository from '../../infrastructure/repositories/sup-organization-learner-repository.js';
 import * as supOrganizationParticipantRepository from '../../infrastructure/repositories/sup-organization-participant-repository.js';
-import * as supervisorAccessRepository from '../../infrastructure/repositories/supervisor-access-repository.js';
 import * as tagRepository from '../../infrastructure/repositories/tag-repository.js';
-import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as targetProfileForAdminRepository from '../../infrastructure/repositories/target-profile-for-admin-repository.js';
+import * as TargetProfileForSpecifierRepository from '../../infrastructure/repositories/campaign/target-profile-for-specifier-repository.js';
 import * as targetProfileForUpdateRepository from '../../infrastructure/repositories/target-profile-for-update-repository.js';
 import * as targetProfileRepository from '../../infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileShareRepository from '../../infrastructure/repositories/target-profile-share-repository.js';
@@ -181,8 +180,8 @@ import * as thematicRepository from '../../infrastructure/repositories/thematic-
 import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
 import * as userEmailRepository from '../../infrastructure/repositories/user-email-repository.js';
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
-import * as userOrgaSettingsRepository from '../../infrastructure/repositories/user-orga-settings-repository.js';
 import * as userOrganizationsForAdminRepository from '../../infrastructure/repositories/user-organizations-for-admin-repository.js';
+import * as userOrgaSettingsRepository from '../../infrastructure/repositories/user-orga-settings-repository.js';
 import * as userReconciliationService from '../services/user-reconciliation-service.js';
 import * as userRepository from '../../infrastructure/repositories/user-repository.js';
 import * as userSavedTutorialRepository from '../../infrastructure/repositories/user-saved-tutorial-repository.js';
@@ -426,6 +425,7 @@ const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './organization-learners-management') })),
   ...(await importNamedExportsFromDirectory({ path: join(path, './organizations-administration') })),
   ...(await importNamedExportsFromDirectory({ path: join(path, './sessions-mass-import') })),
+  ...(await importNamedExportsFromDirectory({ path: join(path, './stages') })),
   ...(await importNamedExportsFromDirectory({ path: join(path, './target-profile-management') })),
   findPaginatedFilteredTargetProfileOrganizations,
   getCampaignDetailsManagement,

--- a/api/lib/domain/usecases/stages/handle-stage-acquisition.js
+++ b/api/lib/domain/usecases/stages/handle-stage-acquisition.js
@@ -1,0 +1,108 @@
+import * as defaultSkillRepository from '../../../infrastructure/repositories/skill-repository.js';
+import * as defaultStageRepository from '../../../infrastructure/repositories/stage-repository.js';
+import * as defaultCampaignRepository from '../../../infrastructure/repositories/campaign-repository.js';
+import * as defaultStageAcquisitionRepository from '../../../infrastructure/repositories/stage-acquisition-repository.js';
+import * as defaultCampaignParticipationRepository from '../../../infrastructure/repositories/campaign-participation-repository.js';
+import * as defaultKnowledgeElementRepositoryRepository from '../../../infrastructure/repositories/knowledge-element-repository.js';
+
+import * as defaultGetNewAcquiredStagesService from '../../services/stages/get-new-acquired-stages-service.js';
+import * as defaultGetMasteryPercentageService from '../../services/get-mastery-percentage-service.js';
+import * as defaultConvertLevelStagesIntoThresholdsService from '../../services/stages/convert-level-stages-into-thresholds-service.js';
+import * as defaultCampaignSkillRepository from '../../../infrastructure/repositories/campaign-skill-repository.js';
+
+/**
+ * @param {Assessment} assessment
+ * @param {DomainTransaction} domainTransaction
+ * @param stageRepository
+ * @param skillRepository
+ * @param campaignRepository
+ * @param campaignSkillRepository
+ * @param stageAcquisitionRepository
+ * @param knowledgeElementRepository
+ * @param campaignParticipationRepository
+ * @param getNewAcquiredStagesService
+ * @param getMasteryPercentageService
+ * @param convertLevelStagesIntoThresholdsService
+ *
+ * @returns {Promise<void>}
+ */
+const handleStageAcquisition = async function ({
+  assessment,
+  domainTransaction,
+  stageRepository = defaultStageRepository,
+  skillRepository = defaultSkillRepository,
+  campaignRepository = defaultCampaignRepository,
+  campaignSkillRepository = defaultCampaignSkillRepository,
+  stageAcquisitionRepository = defaultStageAcquisitionRepository,
+  knowledgeElementRepository = defaultKnowledgeElementRepositoryRepository,
+  campaignParticipationRepository = defaultCampaignParticipationRepository,
+  getNewAcquiredStagesService = defaultGetNewAcquiredStagesService,
+  getMasteryPercentageService = defaultGetMasteryPercentageService,
+  convertLevelStagesIntoThresholdsService = defaultConvertLevelStagesIntoThresholdsService,
+}) {
+  if (!assessment.isForCampaign()) return;
+
+  const campaignParticipation = await campaignParticipationRepository.get(
+    assessment.campaignParticipationId,
+    domainTransaction,
+  );
+
+  const stagesForThisCampaign = await stageRepository.getByCampaignParticipationId(
+    campaignParticipation.id,
+    domainTransaction?.knexTransaction,
+  );
+
+  if (!stagesForThisCampaign.length) return;
+
+  if (stagesAreLevelStages(stagesForThisCampaign)) {
+    const skillIds = await campaignSkillRepository.getSkillIdsByCampaignId(campaignParticipation.campaignId);
+    const skills = await skillRepository.findOperativeByIds(skillIds);
+
+    convertLevelStagesIntoThresholdsService.convertLevelStagesIntoThresholds(stagesForThisCampaign, skills);
+  }
+
+  const [knowledgeElements, campaignSkillsIds] = await Promise.all([
+    knowledgeElementRepository.findUniqByUserId({
+      userId: assessment.userId,
+    }),
+    campaignRepository.findSkillIdsByCampaignParticipationId({
+      campaignParticipationId: assessment.campaignParticipationId,
+      domainTransaction,
+    }),
+  ]);
+
+  const masteryPercentage = getMasteryPercentageService.getMasteryPercentage(knowledgeElements, campaignSkillsIds);
+
+  const alreadyAcquiredStagesIds = await stageAcquisitionRepository.getStageIdsByCampaignParticipation(
+    campaignParticipation.id,
+    domainTransaction?.knexTransaction,
+  );
+
+  const stagesToStore = getNewAcquiredStagesService.getNewAcquiredStages(
+    stagesForThisCampaign,
+    campaignParticipation.validatedSkillsCount,
+    alreadyAcquiredStagesIds,
+    masteryPercentage,
+  );
+
+  if (!stagesToStore.length) return;
+
+  await stageAcquisitionRepository.saveStages(
+    stagesToStore,
+    assessment.userId,
+    campaignParticipation.id,
+    domainTransaction?.knexTransaction,
+  );
+};
+
+/**
+ * If at least one stage is defined by level, we assume that
+ * all stages of this campaign are defined by level.
+ *
+ * @param {Stage[]} stages
+ *
+ * @returns {boolean}
+ */
+const stagesAreLevelStages = (stages) => stages.some((stage) => stage.isLevelStage);
+
+export { handleStageAcquisition };

--- a/api/lib/infrastructure/repositories/campaign-skill-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-skill-repository.js
@@ -1,0 +1,12 @@
+import { knex } from '../../../db/knex-database-connection.js';
+
+/**
+ *
+ * @param {number} campaignId
+ *
+ * @returns Promise<string[]>
+ */
+const getSkillIdsByCampaignId = async (campaignId) =>
+  await knex('campaign_skills').where({ campaignId: campaignId }).pluck('skillId');
+
+export { getSkillIdsByCampaignId };

--- a/api/lib/infrastructure/repositories/stage-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/stage-acquisition-repository.js
@@ -1,0 +1,116 @@
+import { knex } from '../../../db/knex-database-connection.js';
+
+import {
+  CAMPAIGN_PARTICIPATION_ID_COLUMN,
+  STAGE_ACQUISITIONS_TABLE_NAME,
+  STAGE_ID_COLUMN,
+  USER_ID_COLUMN,
+} from '../../../db/migrations/20230721114848_create-stage_acquisitions-table.js';
+
+import { StageAcquisition } from '../../domain/models/index.js';
+
+/**
+ * @typedef stageData
+ * @type {object}
+ * @property {number} id
+ * @property {number} userId
+ * @property {number} stageId
+ * @property {number} campaignParticipationId
+ */
+
+/**
+ * @param {stageData[]} stageAcquisitionData
+ * @returns {StageAcquisition[]}
+ */
+const toDomain = (stageAcquisitionData) =>
+  stageAcquisitionData.map((data) => {
+    return new StageAcquisition(data);
+  });
+
+/**
+ * @param {Knex} knexConnection
+ * @param {string[]} selectedFields
+ *
+ * @returns {*}
+ */
+const buildSelectAllQuery = (knexConnection) =>
+  knexConnection(STAGE_ACQUISITIONS_TABLE_NAME)
+    .select(`${STAGE_ACQUISITIONS_TABLE_NAME}.*`)
+    .from(STAGE_ACQUISITIONS_TABLE_NAME);
+
+/**
+ * @param {number[]} campaignParticipationsIds
+ * @param {Knex} knexConnection
+ *
+ * @returns Promise<StageAcquisition[]>
+ */
+const getByCampaignParticipations = async (campaignParticipationsIds, knexConnection = knex) =>
+  toDomain(
+    await buildSelectAllQuery(knexConnection).whereIn(CAMPAIGN_PARTICIPATION_ID_COLUMN, campaignParticipationsIds),
+  );
+
+/**
+ * @param {number} campaignParticipationsId
+ * @param {Knex} knexConnection
+ *
+ * @returns {Promise<StageAcquisition[]>}
+ */
+const getByCampaignParticipation = async (campaignParticipationsId, knexConnection = knex) =>
+  toDomain(await buildSelectAllQuery(knexConnection).where(CAMPAIGN_PARTICIPATION_ID_COLUMN, campaignParticipationsId));
+
+/**
+ * @param {number} campaignParticipationsId
+ * @param {Knex} knexConnection
+ *
+ * @returns {Promise<number[]>}
+ */
+const getStageIdsByCampaignParticipation = async (campaignParticipationsId, knexConnection = knex) =>
+  await knexConnection(STAGE_ACQUISITIONS_TABLE_NAME)
+    .where(CAMPAIGN_PARTICIPATION_ID_COLUMN, campaignParticipationsId)
+    .pluck(STAGE_ID_COLUMN);
+
+/**
+ * @param {number} campaignId
+ * @param {number} userId
+ * @param {Knex} knexConnection
+ *
+ * @returns {Promise<StageAcquisition[]>}
+ */
+const getByCampaignIdAndUserId = async (campaignId, userId, knexConnection = knex) =>
+  toDomain(
+    await buildSelectAllQuery(knexConnection)
+      .join(
+        'campaign-participations',
+        'campaign-participations.id',
+        `${STAGE_ACQUISITIONS_TABLE_NAME}.${CAMPAIGN_PARTICIPATION_ID_COLUMN}`,
+      )
+      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .where('campaigns.id', campaignId)
+      .where(`${STAGE_ACQUISITIONS_TABLE_NAME}.${USER_ID_COLUMN}`, userId)
+      .orderBy(`${STAGE_ACQUISITIONS_TABLE_NAME}.id`),
+  );
+
+/**
+ * @param {Stage[]} stages
+ * @param {number} userId
+ * @param {number} campaignParticipationId
+ * @param {Knex} knexConnection
+ *
+ * @returns {Promise<[]>}
+ */
+const saveStages = async (stages, userId, campaignParticipationId, knexConnection = knex) => {
+  const acquiredStages = stages.map((stage) => ({
+    stageId: stage.id,
+    userId,
+    campaignParticipationId,
+  }));
+  return knexConnection(STAGE_ACQUISITIONS_TABLE_NAME).insert(acquiredStages);
+};
+
+export {
+  getByCampaignParticipations,
+  getByCampaignIdAndUserId,
+  saveStages,
+  getByCampaignParticipation,
+  getStageIdsByCampaignParticipation,
+};

--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -1,0 +1,74 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { Stage } from '../../domain/models/index.js';
+
+/**
+ * @typedef stageData
+ * @type {object}
+ * @property {number} id
+ * @property {string} title
+ * @property {string} message
+ * @property {number|undefined} threshold
+ * @property {number|undefined} level
+ * @property {string} prescriberTitle
+ * @property {string} prescriberDescription
+ * @property {number} targetProfileId
+ * @property {boolean} isFirstSkill
+ */
+
+/**
+ * @param {stageData[]} stageData
+ * @returns {Stage[]}
+ */
+const toDomain = (stageData) =>
+  stageData.map((data) => {
+    return new Stage(data);
+  });
+
+/**
+ * @param knexConnection
+ * @returns {*}
+ */
+const buildBaseQuery = (knexConnection) =>
+  knexConnection('stages')
+    .select('stages.*')
+    .join('campaigns', 'campaigns.targetProfileId', 'stages.targetProfileId')
+    .orderBy(['stages.threshold', 'stages.level']);
+
+/**
+ * Return stages for multiple campaign ids
+ *
+ * @param {number[]} campaignIds
+ * @param knexConnection
+ *
+ * @returns Promise<Stage[]>
+ */
+const getByCampaignIds = async (campaignIds, knexConnection = knex) =>
+  toDomain(await buildBaseQuery(knexConnection).whereIn('campaigns.id', campaignIds));
+
+/**
+ * Return stages for one campaign id
+ *
+ * @param {number} campaignId
+ * @param knexConnection
+ *
+ * @returns Promise<Stage[]>
+ */
+const getByCampaignId = async (campaignId, knexConnection = knex) =>
+  toDomain(await buildBaseQuery(knexConnection).where('campaigns.id', campaignId));
+
+/**
+ * Return campaign stages for a campaign participation id
+ *
+ * @param {number} campaignParticipationId
+ * @param knexConnection
+ *
+ * @returns Promise<Stage[]>
+ */
+const getByCampaignParticipationId = async (campaignParticipationId, knexConnection = knex) =>
+  toDomain(
+    await buildBaseQuery(knexConnection)
+      .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+      .where('campaign-participations.id', campaignParticipationId),
+  );
+
+export { getByCampaignIds, getByCampaignId, getByCampaignParticipationId };

--- a/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -1,0 +1,230 @@
+import { expect, databaseBuilder, knex, mockLearningContent, learningContentBuilder } from '../../../test-helper.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { Assessment } from '../../../../lib/domain/models/Assessment.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { STAGE_ACQUISITIONS_TABLE_NAME } from '../../../../db/migrations/20230721114848_create-stage_acquisitions-table.js';
+
+describe('Integration | Usecase | Handle Stage Acquisition', function () {
+  let userId, assessment, stages, campaignParticipationId, targetProfileId;
+
+  describe('#handleStageAcquisition', function () {
+    beforeEach(async function () {
+      const listSkill = ['web1', 'web2', 'web3', 'web4'];
+
+      const learningContent = [
+        {
+          id: 'recFrameworkId',
+          name: 'monFramework',
+          areas: [
+            {
+              id: 'recArea1',
+              title_i18n: {
+                fr: 'area1_Title',
+              },
+              color: 'someColor',
+              competences: [
+                {
+                  id: 'competenceId',
+                  name_i18n: {
+                    fr: 'Mener une recherche et une veille d’information',
+                  },
+                  index: '1.1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: listSkill[0],
+                          nom: '@web1',
+                          status: 'actif',
+                          challenges: [],
+                          level: 1,
+                        },
+                        {
+                          id: listSkill[1],
+                          nom: '@web2',
+                          status: 'actif',
+                          challenges: [],
+                          level: 1,
+                        },
+                        {
+                          id: listSkill[2],
+                          nom: 'web3',
+                          status: 'actif',
+                          challenges: [],
+                          level: 2,
+                        },
+                        {
+                          id: listSkill[3],
+                          nom: 'web4',
+                          status: 'actif',
+                          challenges: [],
+                          level: 3,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      userId = databaseBuilder.factory.buildUser().id;
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
+
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId }));
+      campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+        validatedSkillsCount: 3,
+      }).id;
+
+      assessment = new Assessment({
+        userId,
+        campaignParticipationId,
+        type: Assessment.types.CAMPAIGN,
+      });
+
+      mockLearningContent(learningContentBuilder(learningContent));
+
+      return databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex(STAGE_ACQUISITIONS_TABLE_NAME).delete();
+    });
+
+    context('when stage acquisitions are already present', function () {
+      it('should not try to insert already existing stages', async function () {
+        // given
+        stages = [
+          databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0 }),
+          databaseBuilder.factory.buildStage.firstSkill({ targetProfileId }),
+          databaseBuilder.factory.buildStage({ targetProfileId, threshold: 20 }),
+          databaseBuilder.factory.buildStage({ targetProfileId, threshold: 40 }),
+          databaseBuilder.factory.buildStage({ targetProfileId, threshold: 100 }),
+        ];
+        stages
+          .slice(0, 3)
+          .map(async (stage) =>
+            databaseBuilder.factory.buildStageAcquisition({ stageId: stage.id, userId, campaignParticipationId }),
+          );
+
+        await databaseBuilder.commit();
+        const stageAcquisitionsBefore = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+
+        // when
+        await usecases.handleStageAcquisition({
+          assessment,
+        });
+
+        // then
+        expect(stageAcquisitionsBefore.length).to.equal(3);
+        const stageAcquisitionsAfter = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+        expect(stageAcquisitionsAfter.length).to.equal(4);
+      });
+    });
+
+    context('when domain transaction is not committed yet', function () {
+      it('should not affect the database', async function () {
+        await DomainTransaction.execute(async (domainTransaction) => {
+          // given
+          stages = [
+            databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0 }),
+            databaseBuilder.factory.buildStage.firstSkill({ targetProfileId }),
+            databaseBuilder.factory.buildStage({ targetProfileId, threshold: 20 }),
+            databaseBuilder.factory.buildStage({ targetProfileId, threshold: 40 }),
+            databaseBuilder.factory.buildStage({ targetProfileId, threshold: 100 }),
+          ];
+          await databaseBuilder.commit();
+
+          // when
+          await usecases.handleStageAcquisition({
+            assessment,
+            domainTransaction,
+          });
+
+          // then
+          const transactionStageAcquisitions = await domainTransaction
+            .knexTransaction(STAGE_ACQUISITIONS_TABLE_NAME)
+            .select('userId', 'stageId')
+            .where({ userId });
+
+          expect(transactionStageAcquisitions).to.have.deep.members([
+            {
+              userId,
+              stageId: stages[0].id,
+            },
+            {
+              userId,
+              stageId: stages[1].id,
+            },
+            {
+              userId,
+              stageId: stages[2].id,
+            },
+            {
+              userId,
+              stageId: stages[3].id,
+            },
+          ]);
+
+          const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+          expect(stageAcquisitions.length).to.equal(0);
+        });
+      });
+    });
+
+    context('when assessment is not for a campaign', function () {
+      it('should not insert stages in database', async function () {
+        // given
+        assessment = new Assessment({
+          userId,
+          campaignParticipationId,
+          type: Assessment.types.COMPETENCE_EVALUATION,
+        });
+        stages = [databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0 })];
+
+        // when
+        await usecases.handleStageAcquisition({
+          assessment,
+        });
+
+        // then
+        const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+        expect(stageAcquisitions.length).to.equal(0);
+      });
+    });
+
+    context('when target profile have level stages', function () {
+      it('should insert stages acquisitions after conversion', async function () {
+        // given
+        stages = [
+          databaseBuilder.factory.buildStage({ targetProfileId, level: 0, threshold: null }),
+          databaseBuilder.factory.buildStage.firstSkill({ targetProfileId }),
+          databaseBuilder.factory.buildStage({ targetProfileId, level: 1, threshold: null }),
+          databaseBuilder.factory.buildStage({ targetProfileId, level: 2, threshold: null }),
+          databaseBuilder.factory.buildStage({ targetProfileId, level: 3, threshold: null }),
+        ];
+
+        await databaseBuilder.commit();
+
+        // when
+        await usecases.handleStageAcquisition({
+          assessment,
+        });
+
+        // then
+        const stageAcquisitions = await knex(STAGE_ACQUISITIONS_TABLE_NAME).where({ userId });
+        expect(stageAcquisitions.length).to.equal(4);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/stage-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-acquisition-repository_test.js
@@ -1,0 +1,201 @@
+import { expect, databaseBuilder, knex } from '../../../test-helper.js';
+import {
+  getByCampaignIdAndUserId,
+  getByCampaignParticipation,
+  getByCampaignParticipations,
+  getStageIdsByCampaignParticipation,
+  saveStages,
+} from '../../../../lib/infrastructure/repositories/stage-acquisition-repository.js';
+import { StageAcquisition } from '../../../../lib/domain/models/index.js';
+describe('Integration | Repository | Stage Acquisition', function () {
+  describe('getByCampaignParticipation', function () {
+    let stageAcquisition;
+
+    beforeEach(async function () {
+      // given
+      stageAcquisition = databaseBuilder.factory.buildStageAcquisition();
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stage-acquisitions').delete();
+    });
+
+    it('should return the expected stage', async function () {
+      // when
+      const result = await getByCampaignParticipation(stageAcquisition.campaignParticipationId);
+
+      // then
+      expect(result.length).to.deep.equal(1);
+    });
+  });
+
+  describe('getStageIdsByCampaignParticipation', function () {
+    let campaignParticipation;
+
+    beforeEach(async function () {
+      // given
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+
+      databaseBuilder.factory.buildStage({ id: 123 });
+      databaseBuilder.factory.buildStage({ id: 456 });
+      databaseBuilder.factory.buildStage({ id: 789 });
+
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 123,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 456,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: 789,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stage-acquisitions').delete();
+    });
+
+    it('should return the expected stage ids', async function () {
+      // when
+      const result = await getStageIdsByCampaignParticipation(campaignParticipation.id);
+
+      // then
+      expect(result.length).to.deep.equal(3);
+      expect(result).to.include(123);
+      expect(result).to.include(456);
+      expect(result).to.include(789);
+    });
+  });
+
+  describe('getByCampaignParticipations', function () {
+    let firstStage;
+    let secondStage;
+
+    beforeEach(async function () {
+      // given
+      firstStage = databaseBuilder.factory.buildStageAcquisition();
+      secondStage = databaseBuilder.factory.buildStageAcquisition();
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stage-acquisitions').delete();
+    });
+
+    it('should return StageAcquisition instances', async function () {
+      // when
+      const result = await getByCampaignParticipations([
+        firstStage.campaignParticipationId,
+        secondStage.campaignParticipationId,
+      ]);
+
+      // then
+      expect(result[0]).to.be.instanceof(StageAcquisition);
+    });
+
+    it('should return the expected stages', async function () {
+      // when
+      const result = await getByCampaignParticipations([
+        firstStage.campaignParticipationId,
+        secondStage.campaignParticipationId,
+      ]);
+
+      // then
+      expect(result.length).to.deep.equal(2);
+    });
+  });
+
+  describe('getByCampaignIdAndUserId', function () {
+    let stage;
+    let user;
+    let campaign;
+    let campaignParticipation;
+    let targetProfile;
+
+    beforeEach(async function () {
+      // given
+      user = databaseBuilder.factory.buildUser();
+      targetProfile = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
+      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      stage = databaseBuilder.factory.buildStage({ campaignId: campaign.id });
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: campaignParticipation.id,
+        userId: user.id,
+        stageId: stage.id,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stage-acquisitions').delete();
+    });
+
+    it('should return StageAcquisition instances', async function () {
+      // when
+      const result = await getByCampaignIdAndUserId(campaign.id, user.id);
+
+      // then
+      expect(result[0]).to.be.instanceof(StageAcquisition);
+    });
+
+    it('should return the expected stages', async function () {
+      // when
+      const result = await getByCampaignIdAndUserId(campaign.id, user.id);
+
+      // then
+      expect(result[0].stageId).to.deep.equal(stage.id);
+    });
+  });
+
+  describe('saveStages', function () {
+    let targetProfile;
+    let stages;
+    let campaign;
+    let user;
+    let campaignParticipation;
+
+    beforeEach(async function () {
+      // given
+      targetProfile = databaseBuilder.factory.buildTargetProfile();
+      stages = [
+        databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id }),
+        databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id }),
+      ];
+      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      user = databaseBuilder.factory.buildUser();
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stage-acquisitions').delete();
+    });
+
+    it('return the expected stage', async function () {
+      // when
+      await saveStages(stages, user.id, campaignParticipation.id);
+
+      // then
+      const result = await knex('stage-acquisitions')
+        .whereIn(
+          'stageId',
+          stages.map(({ id }) => id),
+        )
+        .andWhere('userId', user.id)
+        .andWhere('campaignParticipationId', campaignParticipation.id);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0]).to.contains({ stageId: stages[0].id });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/stage-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-repository_test.js
@@ -1,0 +1,115 @@
+import { expect, databaseBuilder, knex } from '../../../test-helper.js';
+import {
+  getByCampaignIds,
+  getByCampaignId,
+  getByCampaignParticipationId,
+} from '../../../../lib/infrastructure/repositories/stage-repository.js';
+import { Stage } from '../../../../lib/domain/models/Stage.js';
+describe('Integration | Repository | Stage Acquisition', function () {
+  describe('getByCampaignIds', function () {
+    let campaigns;
+    let stages;
+
+    beforeEach(async function () {
+      campaigns = [databaseBuilder.factory.buildCampaign(), databaseBuilder.factory.buildCampaign()];
+      stages = [
+        databaseBuilder.factory.buildStage({ targetProfileId: campaigns[0].targetProfileId }),
+        databaseBuilder.factory.buildStage({ targetProfileId: campaigns[1].targetProfileId, threshold: 20 }),
+        databaseBuilder.factory.buildStage({ targetProfileId: campaigns[1].targetProfileId, threshold: 10 }),
+      ];
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stages').delete();
+    });
+
+    it('should return Stage instances', async function () {
+      const result = await getByCampaignIds(campaigns.map((campaign) => campaign.id));
+      expect(result[0]).to.be.instanceof(Stage);
+    });
+
+    it('should return the expected stages', async function () {
+      const result = await getByCampaignIds(campaigns.map((campaign) => campaign.id));
+      expect(result.length).to.deep.equal(3);
+    });
+
+    it('should sort stages by threshold', async function () {
+      const result = await getByCampaignIds(campaigns.map((campaign) => campaign.id));
+      expect(result[1].id).to.deep.equal(stages[2].id);
+    });
+  });
+
+  describe('getByCampaignId', function () {
+    let campaign;
+    let stages;
+
+    beforeEach(async function () {
+      campaign = databaseBuilder.factory.buildCampaign();
+      stages = [
+        databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 40 }),
+        databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 20 }),
+        databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 10 }),
+      ];
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stages').delete();
+    });
+
+    it('should return Stage instances', async function () {
+      const result = await getByCampaignId(campaign.id);
+      expect(result[0]).to.be.instanceof(Stage);
+    });
+
+    it('should return the expected stages', async function () {
+      const result = await getByCampaignId(campaign.id);
+      expect(result.length).to.deep.equal(3);
+    });
+
+    it('should sort stages by threshold', async function () {
+      const result = await getByCampaignId(campaign.id);
+      expect(result[0].id).to.deep.equal(stages[2].id);
+    });
+  });
+
+  describe('getByCampaignParticipationId', function () {
+    let campaign;
+    let stages;
+    let campaignParticipation;
+
+    beforeEach(async function () {
+      campaign = databaseBuilder.factory.buildCampaign();
+      stages = [
+        databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 40 }),
+        databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 10 }),
+        databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 20 }),
+      ];
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stages').delete();
+    });
+
+    it('should return Stage instances', async function () {
+      const result = await getByCampaignParticipationId(campaignParticipation.id);
+      expect(result[0]).to.be.instanceof(Stage);
+    });
+
+    it('should return the expected stages', async function () {
+      const result = await getByCampaignParticipationId(campaignParticipation.id);
+      expect(result.length).to.deep.equal(3);
+    });
+
+    it('should sort stages by threshold', async function () {
+      const result = await getByCampaignParticipationId(campaignParticipation.id);
+      expect(result[0].id).to.deep.equal(stages[1].id);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-stage-acquisition.js
+++ b/api/tests/tooling/domain-builder/factory/build-stage-acquisition.js
@@ -1,0 +1,17 @@
+import { StageAcquisition } from '../../../../lib/domain/models/StageAcquisition.js';
+
+const buildStageAcquisition = function ({
+  id = 1,
+  userId = 3000,
+  stageId = 4000,
+  campaignParticipationId = 5000,
+} = {}) {
+  return new StageAcquisition({
+    id,
+    userId,
+    stageId,
+    campaignParticipationId,
+  });
+};
+
+export { buildStageAcquisition };

--- a/api/tests/tooling/domain-builder/factory/build-stage.js
+++ b/api/tests/tooling/domain-builder/factory/build-stage.js
@@ -1,5 +1,18 @@
 import { Stage } from '../../../../lib/domain/models/Stage.js';
 
+/**
+ * @param id
+ * @param {string} title
+ * @param {string} message
+ * @param {number} threshold
+ * @param {number} level
+ * @param {string} prescriberTitle
+ * @param {string} prescriberDescription
+ * @param {number} targetProfileId
+ * @param {boolean} isFirstSkill
+ *
+ * @returns {Stage}
+ */
 const buildStage = function ({
   id = 123,
   title = 'Courage',
@@ -9,6 +22,7 @@ const buildStage = function ({
   prescriberTitle = null,
   prescriberDescription = null,
   targetProfileId = null,
+  isFirstSkill = false,
 } = {}) {
   return new Stage({
     id,
@@ -19,6 +33,7 @@ const buildStage = function ({
     prescriberTitle,
     prescriberDescription,
     targetProfileId,
+    isFirstSkill,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -122,6 +122,7 @@ import { buildSkillLearningContentDataObject } from './build-skill-learning-cont
 import { BuildSkillCollection as buildSkillCollection } from './build-skill-collection.js';
 import { buildSolution } from './build-solution.js';
 import { buildStage } from './build-stage.js';
+import { buildStageAcquisition } from './build-stage-acquisition.js';
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
 import { buildStageCollection as buildStageCollectionForUserCampaignResults } from './user-campaign-results/build-stage-collection.js';
 import { buildTag } from './build-tag.js';
@@ -278,6 +279,7 @@ export {
   buildSkillCollection,
   buildSolution,
   buildStage,
+  buildStageAcquisition,
   buildStageCollectionForTargetProfileManagement,
   buildStageCollectionForUserCampaignResults,
   buildTag,

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -146,6 +146,7 @@ describe('Unit | Controller | assessment-controller', function () {
       sinon.stub(usecases, 'completeAssessment');
       sinon.stub(usecases, 'handleBadgeAcquisition');
       sinon.stub(usecases, 'handleTrainingRecommendation');
+      sinon.stub(usecases, 'handleStageAcquisition');
       usecases.completeAssessment.resolves({
         event: assessmentCompletedEvent,
         assessment,

--- a/api/tests/unit/domain/services/compute-mastery-percentage-service_test.js
+++ b/api/tests/unit/domain/services/compute-mastery-percentage-service_test.js
@@ -1,0 +1,61 @@
+import { expect } from '../../../test-helper.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
+import { getMasteryPercentage } from '../../../../lib/domain/services/get-mastery-percentage-service.js';
+import { KnowledgeElement } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Service | Compute mastery percentage', function () {
+  let dataSets;
+
+  before(function () {
+    dataSets = [
+      {
+        knowledgeElements: [
+          { id: 1, skillId: 1, status: KnowledgeElement.StatusType.VALIDATED },
+          { id: 2, skillId: 2, status: KnowledgeElement.StatusType.VALIDATED },
+          { id: 3, skillId: 3, status: KnowledgeElement.StatusType.VALIDATED },
+        ].map(domainBuilder.buildKnowledgeElement),
+        skillIds: [1, 2, 3],
+        expected: 100,
+      },
+      {
+        knowledgeElements: [
+          { id: 1, skillId: 1, status: KnowledgeElement.StatusType.VALIDATED },
+          { id: 2, skillId: 2, status: KnowledgeElement.StatusType.VALIDATED },
+        ].map(domainBuilder.buildKnowledgeElement),
+        skillIds: [1, 2, 3],
+        expected: 67,
+      },
+      {
+        knowledgeElements: [
+          { id: 1, skillId: 1, status: KnowledgeElement.StatusType.INVALIDATED },
+          { id: 2, skillId: 2, status: KnowledgeElement.StatusType.VALIDATED },
+        ].map(domainBuilder.buildKnowledgeElement),
+        skillIds: [1, 2, 3, 4],
+        expected: 25,
+      },
+      {
+        knowledgeElements: [
+          { id: 1, skillId: 1, status: KnowledgeElement.StatusType.INVALIDATED },
+          { id: 2, skillId: 2, status: KnowledgeElement.StatusType.VALIDATED },
+        ].map(domainBuilder.buildKnowledgeElement),
+        skillIds: [],
+        expected: 0,
+      },
+      {
+        knowledgeElements: [{ id: 1, skillId: 1, status: KnowledgeElement.StatusType.VALIDATED }].map(
+          domainBuilder.buildKnowledgeElement,
+        ),
+        skillIds: [4],
+        expected: 0,
+      },
+    ];
+  });
+
+  describe('getMasteryPercentage', function () {
+    it('should return the correct mastery percentage', function () {
+      dataSets.forEach((dataSet) => {
+        expect(getMasteryPercentage(dataSet.knowledgeElements, dataSet.skillIds)).to.deep.equal(dataSet.expected);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/stages/convert-level-stages-into-thresholds-service_test.js
+++ b/api/tests/unit/domain/services/stages/convert-level-stages-into-thresholds-service_test.js
@@ -1,0 +1,48 @@
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { convertLevelStagesIntoThresholds } from '../../../../../lib/domain/services/stages/convert-level-stages-into-thresholds-service.js';
+
+describe('Unit | Service | Convert Level Stages Into Thresholds', function () {
+  describe('convertLevelStagesIntoThresholds', function () {
+    let stages;
+
+    before(function () {
+      stages = [
+        domainBuilder.buildStage({ level: 0, threshold: null }),
+        domainBuilder.buildStage({ level: null, threshold: null, isFirstSkill: true }),
+        domainBuilder.buildStage({ level: 1, threshold: null }),
+        domainBuilder.buildStage({ level: 2, threshold: null }),
+        domainBuilder.buildStage({ level: 3, threshold: null }),
+      ];
+
+      const skills = [
+        domainBuilder.buildSkill({ id: '1', difficulty: 1 }),
+        domainBuilder.buildSkill({ id: '2', difficulty: 1 }),
+        domainBuilder.buildSkill({ id: '3', difficulty: 1 }),
+        domainBuilder.buildSkill({ id: '4', difficulty: 2 }),
+        domainBuilder.buildSkill({ id: '4', difficulty: 3 }),
+      ];
+
+      convertLevelStagesIntoThresholds(stages, skills);
+    });
+
+    it('should not convert zero stage', function () {
+      expect(stages[0].level).to.deep.equal(0);
+      expect(stages[0].threshold).to.be.null;
+    });
+
+    it('should not convert first skill stage', function () {
+      expect(stages[1].level).to.be.null;
+      expect(stages[1].threshold).to.be.null;
+    });
+
+    it('should convert level stages', function () {
+      expect(stages[2].level).to.be.undefined;
+      expect(stages[2].threshold).to.deep.equal(60);
+      expect(stages[3].level).to.be.undefined;
+      expect(stages[3].threshold).to.deep.equal(80);
+      expect(stages[4].level).to.be.undefined;
+      expect(stages[4].threshold).to.deep.equal(100);
+    });
+  });
+});

--- a/api/tests/unit/domain/services/stages/stage-acquisition-service_test.js
+++ b/api/tests/unit/domain/services/stages/stage-acquisition-service_test.js
@@ -1,0 +1,83 @@
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { getNewAcquiredStages } from '../../../../../lib/domain/services/stages/get-new-acquired-stages-service.js';
+
+describe('Unit | Service | Stages calculation', function () {
+  describe('getNewAcquiredStages', function () {
+    let dataSet;
+    before(function () {
+      dataSet = [
+        {
+          given: {
+            stages: [
+              { id: 50, threshold: 30 },
+              { id: 4, threshold: 40 },
+              { id: 1, threshold: 0 },
+              { id: 8, threshold: null, isFirstSkill: true },
+              { id: 6, threshold: 60 },
+              { id: 5, threshold: 50 },
+              { id: 2, threshold: 20 },
+            ].map(domainBuilder.buildStage),
+            validatedSkillCount: 2,
+            alreadyAcquiredStagesIds: [50],
+            masteryPercentage: 34,
+          },
+          expected: { stageIds: [1, 8, 2] },
+        },
+        {
+          given: {
+            stages: [
+              { id: 4, threshold: 40 },
+              { id: 1, threshold: 0 },
+              { id: 6, threshold: 60 },
+              { id: 5, threshold: 50 },
+              { id: 2, threshold: 20 },
+            ].map(domainBuilder.buildStage),
+            validatedSkillCount: 0,
+            alreadyAcquiredStagesIds: [],
+            masteryPercentage: 2,
+          },
+          expected: { stageIds: [1] },
+        },
+        {
+          given: {
+            stages: [{ id: 8, threshold: null, isFirstSkill: true }].map(domainBuilder.buildStage),
+            validatedSkillCount: 0,
+            alreadyAcquiredStagesIds: [],
+            masteryPercentage: 0,
+          },
+          expected: { stageIds: [] },
+        },
+        {
+          given: {
+            stages: [
+              { id: 8, threshold: 0 },
+              { id: 4, threshold: 2 },
+            ].map(domainBuilder.buildStage),
+            validatedSkillCount: 0,
+            alreadyAcquiredStagesIds: [],
+            masteryPercentage: 2,
+          },
+          expected: { stageIds: [8, 4] },
+        },
+      ];
+    });
+    it('should return the correct number of stages', function () {
+      dataSet.forEach(
+        ({
+          given: { stages, validatedSkillCount, alreadyAcquiredStagesIds, masteryPercentage },
+          expected: { stageIds },
+        }) => {
+          const acquiredStages = getNewAcquiredStages(
+            stages,
+            validatedSkillCount,
+            alreadyAcquiredStagesIds,
+            masteryPercentage,
+          );
+
+          expect(acquiredStages.map(({ id }) => id)).to.deep.equal(stageIds);
+        },
+      );
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/unit/domain/usecases/handle-stage-acquisition_test.js
@@ -1,0 +1,165 @@
+import { expect, sinon, domainBuilder } from '../../../test-helper.js';
+import { handleStageAcquisition } from '../../../../lib/domain/usecases/stages/handle-stage-acquisition.js';
+
+describe('Unit | UseCase | handleStageAcquisition', function () {
+  // Repositories
+  let campaignParticipationRepository;
+  let stageAcquisitionRepository;
+  let knowledgeElementRepository;
+  let campaignSkillRepository;
+  let campaignRepository;
+  let stageRepository;
+  let skillRepository;
+
+  // Services
+  let convertLevelStagesIntoThresholdsService;
+  let getMasteryPercentageService;
+  let getNewAcquiredStagesService;
+
+  let dependencies;
+
+  beforeEach(function () {
+    campaignParticipationRepository = { get: sinon.stub() };
+    stageAcquisitionRepository = { getStageIdsByCampaignParticipation: sinon.stub(), saveStages: sinon.stub() };
+    stageRepository = { getByCampaignParticipationId: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    campaignRepository = { findSkillIdsByCampaignParticipationId: sinon.stub() };
+    skillRepository = { findOperativeByIds: sinon.stub() };
+    campaignSkillRepository = { getSkillIdsByCampaignId: sinon.stub() };
+
+    getNewAcquiredStagesService = { getNewAcquiredStages: sinon.stub() };
+    getMasteryPercentageService = { getMasteryPercentage: sinon.stub() };
+    convertLevelStagesIntoThresholdsService = { convertLevelStagesIntoThresholds: sinon.stub() };
+
+    dependencies = {
+      campaignParticipationRepository,
+      campaignSkillRepository,
+      stageAcquisitionRepository,
+      knowledgeElementRepository,
+      campaignRepository,
+      stageRepository,
+      skillRepository,
+      convertLevelStagesIntoThresholdsService,
+      getMasteryPercentageService,
+      getNewAcquiredStagesService,
+    };
+  });
+
+  context('when assessment is not of type campaign', function () {
+    it('should not attempt to create any stages acquisition', async function () {
+      // given
+      campaignParticipationRepository.get.rejects('I should not be called');
+      stageRepository.getByCampaignParticipationId.rejects('I should not be called');
+      stageAcquisitionRepository.getStageIdsByCampaignParticipation.rejects('I should not be called');
+
+      const assessmentCertification = domainBuilder.buildAssessment.ofTypeCertification();
+      const assessmentCompetenceEvaluation = domainBuilder.buildAssessment.ofTypeCompetenceEvaluation();
+
+      // when
+      await handleStageAcquisition({ ...dependencies, assessment: assessmentCertification });
+      await handleStageAcquisition({ ...dependencies, assessment: assessmentCompetenceEvaluation });
+
+      // then
+      expect(stageAcquisitionRepository.saveStages).to.not.have.been.called;
+    });
+  });
+
+  context('when assessment is of type campaign', function () {
+    context('no stages are associated with this campaign', function () {
+      it('should not attempt to create any stages acquisition', async function () {
+        const assessment = domainBuilder.buildAssessment.ofTypeCampaign();
+        const campaignParticipation = {
+          id: 1,
+        };
+
+        // given
+        campaignParticipationRepository.get
+          .withArgs(assessment.campaignParticipationId)
+          .resolves(campaignParticipation);
+        stageRepository.getByCampaignParticipationId.withArgs(campaignParticipation.id).resolves([]);
+        stageAcquisitionRepository.getStageIdsByCampaignParticipation.withArgs(campaignParticipation.id).resolves([]);
+
+        // when
+        await handleStageAcquisition({ ...dependencies, assessment });
+
+        // then
+        expect(stageAcquisitionRepository.saveStages).to.not.have.been.called;
+      });
+    });
+
+    context('there are associated stages', function () {
+      it('it should attempt to create new stages', async function () {
+        const assessment = domainBuilder.buildAssessment.ofTypeCampaign();
+        const campaign = domainBuilder.buildCampaign({});
+        const stages = [
+          domainBuilder.buildStage({ targetProfileId: campaign.targetProfileId }),
+          domainBuilder.buildStage({ targetProfileId: campaign.targetProfileId }),
+        ];
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaign: campaign });
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({ id: 1, assessmentId: assessment.id, skillId: '1' }),
+          domainBuilder.buildKnowledgeElement({ id: 2, assessmentId: assessment.id, skillId: '2' }),
+        ];
+
+        // given
+        campaignParticipationRepository.get
+          .withArgs(assessment.campaignParticipationId)
+          .resolves(campaignParticipation);
+        stageRepository.getByCampaignParticipationId.withArgs(campaignParticipation.id).resolves(stages);
+        getNewAcquiredStagesService.getNewAcquiredStages.returns(stages);
+        stageAcquisitionRepository.getStageIdsByCampaignParticipation.withArgs(campaignParticipation.id).resolves([]);
+        knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
+        campaignRepository.findSkillIdsByCampaignParticipationId
+          .withArgs({
+            campaignParticipationId: assessment.campaignParticipationId,
+          })
+          .resolves([1, 2, 3]);
+
+        // when
+        await handleStageAcquisition({ ...dependencies, assessment });
+
+        // then
+        expect(stageAcquisitionRepository.saveStages).to.have.been.called;
+      });
+    });
+
+    context('stages have levels', function () {
+      it('it should call convertLevelStagesIntoThresholdsService service', async function () {
+        const assessment = domainBuilder.buildAssessment.ofTypeCampaign();
+        const campaign = domainBuilder.buildCampaign({});
+        const skills = Symbol('skills');
+        skillRepository.findOperativeByIds.returns(skills);
+        const stages = [
+          domainBuilder.buildStage({ targetProfileId: campaign.targetProfileId, level: 1, threshold: null }),
+          domainBuilder.buildStage({ targetProfileId: campaign.targetProfileId, level: 2, threshold: null }),
+        ];
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaign: campaign });
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({ id: 1, assessmentId: assessment.id, skillId: '1' }),
+          domainBuilder.buildKnowledgeElement({ id: 2, assessmentId: assessment.id, skillId: '2' }),
+        ];
+        campaignParticipationRepository.get
+          .withArgs(assessment.campaignParticipationId)
+          .resolves(campaignParticipation);
+        stageRepository.getByCampaignParticipationId.withArgs(campaignParticipation.id).resolves(stages);
+        getNewAcquiredStagesService.getNewAcquiredStages.returns(stages);
+        stageAcquisitionRepository.getStageIdsByCampaignParticipation.withArgs(campaignParticipation.id).resolves([]);
+        knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
+        campaignRepository.findSkillIdsByCampaignParticipationId
+          .withArgs({
+            campaignParticipationId: assessment.campaignParticipationId,
+          })
+          .resolves([1, 2, 3]);
+
+        // when
+        await handleStageAcquisition({ ...dependencies, assessment });
+
+        // then
+        expect(convertLevelStagesIntoThresholdsService.convertLevelStagesIntoThresholds).to.have.been.calledWithExactly(
+          stages,
+          skills,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Lors d'une précédente PR nous avons contraint la modification des paliers. 
Dorénavant dès lors qu’une campagne associée au “profil cible” est créée, il devient impossible de modifier lesdits paliers.
S’il n’est plus possible de modifier les conditions d’acquisition des paliers, il n’est plus non plus nécessaire de les recalculer à chaque affichage. 
Enregistrer et requêter les paliers depuis une table semble beaucoup plus élégant.
De plus, l'extraction de données s’en trouve grandement facilitée.

## :robot: Proposition

Cette PR propose de créer une table d’acquisition pour les stages.
Le calcul et l’insertion s’effectuent à la fin d’une campagne. 
Il s’agit ici uniquement de l’insertion. Lors de la lecture, les paliers seront toujours calculés à la volée. 
De futures PR viendront modifier ces lectures pour venir chercher les données en base.
La coexistence de ces deux approches est possible le temps de gérer la lecture des acquisitions.

## :100: Pour tester

Vérifier que les tests fonctionnent toujours.
Sur le front, compléter une campagne avec paliers et s’assurer qu’il n’y a pas de soucis et que les données arrivent bien dans la table 'stage-acquisitions'
