### PR TITLE
[FEATURE] Authorise la mise à jour d'un Profil Cible sans avoir une image (PIX-8904)

### DIFF
--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -396,7 +396,7 @@ const register = async function (server) {
             data: {
               attributes: {
                 name: Joi.string().required().min(1),
-                'image-url': Joi.string().required(),
+                'image-url': Joi.string().uri().allow('', null),
                 description: Joi.string().required().allow(null).max(500),
                 comment: Joi.string().required().allow(null).max(500),
                 category: Joi.string().required(),

--- a/api/lib/domain/validators/target-profile/base-validation.js
+++ b/api/lib/domain/validators/target-profile/base-validation.js
@@ -1,10 +1,9 @@
 import Joi from 'joi';
 import lodash from 'lodash';
-
-const { first } = lodash;
-
 import { EntityValidationError } from '../../errors.js';
 import { TargetProfile } from '../../models/TargetProfile.js';
+
+const { first } = lodash;
 
 const categories = TargetProfile.categories;
 
@@ -30,10 +29,7 @@ const schema = Joi.object({
       'string.base': 'CATEGORY_IS_REQUIRED',
       'any.only': 'CATEGORY_IS_REQUIRED',
     }),
-  imageUrl: Joi.string().uri().required().messages({
-    'any.required': 'IMAGE_URL_IS_REQUIRED',
-    'string.base': 'IMAGE_URL_IS_REQUIRED',
-    'string.empty': 'IMAGE_URL_IS_REQUIRED',
+  imageUrl: Joi.string().uri().allow('', null).messages({
     'string.uri': 'IMAGE_URL_IS_REQUIRED',
   }),
 });

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -342,7 +342,7 @@ describe('Acceptance | Route | target-profiles', function () {
   });
 
   describe('PATCH /api/admin/target-profiles/{id}', function () {
-    it('should return 204', async function () {
+    it('should return 204 when all attributes are provided', async function () {
       const targetProfile = databaseBuilder.factory.buildTargetProfile();
       const user = databaseBuilder.factory.buildUser.withRole();
       await databaseBuilder.commit();
@@ -360,6 +360,36 @@ describe('Acceptance | Route | target-profiles', function () {
               category: 'OTHER',
               'image-url': 'http://valid-uri.com/image.png',
               'are-knowledge-elements-resettable': false,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return 204 when imageUrl is not provided', async function () {
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const user = databaseBuilder.factory.buildUser.withRole();
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/target-profiles/${targetProfile.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        payload: {
+          data: {
+            attributes: {
+              name: 'CoolPixer',
+              description: 'Amazing description',
+              comment: 'Amazing comment',
+              category: 'OTHER',
+              'are-knowledge-elements-resettable': false,
+              'image-url': null,
             },
           },
         },

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -648,7 +648,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
           description: 'description changée.',
           comment: 'commentaire changé.',
           category: 'OTHER',
-          'image-url': 'some image',
+          'image-url': 'http://valid-uri.com/image.png',
           'are-knowledge-elements-resettable': false,
         },
       },

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -97,6 +97,40 @@ describe('Unit | Controller | target-profile-controller', function () {
           areKnowledgeElementsResettable: false,
         });
       });
+
+      it('should succeed when image is not provided', async function () {
+        const requestWithNoImage = {
+          params: {
+            id: 123,
+          },
+          payload: {
+            data: {
+              attributes: {
+                name: 'Pixer123',
+                'are-knowledge-elements-resettable': false,
+                description: 'description changée',
+                comment: 'commentaire changée',
+                'image-url': null,
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await targetProfileController.updateTargetProfile(requestWithNoImage, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+        expect(usecases.updateTargetProfile).to.have.been.calledOnce;
+        expect(usecases.updateTargetProfile).to.have.been.calledWithMatch({
+          id: 123,
+          name: 'Pixer123',
+          description: 'description changée',
+          comment: 'commentaire changée',
+          imageUrl: null,
+          areKnowledgeElementsResettable: false,
+        });
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/update-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/update-target-profile_test.js
@@ -1,4 +1,4 @@
-import { expect, sinon, catchErr } from '../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../test-helper.js';
 import { EntityValidationError } from '../../../../lib/domain/errors.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 
@@ -111,56 +111,6 @@ describe('Unit | UseCase | update-target-profile', function () {
     expect(error).to.be.an.instanceOf(EntityValidationError);
     expect(error.invalidAttributes[0].attribute).to.eq('category');
     expect(error.invalidAttributes[0].message).to.eq('CATEGORY_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-  it('should throw error when imageUrl is null', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: null,
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-  it('should throw error when imageUrl is undefined', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-  it('should throw error when imageUrl is empty', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: '',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
     expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
   });
   it('should throw error when imageUrl is not an URI', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Quand je modifie un profil cible dans Pix Admin et que j’essaie de l’enregistrer j’ai une erreur qui s’affiche  Bad Request”, detail: “”data.attributes.image-url” must be a string.
Cela vient du fait qu’il n’y avait pas d’image sélectionné.

## :robot: Proposition
Ne pas déclencher d’erreur si il n’y a pas d’image saisi dans le PC 

## :rainbow: Remarques
RAS

## :100: Pour tester
Allez sur Pix Admin
Allez sur un ProfileCible et cliquer sur `editer`
Supprimez le lien d'image de Profil Cible et cliquer sur `enregistrer`
Verifiez que la requete et bien (reponse 2XX) et que quand vous refresh la page le lien de Profil Cible est bien vide

