### PR TITLE
[BUGFIX] Pouvoir supprimer une méthode de connexion FWB d'un utilisateur depuis Pix Admin (PIX-8924)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information.js
+++ b/admin/app/components/users/user-detail-personal-information.js
@@ -12,6 +12,7 @@ const typesLabel = {
   POLE_EMPLOI: 'Pôle Emploi',
   GAR: 'Médiacentre',
   CNAV: 'CNAV',
+  FWB: 'Fédération Wallonie-Bruxelles',
 };
 
 export default class UserDetailPersonalInformationComponent extends Component {

--- a/admin/app/controllers/authenticated/users/get/information.js
+++ b/admin/app/controllers/authenticated/users/get/information.js
@@ -12,6 +12,7 @@ export default class UserInformationController extends Controller {
       POLE_EMPLOI: "L'utilisateur a déjà une méthode de connexion Pôle Emploi.",
       GAR: "L'utilisateur a déjà une méthode de connexion Médiacentre.",
       CNAV: "L'utilisateur a déjà une méthode de connexion CNAV.",
+      FWB: "L'utilisateur a déjà une méthode de connexion Fédération Wallonie-Bruxelles.",
     },
     STATUS_400: 'Cette requête est impossible',
     STATUS_404: "Cet utilisateur n'existe pas.",

--- a/admin/tests/unit/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information_test.js
@@ -100,5 +100,15 @@ module('Unit | Component | users | user-detail-personal-information', function (
         assert.strictEqual(component.translatedType, 'CNAV');
       });
     });
+
+    module('when authentication method is FWB', function () {
+      test('it displays "Fédération Wallonie-Bruxelles"', function (assert) {
+        // given
+        component.authenticationMethodType = 'FWB';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'Fédération Wallonie-Bruxelles');
+      });
+    });
   });
 });

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -20,6 +20,7 @@ const reassignAuthenticationMethodJoiSchema = Joi.object({
           NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
           OidcIdentityProviders.POLE_EMPLOI.code,
           OidcIdentityProviders.CNAV.code,
+          OidcIdentityProviders.FWB.code,
         )
         .required(),
     },
@@ -372,6 +373,7 @@ const register = async function (server) {
                     'USERNAME',
                     OidcIdentityProviders.POLE_EMPLOI.code,
                     OidcIdentityProviders.CNAV.code,
+                    OidcIdentityProviders.FWB.code,
                   )
                   .required(),
               },

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -27,6 +27,9 @@ const removeAuthenticationMethod = async function ({ userId, type, userRepositor
     case OidcIdentityProviders.CNAV.code:
       await _removeAuthenticationMethod(userId, OidcIdentityProviders.CNAV.code, authenticationMethodRepository);
       break;
+    case OidcIdentityProviders.FWB.code:
+      await _removeAuthenticationMethod(userId, OidcIdentityProviders.FWB.code, authenticationMethodRepository);
+      break;
   }
 };
 

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1197,7 +1197,7 @@ describe('Unit | Router | user-router', function () {
         // then
         expect(statusCode).to.equal(400);
         expect(result.errors[0].detail).to.equal(
-          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV]',
+          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV, FWB]',
         );
       });
       it('returns 400 when the payload contains an invalid user id', async function () {

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -213,6 +213,26 @@ describe('Unit | UseCase | remove-authentication-method', function () {
     });
   });
 
+  context('When type is FWB', function () {
+    it('removes FWB authentication method', async function () {
+      // given
+      const type = OidcIdentityProviders.FWB.code;
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildAllAuthenticationMethodsForUser(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+        userId: user.id,
+        identityProvider: OidcIdentityProviders.FWB.code,
+      });
+    });
+  });
+
   context('When there is only one remaining authentication method', function () {
     it('should throw a UserNotAuthorizedToRemoveAuthenticationMethod', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans Pix Admin, il n'est pas possible de supprimer une méthode de connexion FWB d'un utilisateur.

## :robot: Proposition
Ajouter la méthode permettant de supprimer une méthode de connexion dans le cas de la FWB.

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Se connecter à Pix Admin
2. Se rendre dans l'onglet `Utilisateurs`
3. Filtrer par `Nom` en cherchant `FWB`
4. Vous devez trouver dans la liste `Henry FWB`
5. Cliquer sur cet utilisateur, vous devez arriver sur sa page d'informations
6. Dans la partie `Méthodes de connexion`, ajouter-lui une adresse e-mail `user-fwb@example.net`
7. Vous devez maintenant voir à côté de la méthode de connexion `Fédération Wallonie-Bruxelles` un bouton `Supprimer`
8. Cliquer dessus et confirmer la suppression lors de l'apparition de la modale.
9. Vérifier que la modale disparait ainsi que les boutons précédemment visibles et que l'utilisateur n'a plu de méthode de connexion `Fédération Wallonie-Bruxelles`.