### PR TITLE
[FEATURE] Ajouter un script pour reprendre les profils cibles qui n'ont pas d'images (PIX-8904).

### DIFF
--- a/api/scripts/fill-target-profiles-with-default-image-url.js
+++ b/api/scripts/fill-target-profiles-with-default-image-url.js
@@ -1,0 +1,45 @@
+import dotenv from 'dotenv';
+import perf_hooks from 'perf_hooks';
+import * as url from 'url';
+import { logger } from '../lib/infrastructure/logger.js';
+import { disconnect, knex } from '../db/knex-database-connection.js';
+
+dotenv.config();
+
+const { performance } = perf_hooks;
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+const __filename = modulePath;
+
+const DEFAULT_IMAGE_URL = 'https://images.pix.fr/profil-cible/Illu_GEN.svg';
+
+async function fillTargetProfilesWithDefaultImageUrl() {
+  await knex('target-profiles').whereNull('imageUrl').update({
+    imageUrl: DEFAULT_IMAGE_URL,
+  });
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  await fillTargetProfilesWithDefaultImageUrl();
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+export { fillTargetProfilesWithDefaultImageUrl };

--- a/api/tests/integration/scripts/fill-target-profiles-with-default-image-url_test.js
+++ b/api/tests/integration/scripts/fill-target-profiles-with-default-image-url_test.js
@@ -1,0 +1,27 @@
+import { fillTargetProfilesWithDefaultImageUrl } from '../../../scripts/fill-target-profiles-with-default-image-url.js';
+import { databaseBuilder, expect, knex } from '../../test-helper.js';
+
+describe('Integration | Script | fillTargetProfilesWithDefaultImageUrl', function () {
+  it('should fill target profiles with default image url', async function () {
+    // given
+    const targetProfileWithoutImageUrl = databaseBuilder.factory.buildTargetProfile({ imageUrl: null });
+    const targetProfileWithImageUrl = databaseBuilder.factory.buildTargetProfile({
+      imageUrl: 'https://example.net/image.png',
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await fillTargetProfilesWithDefaultImageUrl();
+
+    // then
+    const updatedTargetProfile = await knex('target-profiles')
+      .where({ id: targetProfileWithoutImageUrl.id })
+      .first('imageUrl');
+    expect(updatedTargetProfile.imageUrl).to.equal('https://images.pix.fr/profil-cible/Illu_GEN.svg');
+
+    const notUpdatedTargetProfile = await knex('target-profiles')
+      .where({ id: targetProfileWithImageUrl.id })
+      .first('imageUrl');
+    expect(notUpdatedTargetProfile.imageUrl).to.equal('https://example.net/image.png');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, certains PC n'ont pas d'image alors qu'ils devraient tous en avoir.
Une première migration a été faite en 2021 : https://github.com/1024pix/pix/blob/ed6026c659e70d14bfcbc9a566bbeb399c531828/api/db/migrations/20210713145931_set-default-target-profile-image.js
Mais visiblement il y avait des trous dans la raquette et d'autres PC ont vu le jour sans avoir d'imageUrl.

## :robot: Proposition
Ajouter un script pour pouvoir remplir l'imageUrl à ceux qui n'en ont pas. L'avantage du script, ce qu'on pourra le relancer si il existe toujours des trous dans la raquette

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- En base retirer des `imageUrl` à certains PC
- Lancer le script `node scripts/fill-target-profiles-with-default-image-url.js`
- Constater que les imageUrl ont été rempli 