### PR TITLE
[FEATURE] Ajoute le batch de nuit qui calcule la certificabilité des prescrits SCO automatiquement (PIX-8896).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -211,6 +211,8 @@ const configuration = (function () {
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
+      scheduleComputeOrganizationLearnersCertificabilityJobCron:
+        process.env.SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },
 

--- a/api/lib/infrastructure/jobs/JobQueue.js
+++ b/api/lib/infrastructure/jobs/JobQueue.js
@@ -9,9 +9,9 @@ class JobQueue {
     this.pgBoss = pgBoss;
   }
 
-  performJob(name, handlerClass) {
+  performJob(name, handlerClass, dependencies) {
     this.pgBoss.work(name, { teamSize, teamConcurrency }, async (job) => {
-      const jobHandler = new handlerClass();
+      const jobHandler = new handlerClass(dependencies);
       const monitoredJobHandler = new MonitoredJobHandler(jobHandler, logger);
       return monitoredJobHandler.handle(job.data);
     });

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
@@ -9,8 +9,8 @@ class MonitoredJobQueue {
     this.jobQueue = jobQueue;
   }
 
-  performJob(name, handlerClass) {
-    this.jobQueue.performJob(name, handlerClass);
+  performJob(name, handlerClass, dependencies) {
+    this.jobQueue.performJob(name, handlerClass, dependencies);
 
     const monitoringJobHandler = new MonitoringJobExecutionTimeHandler({ logger });
     this.jobQueue.pgBoss.onComplete(name, { teamSize, teamConcurrency }, (job) => {

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJob.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJob.js
@@ -1,0 +1,9 @@
+import { JobPgBoss } from '../JobPgBoss.js';
+
+class ScheduleComputeOrganizationLearnersCertificabilityJob extends JobPgBoss {
+  constructor(queryBuilder) {
+    super({ name: 'ScheduleComputeOrganizationLearnersCertificabilityJob', retryLimit: 0 }, queryBuilder);
+  }
+}
+
+export { ScheduleComputeOrganizationLearnersCertificabilityJob };

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
@@ -1,0 +1,30 @@
+import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './ScheduleComputeOrganizationLearnersCertificabilityJob.js';
+import { ComputeCertificabilityJob } from './ComputeCertificabilityJob.js';
+
+class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
+  constructor({ organizationLearnerRepository, pgBoss }) {
+    this.organizationLearnerRepository = organizationLearnerRepository;
+    this.pgBoss = pgBoss;
+  }
+
+  async handle() {
+    const organizationLearnerIds =
+      await this.organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+
+    await this.pgBoss.insert(
+      organizationLearnerIds.map((organizationLearnerId) => ({
+        name: ComputeCertificabilityJob.name,
+        data: { organizationLearnerId },
+        retryLimit: 0,
+        retryDelay: 30,
+        on_complete: true,
+      })),
+    );
+  }
+
+  get name() {
+    return ScheduleComputeOrganizationLearnersCertificabilityJob.name;
+  }
+}
+
+export { ScheduleComputeOrganizationLearnersCertificabilityJobHandler };

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -14,6 +14,7 @@ import * as studentRepository from './student-repository.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import { fetchPage } from '../utils/knex-utils.js';
 import { DomainTransaction } from '../DomainTransaction.js';
+import { ORGANIZATION_FEATURE } from '../../domain/constants.js';
 
 function _shouldStudentToImportBeReconciled(
   allOrganizationLearnersInSameOrganization,
@@ -355,8 +356,17 @@ async function updateCertificability(organizationLearner) {
   });
 }
 
+function findByOrganizationsWhichNeedToComputeCertificability() {
+  return knex('organization-learners')
+    .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
+    .join('features', 'organization-features.featureId', '=', 'features.id')
+    .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
+    .pluck('organization-learners.id');
+}
+
 export {
   findByIds,
+  findByOrganizationsWhichNeedToComputeCertificability,
   findByOrganizationId,
   findByOrganizationIdAndUpdatedAtOrderByDivision,
   findByUserId,

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -1,0 +1,43 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from '../../../../../lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
+
+describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCertificabilityJobHandler', function () {
+  context('#handle', function () {
+    it('should schedule multiple ComputeCertificabilityJob', async function () {
+      // given
+      const pgBoss = {
+        insert: sinon.stub(),
+      };
+      const organizationLearnerRepository = {
+        findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
+      };
+      organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability.resolves([1, 2]);
+      const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
+        new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
+          pgBoss,
+          organizationLearnerRepository,
+        });
+
+      // when
+      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle();
+
+      // then
+      expect(pgBoss.insert.getCall(0).args[0]).to.be.deep.equal([
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 1 },
+          retryLimit: 0,
+          retryDelay: 30,
+          on_complete: true,
+        },
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 2 },
+          retryLimit: 0,
+          retryDelay: 30,
+          on_complete: true,
+        },
+      ]);
+    });
+  });
+});

--- a/api/worker.js
+++ b/api/worker.js
@@ -12,6 +12,9 @@ import { ParticipationResultCalculationJobHandler } from './lib/infrastructure/j
 import { SendSharedParticipationResultsToPoleEmploiHandler } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler.js';
 import { ComputeCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJob.js';
 import { ComputeCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js';
+import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJob.js';
+import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
+import * as organizationLearnerRepository from './lib/infrastructure/repositories/organization-learner-repository.js';
 import { scheduleCpfJobs } from './lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js';
 import { MonitoredJobQueue } from './lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js';
 import * as url from 'url';
@@ -45,13 +48,27 @@ async function runJobs() {
     process.exit(0);
   });
 
-  monitoredJobQueue.performJob(ParticipationResultCalculationJob.name, ParticipationResultCalculationJobHandler);
+  monitoredJobQueue.performJob(
+    ScheduleComputeOrganizationLearnersCertificabilityJob.name,
+    ScheduleComputeOrganizationLearnersCertificabilityJobHandler,
+    {
+      pgBoss,
+      organizationLearnerRepository,
+    },
+  );
   monitoredJobQueue.performJob(ComputeCertificabilityJob.name, ComputeCertificabilityJobHandler);
+  monitoredJobQueue.performJob(ParticipationResultCalculationJob.name, ParticipationResultCalculationJobHandler);
   monitoredJobQueue.performJob(
     SendSharedParticipationResultsToPoleEmploiJob.name,
     SendSharedParticipationResultsToPoleEmploiHandler,
   );
 
+  await pgBoss.schedule(
+    ScheduleComputeOrganizationLearnersCertificabilityJob.name,
+    config.features.scheduleComputeOrganizationLearnersCertificabilityJobCron,
+    null,
+    { tz: 'Europe/Paris' },
+  );
   await scheduleCpfJobs(pgBoss);
 }
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -51,10 +51,6 @@ async function runJobs() {
     SendSharedParticipationResultsToPoleEmploiJob.name,
     SendSharedParticipationResultsToPoleEmploiHandler,
   );
-  monitoredJobQueue.performJob(
-    'SendSharedParticipationResultsToPoleEmploi',
-    SendSharedParticipationResultsToPoleEmploiHandler,
-  );
 
   await scheduleCpfJobs(pgBoss);
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix qui met en place la remontée de la certificabilité automatique pour les organisations SCO qui gèrent des élèves, on a besoin de lancer toutes les nuits un batch qui va lancer le calcul de la certificabilité pour les prescrits des organisations ayant accès la feature **COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY**.

## :robot: Proposition
On ajoute dans PG un job qui sera lancé tous les soirs à 21h. Celui-ci va récupérer la liste des ids des prescrits des organisations qui ont le droit d'avoir accès à la remontée de la certificabilité automatique. A partir de cette liste le job va créer autant de job **ComputeCertificability** qu'il y a d'id de prescrits.

## :rainbow: Remarques
Suppression d'un relicat de la migration ESM : [c2351c7](https://github.com/1024pix/pix/pull/6888/commits/c2351c7d7728e1a1a3b9a8e5b347944c1517c542)

## :100: Pour tester
- Ajouter la feature 100001 sur une organization avec des prescrits (ex: 2023)
- Lancer SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_JOB_CRON="* * * * *" npm run start:job
- Regarder dans les logs que le job est bien lancé toutes les minutes et que des jobs ComputeCertificability sont bien loggé aussi
- Aller voir dans la table organization-learners et vérifier que les colonnes certifiableAt et isCertifiable sont bien mis à jour pour les prescrits des organisations qui ont la feature
