### PR TITLE
[TECH] Corriger la taille de le bouton `repasser mon parcours`

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -38,6 +38,7 @@
     text-align: initial;
 
     &__pix-button {
+      width: fit-content;
       margin: 0 auto ;
 
       &:first-child {


### PR DESCRIPTION
## :unicorn: Problème
Le bouton `repasser mon parcours` prend l'espace entier de la ligne

## :robot: Proposition
Modifier la taille de le bouton pour prend que l'espace de la contenu

## :rainbow: Remarques
RAS

## :100: Pour tester
Allez sur orga et creer un campagne avec envoi multipe activer
- copie la code

Allez sur Pix App et commence une campagn avec le code que vous avez copier
A la fin de la parcours - verifier que la taille de le bouton `repasser mon parcours` est correct
