### PR TITLE
[FEATURE] Affiche les Contenu Formatifs une fois les résultats envoyés (PIX-8730) 

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-target-profiles.js
+++ b/api/db/seeds/data/team-devcomp/build-target-profiles.js
@@ -3,12 +3,13 @@ import { PIX_EDU_SMALL_TARGET_PROFILE_ID } from './constants.js';
 export function buildTargetProfiles(databaseBuilder) {
   databaseBuilder.factory.buildTargetProfile({
     id: PIX_EDU_SMALL_TARGET_PROFILE_ID,
-    imageUrl: null,
+    imageUrl: 'https://images.pix.fr/profil-cible/Illu_GEN.svg',
     description: null,
     name: '[Pix+Édu 1D FC] Prêt pour la certification du volet 1',
     isSimplifiedAccess: false,
     category: 'PREDEFINED',
     isPublic: true,
+    areKnowledgeElementsResettable: true,
   });
   [
     { tubeId: 'tube2l7fFnDh1vPn4s', level: 5 },

--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -1,0 +1,47 @@
+import { PIX_EDU_SMALL_TARGET_PROFILE_ID } from './constants.js';
+
+export function buildTrainings(databaseBuilder) {
+  const frTrainingId = databaseBuilder.factory.buildTraining({
+    title: 'Eating Croissants the French way',
+    locale: 'fr',
+  }).id;
+
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
+    trainingId: frTrainingId,
+  });
+
+  const frTrainingTriggerId = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: frTrainingId,
+    threshold: 0,
+    type: 'prerequisite',
+  }).id;
+
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: frTrainingTriggerId,
+    tubeId: 'tube1NLpOetQhutFlA',
+    level: 2,
+  });
+
+  const frFrTrainingId = databaseBuilder.factory.buildTraining({
+    title: 'Apprendre à peindre comme Monet',
+    locale: 'fr-fr',
+  }).id;
+
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
+    trainingId: frFrTrainingId,
+  });
+
+  const frFrTrainingTriggerId = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: frFrTrainingId,
+    threshold: 0,
+    type: 'prerequisite',
+  }).id;
+
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: frFrTrainingTriggerId,
+    tubeId: 'tube1NLpOetQhutFlA',
+    level: 2,
+  });
+}

--- a/api/db/seeds/data/team-devcomp/data-builder.js
+++ b/api/db/seeds/data/team-devcomp/data-builder.js
@@ -1,10 +1,12 @@
 import { buildCampaigns } from './build-campaigns.js';
 import { buildOrganizations } from './build-organization.js';
 import { buildTargetProfiles } from './build-target-profiles.js';
+import { buildTrainings } from './build-trainings.js';
 
 async function teamDevcompDataBuilder({ databaseBuilder }) {
   await buildOrganizations(databaseBuilder);
   await buildTargetProfiles(databaseBuilder);
+  await buildTrainings(databaseBuilder);
   await databaseBuilder.commit();
   await buildCampaigns(databaseBuilder);
 }

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,13 +1,13 @@
 import { DatabaseBuilder } from '../database-builder/database-builder.js';
 import { commonBuilder } from './data/common/common-builder.js';
 import { featuresBuilder } from './data/common/feature-builder.js';
+import { teamDevcompDataBuilder } from './data/team-devcomp/data-builder.js';
+import { teamAccesDataBuilder } from './data/team-acces/data-builder.js';
 import { team1dDataBuilder } from './data/team-1d/data-builder.js';
 import { teamContenuDataBuilder } from './data/team-contenu/data-builder.js';
 import { teamCertificationDataBuilder } from './data/team-certification/data-builder.js';
-import { teamDevcompDataBuilder } from './data/team-devcomp/data-builder.js';
-import { teamEvaluationDataBuilder } from './data/team-evaluation/data-builder.js';
 import { teamPrescriptionDataBuilder } from './data/team-prescription/data-builder.js';
-import { teamAccesDataBuilder } from './data/team-acces/data-builder.js';
+import { teamEvaluationDataBuilder } from './data/team-evaluation/data-builder.js';
 
 const seed = async function (knex) {
   const databaseBuilder = new DatabaseBuilder({ knex });

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -26,8 +26,8 @@ Fonctionnalité: Campagne d'évaluation
     Et je clique sur "Voir mes résultats"
     Alors je vois un résultat global à 50%
     Alors je vois 2 résultats pour la compétence
-    Alors je vois la formation recommandée ayant le titre "Comment gagner des pièces d'or"
     Lorsque je clique sur "J'envoie mes résultats"
+    Alors je vois la formation recommandée ayant le titre "Comment gagner des pièces d'or"
     Alors je vois que j'ai envoyé les résultats
     Lorsque je clique sur "Continuez votre expérience Pix"
     Alors je vois le lien "Mes formations" dans la navigation

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -222,7 +222,7 @@
           </div>
         </div>
       {{/if}}
-      {{#if @model.trainings}}
+      {{#if (and @model.trainings this.isShared)}}
         <section class="skill-review__trainings">
           <h2 class="skill-review-trainings__title">{{t "pages.skill-review.trainings.title"}}</h2>
           <p class="skill-review-trainings__description">{{t "pages.skill-review.trainings.description"}}</p>

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -1,4 +1,4 @@
-import { findAll, currentURL, click, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn, findAll } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';


### PR DESCRIPTION
## :unicorn: Problème
On affiche les contenu formatifs des que un parcours est fini et les prescris souvent oublient d'envoyer leur resultat.

## :robot: Proposition
Changer la condition d'affichage de la page pour que les contenus formatifs ne s'affichent qu'apres l'envoi.

## :rainbow: Remarques
Nous n'avons pas decalé la logique dans l'API, l'obtention se fait toujours à la fin de le parcours.

## :100: Pour tester
Rejoindre le parcours `SCOMULTIP` 
Verifiez que les contenus formatifs ne sont pas affichés avant l'envoi resultat
