### PR TITLE
[BUGFIX] Le switcher des profils cibles change d'ordre (PIX-8944)

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/information.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.hbs
@@ -9,8 +9,8 @@
         @label="Accéder aux détails des profils cibles courants"
         @onLabel="Profil 1"
         @offLabel="Profil 2"
-        @toggled={{this.isToggled}}
-        @onChange={{this.onChange}}
+        @toggled={{@switchToggle}}
+        @onChange={{@switchTargetProfile}}
         @screenReaderOnly={{true}}
       />
     {{/if}}

--- a/admin/app/components/complementary-certifications/target-profiles/information.js
+++ b/admin/app/components/complementary-certifications/target-profiles/information.js
@@ -1,16 +1,7 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 export default class Information extends Component {
-  @tracked isToggled = true;
-
   get isMultipleCurrentTargetProfiles() {
     return this.args.complementaryCertification.currentTargetProfiles?.length > 1;
-  }
-
-  @action onChange() {
-    this.isToggled = !this.isToggled;
-    this.args.switchTargetProfile();
   }
 }

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/details.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class DetailsController extends Controller {
   @tracked _targetProfileId;
+  @tracked isToggleSwitched = true;
 
   get currentTargetProfile() {
     return this.model.currentTargetProfiles?.find(({ id }) => id === this.targetProfileId);
@@ -15,6 +16,7 @@ export default class DetailsController extends Controller {
 
   @action
   switchTargetProfile() {
+    this.isToggleSwitched = !this.isToggleSwitched;
     this._targetProfileId = this.model.currentTargetProfiles?.find(({ id }) => id !== this.targetProfileId).id;
   }
 }

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/details.hbs
@@ -7,6 +7,7 @@
     @complementaryCertification={{@model}}
     @currentTargetProfile={{this.currentTargetProfile}}
     @switchTargetProfile={{this.switchTargetProfile}}
+    @switchToggle={{this.isToggleSwitched}}
   />
   <ComplementaryCertifications::TargetProfiles::BadgesList @currentTargetProfile={{this.currentTargetProfile}} />
   <ComplementaryCertifications::TargetProfiles::History @targetProfilesHistory={{@model.targetProfilesHistory}} />

--- a/admin/tests/unit/components/complementary-certifications/target-profiles/information_test.js
+++ b/admin/tests/unit/components/complementary-certifications/target-profiles/information_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
-import sinon from 'sinon';
 
 module('Unit | Component | complementary-certifications/target-profiles/information', function (hooks) {
   setupTest(hooks);
@@ -56,33 +55,6 @@ module('Unit | Component | complementary-certifications/target-profiles/informat
         // when & then
         assert.false(component.isMultipleCurrentTargetProfiles);
       });
-    });
-  });
-
-  module('#onChange', function () {
-    test('it should call switchTargetProfile method', async function (assert) {
-      // given
-      const component = createGlimmerComponent('component:complementary-certifications/target-profiles/information');
-
-      component.args = {
-        complementaryCertification: {
-          currentTargetProfiles: [
-            { id: 1, name: 'current target' },
-            { id: 2, name: 'another current target' },
-          ],
-        },
-        switchTargetProfile: sinon.stub(),
-      };
-
-      // when & then
-      assert.true(component.isToggled);
-
-      // when
-      component.onChange();
-
-      // then
-      assert.false(component.isToggled);
-      sinon.assert.called(component.args.switchTargetProfile);
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -64,10 +64,14 @@ module(
         controller.model = { currentTargetProfiles: [{ id: 55 }, { id: 66 }] };
         controller._targetProfileId = 55;
 
+        // when & then
+        assert.true(controller.isToggleSwitched);
+
         // when
         controller.switchTargetProfile();
 
         // then
+        assert.false(controller.isToggleSwitched);
         assert.strictEqual(controller.targetProfileId, 66);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Sur une certification complémentaire avec 2 profils cibles, on enclenche le bouton toggle pour afficher le second profil cible. Ensuite on clique sur `Rattacher un nouveau profil cible` puis sur le bouton `Annuler` alors le profile cible est toujours le bon mais le bouton toggle est repasser à gauche (son état par défaut).

## :robot: Proposition
Gérer la valeur du toggle dans le template parent, qui gère aussi le profile cible courant

## :100: Pour tester
- Se connecter à Pix Admin avec le compte superadmin
- Aller sur la page de la certification complémentaire "Pix+ Droit 1ere degré"
- Appuyer sur le toggle des profiles (il passe à droite) puis sur `Rattacher un nouveau profil cible`
- Annuler et observer que c'est toujours le même profile cible et que le toggle est toujours bien à droite