### PR TITLE
[FEATURE] Ajouter un script pour migrer en BDD les acquisitions de palier (PIX-8899).

### DIFF
--- a/api/scripts/add-existing-stage-acquisitions.js
+++ b/api/scripts/add-existing-stage-acquisitions.js
@@ -1,0 +1,97 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+import perf_hooks from 'perf_hooks';
+import * as url from 'url';
+
+const { performance } = perf_hooks;
+
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
+import { logger } from '../lib/infrastructure/logger.js';
+import { learningContentCache as cache } from '../lib/infrastructure/caches/learning-content-cache.js';
+import { knex, disconnect } from '../db/knex-database-connection.js';
+import { batch } from '../db/batch-processing.js';
+import { usecases } from '../lib/domain/usecases/index.js';
+import { Assessment } from '../lib/domain/models/Assessment.js';
+
+const MAX_RANGE_SIZE = 100_000;
+
+const handleStageAcquisitions = async ({ idMin, idMax, throwError }) => {
+  if (throwError) {
+    throw new Error('An error occurred');
+  }
+  return knex('assessments')
+    .select('*')
+    .whereBetween('id', [idMin, idMax])
+    .where({
+      state: 'completed',
+      type: 'CAMPAIGN',
+    })
+    .orderBy('id', 'asc')
+    .then((allCompletedAssessments) => {
+      return batch(knex, allCompletedAssessments, (completedAssessment) => {
+        const assessment = new Assessment(completedAssessment);
+        return usecases.handleStageAcquisition({ assessment });
+      });
+    });
+};
+
+function getAllArgs() {
+  return yargs(hideBin(process.argv))
+    .option('idMin', {
+      type: 'number',
+      demand: true,
+      description: 'id du premier assessment',
+    })
+    .option('idMax', {
+      type: 'number',
+      demand: true,
+      description: 'id du dernier assessment',
+    })
+    .help().argv;
+}
+
+function normalizeRange({ idMin, idMax }) {
+  const rangeSize = idMax - idMin;
+  if (rangeSize > MAX_RANGE_SIZE) {
+    const newIdMax = idMin + MAX_RANGE_SIZE;
+    logger.info(`Max range size exceeded : new idMax is ${newIdMax}`);
+    return { idMin, idMax: newIdMax };
+  }
+  return { idMin, idMax };
+}
+
+async function main() {
+  const startTime = performance.now();
+
+  logger.info('\n---\n* Starting existing stage-acquisitions insertions.\n---\n');
+  const { idMin, idMax } = getAllArgs();
+  const range = normalizeRange({ idMin, idMax });
+
+  await handleStageAcquisitions({ ...range, throwError: false });
+  logger.info('\n---\n* Done.\n---\n');
+
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`\n---\n* Script has ended: took ${duration} milliseconds\n---\n`);
+}
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+export { handleStageAcquisitions };


### PR DESCRIPTION
## :unicorn: Problème

Dans une autre PR, nous avons ajouté la table `stage-acquisitions` et le use-case pour stocker les paliers acquis par les utilisateurs lors des campagnes.

Seulement, cela ne marche que pour les futurs paliers qui seront acquis.

Nous souhaitons conserver dans cette table les paliers déjà acquis par les utilisateurs.

## :robot: Proposition

Créer un script qui permet d’insérer dans la table `stage-acquisitions` les paliers qu’un utilisateur a déjà acquis sur ses précédentes participations à des campagnes.

## :rainbow: Remarques

- On ne considère que les `campaign-participations` reliées à des `campaigns` qui ont des `target-profiles` avec `stages`.
- Pour ne pas lancer le script sur un trop gros nombre d'assessments à la fois, on définit au lancement du script un `idMin` et un `idMax` pour traiter par paquets.

## :100: Pour tester

**En local** :
- 🧹 Faire un `npm run db:reset` pour avoir une BDD clean
- 🚀 Lancer le nouveau script à partir du dossier `api` :
```
node scripts/add-existing-stage-acquisitions.js --idMin=100000 --idMax=200000
```
- ✅ Attester que la table `stage-acquisitions` est remplie par les données souhaitées