### PR TITLE
[BUGFIX] La prévisualisation d'épreuve cause le crash du conteneur par épuisement mémoire (Pix-8884)

### DIFF
--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -42,11 +42,9 @@ const _DatasourcePrototype = {
 
   async refreshLearningContentCacheRecord(id, newEntry) {
     const currentLearningContent = await this._getLearningContent();
-    const currentRecords = currentLearningContent[this.modelName];
-    const updatedRecords = _.reject(currentRecords, { id }).concat([newEntry]);
-    const newLearningContent = _.cloneDeep(currentLearningContent);
-    newLearningContent[this.modelName] = updatedRecords;
-    await learningContentCache.set(newLearningContent);
+    const index = currentLearningContent[this.modelName].findIndex((element) => element?.id === id);
+    currentLearningContent[this.modelName][index] = newEntry;
+    await learningContentCache.set(currentLearningContent);
     return newEntry;
   },
 };

--- a/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -208,7 +208,11 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
       // given
       const record = { id: 'rec1', property: 'updatedValue' };
       const learningContent = {
-        learningContentModel: [null, { id: 'rec1', property: 'value1' }, { id: 'rec2', property: 'value2' }],
+        learningContentModel: [
+          null,
+          { id: 'rec1', property: 'value1', oldProperty: 'value' },
+          { id: 'rec2', property: 'value2' },
+        ],
         learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
       };
       learningContentCache.get.resolves(learningContent);

--- a/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -225,10 +225,12 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
         id: 'rec1',
         property: 'updatedValue',
       });
-      expect(learningContentCache.set).to.have.been.deep.calledWith({
+      expect(learningContentCache.set).to.have.been.calledOnce;
+      const argument = learningContentCache.set.firstCall.args[0];
+      expect(argument).to.deep.equal({
         learningContentModel: [
-          { id: 'rec2', property: 'value2' },
           { id: 'rec1', property: 'updatedValue' },
+          { id: 'rec2', property: 'value2' },
         ],
         learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
       });

--- a/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -208,10 +208,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
       // given
       const record = { id: 'rec1', property: 'updatedValue' };
       const learningContent = {
-        learningContentModel: [
-          { id: 'rec1', property: 'value1' },
-          { id: 'rec2', property: 'value2' },
-        ],
+        learningContentModel: [null, { id: 'rec1', property: 'value1' }, { id: 'rec2', property: 'value2' }],
         learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
       };
       learningContentCache.get.resolves(learningContent);
@@ -228,10 +225,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
       expect(learningContentCache.set).to.have.been.calledOnce;
       const argument = learningContentCache.set.firstCall.args[0];
       expect(argument).to.deep.equal({
-        learningContentModel: [
-          { id: 'rec1', property: 'updatedValue' },
-          { id: 'rec2', property: 'value2' },
-        ],
+        learningContentModel: [null, { id: 'rec1', property: 'updatedValue' }, { id: 'rec2', property: 'value2' }],
         learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
La mise à jour du référentiel lors de la preview des épreuves fait régulièrement crasher la recette. Cela est du à une consommation excessive de la mémoire qui est due à plusieurs chargements mémoire successifs du référentiel.

## :robot: Proposition
Muter le référentiel sur place pour ne le charger qu'une seule fois

## :rainbow: Remarques
Les tests ont été améliorés : l'ordre des enregistrements dans le référentiel n'est pas significatif.

## :100: Pour tester

### En local

Sur les branches 
- dev
-  de cette PR

Démarrer le serveur en simulant la mémoire disponible sur Scalingo
``` bash
NODE_OPTIONS=--max-old-space-size=259 npm start
```

Exécuter ce script bash
```bash
ACCESS_TOKEN=$(curl --silent 'http://localhost:3000/api/token' \
-H 'content-type: application/x-www-form-urlencoded' \
--data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=mon-pix' | jq --raw-output  .access_token)

for i in {1..3}
do
  curl -X PATCH 'http://localhost:3000/api/cache/challenges/challenge1oSG8enNULGgUS' -H "Authorization: Bearer $ACCESS_TOKEN" &
  echo "."
  sleep 1
done
```

Vérifier que 
- le serveur sort en OOM sur dev
- le serveur répond en 204 sur la PR

### Sur Scalingo
Ce script bash ance 3 requêtes à 3 secondes d'intervalles vers le endpoint incriminé.
```bash

BASE_URL=https://api-pr6899.review.pix.fr/api
#BASE_URL=https://api.integration.pix.fr/api
PAUSE_SECONDS=3

ACCESS_TOKEN=$(curl --silent "$BASE_URL/token" \
-H 'content-type: application/x-www-form-urlencoded' \
--data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=mon-pix' | jq --raw-output  .access_token)

for i in {1..3}
do
  curl --include --write-out  %{time_total}s\n -X PATCH "$BASE_URL/cache/challenges/challenge1oSG8enNULGgUS" -H "Authorization: Bearer $ACCESS_TOKEN" &
sleep $PAUSE_SECONDS
done
```
#### Version actuelle
Exécuter le script sur l'intégration
Il doit renvoyer des 502.

Le conteneur doit redémarrer suite à un OOM.
``` bash
 scalingo --region osc-fr1 --app pix-api-integration timeline --per-page=10 --page=1 | grep crashed
```

#### Version corrigée
Exécuter le script sur la RA
Il doit renvoyer des 204.
Le conteneur ne doit pas redémarrer.
``` bash
 scalingo --region osc-fr1 --app pix-api-review-pr6899 timeline --per-page=10 --page=1 | grep crashed
```
