### PR TITLE
[BUGFIX] Ajoute de la pagination sur le job de calcul automatique de la certificabilité pour le SCO (PIX-8950).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -211,8 +211,10 @@ const configuration = (function () {
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
-      scheduleComputeOrganizationLearnersCertificabilityJobCron:
-        process.env.SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
+      scheduleComputeOrganizationLearnersCertificability: {
+        cron: process.env.SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
+        chunkSize: process.env.SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 50000,
+      },
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },
 

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
@@ -1,25 +1,40 @@
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './ScheduleComputeOrganizationLearnersCertificabilityJob.js';
 import { ComputeCertificabilityJob } from './ComputeCertificabilityJob.js';
+import { DomainTransaction } from '../../DomainTransaction.js';
 
 class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
-  constructor({ organizationLearnerRepository, pgBoss }) {
+  constructor({ organizationLearnerRepository, pgBossRepository, config }) {
     this.organizationLearnerRepository = organizationLearnerRepository;
-    this.pgBoss = pgBoss;
+    this.pgBossRepository = pgBossRepository;
+    this.config = config;
   }
 
   async handle() {
-    const organizationLearnerIds =
-      await this.organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+    const chunkSize = this.config.features.scheduleComputeOrganizationLearnersCertificability.chunkSize;
+    const count = await this.organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability();
+    const chunkCount = Math.ceil(count / chunkSize);
 
-    await this.pgBoss.insert(
-      organizationLearnerIds.map((organizationLearnerId) => ({
-        name: ComputeCertificabilityJob.name,
-        data: { organizationLearnerId },
-        retryLimit: 0,
-        retryDelay: 30,
-        on_complete: true,
-      })),
-    );
+    await DomainTransaction.execute(async (domainTransaction) => {
+      for (let index = 0; index < chunkCount; index++) {
+        const organizationLearnerIds =
+          await this.organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+            limit: chunkSize,
+            offset: index * chunkSize,
+          });
+        await this.pgBossRepository.insert(
+          organizationLearnerIds.map(
+            (organizationLearnerId) => ({
+              name: ComputeCertificabilityJob.name,
+              data: { organizationLearnerId },
+              retrylimit: 0,
+              retrydelay: 30,
+              on_complete: true,
+            }),
+            domainTransaction,
+          ),
+        );
+      }
+    });
   }
 
   get name() {

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -356,16 +356,35 @@ async function updateCertificability(organizationLearner) {
   });
 }
 
-function findByOrganizationsWhichNeedToComputeCertificability() {
-  return knex('organization-learners')
+async function countByOrganizationsWhichNeedToComputeCertificability() {
+  const [{ count }] = await knex('organization-learners')
     .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
     .join('features', 'organization-features.featureId', '=', 'features.id')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
-    .pluck('organization-learners.id');
+    .count('organization-learners.id');
+  return count;
+}
+
+function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset } = {}) {
+  const queryBuilder = knex('organization-learners')
+    .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
+    .join('features', 'organization-features.featureId', '=', 'features.id')
+    .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key);
+
+  if (limit) {
+    queryBuilder.limit(limit);
+  }
+
+  if (offset) {
+    queryBuilder.offset(offset);
+  }
+
+  return queryBuilder.pluck('organization-learners.id');
 }
 
 export {
   findByIds,
+  countByOrganizationsWhichNeedToComputeCertificability,
   findByOrganizationsWhichNeedToComputeCertificability,
   findByOrganizationId,
   findByOrganizationIdAndUpdatedAtOrderByDivision,

--- a/api/lib/infrastructure/repositories/pgboss-repository.js
+++ b/api/lib/infrastructure/repositories/pgboss-repository.js
@@ -1,0 +1,9 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../DomainTransaction.js';
+
+function insert(jobs, domainTransaction = DomainTransaction.emptyTransaction()) {
+  const knexConn = domainTransaction.knexTransaction || knex;
+  return knexConn('pgboss.job').insert(jobs);
+}
+
+export { insert };

--- a/api/tests/integration/infrastructure/repositories/pgboss-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pgboss-repository_test.js
@@ -1,0 +1,49 @@
+import { expect, knex, sinon } from '../../../test-helper.js';
+import * as pgBossRepository from '../../../../lib/infrastructure/repositories/pgboss-repository.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+
+describe('Integration | Repository | PgBoss', function () {
+  afterEach(function () {
+    return knex('pgboss.job').truncate();
+  });
+
+  describe('#insert', function () {
+    it('should insert two jobs', async function () {
+      await pgBossRepository.insert([
+        {
+          name: 'Something',
+          data: { prop: 1 },
+          on_complete: true,
+        },
+        {
+          name: 'Else',
+          data: { prop: 2 },
+          on_complete: true,
+        },
+      ]);
+
+      const jobs = await knex('pgboss.job').whereIn('name', ['Something', 'Else']);
+      expect(jobs.length).to.equal(2);
+    });
+
+    it('should use transaction', async function () {
+      let transaction;
+      await DomainTransaction.execute(function (domainTransaction) {
+        sinon.stub(domainTransaction, 'knexTransaction').callsFake(knex);
+        transaction = domainTransaction.knexTransaction;
+        return pgBossRepository.insert(
+          [
+            {
+              name: 'Something',
+              data: { prop: 1 },
+              on_complete: true,
+            },
+          ],
+          domainTransaction,
+        );
+      });
+
+      sinon.assert.called(transaction);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -5,36 +5,69 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
   context('#handle', function () {
     it('should schedule multiple ComputeCertificabilityJob', async function () {
       // given
-      const pgBoss = {
+      const pgBossRepository = {
         insert: sinon.stub(),
       };
       const organizationLearnerRepository = {
         findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
+        countByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
       };
-      organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability.resolves([1, 2]);
+      const config = {
+        features: {
+          scheduleComputeOrganizationLearnersCertificability: {
+            chunkSize: 2,
+          },
+        },
+      };
+      organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability.resolves(3);
+      organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
+        .withArgs({ limit: 2, offset: 0 })
+        .resolves([1, 2]);
+      organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
+        .withArgs({ limit: 2, offset: 2 })
+        .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
         new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
-          pgBoss,
+          pgBossRepository,
           organizationLearnerRepository,
+          config,
         });
 
       // when
       await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle();
 
       // then
-      expect(pgBoss.insert.getCall(0).args[0]).to.be.deep.equal([
+      expect(pgBossRepository.insert.getCall(0).args[0]).to.be.deep.equal([
         {
           name: 'ComputeCertificabilityJob',
           data: { organizationLearnerId: 1 },
-          retryLimit: 0,
-          retryDelay: 30,
+          retrylimit: 0,
+          retrydelay: 30,
           on_complete: true,
         },
         {
           name: 'ComputeCertificabilityJob',
           data: { organizationLearnerId: 2 },
-          retryLimit: 0,
-          retryDelay: 30,
+          retrylimit: 0,
+          retrydelay: 30,
+          on_complete: true,
+        },
+      ]);
+      expect(pgBossRepository.insert.getCall(1).args[0]).to.be.deep.equal([
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 3 },
+          retrylimit: 0,
+          retrydelay: 30,
+          on_complete: true,
+        },
+      ]);
+      expect(pgBossRepository.insert.getCall(1).args[0]).to.be.deep.equal([
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 3 },
+          retrylimit: 0,
+          retrydelay: 30,
           on_complete: true,
         },
       ]);

--- a/api/worker.js
+++ b/api/worker.js
@@ -15,6 +15,7 @@ import { ComputeCertificabilityJobHandler } from './lib/infrastructure/jobs/orga
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJob.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
 import * as organizationLearnerRepository from './lib/infrastructure/repositories/organization-learner-repository.js';
+import * as pgBossRepository from './lib/infrastructure/repositories/pgboss-repository.js';
 import { scheduleCpfJobs } from './lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js';
 import { MonitoredJobQueue } from './lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js';
 import * as url from 'url';
@@ -52,8 +53,9 @@ async function runJobs() {
     ScheduleComputeOrganizationLearnersCertificabilityJob.name,
     ScheduleComputeOrganizationLearnersCertificabilityJobHandler,
     {
-      pgBoss,
+      pgBossRepository,
       organizationLearnerRepository,
+      config,
     },
   );
   monitoredJobQueue.performJob(ComputeCertificabilityJob.name, ComputeCertificabilityJobHandler);
@@ -65,7 +67,7 @@ async function runJobs() {
 
   await pgBoss.schedule(
     ScheduleComputeOrganizationLearnersCertificabilityJob.name,
-    config.features.scheduleComputeOrganizationLearnersCertificabilityJobCron,
+    config.features.scheduleComputeOrganizationLearnersCertificability.cron,
     null,
     { tz: 'Europe/Paris' },
   );


### PR DESCRIPTION
## :unicorn: Problème
Le job ScheduleComputeOrganizationLearnersCertificability va récupérer la liste des prescrits pour qui on doit calculer la certificabilité. Actuellement cela représente 4,5 millions de prescrits. Le plus grand conteneur de Scalingo n'a pas assez de mémoire pour stocker une telle quantité de donnée et crash.

## :robot: Proposition
Cette PR pagine le lancement des jobs pour les 4,5 millions de prescrits en les faisant 50000 à la fois.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que les jobs sont toujours lancé en local puis en production vérifier que le job ne crash pas en out of memory.
