### PR TITLE
[FEATURE] Jouer des épreuves avec des déclinaisons pas encore rencontrées.(Pix-8941) 

### DIFF
--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -48,7 +48,7 @@ const challengeDatasource = datasource.extend({
     const challenges = await this.list();
     const filteredChallenges = challenges.filter(
       (challenge) =>
-        challenge.skillId === skillId &&
+        challenge.skill.id === skillId &&
         (challenge.status === VALIDATED_CHALLENGE || challenge.status === PROPOSED_CHALLENGE),
     );
 

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -48,7 +48,7 @@ const challengeDatasource = datasource.extend({
     const challenges = await this.list();
     const filteredChallenges = challenges.filter(
       (challenge) =>
-        challenge.skill.id === skillId &&
+        challenge.skillId === skillId &&
         (challenge.status === VALIDATED_CHALLENGE || challenge.status === PROPOSED_CHALLENGE),
     );
 

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -377,19 +377,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     });
 
     context('when there are several challenges for the skillId', function () {
-      // it('should return a challenge randomly if the alternativeVersion is not provided', async function () {
-      //   // when
-      //   sinon.stub(lcms, 'getLatestRelease').resolves({
-      //     challenges: [challenge_web1, challenge_competence2, challenge_pix1d1, challenge_pix1d2],
-      //   });
-      //   const result = await challengeDatasource.getBySkillId(skillId);
-      //
-      //   // then
-      //   expect(lcms.getLatestRelease).to.have.been.called;
-      //
-      //   expect([result]).to.contain.oneOf(expectedChallenges);
-      // });
-
       it('should return an array of validated or proposed challenges', async function () {
         // when
         sinon.stub(lcms, 'getLatestRelease').resolves({


### PR DESCRIPTION
## :unicorn: Problème
Pour Pix1D, les épreuves d'une même activité peuvent porter sur un thème commun. Pour cela, on utilise le numéro de déclinaison pour récupérer les épreuves d'un même thème.
Si un élève a déjà jouée un activité, lorsqu'il jouera de nouveau cette activé, il peut tomber sur une déclinaison qu'il a déjà rencontré.

## :robot: Proposition
Jouer des épreuves avec des déclinaisons pas encore rencontrées.

## :rainbow: Remarques


## :100: Pour tester
- Aller sur pix1d et participer à une mission
- échouer la 1ere activité
- réussir la seconde activité pour remonter au niveau de la 1 ere activité
- constater que l'épreuve n'est pas la même que pour la première activité.
