### PR TITLE
[BUGFIX] Affichage des pages de détail de certif complémentaire une fois le switch Pix+ Edu utilisé

### DIFF
--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/details.js
@@ -19,4 +19,9 @@ export default class DetailsController extends Controller {
     this.isToggleSwitched = !this.isToggleSwitched;
     this._targetProfileId = this.model.currentTargetProfiles?.find(({ id }) => id !== this.targetProfileId).id;
   }
+
+  reset() {
+    this._targetProfileId = null;
+    this.isToggleSwitched = true;
+  }
 }

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class ComplementaryCertificationDetailsRoute extends Route {
+export default class DetailsRoute extends Route {
   @service accessControl;
 
   beforeModel() {
@@ -14,7 +14,7 @@ export default class ComplementaryCertificationDetailsRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller._targetProfileId = null;
+      controller.reset();
     }
   }
 }

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
@@ -11,4 +11,10 @@ export default class ComplementaryCertificationDetailsRoute extends Route {
   async model() {
     return this.modelFor('authenticated.complementary-certifications.complementary-certification');
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller._targetProfileId = null;
+    }
+  }
 }

--- a/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -75,5 +75,20 @@ module(
         assert.strictEqual(controller.targetProfileId, 66);
       });
     });
+
+    module('#reset', function () {
+      test('it should set targetProfileId to null', function (assert) {
+        // given
+        controller._targetProfileId = '55';
+        controller.isToggleSwitched = false;
+
+        // when
+        controller.reset();
+
+        // then
+        assert.strictEqual(controller._targetProfileId, null);
+        assert.true(controller.isToggleSwitched);
+      });
+    });
   },
 );

--- a/admin/tests/unit/routes/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/unit/routes/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -40,17 +40,17 @@ module(
           'route:authenticated/complementary-certifications/complementary-certification/details',
         );
         controller = {
-          _targetProfileId: '42',
+          reset: sinon.stub(),
         };
       });
 
       module('when route is exiting', function () {
-        test('it should reset the toggle target id', function (assert) {
+        test('it should reset the toggle state', function (assert) {
           // when
           route.resetController(controller, true);
 
           // then
-          assert.strictEqual(controller._targetProfileId, null);
+          assert.ok(controller.reset.calledOnce);
         });
       });
 
@@ -60,7 +60,7 @@ module(
           route.resetController(controller, false);
 
           // then
-          assert.strictEqual(controller._targetProfileId, '42');
+          assert.ok(controller.reset.notCalled);
         });
       });
     });

--- a/admin/tests/unit/routes/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/unit/routes/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module(
+  'Unit | Route | authenticated/complementary-certifications/complementary-certification/details',
+  function (hooks) {
+    setupTest(hooks);
+
+    module('#beforeModel', function () {
+      test('it should check if current user is "SUPER_ADMIN", "SUPPORT", or "METIER"', function (assert) {
+        // given
+        const route = this.owner.lookup(
+          'route:authenticated/complementary-certifications/complementary-certification/details',
+        );
+
+        const restrictAccessToStub = sinon.stub().returns();
+
+        class AccessControlStub extends Service {
+          restrictAccessTo = restrictAccessToStub;
+        }
+
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        route.beforeModel();
+
+        // then
+        assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isMetier', 'isSupport'], 'authenticated'));
+      });
+    });
+
+    module('#resetController', function (hooks) {
+      let controller;
+      let route;
+
+      hooks.beforeEach(function () {
+        route = this.owner.lookup(
+          'route:authenticated/complementary-certifications/complementary-certification/details',
+        );
+        controller = {
+          _targetProfileId: '42',
+        };
+      });
+
+      module('when route is exiting', function () {
+        test('it should reset the toggle target id', function (assert) {
+          // when
+          route.resetController(controller, true);
+
+          // then
+          assert.strictEqual(controller._targetProfileId, null);
+        });
+      });
+
+      module('when route is not exiting', function () {
+        test('it should not reset controller', function (assert) {
+          // when
+          route.resetController(controller, false);
+
+          // then
+          assert.strictEqual(controller._targetProfileId, '42');
+        });
+      });
+    });
+  },
+);


### PR DESCRIPTION
## :unicorn: Problème
Un utilisateur Pix Admin autorisé (ADMIN, METIER, SUPPORT) : 
- clique sur l’onglet “Certifications complémentaires” dans Pix Admin
- puis sur Pix+ Edu 1er degré ou Pix+ Edu 2nd degré
- il utilise le switcher pour passer du “Profil 1” au “Profil 2” (ou inversement)
- il retourne ensuite sur la liste des certifications complémentaires en cliquant sur “Toutes les certifications complémentaires”
- il choisit alors une autre certification complémentaire
Une erreur apparait

## :robot: Proposition
Remettre à null la valeur du target profile id lors de l'appel de la route après un click sur le toggle.

## :100: Pour tester
- se connecter à Pix Admin avec le compte `superadmin`
- cliquer sur l’onglet “Certifications complémentaires”
- puis sur Pix+ Edu 1er degré ou Pix+ Edu 2nd degré
- utiliser le toggle pour passer du “Profil 1” au “Profil 2” (ou inversement)
- retourner ensuite sur la liste des certifications complémentaires en cliquant sur “Toutes les certifications complémentaires”
- cliquer sur une autre certification complémentaire
- s'assurer que la page s'affiche correctement avec les données du bon target profile