### PR TITLE
[BUMP] Mise à jour de ember-keyboard 

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -18917,21 +18917,18 @@
       "dev": true
     },
     "node_modules/ember-keyboard": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-8.2.0.tgz",
-      "integrity": "sha512-h2kuS2irtIyvNbAMkGDlDTB4TPXwgmC6Nu9bIuGWoCjkGdgJbUg0VegfyRJ1TlxbIHlAelbqVpE8UhfgY5wEag==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-8.2.1.tgz",
+      "integrity": "sha512-wT9xpt3GKsiodGZoifKU4OyeRjXWlmKV9ZHHsp6wJBwMFpl4wWPjTNdINxivk2qg/WFNIh8nUiwuG4+soWXPdw==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.5.0",
+        "@embroider/addon-shim": "^1.8.4",
         "ember-destroyable-polyfill": "^2.0.3",
         "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0",
         "ember-modifier-manager-polyfill": "^1.2.0"
       },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      },
       "peerDependencies": {
-        "@ember/test-helpers": "^2.6.0"
+        "@ember/test-helpers": "^2.6.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@ember/test-helpers": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -112,10 +112,5 @@
     "stylelint-config-standard-scss": "^10.0.0",
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.76.2"
-  },
-  "overrides": {
-    "ember-keyboard": {
-      "@ember/test-helpers": "^3.0.0"
-    }
   }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -17951,21 +17951,18 @@
       "dev": true
     },
     "node_modules/ember-keyboard": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-8.2.0.tgz",
-      "integrity": "sha512-h2kuS2irtIyvNbAMkGDlDTB4TPXwgmC6Nu9bIuGWoCjkGdgJbUg0VegfyRJ1TlxbIHlAelbqVpE8UhfgY5wEag==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-8.2.1.tgz",
+      "integrity": "sha512-wT9xpt3GKsiodGZoifKU4OyeRjXWlmKV9ZHHsp6wJBwMFpl4wWPjTNdINxivk2qg/WFNIh8nUiwuG4+soWXPdw==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.5.0",
+        "@embroider/addon-shim": "^1.8.4",
         "ember-destroyable-polyfill": "^2.0.3",
         "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0",
         "ember-modifier-manager-polyfill": "^1.2.0"
       },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      },
       "peerDependencies": {
-        "@ember/test-helpers": "^2.6.0"
+        "@ember/test-helpers": "^2.6.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@ember/test-helpers": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -124,10 +124,5 @@
     "stylelint-order": "^6.0.0",
     "webpack": "^5.76.0",
     "xss": "^1.0.13"
-  },
-  "overrides": {
-    "ember-keyboard": {
-      "@ember/test-helpers": "^3.0.0"
-    }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version de ember-keyboard est disponible qui est compatible avec @ember/test-helpers >= 3.0.0

## :robot: Proposition
Mettre à jour ember-keyboard sur les applis concernés et supprimer l'override npm.

## :100: Pour tester
:green_circle: tests
