### PR TITLE
[FEATURE] Ajoute plus d'information sur la remise à zéro du parcours lors de sa creation (PIX-8771).

### DIFF
--- a/api/lib/domain/read-models/campaign/TargetProfileForSpecifier.js
+++ b/api/lib/domain/read-models/campaign/TargetProfileForSpecifier.js
@@ -1,5 +1,14 @@
 class TargetProfileForSpecifier {
-  constructor({ id, name, tubeCount, thematicResultCount, hasStage, description, category }) {
+  constructor({
+    id,
+    name,
+    tubeCount,
+    thematicResultCount,
+    hasStage,
+    description,
+    category,
+    areKnowledgeElementsResettable,
+  }) {
     this.id = id;
     this.name = name;
     this.tubeCount = tubeCount;
@@ -7,6 +16,7 @@ class TargetProfileForSpecifier {
     this.hasStage = hasStage;
     this.description = description;
     this.category = category;
+    this.areKnowledgeElementsResettable = areKnowledgeElementsResettable;
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
@@ -19,6 +19,7 @@ function _fetchTargetProfiles(organizationId) {
       'target-profiles.name',
       'target-profiles.description',
       'target-profiles.category',
+      'target-profiles.areKnowledgeElementsResettable',
       knex.count('id').from('badges').whereRaw('badges."targetProfileId"="target-profiles".id').as('countBadges'),
       knex.count('id').from('stages').whereRaw('stages."targetProfileId"="target-profiles".id').as('countStages'),
       knex
@@ -48,6 +49,7 @@ async function _buildTargetProfileForSpecifier(row) {
     hasStage,
     description: row.description,
     category: row.category,
+    areKnowledgeElementsResettable: row.areKnowledgeElementsResettable,
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer.js
@@ -4,7 +4,15 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (targetProfiles, meta) {
   return new Serializer('target-profile', {
-    attributes: ['name', 'tubeCount', 'thematicResultCount', 'hasStage', 'description', 'category'],
+    attributes: [
+      'name',
+      'tubeCount',
+      'thematicResultCount',
+      'hasStage',
+      'description',
+      'category',
+      'areKnowledgeElementsResettable',
+    ],
     meta,
   }).serialize(targetProfiles);
 };

--- a/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
@@ -1,7 +1,7 @@
-import { expect, databaseBuilder } from '../../../../test-helper.js';
-import * as TargetProfileForSpecifierRepository from '../../../../../lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js';
-import { TargetProfileForSpecifier } from '../../../../../lib/domain/read-models/campaign/TargetProfileForSpecifier.js';
 import { categories } from '../../../../../lib/domain/models/TargetProfile.js';
+import { TargetProfileForSpecifier } from '../../../../../lib/domain/read-models/campaign/TargetProfileForSpecifier.js';
+import * as TargetProfileForSpecifierRepository from '../../../../../lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repository | target-profile-for-campaign-repository', function () {
   describe('#availableForOrganization', function () {
@@ -70,6 +70,17 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
 
         expect(targetProfileForSpecifier.description).to.equal('THIS IS SPARTA!');
       });
+
+      it('returns the target profile areKnowledgeElementsResettable', async function () {
+        databaseBuilder.factory.buildTargetProfile({ areKnowledgeElementsResettable: false });
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+        await databaseBuilder.commit();
+
+        const [targetProfileForSpecifier] =
+          await TargetProfileForSpecifierRepository.availableForOrganization(organizationId);
+
+        expect(targetProfileForSpecifier.areKnowledgeElementsResettable).to.equal(false);
+      });
     });
 
     context('when there are several target profile', function () {
@@ -92,6 +103,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           hasStage: false,
           description: null,
           category: 'OTHER',
+          areKnowledgeElementsResettable: false,
         });
         const targetProfile2 = new TargetProfileForSpecifier({
           id: targetProfileId2,
@@ -101,6 +113,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           hasStage: false,
           description: null,
           category: 'OTHER',
+          areKnowledgeElementsResettable: false,
         });
         const availableTargetProfiles =
           await TargetProfileForSpecifierRepository.availableForOrganization(organizationId);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer_test.js
@@ -13,6 +13,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
         hasStage: true,
         description: 'description',
         category: 'SUBJECT',
+        areKnowledgeElementsResettable: true,
       });
 
       const meta = { some: 'meta' };
@@ -28,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
             'has-stage': true,
             description: 'description',
             category: 'SUBJECT',
+            'are-knowledge-elements-resettable': true,
           },
         },
         meta,

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -170,6 +170,11 @@
             <span>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</span>
           </span>
           <span class="form__field-info-message">{{t this.multipleSendingWording.info}}</span>
+          {{#if this.campaign.targetProfile.areKnowledgeElementsResettable}}
+            <span class="form__field-info-message">{{t
+                "pages.campaign-creation.multiple-sendings.knowledge-elements-resettable"
+              }}</span>
+          {{/if}}
         </div>
       </div>
     </div>

--- a/orga/app/models/target-profile.js
+++ b/orga/app/models/target-profile.js
@@ -7,4 +7,5 @@ export default class TargetProfile extends Model {
   @attr('number') thematicResultCount;
   @attr('boolean') hasStage;
   @attr('string') category;
+  @attr('boolean') areKnowledgeElementsResettable;
 }

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -384,6 +384,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // then
         assert.contains(t('common.target-profile-details.results.common'));
       });
+
       module('Displaying options and categories', function () {
         test('it should display options in alphapetical order', async function (assert) {
           // given
@@ -569,6 +570,96 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
         // then
         assert.contains(t('common.target-profile-details.results.common'));
+      });
+
+      module('when target profile are knowledge elements resettable', function () {
+        test('it should display specific message', async function (assert) {
+          // given
+          this.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              description: 'description1',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+              areKnowledgeElementsResettable: true,
+            }),
+            store.createRecord('target-profile', {
+              id: '2',
+              name: 'targetProfile2',
+              description: 'description2',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+            }),
+          ];
+          prescriber.enableMultipleSendingAssessment = true;
+
+          // when
+          const screen = await render(
+            hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @targetProfiles={{this.targetProfiles}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+          );
+          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { name: 'targetProfile1' }));
+
+          // then
+          assert.contains(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
+        });
+      });
+
+      module('when target profile are not knowledge elements resettable', function () {
+        test('it should not display specific message', async function (assert) {
+          // given
+          this.targetProfiles = [
+            store.createRecord('target-profile', {
+              id: '1',
+              name: 'targetProfile1',
+              description: 'description1',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+              areKnowledgeElementsResettable: false,
+            }),
+            store.createRecord('target-profile', {
+              id: '2',
+              name: 'targetProfile2',
+              description: 'description2',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+            }),
+          ];
+          prescriber.enableMultipleSendingAssessment = true;
+
+          // when
+          const screen = await render(
+            hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @targetProfiles={{this.targetProfiles}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+          );
+          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(await screen.findByRole('option', { name: 'targetProfile1' }));
+
+          // then
+          assert.notContains(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
+        });
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -371,6 +371,7 @@
           "question-label": "Do you want to allow participants to submit their results more than once?"
         },
         "info-title": "Multiple submissions",
+        "knowledge-elements-resettable": "As part of the customised test, participants can try to improve their results by repeating all the questions in the customised test.",
         "profiles": {
           "info": "If you choose to allow multiple submissions, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile.",
           "question-label": "Do you want to allow participants to submit their profile more than once?"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -374,6 +374,7 @@
           "question-label": "Souhaitez-vous permettre aux participants d’envoyer plusieurs fois leurs résultats ?"
         },
         "info-title": "Envoi multiple",
+        "knowledge-elements-resettable": "Dans le cadre de ce parcours, le participant pourra tenter d'améliorer ses résultats en repassant toutes les questions du parcours.",
         "profiles": {
           "info": "Si vous choisissez l’envoi multiple, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.",
           "question-label": "Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?"


### PR DESCRIPTION
## :unicorn: Problème
A la creation d'une camapaign la notion de remettre à zéro n'est pas expliqué aux prescripteurs

## :robot: Proposition
Ajouter un texte dans le bloc info "envoi multiple" si le PC sélectionné est coché "RAZ"

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Aller sur Orga et créer un nouveau campaign 
choisir un profil cible avec `areKnowledgeElementsResettable` = true
verifiez que la nouveau paragraph est visible
