### PR TITLE
[FEATURE] Afficher les méthodes d'authentification même si le fournisseur d'identité correspondant est désactivé (PIX-8951)

### DIFF
--- a/admin/app/adapters/oidc-identity-provider.js
+++ b/admin/app/adapters/oidc-identity-provider.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
   urlForFindAll() {
-    return `${this.host}/${this.namespace}/oidc/identity-providers`;
+    return `${this.host}/${this.namespace}/admin/oidc/identity-providers`;
   }
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -470,7 +470,7 @@ function routes() {
 
   this.post('/admin/campaigns', async () => new Response(204));
 
-  this.get('/oidc/identity-providers', () => {
+  this.get('/admin/oidc/identity-providers', () => {
     return {
       data: [
         {

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -5,7 +5,23 @@ import { oidcController } from './oidc-controller.js';
 const validOidcProviderCodes = OidcIdentityProviders.getValidOidcProviderCodes();
 
 const register = async function (server) {
+  const adminRoutes = [
+    {
+      method: 'GET',
+      path: '/api/admin/oidc/identity-providers',
+      config: {
+        auth: false,
+        handler: oidcController.getAllIdentityProvidersForAdmin,
+        notes: [
+          'Cette route renvoie un objet contenant les informations requises par le front pour les partenaires oidc',
+        ],
+        tags: ['api', 'oidc'],
+      },
+    },
+  ];
+
   server.route([
+    ...adminRoutes,
     {
       method: 'GET',
       path: '/api/oidc/identity-providers',

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -5,7 +5,7 @@ import { usecases } from '../../../domain/usecases/index.js';
 import { UnauthorizedError } from '../../http-errors.js';
 
 const getIdentityProviders = async function (request, h) {
-  const identityProviders = usecases.getIdentityProviders();
+  const identityProviders = usecases.getReadyIdentityProviders();
   return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
 };
 

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -4,6 +4,11 @@ import * as oidcSerializer from '../../../infrastructure/serializers/jsonapi/oid
 import { usecases } from '../../../domain/usecases/index.js';
 import { UnauthorizedError } from '../../http-errors.js';
 
+const getAllIdentityProvidersForAdmin = async function (request, h) {
+  const identityProviders = usecases.getAllIdentityProviders();
+  return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
+};
+
 const getIdentityProviders = async function (request, h) {
   const identityProviders = usecases.getReadyIdentityProviders();
   return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
@@ -135,6 +140,7 @@ const createUser = async function (
 };
 
 const oidcController = {
+  getAllIdentityProvidersForAdmin,
   getIdentityProviders,
   getRedirectLogoutUrl,
   findUserForReconciliation,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -434,6 +434,7 @@ const configuration = (function () {
     config.cnav.tokenUrl = 'http://idp.cnav/token';
     config.cnav.clientSecret = 'PIX_CNAV_CLIENT_SECRET';
 
+    config.fwb.isEnabled = false;
     config.fwb.logoutUrl = 'http://logout-url.org';
 
     config.saml.accessTokenLifespanMs = 1000;

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -17,11 +17,11 @@ function _associateServiceToCode(map, service) {
   };
 }
 
-const oidcProviderServiceCodes = Object.keys(oidcProviderServiceMap);
-
-function getOidcProviderServices() {
+function getReadyOidcProviderServices() {
   return Object.values(oidcProviderServiceMap);
 }
+
+const oidcProviderServiceCodes = Object.keys(oidcProviderServiceMap);
 
 function getOidcProviderServiceByCode(identityProvider) {
   if (!oidcProviderServiceCodes.includes(identityProvider)) throw new InvalidIdentityProviderError(identityProvider);
@@ -29,4 +29,4 @@ function getOidcProviderServiceByCode(identityProvider) {
   return oidcProviderServiceMap[identityProvider];
 }
 
-export { getOidcProviderServices, getOidcProviderServiceByCode };
+export { getReadyOidcProviderServices, getOidcProviderServiceByCode };

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -3,18 +3,24 @@ import { PoleEmploiOidcAuthenticationService } from './pole-emploi-oidc-authenti
 import { CnavOidcAuthenticationService } from './cnav-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
 
-const oidcProviderServices = [
+const allOidcProviderServices = [
   new PoleEmploiOidcAuthenticationService(),
   new CnavOidcAuthenticationService(),
   new FwbOidcAuthenticationService(),
-].filter((oidcProvider) => oidcProvider.isReady);
+];
+
+const readyOidcProviderServices = allOidcProviderServices.filter((oidcProvider) => oidcProvider.isReady);
 
 function getReadyOidcProviderServices() {
-  return oidcProviderServices;
+  return readyOidcProviderServices;
+}
+
+function getAllOidcProviderServices() {
+  return allOidcProviderServices;
 }
 
 function getOidcProviderServiceByCode(identityProvider) {
-  const oidcProviderService = oidcProviderServices.find((service) => identityProvider === service.code);
+  const oidcProviderService = readyOidcProviderServices.find((service) => identityProvider === service.code);
   if (!oidcProviderService) {
     throw new InvalidIdentityProviderError(identityProvider);
   }
@@ -22,4 +28,4 @@ function getOidcProviderServiceByCode(identityProvider) {
   return oidcProviderService;
 }
 
-export { getReadyOidcProviderServices, getOidcProviderServiceByCode };
+export { getReadyOidcProviderServices, getOidcProviderServiceByCode, getAllOidcProviderServices };

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -9,24 +9,17 @@ const oidcProviderServices = [
   new FwbOidcAuthenticationService(),
 ].filter((oidcProvider) => oidcProvider.isReady);
 
-const oidcProviderServiceMap = oidcProviderServices.reduce(_associateServiceToCode, {});
-function _associateServiceToCode(map, service) {
-  return {
-    ...map,
-    [service.code]: service,
-  };
-}
-
 function getReadyOidcProviderServices() {
-  return Object.values(oidcProviderServiceMap);
+  return oidcProviderServices;
 }
-
-const oidcProviderServiceCodes = Object.keys(oidcProviderServiceMap);
 
 function getOidcProviderServiceByCode(identityProvider) {
-  if (!oidcProviderServiceCodes.includes(identityProvider)) throw new InvalidIdentityProviderError(identityProvider);
+  const oidcProviderService = oidcProviderServices.find((service) => identityProvider === service.code);
+  if (!oidcProviderService) {
+    throw new InvalidIdentityProviderError(identityProvider);
+  }
 
-  return oidcProviderServiceMap[identityProvider];
+  return oidcProviderService;
 }
 
 export { getReadyOidcProviderServices, getOidcProviderServiceByCode };

--- a/api/lib/domain/usecases/get-all-identity-providers.js
+++ b/api/lib/domain/usecases/get-all-identity-providers.js
@@ -1,0 +1,5 @@
+const getAllIdentityProviders = function ({ authenticationServiceRegistry }) {
+  return authenticationServiceRegistry.getAllOidcProviderServices();
+};
+
+export { getAllIdentityProviders };

--- a/api/lib/domain/usecases/get-identity-providers.js
+++ b/api/lib/domain/usecases/get-identity-providers.js
@@ -1,5 +1,0 @@
-const getIdentityProviders = function ({ authenticationServiceRegistry }) {
-  return authenticationServiceRegistry.getReadyOidcProviderServices();
-};
-
-export { getIdentityProviders };

--- a/api/lib/domain/usecases/get-identity-providers.js
+++ b/api/lib/domain/usecases/get-identity-providers.js
@@ -1,5 +1,5 @@
 const getIdentityProviders = function ({ authenticationServiceRegistry }) {
-  return authenticationServiceRegistry.getOidcProviderServices();
+  return authenticationServiceRegistry.getReadyOidcProviderServices();
 };
 
 export { getIdentityProviders };

--- a/api/lib/domain/usecases/get-ready-identity-providers.js
+++ b/api/lib/domain/usecases/get-ready-identity-providers.js
@@ -1,0 +1,5 @@
+const getReadyIdentityProviders = function ({ authenticationServiceRegistry }) {
+  return authenticationServiceRegistry.getReadyOidcProviderServices();
+};
+
+export { getReadyIdentityProviders };

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -9,7 +9,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
   describe('#getIdentityProviders', function () {
     it('returns the list of oidc identity providers', async function () {
       // given
-      sinon.stub(usecases, 'getIdentityProviders').returns([
+      sinon.stub(usecases, 'getReadyIdentityProviders').returns([
         {
           code: 'SOME_OIDC_PROVIDER',
           source: 'some_oidc_provider',
@@ -23,7 +23,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       const response = await oidcController.getIdentityProviders(null, hFake);
 
       // then
-      expect(usecases.getIdentityProviders).to.have.been.called;
+      expect(usecases.getReadyIdentityProviders).to.have.been.called;
       expect(response.statusCode).to.equal(200);
       expect(response.source.data.length).to.equal(1);
       expect(response.source.data).to.deep.contain({

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -6,6 +6,58 @@ import { UnauthorizedError } from '../../../../../lib/application/http-errors.js
 describe('Unit | Application | Controller | Authentication | OIDC', function () {
   const identityProvider = 'OIDC';
 
+  describe('#getAllIdentityProvidersForAdmin', function () {
+    it('returns the list of oidc identity providers', async function () {
+      // given
+      sinon.stub(usecases, 'getAllIdentityProviders').returns([
+        {
+          code: 'LIMONADE_OIDC_PROVIDER',
+          source: 'limonade_oidc_provider',
+          organizationName: 'Limonade OIDC Provider',
+          slug: 'limonade-oidc-provider',
+          hasLogoutUrl: false,
+        },
+        {
+          code: 'KOMBUCHA_OIDC_PROVIDER',
+          source: 'kombucha_oidc_provider',
+          organizationName: 'Kombucha OIDC Provider',
+          slug: 'kombucha-oidc-provider',
+          hasLogoutUrl: true,
+        },
+      ]);
+
+      // when
+      const response = await oidcController.getAllIdentityProvidersForAdmin(null, hFake);
+
+      // then
+      expect(usecases.getAllIdentityProviders).to.have.been.called;
+      expect(response.statusCode).to.equal(200);
+      expect(response.source.data.length).to.equal(2);
+      expect(response.source.data).to.deep.equal([
+        {
+          type: 'oidc-identity-providers',
+          id: 'limonade-oidc-provider',
+          attributes: {
+            code: 'LIMONADE_OIDC_PROVIDER',
+            'organization-name': 'Limonade OIDC Provider',
+            'has-logout-url': false,
+            source: 'limonade_oidc_provider',
+          },
+        },
+        {
+          type: 'oidc-identity-providers',
+          id: 'kombucha-oidc-provider',
+          attributes: {
+            code: 'KOMBUCHA_OIDC_PROVIDER',
+            'organization-name': 'Kombucha OIDC Provider',
+            'has-logout-url': true,
+            source: 'kombucha_oidc_provider',
+          },
+        },
+      ]);
+    });
+  });
+
   describe('#getIdentityProviders', function () {
     it('returns the list of oidc identity providers', async function () {
       // given

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -3,8 +3,21 @@ import * as authenticationRegistry from '../../../../../lib/domain/services/auth
 import { InvalidIdentityProviderError } from '../../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | Services | authentication registry', function () {
+  describe('#getAllOidcProviderServices', function () {
+    it('returns all OIDC Providers', async function () {
+      // when
+      const services = authenticationRegistry.getAllOidcProviderServices();
+
+      // then
+      const serviceCodes = services.map((service) => service.code);
+      expect(serviceCodes).to.contain('POLE_EMPLOI');
+      expect(serviceCodes).to.contain('CNAV');
+      expect(serviceCodes).to.contain('FWB');
+    });
+  });
+
   describe('#getReadyOidcProviderServices', function () {
-    it('returns all ready OIDC Providers', async function () {
+    it('returns ready OIDC Providers', function () {
       // when
       const services = authenticationRegistry.getReadyOidcProviderServices();
 
@@ -12,6 +25,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
       const serviceCodes = services.map((service) => service.code);
       expect(serviceCodes).to.contain('POLE_EMPLOI');
       expect(serviceCodes).to.contain('CNAV');
+      expect(serviceCodes).not.to.contain('FWB');
     });
   });
 

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -3,10 +3,10 @@ import * as authenticationRegistry from '../../../../../lib/domain/services/auth
 import { InvalidIdentityProviderError } from '../../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | Services | authentication registry', function () {
-  describe('#getOidcProviderServices', function () {
+  describe('#getReadyOidcProviderServices', function () {
     it('returns all ready OIDC Providers', async function () {
       // when
-      const services = authenticationRegistry.getOidcProviderServices();
+      const services = authenticationRegistry.getReadyOidcProviderServices();
 
       // then
       const serviceCodes = services.map((service) => service.code);

--- a/api/tests/unit/domain/usecases/get-all-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-all-identity-providers_test.js
@@ -1,0 +1,21 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { getAllIdentityProviders } from '../../../../lib/domain/usecases/get-all-identity-providers.js';
+
+describe('Unit | UseCase | get-all-identity-providers', function () {
+  it('returns oidc providers from authenticationServiceRegistry', function () {
+    // given
+    const oneOidcProviderService = {};
+    const anotherOidcProviderService = {};
+    const authenticationServiceRegistryStub = {
+      getAllOidcProviderServices: sinon.stub().returns([oneOidcProviderService, anotherOidcProviderService]),
+    };
+
+    // when
+    const identityProviders = getAllIdentityProviders({
+      authenticationServiceRegistry: authenticationServiceRegistryStub,
+    });
+
+    // then
+    expect(identityProviders).to.deep.equal([oneOidcProviderService, anotherOidcProviderService]);
+  });
+});

--- a/api/tests/unit/domain/usecases/get-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-identity-providers_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | get-identity-providers', function () {
     const oneOidcProviderService = {};
     const anotherOidcProviderService = {};
     const authenticationServiceRegistryStub = {
-      getOidcProviderServices: sinon.stub().returns([oneOidcProviderService, anotherOidcProviderService]),
+      getReadyOidcProviderServices: sinon.stub().returns([oneOidcProviderService, anotherOidcProviderService]),
     };
 
     // when

--- a/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../test-helper.js';
-import { getIdentityProviders } from '../../../../lib/domain/usecases/get-identity-providers.js';
+import { getReadyIdentityProviders } from '../../../../lib/domain/usecases/get-ready-identity-providers.js';
 
-describe('Unit | UseCase | get-identity-providers', function () {
+describe('Unit | UseCase | get-ready-identity-providers', function () {
   it('returns oidc providers from authenticationServiceRegistry', function () {
     // given
     const oneOidcProviderService = {};
@@ -11,7 +11,7 @@ describe('Unit | UseCase | get-identity-providers', function () {
     };
 
     // when
-    const identityProviders = getIdentityProviders({
+    const identityProviders = getReadyIdentityProviders({
       authenticationServiceRegistry: authenticationServiceRegistryStub,
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, on ne voit sur la page utilisateur de Pix Admin que les méthodes d’authentification associées à un fournisseur d’identité activé. Si un utilisateur possède par exemple une méthode d’authentification FWB mais que le fournisseur d’identité FWB est désactivé, elle n’apparaîtra pas sur sa page utilisateur et on ne pourra pas les supprimer ou les déplacer.

## :robot: Proposition
Faire en sorte que l’affichage des méthodes d’authentification dans Pix Admin ne dépendent pas de l’activation d’un fournisseur d’identité et puissent être supprimées ou déplacées.

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Se connecter à **Pix Admin**
2. Trouver un utilisateur avec une **méthode d’authentification SSO** _(ex: David Cnav)_
3. Désactiver le fournisseur d’identité correspondant (mettre la var d’env `{IDP}_ENABLED` à `false`)
4. Constater que la méthode d’authentification apparaît toujours
5. Tenter de la déplacer vers un autre utilisateur et constater que ça fonctionne
6. Tenter de la supprimer et constater que ça fonctionne
