### PR TITLE
[TECH] Ne plus jeter une erreur quand la connexion à Redis est déjà fermée

### DIFF
--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -59,10 +59,14 @@ class RedisClient {
   }
 
   async quit() {
-    if (this._client.status == 'end') {
-      return;
+    try {
+      await this._client.quit();
+    } catch (e) {
+      if (e.message === 'Connection is closed.') {
+        return;
+      }
+      logger.warn({ redisClient: this._clientName, err: e }, 'Error encountered while quitting');
     }
-    await this._client.quit();
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque nous coupons l'API qui a été préalablement lancé par npm, plusieurs SIGINT sont envoyés, ce qui provoque plusieurs appels à la méthode `quit` de la classe `RedisClient`. Cependant [depuis le passage à `ioredis`](https://github.com/1024pix/pix/pull/6695), ce dernier jette une erreur quand la connexion est déjà fermée, bien qu'un code pour prévenir cela a été mis en place.

## :robot: Proposition
Changer le code mis en place par une version plus radicale et pas basée sur le statut de la connexion qui n'est pas forcement à jour.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer un `npm start`
- Couper le serveur avec un `Ctrl+C` constater qu'il n'y a pas d'erreur 