### PR TITLE
[BUGFIX] Réduit la taille des variables d'environnement et ignore les prescrits désactivés pour le batch (PIX-8955)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -212,8 +212,8 @@ const configuration = (function () {
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
       scheduleComputeOrganizationLearnersCertificability: {
-        cron: process.env.SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
-        chunkSize: process.env.SCHEDULE_COMPUTE_ORGANIZATION_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 50000,
+        cron: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
+        chunkSize: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 50000,
       },
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -357,21 +357,31 @@ async function updateCertificability(organizationLearner) {
 }
 
 async function countByOrganizationsWhichNeedToComputeCertificability() {
-  const [{ count }] = await knex('organization-learners')
-    .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
+  const [{ count }] = await knex('view-active-organization-learners')
+    .join(
+      'organization-features',
+      'view-active-organization-learners.organizationId',
+      '=',
+      'organization-features.organizationId',
+    )
     .join('features', 'organization-features.featureId', '=', 'features.id')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
-    .where('organization-learners.isDisabled', false)
-    .count('organization-learners.id');
+    .where('view-active-organization-learners.isDisabled', false)
+    .count('view-active-organization-learners.id');
   return count;
 }
 
 function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset } = {}) {
-  const queryBuilder = knex('organization-learners')
-    .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
+  const queryBuilder = knex('view-active-organization-learners')
+    .join(
+      'organization-features',
+      'view-active-organization-learners.organizationId',
+      '=',
+      'organization-features.organizationId',
+    )
     .join('features', 'organization-features.featureId', '=', 'features.id')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
-    .where('organization-learners.isDisabled', false);
+    .where('view-active-organization-learners.isDisabled', false);
 
   if (limit) {
     queryBuilder.limit(limit);
@@ -381,7 +391,7 @@ function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset } 
     queryBuilder.offset(offset);
   }
 
-  return queryBuilder.pluck('organization-learners.id');
+  return queryBuilder.pluck('view-active-organization-learners.id');
 }
 
 export {

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -361,6 +361,7 @@ async function countByOrganizationsWhichNeedToComputeCertificability() {
     .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
     .join('features', 'organization-features.featureId', '=', 'features.id')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
+    .where('organization-learners.isDisabled', false)
     .count('organization-learners.id');
   return count;
 }
@@ -369,7 +370,8 @@ function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset } 
   const queryBuilder = knex('organization-learners')
     .join('organization-features', 'organization-learners.organizationId', '=', 'organization-features.organizationId')
     .join('features', 'organization-features.featureId', '=', 'features.id')
-    .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key);
+    .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
+    .where('organization-learners.isDisabled', false);
 
   if (limit) {
     queryBuilder.limit(limit);

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2092,6 +2092,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
     it('should return count of organization learners from organization that can compute certificability', async function () {
       // given
       const { organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, isDisabled: true });
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
       const { organizationId: otherOrganizationId } = databaseBuilder.factory.buildOrganizationLearner();
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId: otherOrganizationId });
@@ -2126,6 +2127,19 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
       // then
       expect(result).to.deep.equal([organizationLearnerId]);
+    });
+
+    it('should not return a disabled organization learner id for organizations that cannot compute certificability', async function () {
+      // given
+      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ isDisabled: true });
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+
+      // then
+      expect(result).to.deep.equal([]);
     });
 
     it('should not return an organization learner id for organizations that cannot compute certificability', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Scalingo n'autorise pas les variables d'environnement de plus de 64 caractères. De plus, on prenait en compte les prescrits désactivés ce qui faisait passer le nombre de jobs à traiter de 6,3M à 11M. 

## :robot: Proposition
- Réduire la longueur des variables d'environnement
- Ignorer les prescrits désactivés
- Utiliser la vue des learners actifs

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
