### PR TITLE
[FEATURE] Permettre de désactiver la journalisation (PIX-8953)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -81,6 +81,7 @@ const configuration = (function () {
       },
     ],
     auditLogger: {
+      isEnabled: isBooleanFeatureEnabledElseDefault(process.env.PIX_AUDIT_LOGGER_ENABLED, false),
       baseUrl: process.env.PIX_AUDIT_LOGGER_BASE_URL,
       clientSecret: process.env.PIX_AUDIT_LOGGER_CLIENT_SECRET,
     },

--- a/api/lib/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler.js
+++ b/api/lib/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler.js
@@ -1,4 +1,5 @@
 import { UserAnonymized } from '../../../../domain/events/UserAnonymized.js';
+import { config } from '../../../../config.js';
 
 export class UserAnonymizedEventLoggingJobScheduler {
   constructor({ userAnonymizedEventLoggingJob }) {
@@ -12,6 +13,8 @@ export class UserAnonymizedEventLoggingJobScheduler {
   }
 
   async handle(event) {
-    await this.userAnonymizedEventLoggingJob.schedule(event);
+    if (config.auditLogger.isEnabled) {
+      await this.userAnonymizedEventLoggingJob.schedule(event);
+    }
   }
 }

--- a/api/sample.env
+++ b/api/sample.env
@@ -999,6 +999,13 @@ FT_TRAINING_RECOMMENDATION=false
 # presence: required
 # type: string
 # sample: PIX_AUDIT_LOGGER_BASE_URL=http://audit-logger.local
+PIX_AUDIT_LOGGER_ENABLED=false
+
+# Pix Audit Logger base URL
+#
+# presence: required
+# type: string
+# sample: PIX_AUDIT_LOGGER_BASE_URL=http://audit-logger.local
 PIX_AUDIT_LOGGER_BASE_URL=
 
 # Pix Audit Logger client secret

--- a/api/tests/unit/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler_test.js
+++ b/api/tests/unit/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler_test.js
@@ -1,0 +1,43 @@
+import { expect, sinon } from '../../../../../test-helper.js';
+import { UserAnonymizedEventLoggingJobScheduler } from '../../../../../../lib/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler.js';
+import { config } from '../../../../../../lib/config.js';
+
+describe('Unit | Infrastructure | Events | Subscribers | UserAnonymizedEventLoggingJobScheduler', function () {
+  describe('#handle', function () {
+    describe('when audit logger in not enabled in config', function () {
+      it('schedules the event', function () {
+        // given
+        config.auditLogger.isEnabled = false;
+        const event = Symbol('event');
+        const userAnonymizedEventLoggingJob = {
+          schedule: sinon.stub(),
+        };
+        const scheduler = new UserAnonymizedEventLoggingJobScheduler({ userAnonymizedEventLoggingJob });
+
+        // when
+        scheduler.handle(event);
+
+        // then
+        expect(userAnonymizedEventLoggingJob.schedule).to.not.have.been.calledWith(event);
+      });
+    });
+
+    describe('when audit logger in enabled in config', function () {
+      it('schedules the event', function () {
+        // given
+        config.auditLogger.isEnabled = true;
+        const event = Symbol('event');
+        const userAnonymizedEventLoggingJob = {
+          schedule: sinon.stub(),
+        };
+        const scheduler = new UserAnonymizedEventLoggingJobScheduler({ userAnonymizedEventLoggingJob });
+
+        // when
+        scheduler.handle(event);
+
+        // then
+        expect(userAnonymizedEventLoggingJob.schedule).to.have.been.calledWith(event);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Une fois déployée, la journalisation ne pourra plus être désactivée.

## :robot: Proposition

- Ajouter une variable d’env `PIX_AUDIT_LOGGER_ENABLED` avec pour valeur par défaut false
- Dans AnonymizeUserEventLoggingJobScheduler vérifier la valeur de la variable d’environnement dans la méthode `handle` et ignorer si elle est différente de true.

## :rainbow: Remarques
*RAS*

## :100: Pour tester

### Sans la var d'env

1. Se connecter à Pix Admin
2. Anonymiser un utilisateur
3. Constater qu'aucun job n'est créé dans la table pgboss.job

### Avec la var d'env à `true`

1. Définir la var d'env `PIX_AUDIT_LOGGER_ENABLED` à `true` dans l'API Pix
2. Se connecter à Pix Admin
3. Anonymiser un utilisateur
4. Constater qu'un job est créé dans la table pgboss.job

### Avec la var d'env à `false`

1. Définir la var d'env `PIX_AUDIT_LOGGER_ENABLED` à `false` dans l'API Pix
2. Se connecter à Pix Admin
3. Anonymiser un utilisateur
4. Constater qu'aucun job n'est créé dans la table pgboss.job
