### PR TITLE
[TECH] Ajouter le modèle Grain (PIX-8968).

### DIFF
--- a/api/src/devcomp/domain/models/Grain.js
+++ b/api/src/devcomp/domain/models/Grain.js
@@ -1,0 +1,9 @@
+class Grain {
+  constructor({ id, title, description }) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+  }
+}
+
+export { Grain };

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -1,0 +1,16 @@
+import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Grain', function () {
+  describe('#constructor', function () {
+    it('should create a grain and keep attributes', function () {
+      // when
+      const grain = new Grain({ id: 'id', title: 'title', description: 'description' });
+
+      // then
+      expect(grain.id).to.equal('id');
+      expect(grain.title).to.equal('title');
+      expect(grain.description).to.equal('description');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de Modulix, l'élément de base est un `Grain` nous souhaitons avoir un modèle dédié pour cet élément.

## :robot: Proposition
Ajouter le modèle

## :rainbow: Remarques
Nous avons utilisé la nouvelle arborescence de l'API #6670 

## :100: Pour tester
CI OK