### PR TITLE
[TECH] Sécuriser le model Campaign Participant afin de ne pas autoriser les learner désactivé (PIX-8918)

### DIFF
--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -21,9 +21,9 @@ class CampaignParticipant {
     this.campaignToStartParticipation = campaignToStartParticipation;
     this.userIdentity = userIdentity;
     this.previousCampaignParticipationForUser = previousCampaignParticipationForUser;
-    this.organizationLearnerId = organizationLearner?.id;
-    this.organizationLearnerisDisabled = organizationLearner?.isDisabled;
-    this.organizationLearnerHasParticipatedForAnotherUser = organizationLearner?.hasParticipated;
+    this.organizationLearnerId = organizationLearner.id;
+    this.isOrganizationLearnerDisabled = organizationLearner.isDisabled;
+    this.hasOrganizationLearnerParticipatedForAnotherUser = organizationLearner.hasParticipated;
   }
 
   start({ participantExternalId, isReset }) {
@@ -67,7 +67,7 @@ class CampaignParticipant {
   }
 
   _checkCanParticipateToCampaign(participantExternalId, isReset) {
-    if (this.organizationLearnerisDisabled) {
+    if (this.isOrganizationLearnerDisabled) {
       throw new ForbiddenAccess(couldNotJoinCampaignErrorMessage);
     }
 
@@ -112,7 +112,7 @@ class CampaignParticipant {
       });
     }
 
-    if (this.organizationLearnerHasParticipatedForAnotherUser) {
+    if (this.hasOrganizationLearnerParticipatedForAnotherUser) {
       throw new AlreadyExistingCampaignParticipationError('ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED');
     }
   }

--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -19,10 +19,11 @@ class CampaignParticipant {
     previousCampaignParticipationForUser,
   }) {
     this.campaignToStartParticipation = campaignToStartParticipation;
-    this.organizationLearnerId = organizationLearner?.id;
     this.userIdentity = userIdentity;
     this.previousCampaignParticipationForUser = previousCampaignParticipationForUser;
-    this.organizationLearnerHasParticipatedForAnotherUser = organizationLearner.hasParticipated;
+    this.organizationLearnerId = organizationLearner?.id;
+    this.organizationLearnerisDisabled = organizationLearner?.isDisabled;
+    this.organizationLearnerHasParticipatedForAnotherUser = organizationLearner?.hasParticipated;
   }
 
   start({ participantExternalId, isReset }) {
@@ -66,6 +67,10 @@ class CampaignParticipant {
   }
 
   _checkCanParticipateToCampaign(participantExternalId, isReset) {
+    if (this.organizationLearnerisDisabled) {
+      throw new ForbiddenAccess(couldNotJoinCampaignErrorMessage);
+    }
+
     if (this.campaignToStartParticipation.isArchived) {
       throw new ForbiddenAccess(couldNotJoinCampaignErrorMessage);
     }

--- a/api/lib/domain/read-models/OrganizationLearnerForStartingParticipation.js
+++ b/api/lib/domain/read-models/OrganizationLearnerForStartingParticipation.js
@@ -1,0 +1,9 @@
+class OrganizationLearnerForStartingParticipation {
+  constructor({ id, hasParticipated, isDisabled } = {}) {
+    this.id = id;
+    this.hasParticipated = hasParticipated;
+    this.isDisabled = isDisabled;
+  }
+}
+
+export { OrganizationLearnerForStartingParticipation };

--- a/api/lib/domain/read-models/UserIdentity.js
+++ b/api/lib/domain/read-models/UserIdentity.js
@@ -1,0 +1,9 @@
+class UserIdentity {
+  constructor({ id, firstName, lastName } = {}) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+}
+
+export { UserIdentity };

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -149,7 +149,11 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
   const organizationLearner = { id: null, hasParticipated: false };
   const row = await domainTransaction
     .knexTransaction('campaigns')
-    .select({ id: 'view-active-organization-learners.id', campaignParticipationId: 'campaign-participations.id' })
+    .select({
+      id: 'view-active-organization-learners.id',
+      campaignParticipationId: 'campaign-participations.id',
+      isDisabled: 'view-active-organization-learners.isDisabled',
+    })
     .join(
       'view-active-organization-learners',
       'view-active-organization-learners.organizationId',
@@ -176,6 +180,7 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
   if (row) {
     organizationLearner.id = row.id;
     organizationLearner.hasParticipated = Boolean(row.campaignParticipationId);
+    organizationLearner.isDisabled = row.isDisabled;
   }
   return organizationLearner;
 }

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -1,6 +1,8 @@
 import lodash from 'lodash';
 import { CampaignParticipant } from '../../domain/models/CampaignParticipant.js';
+import { OrganizationLearnerForStartingParticipation } from '../../domain/read-models/OrganizationLearnerForStartingParticipation.js';
 import { CampaignToStartParticipation } from '../../domain/models/CampaignToStartParticipation.js';
+import { UserIdentity } from '../../domain/read-models/UserIdentity.js';
 import { AlreadyExistingCampaignParticipationError, NotFoundError } from '../../domain/errors.js';
 import * as campaignRepository from '../repositories/campaign-repository.js';
 import { knex } from '../../../db/knex-database-connection.js';
@@ -116,8 +118,14 @@ async function get({ userId, campaignId, domainTransaction }) {
   });
 }
 
-function _getUserIdentityForTrainee(userId, domainTransaction) {
-  return domainTransaction.knexTransaction('users').select('id', 'firstName', 'lastName').where({ id: userId }).first();
+async function _getUserIdentityForTrainee(userId, domainTransaction) {
+  const userIdentity = await domainTransaction
+    .knexTransaction('users')
+    .select('id', 'firstName', 'lastName')
+    .where({ id: userId })
+    .first();
+
+  return new UserIdentity(userIdentity);
 }
 
 async function _getCampaignToStart(campaignId, domainTransaction) {
@@ -146,7 +154,6 @@ async function _getCampaignToStart(campaignId, domainTransaction) {
 }
 
 async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
-  const organizationLearner = { id: null, hasParticipated: false };
   const row = await domainTransaction
     .knexTransaction('campaigns')
     .select({
@@ -178,11 +185,18 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
     .first();
 
   if (row) {
-    organizationLearner.id = row.id;
-    organizationLearner.hasParticipated = Boolean(row.campaignParticipationId);
-    organizationLearner.isDisabled = row.isDisabled;
+    return new OrganizationLearnerForStartingParticipation({
+      id: row.id,
+      hasParticipated: Boolean(row.campaignParticipationId),
+      isDisabled: row.isDisabled,
+    });
   }
-  return organizationLearner;
+
+  return new OrganizationLearnerForStartingParticipation({
+    id: null,
+    hasParticipated: false,
+    isDisabled: false,
+  });
 }
 
 async function _findpreviousCampaignParticipationForUser({

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -693,6 +693,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
           userId,
           organizationId,
+          isDisabled: false,
         });
 
         await databaseBuilder.commit();
@@ -706,6 +707,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         });
 
         expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
+        expect(campaignParticipant.organizationLearnerisDisabled).to.be.false;
         expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(false);
       });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -707,8 +707,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         });
 
         expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
-        expect(campaignParticipant.organizationLearnerisDisabled).to.be.false;
-        expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(false);
+        expect(campaignParticipant.isOrganizationLearnerDisabled).to.be.false;
+        expect(campaignParticipant.hasOrganizationLearnerParticipatedForAnotherUser).to.equal(false);
       });
 
       it('find only organization learner which is not disabled', async function () {
@@ -762,7 +762,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
             });
 
             expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
-            expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(false);
+            expect(campaignParticipant.hasOrganizationLearnerParticipatedForAnotherUser).to.equal(false);
           });
 
           context('when there is participation for another campaign', function () {
@@ -789,7 +789,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
               });
 
               expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
-              expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(false);
+              expect(campaignParticipant.hasOrganizationLearnerParticipatedForAnotherUser).to.equal(false);
             });
           });
         });
@@ -819,7 +819,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
             });
 
             expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
-            expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(true);
+            expect(campaignParticipant.hasOrganizationLearnerParticipatedForAnotherUser).to.equal(true);
           });
 
           context('when the participation is deleted', function () {
@@ -849,7 +849,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
               });
 
               expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
-              expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(false);
+              expect(campaignParticipant.hasOrganizationLearnerParticipatedForAnotherUser).to.equal(false);
             });
 
             context('when there are several previous participations', function () {
@@ -892,7 +892,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
                 });
 
                 expect(campaignParticipant.organizationLearnerId).to.equal(organizationLearnerId);
-                expect(campaignParticipant.organizationLearnerHasParticipatedForAnotherUser).to.equal(false);
+                expect(campaignParticipant.hasOrganizationLearnerParticipatedForAnotherUser).to.equal(false);
               });
             });
           });

--- a/api/tests/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipant_test.js
@@ -597,8 +597,8 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
     });
   });
 
-  context('when the organization learner has already participated', function () {
-    it('throws an error', async function () {
+  context('when the organization learner is not allowed', function () {
+    it('throws an error if has already participated', async function () {
       const campaignToStartParticipation = domainBuilder.buildCampaignToStartParticipation({ idPixLabel: null });
       const organizationLearnerId = 12;
       const userIdentity = { id: 13 };
@@ -614,6 +614,25 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
 
       expect(error).to.be.an.instanceof(AlreadyExistingCampaignParticipationError);
       expect(error.message).to.equal('ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED');
+    });
+
+    it('throws an error if is disabled', async function () {
+      const campaignToStartParticipation = domainBuilder.buildCampaignToStartParticipation({ idPixLabel: null });
+      const organizationLearnerId = 12;
+      const userIdentity = { id: 13 };
+      const campaignParticipant = new CampaignParticipant({
+        campaignToStartParticipation,
+        userIdentity,
+        organizationLearner: {
+          id: organizationLearnerId,
+          hasParticipated: false,
+          isDisabled: true,
+        },
+      });
+      const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
+
+      expect(error).to.be.an.instanceof(ForbiddenAccess);
+      expect(error.message).to.equal("Vous n'êtes pas autorisé à rejoindre la campagne");
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le model Campaign Participant ne disait pas explicitement que les learner désactivé n'avait pas accès à la campagne

## :robot: Proposition
Ajouter cette règle métier explicite

## :rainbow: Remarques
le CampaignParticipantRepository.get filtre déjà les learner désactivé.

## :100: Pour tester
Vérifier qu'un learner actif à toujours le droit de participer à une campagne