### PR TITLE
[FEATURE] Ajouter la notion RAZ dans la page de paramètres de campagne

### DIFF
--- a/api/lib/domain/read-models/CampaignReport.js
+++ b/api/lib/domain/read-models/CampaignReport.js
@@ -63,6 +63,7 @@ class CampaignReport {
     this.targetProfileTubesCount = targetProfile.tubeCount;
     this.targetProfileThematicResultCount = targetProfile.thematicResultCount;
     this.targetProfileHasStage = targetProfile.hasStage;
+    this.targetProfileAreKnowledgeElementsResettable = targetProfile.areKnowledgeElementsResettable;
   }
 
   setBadges(badges) {

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -46,6 +46,7 @@ const get = async function (id) {
       targetProfileDescription: 'target-profiles.description',
       targetProfileName: 'target-profiles.name',
       multipleSendings: 'campaigns.multipleSendings',
+      areKnowledgeElementsResettable: 'target-profiles.areKnowledgeElementsResettable',
     })
     .select(
       knex.raw('ARRAY_AGG("badges"."id")  AS "badgeIds"'),
@@ -81,6 +82,7 @@ const get = async function (id) {
       thematicResultCount: _.uniq(result.badgeIds).filter((id) => id).length,
       hasStage: result.stageIds.some((stage) => stage),
       description: result.targetProfileDescription,
+      areKnowledgeElementsResettable: result.areKnowledgeElementsResettable,
     });
 
     campaignReport.setTargetProfileInformation(targetProfile);

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -26,6 +26,7 @@ const serialize = function (campaignReports, meta, { tokenForCampaignResults } =
       'targetProfileTubesCount',
       'targetProfileThematicResultCount',
       'targetProfileHasStage',
+      'targetProfileAreKnowledgeElementsResettable',
       'ownerId',
       'ownerLastName',
       'ownerFirstName',

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, catchErr, mockLearningContent } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../test-helper.js';
 import * as campaignReportRepository from '../../../../lib/infrastructure/repositories/campaign-report-repository.js';
 import { CampaignReport } from '../../../../lib/domain/read-models/CampaignReport.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
@@ -75,6 +75,7 @@ describe('Integration | Repository | Campaign-Report', function () {
           targetProfileDescription: targetProfile.description,
           targetProfileName: targetProfile.name,
           targetProfileTubesCount: 2,
+          targetProfileAreKnowledgeElementsResettable: false,
         });
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function () {
@@ -110,6 +110,7 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
             'target-profile-has-stage': report.targetProfileHasStage,
             'target-profile-tubes-count': report.targetProfileTubesCount,
             'target-profile-thematic-result-count': report.targetProfileThematicResultCount,
+            'target-profile-are-knowledge-elements-resettable': report.targetProfileAreKnowledgeElementsResettable,
             'token-for-campaign-results': report.tokenForCampaignResults,
             'participations-count': report.participationsCount,
             'shared-participations-count': report.sharedParticipationsCount,

--- a/orga/app/components/campaign/settings/view.hbs
+++ b/orga/app/components/campaign/settings/view.hbs
@@ -26,6 +26,27 @@
           <dd class="content-text campaign-settings-content__text">{{this.multipleSendingsText}}</dd>
         </div>
       {{/if}}
+      {{#if this.displayResetToZero}}
+        <div class="campaign-settings-content">
+          <dt class="label-text campaign-settings-content__label campaign-settings-content__label--with-tooltip">
+            <span>{{t "pages.campaign-settings.reset-to-zero.title"}}</span>
+            <PixTooltip @id="reset-to-zero-info-tooltip" @position="top" @isWide={{true}}>
+              <:triggerElement>
+                <FaIcon
+                  @icon="circle-info"
+                  class="campaign-settings-content__tooltip-icon"
+                  tabindex="0"
+                  aria-describedby={{t "pages.campaign-settings.reset-to-zero.tooltip.aria-label" htmlSafe=true}}
+                />
+              </:triggerElement>
+              <:tooltip>
+                {{t "pages.campaign-settings.reset-to-zero.tooltip.text"}}
+              </:tooltip>
+            </PixTooltip>
+          </dt>
+          <dd class="content-text campaign-settings-content__text">{{this.resetToZeroText}}</dd>
+        </div>
+      {{/if}}
     </div>
     <div class="campaign-settings-row">
       {{#if @campaign.isTypeAssessment}}

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -44,10 +44,21 @@ export default class CampaignView extends Component {
   }
 
   get isMultipleSendingsEnable() {
-    return (
-      !this.args.campaign.isTypeAssessment ||
-      (this.args.campaign.isTypeAssessment && this.currentUser.prescriber.enableMultipleSendingAssessment)
-    );
+    return !this.args.campaign.isTypeAssessment || this.isMultipleSendingsForAssessmentEnabled;
+  }
+
+  get isMultipleSendingsForAssessmentEnabled() {
+    return this.args.campaign.isTypeAssessment && this.currentUser.prescriber.enableMultipleSendingAssessment;
+  }
+
+  get displayResetToZero() {
+    return this.isMultipleSendingsForAssessmentEnabled && this.args.campaign.multipleSendings;
+  }
+
+  get resetToZeroText() {
+    return this.args.campaign.targetProfileAreKnowledgeElementsResettable
+      ? this.intl.t('pages.campaign-settings.reset-to-zero.status.enabled')
+      : this.intl.t('pages.campaign-settings.reset-to-zero.status.disabled');
   }
 
   get queryForDuplicate() {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -24,6 +24,7 @@ export default class Campaign extends Model {
   @attr('number') targetProfileTubesCount;
   @attr('number') targetProfileThematicResultCount;
   @attr('boolean') targetProfileHasStage;
+  @attr('boolean') targetProfileAreKnowledgeElementsResettable;
   @attr('number') participationsCount;
   @attr('number') sharedParticipationsCount;
   @attr('number') averageResult;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -571,6 +571,17 @@
         }
       },
       "personalised-test-title": "Title of the customised test",
+      "reset-to-zero": {
+        "title": "Reset to zero",
+        "status": {
+          "disabled": "No",
+          "enabled": "Yes"
+        },
+        "tooltip": {
+          "aria-label": "Description of Reset to zero",
+          "text": "If the reset to zero function is activated, the participant can reset the entire customised test and submit their results multiple times by re-entering the campaign code."
+        }
+      },
       "target-profile": {
         "title": "Customised test",
         "tooltip": "Customised test's description"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -574,6 +574,17 @@
         }
       },
       "personalised-test-title": "Titre du parcours",
+      "reset-to-zero": {
+        "title": "Remise à zéro",
+        "status": {
+          "disabled": "Non",
+          "enabled": "Oui"
+        },
+        "tooltip": {
+          "aria-label": "Description de Remise à zéro",
+          "text": "Si la remise à zéro est activée, le participant peut repasser entièrement son parcours et renvoyer ses résultats, plusieurs fois, en saisissant à nouveau le code campagne."
+        }
+      },
       "target-profile": {
         "title": "Parcours",
         "tooltip": "Description du parcours"


### PR DESCRIPTION
## :unicorn: Problème
La notion de remettre a zero pour un campaign est pas explicit pour un prescripteur lorsqu'ils vont a la page de parametres d'un campaign

## :robot: Proposition
Ajouter sur la page de parametres d'un campaign l'infomation sur si la campaign contiens les profil cibles qui peuvent remettre a zero avec un tool tip qui explique la notion de remettre a zero.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sur orga, choissisez un campaign
verifiez que sur haute droit l'infomation sur si la campaign a un profil cible qui est remettable a zero est bien affiché
verifiez qu'il y a un tool tip qui explique la notion de remettre a zero

Conditions pour afficher la case `Remise a zero`:
  Profil Cible: areKnowledgeElements = true
  Campaign: envoi multip = true
  Orga, prescriber = enable Multiple Sending Assessment = true

ou

 Profil Cible: areKnowledgeElements = false
 Campaign: envoi multip = true
 Orga, prescriber: enable Multiple Sending Assessment = true

Quand envoi multip = false ou enable multiple sending assessment = false, on n'affiche pas la case `remise a zero`
