### PR TITLE
[FEATURE] ETQ user Pix Admin, JV rechercher un utilisateur dans la liste par son id (PIX-389)

### DIFF
--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -5,15 +5,17 @@ import { action } from '@ember/object';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'firstName', 'lastName', 'email', 'username'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'firstName', 'lastName', 'email', 'username'];
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
+  @tracked id = null;
   @tracked firstName = null;
   @tracked lastName = null;
   @tracked email = null;
   @tracked username = null;
 
+  @tracked idForm = null;
   @tracked firstNameForm = null;
   @tracked lastNameForm = null;
   @tracked emailForm = null;
@@ -22,11 +24,17 @@ export default class ListController extends Controller {
   @action
   async refreshModel(event) {
     event.preventDefault();
+    this.id = this.idForm;
     this.firstName = this.firstNameForm;
     this.lastName = this.lastNameForm;
     this.email = this.emailForm;
     this.username = this.usernameForm;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
+  }
+
+  @action
+  onChangeUserId(event) {
+    this.idForm = event.target.value;
   }
 
   @action
@@ -51,11 +59,13 @@ export default class ListController extends Controller {
 
   @action
   clearSearchFields() {
+    this.id = null;
     this.firstName = null;
     this.lastName = null;
     this.email = null;
     this.username = null;
 
+    this.idForm = null;
     this.firstNameForm = null;
     this.lastNameForm = null;
     this.emailForm = null;

--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -7,6 +7,7 @@ export default class ListRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    id: { refreshModel: true },
     firstName: { refreshModel: true },
     lastName: { refreshModel: true },
     email: { refreshModel: true },
@@ -14,10 +15,11 @@ export default class ListRoute extends Route {
   };
 
   async model(params) {
-    if (!params.firstName && !params.lastName && !params.email && !params.username) return [];
+    if (!params.id && !params.firstName && !params.lastName && !params.email && !params.username) return [];
 
     return this.store.query('user', {
       filter: {
+        id: params.id ? params.id.replace(/ /g, '') : '',
         firstName: params.firstName ? params.firstName.trim() : '',
         lastName: params.lastName ? params.lastName.trim() : '',
         email: params.email ? params.email.trim() : '',
@@ -34,6 +36,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 10;
+      controller.id = null;
       controller.firstName = null;
       controller.lastName = null;
       controller.email = null;

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -5,6 +5,13 @@
   <div class="page-actions">
     <form class="user-list-form" {{on "submit" this.refreshModel}}>
       <PixInput
+        @id="userId"
+        {{on "change" this.onChangeUserId}}
+        placeholder="ID"
+        @ariaLabel="Identifiant de l'utilisateur"
+        class="user-list-form__input--small"
+      />
+      <PixInput
         @id="firstName"
         {{on "change" this.onChangeFirstName}}
         placeholder="Prénom"

--- a/admin/tests/acceptance/authenticated/users/list_test.js
+++ b/admin/tests/acceptance/authenticated/users/list_test.js
@@ -49,6 +49,37 @@ module('Acceptance | authenticated/users | list', function (hooks) {
     });
 
     module('when users are filtered', function () {
+      module('when filtering on user id', function () {
+        test('it displays the current user', async function (assert) {
+          // given
+          const result = {
+            data: [
+              {
+                type: 'users',
+                id: '123',
+                attributes: {
+                  'first-name': 'Victor',
+                  'last-name': 'MacBernik',
+                  email: 'victor@famille-pirate.net',
+                  username: 'victor123',
+                },
+              },
+            ],
+          };
+
+          this.server.get('/admin/users', () => result);
+
+          // when
+          const screen = await visit('/users/list?id=123');
+
+          // then
+          assert
+            .dom(screen.getByLabelText("Informations de l'utilisateur Victor MacBernik"))
+            .hasText('123 Victor MacBernik victor@famille-pirate.net victor123');
+          assert.strictEqual(screen.queryAllByLabelText("Informations de l'utilisateur", { exact: false }).length, 1);
+        });
+      });
+
       module('when user has only username or email', function () {
         test('it should display the current user', async function (assert) {
           // given

--- a/admin/tests/unit/routes/authenticated/users/list_test.js
+++ b/admin/tests/unit/routes/authenticated/users/list_test.js
@@ -30,6 +30,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
+          id: '',
           firstName: '',
           lastName: '',
           email: '',
@@ -45,11 +46,13 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
     module('when queryParams filters are truthy', function () {
       test('it should call store.query with filters containing trimmed values', async function (assert) {
         // given
+        params.id = ' 12 3 456 ';
         params.firstName = ' someFirstName';
         params.lastName = 'someLastName ';
         params.email = 'someEmail';
         params.username = 'someUsername';
         expectedQueryArgs.filter = {
+          id: '123456',
           firstName: 'someFirstName',
           lastName: 'someLastName',
           email: 'someEmail',
@@ -74,6 +77,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
+        id: '123',
         firstName: 'someFirstName',
         lastName: 'someLastName',
         email: 'someEmail',
@@ -89,6 +93,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         // then
         assert.deepEqual(controller.pageNumber, 1);
         assert.deepEqual(controller.pageSize, 10);
+        assert.deepEqual(controller.id, null);
         assert.deepEqual(controller.firstName, null);
         assert.deepEqual(controller.lastName, null);
         assert.deepEqual(controller.email, null);
@@ -104,6 +109,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         // then
         assert.deepEqual(controller.pageNumber, 'somePageNumber');
         assert.deepEqual(controller.pageSize, 'somePageSize');
+        assert.deepEqual(controller.id, '123');
         assert.deepEqual(controller.firstName, 'someFirstName');
         assert.deepEqual(controller.lastName, 'someLastName');
         assert.deepEqual(controller.email, 'someEmail');

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -50,7 +50,7 @@ const register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             '- Elle permet de récupérer & chercher une liste d’utilisateurs\n' +
-            '- Cette liste est paginée et filtrée selon un **firstName**, un **lastName**, un **email** et **identifiant** donnés',
+            '- Cette liste est paginée et filtrée selon un **id**, **firstName**, un **lastName**, un **email** et **identifiant** donnés',
         ],
         tags: ['api', 'admin', 'user'],
       },

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -679,8 +679,11 @@ function _toDomainFromDTO({
 }
 
 function _setSearchFiltersForQueryBuilder(filter, qb) {
-  const { firstName, lastName, email, username } = filter;
+  const { id, firstName, lastName, email, username } = filter;
 
+  if (id) {
+    qb.where({ id });
+  }
   if (firstName) {
     qb.whereILike('firstName', `%${firstName}%`);
   }

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -207,6 +207,40 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         });
       });
 
+      it('returns only ther user matching "id" if given in filter', async function () {
+        // given
+        const filter = { id: '123456' };
+        const page = { number: 1, size: 10 };
+
+        const nanaOsaki = databaseBuilder.factory.buildUser({
+          id: 123456,
+          firstName: 'Nana',
+          lastName: 'Osaki',
+        });
+        databaseBuilder.factory.buildUser({
+          id: 987654,
+          firstName: 'Hachi',
+          lastName: 'Komatsu',
+        });
+        databaseBuilder.factory.buildUser({
+          id: 789123,
+          firstName: 'Reira',
+          lastName: 'Serizawa',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
+
+        // then
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
+
+        expect(matchingUsers).to.have.lengthOf(1);
+        expect(matchingUsers[0].id).to.equal(nanaOsaki.id);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+
       context('when there are lots of users (> 10) in the database', function () {
         it('should return paginated matching users', async function () {
           // given

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -448,32 +448,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           });
         },
       );
-
-      context('when there are filter that should be ignored', function () {
-        let firstUserId;
-        let secondUserId;
-
-        beforeEach(async function () {
-          firstUserId = databaseBuilder.factory.buildUser().id;
-          secondUserId = databaseBuilder.factory.buildUser().id;
-
-          await databaseBuilder.commit();
-        });
-
-        it('should ignore the filter and retrieve all users', async function () {
-          // given
-          const filter = { id: firstUserId };
-          const page = { number: 1, size: 10 };
-          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
-
-          // when
-          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
-
-          // then
-          expect(map(matchingUsers, 'id')).to.have.members([firstUserId, secondUserId]);
-          expect(pagination).to.deep.equal(expectedPagination);
-        });
-      });
     });
 
     describe('#findAnotherUserByEmail', function () {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans Pix Admin, il n'est pas possible de rechercher un utilisateur avec son id.

## :robot: Proposition

- Dans Pix Admin > Utilisateurs, ajouter un nouveau champ de recherche `ID` positionné en 1er, à gauche du champ “prénom”.
- Proposer une recherche sur l’ID exact. 
- Ignorer TOUS les espaces dans la saisie de l’ID (au début, à la fin ET au milieu).

## :rainbow: Remarques
RAS

## :100: Pour tester

1. Se connecter à Pix Admin
2. Se rendre sur la page des `Utilisateurs`
3. Vérifier qu'un nouveau filtre `ID` est présent 
4. Saisir l'ID exact d'un utilisateur (ex: `100730`)
5. Vérifier que la liste vous retourne bien un seul résultat et que celui-ci correspond à l'utilisateur `Bart Simpson`
6. Dans le champs `ID` faite une nouvelle recherche avec comme saisi `1`
7. Vérifier que la liste ne vous retourne aucun résultat car trop d'utilisateurs ont un `ID` commençant par le chiffre 1
