### PR TITLE
[BUGFIX] Corrige la difficulté des questions qui ne change pas lors d'une certif v3

### DIFF
--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -13,10 +13,15 @@ class FlashAssessmentAlgorithm {
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
   }
 
-  getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel }) {
+  getPossibleNextChallenges({ allAnswers, challenges }) {
     if (allAnswers.length >= this.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }
+
+    const { estimatedLevel } = this.getEstimatedLevelAndErrorRate({
+      allAnswers,
+      challenges,
+    });
 
     const { possibleChallenges, hasAssessmentEnded } = getPossibleNextChallenges({
       allAnswers,


### PR DESCRIPTION
## :unicorn: Problème
A l’heure actuelle, lorsque nous passons une session de certification V3, la difficulté des questions n’est pas réajustée en fonction des réponses données par l’utilisateur et celle-ci reste stable tout au long de la session.

## :100: Pour tester
- Se connecter dans l'espace surveillant d'une certif v3
- Valider la présence du candidat
- Rejoindre la session avec un candidat v3
- Bien répondre à quelques questions (2 réponses devraient suffire)
- La question actuelle devrait être plus difficile que les précédentes. Pour vérifier :
- Récupérer l'identifiant de la question dans l'onglet réseau des outils de développement.
- Rechercher cet identifiant dans airtable (PIX- Prod) et voir qu'il est "suffisamment loin" de 0 (au dessus de 1 ou 2 devrait être significatif).