### PR TITLE
[BUGFIX] Corrige la difficulté des questions qui ne change pas lors d'une certif v3 (PIX-8984)

### DIFF
--- a/api/lib/domain/models/AssessmentSimulator.js
+++ b/api/lib/domain/models/AssessmentSimulator.js
@@ -20,8 +20,9 @@ export class AssessmentSimulator {
         const possibleChallenges = this.algorithm.getPossibleNextChallenges({
           allAnswers: challengesAnswers,
           challenges: this.challenges,
-          estimatedLevel,
+          initialCapacity: this.initialCapacity,
         });
+
         const nextChallenge = this.pickChallenge({ possibleChallenges });
 
         const answerStatus = this.pickAnswerStatus({
@@ -46,11 +47,13 @@ export class AssessmentSimulator {
         estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({
           allAnswers: challengesAnswers,
           challenges: this.challenges,
+          initialCapacity: this.initialCapacity,
         }).estimatedLevel;
 
         const errorRate = this.algorithm.getEstimatedLevelAndErrorRate({
           allAnswers: challengesAnswers,
           challenges: this.challenges,
+          initialCapacity: this.initialCapacity,
         }).errorRate;
 
         result.push({

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -13,10 +13,16 @@ class FlashAssessmentAlgorithm {
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
   }
 
-  getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel }) {
+  getPossibleNextChallenges({ allAnswers, challenges, initialCapacity }) {
     if (allAnswers.length >= this.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }
+
+    const { estimatedLevel } = this.getEstimatedLevelAndErrorRate({
+      allAnswers,
+      challenges,
+      initialCapacity,
+    });
 
     const { possibleChallenges, hasAssessmentEnded } = getPossibleNextChallenges({
       allAnswers,
@@ -33,8 +39,8 @@ class FlashAssessmentAlgorithm {
     return possibleChallenges;
   }
 
-  getEstimatedLevelAndErrorRate({ allAnswers, challenges }) {
-    return getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+  getEstimatedLevelAndErrorRate({ allAnswers, challenges, initialCapacity }) {
+    return getEstimatedLevelAndErrorRate({ allAnswers, challenges, estimatedLevel: initialCapacity });
   }
 
   getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -60,12 +60,12 @@ function getPossibleNextChallenges({
   };
 }
 
-function getEstimatedLevelAndErrorRate({ allAnswers, challenges }) {
+function getEstimatedLevelAndErrorRate({ allAnswers, challenges, estimatedLevel = DEFAULT_ESTIMATED_LEVEL }) {
   if (allAnswers.length === 0) {
-    return { estimatedLevel: DEFAULT_ESTIMATED_LEVEL, errorRate: DEFAULT_ERROR_RATE };
+    return { estimatedLevel, errorRate: DEFAULT_ERROR_RATE };
   }
 
-  let latestEstimatedLevel = DEFAULT_ESTIMATED_LEVEL;
+  let latestEstimatedLevel = estimatedLevel;
 
   const samplesWithResults = samples.map((sample) => ({
     sample,

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -14,7 +14,7 @@ const getNextChallengeForCampaignAssessment = async function ({
   let algoResult;
 
   if (assessment.isFlash()) {
-    const { allAnswers, challenges, estimatedLevel } = await algorithmDataFetcherService.fetchForFlashCampaigns({
+    const { allAnswers, challenges } = await algorithmDataFetcherService.fetchForFlashCampaigns({
       assessmentId: assessment.id,
       answerRepository,
       challengeRepository,
@@ -27,7 +27,6 @@ const getNextChallengeForCampaignAssessment = async function ({
     const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({
       allAnswers,
       challenges,
-      estimatedLevel,
     });
 
     return pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });

--- a/api/tests/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/unit/domain/models/AssessmentSimulator_test.js
@@ -13,7 +13,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           const answer1 = { challengeId: challenge2.id, result: answersForSimulator[0] };
           const answer2 = { challengeId: challenge1.id, result: answersForSimulator[1] };
           const allChallenges = [challenge1, challenge2];
-          const initialEstimatedLevel = 0;
+          const initialCapacity = 0;
           const expectedEstimatedLevels = [0.4, 0.1];
           const expectedErrorRates = [0.2, 0.5];
           const expectedRewards = [5, 6];
@@ -30,16 +30,18 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
               allAnswers: [],
             })
             .returns({
-              estimatedLevel: initialEstimatedLevel,
+              estimatedLevel: initialCapacity,
             })
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
+              initialCapacity,
             })
             .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
             .withArgs({
               allAnswers: [sinon.match(answer1), sinon.match(answer2)],
               challenges: allChallenges,
+              initialCapacity,
             })
             .returns({
               estimatedLevel: expectedEstimatedLevels[1],
@@ -50,13 +52,13 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             .withArgs({
               allAnswers: [],
               challenges: allChallenges,
-              estimatedLevel: initialEstimatedLevel,
+              initialCapacity,
             })
             .returns([challenge2, challenge1])
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
-              estimatedLevel: expectedEstimatedLevels[0],
+              initialCapacity,
             })
             .returns([challenge1]);
 
@@ -74,7 +76,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
 
           algorithm.getReward
             .withArgs({
-              estimatedLevel: initialEstimatedLevel,
+              estimatedLevel: initialCapacity,
               difficulty: challenge1.difficulty,
               discriminant: challenge1.discriminant,
             })
@@ -109,6 +111,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             challenges: allChallenges,
             pickChallenge,
             pickAnswerStatus,
+            initialCapacity,
           }).run();
 
           // then
@@ -124,7 +127,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
           const answer = { challengeId: challenge2.id, result: answersForSimulator[0] };
           const allChallenges = [challenge1, challenge2];
-          const initialEstimatedLevel = 0;
+          const initialCapacity = 0;
           const expectedEstimatedLevels = [0.4, 0.1];
           const expectedErrorRates = [0.2, 0.5];
           const expectedRewards = [5, 6];
@@ -141,11 +144,12 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
               allAnswers: [],
             })
             .returns({
-              estimatedLevel: initialEstimatedLevel,
+              estimatedLevel: initialCapacity,
             })
             .withArgs({
               allAnswers: [sinon.match(answer)],
               challenges: allChallenges,
+              initialCapacity,
             })
             .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] });
 
@@ -153,13 +157,13 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             .withArgs({
               allAnswers: [],
               challenges: allChallenges,
-              estimatedLevel: initialEstimatedLevel,
+              initialCapacity,
             })
             .returns([challenge2, challenge1])
             .withArgs({
               allAnswers: [sinon.match(answer)],
               challenges: allChallenges,
-              estimatedLevel: expectedEstimatedLevels[0],
+              initialCapacity,
             })
             .returns([challenge1]);
 
@@ -173,7 +177,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
 
           algorithm.getReward
             .withArgs({
-              estimatedLevel: initialEstimatedLevel,
+              estimatedLevel: initialCapacity,
               difficulty: challenge1.difficulty,
               discriminant: challenge1.discriminant,
             })
@@ -195,6 +199,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             challenges: allChallenges,
             pickChallenge,
             pickAnswerStatus,
+            initialCapacity,
           }).run();
 
           // then
@@ -212,7 +217,6 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
         const answer1 = { challengeId: challenge2.id, result: answersForSimulator[0] };
         const answer2 = { challengeId: challenge1.id, result: answersForSimulator[1] };
         const allChallenges = [challenge1, challenge2];
-        const initialEstimatedLevel = 0;
         const expectedEstimatedLevels = [0.4, 0.1];
         const expectedErrorRates = [0.2, 0.5];
         const expectedRewards = [5, 6];
@@ -227,19 +231,15 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
 
         algorithm.getEstimatedLevelAndErrorRate
           .withArgs({
-            allAnswers: [],
-          })
-          .returns({
-            estimatedLevel: initialEstimatedLevel,
-          })
-          .withArgs({
             allAnswers: [sinon.match(answer1)],
             challenges: allChallenges,
+            initialCapacity,
           })
           .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
           .withArgs({
             allAnswers: [sinon.match(answer1), sinon.match(answer2)],
             challenges: allChallenges,
+            initialCapacity,
           })
           .returns({
             estimatedLevel: expectedEstimatedLevels[1],
@@ -250,13 +250,13 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           .withArgs({
             allAnswers: [],
             challenges: allChallenges,
-            estimatedLevel: initialCapacity,
+            initialCapacity,
           })
           .returns([challenge2, challenge1])
           .withArgs({
             allAnswers: [sinon.match(answer1)],
             challenges: allChallenges,
-            estimatedLevel: expectedEstimatedLevels[0],
+            initialCapacity,
           })
           .returns([challenge1]);
 

--- a/api/tests/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -1,6 +1,47 @@
-import { FlashAssessmentAlgorithm } from '../../../../lib/domain/models/index.js';
+import { AnswerStatus, FlashAssessmentAlgorithm } from '../../../../lib/domain/models/index.js';
 import { domainBuilder, expect } from '../../../test-helper.js';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
+import _ from 'lodash';
+import { config } from '../../../../lib/config.js';
+
+function initializeTestChallenges(hardAnsweredChallengesCount, difficulty, answerStatus) {
+  const defaultDiscriminantValue = 0.5;
+  const defaultSkill = domainBuilder.buildSkill({
+    id: 'recSK456',
+  });
+  const hardAnsweredChallenges = _.range(0, hardAnsweredChallengesCount).map((index) =>
+    domainBuilder.buildChallenge({
+      id: `recAnsweredHard${index}`,
+      difficulty,
+      discriminant: defaultDiscriminantValue,
+    }),
+  );
+
+  const hardAnsweredChallengesAnswers = hardAnsweredChallenges.map(({ id }) =>
+    domainBuilder.buildAnswer({
+      result: answerStatus,
+      challengeId: id,
+    }),
+  );
+
+  const expectedUnansweredChallenge = domainBuilder.buildChallenge({
+    id: 'recUnansweredHard',
+    difficulty,
+    discriminant: defaultDiscriminantValue,
+    skill: defaultSkill,
+  });
+
+  const mediumUnansweredChallenge = domainBuilder.buildChallenge({
+    id: 'recUnansweredMedium',
+    difficulty: 0,
+    discriminant: defaultDiscriminantValue,
+    skill: defaultSkill,
+  });
+
+  const challenges = [...hardAnsweredChallenges, expectedUnansweredChallenge, mediumUnansweredChallenge];
+  const allAnswers = [...hardAnsweredChallengesAnswers];
+  return { expectedUnansweredChallenge, mediumUnansweredChallenge, challenges, allAnswers };
+}
 
 describe('FlashAssessmentAlgorithm', function () {
   describe('#getPossibleNextChallenges', function () {
@@ -25,6 +66,45 @@ describe('FlashAssessmentAlgorithm', function () {
             estimatedLevel,
           }),
         ).to.throw(AssessmentEndedError);
+      });
+    });
+
+    context('when there are challenges left to answer', function () {
+      let algorithm;
+      const alreadyAnsweredChallengesCount = 10;
+      const remainingAnswersToGive = 1;
+
+      beforeEach(function () {
+        config.features.numberOfChallengesForFlashMethod = 20;
+        algorithm = new FlashAssessmentAlgorithm({
+          warmUpLength: 0,
+          maximumAssessmentLength: alreadyAnsweredChallengesCount + remainingAnswersToGive,
+        });
+      });
+      context('when user has a strong level', function () {
+        it('should choose a hard challenge', function () {
+          const strongLevel = 6;
+          const { expectedUnansweredChallenge, mediumUnansweredChallenge, challenges, allAnswers } =
+            initializeTestChallenges(alreadyAnsweredChallengesCount, strongLevel);
+
+          expect(algorithm.getPossibleNextChallenges({ allAnswers, challenges })).to.deep.equal([
+            expectedUnansweredChallenge,
+            mediumUnansweredChallenge,
+          ]);
+        });
+      });
+
+      context('when user has a weak level', function () {
+        it('should choose a hard challenge', function () {
+          const weakLevel = -6;
+          const { expectedUnansweredChallenge, mediumUnansweredChallenge, challenges, allAnswers } =
+            initializeTestChallenges(alreadyAnsweredChallengesCount, weakLevel, AnswerStatus.KO);
+
+          expect(algorithm.getPossibleNextChallenges({ allAnswers, challenges })).to.deep.equal([
+            expectedUnansweredChallenge,
+            mediumUnansweredChallenge,
+          ]);
+        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -85,13 +85,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
         firstChallenge = domainBuilder.buildChallenge({
           id: '1234',
           difficulty: -5,
-          discriminant: -5,
+          discriminant: 1,
           skill: firstSkill,
         });
         secondChallenge = domainBuilder.buildChallenge({
           id: '5678',
           difficulty: -5,
-          discriminant: -5,
+          discriminant: 1,
           skill: secondSkill,
         });
 


### PR DESCRIPTION
## :unicorn: Problème
A l’heure actuelle, lorsque nous passons une session de certification V3, la difficulté des questions n’est pas réajustée en fonction des réponses données par l’utilisateur et celle-ci reste stable tout au long de la session.

## :100: Pour tester
- Se connecter dans l'espace surveillant d'une certif v3
- Valider la présence du candidat
- Rejoindre la session avec un candidat v3
- Bien répondre à quelques questions (2 réponses devraient suffire)
- La question actuelle devrait être plus difficile que les précédentes. Pour vérifier :
- Récupérer l'identifiant de la question.
- Rechercher cet identifiant dans airtable (PIX- Prod) et voir qu'il est "suffisamment loin" de 0 (au dessus de 1 ou 2 devrait être significatif).