### PR TITLE
[TECH] Utiliser la fonction native de génération d'UUID v4.

### DIFF
--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,4 +1,4 @@
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 import { config } from '../../../config.js';
 import { OidcAuthenticationService } from './oidc-authentication-service.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
@@ -44,7 +44,7 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   async saveIdToken({ idToken, userId }) {
-    const uuid = uuidv4();
+    const uuid = randomUUID();
     const { idTokenLifespanMs } = this.temporaryStorage;
 
     await logoutUrlTemporaryStorage.save({

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 import { config } from '../../../config.js';
 import { OidcAuthenticationService } from './oidc-authentication-service.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -44,7 +44,9 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   async saveIdToken({ idToken, userId }) {
-    const uuid = randomUUID();
+    // The session ID must be unpredictable, thus we disable the entropy cache
+    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
+    const uuid = randomUUID({ disableEntropyCache: true });
     const { idTokenLifespanMs } = this.temporaryStorage;
 
     await logoutUrlTemporaryStorage.save({

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -140,8 +140,10 @@ class OidcAuthenticationService {
 
   getAuthenticationUrl({ redirectUri }) {
     const redirectTarget = new URL(this.authenticationUrl);
-    const state = randomUUID();
-    const nonce = randomUUID();
+    // The session ID must be unpredictable, thus we disable the entropy cache
+    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
+    const state = randomUUID({ disableEntropyCache: true });
+    const nonce = randomUUID({ disableEntropyCache: true });
 
     const params = [
       { key: 'state', value: state },

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 import jsonwebtoken from 'jsonwebtoken';
 import querystring from 'querystring';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 
 import { logger } from '../../../infrastructure/logger.js';
 import {

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 import jsonwebtoken from 'jsonwebtoken';
 import querystring from 'querystring';
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 
 import { logger } from '../../../infrastructure/logger.js';
 import {
@@ -140,8 +140,8 @@ class OidcAuthenticationService {
 
   getAuthenticationUrl({ redirectUri }) {
     const redirectTarget = new URL(this.authenticationUrl);
-    const state = uuidv4();
-    const nonce = uuidv4();
+    const state = randomUUID();
+    const nonce = randomUUID();
 
     const params = [
       { key: 'state', value: state },

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -87,7 +87,9 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   async saveIdToken({ idToken, userId }) {
-    const uuid = randomUUID();
+    // The session ID must be unpredictable, thus we disable the entropy cache
+    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
+    const uuid = randomUUID({ disableEntropyCache: true });
     const { idTokenLifespanMs } = this.temporaryStorage;
 
     await logoutUrlTemporaryStorage.save({

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -3,7 +3,7 @@ import { OidcAuthenticationService } from './oidc-authentication-service.js';
 import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';
 import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
 import dayjs from 'dayjs';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 import { POLE_EMPLOI } from '../../constants/oidc-identity-providers.js';
 

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -3,7 +3,7 @@ import { OidcAuthenticationService } from './oidc-authentication-service.js';
 import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';
 import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
 import dayjs from 'dayjs';
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 import { POLE_EMPLOI } from '../../constants/oidc-identity-providers.js';
 
@@ -87,7 +87,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   async saveIdToken({ idToken, userId }) {
-    const uuid = uuidv4();
+    const uuid = randomUUID();
     const { idTokenLifespanMs } = this.temporaryStorage;
 
     await logoutUrlTemporaryStorage.save({

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -21,7 +21,7 @@ async function buildXmlExport({ cpfCertificationResults, writableStream, opts = 
       'xmlns:cpf': `urn:cdc:cpf:pc5:schema:${schemaVersion}`,
       'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
     })
-      .ele('cpf:idFlux').txt(uuidService.v4()).up()
+      .ele('cpf:idFlux').txt(uuidService.randomUUID()).up()
       .ele('cpf:horodatage').txt(formatedDate).up()
       .ele('cpf:emetteur')
         .ele('cpf:idClient').txt(cpf.idClient).up()

--- a/api/lib/domain/services/refresh-token-service.js
+++ b/api/lib/domain/services/refresh-token-service.js
@@ -1,5 +1,5 @@
 import bluebird from 'bluebird';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 import { tokenService } from './token-service.js';
 
 import { config } from '../../config.js';

--- a/api/lib/domain/services/refresh-token-service.js
+++ b/api/lib/domain/services/refresh-token-service.js
@@ -1,5 +1,5 @@
 import bluebird from 'bluebird';
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 import { tokenService } from './token-service.js';
 
 import { config } from '../../config.js';
@@ -15,7 +15,7 @@ function _prefixForUser(userId) {
   return `${userId}:`;
 }
 
-async function createRefreshTokenFromUserId({ userId, source, uuidGenerator = uuidv4 }) {
+async function createRefreshTokenFromUserId({ userId, source, uuidGenerator = randomUUID }) {
   const expirationDelaySeconds = config.authentication.refreshTokenLifespanMs / 1000;
   const refreshToken = `${_prefixForUser(userId)}${uuidGenerator()}`;
 

--- a/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
+++ b/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
@@ -2,7 +2,7 @@ import { config } from '../../../config.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 
 const sessionMassImportTemporaryStorage = temporaryStorage.withPrefix('sessions-mass-import:');
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 
 const EXPIRATION_DELAY_SECONDS = config.temporarySessionsStorageForMassImport.expirationDelaySeconds;
 

--- a/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
+++ b/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
@@ -2,12 +2,12 @@ import { config } from '../../../config.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 
 const sessionMassImportTemporaryStorage = temporaryStorage.withPrefix('sessions-mass-import:');
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 
 const EXPIRATION_DELAY_SECONDS = config.temporarySessionsStorageForMassImport.expirationDelaySeconds;
 
 const save = async function ({ sessions, userId }) {
-  const uuid = uuidv4();
+  const uuid = randomUUID();
   await sessionMassImportTemporaryStorage.save({
     key: `${userId}:${uuid}`,
     value: sessions,

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 
 import { SessionPublicationBatchResult } from '../models/SessionPublicationBatchResult.js';
 

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -1,4 +1,4 @@
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 
 import { SessionPublicationBatchResult } from '../models/SessionPublicationBatchResult.js';
 
@@ -11,7 +11,7 @@ const publishSessionsInBatch = async function ({
   sessionPublicationService,
   sessionRepository,
   publishedAt = new Date(),
-  batchId = uuidv4(),
+  batchId = randomUUID(),
 }) {
   const result = new SessionPublicationBatchResult(batchId);
   for (const sessionId of sessionIds) {

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -7,7 +7,7 @@ import timezone from 'dayjs/plugin/timezone.js';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-import * as uuid from 'uuid';
+import * as uuid from 'crypto';
 
 const createAndUpload = async function ({
   data,

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -1,8 +1,8 @@
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 
 class TemporaryStorage {
   static generateKey() {
-    return uuidv4();
+    return randomUUID();
   }
 
   async save(/* { key, value, expirationDelaySeconds } */) {

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 
 class TemporaryStorage {
   static generateKey() {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -71,7 +71,6 @@
         "saxpath": "^0.6.5",
         "scalingo": "^0.8.0",
         "schemalint": "^1.0.0",
-        "uuid": "^9.0.0",
         "validator": "^13.7.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.1/xlsx-0.19.1.tgz",
         "xml-buffer-tostring": "^0.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -77,7 +77,6 @@
     "saxpath": "^0.6.5",
     "scalingo": "^0.8.0",
     "schemalint": "^1.0.0",
-    "uuid": "^9.0.0",
     "validator": "^13.7.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.1/xlsx-0.19.1.tgz",
     "xml-buffer-tostring": "^0.2.0",

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -30,7 +30,7 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
     const now = dayjs('2022-01-02T10:43:27Z').tz('Europe/Paris').toDate();
     clock = sinon.useFakeTimers(now);
     logger = { error: noop, info: noop };
-    uuidService = { v4: sinon.stub() };
+    uuidService = { randomUUID: sinon.stub() };
   });
 
   afterEach(function () {
@@ -57,7 +57,7 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
 
     cpfCertificationResultRepository.findByBatchId.withArgs(batchId).resolves(cpfCertificationResults);
 
-    uuidService.v4.returns('xxx-yyy-zzz');
+    uuidService.randomUUID.returns('xxx-yyy-zzz');
 
     cpfExternalStorage.upload
       .withArgs({

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 
 import { RedisTemporaryStorage } from '../../../../lib/infrastructure/temporary-storage/RedisTemporaryStorage.js';
 import { expect } from '../../../test-helper.js';

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -1,4 +1,4 @@
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 
 import { RedisTemporaryStorage } from '../../../../lib/infrastructure/temporary-storage/RedisTemporaryStorage.js';
 import { expect } from '../../../test-helper.js';
@@ -32,7 +32,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
     describe('#expire', function () {
       it('should add an expiration time to the list', async function () {
         // given
-        const key = uuidv4();
+        const key = randomUUID();
         const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
@@ -50,7 +50,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
     describe('#ttl', function () {
       it('should retrieve the remaining expiration time from a list', async function () {
         // given
-        const key = uuidv4();
+        const key = randomUUID();
         const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
@@ -66,7 +66,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
     describe('#lpush', function () {
       it('should add a value to a list and return the length of the list', async function () {
         // given
-        const key = uuidv4();
+        const key = randomUUID();
         const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
@@ -81,7 +81,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
     describe('#lrem', function () {
       it('should remove a value from a list and return the number of removed elements', async function () {
         // given
-        const key = uuidv4();
+        const key = randomUUID();
         const storage = new RedisTemporaryStorage(REDIS_URL);
 
         await storage.lpush(key, 'value1');
@@ -100,7 +100,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
     describe('#lrange', function () {
       it('should return a list of values', async function () {
         // given
-        const key = uuidv4();
+        const key = randomUUID();
         const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'crypto';
 
 import { RedisClient } from '../../../../lib/infrastructure/utils/RedisClient.js';
 import { config } from '../../../../lib/config.js';

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -1,4 +1,4 @@
-import { randomUUID as uuidv4 } from 'crypto';
+import { randomUUID } from 'crypto';
 
 import { RedisClient } from '../../../../lib/infrastructure/utils/RedisClient.js';
 import { config } from '../../../../lib/config.js';
@@ -52,8 +52,8 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should allow to handle a list of values for a key', async function () {
     // given
-    const keyToAdd = uuidv4();
-    const keyToRemove = uuidv4();
+    const keyToAdd = randomUUID();
+    const keyToRemove = randomUUID();
     const redisClient = new RedisClient(config.redis.url);
 
     await redisClient.lpush(keyToRemove, 'value1');

--- a/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -19,7 +19,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
   beforeEach(function () {
     const now = dayjs('2022-02-01T10:43:27Z').tz('Europe/Paris').toDate();
     clock = sinon.useFakeTimers(now);
-    uuidService = { v4: sinon.stub() };
+    uuidService = { randomUUID: sinon.stub() };
   });
 
   afterEach(function () {
@@ -30,7 +30,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
     it('should return a writable stream with cpf certification results', async function () {
       // given
 
-      uuidService.v4.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
+      uuidService.randomUUID.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
 
       const firstCpfCertificationResult = domainBuilder.buildCpfCertificationResult({
         id: 1234,

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,7 +1,7 @@
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 import { createAndUpload } from '../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js';
 import stream from 'stream';
-import * as uuidService from 'uuid';
+import * as uuidService from 'crypto';
 
 const { PassThrough, Readable } = stream;
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'installation des dépendances de l'API, un message nous avertit de l'obsolescence de la version d'uuid que nous utilisons.
Nous utilisons effectivement une version relativement ancienne.
En regardant le [README](https://github.com/uuidjs/uuid) de uuid, on se rend compte que nous sommes dans le cas d'utilisation de cette librairie uniquement pour générer des uuid v4.


## :robot: Proposition
Nous suivons la recommandation de uuid et utilisons la fonction `Crytpo.randomUUID`.

## :rainbow: Remarques
Sur la suggestion de @Steph0, on désactive le cache  (`disableEntropyCache: true`) dans les fichiers liés à l'authentification.

## :100: Pour tester
Les tests doivent passer tout vert :-)
