### PR TITLE
[TECH] Mise à jour de l'index de l'ADR 0049-nouvelle-arborescence-api

### DIFF
--- a/docs/adr/0051-nouvelle-arborescence-api.md
+++ b/docs/adr/0051-nouvelle-arborescence-api.md
@@ -1,4 +1,4 @@
-# 49. Arborescence API
+# 51. Arborescence API
 
 Date : 2023-07-20
 


### PR DESCRIPTION
## :unicorn: Problème
L'ADR 0049-nouvelle-arborescence-api utilise le numéro 49 qui est en conflit avec un autre ADR.

## :robot: Proposition
Utiliser le numéro 51 pour l'ADR en question.

## :100: Pour tester
Vérifier que le numéro 51 n'est pas en conflit avec un autre ADR .
