### PR TITLE
[TECH] Mettre à jour la dépendance xlsx de 0.19.1 vers 0.19.3

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -70,7 +70,7 @@
         "scalingo": "^0.8.0",
         "schemalint": "^1.0.0",
         "validator": "^13.7.0",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.1/xlsx-0.19.1.tgz",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz",
         "xml-buffer-tostring": "^0.2.0",
         "xml2js": "^0.6.0",
         "xmlbuilder2": "^3.0.2",
@@ -11989,9 +11989,9 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.19.1",
-      "resolved": "https://cdn.sheetjs.com/xlsx-0.19.1/xlsx-0.19.1.tgz",
-      "integrity": "sha512-pPh/ybd1bChlhCrtQ9QmRUx2yjQwMbS4tfvV9MSA2Qmm7vRUHQtPDMlLjAvQ2A4v8G92i2RlrNkSOKb1bwY7ww==",
+      "version": "0.19.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz",
+      "integrity": "sha512-8IfgFctB7fkvqkTGF2MnrDrC6vzE28Wcc1aSbdDQ+4/WFtzfS73YuapbuaPZwGqpR2e0EeDMIrFOJubQVLWFNA==",
       "license": "Apache-2.0",
       "bin": {
         "xlsx": "bin/xlsx.njs"

--- a/api/package.json
+++ b/api/package.json
@@ -76,7 +76,7 @@
     "scalingo": "^0.8.0",
     "schemalint": "^1.0.0",
     "validator": "^13.7.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.1/xlsx-0.19.1.tgz",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz",
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.6.0",
     "xmlbuilder2": "^3.0.2",


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'installation de l'API, une message de sévérité haute est affiché
```
xlsx  *
Severity: high
Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
No fix available
node_modules/xlsx
```
Nous ne sommes à priori pas affectés par la vulnérabilité car nous ne manipulons que des spreadsheets (et pas d'autre type de fichiers)
https://github.com/advisories/GHSA-4r6h-8v6p-xvw6

Mais pour le savoir, il faut passer du temps et passer l'information autour de soi.

## :robot: Proposition
Monter en v0.19.3 pour résoudre la vulnérabilité (à laquelle nous ne sommes pas exposés)
https://git.sheetjs.com/sheetjs/sheetjs/src/branch/master/CHANGELOG.md#v0-19-3

## :100: Pour tester
Vérifier que le message n'apparaît plus
