### PR TITLE
[FEATURE] Autoriser la création de campagne en masse en envoi multiple (Pix-8609)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -258,6 +258,13 @@ class UserNotAuthorizedToCreateCampaignError extends DomainError {
   }
 }
 
+class OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError extends DomainError {
+  constructor(organizationId) {
+    const message = `L'organisation ${organizationId}, n'est pas autorisée à créer une campagne d'évaluation à envoi multiple.`;
+    super(message);
+  }
+}
+
 class UserNotAuthorizedToUpdateResourceError extends DomainError {
   constructor(message = "Cet utilisateur n'est pas autorisé à mettre à jour la ressource.") {
     super(message);
@@ -1414,6 +1421,7 @@ export {
   OrganizationLearnerDisabledError,
   OrganizationLearnerNotFound,
   OrganizationLearnersCouldNotBeSavedError,
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
   SendingEmailError,

--- a/api/lib/domain/models/CampaignCreator.js
+++ b/api/lib/domain/models/CampaignCreator.js
@@ -1,17 +1,27 @@
 import { CampaignForCreation } from './CampaignForCreation.js';
 import { CampaignTypes } from './CampaignTypes.js';
-import { UserNotAuthorizedToCreateCampaignError } from '../errors.js';
-
+import {
+  UserNotAuthorizedToCreateCampaignError,
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+} from '../errors.js';
+import * as apps from '../../domain/constants.js';
 class CampaignCreator {
-  constructor(availableTargetProfileIds) {
+  constructor({ availableTargetProfileIds, organizationFeatures }) {
     this.availableTargetProfileIds = availableTargetProfileIds;
+    this.isMultipleSendingsAssessmentEnable =
+      organizationFeatures[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key];
   }
 
   createCampaign(campaignAttributes) {
-    const { type, targetProfileId } = campaignAttributes;
+    const { type, targetProfileId, multipleSendings, organizationId } = campaignAttributes;
 
     if (type === CampaignTypes.ASSESSMENT) {
       _checkAssessmentCampaignCreationAllowed(targetProfileId, this.availableTargetProfileIds);
+      _checkAssessmentCampaignMultipleSendingsCreationAllowed(
+        multipleSendings,
+        this.isMultipleSendingsAssessmentEnable,
+        organizationId,
+      );
     }
 
     return new CampaignForCreation(campaignAttributes);
@@ -23,6 +33,16 @@ function _checkAssessmentCampaignCreationAllowed(targetProfileId, availableTarge
     throw new UserNotAuthorizedToCreateCampaignError(
       `Organization does not have an access to the profile ${targetProfileId}`,
     );
+  }
+}
+
+function _checkAssessmentCampaignMultipleSendingsCreationAllowed(
+  multipleSendings,
+  isMultipleSendingsAssessmentEnable,
+  organizationId,
+) {
+  if (!isMultipleSendingsAssessmentEnable && multipleSendings) {
+    throw new OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError(organizationId);
   }
 }
 

--- a/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
+++ b/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
@@ -4,6 +4,7 @@ const createCampaigns = async function ({
   campaignsToCreate,
   membershipRepository,
   campaignRepository,
+  campaignCreatorRepository,
   campaignCodeGenerator,
 }) {
   const enrichedCampaignsData = await Promise.all(
@@ -12,12 +13,19 @@ const createCampaigns = async function ({
         organizationId: campaign.organizationId,
       });
 
-      return {
-        ...campaign,
+      const generatedCampaignCode = await campaignCodeGenerator.generate(campaignRepository);
+      const campaignCreator = await campaignCreatorRepository.get({
+        userId: campaign.creatorId,
+        organizationId: campaign.organizationId,
         ownerId: administrator.user.id,
-        code: await campaignCodeGenerator.generate(campaignRepository),
+      });
+
+      return campaignCreator.createCampaign({
+        ...campaign,
         type: CampaignTypes.ASSESSMENT,
-      };
+        code: generatedCampaignCode,
+        ownerId: administrator.user.id,
+      });
     }),
   );
 

--- a/api/lib/domain/validators/campaign-creation-validator.js
+++ b/api/lib/domain/validators/campaign-creation-validator.js
@@ -25,7 +25,7 @@ const schema = Joi.object({
     'number.base': 'MISSING_CREATOR',
   }),
 
-  customLandingPageText: Joi.string().allow(null).default(null).max(5000).messages({
+  customLandingPageText: Joi.string().empty('').allow(null).default(null).max(5000).messages({
     'string.max': 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG',
   }),
 
@@ -60,7 +60,9 @@ const schema = Joi.object({
     }),
 
   title: Joi.string()
+    .empty('')
     .allow(null)
+    .default(null)
     .when('type', {
       is: Joi.string().required().valid(CampaignTypes.PROFILES_COLLECTION),
       then: Joi.valid(null),

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -209,6 +209,7 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     creatorId: data['Identifiant du créateur*'],
     title: data['Titre du parcours'],
     customLandingPageText: data['Descriptif du parcours'],
+    multipleSendings: data['Envoi multiple'].toLowerCase() === 'oui' ? true : false,
   }));
 }
 

--- a/api/tests/acceptance/application/campaign-administration/create-campaigns_test.js
+++ b/api/tests/acceptance/application/campaign-administration/create-campaigns_test.js
@@ -1,6 +1,6 @@
 import { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
-import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
+import { PIX_ADMIN, ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 
 const { ROLES } = PIX_ADMIN;
@@ -27,13 +27,16 @@ describe('Acceptance | Application | campaign-controller-create-campaigns', func
 
       it('creates two campaigns', async function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
+
+        databaseBuilder.factory.buildOrganizationFeature({ organizationId, featureId });
         databaseBuilder.factory.buildMembership({ organizationId, userId, organizationRole: Membership.roles.ADMIN });
         const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
         await databaseBuilder.commit();
 
-        const buffer = `Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours
-          ${organizationId};Parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};
-          ${organizationId};Autre parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};Titre;Superbe descriptif de parcours`;
+        const buffer = `Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple
+          ${organizationId};Parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};;;non
+          ${organizationId};Autre parcours importé par CSV;${targetProfileId};numéro d'étudiant;${userId};Titre;Superbe descriptif de parcours;oui`;
         const options = {
           method: 'POST',
           url: '/api/admin/campaigns',

--- a/api/tests/unit/domain/models/CampaignCreator_test.js
+++ b/api/tests/unit/domain/models/CampaignCreator_test.js
@@ -2,14 +2,55 @@ import { CampaignCreator } from '../../../../lib/domain/models/CampaignCreator.j
 import { expect, catchErr } from '../../../test-helper.js';
 import { CampaignTypes } from '../../../../lib/domain/models/CampaignTypes.js';
 import { CampaignForCreation } from '../../../../lib/domain/models/CampaignForCreation.js';
-import { UserNotAuthorizedToCreateCampaignError, EntityValidationError } from '../../../../lib/domain/errors.js';
+import {
+  UserNotAuthorizedToCreateCampaignError,
+  EntityValidationError,
+  OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
+} from '../../../../lib/domain/errors.js';
+import * as apps from '../../../../lib/domain/constants.js';
 
 describe('Unit | Domain | Models | CampaignCreator', function () {
+  let organizationFeatures;
+  beforeEach(function () {
+    organizationFeatures = {};
+    organizationFeatures[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] = true;
+  });
+
+  describe('#constructor', function () {
+    describe('#availableTargetProfileIds', function () {
+      it('should instanciate CampaignCreator available target profile for campaign', function () {
+        const availableTargetProfileIds = [1, 2];
+
+        const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+
+        expect(creator.availableTargetProfileIds).to.deep.equal(availableTargetProfileIds);
+      });
+    });
+
+    describe('#isMultipleSendingsAssessmentEnabled', function () {
+      it('should instanciate CampaignCreator multiple sendings assessment for campaign to true', function () {
+        organizationFeatures[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] = true;
+
+        const creator = new CampaignCreator({ availableTargetProfileIds: [], organizationFeatures });
+
+        expect(creator.isMultipleSendingsAssessmentEnable).to.be.true;
+      });
+
+      it('should instanciate CampaignCreator multiple sendings assessment for campaign to false', function () {
+        organizationFeatures[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] = false;
+
+        const creator = new CampaignCreator({ availableTargetProfileIds: [], organizationFeatures });
+
+        expect(creator.isMultipleSendingsAssessmentEnable).to.be.false;
+      });
+    });
+  });
+
   describe('#createCampaign', function () {
     describe('when the creator is allowed to create the campaign', function () {
       it('creates the campaign', function () {
         const availableTargetProfileIds = [1, 2];
-        const creator = new CampaignCreator(availableTargetProfileIds);
+        const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
         const campaignData = {
           name: 'campagne utilisateur',
           type: CampaignTypes.ASSESSMENT,
@@ -17,6 +58,7 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
           ownerId: 1,
           organizationId: 2,
           targetProfileId: 2,
+          multipleSendings: true,
         };
         const expectedCampaignForCreation = new CampaignForCreation(campaignData);
 
@@ -30,7 +72,7 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
       describe('when the creator cannot use the targetProfileId', function () {
         it('throws an error', async function () {
           const availableTargetProfileIds = [1, 2];
-          const creator = new CampaignCreator(availableTargetProfileIds);
+          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
           const campaignData = {
             name: 'campagne utilisateur',
             type: CampaignTypes.ASSESSMENT,
@@ -48,10 +90,31 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
         });
       });
 
+      describe('multiple sending case', function () {
+        it('throws an error when multipleSendings is not available', async function () {
+          organizationFeatures[apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key] = false;
+          const availableTargetProfileIds = [1, 2];
+          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+          const campaignData = {
+            name: 'campagne utilisateur',
+            type: CampaignTypes.ASSESSMENT,
+            creatorId: 1,
+            ownerId: 1,
+            multipleSendings: true,
+            organizationId: 2,
+            targetProfileId: 2,
+          };
+
+          const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+          expect(error).to.be.instanceOf(OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError);
+        });
+      });
+
       describe('when the targetProfileId is not given', function () {
         it('throws an error', async function () {
           const availableTargetProfileIds = [1, 2];
-          const creator = new CampaignCreator(availableTargetProfileIds);
+          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
           const campaignData = {
             name: 'campagne utilisateur',
             type: CampaignTypes.ASSESSMENT,

--- a/api/tests/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/unit/domain/models/CampaignForCreation_test.js
@@ -14,6 +14,8 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
             creatorId: 2,
             ownerId: 2,
             organizationId: 3,
+            title: '',
+            customLandingPageText: '',
           };
 
           expect(() => new CampaignForCreation(attributes)).to.not.throw();

--- a/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
@@ -55,6 +55,19 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
       },
     ];
 
+    const campaignCreatorPOJO = {
+      createCampaign: sinon
+        .stub()
+        .onFirstCall()
+        .resolves(campaignsWithAllData[0])
+        .onSecondCall()
+        .resolves(campaignsWithAllData[1]),
+    };
+
+    const campaignCreatorRepositoryStub = {
+      get: sinon.stub().resolves(campaignCreatorPOJO),
+    };
+
     campaignRepository.save.withArgs(campaignsWithAllData).resolves();
 
     const membershipRepository = {
@@ -69,6 +82,7 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
       membershipRepository,
       campaignRepository,
       campaignCodeGenerator: campaignCodeGeneratorStub,
+      campaignCreatorRepository: campaignCreatorRepositoryStub,
     });
 
     expect(campaignRepository.save).to.have.been.calledWith(campaignsWithAllData);

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -34,7 +34,10 @@ describe('Unit | UseCase | create-campaign', function () {
     };
     const campaignForCreation = new CampaignForCreation({ ...campaignData, code });
 
-    const campaignCreator = new CampaignCreator([targetProfileId]);
+    const campaignCreator = new CampaignCreator({
+      availableTargetProfileIds: [targetProfileId],
+      organizationFeatures: {},
+    });
     campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
 
     campaignCodeGeneratorStub.generate.resolves(code);
@@ -67,7 +70,10 @@ describe('Unit | UseCase | create-campaign', function () {
       targetProfileId,
       organizationId,
     };
-    const campaignCreator = new CampaignCreator([targetProfileId]);
+    const campaignCreator = new CampaignCreator({
+      availableTargetProfileIds: [targetProfileId],
+      organizationFeatures: {},
+    });
     campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
 
     campaignCodeGeneratorStub.generate.resolves(code);

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -2,7 +2,6 @@ import { expect, sinon } from '../../../test-helper.js';
 import { createCampaign } from '../../../../lib/domain/usecases/create-campaign.js';
 import { CampaignTypes } from '../../../../lib/domain/models/CampaignTypes.js';
 import { CampaignCreator } from '../../../../lib/domain/models/CampaignCreator.js';
-import { CampaignForCreation } from '../../../../lib/domain/models/CampaignForCreation.js';
 
 describe('Unit | UseCase | create-campaign', function () {
   let campaignRepository;
@@ -20,66 +19,33 @@ describe('Unit | UseCase | create-campaign', function () {
   it('should save the campaign', async function () {
     // given
     const code = 'ABCDEF123';
-    const targetProfileId = 12;
-    const creatorId = 13;
-    const ownerId = 13;
-    const organizationId = 14;
-    const campaignData = {
-      name: 'campagne utilisateur',
-      type: CampaignTypes.ASSESSMENT,
-      creatorId,
-      ownerId,
-      targetProfileId,
-      organizationId,
-    };
-    const campaignForCreation = new CampaignForCreation({ ...campaignData, code });
-
-    const campaignCreator = new CampaignCreator({
-      availableTargetProfileIds: [targetProfileId],
-      organizationFeatures: {},
-    });
-    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
-
-    campaignCodeGeneratorStub.generate.resolves(code);
-    campaignRepository.save.resolves();
-
-    // when
-    await createCampaign({
-      campaign: campaignData,
-      campaignRepository,
-      campaignCreatorRepository,
-      campaignCodeGenerator: campaignCodeGeneratorStub,
-    });
-
-    // then
-    expect(campaignRepository.save).to.have.been.calledWith(campaignForCreation);
-  });
-
-  it('should return the newly created campaign', async function () {
-    // given
-    const code = 'ABCDEF123';
-    const targetProfileId = 12;
-    const creatorId = 13;
-    const ownerId = 13;
-    const organizationId = 14;
-    const campaignData = {
-      name: 'campagne utilisateur',
-      type: CampaignTypes.ASSESSMENT,
-      creatorId,
-      ownerId,
-      targetProfileId,
-      organizationId,
-    };
-    const campaignCreator = new CampaignCreator({
-      availableTargetProfileIds: [targetProfileId],
-      organizationFeatures: {},
-    });
-    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
-
-    campaignCodeGeneratorStub.generate.resolves(code);
     const savedCampaign = Symbol('a saved campaign');
+    const campaignToCreate = Symbol('campaign to create');
+    const targetProfileId = 12;
+    const creatorId = 13;
+    const ownerId = 13;
+    const organizationId = 14;
+    const campaignData = {
+      name: 'campagne utilisateur',
+      type: CampaignTypes.ASSESSMENT,
+      creatorId,
+      ownerId,
+      targetProfileId,
+      organizationId,
+    };
 
-    campaignRepository.save.resolves(savedCampaign);
+    const campaignCreator = new CampaignCreator({
+      availableTargetProfileIds: [targetProfileId],
+      organizationFeatures: {},
+    });
+    campaignCreator.createCampaign = sinon
+      .stub()
+      .withArgs({ ...campaignData, code })
+      .returns(campaignToCreate);
+
+    campaignCodeGeneratorStub.generate.resolves(code);
+    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
+    campaignRepository.save.withArgs(campaignToCreate).resolves(savedCampaign);
 
     // when
     const campaign = await createCampaign({
@@ -90,6 +56,8 @@ describe('Unit | UseCase | create-campaign', function () {
     });
 
     // then
+    expect(campaignCreator.createCampaign).to.have.been.calledWith({ ...campaignData, code });
+    expect(campaignRepository.save).to.have.been.calledWith(campaignToCreate);
     expect(campaign).to.deep.equal(savedCampaign);
   });
 });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1065,11 +1065,11 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
-      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours\n";
+      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple\n";
 
     it('should return parsed campaign data', async function () {
       // given
-      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2`;
+      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non`;
 
       // when
       const [firstCampaign, secondCampaign] = await csvSerializer.parseForCampaignsImport(csv);
@@ -1084,6 +1084,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           title: 'titre 1',
           customLandingPageText: 'descriptif 1',
           creatorId: 789,
+          multipleSendings: true,
         },
         {
           organizationId: 2,
@@ -1093,6 +1094,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           title: 'titre 2',
           customLandingPageText: 'descriptif 2',
           creatorId: 666,
+          multipleSendings: false,
         },
       ];
       expect(firstCampaign).to.deep.equal(parsedData[0]);


### PR DESCRIPTION
## :unicorn: Problème
La création en masse des campagnes ne permet pas à l'heure actuelle d'activer l'envoi multiple

## :robot: Proposition
Ajouter cette nouvelle entrée dans le CSV afin de le prendre en compte

## :rainbow: Remarques
Utilisation du model CampaignCreator pour l'initialisation de la campaign to Create.
Si une orga dans le fichier n'a pas la feature d'activé rien n'est crée.

## :100: Pour tester
Se connecter sur PixAdmin et faire des import en masse sur une orga ayant la feature d'activer. et sur une ne l'ayant pas.

Vérifier que l'import ne créer pas les campagnes tant que le csv n'est pas correct

Vérifier que l'import ne fonctionne pas
```
Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple
6000;chaussette;1000000;numéro étudiant;6000;titre 1;descriptif 1;Oui
6002;chapeau;1000000;identifiant;6002;titre 2;descriptif 2;non
```
Activer l'envoi multiple sur l'orga 6000, et vérifier que l'import est OK