### PR TITLE
[TECH] Résoudre le problème des tests flaky de la team Accès (PIX-xxxx)

### DIFF
--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
@@ -2,6 +2,12 @@ import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Route | Account-recovery', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
   describe('PATCH /api/account-recovery', function () {
     afterEach(async function () {
       await knex('account-recovery-demands').delete();
@@ -10,7 +16,6 @@ describe('Acceptance | Route | Account-recovery', function () {
     context('when user has pix authentication method', function () {
       it("should proceed to the account recover by changing user's password and email", async function () {
         // given
-        const server = await createServer();
         const userId = databaseBuilder.factory.buildUser.withRawPassword({
           email: 'old-email@example.net',
           rawPassword: 'oldPassword',
@@ -57,7 +62,6 @@ describe('Acceptance | Route | Account-recovery', function () {
     context('when user has no pix authentication method', function () {
       it('should proceed to the account recover by create pix authentication method', async function () {
         // given
-        const server = await createServer();
         const userWithGarAuthenticationMethod = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
           cgu: false,
         });

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
@@ -10,7 +10,7 @@ describe('Acceptance | Route | Account-recovery', function () {
 
   describe('PATCH /api/account-recovery', function () {
     afterEach(async function () {
-      await knex('account-recovery-demands').delete();
+      await knex('account-recovery-demands').truncate();
     });
 
     context('when user has pix authentication method', function () {

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
@@ -96,13 +96,13 @@ describe('Acceptance | Route | Account-recovery', function () {
         const userAuthenticationMethods = await knex('authentication-methods')
           .select('identityProvider')
           .where({ userId: userWithGarAuthenticationMethod.id });
-        const { email: newUserEmail, cgu } = await knex('users')
+        const user = await knex('users')
           .select('email', 'cgu')
           .where({ id: userWithGarAuthenticationMethod.id })
           .first();
         expect(response.statusCode).to.equal(204);
-        expect(newUserEmail).to.equal('new-email@example.net');
-        expect(cgu).to.equal(true);
+        expect(user.email).to.equal('new-email@example.net');
+        expect(user.cgu).to.equal(true);
         expect(userAuthenticationMethods).to.deepEqualArray([{ identityProvider: 'GAR' }, { identityProvider: 'PIX' }]);
       });
     });

--- a/api/tests/integration/infrastructure/adapters/target-profile-adapter_test.js
+++ b/api/tests/integration/infrastructure/adapters/target-profile-adapter_test.js
@@ -4,7 +4,7 @@ import { BookshelfTargetProfileShare } from '../../../../lib/infrastructure/orm-
 import { TargetProfile } from '../../../../lib/domain/models/TargetProfile.js';
 import * as targetProfileAdapter from '../../../../lib/infrastructure/adapters/target-profile-adapter.js';
 
-describe('Unit | Infrastructure | Adapter | targetProfileAdapter', function () {
+describe('Integration | Infrastructure | Adapter | targetProfileAdapter', function () {
   it('should adapt TargetProfile object to domain', function () {
     // given
     const bookshelfTargetProfile = new BookshelfTargetProfile(databaseBuilder.factory.buildTargetProfile());

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -30,9 +30,9 @@ import { config } from '../lib/config.js';
 
 const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 import { knex, disconnect } from '../db/knex-database-connection.js';
-import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
+import { createDatabaseBuilder } from '../db/database-builder/database-builder.js';
 
-const databaseBuilder = new DatabaseBuilder({ knex });
+const databaseBuilder = await createDatabaseBuilder({ knex });
 
 import nock from 'nock';
 


### PR DESCRIPTION
## :unicorn: Problème

Il arrive que le test suivant dépasse le temps maximal autorisé pour les tests qui est par défaut de **2 secondes** ([lien vers CircleCI](https://app.circleci.com/pipelines/github/1024pix/pix/62651/workflows/34ca4e4d-c9e1-440b-99d7-3bf6295de52b/jobs/510449/tests#failed-test-0)).

> Acceptance | Application | Account-Recovery | Routes GET /api/account-recovery/{temporaryKey} should return 200 http status code when account recovery demand found

Ce problème arrive car c'est le premier test exécuté en acceptance et donc le premier test à faire l'initialisation de la base de données via le **DatabaseBuilder**. Cette première initialisation de la base de données peut prendre plus de temps que d'habitude.

Il faudrait retirer ce temps d'initialisation du temps octroyé au.x test.s.

## :robot: Proposition

Ajouter une factory pour créer une instance de DatabaseBuilder et initialiser la base de données.

## :rainbow: Remarques

- Un test unitaire utilisait databaseBuilder. Ce test a été déplacé en intégration
- Les tests unitaires utilise notre module `test-helper.js` qui crée une instance de `DatabaseBuilder`.
  - La solution proposée génère un problème.
  - La création d'une classe `DatabaseBuilderBase` étendu par `DatabaseBuilder`. Elle sera utilisée uniquement pour les tests unitaires

## :100: Pour tester

La CI reste ✅ après plusieurs lancement.
