### PR TITLE
[TECH] Corriger la taille d'image d'affiché sur la contenu formatif (PIX-9000)

### DIFF
--- a/admin/app/styles/components/trainings/training-details-card.scss
+++ b/admin/app/styles/components/trainings/training-details-card.scss
@@ -24,4 +24,9 @@
       content: '';
     }
   }
+
+  &__editor-logo {
+    width: 100%;
+    height: 100%;
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
Certains image sur la page contenu formatif déborde l'ecran

## :robot: Proposition
Ajoute les regles css pour que les images s'affichent correctement

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sur admin, allez sur le page contenu formatifs
Choisissez un contenu formatif et modifier l'image et choisir `reseau-canope.svg`
Verifier que la taille est correcte
