### PR TITLE
[FEATURE] Bloquer certificabilité et accès certif des versions précédentes du RT certifiant (PIX-8855)

### DIFF
--- a/api/lib/domain/models/ComplementaryCertificationBadge.js
+++ b/api/lib/domain/models/ComplementaryCertificationBadge.js
@@ -1,0 +1,31 @@
+class ComplementaryCertificationBadge {
+  constructor({
+    id,
+    level,
+    complementaryCertificationId,
+    badgeId,
+    createdAt,
+    imageUrl,
+    label,
+    certificateMessage,
+    temporaryCertificateMessage,
+    stickerUrl,
+    detachedAt,
+    createdBy,
+  }) {
+    this.id = id;
+    this.level = level;
+    this.complementaryCertificationId = complementaryCertificationId;
+    this.badgeId = badgeId;
+    this.createdAt = createdAt;
+    this.imageUrl = imageUrl;
+    this.label = label;
+    this.certificateMessage = certificateMessage;
+    this.temporaryCertificateMessage = temporaryCertificateMessage;
+    this.stickerUrl = stickerUrl;
+    this.detachedAt = detachedAt;
+    this.createdBy = createdBy;
+  }
+}
+
+export { ComplementaryCertificationBadge };

--- a/api/lib/domain/models/ComplementaryCertificationBadge.js
+++ b/api/lib/domain/models/ComplementaryCertificationBadge.js
@@ -26,6 +26,10 @@ class ComplementaryCertificationBadge {
     this.detachedAt = detachedAt;
     this.createdBy = createdBy;
   }
+
+  isOutdated() {
+    return this.detachedAt !== null;
+  }
 }
 
 export { ComplementaryCertificationBadge };

--- a/api/lib/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/lib/domain/usecases/get-certification-candidate-subscription.js
@@ -5,6 +5,7 @@ const getCertificationCandidateSubscription = async function ({
   certificationBadgesService,
   certificationCandidateRepository,
   certificationCenterRepository,
+  complementaryCertificationBadgeRepository,
 }) {
   const certificationCandidate =
     await certificationCandidateRepository.getWithComplementaryCertification(certificationCandidateId);
@@ -26,11 +27,17 @@ const getCertificationCandidateSubscription = async function ({
     userId: certificationCandidate.userId,
   });
 
-  if (certificationCenter.isHabilitated(certificationCandidate.complementaryCertification.key)) {
-    const isSubscriptionEligible = certifiableBadgeAcquisitions.some(
-      ({ complementaryCertificationKey }) =>
-        complementaryCertificationKey === certificationCandidate.complementaryCertification.key,
+  const complementaryCertificationBadges =
+    await complementaryCertificationBadgeRepository.findAllByComplementaryCertificationId(
+      certificationCandidate.complementaryCertification.id,
     );
+
+  if (certificationCenter.isHabilitated(certificationCandidate.complementaryCertification.key)) {
+    const isSubscriptionEligible =
+      certifiableBadgeAcquisitions.some(
+        ({ complementaryCertificationKey }) =>
+          complementaryCertificationKey === certificationCandidate.complementaryCertification.key,
+      ) && complementaryCertificationBadges.some((ccBadge) => !ccBadge.isOutdated());
 
     if (isSubscriptionEligible) {
       eligibleSubscription = certificationCandidate.complementaryCertification;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -80,6 +80,7 @@ import * as competenceTreeRepository from '../../infrastructure/repositories/com
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as complementaryCertificationHabilitationRepository from '../../infrastructure/repositories/complementary-certification-habilitation-repository.js';
 import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
+import * as complementaryCertificationBadgeRepository from '../../infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as complementaryCertificationTargetProfileHistoryRepository from '../../infrastructure/repositories/complementary-certification-target-profile-history-repository.js';
 import * as countryRepository from '../../infrastructure/repositories/country-repository.js';
 import * as courseRepository from '../../infrastructure/repositories/course-repository.js';
@@ -291,6 +292,7 @@ const dependencies = {
   complementaryCertificationCourseResultRepository,
   complementaryCertificationHabilitationRepository,
   complementaryCertificationRepository,
+  complementaryCertificationBadgeRepository,
   complementaryCertificationTargetProfileHistoryRepository,
   config,
   correctionRepository: repositories.correctionRepository,

--- a/api/lib/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,0 +1,19 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { NotFoundError } from '../../domain/errors.js';
+import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
+
+const findAllByComplementaryCertificationId = async function (complementaryCertificationId) {
+  const results = await knex('complementary-certification-badges').where({ complementaryCertificationId });
+
+  if (!results.length) {
+    throw new NotFoundError();
+  }
+
+  return results.map(_toDomain);
+};
+
+function _toDomain(complementaryCertificationBadge) {
+  return new ComplementaryCertificationBadge({ ...complementaryCertificationBadge });
+}
+
+export { findAllByComplementaryCertificationId };

--- a/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
@@ -1,6 +1,5 @@
 import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
-import { ComplementaryCertification } from '../../../../lib/domain/models/ComplementaryCertification.js';
 
 describe('Acceptance | API | Certifications candidates', function () {
   describe('POST /api/certification-candidates/:id/authorize-to-start', function () {
@@ -164,21 +163,13 @@ describe('Acceptance | API | Certifications candidates', function () {
       const server = await createServer();
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-      const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        key: ComplementaryCertification.CLEA,
-        label: 'CléA Numérique',
-      });
-      const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        key: ComplementaryCertification.PIX_PLUS_DROIT,
-        label: 'Pix+ Droit',
-      });
+      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'COMPLEMENTARY_CERTIFICATION_KEY',
+        label: 'COMPLEMENTARY_CERTIFICATION_LABEL',
+      }).id;
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
         certificationCenterId: certificationCenter.id,
-        complementaryCertificationId: cleaComplementaryCertification.id,
-      });
-      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-        certificationCenterId: certificationCenter.id,
-        complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
+        complementaryCertificationId,
       });
       const session = databaseBuilder.factory.buildSession({
         certificationCenterId: certificationCenter.id,
@@ -187,9 +178,16 @@ describe('Acceptance | API | Certifications candidates', function () {
         sessionId: session.id,
       });
 
+      const badgeId = databaseBuilder.factory.buildBadge().id;
+
       databaseBuilder.factory.buildComplementaryCertificationSubscription({
         certificationCandidateId: candidate.id,
-        complementaryCertificationId: cleaComplementaryCertification.id,
+        complementaryCertificationId,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        complementaryCertificationId,
+        badgeId,
       });
       await databaseBuilder.commit();
 
@@ -211,9 +209,9 @@ describe('Acceptance | API | Certifications candidates', function () {
           'session-id': session.id,
           'eligible-subscription': null,
           'non-eligible-subscription': {
-            id: cleaComplementaryCertification.id,
-            label: 'CléA Numérique',
-            key: ComplementaryCertification.CLEA,
+            id: complementaryCertificationId,
+            label: 'COMPLEMENTARY_CERTIFICATION_LABEL',
+            key: 'COMPLEMENTARY_CERTIFICATION_KEY',
           },
         },
       });

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-badge-repository_test.js
@@ -1,0 +1,59 @@
+import { databaseBuilder, expect, domainBuilder, catchErr } from '../../../test-helper.js';
+import * as complementaryCertificationBadgeRepository from '../../../../lib/infrastructure/repositories/complementary-certification-badge-repository.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Integration | Repository | complementary-certification-repository', function () {
+  describe('#findAllByComplementaryCertificationId', function () {
+    context(
+      'when at least one complementary certification badge is linked to a complementary certification',
+      function () {
+        it('should return a list of ComplementaryCertificationBadge', async function () {
+          // given
+          const badgeId = databaseBuilder.factory.buildBadge().id;
+          const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+          const ccBadge1 = databaseBuilder.factory.buildComplementaryCertificationBadge({
+            badgeId,
+            complementaryCertificationId,
+            label: 'complementary certification badge 1',
+          });
+          const ccBadge2 = databaseBuilder.factory.buildComplementaryCertificationBadge({
+            badgeId,
+            complementaryCertificationId,
+            label: 'complementary certification badge 1',
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const results =
+            await complementaryCertificationBadgeRepository.findAllByComplementaryCertificationId(
+              complementaryCertificationId,
+            );
+
+          // then
+          expect(results).to.deepEqualArray([
+            domainBuilder.buildComplementaryCertificationBadge({ ...ccBadge1 }),
+            domainBuilder.buildComplementaryCertificationBadge({ ...ccBadge2 }),
+          ]);
+        });
+      },
+    );
+
+    context('when no complementary certification badge is linked to a complementary certification', function () {
+      it('should throw an error', async function () {
+        // given
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(complementaryCertificationBadgeRepository.findAllByComplementaryCertificationId)(
+          complementaryCertificationId,
+        );
+
+        // then
+        expect(error).to.be.an.instanceOf(NotFoundError);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-badge.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-badge.js
@@ -1,0 +1,33 @@
+import { ComplementaryCertificationBadge } from '../../../../lib/domain/models/ComplementaryCertificationBadge.js';
+
+const buildComplementaryCertificationBadge = function ({
+  id = 1,
+  level = 1,
+  complementaryCertificationId,
+  badgeId,
+  createdAt = new Date('2020-01-01'),
+  imageUrl = 'http://badge-image-url.fr',
+  label = 'Label par defaut',
+  certificateMessage = null,
+  temporaryCertificateMessage = null,
+  stickerUrl = 'http://stiker-url.fr',
+  detachedAt = null,
+  createdBy = null,
+}) {
+  return new ComplementaryCertificationBadge({
+    id,
+    level,
+    complementaryCertificationId,
+    badgeId,
+    createdAt,
+    imageUrl,
+    label,
+    certificateMessage,
+    temporaryCertificateMessage,
+    stickerUrl,
+    detachedAt,
+    createdBy,
+  });
+};
+
+export { buildComplementaryCertificationBadge };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -68,6 +68,7 @@ import { buildCompetenceMark } from './build-competence-mark.js';
 import { buildCompetenceResult } from './build-competence-result.js';
 import { buildCompetenceTree } from './build-competence-tree.js';
 import { buildComplementaryCertification } from './build-complementary-certification.js';
+import { buildComplementaryCertificationBadge } from './build-complementary-certification-badge.js';
 import { buildComplementaryCertificationBadgeForAdmin } from './build-complementary-certification-badge-for-admin.js';
 import { buildComplementaryCertificationTargetProfileHistory } from './build-complementary-certification-target-profile-history-for-admin.js';
 import { buildComplementaryCertificationForSupervising } from './build-complementary-certification-for-supervising.js';
@@ -224,6 +225,7 @@ export {
   buildCompetenceResult,
   buildCompetenceTree,
   buildComplementaryCertification,
+  buildComplementaryCertificationBadge,
   buildComplementaryCertificationBadgeForAdmin,
   buildComplementaryCertificationTargetProfileHistory,
   buildComplementaryCertificationForSupervising,

--- a/api/tests/unit/domain/models/ComplementaryCertificationBadge_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationBadge_test.js
@@ -1,0 +1,31 @@
+import { expect, domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Domain | Models | ComplementaryCertificationBadge', function () {
+  describe('#isOutdated', function () {
+    it('should return true if detached at is not null', function () {
+      // given
+      const complementaryCertificationBadge = domainBuilder.buildComplementaryCertificationBadge({
+        detachedAt: new Date(),
+      });
+
+      // when
+      const result = complementaryCertificationBadge.isOutdated();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if detached at is null', function () {
+      // given
+      const complementaryCertificationBadge = domainBuilder.buildComplementaryCertificationBadge({
+        detachedAt: null,
+      });
+
+      // when
+      const result = complementaryCertificationBadge.isOutdated();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le versioning des profils cibles et des résultats thématiques certifiants doit permettre d’assurer la pérennité des certifications complémentaires Pix en conservant un historique des différentes versions de profil cible et de RT certifiants sur lesquels elles sont basées.

Les utilisateurs Pix Admin habilités (ADMIN, METIER, SUPPORT) à créer de nouveaux profils cibles ont besoin de pouvoir détacher l'ancien PC et de rattacher le nouveau aux certifications complémentaires correspondantes (ainsi que les RT certifiants liés) afin de faire évoluer celles-ci selon les besoins de nos commanditaires.

Afin de garantir l'équité entre les candidats, une seule version de la certification complémentaire peut être proposée à un instant t. Cette version unique doit être la dernière en date, à l’exclusion des précédentes.

Un candidat ayant passé une campagne basée sur une ancienne version de la certification complémentaire concernée a obtenu un RT certifiant basé sur la version du PC précédemment rattachée à la certification complémentaire et non sur la version actuelle.


## :robot: Proposition
- Prendre en compte le "detachedAt" pour l'éligibilité à une certification complémentaire :

Seul un candidat ayant obtenu le RT certifiant lié au PC actuellement rattaché à la certification complémentaire concernée doit être éligible. Les autres sont exclus.

- Prendre en compte le "detachedAt" pour le passage de la certif : 

Seul un candidat ayant obtenu le RT certifiant lié au PC actuellement rattaché à la certification complémentaire concernée se voit proposer des questions liées à cette certification complémentaire pendant son examen. Les autres sont exclus.

Note : un deuxième volet est prévu pour afficher un message à l’utilisateur. Le message ne fait pas parti de ce ticket.
## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Si un candidat  a acquis un badge qui a depuis été  "détaché" , alors après la réconciliation et avant de rentrer son code d’accès candidat, il doit voir le message suivant.

![image](https://github.com/1024pix/pix/assets/37305474/ffb1808f-df87-43f3-ae42-cf09c0974913)


- Si le surveillant a un candidat  ayant acquis un badge qui a depuis été  "détaché" et qui est malgré tout inscrit à cette certification complémentaire, alors après réconciliation du candidat et avant que celui-ci n’entre son code d’accès candidat, il doit voir le message d’alerte suivant dans l’Espace Surveillant.

![image](https://github.com/1024pix/pix/assets/37305474/788bc67d-9722-4e0e-a713-a321b393f556)
