### PR TITLE
[TECH] Remplacement de la librairie obsolète `request` par `axios`.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -64,8 +64,6 @@
         "pino-pretty": "^10.0.0",
         "randomstring": "^1.2.2",
         "redlock": "^4.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "samlify": "^2.8.5",
         "sax": "^1.2.4",
         "saxpath": "^0.6.5",
@@ -3228,6 +3226,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3485,14 +3484,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3526,19 +3517,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axios": {
       "version": "1.4.0",
@@ -3585,14 +3563,6 @@
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/big-integer": {
@@ -3898,11 +3868,6 @@
         }
       ],
       "peer": true
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chai": {
       "version": "4.3.7",
@@ -4313,17 +4278,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/dateformat": {
@@ -4753,15 +4707,6 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -5823,11 +5768,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5978,14 +5918,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-copy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
@@ -5994,7 +5926,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -6033,7 +5966,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "3.0.0",
@@ -6245,14 +6179,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -6445,14 +6371,6 @@
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
       "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -6630,27 +6548,6 @@
         "joi": "17.x"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6820,20 +6717,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
     },
     "node_modules/http-status": {
       "version": "1.6.2",
@@ -7430,11 +7313,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
@@ -7505,11 +7383,6 @@
         "ws": "*"
       }
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-    },
     "node_modules/jest-diff": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
@@ -7578,11 +7451,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7601,15 +7469,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7620,7 +7484,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7700,20 +7565,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -8807,14 +8658,6 @@
         "set-blocking": "^2.0.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9309,11 +9152,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
     "node_modules/pg": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.2.tgz",
@@ -9776,11 +9614,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -9800,16 +9633,9 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/query-ast": {
@@ -10141,90 +9967,6 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -10958,30 +10700,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "node_modules/sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -10993,14 +10711,6 @@
       "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
       "dependencies": {
         "escodegen": "^1.8.1"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stream-browserify": {
@@ -11413,18 +11123,6 @@
         "node": "*"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -11458,22 +11156,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -11654,6 +11336,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11688,24 +11371,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -70,8 +70,6 @@
     "pino-pretty": "^10.0.0",
     "randomstring": "^1.2.2",
     "redlock": "^4.2.0",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "samlify": "^2.8.5",
     "sax": "^1.2.4",
     "saxpath": "^0.6.5",

--- a/api/scripts/certification/get-results-certifications-old.js
+++ b/api/scripts/certification/get-results-certifications-old.js
@@ -1,4 +1,4 @@
-import request from 'request-promise-native';
+import axios from 'axios';
 import { Parser } from '@json2csv/plainjs';
 import moment from 'moment-timezone';
 import * as url from 'url';
@@ -31,23 +31,18 @@ function parseArgs(argv) {
   return argv.slice(3);
 }
 
-function buildRequestObject(baseUrl, authToken, certificationId) {
+function buildRequestObject(baseURL, authToken, certificationId) {
   return {
     headers: {
       authorization: 'Bearer ' + authToken,
     },
-    baseUrl: baseUrl,
+    baseURL,
     url: `/api/admin/certifications/${certificationId}/details`,
-    json: true,
-    transform: (body) => {
+    transformResponse: (body) => {
       body.certificationId = certificationId;
       return body;
     },
   };
-}
-
-function makeRequest(config) {
-  return request(config);
 }
 
 function findCompetence(profile, competenceName) {
@@ -74,11 +69,11 @@ function toCSVRow(rowJSON) {
 }
 
 function main() {
-  const baseUrl = process.argv[2];
+  const baseURL = process.argv[2];
   const authToken = process.argv[3];
   const ids = parseArgs(process.argv.slice(4));
   const requests = Promise.all(
-    ids.map((id) => buildRequestObject(baseUrl, authToken, id)).map((requestObject) => makeRequest(requestObject)),
+    ids.map((id) => buildRequestObject(baseURL, authToken, id)).map((requestObject) => axios(requestObject)),
   );
 
   requests

--- a/api/scripts/certification/get-results-certifications.js
+++ b/api/scripts/certification/get-results-certifications.js
@@ -1,5 +1,5 @@
 import fileSystem from 'fs';
-import request from 'request-promise-native';
+import axios from 'axios';
 import { Parser } from '@json2csv/plainjs';
 import moment from 'moment-timezone';
 import * as url from 'url';
@@ -37,25 +37,23 @@ const HEADERS = [
   '5.2',
 ];
 
-function buildSessionRequest(baseUrl, authToken, sessionId) {
+function buildSessionRequest(baseURL, authToken, sessionId) {
   return {
     headers: {
       authorization: 'Bearer ' + authToken,
     },
-    baseUrl: baseUrl,
+    baseURL,
     url: `/api/sessions/${sessionId}`,
-    json: true,
   };
 }
 
-function buildCertificationRequest(baseUrl, authToken, certificationId) {
+function buildCertificationRequest(baseURL, authToken, certificationId) {
   return {
     headers: {
       authorization: 'Bearer ' + authToken,
     },
-    baseUrl: baseUrl,
+    baseURL,
     url: `/api/admin/certifications/${certificationId}`,
-    json: true,
     simple: false,
   };
 }
@@ -135,11 +133,11 @@ function saveInFile(csv, sessionId) {
 }
 
 function main() {
-  const baseUrl = process.argv[2];
+  const baseURL = process.argv[2];
   const authToken = process.argv[3];
   const sessionId = process.argv[4];
-  const sessionRequest = buildSessionRequest(baseUrl, authToken, sessionId);
-  return request(sessionRequest)
+  const sessionRequest = buildSessionRequest(baseURL, authToken, sessionId);
+  return axios(sessionRequest)
     .then((session) => {
       return session.data.relationships.certifications.data.map((certification) => {
         return certification.id;
@@ -154,8 +152,8 @@ function main() {
     .then((certificationIds) => {
       const certificationsRequests = Promise.all(
         certificationIds
-          .map((certificationId) => buildCertificationRequest(baseUrl, authToken, certificationId))
-          .map((requestObject) => request(requestObject)),
+          .map((certificationId) => buildCertificationRequest(baseURL, authToken, certificationId))
+          .map((requestObject) => axios(requestObject)),
       );
 
       return certificationsRequests

--- a/api/scripts/create-or-update-sco-organizations.js
+++ b/api/scripts/create-or-update-sco-organizations.js
@@ -4,7 +4,7 @@
 import dotenv from 'dotenv';
 
 dotenv.config();
-import request from 'request-promise-native';
+import axios from 'axios';
 
 import { logoUrl } from './logo/default-sco-organization-logo-base64.js';
 import {
@@ -15,7 +15,7 @@ import { parseCsv } from './helpers/csvHelpers.js';
 import { disconnect } from '../db/knex-database-connection.js';
 import * as url from 'url';
 
-const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
 
 function checkData({ csvData }) {
   return csvData
@@ -50,9 +50,9 @@ async function createOrUpdateOrganizations({ accessToken, organizationsByExterna
     const organization = organizationsByExternalId[externalId];
 
     if (organization && (name !== organization.name || !organization['logo-url'])) {
-      await request(_buildPatchOrganizationRequestObject(accessToken, { id: organization.id, name, logoUrl }));
+      await axios(_buildPatchOrganizationRequestObject(accessToken, { id: organization.id, name, logoUrl }));
     } else if (!organization) {
-      await request(
+      await axios(
         _buildPostOrganizationRequestObject(accessToken, {
           name,
           externalId,
@@ -67,7 +67,7 @@ async function createOrUpdateOrganizations({ accessToken, organizationsByExterna
 function _buildAccessTokenRequestObject() {
   return {
     method: 'POST',
-    baseUrl,
+    baseURL,
     url: '/api/token',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -87,10 +87,10 @@ function _buildPatchOrganizationRequestObject(accessToken, organization) {
     headers: {
       authorization: `Bearer ${accessToken}`,
     },
-    baseUrl,
+    baseURL,
     url: `/api/organizations/${organization.id}`,
     json: true,
-    body: {
+    data: {
       data: {
         type: 'organizations',
         id: organization.id,
@@ -109,10 +109,9 @@ function _buildPostOrganizationRequestObject(accessToken, organization) {
     headers: {
       authorization: `Bearer ${accessToken}`,
     },
-    baseUrl,
+    baseURL,
     url: '/api/organizations',
-    json: true,
-    body: {
+    data: {
       data: {
         type: 'organizations',
         attributes: {
@@ -144,7 +143,7 @@ async function main() {
   console.log('ok');
 
   console.log('Requesting API access token... ');
-  const { access_token: accessToken } = await request(_buildAccessTokenRequestObject());
+  const { access_token: accessToken } = await axios(_buildAccessTokenRequestObject());
   console.log('ok');
 
   console.log('Fetching existing organizations... ');

--- a/api/scripts/fill-score-level.js
+++ b/api/scripts/fill-score-level.js
@@ -1,17 +1,16 @@
-import request from 'request-promise-native';
+import axios from 'axios';
 import * as url from 'url';
 
 function parseArgs(argv) {
   return argv.slice(3);
 }
 
-function buildRequestObject(baseUrl, assessmentId) {
+function buildRequestObject(baseURL, assessmentId) {
   return {
-    baseUrl: baseUrl,
+    baseURL,
     method: 'POST',
     url: '/api/assessment-results/',
-    json: true,
-    body: {
+    data: {
       data: {
         attributes: {
           'estimated-level': null,
@@ -32,10 +31,10 @@ function buildRequestObject(baseUrl, assessmentId) {
 }
 
 function main() {
-  const baseUrl = process.argv[2];
+  const baseURL = process.argv[2];
   const ids = parseArgs(process.argv);
   const requests = Promise.all(
-    ids.map((id) => buildRequestObject(baseUrl, id)).map((requestObject) => request(requestObject)),
+    ids.map((id) => buildRequestObject(baseURL, id)).map((requestObject) => axios(requestObject)),
   );
 
   return requests.then(() => {

--- a/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
+++ b/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 import { disconnect } from '../db/knex-database-connection.js';
-import request from 'request-promise-native';
+import axios from 'axios';
 import {
   findOrganizationsByExternalIds,
   organizeOrganizationsByExternalId,
@@ -13,7 +13,7 @@ import {
 import { parseCsv } from './helpers/csvHelpers.js';
 import * as url from 'url';
 
-const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
 
 function checkData({ csvData }) {
   return csvData
@@ -39,7 +39,7 @@ async function updateOrganizations({ accessToken, organizationsByExternalId, che
     const organization = organizationsByExternalId[externalId];
 
     if (organization) {
-      await request(_buildPatchOrganizationRequestObject(accessToken, { id: organization.id }));
+      await axios(_buildPatchOrganizationRequestObject(accessToken, { id: organization.id }));
     }
   }
 }
@@ -47,7 +47,7 @@ async function updateOrganizations({ accessToken, organizationsByExternalId, che
 function _buildAccessTokenRequestObject() {
   return {
     method: 'POST',
-    baseUrl,
+    baseURL,
     url: '/api/token',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -67,10 +67,9 @@ function _buildPatchOrganizationRequestObject(accessToken, organization) {
     headers: {
       authorization: `Bearer ${accessToken}`,
     },
-    baseUrl,
+    baseURL,
     url: `/api/organizations/${organization.id}`,
-    json: true,
-    body: {
+    data: {
       data: {
         type: 'organizations',
         id: organization.id,
@@ -99,7 +98,7 @@ async function main() {
   console.log('ok');
 
   console.log('Requesting API access token... ');
-  const { access_token: accessToken } = await request(_buildAccessTokenRequestObject());
+  const { access_token: accessToken } = await axios(_buildAccessTokenRequestObject());
   console.log('ok');
 
   console.log('Fetching existing organizations... ');

--- a/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
+++ b/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
@@ -5,7 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { access } from 'fs/promises';
 
-import request from 'request-promise-native';
+import axios from 'axios';
 import papa from 'papaparse';
 import { disconnect } from '../db/knex-database-connection.js';
 import * as url from 'url';
@@ -48,10 +48,9 @@ function _buildRequestObject(accessToken, organization) {
   return {
     method: 'PATCH',
     headers: { authorization: `Bearer ${accessToken}` },
-    baseUrl: process.env.BASE_URL,
+    baseURL: process.env.BASE_URL,
     url: `/api/organizations/${organization.id}`,
-    json: true,
-    body: {
+    data: {
       data: {
         type: 'organizations',
         id: organization.id,
@@ -67,7 +66,7 @@ function _buildRequestObject(accessToken, organization) {
 function _buildTokenRequestObject() {
   return {
     method: 'POST',
-    baseUrl: process.env.BASE_URL,
+    baseURL: process.env.BASE_URL,
     url: '/api/token',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     form: {
@@ -89,7 +88,7 @@ function saveOrganizations(options) {
 
   const promises = options.organizations.map((organization) => {
     const requestConfig = _buildRequestObject(options.accessToken, organization);
-    return request(requestConfig).catch((err) => {
+    return axios(requestConfig).catch((err) => {
       errorObjects.push({
         errorMessage: err.message,
         organization,
@@ -120,7 +119,7 @@ async function main() {
   console.log("Début du script de mise à jour des Organisations avec l'ID externe et le département");
   const filePath = process.argv[2];
 
-  const response = await request(_buildTokenRequestObject());
+  const response = await axios(_buildTokenRequestObject());
   const accessToken = response.access_token;
 
   console.log('\nTest de validité du fichier...');

--- a/api/tests/acceptance/scripts/certification/import-certifications-from-csv_test.js
+++ b/api/tests/acceptance/scripts/certification/import-certifications-from-csv_test.js
@@ -125,7 +125,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', function ()
 
     beforeEach(function () {
       options = {
-        baseUrl: 'http://localhost:3000',
+        baseURL: 'http://localhost:3000',
         accessToken: 'coucou-je-suis-un-token',
         certifications: [],
       };
@@ -440,7 +440,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', function ()
         };
         const expectedErrorObjects = [
           {
-            errorMessage: 'Error: Error 1',
+            errorMessage: 'Error 1',
             certification: {
               id: 1,
               firstName: 'Tony',
@@ -451,7 +451,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', function ()
             },
           },
           {
-            errorMessage: 'Error: Error 2',
+            errorMessage: 'Error 2',
             certification: {
               id: 2,
               firstName: 'Booby',

--- a/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
+++ b/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
@@ -356,7 +356,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
         };
         const expectedErrorObjects = [
           {
-            errorMessage: 'Error: Error 1',
+            errorMessage: 'Error 1',
             organization: {
               id: 1,
               externalId: '9752145V',
@@ -364,7 +364,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
             },
           },
           {
-            errorMessage: 'Error: Error 2',
+            errorMessage: 'Error 2',
             organization: {
               id: 2,
               externalId: '',

--- a/api/tests/unit/scripts/get-results-certifications-old_test.js
+++ b/api/tests/unit/scripts/get-results-certifications-old_test.js
@@ -27,23 +27,22 @@ describe('Get Result Certifications Script OLD', function () {
     it('should take an id and return a request object', function () {
       // given
       const courseId = 12;
-      const baseUrl = 'http://localhost:3000';
+      const baseURL = 'http://localhost:3000';
       const authToken = 'jwt.tokken';
 
       // when
-      const result = buildRequestObject(baseUrl, authToken, courseId);
+      const result = buildRequestObject(baseURL, authToken, courseId);
       // then
-      expect(result).to.have.property('json', true);
       expect(result).to.have.property('url', '/api/admin/certifications/12/details');
       expect(result.headers).to.have.property('authorization', 'Bearer jwt.tokken');
     });
 
     it('should add certificationId to API response when the object is transform after the request', function () {
       // given
-      const baseUrl = 'http://localhost:3000';
-      const requestObject = buildRequestObject(baseUrl, '', 12);
+      const baseURL = 'http://localhost:3000';
+      const requestObject = buildRequestObject(baseURL, '', 12);
       // when
-      const result = requestObject.transform({});
+      const result = requestObject.transformResponse({});
       // then
       expect(result).to.have.property('certificationId', 12);
     });

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -47,7 +47,6 @@ describe('Unit | Scripts | get-results-certifications.js', function () {
       // when
       const result = getResultsCertifications.buildCertificationRequest(baseUrl, authToken, courseId);
       // then
-      expect(result).to.have.property('json', true);
       expect(result).to.have.property('url', '/api/admin/certifications/12');
       expect(result.headers).to.have.property('authorization', 'Bearer jwt.tokken');
     });
@@ -62,7 +61,6 @@ describe('Unit | Scripts | get-results-certifications.js', function () {
       // when
       const result = getResultsCertifications.buildSessionRequest(baseUrl, authToken, sessionId);
       // then
-      expect(result).to.have.property('json', true);
       expect(result).to.have.property('url', '/api/sessions/12');
       expect(result.headers).to.have.property('authorization', 'Bearer jwt.tokken');
     });


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'exécution de `npm ci` dans le dossier `api` on remarque les avertissements suivants : 
```
npm WARN deprecated request-promise-native@1.0.9: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
```

Après analyse, ces 3 avertissements sont liés à l'utilisation de `request` pour effectuer des appels htttp. Le paquet `request` étant désormais obsolète, il est nécessaire de trouver une alternative.

## :robot: Proposition
`axios` offre une solution de remplacement et est déjà utilisée dans l'api.
Principalement, on renomme le paramètre `body` en `data`, et `baseUrl` en `baseURL`.

## :rainbow: Remarques
L'API en elle-même n'effectue pas d'appel http via `request`, les changements sont localisés uniquement dans des scripts.

## :100: Pour tester
Seuls les scripts suivants sont impactés:
```
 api/scripts/certification/get-results-certifications-old.js
 api/scripts/certification/get-results-certifications.js
 api/scripts/certification/import-certifications-from-csv.js
 api/scripts/create-or-update-sco-organizations.js
 api/scripts/fill-score-level.js
 api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
 api/scripts/update-sco-organizations-with-province-code-and-external-id.js
 ```
 
 Il convient de les tester sur la review app pour s'assurer que le changement n'introduit pas de bug.

En local, un `npm ci` dans le dossier `api` ne doit plus afficher d'avertissements liés à l'obsolescence de `request`, `request-promise-native` et `har-validator`.