### PR TITLE
[FEATURE] Ajouter et alimenter une colonne lastLoggedAt dans la table user-logins (PIX-9008)

### DIFF
--- a/api/db/database-builder/factory/build-user-login.js
+++ b/api/db/database-builder/factory/build-user-login.js
@@ -9,6 +9,7 @@ function buildUserLogin({
   blockedAt = null,
   createdAt = new Date(),
   updatedAt = new Date(),
+  lastLoggedAt = null,
 } = {}) {
   if (!userId) {
     userId = buildUser().id;
@@ -22,6 +23,7 @@ function buildUserLogin({
     blockedAt,
     createdAt,
     updatedAt,
+    lastLoggedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'user-logins',

--- a/api/db/migrations/20230828130700_add-user-logged-at-column-in-user-logins.js
+++ b/api/db/migrations/20230828130700_add-user-logged-at-column-in-user-logins.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'user-logins';
+const COLUMN_NAME = 'lastLoggedAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/team-acces/build-sco-organization-learners.js
+++ b/api/db/seeds/data/team-acces/build-sco-organization-learners.js
@@ -98,7 +98,7 @@ function _buildScoOrganizationLearnerWithUsernameAndEmail(databaseBuilder) {
 }
 
 function _buildScoOrganizationLearnerWithEmailAndMediacentre(databaseBuilder) {
-  const user = databaseBuilder.factory.buildUser({
+  const userWithoutPixAuthenticationMethod = databaseBuilder.factory.buildUser({
     firstName: 'Bart',
     lastName: 'Simpson',
     email: 'bart@school.net',
@@ -106,13 +106,13 @@ function _buildScoOrganizationLearnerWithEmailAndMediacentre(databaseBuilder) {
   });
 
   const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
-    firstName: user.firstName,
-    lastName: user.lastName,
-    birthdate: '2013-03-03',
+    firstName: userWithoutPixAuthenticationMethod.firstName,
+    lastName: userWithoutPixAuthenticationMethod.lastName,
+    birthdate: '2010-03-03',
     division: '6B',
     group: null,
     organizationId: SCO_ORGANIZATION_ID,
-    userId: user.id,
+    userId: userWithoutPixAuthenticationMethod.id,
     nationalStudentId: '123456789BS',
   });
 
@@ -121,7 +121,25 @@ function _buildScoOrganizationLearnerWithEmailAndMediacentre(databaseBuilder) {
     userLastName: organizationLearner.lastName,
     identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
     externalIdentifier: 'externalBS',
-    userId: user.id,
+    userId: userWithoutPixAuthenticationMethod.id,
+  });
+
+  const userWithPixAuthenticationMethod = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Chihiro',
+    lastName: 'Ogino',
+    email: 'chihiro.ogino@miyazaki.net',
+    username: null,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: userWithPixAuthenticationMethod.firstName,
+    lastName: userWithPixAuthenticationMethod.lastName,
+    birthdate: '2013-01-01',
+    division: '6B',
+    group: null,
+    organizationId: SCO_ORGANIZATION_ID,
+    userId: userWithPixAuthenticationMethod.id,
+    nationalStudentId: '123456789CO',
   });
 }
 

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -20,6 +20,7 @@ async function authenticateExternalUser({
   obfuscationService,
   authenticationMethodRepository,
   userRepository,
+  userLoginRepository,
 }) {
   try {
     const userFromCredentials = await pixAuthenticationService.getUserByUsernameAndPassword({
@@ -52,7 +53,10 @@ async function authenticateExternalUser({
     }
 
     const token = tokenService.createAccessTokenForSaml(userFromCredentials.id);
+
     await userRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
+    await userLoginRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
+
     return token;
   } catch (error) {
     if (error instanceof UserNotFoundError || error instanceof PasswordNotMatching) {

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -35,6 +35,7 @@ const authenticateUser = async function ({
   pixAuthenticationService,
   tokenService,
   userRepository,
+  userLoginRepository,
   adminMemberRepository,
 }) {
   try {
@@ -66,6 +67,8 @@ const authenticateUser = async function ({
     }
 
     await userRepository.updateLastLoggedAt({ userId: foundUser.id });
+    await userLoginRepository.updateLastLoggedAt({ userId: foundUser.id });
+
     return { accessToken, refreshToken, expirationDelaySeconds };
   } catch (error) {
     if (

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -10,6 +10,7 @@ const authenticateOidcUser = async function ({
   authenticationSessionService,
   authenticationMethodRepository,
   userRepository,
+  userLoginRepository,
 }) {
   if (stateSent !== stateReceived) {
     logger.error(`State sent ${stateSent} did not match the state received ${stateReceived}`);
@@ -46,6 +47,7 @@ const authenticateOidcUser = async function ({
     userId: user.id,
   });
   userRepository.updateLastLoggedAt({ userId: user.id });
+  userLoginRepository.updateLastLoggedAt({ userId: user.id });
 
   return { pixAccessToken, logoutUrlUUID, isAuthenticationComplete: true };
 };

--- a/api/lib/domain/usecases/create-oidc-user.js
+++ b/api/lib/domain/usecases/create-oidc-user.js
@@ -10,6 +10,7 @@ const createOidcUser = async function ({
   authenticationMethodRepository,
   userToCreateRepository,
   userRepository,
+  userLoginRepository,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
   if (!sessionContentAndUserInfo) {
@@ -46,6 +47,7 @@ const createOidcUser = async function ({
   const accessToken = oidcAuthenticationService.createAccessToken(userId);
   const logoutUrlUUID = await oidcAuthenticationService.saveIdToken({ idToken: sessionContent.idToken, userId });
   await userRepository.updateLastLoggedAt({ userId });
+  await userLoginRepository.updateLastLoggedAt({ userId });
 
   return { accessToken, logoutUrlUUID };
 };

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -21,6 +21,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   authenticationMethodRepository,
   campaignRepository,
   userRepository,
+  userLoginRepository,
   userToCreateRepository,
   organizationLearnerRepository,
   studentRepository,
@@ -117,6 +118,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
   const accessToken = tokenService.createAccessTokenForSaml(tokenUserId);
   await userRepository.updateLastLoggedAt({ userId: tokenUserId });
+  await userLoginRepository.updateLastLoggedAt({ userId: tokenUserId });
   return accessToken;
 };
 

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -4,6 +4,7 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js'
 const getExternalAuthenticationRedirectionUrl = async function ({
   userAttributes,
   userRepository,
+  userLoginRepository,
   authenticationMethodRepository,
   tokenService,
   config,
@@ -23,6 +24,7 @@ const getExternalAuthenticationRedirectionUrl = async function ({
       externalUser,
       tokenService,
       userRepository,
+      userLoginRepository,
       authenticationMethodRepository,
     });
   }
@@ -37,10 +39,12 @@ async function _getUrlWithAccessToken({
   externalUser,
   tokenService,
   userRepository,
+  userLoginRepository,
   authenticationMethodRepository,
 }) {
   const token = tokenService.createAccessTokenForSaml(user.id);
   await userRepository.updateLastLoggedAt({ userId: user.id });
+  await userLoginRepository.updateLastLoggedAt({ userId: user.id });
   await _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser });
   return `/connexion/gar#${encodeURIComponent(token)}`;
 }

--- a/api/lib/domain/usecases/reconcile-oidc-user.js
+++ b/api/lib/domain/usecases/reconcile-oidc-user.js
@@ -7,6 +7,7 @@ const reconcileOidcUser = async function ({
   authenticationSessionService,
   authenticationMethodRepository,
   userRepository,
+  userLoginRepository,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
   if (!sessionContentAndUserInfo) {
@@ -35,7 +36,9 @@ const reconcileOidcUser = async function ({
     idToken: sessionContent.idToken,
     userId,
   });
-  userRepository.updateLastLoggedAt({ userId });
+
+  await userRepository.updateLastLoggedAt({ userId });
+  await userLoginRepository.updateLastLoggedAt({ userId });
 
   return { accessToken, logoutUrlUUID };
 };

--- a/api/lib/infrastructure/repositories/user-login-repository.js
+++ b/api/lib/infrastructure/repositories/user-login-repository.js
@@ -1,6 +1,8 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { UserLogin } from '../../domain/models/UserLogin.js';
 
+const USER_LOGINS_TABLE_NAME = 'user-logins';
+
 function _toDomain(userLoginDTO) {
   return new UserLogin({
     id: userLoginDTO.id,
@@ -14,25 +16,28 @@ function _toDomain(userLoginDTO) {
 }
 
 const findByUserId = async function (userId) {
-  const foundUserLogin = await knex.from('user-logins').where({ userId }).first();
+  const foundUserLogin = await knex.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
   return foundUserLogin ? _toDomain(foundUserLogin) : null;
 };
 
 const create = async function (userLogin) {
-  const [userLoginDTO] = await knex('user-logins').insert(userLogin).returning('*');
+  const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME).insert(userLogin).returning('*');
   return _toDomain(userLoginDTO);
 };
 
 const update = async function (userLogin) {
   userLogin.updatedAt = new Date();
-  const [userLoginDTO] = await knex('user-logins').where({ id: userLogin.id }).update(userLogin).returning('*');
+  const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME)
+    .where({ id: userLogin.id })
+    .update(userLogin)
+    .returning('*');
   return _toDomain(userLoginDTO);
 };
 
 const findByUsername = async function (username) {
   const foundUserLogin = await knex
     .select('user-logins.*')
-    .from('user-logins')
+    .from(USER_LOGINS_TABLE_NAME)
     .where('users.email', username.toLowerCase())
     .orWhere('users.username', username.toLowerCase())
     .join('users', 'users.id', 'user-logins.userId')
@@ -44,7 +49,7 @@ const findByUsername = async function (username) {
 const updateLastLoggedAt = async function ({ userId }) {
   const now = new Date();
 
-  await knex('user-logins')
+  await knex(USER_LOGINS_TABLE_NAME)
     .insert({
       userId,
       lastLoggedAt: now,

--- a/api/lib/infrastructure/repositories/user-login-repository.js
+++ b/api/lib/infrastructure/repositories/user-login-repository.js
@@ -41,4 +41,16 @@ const findByUsername = async function (username) {
   return foundUserLogin ? _toDomain(foundUserLogin) : null;
 };
 
-export { findByUserId, create, update, findByUsername };
+const updateLastLoggedAt = async function ({ userId }) {
+  const now = new Date();
+
+  await knex('user-logins')
+    .insert({
+      userId,
+      lastLoggedAt: now,
+    })
+    .onConflict('userId')
+    .merge();
+};
+
+export { findByUserId, create, update, findByUsername, updateLastLoggedAt };

--- a/api/tests/acceptance/application/authentication/oidc/reconcile-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/reconcile-route-post_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder } from '../../../../test-helper.js';
+import { expect, databaseBuilder, knex } from '../../../../test-helper.js';
 import { createServer } from '../../../../../server.js';
 import jsonwebtoken from 'jsonwebtoken';
 import * as authenticationSessionService from '../../../../../lib/domain/services/authentication/authentication-session-service.js';
@@ -10,6 +10,10 @@ describe('Acceptance | Application | Oidc | Routes', function () {
 
     beforeEach(async function () {
       server = await createServer();
+    });
+
+    afterEach(async function () {
+      await knex('user-logins').truncate();
     });
 
     it('should return 200 HTTP status', async function () {

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -42,8 +42,7 @@ describe('Acceptance | Route | oidc | token', function () {
 
     afterEach(async function () {
       clock.restore();
-      await knex('authentication-methods').delete();
-      await knex('users').delete();
+      await knex('user-logins').truncate();
     });
 
     context('When user does not have an account', function () {

--- a/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
@@ -15,6 +15,7 @@ describe('Acceptance | Route | oidc users', function () {
   describe('POST /api/oidc/users', function () {
     afterEach(async function () {
       await knex('authentication-methods').delete();
+      await knex('user-logins').truncate();
       await knex('users').delete();
     });
 

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -13,12 +13,11 @@ describe('Acceptance | API | Badges', function () {
 
   beforeEach(async function () {
     server = await createServer();
+    userId = (await insertUserWithRoleSuperAdmin()).id;
   });
 
   describe('PATCH /api/admin/badges/{id}', function () {
     beforeEach(async function () {
-      userId = (await insertUserWithRoleSuperAdmin()).id;
-
       badge = databaseBuilder.factory.buildBadge({
         id: 1,
         altMessage: 'Message alternatif',
@@ -83,10 +82,6 @@ describe('Acceptance | API | Badges', function () {
   });
 
   describe('DELETE /api/admin/badges/{id}', function () {
-    beforeEach(async function () {
-      userId = (await insertUserWithRoleSuperAdmin()).id;
-    });
-
     afterEach(async function () {
       await knex('badge-acquisitions').delete();
       await knex('badges').delete();

--- a/api/tests/acceptance/application/saml/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml/saml-controller_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 import samlify from 'samlify';
 import { createServer } from '../../../../server.js';
@@ -184,6 +184,10 @@ describe('Acceptance | Controller | saml-controller', function () {
     const firstName = 'Saml';
     const lastName = 'Jackson';
     const samlId = 'IDO-for-saml-jackson';
+
+    afterEach(async function () {
+      await knex('user-logins').truncate();
+    });
 
     it('should return externalUser idToken if the user does not a have an account yet', async function () {
       // given

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -330,8 +330,9 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('authentication-methods').delete();
+    afterEach(async function () {
+      await knex('authentication-methods').delete();
+      await knex('user-logins').truncate();
     });
 
     context('when an external user try to reconcile for the first time', function () {

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -3,6 +3,7 @@ import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as organizationLearnerRepository from '../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import * as userRepository from '../../../../src/shared/infrastructure/repositories/user-repository.js';
+import * as userLoginRepository from '../../../../lib/infrastructure/repositories/user-login-repository.js';
 import * as userToCreateRepository from '../../../../lib/infrastructure/repositories/user-to-create-repository.js';
 import * as studentRepository from '../../../../lib/infrastructure/repositories/student-repository.js';
 import * as authenticationMethodRepository from '../../../../lib/infrastructure/repositories/authentication-method-repository.js';
@@ -172,6 +173,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       await knex('authentication-methods').delete();
       await knex('organization-learners').delete();
       await knex('campaigns').delete();
+      await knex('user-logins').delete();
       await knex('users').delete();
     });
 
@@ -201,6 +203,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
         organizationLearnerRepository,
         studentRepository,
         userRepository,
+        userLoginRepository,
         userToCreateRepository,
       });
 
@@ -239,6 +242,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             campaignRepository,
             organizationLearnerRepository,
             userRepository,
+            userLoginRepository,
           });
 
           // then
@@ -293,6 +297,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
               organizationLearnerRepository,
               studentRepository,
               userRepository,
+              userLoginRepository,
             });
 
             // then
@@ -353,6 +358,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
               organizationLearnerRepository,
               studentRepository,
               userRepository,
+              userLoginRepository,
             });
 
             // then
@@ -405,6 +411,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
           organizationLearnerRepository,
           studentRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -2,6 +2,8 @@ import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 import * as userLoginRepository from '../../../../lib/infrastructure/repositories/user-login-repository.js';
 import { UserLogin } from '../../../../lib/domain/models/UserLogin.js';
 
+const USER_LOGINS_TABLE_NAME = 'user-logins';
+
 describe('Integration | Repository | UserLoginRepository', function () {
   describe('#findByUserId', function () {
     it('should return the found user-login', async function () {
@@ -33,7 +35,7 @@ describe('Integration | Repository | UserLoginRepository', function () {
 
   describe('#create', function () {
     afterEach(async function () {
-      await knex('user-logins').delete();
+      await knex(USER_LOGINS_TABLE_NAME).delete();
     });
 
     it('should return the created user-login', async function () {
@@ -149,22 +151,24 @@ describe('Integration | Repository | UserLoginRepository', function () {
     });
 
     afterEach(async function () {
-      await knex('user-logins').delete();
+      await knex(USER_LOGINS_TABLE_NAME).delete();
       clock.restore();
     });
 
-    it('updates lastLoggedAt column to "now" when it already exist', async function () {
-      // given
-      const lastLoggedAt = new Date();
-      const { userId } = databaseBuilder.factory.buildUserLogin({ lastLoggedAt });
-      await databaseBuilder.commit();
+    context('when a user-login exists for given user id', function () {
+      it('updates lastLoggedAt column to "now" ', async function () {
+        // given
+        const lastLoggedAt = new Date();
+        const { userId } = databaseBuilder.factory.buildUserLogin({ lastLoggedAt });
+        await databaseBuilder.commit();
 
-      // when
-      await userLoginRepository.updateLastLoggedAt({ userId });
+        // when
+        await userLoginRepository.updateLastLoggedAt({ userId });
 
-      // then
-      const userLoginsUpdated = await knex('user-logins').select().where({ userId }).first();
-      expect(userLoginsUpdated.lastLoggedAt).to.deep.equal(now);
+        // then
+        const userLoginsUpdated = await knex(USER_LOGINS_TABLE_NAME).select().where({ userId }).first();
+        expect(userLoginsUpdated.lastLoggedAt).to.deep.equal(now);
+      });
     });
 
     context('when a user-login does not exist for given user id', function () {
@@ -176,9 +180,10 @@ describe('Integration | Repository | UserLoginRepository', function () {
         // when
         await userLoginRepository.updateLastLoggedAt({ userId });
 
-      // then
-      const userLoginsUpdated = await knex('user-logins').select().where({ userId }).first();
-      expect(userLoginsUpdated.lastLoggedAt).to.deep.equal(now);
+        // then
+        const userLoginsUpdated = await knex(USER_LOGINS_TABLE_NAME).select().where({ userId }).first();
+        expect(userLoginsUpdated.lastLoggedAt).to.deep.equal(now);
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -110,7 +110,7 @@ describe('Integration | Repository | UserLoginRepository', function () {
       // when
       const result = await userLoginRepository.findByUsername('POUET@example.net');
 
-      // thens
+      // then
       expect(result).to.be.an.instanceOf(UserLogin);
       expect(result.id).to.equal(userLogin.id);
     });
@@ -125,7 +125,7 @@ describe('Integration | Repository | UserLoginRepository', function () {
       // when
       const result = await userLoginRepository.findByUsername('WINry123');
 
-      // thens
+      // then
       expect(result).to.be.an.instanceOf(UserLogin);
       expect(result.id).to.equal(userLogin.id);
     });

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -19,6 +19,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
   let obfuscationService;
   let authenticationMethodRepository;
   let userRepository;
+  let userLoginRepository;
 
   beforeEach(function () {
     tokenService = {
@@ -38,6 +39,9 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
     userRepository = {
       getBySamlId: sinon.stub(),
       getForObfuscation: sinon.stub(),
+      updateLastLoggedAt: sinon.stub(),
+    };
+    userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
   });
@@ -75,6 +79,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
@@ -113,10 +118,12 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
     });
 
     it("should throw an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {
@@ -150,6 +157,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
@@ -186,6 +194,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -224,6 +233,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -275,6 +285,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -323,6 +334,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -354,6 +366,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         tokenService,
         pixAuthenticationService,
         userRepository,
+        userLoginRepository,
       });
 
       // then
@@ -380,6 +393,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         tokenService,
         pixAuthenticationService,
         userRepository,
+        userLoginRepository,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -15,6 +15,7 @@ import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 describe('Unit | Application | UseCase | authenticate-user', function () {
   let refreshTokenService;
   let userRepository;
+  let userLoginRepository;
   let adminMemberRepository;
   let pixAuthenticationService;
 
@@ -31,6 +32,9 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       getByUsernameOrEmailWithRoles: sinon.stub(),
       updateLastLoggedAt: sinon.stub(),
       update: sinon.stub(),
+    };
+    userLoginRepository = {
+      updateLastLoggedAt: sinon.stub(),
     };
     adminMemberRepository = {
       get: sinon.stub(),
@@ -55,6 +59,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           scope,
           pixAuthenticationService,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -78,6 +83,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           scope,
           pixAuthenticationService,
           userRepository,
+          userLoginRepository,
           adminMemberRepository,
         });
 
@@ -111,6 +117,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           scope,
           pixAuthenticationService,
           userRepository,
+          userLoginRepository,
           adminMemberRepository,
         });
 
@@ -161,6 +168,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           source,
           pixAuthenticationService,
           userRepository,
+          userLoginRepository,
           adminMemberRepository,
           refreshTokenService,
         });
@@ -209,6 +217,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
             pixAuthenticationService,
             refreshTokenService,
             userRepository,
+            userLoginRepository,
           });
 
           // then
@@ -249,6 +258,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       pixAuthenticationService,
       refreshTokenService,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -278,10 +288,12 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       pixAuthenticationService,
       refreshTokenService,
       userRepository,
+      userLoginRepository,
     });
 
     // then
     expect(userRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
+    expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
   });
 
   it('should rejects an error when given username (email) does not match an existing one', async function () {
@@ -294,6 +306,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       username: unknownUserEmail,
       password,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -309,6 +322,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       username: userEmail,
       password,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -342,6 +356,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
         username: 'jean.neymar2008',
         password: 'Password1234',
         userRepository,
+        userLoginRepository,
         pixAuthenticationService,
         tokenService,
       });
@@ -374,6 +389,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           pixAuthenticationService,
           refreshTokenService,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -403,6 +419,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
             pixAuthenticationService,
             refreshTokenService,
             userRepository,
+            userLoginRepository,
           });
 
           // then
@@ -430,6 +447,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
             pixAuthenticationService,
             refreshTokenService,
             userRepository,
+            userLoginRepository,
           });
 
           // then

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -11,6 +11,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
   let authenticationSessionService;
   let authenticationMethodRepository;
   let userRepository;
+  let userLoginRepository;
   const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
 
   beforeEach(function () {
@@ -33,6 +34,9 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
     userRepository = {
       findByExternalIdentifier: sinon.stub(),
+      updateLastLoggedAt: sinon.stub(),
+    };
+    userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
   });
@@ -72,6 +76,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -93,6 +98,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -114,6 +120,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -141,6 +148,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
@@ -161,12 +169,14 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
       expect(oidcAuthenticationService.saveIdToken).to.not.have.been.called;
       expect(oidcAuthenticationService.createAccessToken).to.not.have.been.called;
       expect(userRepository.updateLastLoggedAt).to.not.have.been.called;
+      expect(userLoginRepository.updateLastLoggedAt).to.not.have.been.called;
     });
   });
 
@@ -186,6 +196,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -214,6 +225,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
+          userLoginRepository,
         });
 
         // then
@@ -247,11 +259,13 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
       sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
       sinon.assert.calledOnceWithExactly(userRepository.updateLastLoggedAt, { userId: 10 });
+      sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
       expect(accessToken).to.deep.equal({
         pixAccessToken: 'accessTokenForExistingExternalUser',
         logoutUrlUUID: 'logoutUrlUUID',
@@ -282,6 +296,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/create-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/create-oidc-user_test.js
@@ -6,7 +6,7 @@ import {
 import { createOidcUser } from '../../../../lib/domain/usecases/create-oidc-user.js';
 
 describe('Unit | UseCase | create-oidc-user', function () {
-  let authenticationMethodRepository, userToCreateRepository, userRepository;
+  let authenticationMethodRepository, userToCreateRepository, userRepository, userLoginRepository;
   let authenticationSessionService, oidcAuthenticationService;
   let clock;
   const now = new Date('2021-01-02');
@@ -30,6 +30,10 @@ describe('Unit | UseCase | create-oidc-user', function () {
     };
 
     userRepository = {
+      updateLastLoggedAt: sinon.stub(),
+    };
+
+    userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
   });
@@ -109,6 +113,7 @@ describe('Unit | UseCase | create-oidc-user', function () {
       authenticationMethodRepository,
       userToCreateRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -128,6 +133,7 @@ describe('Unit | UseCase | create-oidc-user', function () {
     sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
     sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
     sinon.assert.calledOnceWithExactly(userRepository.updateLastLoggedAt, { userId: 10 });
+    sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
     expect(result).to.deep.equal({
       accessToken: 'accessTokenForExistingExternalUser',
       logoutUrlUUID: 'logoutUrlUUID',

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -9,6 +9,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   let authenticationMethodRepository;
   let campaignRepository;
   let userRepository;
+  let userLoginRepository;
   let organizationLearnerRepository;
   let studentRepository;
 
@@ -26,6 +27,9 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
     };
     userRepository = {
       getBySamlId: sinon.stub(),
+      updateLastLoggedAt: sinon.stub(),
+    };
+    userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
     userService = {
@@ -59,12 +63,14 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userLoginRepository,
         organizationLearnerRepository,
         studentRepository,
       });
 
       // then
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
     });
 
     it('should return an access token', async function () {
@@ -94,6 +100,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userLoginRepository,
         organizationLearnerRepository,
         studentRepository,
       });
@@ -130,12 +137,14 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userLoginRepository,
         organizationLearnerRepository,
         studentRepository,
       });
 
       // then
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
     });
 
     it('should return an access token', async function () {
@@ -166,6 +175,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userLoginRepository,
         organizationLearnerRepository,
         studentRepository,
       });

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -6,6 +6,7 @@ import { getExternalAuthenticationRedirectionUrl } from '../../../../lib/domain/
 
 describe('Unit | UseCase | get-external-authentication-redirection-url', function () {
   let userRepository;
+  let userLoginRepository;
   let authenticationMethodRepository;
   let tokenService;
   let samlSettings;
@@ -13,6 +14,10 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   beforeEach(function () {
     userRepository = {
       getBySamlId: sinon.stub(),
+      updateLastLoggedAt: sinon.stub(),
+    };
+
+    userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
 
@@ -53,6 +58,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       const result = await getExternalAuthenticationRedirectionUrl({
         userAttributes,
         userRepository,
+        userLoginRepository,
         tokenService,
         config: samlSettings,
       });
@@ -98,6 +104,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       const result = await getExternalAuthenticationRedirectionUrl({
         userAttributes,
         userRepository,
+        userLoginRepository,
         authenticationMethodRepository,
         tokenService,
         config: samlSettings,
@@ -127,6 +134,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       await getExternalAuthenticationRedirectionUrl({
         userAttributes,
         userRepository,
+        userLoginRepository,
         authenticationMethodRepository,
         tokenService,
         config: samlSettings,
@@ -134,6 +142,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
 
       // then
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });
     });
 
     context("when user's authentication method does not contain first and last name", function () {
@@ -158,6 +167,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         await getExternalAuthenticationRedirectionUrl({
           userAttributes: { IDO: 'saml-id', NOM: 'Lisitsa', PRE: 'Vassili' },
           userRepository,
+          userLoginRepository,
           authenticationMethodRepository,
           tokenService,
           config: samlSettings,
@@ -193,6 +203,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         await getExternalAuthenticationRedirectionUrl({
           userAttributes: { IDO: 'saml-id', NOM: 'Lisitsa', PRE: 'Valentina' },
           userRepository,
+          userLoginRepository,
           authenticationMethodRepository,
           tokenService,
           config: samlSettings,
@@ -228,6 +239,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         await getExternalAuthenticationRedirectionUrl({
           userAttributes: { IDO: 'saml-id', NOM: 'Volk', PRE: 'Valentina' },
           userRepository,
+          userLoginRepository,
           authenticationMethodRepository,
           tokenService,
           config: samlSettings,
@@ -263,6 +275,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         await getExternalAuthenticationRedirectionUrl({
           userAttributes: { IDO: 'saml-id', NOM: 'Volk', PRE: 'Valentina' },
           userRepository,
+          userLoginRepository,
           authenticationMethodRepository,
           tokenService,
           config: samlSettings,

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
@@ -4,12 +4,19 @@ import { AuthenticationKeyExpired, MissingUserAccountError } from '../../../../l
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
 
 describe('Unit | UseCase | reconcile-oidc-user', function () {
-  let authenticationMethodRepository, userRepository, authenticationSessionService, oidcAuthenticationService;
+  let authenticationMethodRepository,
+    userRepository,
+    userLoginRepository,
+    authenticationSessionService,
+    oidcAuthenticationService;
   const identityProvider = 'POLE_EMPLOI';
 
   beforeEach(function () {
     authenticationMethodRepository = { create: sinon.stub() };
     userRepository = { updateLastLoggedAt: sinon.stub() };
+    userLoginRepository = {
+      updateLastLoggedAt: sinon.stub(),
+    };
     authenticationSessionService = { getByKey: sinon.stub() };
     oidcAuthenticationService = {
       identityProvider,
@@ -39,6 +46,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -67,6 +75,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
@@ -104,12 +113,14 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
+      userLoginRepository,
     });
 
     // then
     sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
     sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
     sinon.assert.calledOnceWithExactly(userRepository.updateLastLoggedAt, { userId });
+    sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId });
     expect(result).to.deep.equal({
       accessToken: 'accessToken',
       logoutUrlUUID: 'logoutUrlUUID',
@@ -128,6 +139,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then
@@ -150,6 +162,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
+        userLoginRepository,
       });
 
       // then

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { HapiServer } from '../../../src/lib/server';
 import { type Server, type ServerInjectOptions } from '@hapi/hapi';
+import { knex } from '../../../src/db/knex-database-connection';
 
 describe('Acceptance | Controllers | CreateAuditLogController', () => {
   let server: Server;
@@ -30,6 +31,7 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
   });
 
   afterEach(async function (): Promise<void> {
+    await knex('audit-log').truncate();
     await server.stop();
   });
 

--- a/audit-logger/tests/integration/infrastructure/repositories/audit-log-postgres.repository.test.ts
+++ b/audit-logger/tests/integration/infrastructure/repositories/audit-log-postgres.repository.test.ts
@@ -1,15 +1,15 @@
-import { afterEach, describe, expect, test , beforeAll } from 'vitest';
+import { beforeEach, afterEach, describe, expect, test , beforeAll, vi } from 'vitest';
 import { AuditLog } from '../../../../src/lib/domain/models/audit-log.js';
 import { auditLogPostgresRepository } from '../../../../src/lib/infrastructure/repositories/audit-log-postgres.repository.js';
 import { knex } from '../../../../src/db/knex-database-connection.js';
 
 describe('Integration | Infrastructure | Repositories | AuditLogPostgresRepository', () => {
-
-  beforeAll(async() => {
-    await knex('audit-log').truncate();
+  beforeEach(function() {
+    vi.useFakeTimers({ now: new Date('2023-08-29') });
   });
 
   afterEach(async() => {
+    vi.useRealTimers();
     await knex('audit-log').truncate();
   });
 
@@ -17,7 +17,7 @@ describe('Integration | Infrastructure | Repositories | AuditLogPostgresReposito
     test('creates new audit log', async () => {
       // given
       const auditLog = new AuditLog({
-        occurredAt: new Date ('2021-06-19T15:28:18.000Z'),
+        occurredAt: new Date (),
         action: 'ANONYMIZATION',
         userId: '1',
         targetUserId: '2',
@@ -32,7 +32,7 @@ describe('Integration | Infrastructure | Repositories | AuditLogPostgresReposito
       const result = await knex('audit-log').first();
       const expectedResult = new AuditLog({
         id: '1',
-        occurredAt: new Date('2021-06-19T15:28:18.000Z'),
+        occurredAt: new Date(),
         action: 'ANONYMIZATION',
         userId: '1',
         targetUserId: '2',


### PR DESCRIPTION
## :unicorn: Problème

Les informations relatives aux connexions/logins d'un utilisateur sont réparties sur 2 tables différentes ayant des fréquences de mise à jour différentes (`users` et `user-logins`, la dernière étant constamment modifiée par les différents logins alors que la première varie moins) au lieu d'être dans une table unique, ce qui : 
* complexifie la compréhension et le travail des développeurs
* augmente la contention de la base de données, ce qui diminue les performances de la base de données et augmente les risques de deadlock

## :robot: Proposition

Déplacer la colonne `lastLoggedAt` de la table `users` vers la table `user-logins`.

Ceci doit être fait en implémentant une solution rétro-compatible qui est la solution idéale en la matière.

Cette 1ère PR réalise les actions suivantes : 
1. Ajouter une migration pour créer la nouvelle colonne
2. Mettre à jour la nouvelle colonne partout où l’ancienne est mise à jour tout en conservant et continuant à modifier et à lire l’ancienne colonne

## :rainbow: Remarques

Cette PR fait partie d'un ensemble de PR.

## :100: Pour tester

* Se connecter avec succès un utilisateur ayant l'authentification Pix (email: `user-1-7003@example.net `, mot de passe par défaut). Constater que la date et l'heure de connexion correspondent bien à la tentative réussie :
   * dans PixAdmin (qui se base sur la table `users`)
   * dans la table `user-logins`
* Se connecter avec succès un utilisateur ayant une authentification SSO OIDC (par exemple avec Pôle Emploi, n'importe quel compte convient) et ne s'étant encore jamais connecté. Constater que la date et l'heure de connexion correspondent bien à la tentative réussie :
   * dans PixAdmin (qui se base sur la table `users`)
   * dans la table `user-logins`
* Se connecter avec succès un utilisateur ayant une authentification SSO OIDC (par exemple avec Pôle Emploi, n'importe quel compte convient) et s'étant déjà connecté. Constater que la date et l'heure de connexion correspondent bien à la tentative réussie :
   * dans PixAdmin (qui se base sur la table `users`)
   * dans la table `user-logins`
* Se connecter avec succès un utilisateur ayant une authentification SSO OIDC (par exemple avec Pôle Emploi, n'importe quel compte convient) dans le cas d'une réconciliation. Constater que la date et l'heure de connexion correspondent bien à la tentative réussie :
   * dans PixAdmin (qui se base sur la table `users`)
   * dans la table `user-logins`
* Se connecter avec succès un utilisateur ayant une authentification GAR (Saml ID: `SamlID`, Prénom: `Eliza`, Nom: `Delajungle`). Constater que la date et l'heure de connexion correspondent bien à la tentative réussie :
   * Entrer le code campagne `SCOBADGE1`
   * dans PixAdmin (qui se base sur la table `users`)
   * dans la table `user-logins`
* Se connecter avec succès un utilisateur ayant une authentification GAR dans le cas d'une réconcilation, c'est à dire un utilisateur ayant déjà une méthode d'authentification PIX (Saml ID: `SamlID`, Prénom: `Chihiro`, Nom: `Ogino`)
   * Entrer le code campagne `SCOBADGE1`
   * Remplir les informations de reconciliation (date de naissance: `01/01/2013`)
   * Constater l'affichage d'une popup indiquant l'existence d'un compte utilisateur correspondant aux meme identifiants
   * Cliquer sur le bouton `Continuer avec les identifiants PIX`
   * Constater l'affichage d'une double mire de connexion
   * Se connecter avec ses identifiants PIX (email: `chihiro.ogino@miyazaki.net`, mot de passe par défaut)
   * Constater l'affichage du tutoriel de campagne
