### PR TITLE
[BUGFIX] Afficher correctement les déclencheurs des CF sur Pix Admin (PIX-9014).

### DIFF
--- a/admin/app/components/trainings/trigger/details.js
+++ b/admin/app/components/trainings/trigger/details.js
@@ -5,14 +5,14 @@ export default class Details extends Component {
   @service store;
 
   get areasList() {
-    return this.args.areas.map((area) => this.buildAreaViewModel(area));
+    return this.args.areas.sortBy('code').map((area) => this.buildAreaViewModel(area));
   }
 
   buildAreaViewModel(area) {
     return {
       title: `${area.code} · ${area.title}`,
       color: area.color,
-      competences: area.competences.sortBy('index').map((competence) => this.buildCompetenceViewModel(competence)),
+      competences: area.sortedCompetences.map((competence) => this.buildCompetenceViewModel(competence)),
     };
   }
 

--- a/api/lib/domain/read-models/TrainingTriggerForAdmin.js
+++ b/api/lib/domain/read-models/TrainingTriggerForAdmin.js
@@ -12,40 +12,42 @@ class TrainingTriggerForAdmin {
     this.type = type;
     this.threshold = threshold;
     this.tubesCount = triggerTubes.length;
-    this.areas = areas.map((area) => new _Area({ ...area, competences, thematics, triggerTubes }));
+    this.areas = areas.map(
+      (area) => new _Area({ ...area, competences, thematics, triggerTubes, trainingTriggerId: id }),
+    );
   }
 }
 
 TrainingTriggerForAdmin.types = TrainingTrigger.types;
 
 class _Area {
-  constructor({ id, title, code, color, competences = [], thematics = [], triggerTubes = [] } = {}) {
-    this.id = id;
+  constructor({ id, title, code, color, competences = [], thematics = [], triggerTubes = [], trainingTriggerId } = {}) {
+    this.id = `${id}_${trainingTriggerId}`;
     this.title = title;
     this.code = code;
     this.color = color;
 
     this.competences = competences
       .filter((competence) => competence.areaId === id)
-      .map((competence) => new _Competence({ ...competence, thematics, triggerTubes }));
+      .map((competence) => new _Competence({ ...competence, thematics, triggerTubes, trainingTriggerId }));
   }
 }
 
 class _Competence {
-  constructor({ id, name, index, thematics = [], triggerTubes = [] } = {}) {
-    this.id = id;
+  constructor({ id, name, index, thematics = [], triggerTubes = [], trainingTriggerId } = {}) {
+    this.id = `${id}_${trainingTriggerId}`;
     this.name = name;
     this.index = index;
 
     this.thematics = thematics
       .filter((thematic) => thematic.competenceId === id)
-      .map((thematic) => new _Thematic({ ...thematic, triggerTubes }));
+      .map((thematic) => new _Thematic({ ...thematic, triggerTubes, trainingTriggerId }));
   }
 }
 
 class _Thematic {
-  constructor({ id, name, index, triggerTubes = [] } = {}) {
-    this.id = id;
+  constructor({ id, name, index, triggerTubes = [], trainingTriggerId } = {}) {
+    this.id = `${id}_${trainingTriggerId}`;
     this.name = name;
     this.index = index;
 

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -132,17 +132,17 @@ describe('Acceptance | Controller | training-controller', function () {
       expect(returnedTrigger['tubes-count']).to.equal(1);
 
       const returnedTriggerArea = response.result.included.find((included) => included.type === 'areas').attributes;
-      expect(returnedTriggerArea.id).to.deep.equal(areaId);
+      expect(returnedTriggerArea.id).to.deep.equal(`${areaId}_${trainingTrigger.id}`);
 
       const returnedTriggerCompetence = response.result.included.find(
         (included) => included.type === 'competences',
       ).attributes;
-      expect(returnedTriggerCompetence.id).to.deep.equal(competenceId);
+      expect(returnedTriggerCompetence.id).to.deep.equal(`${competenceId}_${trainingTrigger.id}`);
 
       const returnedTriggerThematic = response.result.included.find(
         (included) => included.type === 'thematics',
       ).attributes;
-      expect(returnedTriggerThematic.id).to.deep.equal(thematicId);
+      expect(returnedTriggerThematic.id).to.deep.equal(`${thematicId}_${trainingTrigger.id}`);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, domainBuilder, catchErr, knex, mockLearningContent } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, mockLearningContent } from '../../../test-helper.js';
 
 import * as trainingRepository from '../../../../lib/infrastructure/repositories/training-repository.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
@@ -142,11 +142,13 @@ describe('Integration | Repository | training-repository', function () {
       expect(result.trainingTriggers[0].threshold).to.deep.equal(trainingTrigger.threshold);
       expect(result.trainingTriggers[0].type).to.deep.equal(trainingTrigger.type);
       expect(result.trainingTriggers[0].areas).to.have.lengthOf(1);
-      expect(result.trainingTriggers[0].areas[0].id).to.equal(area1.id);
+      expect(result.trainingTriggers[0].areas[0].id).to.equal(`${area1.id}_${trainingTrigger.id}`);
       expect(result.trainingTriggers[0].areas[0].competences).to.have.lengthOf(1);
-      expect(result.trainingTriggers[0].areas[0].competences[0].id).to.equal(competence1.id);
+      expect(result.trainingTriggers[0].areas[0].competences[0].id).to.equal(`${competence1.id}_${trainingTrigger.id}`);
       expect(result.trainingTriggers[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
-      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].id).to.equal(thematic1.id);
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].id).to.equal(
+        `${thematic1.id}_${trainingTrigger.id}`,
+      );
       expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
       expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].triggerTubes[0].id).to.deep.equal(
         trainingTriggerTube.id,

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -1,12 +1,12 @@
 import {
-  expect,
+  catchErr,
   databaseBuilder,
   domainBuilder,
+  expect,
   knex,
-  mockLearningContent,
   learningContentBuilder,
+  mockLearningContent,
   sinon,
-  catchErr,
 } from '../../../test-helper.js';
 
 import * as trainingTriggerRepository from '../../../../lib/infrastructure/repositories/training-trigger-repository.js';
@@ -149,11 +149,13 @@ describe('Integration | Repository | training-trigger-repository', function () {
         expect(createdTrainingTrigger.type).to.equal(trainingTrigger.type);
         expect(createdTrainingTrigger.threshold).to.equal(trainingTrigger.threshold);
         expect(createdTrainingTrigger.areas).to.have.lengthOf(1);
-        expect(createdTrainingTrigger.areas[0].id).to.equal('recAreaA');
+        expect(createdTrainingTrigger.areas[0].id).to.equal(`recAreaA_${trainingTrigger.id}`);
         expect(createdTrainingTrigger.areas[0].competences).to.have.lengthOf(1);
-        expect(createdTrainingTrigger.areas[0].competences[0].id).to.equal('recCompA');
+        expect(createdTrainingTrigger.areas[0].competences[0].id).to.equal(`recCompA_${trainingTrigger.id}`);
         expect(createdTrainingTrigger.areas[0].competences[0].thematics).to.have.lengthOf(1);
-        expect(createdTrainingTrigger.areas[0].competences[0].thematics[0].id).to.equal('recThemA');
+        expect(createdTrainingTrigger.areas[0].competences[0].thematics[0].id).to.equal(
+          `recThemA_${trainingTrigger.id}`,
+        );
 
         const trainingTriggerTubes = await knex('training-trigger-tubes')
           .where({
@@ -335,11 +337,11 @@ describe('Integration | Repository | training-trigger-repository', function () {
       expect(result[0].type).to.equal(trainingTrigger.type);
       expect(result[0].threshold).to.equal(trainingTrigger.threshold);
       expect(result[0].areas).to.have.lengthOf(1);
-      expect(result[0].areas[0].id).to.equal('recAreaA');
+      expect(result[0].areas[0].id).to.equal(`recAreaA_${trainingTrigger.id}`);
       expect(result[0].areas[0].competences).to.have.lengthOf(1);
-      expect(result[0].areas[0].competences[0].id).to.equal('recCompA');
+      expect(result[0].areas[0].competences[0].id).to.equal(`recCompA_${trainingTrigger.id}`);
       expect(result[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
-      expect(result[0].areas[0].competences[0].thematics[0].id).to.equal('recThemA');
+      expect(result[0].areas[0].competences[0].thematics[0].id).to.equal(`recThemA_${trainingTrigger.id}`);
       expect(result[0].areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
       expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
       expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0].tube.id).to.equal(
@@ -357,11 +359,11 @@ describe('Integration | Repository | training-trigger-repository', function () {
       expect(result[1].type).to.equal(trainingTrigger2.type);
       expect(result[1].threshold).to.equal(trainingTrigger2.threshold);
       expect(result[1].areas).to.have.lengthOf(1);
-      expect(result[1].areas[0].id).to.equal('recAreaA');
+      expect(result[1].areas[0].id).to.equal(`recAreaA_${trainingTrigger2.id}`);
       expect(result[1].areas[0].competences).to.have.lengthOf(1);
-      expect(result[1].areas[0].competences[0].id).to.equal('recCompA');
+      expect(result[1].areas[0].competences[0].id).to.equal(`recCompA_${trainingTrigger2.id}`);
       expect(result[1].areas[0].competences[0].thematics).to.have.lengthOf(1);
-      expect(result[1].areas[0].competences[0].thematics[0].id).to.equal('recThemA');
+      expect(result[1].areas[0].competences[0].thematics[0].id).to.equal(`recThemA_${trainingTrigger2.id}`);
       expect(result[1].areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
       expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
       expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0].tube.id).to.equal(

--- a/api/tests/unit/domain/read-models/TrainingTriggerForAdmin_test.js
+++ b/api/tests/unit/domain/read-models/TrainingTriggerForAdmin_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder, catchErr } from '../../../test-helper.js';
+import { catchErr, domainBuilder, expect } from '../../../test-helper.js';
 import { TrainingTriggerForAdmin } from '../../../../lib/domain/read-models/TrainingTriggerForAdmin.js';
 
 describe('Unit | Domain | Read-Models | TrainingTriggerForAdmin', function () {
@@ -85,16 +85,19 @@ describe('Unit | Domain | Read-Models | TrainingTriggerForAdmin', function () {
 
       // then
       expect(trainingTrigger.areas).to.have.length(1);
-      expect(trainingTrigger.areas[0]).to.have.property('id', area1.id);
+      expect(trainingTrigger.areas[0]).to.have.property('id', `${area1.id}_${trainingTrigger.id}`);
       expect(trainingTrigger.areas[0]).to.have.property('title', area1.title);
       expect(trainingTrigger.areas[0]).to.have.property('code', area1.code);
       expect(trainingTrigger.areas[0]).to.have.property('color', area1.color);
       expect(trainingTrigger.areas[0].competences).to.have.length(1);
-      expect(trainingTrigger.areas[0].competences[0]).to.have.property('id', competence1.id);
+      expect(trainingTrigger.areas[0].competences[0]).to.have.property('id', `${competence1.id}_${trainingTrigger.id}`);
       expect(trainingTrigger.areas[0].competences[0]).to.have.property('name', competence1.name);
       expect(trainingTrigger.areas[0].competences[0]).to.have.property('index', competence1.index);
       expect(trainingTrigger.areas[0].competences[0].thematics).to.have.length(2);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('id', thematic1.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property(
+        'id',
+        `${thematic1.id}_${trainingTrigger.id}`,
+      );
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('name', thematic1.name);
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('index', thematic1.index);
       expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.length(1);
@@ -102,7 +105,10 @@ describe('Unit | Domain | Read-Models | TrainingTriggerForAdmin', function () {
         'id',
         trainingTriggerTube1.id,
       );
-      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('id', thematic2.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property(
+        'id',
+        `${thematic2.id}_${trainingTrigger.id}`,
+      );
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('name', thematic2.name);
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('index', thematic2.index);
       expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes).to.have.length(1);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function () {
@@ -54,7 +54,7 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
             areas: {
               data: [
                 {
-                  id: 'recArea1',
+                  id: `recArea1_${id}`,
                   type: 'areas',
                 },
               ],
@@ -98,7 +98,7 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
                 data: [{ id: 'recTrainingTriggerTube1', type: 'trigger-tubes' }],
               },
             },
-            id: 'recThematic1',
+            id: `recThematic1_${id}`,
             type: 'thematics',
           },
           {
@@ -106,12 +106,12 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
               index: '1.1',
               name: 'Manger des fruits',
             },
-            id: 'recCompetence1',
+            id: `recCompetence1_${id}`,
             relationships: {
               thematics: {
                 data: [
                   {
-                    id: 'recThematic1',
+                    id: `recThematic1_${id}`,
                     type: 'thematics',
                   },
                 ],
@@ -125,12 +125,12 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
               color: 'red',
               title: 'Super domaine',
             },
-            id: 'recArea1',
+            id: `recArea1_${id}`,
             relationships: {
               competences: {
                 data: [
                   {
-                    id: 'recCompetence1',
+                    id: `recCompetence1_${id}`,
                     type: 'competences',
                   },
                 ],


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu'on se rend sur un CF qui a 2 déclencheurs qui ont des domaines en commun, il peut y avoir des mélanges entre les tubes des 2 déclencheurs. 

https://github.com/1024pix/pix/assets/26384707/5e28be92-ab36-428f-b53d-3be8b7f086f6

Nous utilisons les mêmes ids pour la grappe du référentiel dans le cadre des 2 déclencheurs. L'API envoi donc 2 fois le objets mais pas avec la même sous grappe, il reste ensuite qu'un des deux enregistrements dans ember-data car celui-ci ne peut avoir qu'un seul enregistrement pour le même id (ce qui parait logique).

## :robot: Proposition
Utiliser des ids uniques pour chaque déclencheur. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Admin
- Créer un CF
- Ajouter à ce CF 2 déclencheurs avec les mêmes domaines, mais avec des tubes différents 
- Constater que l'affichage se fait correctement. 