### PR TITLE
[BUGFIX] Obliger la saisie de nombre sur le champs 'ID' dans la recherche d'utilisateur (PIX-9005)

### DIFF
--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -17,19 +17,24 @@ export default class ListRoute extends Route {
   async model(params) {
     if (!params.id && !params.firstName && !params.lastName && !params.email && !params.username) return [];
 
-    return this.store.query('user', {
-      filter: {
-        id: params.id ? params.id.replace(/ /g, '') : '',
-        firstName: params.firstName ? params.firstName.trim() : '',
-        lastName: params.lastName ? params.lastName.trim() : '',
-        email: params.email ? params.email.trim() : '',
-        username: params.username ? params.username.trim() : '',
-      },
-      page: {
-        number: params.pageNumber,
-        size: params.pageSize,
-      },
-    });
+    try {
+      const users = await this.store.query('user', {
+        filter: {
+          id: params.id ? params.id.replace(/ /g, '') : '',
+          firstName: params.firstName ? params.firstName.trim() : '',
+          lastName: params.lastName ? params.lastName.trim() : '',
+          email: params.email ? params.email.trim() : '',
+          username: params.username ? params.username.trim() : '',
+        },
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      });
+      return users;
+    } catch (error) {
+      return [];
+    }
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -10,6 +10,7 @@
         placeholder="ID"
         @ariaLabel="Identifiant de l'utilisateur"
         class="user-list-form__input--small"
+        type="number"
       />
       <PixInput
         @id="firstName"
@@ -30,6 +31,7 @@
         {{on "change" this.onChangeEmail}}
         placeholder="Adresse e-mail"
         @ariaLabel="Adresse e-mail"
+        type="email"
       />
       <PixInput
         @id="username"

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -10,6 +10,7 @@
         placeholder="ID"
         @ariaLabel="Identifiant de l'utilisateur"
         class="user-list-form__input--small"
+        min="1"
         type="number"
       />
       <PixInput

--- a/admin/tests/unit/routes/authenticated/users/list_test.js
+++ b/admin/tests/unit/routes/authenticated/users/list_test.js
@@ -67,6 +67,20 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         assert.ok(true);
       });
     });
+
+    module('when an error occurs', function () {
+      test('returns an empty array', async function (assert) {
+        // given
+        params.id = '1';
+
+        route.store.query = sinon.stub().rejects();
+        // then
+        const users = await route.model(params);
+
+        // then
+        assert.deepEqual(users, []);
+      });
+    });
   });
 
   module('#resetController', function (hooks) {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -46,6 +46,20 @@ const register = async function (server) {
               ])(request, h),
           },
         ],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          query: Joi.object({
+            'filter[id]': identifiersType.userId.empty('').allow(null).optional(),
+            'filter[firstName]': Joi.string().empty('').allow(null).optional(),
+            'filter[lastName]': Joi.string().empty('').allow(null).optional(),
+            'filter[email]': Joi.string().email().empty('').allow(null).optional(),
+            'filter[username]': Joi.string().empty('').allow(null).optional(),
+            'page[number]': Joi.number().integer().empty('').allow(null).optional(),
+            'page[size]': Joi.number().integer().empty('').allow(null).optional(),
+          }),
+        },
         handler: userController.findPaginatedFilteredUsers,
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -612,6 +612,34 @@ describe('Unit | Router | user-router', function () {
         sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
         expect(response.statusCode).to.equal(403);
       });
+
+      describe('when the email provided in users filter is not valid', function () {
+        it('returns a BadRequest error (400)', async function () {
+          // given
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('GET', '/api/admin/users?filter[email]=999');
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
+      describe('when the id provided in users filter is not numeric', function () {
+        it('returns a BadRequest error (400)', async function () {
+          // given
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('GET', '/api/admin/users?filter[id]=mmmm');
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
     });
 
     describe('GET /api/admin/users/{id}', function () {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un utilisateur écrit un prénom dans le champs `ID`, il reçoit une erreur 500.

## :robot: Proposition
Ajouter un `type=number` sur le champ dédié à l'ID afin d'empêcher les utilisateurs de saisir un nom dans ce filtre.

## :rainbow: Remarques
- Ajout d'un `type=email` sur le champ dédié à l'adresse e-mail pour que le navigateur notifie l'utilisateur s'il écrit une adresse au mauvais format.
- Ajout d'une règle sur le champ ID pour n'accepter que les nombres supérieurs à 0

## :100: Pour tester

1. Se connecter à **Pix Admin**
2. Allez dans l'onglet Utilisateurs
3. Dans le champs `ID` tenter d'écrire un nom et vérifier que c'est impossible
4. Tentez d'écrire des nombres, puis cliquez sur le bouton `Charger` et vérifier que vous pouvez bien saisir cet ID
5. Dans le champs `Adresse e-mail` saisissez une suite de chiffre
6. Cliquez sur le bouton `Charger` et vérifiez que votre navigateur vous notifie qu'il y a une erreur de saisie dans ce champs