### PR TITLE
[FEATURE] Changer la couleur du bouton de connexion de la FWB (PIX-8661)

### DIFF
--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -77,13 +77,13 @@
         <div class="sign-form-body__bottom-decoration">
           <span>{{t "pages.sign-in.or"}}</span>
         </div>
-        <LinkTo
-          @route="authentication.login-oidc"
-          @model="fwb"
-          class="sign-form-body__oidc-connect-link oidc-provider-fwb"
-        >
-          <img src="/images/logo/fwb-connect-logo.svg" alt="{{t 'pages.sign-in.fwb.link.img'}}" />
-          <span>{{t "pages.sign-in.fwb.title"}}</span>
+        <LinkTo @route="authentication.login-oidc" @model="fwb" class="sign-form-body__fwb-oidc-connect-link">
+          <img
+            src="/images/logo/fwb-connect-logo.svg"
+            alt="{{t 'pages.sign-in.fwb.link.img'}}"
+            class="sign-form-body__fwb-oidc-connect-link__logo"
+          />
+          <p class="oidc-provider-fwb">{{t "pages.sign-in.fwb.title"}}</p>
         </LinkTo>
       {{/if}}
     {{/if}}

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -187,14 +187,54 @@
     margin: 5px 0 20px;
     font-size: 0.875rem;
   }
+
+  &__fwb-oidc-connect-link {
+    @extend %pix-body-s;
+    
+    display: flex;
+    align-items: center;
+    font-weight: $font-medium;
+    text-decoration: none;
+    background-color: $pix-neutral-0;
+    border: 1px solid $pix-neutral-50;
+    border-radius: 100px;
+
+    &:focus,
+    &:hover,
+    &:focus-within {
+      color: $pix-neutral-0;
+      border: 1px solid $pix-neutral-50;
+    }
+
+    &__logo {
+      width: $pix-spacing-m;
+      margin: 6px $pix-spacing-xs 6px $pix-spacing-s;
+
+      &:focus,
+      &:hover,
+      &:focus-within {
+        color: $pix-neutral-0;
+        background-color: $pix-neutral-0;
+      }
+    }
+  }
 }
 
 .oidc-provider-pole-emploi {
   color: $pix-neutral-0;
   background-color: #1B2E57;
+  border-style : 1px solid $pix-neutral-50;
 }
 
 .oidc-provider-fwb {
-  color: $pix-neutral-70;
-  background-color: #EDEDED;
+  padding: $pix-spacing-xs $pix-spacing-s $pix-spacing-xs $pix-spacing-xs;
+  color: $pix-neutral-90;
+  
+  &:focus,
+  &:hover,
+  &:focus-within {
+    color: $pix-neutral-0;
+    background-color: $pix-neutral-60;
+    border-radius: 0 100px 100px 0;
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
Demande de la FWB qui trouve que le bouton existant, “se connecter avec la FWB”, n’est pas assez visible.

## :robot: Proposition
Changer la couleur de fond du bouton pour le mettre plus en avant (validé avec les UX).

## :rainbow: Remarques
Le style du bouton de connexion SSO de la FWB diffère de celui de Pole Emploi : 
- border radius moins épais
- font weight moins grasse 
- couleur de fond différente selon les états (active, hover, focus)

## :100: Pour tester

1. Se rendre sur la page de Connexion de Pix avec le domaine .org
2. Vérifier que le nouveau design du bouton de connexion SSO de la FWB correspond bien à la maquette (voir ticket)
3. Vérifier les changements au hover et au focus
4. Vérifier que l'A11Y est valide avec un outil de votre navigateur (ex: wave)
5. ⚠️ Faire des tests de non régression en vérifiant que le bouton de connexion SSO PE (sur le domaine .fr) correspond toujours à celui que l'on a en production
