### PR TITLE
[FEATURE] Ajouter un script pour synchroniser les données de users.lastLoggedAt et de user-logins.lastLoggedAt (PIX-9009)

### DIFF
--- a/api/scripts/team-acces/sync-user-logins-last-logged-at.js
+++ b/api/scripts/team-acces/sync-user-logins-last-logged-at.js
@@ -1,0 +1,39 @@
+import { fileURLToPath } from 'node:url';
+
+import { knex, disconnect } from '../../db/knex-database-connection.js';
+
+const modulePath = fileURLToPath(import.meta.url);
+const IS_LAUNCHED_FROM_CLI = process.argv[1] === modulePath;
+
+const TIMER_NAME = 'user-logins-last-logged-at-syncing';
+
+async function main() {
+  console.time(TIMER_NAME);
+  console.log('Starting user-logins-last-logged-at syncing…');
+
+  await syncUserLoginsLastLoggedAt();
+
+  console.timeEnd(TIMER_NAME);
+}
+
+async function syncUserLoginsLastLoggedAt() {
+  await knex.raw(`
+  UPDATE "user-logins" t2
+  SET "lastLoggedAt" = t1."lastLoggedAt"
+  FROM "users" t1
+    WHERE t1."id" = t2."userId"
+    AND t2."lastLoggedAt" IS NULL
+  ;
+  `);
+}
+
+if (IS_LAUNCHED_FROM_CLI) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème

Une fois la colonne `user-logins.lastLoggedAt` créée, il faut en synchroniser les valeurs avec la colonne de `users.lastLoggedAt` pour ne pas perdre de données.

## :robot: Proposition

Mettre à jour la valeur de la nouvelle colonne si vide avec la valeur de l’ancienne.

On souhaite utiliser un script et non une migration de manière à pouvoir lancer le script rapidement sans attendre une prochaine livraison. En effet on souhaite pouvoir réaliser la migration des données de `users.lastLoggedAt` avant la rentrée scolaire pour des raisons de charge sur les serveurs à cette période. Mais la bonne pratique est normalement d'utiliser une migration lorsque c'est possible.

De plus plutôt que de passer par les modèles métiers et les repositories (ici `user-repository` et `user-login-repository`) qui assure la validation de toutes les données et opérations ainsi que l’exécution de potentielles règles métiers ici on souhaite **exceptionnellement** utiliser un script exécutant une simple requête SQL _raw_ la plus rapide possible car : 
* de très nombreuses données doivent être modifiées et on ne veut pas bloquer la production en créant des deadlocks (la volumétrie est celle de toute la base de données `users`)
* et il s’agit d’un scope Accès uniquement

Enfin on n'utilise aucun mécanisme de transaction car : 
* le script n'a qu'une instruction SQL
* on n'est pas intéressé par du rollback en cas d'erreur, on souhaite au contraire synchroniser le maximum d'enregistrements possibles à chaque exécution du script qui pourrait être faite

## :rainbow: Remarques

En attendant que le sujet soit discuté avec toute l'équipe, le script a été ajouté dans un répertoire `team-acces` dans le répertoire `api/scripts`, suivant le nom de l'équipe, mais sans mettre d'accent pour un bon fonctionnement avec Git. Mais ce n'est pas très satisfaisant car au lieu d'utiliser le nom d'une équipe, qui est susceptible d'être supprimée/splittée avec le temps,  il faudrait plutôt créer un répertoire correspondant au nom du _bounded context_ (au sens DDD).

Cette PR fait partie d'un ensemble de PR : 
* La branche de cette PR se base sur la branche de #6952 et non sur `dev`.
* Cette PR ne fait qu'ajouter le script `api/scripts/acces/sync-user-logins-last-logged-at.js`

## :100: Pour tester

1. Pour un utilisateur particulier u1 (`Goldi Locks`, `blocked@example.net`, `100707`) modifier son `users.lastLoggedAt` pour y mettre une valeur particulière et modifier son `user-logins.lastLoggedAt` pour qu'il soit `null`
   ```sql
   update "users" set "lastLoggedAt"='2019-01-01' where "id"=100707;
   update "user-logins" set "lastLoggedAt"=null where "userId"=100707;
   ```
2. Pour un utilisateur particulier u2 (`Little Bear`, `temporary-blocked@example.net`, `100710`) modifier son `users.lastLoggedAt` pour y mettre une valeur particulière et modifier son `user-logins.lastLoggedAt` pour qu'il soit non `null` avec une valeur particulière
   ```sql
   update "users" set "lastLoggedAt"='2019-01-01' where "id"=100710;
   update "user-logins" set "lastLoggedAt"='2020-01-01' where "userId"=100710;
   ```
3. Exécuter le script :
   ```shell
   node scripts/team-acces/sync-user-logins-last-logged-at.js
   ```
4. Vérifier que l'exécution du script s'est déroulée sans erreur. Vérifier notamment que le code de retour de la commande exécutée est bien `0`.
   ```shell
   echo $?
   ```
5. Vérifier que pour l'utilisateur particulier u1 son `users.lastLoggedAt` et son `user-logins.lastLoggedAt` sont identiques et valent `2019-01-01 00:00:00+00`
6. Vérifier que pour l'utilisateur particulier u2 son `user-logins.lastLoggedAt` n'a pas été modifié et vaut toujours `2020-01-01 00:00:00+00`
