### PR TITLE
[FEATURE] Ordonner la liste des certifications complémentaires dans Pix Admin. (PIX-8943)

### DIFF
--- a/admin/app/components/complementary-certifications/list.hbs
+++ b/admin/app/components/complementary-certifications/list.hbs
@@ -9,7 +9,7 @@
       </thead>
 
       <tbody>
-        {{#each @complementaryCertifications as |complementaryCertification|}}
+        {{#each this.sortedComplementaryCertifications as |complementaryCertification|}}
           <tr>
             <td class="table__column--id">{{complementaryCertification.id}}</td>
             <td>

--- a/admin/app/components/complementary-certifications/list.js
+++ b/admin/app/components/complementary-certifications/list.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class List extends Component {
+  get sortedComplementaryCertifications() {
+    return this.args.complementaryCertifications.sortBy('label');
+  }
+}

--- a/admin/tests/unit/components/complementary-certifications/list_test.js
+++ b/admin/tests/unit/components/complementary-certifications/list_test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | complementary-certifications/list', function (hooks) {
+  setupTest(hooks);
+
+  module('#sortedComplementaryCertifications', function () {
+    test('it should return an array of complementary certifications ordered by label', async function (assert) {
+      // given
+      const component = createGlimmerComponent('component:complementary-certifications/list');
+
+      component.args = {
+        complementaryCertifications: [
+          { id: 1, label: 'Certif+ B' },
+          { id: 2, label: 'Certif+ C' },
+          {
+            id: 3,
+            label: 'Certif+ A',
+          },
+        ],
+      };
+
+      // when
+      const sortedComplementaryCertifications = component.sortedComplementaryCertifications;
+
+      // then
+      assert.deepEqual(sortedComplementaryCertifications, [
+        { id: 3, label: 'Certif+ A' },
+        {
+          id: 1,
+          label: 'Certif+ B',
+        },
+        { id: 2, label: 'Certif+ C' },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'onglet Certifications complémentaires dans Pix admin affiche la liste des certifications complémentaires, mais cette liste n’est pas ordonnée.
Il en résulte que la page n’affiche pas toujours le même ordre des certifications complémentaires.

## :robot: Proposition
Un tri est déjà effectué côté back sur les id, mais pour le front, on souhaite que la liste soit ordonnée par label.

## :100: Pour tester
- Se connecter sur Pix Admin avec le compte `superadmin@example.net`
- Aller dans l'onglet `Certifications complémentaires`
- Observer que la liste est bien triée par ordre alphabétique
- Aller sur la dernière certification et faire un refresh de la page de détail
- Revenir sur la liste des Certifications et observer qu'elle est toujours triée.
- Aller prendre une pause parce que vous l'avez bien mérité 💪 