### PR TITLE
[TECH] Augmentation du timeout du test courant en cas de truncate sur la BDD.

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -4,13 +4,14 @@ import { factory } from './factory/index.js';
 import { databaseBuffer } from './database-buffer.js';
 
 class DatabaseBuilder {
-  constructor({ knex, emptyFirst = true }) {
+  constructor({ knex, emptyFirst = true, beforeEmptyDatabase = () => undefined }) {
     this.knex = knex;
     this.databaseBuffer = databaseBuffer;
     this.tablesOrderedByDependencyWithDirtinessMap = [];
     this.factory = factory;
     this.isFirstCommit = true;
     this.emptyFirst = emptyFirst;
+    this._beforeEmptyDatabase = beforeEmptyDatabase;
   }
 
   async commit() {
@@ -106,6 +107,7 @@ class DatabaseBuilder {
   }
 
   async _emptyDatabase() {
+    this._beforeEmptyDatabase();
     const sortedTables = _.without(
       _.map(this.tablesOrderedByDependencyWithDirtinessMap, 'table'),
       'knex_migrations',

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -32,7 +32,14 @@ const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 import { knex, disconnect } from '../db/knex-database-connection.js';
 import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 
-const databaseBuilder = new DatabaseBuilder({ knex });
+const databaseBuilder = new DatabaseBuilder({
+  knex,
+  beforeEmptyDatabase: () => {
+    // Sometimes, truncating tables may cause the first ran test to timeout, so
+    // we increase the timeout to ensure we don't have flaky tests
+    increaseCurrentTestTimeout(2000);
+  },
+});
 
 import nock from 'nock';
 
@@ -49,6 +56,7 @@ import { PIX_ADMIN } from '../lib/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;
 import { createTempFile, removeTempFile } from './tooling/temporary-file.js';
+import { increaseCurrentTestTimeout } from './tooling/mocha-tools.js';
 
 /* eslint-disable mocha/no-top-level-hooks */
 afterEach(function () {

--- a/api/tests/tooling/mocha-tools.js
+++ b/api/tests/tooling/mocha-tools.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line n/no-unpublished-import
+import Runnable from 'mocha/lib/runnable.js';
+
+const superRun = Runnable.prototype.run;
+let mochaContext;
+
+Runnable.prototype.run = function (...args) {
+  mochaContext = this;
+  return superRun.bind(this)(...args);
+};
+
+/**
+ * Dirty hack to allow to increase the timeout of the current mocha test
+ * without having the current this context.
+ * @param timeIncrement the increment to the timeout in ms.
+ */
+export const increaseCurrentTestTimeout = (timeIncrement) => {
+  if (mochaContext) {
+    mochaContext.timeout(mochaContext._timeout + timeIncrement);
+  }
+};


### PR DESCRIPTION
## :unicorn: Problème

Il arrive que le test suivant dépasse le temps maximal autorisé pour les tests qui est par défaut de **2 secondes** ([lien vers CircleCI](https://app.circleci.com/pipelines/github/1024pix/pix/62651/workflows/34ca4e4d-c9e1-440b-99d7-3bf6295de52b/jobs/510449/tests#failed-test-0)).

> Acceptance | Application | Account-Recovery | Routes GET /api/account-recovery/{temporaryKey} should return 200 http status code when account recovery demand found

Ce problème arrive car c'est le premier test exécuté en acceptance et donc le premier test à faire l'initialisation de la base de données via le **DatabaseBuilder**. Cette première initialisation de la base de données peut prendre plus de temps que d'habitude.

## :robot: Proposition

Augmenter le timeout du test lorsque le database builder truncate la db

## :rainbow: Remarques

- La modification du timeout du test par le database builder est assez obscure, étant donné que le contexte d'éxécution du test n'est accessible dans mocha que par le `this`.
- L'objectif était de régler le problème des tests flaky lorsque la base de données était utilisée sans impacter l'expérience de développement.

## :100: Pour tester

La CI reste ✅ après plusieurs lancement.
