### PR TITLE
[TECH] Remise à "null" les colonnes liées à la certificabilité d'un organization-learner dissocié (PIX-9017)

### DIFF
--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -260,7 +260,9 @@ const getOrganizationLearnerForAdmin = async function (organizationLearnerId) {
 };
 
 const dissociateUserFromOrganizationLearner = async function (organizationLearnerId) {
-  await knex('organization-learners').where({ id: organizationLearnerId }).update({ userId: null });
+  await knex('organization-learners')
+    .where({ id: organizationLearnerId })
+    .update({ userId: null, certifiableAt: null, isCertifiable: null });
 };
 
 const dissociateAllStudentsByUserId = async function ({

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1480,6 +1480,27 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         .first();
       expect(robotInBDD.userId).to.equal(userToNotDissociate.id);
     });
+
+    it('should reset isCertifiable and certifiableAt to null', async function () {
+      // given
+      const userToDissociate = databaseBuilder.factory.buildUser();
+      const organizationLearnerToDissociate = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userToDissociate.id,
+        isCertifiable: true,
+        certifiableAt: new Date(),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await organizationLearnerRepository.dissociateUserFromOrganizationLearner(organizationLearnerToDissociate.id);
+
+      // then
+      const organizationLearnerPatched = await knex('organization-learners')
+        .where({ id: organizationLearnerToDissociate.id })
+        .first();
+      expect(organizationLearnerPatched.isCertifiable).to.equal(null);
+      expect(organizationLearnerPatched.certifiableAt).to.equal(null);
+    });
   });
 
   describe('#dissociateAllStudentsByUserId', function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans notre epix lié à la remontée auto de la certif, nous avons ajoutés les colonnes isCertifiable et certifiableAt sur la table organization-learner. 
Ces deux colonnes sont liées au learner de l'organisation et ne doivent pas persister si celui ci ne fait plus parti de l'orga en question
Cependant, lorsque qu'un organization learner est dissocié via Pix Admin, seul le champ userId était mis à null

## :robot: Proposition
Mettre également les colonnes isCertifiable et certifiableAt à null lors de la dissociation du learner.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

**Pré-requis : Ajouter en base les valeurs isCertifiable à true (ou false) et certifiableAt avec une date sur un learner d'une orga.**
- Aller sur Pix Admin
- Chercher l'utilisateur précédemment modifié avec des infos sur sa certificabilité
- Le dissocier de son organisation
- Verifier en BDD que les colonnes isCertifiable & certifiableAt (également userId, mais la fonctionnalité existait déjà) sont à null

