### PR TITLE
[TECH] Ajout d'un script pour récupérer les difficultés des challenges depuis redis

### DIFF
--- a/api/scripts/get-difficulties-from-challenge-ids.js
+++ b/api/scripts/get-difficulties-from-challenge-ids.js
@@ -1,0 +1,22 @@
+import yargs from 'yargs';
+import { readFile } from 'fs/promises';
+import { hideBin } from 'yargs/helpers';
+import dotenv from 'dotenv';
+import Redis from 'ioredis';
+
+dotenv.config();
+
+const { challengeIdsFile, redisUrl } = yargs(hideBin(process.argv)).argv;
+const rawChallengeIdsFile = await readFile(challengeIdsFile, 'utf-8');
+const challengeIds = rawChallengeIdsFile.split('\n').filter((challengeId) => challengeId);
+
+const REDIS_URL = redisUrl || process.env.REDIS_URL;
+const redisClient = new Redis(REDIS_URL);
+const rawLearningContent = await redisClient.get('cache:LearningContent');
+const learningContent = JSON.parse(rawLearningContent);
+await redisClient.quit();
+
+const challenges = challengeIds.map((challengeId) => learningContent.challenges.find(({ id }) => challengeId === id));
+const difficulties = challenges.map(({ delta }) => delta);
+
+difficulties.forEach((difficulty) => console.log(`${difficulty}`.replace('.', ',')));


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la certification next gen, nous souhaitons récupérer les difficultés des challenges passés afin de visualiser la progression des utilisateurs lors du parcours de certification.

## :robot: Proposition
Ajout d'un script prenant en entrée une liste de challengeIds et renvoyant la liste des difficultés associées

## :100: Pour tester

```
cd api
echo "rec1XLvN9llSEvKRm" > challengeIds.txt
node ./scripts/get-difficulties-from-challenge-ids.js --challengeIdsFile challengeIds.txt
```

Attention a bien choisir des challengeIds qui sont chargé dans votre cache redis.