### PR TITLE
[FEATURE] Afficher de nouvelles informations sur la liste des contenus formatifs (PIX-8342).

### DIFF
--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -6,7 +6,9 @@
         <tr>
           <th class="table__column table__column--id" id="training-id" scope="col">ID</th>
           <th id="training-titre" scope="col">Titre</th>
-          <th id="training-recommendable" scope="col" class="col-status">Statut</th>
+          <th id="training-prerequisite-threshold" scope="col" class="col-status">Prérequis</th>
+          <th id="training-goal-threshold" scope="col" class="col-status">Objectif à ne pas dépasser</th>
+          <th id="training-target-profile-count" scope="col" class="col-status">Profils cibles associés</th>
         </tr>
         {{#if @triggerFiltering}}
           <tr>
@@ -29,6 +31,8 @@
               />
             </td>
             <td></td>
+            <td></td>
+            <td></td>
           </tr>
         {{/if}}
       </thead>
@@ -43,8 +47,14 @@
                   {{summary.title}}
                 </LinkTo>
               </td>
-              <td headers="training-recommendable">
-                {{if summary.isRecommendable "Déclenchable" "Non déclenchable"}}
+              <td headers="training-prerequisite-threshold">
+                {{summary.prerequisiteThreshold}}
+              </td>
+              <td headers="training-goal-threshold">
+                {{summary.goalThreshold}}
+              </td>
+              <td headers="training-target-profiles-count">
+                {{summary.targetProfilesCount}}
               </td>
             </tr>
           {{/each}}

--- a/admin/app/models/training-summary.js
+++ b/admin/app/models/training-summary.js
@@ -2,5 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TrainingSummary extends Model {
   @attr() title;
-  @attr('boolean') isRecommendable;
+  @attr('number') targetProfilesCount;
+  @attr('number') prerequisiteThreshold;
+  @attr('number') goalThreshold;
 }

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, click } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -44,8 +44,20 @@ module('Acceptance | Trainings | List', function (hooks) {
       test('it should list training summaries', async function (assert) {
         // given
         server.createList('training-summary', 10);
-        server.create('training-summary', { id: 11, title: 'Formation 11', isRecommendable: false });
-        server.create('training-summary', { id: 12, title: 'Formation 12', isRecommendable: true });
+        server.create('training-summary', {
+          id: 11,
+          title: 'Formation 11',
+          prerequisiteThreshold: 33,
+          goalThreshold: 88,
+          targetProfilesCount: 40,
+        });
+        server.create('training-summary', {
+          id: 12,
+          title: 'Formation 12',
+          prerequisiteThreshold: 34,
+          goalThreshold: 89,
+          targetProfilesCount: 41,
+        });
 
         // when
         const screen = await visit('/trainings/list');
@@ -53,9 +65,13 @@ module('Acceptance | Trainings | List', function (hooks) {
 
         // then
         assert.dom(screen.getByText('Formation 11')).exists();
-        assert.dom(screen.getByText('Déclenchable')).exists();
+        assert.dom(screen.getByText('33')).exists();
+        assert.dom(screen.getByText('88')).exists();
+        assert.dom(screen.getByText('40')).exists();
         assert.dom(screen.getByText('Formation 12')).exists();
-        assert.dom(screen.getByText('Non déclenchable')).exists();
+        assert.dom(screen.getByText('34')).exists();
+        assert.dom(screen.getByText('89')).exists();
+        assert.dom(screen.getByText('41')).exists();
       });
 
       module('when filters are used', function (hooks) {

--- a/api/lib/domain/read-models/TrainingSummary.js
+++ b/api/lib/domain/read-models/TrainingSummary.js
@@ -1,9 +1,10 @@
 class TrainingSummary {
-  constructor({ id, title, prerequisiteThreshold, goalThreshold } = {}) {
+  constructor({ id, title, prerequisiteThreshold, goalThreshold, targetProfilesCount } = {}) {
     this.id = id;
     this.title = title;
     this.prerequisiteThreshold = prerequisiteThreshold;
     this.goalThreshold = goalThreshold;
+    this.targetProfilesCount = targetProfilesCount;
   }
 }
 

--- a/api/lib/domain/read-models/TrainingSummary.js
+++ b/api/lib/domain/read-models/TrainingSummary.js
@@ -1,7 +1,9 @@
 class TrainingSummary {
-  constructor({ id, title } = {}) {
+  constructor({ id, title, prerequisiteThreshold, goalThreshold } = {}) {
     this.id = id;
     this.title = title;
+    this.prerequisiteThreshold = prerequisiteThreshold;
+    this.goalThreshold = goalThreshold;
   }
 }
 

--- a/api/lib/domain/read-models/TrainingSummary.js
+++ b/api/lib/domain/read-models/TrainingSummary.js
@@ -1,8 +1,7 @@
 class TrainingSummary {
-  constructor({ id, title, isRecommendable } = {}) {
+  constructor({ id, title } = {}) {
     this.id = id;
     this.title = title;
-    this.isRecommendable = isRecommendable;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (trainingSummaries, meta) {
   return new Serializer('training-summaries', {
-    attributes: ['title'],
+    attributes: ['title', 'targetProfilesCount', 'prerequisiteThreshold', 'goalThreshold'],
     meta,
   }).serialize(trainingSummaries);
 };

--- a/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (trainingSummaries, meta) {
   return new Serializer('training-summaries', {
-    attributes: ['title', 'isRecommendable'],
+    attributes: ['title'],
     meta,
   }).serialize(trainingSummaries);
 };

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -891,6 +891,9 @@ describe('Acceptance | Route | target-profiles', function () {
           type: 'training-summaries',
           id: training.id.toString(),
           attributes: {
+            'goal-threshold': undefined,
+            'prerequisite-threshold': undefined,
+            'target-profiles-count': 1,
             title: 'title',
           },
         },

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -892,7 +892,6 @@ describe('Acceptance | Route | target-profiles', function () {
           id: training.id.toString(),
           attributes: {
             title: 'title',
-            'is-recommendable': false,
           },
         },
       ];

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -304,7 +304,6 @@ describe('Acceptance | Controller | training-controller', function () {
             id: '1',
             attributes: {
               title: training.title,
-              'is-recommendable': false,
             },
           },
         };

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -303,6 +303,9 @@ describe('Acceptance | Controller | training-controller', function () {
             type: 'training-summaries',
             id: '1',
             attributes: {
+              'goal-threshold': undefined,
+              'prerequisite-threshold': undefined,
+              'target-profiles-count': 0,
               title: training.title,
             },
           },

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -163,18 +163,46 @@ describe('Integration | Repository | training-repository', function () {
   });
 
   describe('#findPaginatedSummaries', function () {
+    function createDatabaseRepresentationForTrainingSummary({ trainingSummary, databaseBuilder }) {
+      const training = databaseBuilder.factory.buildTraining({ ...trainingSummary });
+      if (trainingSummary.prerequisiteThreshold !== undefined) {
+        databaseBuilder.factory.buildTrainingTrigger({
+          trainingId: training.id,
+          type: TrainingTrigger.types.PREREQUISITE,
+          threshold: trainingSummary.prerequisiteThreshold,
+        });
+      }
+      if (trainingSummary.goalThreshold !== undefined) {
+        databaseBuilder.factory.buildTrainingTrigger({
+          trainingId: training.id,
+          type: TrainingTrigger.types.GOAL,
+          threshold: trainingSummary.goalThreshold,
+        });
+      }
+    }
+
     context('when trainings exist', function () {
       it('should return paginated results', async function () {
         // given
-        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1 });
-        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2 });
-        const trainingSummary3 = domainBuilder.buildTrainingSummary({ id: 3 });
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({
+          id: 1,
+          prerequisiteThreshold: 0,
+          goalThreshold: 100,
+        });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({
+          id: 2,
+          prerequisiteThreshold: 10,
+          goalThreshold: 90,
+        });
+        const trainingSummary3 = domainBuilder.buildTrainingSummary({
+          id: 3,
+          prerequisiteThreshold: undefined,
+          goalThreshold: undefined,
+        });
 
-        databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
-        databaseBuilder.factory.buildTraining({ ...trainingSummary2 });
-        databaseBuilder.factory.buildTraining({ ...trainingSummary3 });
-
-        databaseBuilder.factory.buildTrainingTrigger({ trainingId: trainingSummary1.id });
+        createDatabaseRepresentationForTrainingSummary({ trainingSummary: trainingSummary1, databaseBuilder });
+        createDatabaseRepresentationForTrainingSummary({ trainingSummary: trainingSummary2, databaseBuilder });
+        createDatabaseRepresentationForTrainingSummary({ trainingSummary: trainingSummary3, databaseBuilder });
 
         await databaseBuilder.commit();
         const filter = {};

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -166,8 +166,8 @@ describe('Integration | Repository | training-repository', function () {
     context('when trainings exist', function () {
       it('should return paginated results', async function () {
         // given
-        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1, isRecommendable: true });
-        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, isRecommendable: false });
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1 });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2 });
         const trainingSummary3 = domainBuilder.buildTrainingSummary({ id: 3 });
 
         databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
@@ -259,8 +259,8 @@ describe('Integration | Repository | training-repository', function () {
     context('when trainings exist', function () {
       it('should return paginated results', async function () {
         // given
-        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1, isRecommendable: true });
-        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, isRecommendable: false });
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1 });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2 });
         const trainingSummaryLinkToAnotherTargetProfile = domainBuilder.buildTrainingSummary({ id: 3 });
 
         databaseBuilder.factory.buildTraining({ ...trainingSummary1 });

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -1,10 +1,9 @@
 import { TrainingSummary } from '../../../../lib/domain/read-models/TrainingSummary.js';
 
-const buildTrainingSummary = function ({ id = 1, title = 'Training Summary 1', isRecommendable = false } = {}) {
+const buildTrainingSummary = function ({ id = 1, title = 'Training Summary 1' } = {}) {
   return new TrainingSummary({
     id,
     title,
-    isRecommendable,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -1,9 +1,16 @@
 import { TrainingSummary } from '../../../../lib/domain/read-models/TrainingSummary.js';
 
-const buildTrainingSummary = function ({ id = 1, title = 'Training Summary 1' } = {}) {
+const buildTrainingSummary = function ({
+  id = 1,
+  title = 'Training Summary 1',
+  prerequisiteThreshold,
+  goalThreshold,
+} = {}) {
   return new TrainingSummary({
     id,
     title,
+    prerequisiteThreshold,
+    goalThreshold,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -5,12 +5,14 @@ const buildTrainingSummary = function ({
   title = 'Training Summary 1',
   prerequisiteThreshold,
   goalThreshold,
+  targetProfilesCount = 0,
 } = {}) {
   return new TrainingSummary({
     id,
     title,
     prerequisiteThreshold,
     goalThreshold,
+    targetProfilesCount,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
@@ -9,6 +9,9 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
         domainBuilder.buildTrainingSummary({
           id: 1,
           title: 'Training Summary 1',
+          targetProfilesCount: 1,
+          prerequisiteThreshold: 2,
+          goalThreshold: 30,
         }),
         domainBuilder.buildTrainingSummary({ id: 2, title: 'Training Summary 2' }),
       ];
@@ -24,6 +27,9 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
             type: 'training-summaries',
             id: '1',
             attributes: {
+              'goal-threshold': 30,
+              'prerequisite-threshold': 2,
+              'target-profiles-count': 1,
               title: 'Training Summary 1',
             },
           },
@@ -31,6 +37,9 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
             type: 'training-summaries',
             id: '2',
             attributes: {
+              'goal-threshold': undefined,
+              'prerequisite-threshold': undefined,
+              'target-profiles-count': 0,
               title: 'Training Summary 2',
             },
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/training-summary-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | training-summary-serializer', function () {
@@ -6,7 +6,10 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
     it('should serialize training summaries to JSONAPI with meta data', function () {
       // given
       const trainingSummaries = [
-        domainBuilder.buildTrainingSummary({ id: 1, title: 'Training Summary 1', isRecommendable: true }),
+        domainBuilder.buildTrainingSummary({
+          id: 1,
+          title: 'Training Summary 1',
+        }),
         domainBuilder.buildTrainingSummary({ id: 2, title: 'Training Summary 2' }),
       ];
       const meta = { pagination: { page: 1, pageSize: 3, pageCount: 1, rowCount: 2 } };
@@ -22,7 +25,6 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
             id: '1',
             attributes: {
               title: 'Training Summary 1',
-              'is-recommendable': true,
             },
           },
           {
@@ -30,7 +32,6 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
             id: '2',
             attributes: {
               title: 'Training Summary 2',
-              'is-recommendable': false,
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, nous avons actuellement sur la liste des CF une colonne pour savoir si le CF est recommandé ou non. Cette information n'est pas satisfaisante pour le métier qui préférerait savoir : si un déclencheur est présent et son threshold et connaître sur le CF est lié à un profil cible

## :robot: Proposition
- Supprimer la colonne pour afficher sur un CF est recommandée.
- Ajouter 3 colonnes : 
	- Le seuil pour le prérequis s'il existe
	- Le seuil pour l'objectif à atteindre s'il existe
	- Le nombre de PC liés
	
## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Admin 
- Aller dans l'onglet CF et regarder le fonctionnement des nouvelles colonnes
- Aller sur PC puis dans l'onglet CF et regarder le fonctionnement des nouvelles colonnes