### PR TITLE
[FEATURE] Envoyer les informations de RT certifiants pour attacher un PC à une complémentaire  (PIX-9001).

### DIFF
--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -12,22 +12,28 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
   }
 
   async updateRecord(store, type, complementaryCertification) {
-    if (complementaryCertification.adapterOptions?.attachBadges === true) {
+    if (complementaryCertification.adapterOptions?.attachBadges) {
       const payload = this.serialize(complementaryCertification);
       delete payload.data.attributes['key'];
       delete payload.data.attributes['label'];
       delete payload.data.attributes['target-profiles-history'];
 
-      const {targetProfileId} = complementaryCertification.adapterOptions;
+      const { targetProfileId } = complementaryCertification.adapterOptions;
       payload.data.attributes['target-profile-id'] = targetProfileId;
 
-      const complementaryCertificationBadges = complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];
-      payload.data.attributes['complementary-certification-badges'] = complementaryCertificationBadges
-        .map(complementaryCertificationBadge => {
-          return this.serialize(complementaryCertificationBadge, {includeId: true});
-        });
+      const complementaryCertificationBadges =
+        complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];
+      payload.data.attributes['complementary-certification-badges'] = complementaryCertificationBadges.map(
+        (complementaryCertificationBadge) => {
+          return this.serialize(complementaryCertificationBadge, { includeId: true });
+        },
+      );
 
-      return this.ajax(this.urlForUpdateRecord(complementaryCertification.id, type.modelName, complementaryCertification), 'PUT', { data: payload });
+      return this.ajax(
+        this.urlForUpdateRecord(complementaryCertification.id, type.modelName, complementaryCertification),
+        'PUT',
+        { data: payload },
+      );
     }
 
     return super.updateRecord(...arguments);

--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -6,4 +6,30 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
   urlForFindRecord(id) {
     return `${this.host}/${this.namespace}/complementary-certifications/${id}/target-profiles`;
   }
+
+  urlForUpdateRecord(id) {
+    return `${this.host}/${this.namespace}/complementary-certifications/${id}/badges`;
+  }
+
+  async updateRecord(store, type, complementaryCertification) {
+    if (complementaryCertification.adapterOptions?.attachBadges === true) {
+      const {detachedTargetProfileId, attachedTargetProfileId} = complementaryCertification.adapterOptions;
+      const payload = this.serialize(complementaryCertification, {includeId: true});
+      delete payload.data.attributes['target-profiles-history'];
+
+      payload.data.attributes.attachedTargetProfileId = attachedTargetProfileId;
+      payload.data.attributes.detachedTargetProfileId = detachedTargetProfileId;
+
+      const relatedBadges = complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];
+      payload.data.attributes.badges = relatedBadges
+        .filterBy('isNew', true)
+        .map(complementaryCertificationBadge => {
+          return this.serialize(complementaryCertificationBadge, {includeId: true});
+        });
+
+      return this.ajax(this.urlForUpdateRecord(complementaryCertification.id, type.modelName, complementaryCertification), 'PUT', payload);
+    }
+
+    return super.updateRecord(...arguments);
+  }
 }

--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -13,21 +13,21 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
 
   async updateRecord(store, type, complementaryCertification) {
     if (complementaryCertification.adapterOptions?.attachBadges === true) {
-      const {detachedTargetProfileId, attachedTargetProfileId} = complementaryCertification.adapterOptions;
-      const payload = this.serialize(complementaryCertification, {includeId: true});
+      const payload = this.serialize(complementaryCertification);
+      delete payload.data.attributes['key'];
+      delete payload.data.attributes['label'];
       delete payload.data.attributes['target-profiles-history'];
 
-      payload.data.attributes.attachedTargetProfileId = attachedTargetProfileId;
-      payload.data.attributes.detachedTargetProfileId = detachedTargetProfileId;
+      const {targetProfileId} = complementaryCertification.adapterOptions;
+      payload.data.attributes['target-profile-id'] = targetProfileId;
 
-      const relatedBadges = complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];
-      payload.data.attributes.badges = relatedBadges
-        .filterBy('isNew', true)
+      const complementaryCertificationBadges = complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];
+      payload.data.attributes['complementary-certification-badges'] = complementaryCertificationBadges
         .map(complementaryCertificationBadge => {
           return this.serialize(complementaryCertificationBadge, {includeId: true});
         });
 
-      return this.ajax(this.urlForUpdateRecord(complementaryCertification.id, type.modelName, complementaryCertification), 'PUT', payload);
+      return this.ajax(this.urlForUpdateRecord(complementaryCertification.id, type.modelName, complementaryCertification), 'PUT', { data: payload });
     }
 
     return super.updateRecord(...arguments);

--- a/admin/app/components/complementary-certifications/attach-badges/badges/header.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/header.hbs
@@ -1,0 +1,14 @@
+<th class="attach-badges-header">
+  <span class="attach-badges-header__content">
+    {{yield}}
+    {{#if @isRequired}}
+      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
+    {{/if}}
+    {{#if (has-block "tooltip")}}
+      <PixTooltip role="tooltip" @isLight={{true}} @isWide={{true}} @position="bottom">
+        <:triggerElement><FaIcon @icon="circle-info" /></:triggerElement>
+        <:tooltip>{{yield to="tooltip"}}</:tooltip>
+      </PixTooltip>
+    {{/if}}
+  </span>
+</th>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/header.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/header.hbs
@@ -5,7 +5,7 @@
       <abbr title="obligatoire" class="mandatory-mark">*</abbr>
     {{/if}}
     {{#if (has-block "tooltip")}}
-      <PixTooltip role="tooltip" @isLight={{true}} @isWide={{true}} @position="bottom">
+      <PixTooltip role="tooltip" @isLight={{true}} @isWide={{true}} @position="bottom-left" class="content_tooltip">
         <:triggerElement><FaIcon @icon="circle-info" /></:triggerElement>
         <:tooltip>{{yield to="tooltip"}}</:tooltip>
       </PixTooltip>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/index.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/index.hbs
@@ -3,6 +3,6 @@
 {{/if}}
 <ComplementaryCertifications::AttachBadges::Badges::List
   @options={{this.badges}}
-  @onUpdateLevel={{this.onBadgeUpdated}}
+  @onBadgeUpdated={{this.onBadgeUpdated}}
   @error={{this.getTargetProfileBadgesErrorMessage}}
 />

--- a/admin/app/components/complementary-certifications/attach-badges/badges/index.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/index.js
@@ -56,7 +56,6 @@ export default class Badges extends Component {
   }
 
   #onfetchBadgesError(error) {
-    console.log(error);
     this.args.onError('Une erreur est survenue lors de la recherche de résultats thématiques.');
   }
 

--- a/admin/app/components/complementary-certifications/attach-badges/badges/index.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/index.js
@@ -1,7 +1,7 @@
-import { action } from '@ember/object';
+import {action} from '@ember/object';
 import Component from '@glimmer/component';
-import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
+import {service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
 
 export default class Badges extends Component {
   @tracked isLoading;
@@ -22,12 +22,12 @@ export default class Badges extends Component {
   }
 
   @action
-  onBadgeUpdated(badgeId, badgeLevel) {
+  onBadgeUpdated({badgeId, fieldName, fieldValue}) {
     if (!badgeId) {
       return;
     }
 
-    this.args.onBadgeUpdated({ badgeId, badgeLevel });
+    this.args.onBadgeUpdated({badges: this.badges, update: {badgeId, fieldName, fieldValue}});
   }
 
   #initBadges(targetProfile) {

--- a/admin/app/components/complementary-certifications/attach-badges/badges/index.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/index.js
@@ -1,7 +1,7 @@
-import {action} from '@ember/object';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import {service} from '@ember/service';
-import {tracked} from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class Badges extends Component {
   @tracked isLoading;
@@ -22,12 +22,12 @@ export default class Badges extends Component {
   }
 
   @action
-  onBadgeUpdated({badgeId, fieldName, fieldValue}) {
+  onBadgeUpdated({ badgeId, fieldName, fieldValue }) {
     if (!badgeId) {
       return;
     }
 
-    this.args.onBadgeUpdated({badges: this.badges, update: {badgeId, fieldName, fieldValue}});
+    this.args.onBadgeUpdated({ update: { badgeId, fieldName, fieldValue } });
   }
 
   #initBadges(targetProfile) {
@@ -55,7 +55,7 @@ export default class Badges extends Component {
       .finally(() => (this.isLoading = false));
   }
 
-  #onfetchBadgesError(error) {
+  #onfetchBadgesError() {
     this.args.onError('Une erreur est survenue lors de la recherche de résultats thématiques.');
   }
 

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
@@ -1,9 +1,4 @@
 <div class="complementary-certification-attach-badges">
-  <p class="complementary-certification-attach-badges__description">
-    Les niveaux de RT sont déterminés en fonction de leur difficulté, avec le chiffre le plus bas étant le plus facile à
-    obtenir et le chiffre le plus haut étant le chiffre le plus difficile à obtenir (1 &#60; 3).
-  </p>
-
   {{#if @error}}
     <PixMessage role="alert" @type="error" @withIcon={{true}} class="complementary-certification-attach-badges__error">
       {{@error}}
@@ -44,7 +39,7 @@
           <ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
             <:default>Macaron de l'attestation PDF</:default>
             <:tooltip>
-              Renseignez l’URL de l’image au format .svg (fournie par les devs) pour l’attestation de certification PDF
+              Renseignez l’URL de l’image au format .pdf (fournie par les devs) pour l’attestation de certification PDF
               du candidat.
             </:tooltip>
           </ComplementaryCertifications::AttachBadges::Badges::Header>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
@@ -24,27 +24,44 @@
           </ComplementaryCertifications::AttachForm::Badges::Header>
           <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
             <:default>Niveau</:default>
-            <:tooltip>A compléter</:tooltip>
+            <:tooltip>
+              Renseignez un chiffre unique pour chaque RT, niveau minimum = 1 niveau maximum = nombre total de RT.
+            </:tooltip>
           </ComplementaryCertifications::AttachForm::Badges::Header>
           <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
             <:default>Image svg certificat Pix App</:default>
-            <:tooltip>A compléter</:tooltip>
+            <:tooltip>
+              Renseignez l’URL de l’image au format .svg (fournie par les devs) pour le certificat Pix App du candidat.
+            </:tooltip>
           </ComplementaryCertifications::AttachForm::Badges::Header>
           <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
             <:default>Label du certificat</:default>
-            <:tooltip>A compléter</:tooltip>
+            <:tooltip>
+              Renseignez un label qui permet de distinguer chaque RT (exemples : Pix+ Droit Expert, CléA Numérique, Pix+
+              Edu 2nd degré Confirmé etc…)
+            </:tooltip>
           </ComplementaryCertifications::AttachForm::Badges::Header>
           <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
             <:default>Macaron de l'attestation PDF</:default>
-            <:tooltip>A compléter</:tooltip>
+            <:tooltip>
+              Renseignez l’URL de l’image au format .svg (fournie par les devs) pour l’attestation de certification PDF
+              du candidat.
+            </:tooltip>
           </ComplementaryCertifications::AttachForm::Badges::Header>
           <ComplementaryCertifications::AttachForm::Badges::Header>
             <:default>Message du certificat</:default>
-            <:tooltip>A compléter</:tooltip>
+            <:tooltip>
+              Renseignez le message définitif à afficher sur le certificat Pix App pour les certifications comportant
+              plusieurs volets (exemple : Vous avez obtenu la certification Pix+ Edu niveau “Avancé”).
+            </:tooltip>
           </ComplementaryCertifications::AttachForm::Badges::Header>
           <ComplementaryCertifications::AttachForm::Badges::Header>
             <:default>Message temporaire certificat</:default>
-            <:tooltip>A compléter</:tooltip>
+            <:tooltip>
+              Renseignez le message temporaire à afficher sur le certificat Pix App en attendant la validation de tous
+              les volets de la certification (exemple : Vous avez obtenu le niveau “Avancé” dans le cadre du volet 1 de
+              la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2).
+            </:tooltip>
           </ComplementaryCertifications::AttachForm::Badges::Header>
         </tr>
       </thead>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
@@ -16,58 +16,58 @@
     <table aria-label="Liste des résultats thématiques">
       <thead>
         <tr>
-          <ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header>
             ID
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header>
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header>
             Nom
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
             <:default>Niveau</:default>
             <:tooltip>
               Renseignez un chiffre unique pour chaque RT, niveau minimum = 1 niveau maximum = nombre total de RT.
             </:tooltip>
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
             <:default>Image svg certificat Pix App</:default>
             <:tooltip>
               Renseignez l’URL de l’image au format .svg (fournie par les devs) pour le certificat Pix App du candidat.
             </:tooltip>
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
             <:default>Label du certificat</:default>
             <:tooltip>
               Renseignez un label qui permet de distinguer chaque RT (exemples : Pix+ Droit Expert, CléA Numérique, Pix+
               Edu 2nd degré Confirmé etc…)
             </:tooltip>
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
             <:default>Macaron de l'attestation PDF</:default>
             <:tooltip>
               Renseignez l’URL de l’image au format .svg (fournie par les devs) pour l’attestation de certification PDF
               du candidat.
             </:tooltip>
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header>
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header>
             <:default>Message du certificat</:default>
             <:tooltip>
               Renseignez le message définitif à afficher sur le certificat Pix App pour les certifications comportant
               plusieurs volets (exemple : Vous avez obtenu la certification Pix+ Edu niveau “Avancé”).
             </:tooltip>
-          </ComplementaryCertifications::AttachForm::Badges::Header>
-          <ComplementaryCertifications::AttachForm::Badges::Header>
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
+          <ComplementaryCertifications::AttachBadges::Badges::Header>
             <:default>Message temporaire certificat</:default>
             <:tooltip>
               Renseignez le message temporaire à afficher sur le certificat Pix App en attendant la validation de tous
               les volets de la certification (exemple : Vous avez obtenu le niveau “Avancé” dans le cadre du volet 1 de
               la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2).
             </:tooltip>
-          </ComplementaryCertifications::AttachForm::Badges::Header>
+          </ComplementaryCertifications::AttachBadges::Badges::Header>
         </tr>
       </thead>
       <tbody>
         {{#each @options as |option|}}
-          <ComplementaryCertifications::AttachForm::Badges::Row
+          <ComplementaryCertifications::AttachBadges::Badges::Row
             @badgeId={{option.id}}
             @badgeLabel={{option.label}}
             @badgeMaxLevel={{option.length}}

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
@@ -16,29 +16,53 @@
     <table aria-label="Liste des résultats thématiques">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Nom</th>
-          <th>Niveau</th>
+          <ComplementaryCertifications::AttachForm::Badges::Header>
+            ID
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header>
+            Nom
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+            <:default>Niveau</:default>
+            <:tooltip>A compléter</:tooltip>
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+            <:default>Image svg certificat Pix App</:default>
+            <:tooltip>A compléter</:tooltip>
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+            <:default>Label du certificat</:default>
+            <:tooltip>A compléter</:tooltip>
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+            <:default>Macaron de l'attestation PDF</:default>
+            <:tooltip>A compléter</:tooltip>
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header>
+            <:default>Message du certificat</:default>
+            <:tooltip>A compléter</:tooltip>
+          </ComplementaryCertifications::AttachForm::Badges::Header>
+          <ComplementaryCertifications::AttachForm::Badges::Header>
+            <:default>Message temporaire certificat</:default>
+            <:tooltip>A compléter</:tooltip>
+          </ComplementaryCertifications::AttachForm::Badges::Header>
         </tr>
       </thead>
       <tbody>
         {{#each @options as |option|}}
-          <tr aria-label="Résultat thématique {{option.id}} {{option.label}}">
-            <td>{{option.id}}</td>
-            <td>{{option.label}}</td>
-            <td>
-              <PixInput
-                @id="{{option.id}}"
-                placeholder="Exemple de niveau de RT : 1"
-                type="number"
-                min="1"
-                max="{{@options.length}}"
-                {{on "input" this.onUpdateLevel}}
-              />
-            </td>
-          </tr>
+          <ComplementaryCertifications::AttachForm::Badges::Row
+            @badgeId={{option.id}}
+            @badgeLabel={{option.label}}
+            @badgeMaxLevel={{option.length}}
+            @onFieldUpdate={{this.onBadgeUpdated}}
+          />
         {{/each}}
       </tbody>
     </table>
+
+    <p aria-details="Les colonnes marquées avec un astérisque sont des champs obligatoires">
+      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
+      Champs obligatoires
+    </p>
   </section>
 </div>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.js
@@ -6,7 +6,7 @@ export default class List extends Component {
   onBadgeUpdated(badgeId, event) {
     this.args.onBadgeUpdated({
       badgeId,
-      fieldName: event.target.id,
+      fieldName: event.target.name,
       fieldValue: event.target.value
     });
   }

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.js
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import {action} from '@ember/object';
 
 export default class List extends Component {
   @action
-  onUpdateLevel(event) {
-    this.args.onUpdateLevel(event.target.id, event.target.value);
+  onBadgeUpdated(badgeId, event) {
+    this.args.onBadgeUpdated({
+      badgeId,
+      fieldName: event.target.id,
+      fieldValue: event.target.value
+    });
   }
 }

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import {action} from '@ember/object';
+import { action } from '@ember/object';
 
 export default class List extends Component {
   @action
@@ -7,7 +7,7 @@ export default class List extends Component {
     this.args.onBadgeUpdated({
       badgeId,
       fieldName: event.target.name,
-      fieldValue: event.target.value
+      fieldValue: event.target.value,
     });
   }
 }

--- a/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
@@ -1,13 +1,15 @@
-<tr aria-label="Résultat thématique {{@badgeId}} {{@badgeLabel}}">
-  <td>{{@badgeId}}</td>
-  <td>{{@badgeLabel}}</td>
+<tr class="badge" aria-label="Résultat thématique {{@badgeId}} {{@badgeLabel}}">
+  <th scope="row">{{@badgeId}}</th>
+  <th scope="row">{{@badgeLabel}}</th>
   <td>
     <PixInput
-      @id="{{@badgeId}}.level"
+      @id="{{@badgeId}}-level"
       name="level"
       placeholder="Exemple de niveau de RT : 1"
+      required="true"
       aria-required="true"
-      aria-label="niveau"
+      @ariaLabel="{{@badgeId}} {{@badgeLabel}} Niveau"
+      title="{{@badgeId}} {{@badgeLabel}} Niveau"
       type="number"
       min="1"
       max="{{@badgeMaxLevel}}"
@@ -16,51 +18,59 @@
   </td>
   <td>
     <PixInput
-      @id="{{@badgeId}}.certificate-image"
+      @id="{{@badgeId}}-certificate-image"
       name="certificate-image"
       placeholder="Ex : https://images.pix.fr/..."
+      required="true"
       aria-required="true"
-      aria-label="image certificat Pix App"
+      @ariaLabel="{{@badgeId}} {{@badgeLabel}} Image svg certificat Pix App"
+      title="{{@badgeId}} {{@badgeLabel}} Image svg certificat Pix App"
       type="text"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
     />
   </td>
   <td>
     <PixTextarea
-      @id="{{@badgeId}}.certificate-label"
+      @id="{{@badgeId}}-certificate-label"
       name="certificate-label"
       placeholder="Ex : Pix+ Édu 1er degré Initié (entrée dans le métier)"
+      required="true"
       aria-required="true"
-      aria-label="label du certificat"
+      aria-label="{{@badgeId}} {{@badgeLabel}} Label du certificat"
+      title="{{@badgeId}} {{@badgeLabel}} Label du certificat"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
     />
   </td>
   <td>
     <PixInput
-      @id="{{@badgeId}}.certificate-sticker"
+      @id="{{@badgeId}}-certificate-sticker"
       name="certificate-sticker"
       placeholder="Ex : https://images.pix.fr/..."
+      required="true"
       aria-required="true"
-      aria-label="macaron du certificat"
+      @ariaLabel="{{@badgeId}} {{@badgeLabel}} Macaron de l'attestation PDF"
+      title="{{@badgeId}} {{@badgeLabel}} Macaron de l'attestation PDF"
       type="text"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
     />
   </td>
   <td>
     <PixTextarea
-      @id="{{@badgeId}}.certificate-message"
+      @id="{{@badgeId}}-certificate-message"
       name="certificate-message"
       placeholder="Ex : Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”"
-      aria-label="message du certificat"
+      aria-label="{{@badgeId}} {{@badgeLabel}} Message du certificat"
+      title="{{@badgeId}} {{@badgeLabel}} Message du certificat"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
     />
   </td>
   <td>
     <PixTextarea
-      @id="{{@badgeId}}.certificate-temporary-message"
+      @id="{{@badgeId}}-certificate-temporary-message"
       name="certificate-temporary-message"
       placeholder="Ex : Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”"
-      aria-label="message temporaire du certificat"
+      aria-label="{{@badgeId}} {{@badgeLabel}} Message temporaire certificat"
+      title="{{@badgeId}} {{@badgeLabel}} Message temporaire certificat"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
     />
   </td>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
@@ -1,0 +1,61 @@
+<tr aria-label="Résultat thématique {{@badgeId}} {{@badgeLabel}}">
+  <td>{{@badgeId}}</td>
+  <td>{{@badgeLabel}}</td>
+  <td>
+    <PixInput
+      @id="level"
+      placeholder="Exemple de niveau de RT : 1"
+      aria-required="true"
+      aria-label="niveau"
+      type="number"
+      min="1"
+      max="{{@badgeMaxLevel}}"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+  <td>
+    <PixInput
+      @id="certificate-image"
+      placeholder="Ex : https://images.pix.fr/..."
+      aria-required="true"
+      aria-label="image certificat Pix App"
+      type="text"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+  <td>
+    <PixTextarea
+      @id="certificate-label"
+      placeholder="Ex : Pix+ Édu 1er degré Initié (entrée dans le métier)"
+      aria-required="true"
+      aria-label="label du certificat"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+  <td>
+    <PixInput
+      @id="certificate-sticker"
+      placeholder="Ex : https://images.pix.fr/..."
+      aria-required="true"
+      aria-label="macaron du certificat"
+      type="text"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+  <td>
+    <PixTextarea
+      @id="certificate-message"
+      placeholder="Ex : Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”"
+      aria-label="message du certificat"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+  <td>
+    <PixTextarea
+      @id="certificate-temporary-message"
+      placeholder="Ex : Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”"
+      aria-label="message temporaire du certificat"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+</tr>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
@@ -3,7 +3,8 @@
   <td>{{@badgeLabel}}</td>
   <td>
     <PixInput
-      @id="level"
+      @id="{{@badgeId}}.level"
+      name="level"
       placeholder="Exemple de niveau de RT : 1"
       aria-required="true"
       aria-label="niveau"
@@ -15,7 +16,8 @@
   </td>
   <td>
     <PixInput
-      @id="certificate-image"
+      @id="{{@badgeId}}.certificate-image"
+      name="certificate-image"
       placeholder="Ex : https://images.pix.fr/..."
       aria-required="true"
       aria-label="image certificat Pix App"
@@ -25,7 +27,8 @@
   </td>
   <td>
     <PixTextarea
-      @id="certificate-label"
+      @id="{{@badgeId}}.certificate-label"
+      name="certificate-label"
       placeholder="Ex : Pix+ Édu 1er degré Initié (entrée dans le métier)"
       aria-required="true"
       aria-label="label du certificat"
@@ -34,7 +37,8 @@
   </td>
   <td>
     <PixInput
-      @id="certificate-sticker"
+      @id="{{@badgeId}}.certificate-sticker"
+      name="certificate-sticker"
       placeholder="Ex : https://images.pix.fr/..."
       aria-required="true"
       aria-label="macaron du certificat"
@@ -44,7 +48,8 @@
   </td>
   <td>
     <PixTextarea
-      @id="certificate-message"
+      @id="{{@badgeId}}.certificate-message"
+      name="certificate-message"
       placeholder="Ex : Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”"
       aria-label="message du certificat"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
@@ -52,7 +57,8 @@
   </td>
   <td>
     <PixTextarea
-      @id="certificate-temporary-message"
+      @id="{{@badgeId}}.certificate-temporary-message"
+      name="certificate-temporary-message"
       placeholder="Ex : Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”"
       aria-label="message temporaire du certificat"
       {{on "input" (fn @onFieldUpdate @badgeId)}}

--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/index.js
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/index.js
@@ -33,7 +33,6 @@ export default class TargetProfileSelectorComponent extends Component {
           value: attachableTargetProfile,
         }));
       } catch (e) {
-        console.log(e);
         this.args.onError('Une erreur est survenue lors de la recherche de profils cibles.');
       } finally {
         this.isAttachableTargetProfilesLoading = false;

--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/selected-target-profile.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/selected-target-profile.hbs
@@ -18,4 +18,6 @@
     >Changer
     </PixButton>
   </div>
+
+  <input type="hidden" id="target-profile" name="target-profile" value="{{@attachableTargetProfile.id}}" />
 </div>

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -8,13 +8,9 @@ export default class AttachTargetProfileController extends Controller {
   @service router;
   @service store;
 
+  @tracked isSubmitDisabled = true;
   @tracked selectedTargetProfile;
   @tracked targetProfileBadges;
-
-  @action
-  async cancel() {
-    this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
-  }
 
   @action
   async onError(errorMessage) {
@@ -28,6 +24,7 @@ export default class AttachTargetProfileController extends Controller {
     if (selectedAttachableTargetProfile) {
       this.selectedTargetProfile = selectedAttachableTargetProfile;
       this.targetProfileBadges = new Map();
+      this.isSubmitDisabled = false;
     }
   }
 
@@ -35,11 +32,22 @@ export default class AttachTargetProfileController extends Controller {
   onReset() {
     this.selectedTargetProfile = undefined;
     this.targetProfileBadges = undefined;
+    this.isSubmitDisabled = true;
   }
 
   @action
-  onBadgeUpdated({ badgeId, badgeLevel }) {
-    console.log('A badge level has been updated: ', { badgeId, badgeLevel });
-    this.targetProfileBadges.set(badgeId, badgeLevel);
+  onBadgeUpdated({badges, update: {badgeId, fieldName, fieldValue}}) {
+    console.log('A badge has been updated: ', {badges, update: {badgeId, fieldName, fieldValue}});
+  }
+
+  @action
+  async onCancel() {
+    this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
+  }
+
+  @action
+  async onSubmit() {
+    console.log('SUBMIT');
+    this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
   }
 }

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -1,7 +1,7 @@
-import {action} from '@ember/object';
-import {service} from '@ember/service';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
-import {tracked} from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
 
 export default class AttachTargetProfileController extends Controller {
   @service notifications;
@@ -38,8 +38,8 @@ export default class AttachTargetProfileController extends Controller {
   }
 
   @action
-  onBadgeUpdated({badges, update: {badgeId, fieldName, fieldValue}}) {
-    this.#updateBadge({badgeId, fieldName, fieldValue});
+  onBadgeUpdated({ update: { badgeId, fieldName, fieldValue } }) {
+    this.#updateBadge({ badgeId, fieldName, fieldValue });
   }
 
   @action
@@ -55,6 +55,10 @@ export default class AttachTargetProfileController extends Controller {
 
     try {
       const complementaryCertification = this.model.complementaryCertification;
+
+      this.store.peekAll('complementary-certification-badge').forEach(function (model) {
+        model.deleteRecord();
+      });
 
       this.#targetProfileBadges.forEach((badge, badgeId) => {
         const aBadge = this.store.createRecord('complementary-certification-badge', {
@@ -74,25 +78,21 @@ export default class AttachTargetProfileController extends Controller {
         adapterOptions: {
           attachBadges: true,
           targetProfileId: this.model.currentTargetProfile.id,
-        }
+        },
       });
       this.notifications.success('Profil cible rattaché avec succès');
-
     } catch (error) {
-      this.store.peekAll('complementary-certification-badge').forEach(function(model){
-        model.deleteRecord();
-      });
+      console.log(error);
       await this.onError("Une erreur est survenue lors de l'enregistrement du profil cible.");
     } finally {
       this.isSubmitting = false;
     }
   }
 
-  #updateBadge({badgeId, fieldName, fieldValue}) {
+  #updateBadge({ badgeId, fieldName, fieldValue }) {
     const currentBadge = this.#targetProfileBadges.get(badgeId);
     this.#targetProfileBadges.set(badgeId, {
       ...currentBadge,
-      id: badgeId,
       [fieldName]: fieldValue,
     });
   }

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -1,7 +1,7 @@
-import { action } from '@ember/object';
-import { service } from '@ember/service';
+import {action} from '@ember/object';
+import {service} from '@ember/service';
 import Controller from '@ember/controller';
-import { tracked } from '@glimmer/tracking';
+import {tracked} from '@glimmer/tracking';
 
 export default class AttachTargetProfileController extends Controller {
   @service notifications;
@@ -9,8 +9,9 @@ export default class AttachTargetProfileController extends Controller {
   @service store;
 
   @tracked isSubmitDisabled = true;
+  @tracked isSubmitting = false;
   @tracked selectedTargetProfile;
-  @tracked targetProfileBadges;
+  #targetProfileBadges = new Map();
 
   @action
   async onError(errorMessage) {
@@ -23,7 +24,7 @@ export default class AttachTargetProfileController extends Controller {
   async onSelection(selectedAttachableTargetProfile) {
     if (selectedAttachableTargetProfile) {
       this.selectedTargetProfile = selectedAttachableTargetProfile;
-      this.targetProfileBadges = new Map();
+      this.#targetProfileBadges = new Map();
       this.isSubmitDisabled = false;
     }
   }
@@ -31,13 +32,15 @@ export default class AttachTargetProfileController extends Controller {
   @action
   onReset() {
     this.selectedTargetProfile = undefined;
-    this.targetProfileBadges = undefined;
+    this.#targetProfileBadges = new Map();
     this.isSubmitDisabled = true;
+    this.isSubmitting = false;
   }
 
   @action
   onBadgeUpdated({badges, update: {badgeId, fieldName, fieldValue}}) {
     console.log('A badge has been updated: ', {badges, update: {badgeId, fieldName, fieldValue}});
+    this.#updateBadge({badgeId, fieldName, fieldValue});
   }
 
   @action
@@ -46,8 +49,54 @@ export default class AttachTargetProfileController extends Controller {
   }
 
   @action
-  async onSubmit() {
-    console.log('SUBMIT');
-    this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
+  async onSubmit(event) {
+    event.preventDefault();
+
+    this.isSubmitting = true;
+
+    try {
+      const complementaryCertification = this.model.complementaryCertification;
+
+      this.#targetProfileBadges.forEach((badge, badgeId) => {
+        const aBadge = this.store.createRecord('complementary-certification-badge', {
+          complementaryCertification,
+          badgeId,
+          level: badge.level,
+          imageUrl: badge['certificate-image'],
+          label: badge['certificate-label'],
+          certificateMessage: badge['certificate-message'],
+          temporaryCertificateMessage: badge['certificate-temporary-message'],
+          stickerUrl: badge['certificate-sticker'],
+        });
+        complementaryCertification.complementaryCertificationBadges.pushObject(aBadge);
+      });
+
+      await complementaryCertification.save({
+        adapterOptions: {
+          attachBadges: true,
+          detachedTargetProfileId: this.model.currentTargetProfile.id,
+          attachedTargetProfileId: this.selectedTargetProfile.id,
+        }
+      });
+      this.notifications.success('Target profile rattaché avec succès');
+
+    } catch (error) {
+      console.log(error);
+      this.store.peekAll('complementary-certification-badge').filterBy('isNew', true).forEach(function(model){
+        model.deleteRecord();
+      });
+      await this.onError("Une erreur est survenue lors de l'enregistrement du profil cible.");
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  #updateBadge({badgeId, fieldName, fieldValue}) {
+    const currentBadge = this.#targetProfileBadges.get(badgeId);
+    this.#targetProfileBadges.set(badgeId, {
+      ...currentBadge,
+      id: badgeId,
+      [fieldName]: fieldValue,
+    });
   }
 }

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -74,15 +74,14 @@ export default class AttachTargetProfileController extends Controller {
       await complementaryCertification.save({
         adapterOptions: {
           attachBadges: true,
-          detachedTargetProfileId: this.model.currentTargetProfile.id,
-          attachedTargetProfileId: this.selectedTargetProfile.id,
+          targetProfileId: this.model.currentTargetProfile.id,
         }
       });
       this.notifications.success('Target profile rattaché avec succès');
 
     } catch (error) {
       console.log(error);
-      this.store.peekAll('complementary-certification-badge').filterBy('isNew', true).forEach(function(model){
+      this.store.peekAll('complementary-certification-badge').forEach(function(model){
         model.deleteRecord();
       });
       await this.onError("Une erreur est survenue lors de l'enregistrement du profil cible.");

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -39,7 +39,6 @@ export default class AttachTargetProfileController extends Controller {
 
   @action
   onBadgeUpdated({badges, update: {badgeId, fieldName, fieldValue}}) {
-    console.log('A badge has been updated: ', {badges, update: {badgeId, fieldName, fieldValue}});
     this.#updateBadge({badgeId, fieldName, fieldValue});
   }
 
@@ -77,10 +76,9 @@ export default class AttachTargetProfileController extends Controller {
           targetProfileId: this.model.currentTargetProfile.id,
         }
       });
-      this.notifications.success('Target profile rattaché avec succès');
+      this.notifications.success('Profil cible rattaché avec succès');
 
     } catch (error) {
-      console.log(error);
       this.store.peekAll('complementary-certification-badge').forEach(function(model){
         model.deleteRecord();
       });

--- a/admin/app/models/complementary-certification-badge.js
+++ b/admin/app/models/complementary-certification-badge.js
@@ -1,0 +1,13 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ComplementaryCertificationBadge extends Model {
+  @belongsTo('complementary-certification') complementaryCertification;
+
+  @attr('number') badgeId;
+  @attr('number') level;
+  @attr('string') imageUrl;
+  @attr('string') label;
+  @attr('string') certificateMessage;
+  @attr('string') temporaryCertificateMessage;
+  @attr('string') stickerUrl;
+}

--- a/admin/app/models/complementary-certification.js
+++ b/admin/app/models/complementary-certification.js
@@ -1,9 +1,11 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ComplementaryCertification extends Model {
   @attr() key;
   @attr() label;
   @attr() targetProfilesHistory;
+
+  @hasMany('complementary-certification-badge') complementaryCertificationBadges;
 
   get currentTargetProfiles() {
     return this.targetProfilesHistory?.filter(({ detachedAt }) => !detachedAt);

--- a/admin/app/models/complementary-certification.js
+++ b/admin/app/models/complementary-certification.js
@@ -5,7 +5,7 @@ export default class ComplementaryCertification extends Model {
   @attr() label;
   @attr() targetProfilesHistory;
 
-  @hasMany('complementary-certification-badge') complementaryCertificationBadges;
+  @hasMany('complementary-certification-badge', { async: false }) complementaryCertificationBadges;
 
   get currentTargetProfiles() {
     return this.targetProfilesHistory?.filter(({ detachedAt }) => !detachedAt);

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -22,8 +22,7 @@ export default class AttachTargetProfileRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.selectedTargetProfile = undefined;
-      controller.targetProfileBadges = undefined;
+      controller.onReset();
     }
   }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -44,7 +44,8 @@
 @import 'components/certification-issue-reports';
 @import 'components/certification-center-invitations';
 @import 'components/complementary-certifications/details';
-@import 'components/complementary-certifications/attach-badges';
+@import 'components/complementary-certifications/attach-badges/header.scss';
+@import 'components/complementary-certifications/attach-badges/list.scss';
 @import 'components/complementary-certifications/attach-target-profile';
 @import 'components/complementary-certifications/link-to-current-target-profile';
 @import 'components/complementary-certifications/search-bar';

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -44,8 +44,8 @@
 @import 'components/certification-issue-reports';
 @import 'components/certification-center-invitations';
 @import 'components/complementary-certifications/details';
-@import 'components/complementary-certifications/attach-badges/header.scss';
-@import 'components/complementary-certifications/attach-badges/list.scss';
+@import 'components/complementary-certifications/attach-badges/header';
+@import 'components/complementary-certifications/attach-badges/list';
 @import 'components/complementary-certifications/attach-target-profile';
 @import 'components/complementary-certifications/link-to-current-target-profile';
 @import 'components/complementary-certifications/search-bar';

--- a/admin/app/styles/components/complementary-certifications/attach-badges.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-badges.scss
@@ -1,5 +1,0 @@
-.complementary-certification-attach-badges {
-  &__description, &__error, &__list {
-    margin-top: $pix-spacing-s;
-  }
-}

--- a/admin/app/styles/components/complementary-certifications/attach-badges/header.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-badges/header.scss
@@ -1,0 +1,10 @@
+.attach-badges-header {
+
+  &__content {
+    display: flex;
+
+    .pix-tooltip {
+      padding-left: $pix-spacing-s;
+    }
+  }
+}

--- a/admin/app/styles/components/complementary-certifications/attach-badges/header.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-badges/header.scss
@@ -3,7 +3,7 @@
   &__content {
     display: flex;
 
-    .pix-tooltip {
+    .content_tooltip {
       padding-left: $pix-spacing-s;
     }
   }

--- a/admin/app/styles/components/complementary-certifications/attach-badges/list.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-badges/list.scss
@@ -1,0 +1,41 @@
+.complementary-certification-attach-badges {
+  &__description, &__error, &__list {
+    margin-top: $pix-spacing-s;
+  }
+
+  &__list table {
+    height: 100%;
+    margin-top: $pix-spacing-s;
+    margin-bottom: $pix-spacing-s;
+
+    thead tr{
+      height: 72px;
+
+      th {
+        padding: $pix-spacing-s;
+        border: 1px solid $pix-neutral-20;
+      }
+    }
+
+    tbody {
+      vertical-align: top;
+
+      > tr:nth-child(even) {
+        background-color: rgb(0 0 0 / 3%);
+      }
+
+      tr {
+        height: 180px;
+
+        td {
+          padding: $pix-spacing-s;
+          border: 1px solid $pix-neutral-20;
+
+          .pix-textarea, .pix-textarea textarea {
+            height: 100%;
+          }
+        }
+      }
+    }
+  }
+}

--- a/admin/app/styles/components/complementary-certifications/attach-badges/list.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-badges/list.scss
@@ -27,7 +27,11 @@
       tr {
         height: 180px;
 
-        td {
+        th {
+          font-weight: normal
+        }
+
+        th, td {
           padding: $pix-spacing-s;
           border: 1px solid $pix-neutral-20;
 

--- a/admin/app/styles/components/complementary-certifications/attach-badges/list.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-badges/list.scss
@@ -20,10 +20,6 @@
     tbody {
       vertical-align: top;
 
-      > tr:nth-child(even) {
-        background-color: rgb(0 0 0 / 3%);
-      }
-
       tr {
         height: 180px;
 
@@ -39,6 +35,10 @@
             height: 100%;
           }
         }
+      }
+
+      > tr:nth-child(even) {
+        background-color: rgb(0 0 0 / 3%);
       }
     }
   }

--- a/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
@@ -10,6 +10,10 @@
     line-height: 36px;
   }
 
+  &__card {
+    margin-bottom: $pix-spacing-l;
+  }
+
   &__card-badges {
     .card__content {
       position: relative;
@@ -37,7 +41,6 @@
     display: flex;
     justify-content: flex-start;
     width: 100%;
-    padding: 16px 0;
 
     .pix-button {
       margin-right: 16px;

--- a/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
@@ -32,5 +32,16 @@
       }
     }
   }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-start;
+    width: 100%;
+    padding: 16px 0;
+
+    .pix-button {
+      margin-right: 16px;
+    }
+  }
 }
 

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -15,7 +15,7 @@
     </Card>
 
     {{#if this.selectedTargetProfile}}
-      <Card class="attach-target-profile__card-badges" @title="2. Complétez les niveaux des résultats thématiques">
+      <Card class="attach-target-profile__card-badges" @title="2. Complétez les informations des résultats thématiques">
         <ComplementaryCertifications::AttachBadges::Badges
           @targetProfile={{this.selectedTargetProfile}}
           @onError={{this.onError}}

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -17,19 +17,31 @@
     <Card class="attach-target-profile__card-badges" @title="2. Complétez les niveaux des résultats thématiques">
       <ComplementaryCertifications::AttachBadges::Badges
         @targetProfile={{this.selectedTargetProfile}}
-        @onError={{this.onError}}
-        @onBadgeUpdated={{this.onBadgeUpdated}}
+          @onError={{this.onError}}
+          @onBadgeUpdated={{this.onBadgeUpdated}}
       />
     </Card>
   {{/if}}
 
-  <div>
-    <PixButton
-      @size="small"
-      @backgroundColor="transparent-light"
-      @isBorderVisible={{true}}
-      @triggerAction={{this.cancel}}
-    >Annuler
-    </PixButton>
-  </div>
+    <div class="attach-target-profile__actions">
+      <PixButton
+        @type="submit"
+        @size="big"
+        @isBorderVisible={{true}}
+        @isDisabled={{this.isSubmitDisabled}}
+        aria-disabled={{this.isSubmitDisabled}}
+        @triggerAction={{this.onSubmit}}
+      >
+        Rattacher le profil cible
+      </PixButton>
+      <PixButton
+        @size="big"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{this.onCancel}}
+      >
+        Annuler
+      </PixButton>
+    </div>
+  </form>
 </div>

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -5,23 +5,24 @@
   </h1>
   <ComplementaryCertifications::Common::LinkToCurrentTargetProfile @model={{@model.currentTargetProfile}} />
 
-  <Card @title="1. Renseigner le nouveau profil cible à rattacher">
-    <ComplementaryCertifications::AttachBadges::TargetProfileSelector
-      @onError={{this.onError}}
-      @onSelection={{this.onSelection}}
-      @onChange={{this.onReset}}
-    />
-  </Card>
-
-  {{#if this.selectedTargetProfile}}
-    <Card class="attach-target-profile__card-badges" @title="2. Complétez les niveaux des résultats thématiques">
-      <ComplementaryCertifications::AttachBadges::Badges
-        @targetProfile={{this.selectedTargetProfile}}
-          @onError={{this.onError}}
-          @onBadgeUpdated={{this.onBadgeUpdated}}
+  <form class="form" {{on "submit" this.onSubmit}}>
+    <Card @title="1. Renseigner le nouveau profil cible à rattacher">
+      <ComplementaryCertifications::AttachBadges::TargetProfileSelector
+        @onError={{this.onError}}
+        @onSelection={{this.onSelection}}
+        @onChange={{this.onReset}}
       />
     </Card>
-  {{/if}}
+
+    {{#if this.selectedTargetProfile}}
+      <Card class="attach-target-profile__card-badges" @title="2. Complétez les niveaux des résultats thématiques">
+        <ComplementaryCertifications::AttachBadges::Badges
+          @targetProfile={{this.selectedTargetProfile}}
+          @onError={{this.onError}}
+          @onBadgeUpdated={{this.onBadgeUpdated}}
+        />
+      </Card>
+    {{/if}}
 
     <div class="attach-target-profile__actions">
       <PixButton
@@ -30,7 +31,7 @@
         @isBorderVisible={{true}}
         @isDisabled={{this.isSubmitDisabled}}
         aria-disabled={{this.isSubmitDisabled}}
-        @triggerAction={{this.onSubmit}}
+        @isLoading={{this.isSubmitting}}
       >
         Rattacher le profil cible
       </PixButton>

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -6,7 +6,7 @@
   <ComplementaryCertifications::Common::LinkToCurrentTargetProfile @model={{@model.currentTargetProfile}} />
 
   <form class="form" {{on "submit" this.onSubmit}}>
-    <Card @title="1. Renseigner le nouveau profil cible à rattacher">
+    <Card class="attach-target-profile__card" @title="1. Renseigner le nouveau profil cible à rattacher">
       <ComplementaryCertifications::AttachBadges::TargetProfileSelector
         @onError={{this.onError}}
         @onSelection={{this.onSelection}}
@@ -15,7 +15,10 @@
     </Card>
 
     {{#if this.selectedTargetProfile}}
-      <Card class="attach-target-profile__card-badges" @title="2. Complétez les informations des résultats thématiques">
+      <Card
+        class="attach-target-profile__card attach-target-profile__card-badges"
+        @title="2. Complétez les informations des résultats thématiques"
+      >
         <ComplementaryCertifications::AttachBadges::Badges
           @targetProfile={{this.selectedTargetProfile}}
           @onError={{this.onError}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -430,6 +430,10 @@ function routes() {
     };
   });
 
+  this.put('admin/complementary-certifications/:id/badges', () => {
+    return new Response(204);
+  });
+
   this.put('/admin/sessions/:id/comment', (schema, request) => {
     const sessionToUpdate = schema.sessions.find(request.params.id);
     const params = JSON.parse(request.requestBody);

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -140,7 +140,7 @@ module(
 
           // then
           assert
-            .dom(await screen.findByRole('heading', { name: '2. Complétez les niveaux des résultats thématiques' }))
+            .dom(await screen.findByRole('heading', { name: '2. Complétez les informations des résultats thématiques' }))
             .exists();
           assert.dom(await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' })).exists();
           assert.dom(await screen.queryByRole('img', { name: 'loader' })).doesNotExist();
@@ -189,7 +189,7 @@ module(
           await clickByName('Rattacher le profil cible');
 
           // then
-          assert.dom(await screen.findByText('Target profile rattaché avec succès')).exists();
+          assert.dom(await screen.findByText('Profil cible rattaché avec succès')).exists();
         });
       });
     });

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -140,7 +140,9 @@ module(
 
           // then
           assert
-            .dom(await screen.findByRole('heading', { name: '2. Complétez les informations des résultats thématiques' }))
+            .dom(
+              await screen.findByRole('heading', { name: '2. Complétez les informations des résultats thématiques' }),
+            )
             .exists();
           assert.dom(await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' })).exists();
           assert.dom(await screen.queryByRole('img', { name: 'loader' })).doesNotExist();
@@ -178,13 +180,21 @@ module(
           await targetProfileSelectable.click();
           await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' });
 
-
-          await fillIn(screen.getByRole('spinbutton', {name: 'niveau'}), '1');
-          await fillIn(screen.getByRole('textbox', {name: 'image certificat Pix App'}), 'IMAGE1.svg');
-          await fillIn(screen.getByRole('textbox', {name: 'label du certificat'}), 'LABEL');
-          await fillIn(screen.getByRole('textbox', {name: 'macaron du certificat'}), 'MACARON.pdf');
-          await fillIn(screen.getByRole('textbox', {name: 'message du certificat'}), 'MESSAGE');
-          await fillIn(screen.getByRole('textbox', {name: 'message temporaire du certificat'}), 'TEMP MESSAGE');
+          await fillIn(screen.getByRole('spinbutton', { name: '200 Badge Arène Feu Niveau' }), '1');
+          await fillIn(
+            screen.getByRole('textbox', { name: '200 Badge Arène Feu Image svg certificat Pix App' }),
+            'IMAGE1.svg',
+          );
+          await fillIn(screen.getByRole('textbox', { name: '200 Badge Arène Feu Label du certificat' }), 'LABEL');
+          await fillIn(
+            screen.getByRole('textbox', { name: "200 Badge Arène Feu Macaron de l'attestation PDF" }),
+            'MACARON.pdf',
+          );
+          await fillIn(screen.getByRole('textbox', { name: '200 Badge Arène Feu Message du certificat' }), 'MESSAGE');
+          await fillIn(
+            screen.getByRole('textbox', { name: '200 Badge Arène Feu Message temporaire certificat' }),
+            'TEMP MESSAGE',
+          );
           // when
           await clickByName('Rattacher le profil cible');
 

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
@@ -1,51 +1,48 @@
 import { module, test } from 'qunit';
-import { render, getByText, fireEvent } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
-import { fillIn } from '@ember/test-helpers';
-import sinon from 'sinon';
 
 module('Integration | Component | ComplementaryCertifications::AttachBadges::Badges::Row', function (hooks) {
   setupIntlRenderingTest(hooks);
   setupMirage(hooks);
 
-
-    test('it should display the header label with no required mark and no tooltip by default', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
+  test('it should display the header label with no required mark and no tooltip by default', async function (assert) {
+    // given & when
+    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
           LABEL
         </ComplementaryCertifications::AttachBadges::Badges::Header>
       `);
 
-      // then
-      assert.dom(screen.getByText('LABEL')).exists();
-      assert.dom(screen.queryByTitle('obligatoire')).doesNotExist();
-      assert.dom(screen.queryByRole('info')).doesNotExist();
-      assert.dom(screen.queryByRole('tooltip')).doesNotExist();
-    });
+    // then
+    assert.dom(screen.getByText('LABEL')).exists();
+    assert.dom(screen.queryByTitle('obligatoire')).doesNotExist();
+    assert.dom(screen.queryByRole('info')).doesNotExist();
+    assert.dom(screen.queryByRole('tooltip')).doesNotExist();
+  });
 
-    test('it should display the mandatory mark if header is required', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
+  test('it should display the mandatory mark if header is required', async function (assert) {
+    // given & when
+    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
           LABEL
         </ComplementaryCertifications::AttachBadges::Badges::Header>
       `);
 
-      // then
-      assert.dom(screen.getByText('LABEL')).exists();
-      assert.dom(screen.getByTitle('obligatoire')).exists();
-    });
+    // then
+    assert.dom(screen.getByText('LABEL')).exists();
+    assert.dom(screen.getByTitle('obligatoire')).exists();
+  });
 
-    test('it should display the tooltip if provided', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
+  test('it should display the tooltip if provided', async function (assert) {
+    // given & when
+    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
           <:default>Label</:default>
           <:tooltip>A compléter</:tooltip>
         </ComplementaryCertifications::AttachBadges::Badges::Header>
       `);
 
-      // then
-      assert.dom(screen.getByRole('tooltip')).exists();
-    });
+    // then
+    assert.dom(screen.getByRole('tooltip')).exists();
+  });
 });

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { render, getByText, fireEvent } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import { fillIn } from '@ember/test-helpers';
+import sinon from 'sinon';
+
+module('Integration | Component | ComplementaryCertifications::AttachForm::Badges::Row', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  setupMirage(hooks);
+
+
+    test('it should display the header label with no required mark and no tooltip by default', async function (assert) {
+      // given
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::AttachForm::Badges::Header>
+        LABEL
+      </ComplementaryCertifications::AttachForm::Badges::Header>
+    `);
+
+    // then
+    assert.dom(screen.getByText('LABEL')).exists();
+    assert.dom(screen.queryByTitle('obligatoire')).doesNotExist();
+    assert.dom(screen.queryByRole('info')).doesNotExist();
+    assert.dom(screen.queryByRole('tooltip')).doesNotExist();
+    });
+
+    test('it should display the mandatory mark if header is required', async function (assert) {
+      // given
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+        LABEL
+      </ComplementaryCertifications::AttachForm::Badges::Header>
+    `);
+
+    // then
+    assert.dom(screen.getByText('LABEL')).exists();
+    assert.dom(screen.getByTitle('obligatoire')).exists();
+    });
+
+    test('it should display the tooltip if provided', async function (assert) {
+      // given
+    // when
+    const screen = await render(hbs`<ComplementaryCertifications::AttachForm::Badges::Header>
+        <:default>Label</:default>
+        <:tooltip>A compléter</:tooltip>
+      </ComplementaryCertifications::AttachForm::Badges::Header>
+    `);
+
+    // then
+    assert.dom(screen.getByRole('tooltip')).exists();
+    });
+});

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
@@ -6,7 +6,7 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 import { fillIn } from '@ember/test-helpers';
 import sinon from 'sinon';
 
-module('Integration | Component | ComplementaryCertifications::AttachForm::Badges::Row', function (hooks) {
+module('Integration | Component | ComplementaryCertifications::AttachBadges::Badges::Row', function (hooks) {
   setupIntlRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -14,9 +14,9 @@ module('Integration | Component | ComplementaryCertifications::AttachForm::Badge
     test('it should display the header label with no required mark and no tooltip by default', async function (assert) {
       // given
     // when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachForm::Badges::Header>
+    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
         LABEL
-      </ComplementaryCertifications::AttachForm::Badges::Header>
+      </ComplementaryCertifications::AttachBadges::Badges::Header>
     `);
 
     // then
@@ -29,9 +29,9 @@ module('Integration | Component | ComplementaryCertifications::AttachForm::Badge
     test('it should display the mandatory mark if header is required', async function (assert) {
       // given
     // when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachForm::Badges::Header @isRequired="true">
+    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
         LABEL
-      </ComplementaryCertifications::AttachForm::Badges::Header>
+      </ComplementaryCertifications::AttachBadges::Badges::Header>
     `);
 
     // then
@@ -42,10 +42,10 @@ module('Integration | Component | ComplementaryCertifications::AttachForm::Badge
     test('it should display the tooltip if provided', async function (assert) {
       // given
     // when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachForm::Badges::Header>
+    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
         <:default>Label</:default>
         <:tooltip>A compléter</:tooltip>
-      </ComplementaryCertifications::AttachForm::Badges::Header>
+      </ComplementaryCertifications::AttachBadges::Badges::Header>
     `);
 
     // then

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
@@ -12,43 +12,40 @@ module('Integration | Component | ComplementaryCertifications::AttachBadges::Bad
 
 
     test('it should display the header label with no required mark and no tooltip by default', async function (assert) {
-      // given
-    // when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
-        LABEL
-      </ComplementaryCertifications::AttachBadges::Badges::Header>
-    `);
+      // given & when
+      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
+          LABEL
+        </ComplementaryCertifications::AttachBadges::Badges::Header>
+      `);
 
-    // then
-    assert.dom(screen.getByText('LABEL')).exists();
-    assert.dom(screen.queryByTitle('obligatoire')).doesNotExist();
-    assert.dom(screen.queryByRole('info')).doesNotExist();
-    assert.dom(screen.queryByRole('tooltip')).doesNotExist();
+      // then
+      assert.dom(screen.getByText('LABEL')).exists();
+      assert.dom(screen.queryByTitle('obligatoire')).doesNotExist();
+      assert.dom(screen.queryByRole('info')).doesNotExist();
+      assert.dom(screen.queryByRole('tooltip')).doesNotExist();
     });
 
     test('it should display the mandatory mark if header is required', async function (assert) {
-      // given
-    // when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
-        LABEL
-      </ComplementaryCertifications::AttachBadges::Badges::Header>
-    `);
+      // given & when
+      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header @isRequired="true">
+          LABEL
+        </ComplementaryCertifications::AttachBadges::Badges::Header>
+      `);
 
-    // then
-    assert.dom(screen.getByText('LABEL')).exists();
-    assert.dom(screen.getByTitle('obligatoire')).exists();
+      // then
+      assert.dom(screen.getByText('LABEL')).exists();
+      assert.dom(screen.getByTitle('obligatoire')).exists();
     });
 
     test('it should display the tooltip if provided', async function (assert) {
-      // given
-    // when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
-        <:default>Label</:default>
-        <:tooltip>A compléter</:tooltip>
-      </ComplementaryCertifications::AttachBadges::Badges::Header>
-    `);
+      // given & when
+      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
+          <:default>Label</:default>
+          <:tooltip>A compléter</:tooltip>
+        </ComplementaryCertifications::AttachBadges::Badges::Header>
+      `);
 
-    // then
-    assert.dom(screen.getByRole('tooltip')).exists();
+      // then
+      assert.dom(screen.getByRole('tooltip')).exists();
     });
 });

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
@@ -25,7 +25,7 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
       assert.dom(getByText(rows[0], 'Niveau')).exists();
       assert.dom(getByText(rows[0], 'Image svg certificat Pix App')).exists();
       assert.dom(getByText(rows[0], 'Label du certificat')).exists();
-      assert.dom(getByText(rows[0], 'Macaron de l\'attestation PDF')).exists();
+      assert.dom(getByText(rows[0], "Macaron de l'attestation PDF")).exists();
       assert.dom(getByText(rows[0], 'Message du certificat')).exists();
       assert.dom(getByText(rows[0], 'Message temporaire certificat')).exists();
     });
@@ -49,12 +49,18 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
       assert.dom(screen.getByRole('row', { name: 'Résultat thématique 12 BoyNextDoor One And Only' })).exists();
       assert.dom(screen.getByText('12')).exists();
       assert.dom(screen.getByText('BoyNextDoor One And Only')).exists();
-      assert.dom(screen.getByRole('spinbutton', {name: 'niveau'})).exists();
-      assert.dom(screen.getByRole('textbox', {name: 'image certificat Pix App'})).exists();
-      assert.dom(screen.getByRole('textbox', {name: 'label du certificat'})).exists();
-      assert.dom(screen.getByRole('textbox', {name: 'macaron du certificat'})).exists();
-      assert.dom(screen.getByRole('textbox', {name: 'message du certificat'})).exists();
-      assert.dom(screen.getByRole('textbox', {name: 'message temporaire du certificat'})).exists();
+      assert.dom(screen.getByRole('spinbutton', { name: '12 BoyNextDoor One And Only Niveau' })).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Image svg certificat Pix App' }))
+        .exists();
+      assert.dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Label du certificat' })).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: "12 BoyNextDoor One And Only Macaron de l'attestation PDF" }))
+        .exists();
+      assert.dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Message du certificat' })).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Message temporaire certificat' }))
+        .exists();
     });
 
     test('it should call trigger action when a badge is updated', async function (assert) {
@@ -70,15 +76,17 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
         @onBadgeUpdated={{this.onBadgeUpdated}}
       />`);
 
-      const input = screen.getByRole('textbox', {name: 'image certificat Pix App'});
+      const input = screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Image svg certificat Pix App' });
       await fillIn(input, 'image');
 
       // then
-      assert.ok(onBadgeUpdated.calledOnceWith({
-        badgeId: 12,
-        fieldName: 'certificate-image',
-        fieldValue: 'image'
-      }));
+      assert.ok(
+        onBadgeUpdated.calledOnceWith({
+          badgeId: 12,
+          fieldName: 'certificate-image',
+          fieldValue: 'image',
+        }),
+      );
     });
   });
 

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
@@ -23,6 +23,11 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
       assert.dom(getByText(rows[0], 'ID')).exists();
       assert.dom(getByText(rows[0], 'Nom')).exists();
       assert.dom(getByText(rows[0], 'Niveau')).exists();
+      assert.dom(getByText(rows[0], 'Image svg certificat Pix App')).exists();
+      assert.dom(getByText(rows[0], 'Label du certificat')).exists();
+      assert.dom(getByText(rows[0], 'Macaron de l\'attestation PDF')).exists();
+      assert.dom(getByText(rows[0], 'Message du certificat')).exists();
+      assert.dom(getByText(rows[0], 'Message temporaire certificat')).exists();
     });
   });
 
@@ -36,33 +41,44 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
       // when
       const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::List
         @options={{this.options}}
-        @onUpdateLevel={{this.noop}}
+        @onBadgeUpdated={{this.noop}}
       />`);
 
       // then
       assert.strictEqual(screen.getAllByRole('row').length, 2);
       assert.dom(screen.getByRole('row', { name: 'Résultat thématique 12 BoyNextDoor One And Only' })).exists();
-      assert.dom(screen.getByRole('spinbutton')).exists();
+      assert.dom(screen.getByText('12')).exists();
+      assert.dom(screen.getByText('BoyNextDoor One And Only')).exists();
+      assert.dom(screen.getByRole('spinbutton', {name: 'niveau'})).exists();
+      assert.dom(screen.getByRole('textbox', {name: 'image certificat Pix App'})).exists();
+      assert.dom(screen.getByRole('textbox', {name: 'label du certificat'})).exists();
+      assert.dom(screen.getByRole('textbox', {name: 'macaron du certificat'})).exists();
+      assert.dom(screen.getByRole('textbox', {name: 'message du certificat'})).exists();
+      assert.dom(screen.getByRole('textbox', {name: 'message temporaire du certificat'})).exists();
     });
 
-    test('it should call trigger on level update', async function (assert) {
+    test('it should call trigger action when a badge is updated', async function (assert) {
       // given
       const badges = [{ id: 12, label: 'BoyNextDoor One And Only' }];
       this.set('options', badges);
-      const onUpdateLevel = sinon.stub();
-      this.set('onUpdateLevel', onUpdateLevel);
+      const onBadgeUpdated = sinon.stub();
+      this.set('onBadgeUpdated', onBadgeUpdated);
 
       // when
       const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::List
         @options={{this.options}}
-        @onUpdateLevel={{this.onUpdateLevel}}
+        @onBadgeUpdated={{this.onBadgeUpdated}}
       />`);
 
-      const input = screen.getByRole('spinbutton');
-      await fillIn(input, '1');
+      const input = screen.getByRole('textbox', {name: 'image certificat Pix App'});
+      await fillIn(input, 'image');
 
       // then
-      assert.ok(onUpdateLevel.calledOnceWith('12', '1'));
+      assert.ok(onBadgeUpdated.calledOnceWith({
+        badgeId: 12,
+        fieldName: 'certificate-image',
+        fieldValue: 'image'
+      }));
     });
   });
 

--- a/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -16,8 +16,8 @@ module('Unit | Controller | attach-target-profile', function (hooks) {
 
       // then
       assert.strictEqual(controller.selectedTargetProfile, undefined);
-      assert.strictEqual(controller.isSubmitDisabled, true);
-      assert.strictEqual(controller.isSubmitting, false);
+      assert.true(controller.isSubmitDisabled);
+      assert.false(controller.isSubmitting);
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/unit/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -16,7 +16,8 @@ module('Unit | Controller | attach-target-profile', function (hooks) {
 
       // then
       assert.strictEqual(controller.selectedTargetProfile, undefined);
-      assert.strictEqual(controller.targetProfileBadges, undefined);
+      assert.strictEqual(controller.isSubmitDisabled, true);
+      assert.strictEqual(controller.isSubmitting, false);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création du nouveau PC dans l’onglet dédié de Pix Admin et du rattachement des nouveaux RT dans l’onglet “Clés de lecture”, certaines informations nécessaires pour un RT certifiant sont manquantes :

le niveau
l’image .svg du certificat dans Pix App
le label du certificat
le macaron de l’attestation PDF
le message du certificat (pour certaines certifications complémentaires seulement)
le message temporaire du certificat (pour certaines certifications complémentaires seulement)

## :robot: Proposition

* Ajouter les colonnes manquantes
* Envoyer tout cela vers l'API

## :rainbow: Remarques

* Je veux bien une revue de bonnes pratiques / avis sur la façon d'enregistrer les nouveaux badges. Pour m'expliquer, je n'ai pas trouvé évident de dire à Ember de sauver une liste d'un coup de nouveaux objets.
  * Une autre façon de faire aurait été de crééer un nouveau model spécifiquement pour notre cas, mais je trouvais pas ça top, et je me dis qu'en passant par le belongsTo + des model de c-c-badges on exploite bien l'idée de store de Ember et de représentation fonctionnel de notre modèle métier

## :100: Pour tester

* Se connecter sur Pix Admin avec `superadmin@example.net`
* http://localhost:4202/complementary-certifications/list (page des certifications complémentaires)
* En prendre une, Rattacher un nouveau profil cible
* Faire une recherche, exemple 'num', remplir les badges, sauvegarder
