### PR TITLE
[FEATURE] Utiliser l'information de certificabilité la plus récente (PIX-9018)

### DIFF
--- a/api/lib/domain/read-models/ScoOrganizationParticipant.js
+++ b/api/lib/domain/read-models/ScoOrganizationParticipant.js
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 class ScoOrganizationParticipant {
   constructor({
     id,
@@ -16,6 +17,8 @@ class ScoOrganizationParticipant {
     participationStatus,
     isCertifiableFromCampaign,
     certifiableAtFromCampaign,
+    isCertifiableFromLearner,
+    certifiableAtFromLearner,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -31,8 +34,31 @@ class ScoOrganizationParticipant {
     this.campaignName = campaignName;
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
-    this.isCertifiable = isCertifiableFromCampaign;
-    this.certifiableAt = isCertifiableFromCampaign ? certifiableAtFromCampaign : null;
+
+    this._buildCertificability({
+      isCertifiableFromCampaign,
+      certifiableAtFromCampaign,
+      isCertifiableFromLearner,
+      certifiableAtFromLearner,
+    });
+  }
+
+  _buildCertificability({
+    isCertifiableFromCampaign,
+    certifiableAtFromCampaign,
+    isCertifiableFromLearner,
+    certifiableAtFromLearner,
+  }) {
+    const isCertifiableFromCampaignMostRecent =
+      certifiableAtFromLearner === null || dayjs(certifiableAtFromCampaign).isAfter(dayjs(certifiableAtFromLearner));
+
+    if (isCertifiableFromCampaignMostRecent) {
+      this.isCertifiable = isCertifiableFromCampaign;
+      this.certifiableAt = this.isCertifiable ? certifiableAtFromCampaign : null;
+    } else {
+      this.isCertifiable = isCertifiableFromLearner;
+      this.certifiableAt = this.isCertifiable ? certifiableAtFromLearner : null;
+    }
   }
 }
 

--- a/api/lib/domain/read-models/ScoOrganizationParticipant.js
+++ b/api/lib/domain/read-models/ScoOrganizationParticipant.js
@@ -14,8 +14,8 @@ class ScoOrganizationParticipant {
     campaignName,
     campaignType,
     participationStatus,
-    isCertifiable,
-    certifiableAt,
+    isCertifiableFromCampaign,
+    certifiableAtFromCampaign,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -31,8 +31,8 @@ class ScoOrganizationParticipant {
     this.campaignName = campaignName;
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
-    this.isCertifiable = isCertifiable;
-    this.certifiableAt = isCertifiable ? certifiableAt : null;
+    this.isCertifiable = isCertifiableFromCampaign;
+    this.certifiableAt = isCertifiableFromCampaign ? certifiableAtFromCampaign : null;
   }
 }
 

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -46,9 +46,9 @@ function _setFilters(qb, { search, divisions, connectionTypes, certificability }
   }
   if (certificability) {
     qb.where(function (query) {
-      query.whereInArray('subquery.isCertifiable', certificability);
+      query.whereInArray('subquery.isCertifiableFromCampaign', certificability);
       if (certificability.includes(null)) {
-        query.orWhereRaw('"subquery"."isCertifiable" IS NULL');
+        query.orWhereRaw('"subquery"."isCertifiableFromCampaign" IS NULL');
       }
     });
   }
@@ -60,10 +60,10 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
     .select([
       'view-active-organization-learners.id as organizationLearnerId',
       knex.raw(
-        'FIRST_VALUE("campaign-participations"."isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"',
+        'FIRST_VALUE("campaign-participations"."isCertifiable") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiableFromCampaign"',
       ),
       knex.raw(
-        'FIRST_VALUE("campaign-participations"."sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"',
+        'FIRST_VALUE("campaign-participations"."sharedAt") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAtFromCampaign"',
       ),
     ])
     .from('view-active-organization-learners')
@@ -130,8 +130,8 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
       'users.username',
       'users.email',
       'authentication-methods.externalIdentifier as samlId',
-      'subquery.isCertifiable',
-      'subquery.certifiableAt',
+      'subquery.isCertifiableFromCampaign',
+      'subquery.certifiableAtFromCampaign',
       knex.raw(
         'FIRST_VALUE("name") OVER(PARTITION BY "view-active-organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"',
       ),

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -363,7 +363,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
 
       context('when participants are filterd by certificability', function () {
         context('when one value is given for certificability', function () {
-          it('should return sco participants filtered by the given value', async function () {
+          it('should return certifiable sco participants', async function () {
             const organizationId = databaseBuilder.factory.buildOrganization().id;
             const campaignId = databaseBuilder.factory.buildCampaign({
               organizationId,
@@ -374,6 +374,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             });
             const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
               organizationId,
+              isCertifiable: true,
+              certifiableAt: new Date('2021-01-01'),
             });
 
             databaseBuilder.factory.buildCampaignParticipation({
@@ -396,6 +398,80 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
               organizationId,
               filter: { certificability: [true] },
+            });
+
+            // then
+            expect(data.length).to.deep.equal(1);
+            expect(data[0].id).to.deep.equal(organizationLearnerId1);
+          });
+
+          it('should return non certifiable sco participants', async function () {
+            const organizationId = databaseBuilder.factory.buildOrganization().id;
+            const campaignId = databaseBuilder.factory.buildCampaign({
+              organizationId,
+              type: CampaignTypes.PROFILES_COLLECTION,
+            }).id;
+            const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
+            const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+              isCertifiable: true,
+              certifiableAt: new Date('2021-01-01'),
+            });
+
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId,
+              organizationLearnerId: organizationLearnerId1,
+              userId: userId1,
+              status: CampaignParticipationStatuses.SHARED,
+              sharedAt: new Date('2022-01-01'),
+              isCertifiable: true,
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId,
+              organizationLearnerId: organizationLearnerId2,
+              userId: userId2,
+              status: CampaignParticipationStatuses.SHARED,
+              sharedAt: new Date('2022-01-01'),
+              isCertifiable: false,
+            });
+            await databaseBuilder.commit();
+            const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              filter: { certificability: [false] },
+            });
+
+            // then
+            expect(data.length).to.deep.equal(1);
+            expect(data[0].id).to.deep.equal(organizationLearnerId2);
+          });
+
+          it('should return non communicate sco participants', async function () {
+            const organizationId = databaseBuilder.factory.buildOrganization().id;
+            const campaignId = databaseBuilder.factory.buildCampaign({
+              organizationId,
+              type: CampaignTypes.PROFILES_COLLECTION,
+            }).id;
+            const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
+            const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
+
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId,
+              organizationLearnerId: organizationLearnerId2,
+              userId: userId2,
+              status: CampaignParticipationStatuses.SHARED,
+              sharedAt: new Date('2022-01-01'),
+              isCertifiable: false,
+            });
+            await databaseBuilder.commit();
+            const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              filter: { certificability: [null] },
             });
 
             // then
@@ -486,6 +562,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           participationStatus: null,
           isCertifiableFromCampaign: null,
           certifiableAtFromCampaign: null,
+          isCertifiableFromLearner: null,
+          certifiableAtFromLearner: null,
         });
         await databaseBuilder.commit();
 
@@ -534,6 +612,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           participationStatus: null,
           isCertifiableFromCampaign: null,
           certifiableAtFromCampaign: null,
+          isCertifiableFromLearner: null,
+          certifiableAtFromLearner: null,
         });
         await databaseBuilder.commit();
 
@@ -575,6 +655,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           participationStatus: null,
           isCertifiableFromCampaign: null,
           certifiableAtFromCampaign: null,
+          isCertifiableFromLearner: null,
+          certifiableAtFromLearner: null,
         });
         await databaseBuilder.commit();
 
@@ -1294,6 +1376,42 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
     });
 
     context('#isCertifiable', function () {
+      it('should take the learner certifiable value', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          certifiableAt: new Date('2023-01-01'),
+          isCertifiable: false,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: true,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable, certifiableAt }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.be.false;
+        expect(certifiableAt).to.be.null;
+      });
+
       it('should take the shared participation', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -484,8 +484,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           campaignName: null,
           campaignType: null,
           participationStatus: null,
-          isCertifiable: null,
-          certifiableAt: null,
+          isCertifiableFromCampaign: null,
+          certifiableAtFromCampaign: null,
         });
         await databaseBuilder.commit();
 
@@ -532,8 +532,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           campaignName: null,
           campaignType: null,
           participationStatus: null,
-          isCertifiable: null,
-          certifiableAt: null,
+          isCertifiableFromCampaign: null,
+          certifiableAtFromCampaign: null,
         });
         await databaseBuilder.commit();
 
@@ -573,8 +573,8 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           campaignName: null,
           campaignType: null,
           participationStatus: null,
-          isCertifiable: null,
-          certifiableAt: null,
+          isCertifiableFromCampaign: null,
+          certifiableAtFromCampaign: null,
         });
         await databaseBuilder.commit();
 

--- a/api/tests/unit/domain/read-models/ScoOrganizationParticipant_test.js
+++ b/api/tests/unit/domain/read-models/ScoOrganizationParticipant_test.js
@@ -1,0 +1,68 @@
+import { expect } from '../../../test-helper.js';
+import { ScoOrganizationParticipant } from '../../../../lib/domain/read-models/ScoOrganizationParticipant.js';
+
+describe('Unit | Domain | Read-models | ScoOrganizationParticipant', function () {
+  it('should return certificability from learner', function () {
+    // given
+
+    // when
+    const organizationParticipant = new ScoOrganizationParticipant({
+      certifiableAtFromCampaign: new Date('2022-01-01'),
+      isCertifiableFromCampaign: false,
+      isCertifiableFromLearner: true,
+      certifiableAtFromLearner: new Date('2023-01-01'),
+    });
+
+    // then
+    expect(organizationParticipant.isCertifiable).to.be.true;
+    expect(organizationParticipant.certifiableAt).to.be.deep.equal(new Date('2023-01-01'));
+  });
+
+  it('should return certificability from campaign', function () {
+    // given
+
+    // when
+    const organizationParticipant = new ScoOrganizationParticipant({
+      certifiableAtFromCampaign: new Date('2023-01-01'),
+      isCertifiableFromCampaign: false,
+      isCertifiableFromLearner: true,
+      certifiableAtFromLearner: new Date('2022-01-01'),
+    });
+
+    // then
+    expect(organizationParticipant.isCertifiable).to.be.false;
+    expect(organizationParticipant.certifiableAt).to.be.null;
+  });
+
+  it('should return certificability from learner when campaign is null', function () {
+    // given
+
+    // when
+    const organizationParticipant = new ScoOrganizationParticipant({
+      certifiableAtFromCampaign: null,
+      isCertifiableFromCampaign: null,
+      isCertifiableFromLearner: true,
+      certifiableAtFromLearner: new Date('2022-01-01'),
+    });
+
+    // then
+    expect(organizationParticipant.isCertifiable).to.be.true;
+    expect(organizationParticipant.certifiableAt).to.be.deep.equal(new Date('2022-01-01'));
+  });
+
+  it('should return certificability from campaign when learner is null', function () {
+    // given
+
+    // when
+    const organizationParticipant = new ScoOrganizationParticipant({
+      certifiableAtFromCampaign: new Date('2023-01-01'),
+      isCertifiableFromCampaign: true,
+      isCertifiableFromLearner: null,
+      certifiableAtFromLearner: null,
+    });
+
+    // then
+    expect(organizationParticipant.isCertifiable).to.be.true;
+    expect(organizationParticipant.certifiableAt).to.be.deep.equal(new Date('2023-01-01'));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La certificabilité peut maintenant être calculée de 2 manières différentes : par une campagne de collecte de profile ou par le batch de nuit directement sur le learner.
Pour l'instant, seule l'information de certificabilité venant de la campagne de collecte de profile est utilisée et affichée

## :robot: Proposition
Utiliser les infos de certificabilité depuis organization-learners et fallback sur campaign-participations si plus récent ou pas renseigné.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer le calcul de certificabilité avec PGBoss
```sql
INSERT INTO "pgboss"."job" (name, retrylimit, retrydelay, on_complete) VALUES('ScheduleComputeOrganizationLearnersCertificabilityJob', 0, 30, true);
```
- Vérifier sur la page Eleves que la certificabilité est renseigné pour tout le monde (parce que ça a pas été rebase donc on a pas besoin de se connecter)
- Créer une campagne de collecte de profils
- Participer à la campagne avec un élève et vérifier que la date est plus récente
