### PR TITLE
[TECH] Améliorer les performances de la remontée de la certif auto (PIX-9019)

### DIFF
--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -367,8 +367,10 @@ async function countByOrganizationsWhichNeedToComputeCertificability() {
       'organization-features.organizationId',
     )
     .join('features', 'organization-features.featureId', '=', 'features.id')
+    .join('users', 'view-active-organization-learners.userId', '=', 'users.id')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
     .where('view-active-organization-learners.isDisabled', false)
+    .where('users.lastLoggedAt', '>', knex.raw(`(now()- interval '1 days')`))
     .count('view-active-organization-learners.id');
   return count;
 }
@@ -382,8 +384,10 @@ function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset } 
       'organization-features.organizationId',
     )
     .join('features', 'organization-features.featureId', '=', 'features.id')
+    .join('users', 'view-active-organization-learners.userId', '=', 'users.id')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
-    .where('view-active-organization-learners.isDisabled', false);
+    .where('view-active-organization-learners.isDisabled', false)
+    .where('users.lastLoggedAt', '>', knex.raw(`(now()- interval '1 days')`));
 
   if (limit) {
     queryBuilder.limit(limit);


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création et des tests du job pgboss pour le calcul de la remontée de la certif auto. La durée du calcul pour la totalité des organization learners ne tenait pas dans l'intervalle 21h -> 8h que l'on s'était fixé

## :robot: Proposition
Ne calculer la certificabilitée que pour les utilisateurs s'étant connecté dans les 24h avant le début du batch. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Pré-requis : Avoir une organisation (ayant au moins 2 learners) avec la feature d'activée. 
- Se connecter sur PixApp avec un des learners
- Insérer un job "ScheduleComputeOrganizationLearnersCertificabilityJob" dans la base PgBoss
- Vérifier que seul le learner s'étant connecté à les infos de sa certificabilitée mise à jour dans la table organization-learners
