### PR TITLE
[TECH] Afficher l'état d'avancement absolu de la migration des usecases

### DIFF
--- a/api/scripts/arborescence-monitoring/quickcharts/time-series.js
+++ b/api/scripts/arborescence-monitoring/quickcharts/time-series.js
@@ -30,6 +30,13 @@ function _generateTimeSeriesChartConfiguration(data) {
             },
           },
         ],
+        yAxes: [
+          {
+            ticks: {
+              min: 0,
+            },
+          },
+        ],
       },
     },
   };


### PR DESCRIPTION
## :unicorn: Problème
L'évolution du nombre de usecases dans le dossier `lib` est un peu trompeur car on affiche les résultats seulement depuis juillet 2023. On démarre ainsi l'axe Y avec 298 fichiers usecases.

![usecases-count-evolution](https://github.com/1024pix/pix/assets/5855339/8f3d405a-ef21-49cf-8305-5e71d27cdbe0)

Cela risque d'être assez décourageant quand on descendra jusqu'à atteindre 298 et se rendre compte que ce n'était que le début du travail.

## :robot: Proposition
Afficher un état complet de l'avancement de la migration des fichiers en démarrant l'axe Y à 0. [Lien vers la doc](https://quickchart.io/documentation/reference/axes/#minimum-and-maximum-values).

## :rainbow: Remarques
RAS

## :100: Pour tester
- Créer un fichier tech_days_api_arbo.json dans api/scripts/arborescence-monitoring/
 et mettre le contenu du fichier [gist](https://gist.githubusercontent.com/pix-service/62aad2c4b2fbfddd519dc86413e14b7b/raw/tech_days_api_arbo.json) dedans
 - Exécuter, dans le dossier api, le script arborescence-monitoring.js : `node scripts/arborescence-monitoring/arborescence-monitoring.js scripts/arborescence-monitoring/tech_days_api_arbo.json`. 
 - Récupérer l'url de quickchart se trouvant dans le champ `image_url` du dernier élément du tableau (bien copier toutes les lignes vu qu'elles ne sont pas toutes surlignées)
 - Afficher le graphe sur votre navigateur préféré 😄 
