### PR TITLE
[TECH] Obtenir les sourcemaps dans les fronts ember en developpement (PIX-9045)

### DIFF
--- a/1d/ember-cli-build.js
+++ b/1d/ember-cli-build.js
@@ -2,6 +2,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const isDeveloppement = process.env.NODE_ENV === 'development';
+
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     sourcemaps: { enabled: true },
@@ -38,5 +40,11 @@ module.exports = function (defaults) {
   // along with the exports of each module as its value.
 
   const { Webpack } = require('@embroider/webpack');
-  return require('@embroider/compat').compatBuild(app, Webpack);
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    packagerOptions: {
+      webpackConfig: {
+        devtool: isDeveloppement ? 'eval-source-map' : false,
+      },
+    },
+  });
 };

--- a/admin/ember-cli-build.js
+++ b/admin/ember-cli-build.js
@@ -2,6 +2,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const isDeveloppement = process.env.NODE_ENV === 'development';
+
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     sassOptions: {
@@ -41,5 +43,10 @@ module.exports = function (defaults) {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
     staticModifiers: true,
+    packagerOptions: {
+      webpackConfig: {
+        devtool: isDeveloppement ? 'eval-source-map' : false,
+      },
+    },
   });
 };

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -2,6 +2,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const isDeveloppement = process.env.NODE_ENV === 'development';
+
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     sassOptions: {
@@ -37,5 +39,11 @@ module.exports = function (defaults) {
   // along with the exports of each module as its value.
 
   const { Webpack } = require('@embroider/webpack');
-  return require('@embroider/compat').compatBuild(app, Webpack);
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    packagerOptions: {
+      webpackConfig: {
+        devtool: isDeveloppement ? 'eval-source-map' : false,
+      },
+    },
+  });
 };

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -2,6 +2,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const isDeveloppement = process.env.NODE_ENV === 'development';
+
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     sassOptions: {
@@ -42,5 +44,10 @@ module.exports = function (defaults) {
     staticHelpers: true,
     staticModifiers: true,
     staticComponents: true,
+    packagerOptions: {
+      webpackConfig: {
+        devtool: isDeveloppement ? 'eval-source-map' : false,
+      },
+    },
   });
 };

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -2,6 +2,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const isDeveloppement = process.env.NODE_ENV === 'development';
+
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     sassOptions: {
@@ -36,5 +38,11 @@ module.exports = function (defaults) {
   // along with the exports of each module as its value.
 
   const { Webpack } = require('@embroider/webpack');
-  return require('@embroider/compat').compatBuild(app, Webpack);
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    packagerOptions: {
+      webpackConfig: {
+        devtool: isDeveloppement ? 'eval-source-map' : false,
+      },
+    },
+  });
 };


### PR DESCRIPTION
## :unicorn: Problème
Les sourcemaps dans les apps ember sont incorrects. Elles sont genérées après le build webpack. On récupère donc bien un fichier unique (et non le chunk), mais ce n’est pas le fichier source de la codebase

## :robot: Proposition
Ajouter la config pour l’avoir bien!

## :rainbow: Remarques
Il y avait des problème de RAM sur la CI/CD, j'ai donc activé uniquement en NODE_ENV=development

## :100: Pour tester
Ouvrir n’importe quel fichier en local et constater qu’il correspond bien au fichier source

Avant:
<img width="621" alt="image" src="https://github.com/1024pix/pix/assets/3769147/7e3492c3-e53b-45f7-94fe-dcd0cf92f654">

Apres: 
![image](https://github.com/1024pix/pix/assets/3769147/d56a2f27-045e-41fc-81fe-ca0d50529650)


