### PR TITLE
[TECH] Ne pas attendre les lint et test de root pour exécuter les jobs suivants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,13 +251,13 @@ jobs:
       - attach_workspace:
           at: ~/pix
       - run:
-          name: Lint root scripts
+          name: Lint scripts
           command: npm run lint:scripts
       - run:
-          name: Lint root yaml
+          name: Lint yaml
           command: npm run lint:yaml
       - run:
-          name: Test root
+          name: Test
           command: npm run test:root
 
   api_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,17 @@ jobs:
                 git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
                 git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
             fi
+      - run: cat package*.json > cachekey
+      - restore_cache:
+          keys:
+            - v7-root-npm-{{ checksum "cachekey" }}
       - run:
           name: Install root dependencies
           command: npm ci
+      - save_cache:
+          key: v7-root-npm-{{ checksum "cachekey" }}
+          paths:
+            - ~/.npm
       - run:
           name: Remove .git folder
           command: rm -rf .git/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,11 @@ workflows:
       - checkout:
           context: Pix
 
+      - root_lint_and_test:
+          context: Pix
+          requires:
+            - checkout
+
       - api_install:
           context: Pix
           requires:
@@ -220,17 +225,32 @@ jobs:
                 git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
             fi
       - run:
-          name: Lint and test root
-          command: |
-            npm ci
-            npm run lint:scripts
-            npm run lint:yaml
-            npm run test:root
-            rm -rf .git/
+          name: Install root dependencies
+          command: npm ci
+      - run:
+          name: Remove .git folder
+          command: rm -rf .git/
       - persist_to_workspace:
           root: ~/pix
           paths:
             - .
+
+  root_lint_and_test:
+    executor:
+      name: node-docker
+    working_directory: ~/pix
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Lint root scripts
+          command: npm run lint:scripts
+      - run:
+          name: Lint root yaml
+          command: npm run lint:yaml
+      - run:
+          name: Test root
+          command: npm run test:root
 
   api_install:
     executor:


### PR DESCRIPTION
## :unicorn: Problème
Notre job Circle CI `checkout` ne fait en réalité pas uniquement le checkout du projet : 
- Clone du projet
- Installation des dépendances à la racine
- Lint des scripts dans `pix/scripts`
- Lint des fichiers yaml
- Test des scripts
- Suppression du dossier `.git`

De plus les dépendances npm bien que peu nombreuses ne sont pas mises en cache.

## :robot: Proposition
Déplacer les étapes de lint et test de l'étape `checkout` à une nouvelle étape `root_lint_and_test` pour moins bloquer les autres jobs.

J'ai aussi ajouté du cache sur les dépendances npm de la racine pour gagner quelques secondes de plus.

## :rainbow: Remarques
 Il serait aussi intéressant de ne pas `npm ci` dans cette étape mais plusieurs jobs suivants requièrent les `node_modules` racines pour fonctionner (`npm-run-all`, `eslint-plugin-i18n-json`...).

## :100: Pour tester
CI verte et plus rapide qu'avant.
