### PR TITLE
[FEATURE] Utiliser uniquement la colonne user-logins.lastLoggedAt pour lire et écrire la date de dernière connexion (PIX-9010)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -81,7 +81,6 @@ const buildUser = function buildUser({
   isAnonymous = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-  lastLoggedAt = new Date(),
   emailConfirmedAt = null,
   hasBeenAnonymised = false,
   hasBeenAnonymisedBy = null,
@@ -112,7 +111,6 @@ const buildUser = function buildUser({
     isAnonymous,
     createdAt,
     updatedAt,
-    lastLoggedAt,
     emailConfirmedAt,
     hasBeenAnonymised,
     hasBeenAnonymisedBy,
@@ -145,7 +143,6 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   updatedAt = new Date(),
   rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
-  lastLoggedAt = new Date('2022-04-28T02:42:00Z'),
   emailConfirmedAt = new Date('2021-04-28T02:42:00Z'),
 } = {}) {
   email = _generateAnEmailIfNecessary(email, id, lastName, firstName);
@@ -168,7 +165,6 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     hasSeenAssessmentInstructions,
     createdAt,
     updatedAt,
-    lastLoggedAt,
     emailConfirmedAt,
   };
 

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -36,7 +36,25 @@ function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
   });
 }
 
+function _buildUsers(databaseBuilder) {
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Salvor',
+    lastName: 'Hardin',
+    username: 'salvor.hardin',
+    email: 'salvor.hardin@foundation.verse',
+  });
+
+  const userWithLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Gaal',
+    lastName: 'Dornick',
+    username: 'gaal.dornick',
+    email: 'gaal.dornick@foundation.verse',
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+}
+
 export function buildUsers(databaseBuilder) {
+  _buildUsers(databaseBuilder);
   _buildUserWithCnavAuthenticationMethod(databaseBuilder);
   _buildUserWithFwbAuthenticationMethod(databaseBuilder);
   _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder);

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -54,7 +54,6 @@ async function authenticateExternalUser({
 
     const token = tokenService.createAccessTokenForSaml(userFromCredentials.id);
 
-    await userRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
     await userLoginRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
 
     return token;

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -66,7 +66,6 @@ const authenticateUser = async function ({
       await userRepository.update({ id: foundUser.id, locale: foundUser.locale });
     }
 
-    await userRepository.updateLastLoggedAt({ userId: foundUser.id });
     await userLoginRepository.updateLastLoggedAt({ userId: foundUser.id });
 
     return { accessToken, refreshToken, expirationDelaySeconds };

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -46,7 +46,6 @@ const authenticateOidcUser = async function ({
     idToken: sessionContent.idToken,
     userId: user.id,
   });
-  userRepository.updateLastLoggedAt({ userId: user.id });
   userLoginRepository.updateLastLoggedAt({ userId: user.id });
 
   return { pixAccessToken, logoutUrlUUID, isAuthenticationComplete: true };

--- a/api/lib/domain/usecases/create-oidc-user.js
+++ b/api/lib/domain/usecases/create-oidc-user.js
@@ -9,7 +9,6 @@ const createOidcUser = async function ({
   oidcAuthenticationService,
   authenticationMethodRepository,
   userToCreateRepository,
-  userRepository,
   userLoginRepository,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
@@ -46,7 +45,6 @@ const createOidcUser = async function ({
 
   const accessToken = oidcAuthenticationService.createAccessToken(userId);
   const logoutUrlUUID = await oidcAuthenticationService.saveIdToken({ idToken: sessionContent.idToken, userId });
-  await userRepository.updateLastLoggedAt({ userId });
   await userLoginRepository.updateLastLoggedAt({ userId });
 
   return { accessToken, logoutUrlUUID };

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -117,7 +117,6 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   }
   const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
   const accessToken = tokenService.createAccessTokenForSaml(tokenUserId);
-  await userRepository.updateLastLoggedAt({ userId: tokenUserId });
   await userLoginRepository.updateLastLoggedAt({ userId: tokenUserId });
   return accessToken;
 };

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -23,7 +23,6 @@ const getExternalAuthenticationRedirectionUrl = async function ({
       user,
       externalUser,
       tokenService,
-      userRepository,
       userLoginRepository,
       authenticationMethodRepository,
     });
@@ -38,12 +37,10 @@ async function _getUrlWithAccessToken({
   user,
   externalUser,
   tokenService,
-  userRepository,
   userLoginRepository,
   authenticationMethodRepository,
 }) {
   const token = tokenService.createAccessTokenForSaml(user.id);
-  await userRepository.updateLastLoggedAt({ userId: user.id });
   await userLoginRepository.updateLastLoggedAt({ userId: user.id });
   await _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser });
   return `/connexion/gar#${encodeURIComponent(token)}`;

--- a/api/lib/domain/usecases/reconcile-oidc-user.js
+++ b/api/lib/domain/usecases/reconcile-oidc-user.js
@@ -6,7 +6,6 @@ const reconcileOidcUser = async function ({
   oidcAuthenticationService,
   authenticationSessionService,
   authenticationMethodRepository,
-  userRepository,
   userLoginRepository,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
@@ -37,7 +36,6 @@ const reconcileOidcUser = async function ({
     userId,
   });
 
-  await userRepository.updateLastLoggedAt({ userId });
   await userLoginRepository.updateLastLoggedAt({ userId });
 
   return { accessToken, logoutUrlUUID };

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -368,9 +368,10 @@ async function countByOrganizationsWhichNeedToComputeCertificability() {
     )
     .join('features', 'organization-features.featureId', '=', 'features.id')
     .join('users', 'view-active-organization-learners.userId', '=', 'users.id')
+    .join('user-logins', 'view-active-organization-learners.userId', '=', 'user-logins.userId')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
     .where('view-active-organization-learners.isDisabled', false)
-    .where('users.lastLoggedAt', '>', knex.raw(`(now()- interval '1 days')`))
+    .where('user-logins.lastLoggedAt', '>', knex.raw(`(now()- interval '1 days')`))
     .count('view-active-organization-learners.id');
   return count;
 }
@@ -385,9 +386,10 @@ function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset } 
     )
     .join('features', 'organization-features.featureId', '=', 'features.id')
     .join('users', 'view-active-organization-learners.userId', '=', 'users.id')
+    .join('user-logins', 'view-active-organization-learners.userId', '=', 'user-logins.userId')
     .where('features.key', '=', ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key)
     .where('view-active-organization-learners.isDisabled', false)
-    .where('users.lastLoggedAt', '>', knex.raw(`(now()- interval '1 days')`));
+    .where('user-logins.lastLoggedAt', '>', knex.raw(`(now()- interval '1 days')`));
 
   if (limit) {
     queryBuilder.limit(limit);

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -118,6 +118,7 @@ const getUserDetailsForAdmin = async function (userId) {
       'user-logins.failureCount',
       'user-logins.temporaryBlockedUntil',
       'user-logins.blockedAt',
+      'user-logins.lastLoggedAt AS lastLoggedAt',
       'anonymisedBy.firstName AS anonymisedByFirstName',
       'anonymisedBy.lastName AS anonymisedByLastName',
     ])

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -409,12 +409,6 @@ const findAnotherUserByUsername = async function (userId, username) {
     .then((users) => bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, users));
 };
 
-const updateLastLoggedAt = async function ({ userId }) {
-  const now = new Date();
-
-  await knex('users').where({ id: userId }).update({ lastLoggedAt: now });
-};
-
 const updateLastDataProtectionPolicySeenAt = async function ({ userId }) {
   const now = new Date();
 
@@ -454,7 +448,6 @@ export {
   updateHasSeenLevelSevenInfoToTrue,
   updateHasSeenNewDashboardInfoToTrue,
   updateLastDataProtectionPolicySeenAt,
-  updateLastLoggedAt,
   updatePixCertifTermsOfServiceAcceptedToTrue,
   updatePixOrgaTermsOfServiceAcceptedToTrue,
   updateUserDetailsForAdministration,

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -62,6 +62,7 @@ describe('Acceptance | Controller | users-controller-get-user-details-for-admin'
           blockedAt,
           temporaryBlockedUntil,
           userId: user.id,
+          lastLoggedAt: new Date(),
         }).id;
 
         await databaseBuilder.commit();

--- a/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
+++ b/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
@@ -57,7 +57,6 @@ describe('Acceptance | Scripts | create-users-accounts-for-contest', function ()
         isAnonymous: false,
         emailConfirmedAt: null,
         hasSeenFocusedChallengeTooltip: false,
-        lastLoggedAt: null,
         hasSeenOtherChallengesTooltip: false,
         lastPixOrgaTermsOfServiceValidatedAt: null,
         lastPixCertifTermsOfServiceValidatedAt: null,

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2112,12 +2112,17 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
     it('should return count of organization learners from organization that can compute certificability', async function () {
       // given
-      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const { organizationId, userId } = databaseBuilder.factory.buildOrganizationLearner();
       databaseBuilder.factory.buildOrganizationLearner({ organizationId, isDisabled: true });
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
-      const { organizationId: otherOrganizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildUserLogin({ userId, lastLoggedAt: new Date() });
+
+      const { organizationId: otherOrganizationId, userId: otherUserId } =
+        databaseBuilder.factory.buildOrganizationLearner();
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId: otherOrganizationId });
       databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildUserLogin({ userId: otherUserId, lastLoggedAt: new Date() });
+
       await databaseBuilder.commit();
 
       // when
@@ -2129,8 +2134,13 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
     it('should return count of organization learners with lastLoggedAt in the past 24hours', async function () {
       // given
-      const userRecentlyConnectedId = databaseBuilder.factory.buildUser({ lastLoggedAt: new Date() }).id;
-      const userNotRecentlyConnectedId = databaseBuilder.factory.buildUser({ lastLoggedAt: new Date('2023-07-01') }).id;
+      const userRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserLogin({ userId: userRecentlyConnectedId, lastLoggedAt: new Date() });
+      const userNotRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserLogin({
+        userId: userNotRecentlyConnectedId,
+        lastLoggedAt: new Date('2023-07-01'),
+      });
 
       const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ userId: userRecentlyConnectedId });
       databaseBuilder.factory.buildOrganizationLearner({ userId: userNotRecentlyConnectedId, organizationId });
@@ -2157,8 +2167,9 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
     it('should return an organization learner id from organizations that can compute certificability', async function () {
       // given
-      const { id: organizationLearnerId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const { id: organizationLearnerId, organizationId, userId } = databaseBuilder.factory.buildOrganizationLearner();
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      databaseBuilder.factory.buildUserLogin({ userId, lastLoggedAt: new Date() });
       await databaseBuilder.commit();
 
       // when
@@ -2170,8 +2181,13 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
     it('should return only organization learner with lastLoggedAt in the past 24hours', async function () {
       // given
-      const userRecentlyConnectedId = databaseBuilder.factory.buildUser({ lastLoggedAt: new Date() }).id;
-      const userNotRecentlyConnectedId = databaseBuilder.factory.buildUser({ lastLoggedAt: new Date('2023-07-01') }).id;
+      const userRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserLogin({ userId: userRecentlyConnectedId, lastLoggedAt: new Date() });
+      const userNotRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserLogin({
+        userId: userNotRecentlyConnectedId,
+        lastLoggedAt: new Date('2023-07-01'),
+      });
 
       const { id: organizationLearnerRecentlyConnecterId, organizationId } =
         databaseBuilder.factory.buildOrganizationLearner({ userId: userRecentlyConnectedId });
@@ -2228,8 +2244,10 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
     it('should limit ids returned', async function () {
       // given
-      const { id: organizationLearnerId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
-      databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const { id: organizationLearnerId, organizationId, userId } = databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildUserLogin({ userId, lastLoggedAt: new Date() });
+      const { userId: otherUserId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      databaseBuilder.factory.buildUserLogin({ userId: otherUserId, lastLoggedAt: new Date() });
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
       await databaseBuilder.commit();
 
@@ -2244,8 +2262,12 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
     it('should return ids from offset', async function () {
       // given
-      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner();
-      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const { organizationId, userId } = databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildUserLogin({ userId, lastLoggedAt: new Date() });
+      const { id: organizationLearnerId, userId: otherUserId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+      databaseBuilder.factory.buildUserLogin({ userId: otherUserId, lastLoggedAt: new Date() });
       databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
       await databaseBuilder.commit();
 

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -1091,7 +1091,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           lastTermsOfServiceValidatedAt,
           lastPixOrgaTermsOfServiceValidatedAt,
           lastPixCertifTermsOfServiceValidatedAt: lastLoggedAt,
-          lastLoggedAt,
           emailConfirmedAt,
         });
         await databaseBuilder.commit();

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -207,7 +207,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         });
       });
 
-      it('returns only ther user matching "id" if given in filter', async function () {
+      it('returns only the user matching "id" if given in filter', async function () {
         // given
         const filter = { id: '123456' };
         const page = { number: 1, size: 10 };
@@ -1093,6 +1093,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           lastPixCertifTermsOfServiceValidatedAt: lastLoggedAt,
           emailConfirmedAt,
         });
+        await databaseBuilder.factory.buildUserLogin({ userId: userInDB.id, lastLoggedAt });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -1654,33 +1654,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         expect(actualUser.hasSeenOtherChallengesTooltip).to.be.true;
       });
     });
-
-    describe('#updateLastLoggedAt', function () {
-      let clock;
-      const now = new Date('2020-01-02');
-
-      beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
-      });
-
-      afterEach(function () {
-        clock.restore();
-      });
-
-      it('should update the last login date to now', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser();
-        const userId = user.id;
-        await databaseBuilder.commit();
-
-        // when
-        await userRepository.updateLastLoggedAt({ userId });
-
-        // then
-        const userUpdated = await knex('users').select().where({ id: userId }).first();
-        expect(userUpdated.lastLoggedAt).to.deep.equal(now);
-      });
-    });
   });
 
   describe('#checkIfEmailIsAvailable', function () {

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -39,7 +39,6 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
     userRepository = {
       getBySamlId: sinon.stub(),
       getForObfuscation: sinon.stub(),
-      updateLastLoggedAt: sinon.stub(),
     };
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
@@ -122,7 +121,6 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       // then
-      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
       expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
     });
 

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -30,7 +30,6 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
     };
     userRepository = {
       getByUsernameOrEmailWithRoles: sinon.stub(),
-      updateLastLoggedAt: sinon.stub(),
       update: sinon.stub(),
     };
     userLoginRepository = {
@@ -292,7 +291,6 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
     });
 
     // then
-    expect(userRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
     expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
   });
 

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -32,10 +32,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       save: sinon.stub(),
     };
 
-    userRepository = {
-      findByExternalIdentifier: sinon.stub(),
-      updateLastLoggedAt: sinon.stub(),
-    };
+    userRepository = { findByExternalIdentifier: sinon.stub() };
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
@@ -175,7 +172,6 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       // then
       expect(oidcAuthenticationService.saveIdToken).to.not.have.been.called;
       expect(oidcAuthenticationService.createAccessToken).to.not.have.been.called;
-      expect(userRepository.updateLastLoggedAt).to.not.have.been.called;
       expect(userLoginRepository.updateLastLoggedAt).to.not.have.been.called;
     });
   });
@@ -264,7 +260,6 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
       // then
       sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-      sinon.assert.calledOnceWithExactly(userRepository.updateLastLoggedAt, { userId: 10 });
       sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
       expect(accessToken).to.deep.equal({
         pixAccessToken: 'accessTokenForExistingExternalUser',

--- a/api/tests/unit/domain/usecases/create-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/create-oidc-user_test.js
@@ -6,7 +6,7 @@ import {
 import { createOidcUser } from '../../../../lib/domain/usecases/create-oidc-user.js';
 
 describe('Unit | UseCase | create-oidc-user', function () {
-  let authenticationMethodRepository, userToCreateRepository, userRepository, userLoginRepository;
+  let authenticationMethodRepository, userToCreateRepository, userLoginRepository;
   let authenticationSessionService, oidcAuthenticationService;
   let clock;
   const now = new Date('2021-01-02');
@@ -27,10 +27,6 @@ describe('Unit | UseCase | create-oidc-user', function () {
       createUserAccount: sinon.stub(),
       createAccessToken: sinon.stub(),
       saveIdToken: sinon.stub(),
-    };
-
-    userRepository = {
-      updateLastLoggedAt: sinon.stub(),
     };
 
     userLoginRepository = {
@@ -112,7 +108,6 @@ describe('Unit | UseCase | create-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userToCreateRepository,
-      userRepository,
       userLoginRepository,
     });
 
@@ -132,7 +127,6 @@ describe('Unit | UseCase | create-oidc-user', function () {
     });
     sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
     sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
-    sinon.assert.calledOnceWithExactly(userRepository.updateLastLoggedAt, { userId: 10 });
     sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
     expect(result).to.deep.equal({
       accessToken: 'accessTokenForExistingExternalUser',

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -27,7 +27,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
     };
     userRepository = {
       getBySamlId: sinon.stub(),
-      updateLastLoggedAt: sinon.stub(),
     };
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
@@ -69,7 +68,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       });
 
       // then
-      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
       expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
     });
 
@@ -143,7 +141,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       });
 
       // then
-      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
       expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
     });
 

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -14,7 +14,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   beforeEach(function () {
     userRepository = {
       getBySamlId: sinon.stub(),
-      updateLastLoggedAt: sinon.stub(),
     };
 
     userLoginRepository = {
@@ -141,7 +140,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       });
 
       // then
-      expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });
       expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });
     });
 

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
@@ -4,16 +4,11 @@ import { AuthenticationKeyExpired, MissingUserAccountError } from '../../../../l
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
 
 describe('Unit | UseCase | reconcile-oidc-user', function () {
-  let authenticationMethodRepository,
-    userRepository,
-    userLoginRepository,
-    authenticationSessionService,
-    oidcAuthenticationService;
+  let authenticationMethodRepository, userLoginRepository, authenticationSessionService, oidcAuthenticationService;
   const identityProvider = 'POLE_EMPLOI';
 
   beforeEach(function () {
     authenticationMethodRepository = { create: sinon.stub() };
-    userRepository = { updateLastLoggedAt: sinon.stub() };
     userLoginRepository = {
       updateLastLoggedAt: sinon.stub(),
     };
@@ -45,7 +40,6 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       oidcAuthenticationService,
       authenticationSessionService,
       authenticationMethodRepository,
-      userRepository,
       userLoginRepository,
     });
 
@@ -74,7 +68,6 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       oidcAuthenticationService,
       authenticationSessionService,
       authenticationMethodRepository,
-      userRepository,
       userLoginRepository,
     });
 
@@ -112,14 +105,12 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       oidcAuthenticationService,
       authenticationSessionService,
       authenticationMethodRepository,
-      userRepository,
       userLoginRepository,
     });
 
     // then
     sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
     sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
-    sinon.assert.calledOnceWithExactly(userRepository.updateLastLoggedAt, { userId });
     sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId });
     expect(result).to.deep.equal({
       accessToken: 'accessToken',
@@ -138,7 +129,6 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
-        userRepository,
         userLoginRepository,
       });
 
@@ -161,7 +151,6 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
-        userRepository,
         userLoginRepository,
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour des soucis de retro-compatibilité, nous avons choisi de mettre à jour la même information, c'est-à-dire la date de dernière connexion d'un utilisateur, sur les tables suivantes `Users` et `UserLogins`.

A terme, nous voulons uniquement utiliser la table `UserLogins` pour porter l'information de la date de dernière connexion.

## :robot: Proposition
Retirer toutes utilisations de la méthode `userRepository.updateLastLoggedAt(...)`, et modifier le code existant pour n'utiliser que la propriété `lastLoggedAt` de la table `UserLogins`.

## :rainbow: Remarques
⚠️ Cette modification touche le scope de la team prescription. Il faudrait voir pour un scénario (ou plusieurs) pour s'assurer qu'aucune régression n'a été introduite dans leur scope.

## :100: Pour tester

Utiliser PixAdmin comme outil de contrôle pour vérifier que la date de dernière connexion est la bonne.

- Se connecter sur [PixAdmin](https://admin-pr6977.review.pix.fr/) avec le compte `superadmin@example.net`
- Une fois connecté sur Pix App avec un compte standard ou _partenaire_ (GAR, Pole Emploi, ...)
 - Faire une recherche avec l'ID ou le nom, prénom de l'utilisateur
 - Vérifier dans les détails de cet utilisateur que la date de dernière connexion est la bonne

### Scénarios possibles :

#### Connexion simple (identifiant ou e-mail, et mot de passe) sans date de dernière connexion

- Se connecter sur [PixApp](https://app-pr6977.review.pix.fr/) avec le compte `salvor.hardin`
- Vérifier, avec PixAdmin, sur les détails de ce compte qu'une date de dernière connexion est disponible

#### Connexion simple (identifiant ou e-mail, et mot de passe) avec date de dernière connexion

- Prendre note de la date de dernière connexion du compte avec PixAdmin
- Se connecter sur [PixApp](https://app-pr6977.review.pix.fr/) avec le compte `gaal.dornick`
- Vérifier, avec PixAdmin, sur les détails de ce compte à une nouvelle date de dernière connexion

#### Connexion GAR

Ce scénario est à tester en local avec l'utilisation du `Faux GAR`.

- Prendre note de la date de dernière connexion, si présente, du compte `Eliza Delajungle` avec PixAdmin
- Se connecter au `Faux GAR` avec ces informations
  - Saml ID = <id de votre choix>
  - Prénom = Eliza
  - Nom = Delajungle
- Fournir le code campagne `SCOBADGE1`
- Commencer le parcours
- Fournir la date de naissance du compte `01-01-2011`
- Une fois sur le parcours, tutoriel affiché ou page d'accueil affiché, vérifier sur PixAdmin la date de dernière connexion

#### Connexion OIDC (Pole Emploi, ...)

Ce scénario est à tester en local

- Prendre note de la date de dernière connexion, si présente, pour l'un des comptes que vous allez utiliser
- Se connecter via le SSO de Pole Emploi avec l'un des comptes fournis dans Confluence
- Créer un nouveau compte si ce n'est pas déjà le cas
- Vérifier sur PixAdmin que le compte a une nouvelle date de dernière connexion