### PR TITLE
[FEATURE] Appeler la nouvelle méthode "manageEmails" dans les usecases publishSession et publishSessionInBatch (PIX-8215).

### DIFF
--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -11,14 +11,11 @@ const { some, uniqBy } = lodash;
 import { logger } from '../../infrastructure/logger.js';
 
 async function publishSession({
-  i18n,
   publishedAt = new Date(),
   sessionId,
-  certificationCenterRepository,
   certificationRepository,
   finalizedSessionRepository,
   sessionRepository,
-  dependencies = { mailService },
 }) {
   const session = await sessionRepository.getWithCertificationCandidates(sessionId);
   if (session.isPublished()) {
@@ -31,14 +28,7 @@ async function publishSession({
 
   await _updateFinalizedSession(finalizedSessionRepository, sessionId, publishedAt);
 
-  await manageEmails({
-    i18n,
-    session,
-    publishedAt,
-    certificationCenterRepository,
-    sessionRepository,
-    dependencies,
-  });
+  return session;
 }
 
 async function manageEmails({

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -1,21 +1,27 @@
 const publishSession = async function ({
   i18n,
   sessionId,
+  publishedAt = new Date(),
   certificationRepository,
   certificationCenterRepository,
   finalizedSessionRepository,
   sessionRepository,
   sessionPublicationService,
-  publishedAt = new Date(),
 }) {
-  await sessionPublicationService.publishSession({
-    i18n,
+  const session = await sessionPublicationService.publishSession({
     sessionId,
+    publishedAt,
     certificationRepository,
-    certificationCenterRepository,
     finalizedSessionRepository,
     sessionRepository,
+  });
+
+  await sessionPublicationService.manageEmails({
+    i18n,
+    session,
     publishedAt,
+    certificationCenterRepository,
+    sessionRepository,
   });
 
   return sessionRepository.get(sessionId);

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -5,25 +5,31 @@ import { SessionPublicationBatchResult } from '../models/SessionPublicationBatch
 const publishSessionsInBatch = async function ({
   i18n,
   sessionIds,
+  publishedAt = new Date(),
+  batchId = randomUUID(),
   certificationCenterRepository,
   certificationRepository,
   finalizedSessionRepository,
-  sessionPublicationService,
   sessionRepository,
-  publishedAt = new Date(),
-  batchId = randomUUID(),
+  sessionPublicationService,
 }) {
   const result = new SessionPublicationBatchResult(batchId);
   for (const sessionId of sessionIds) {
     try {
-      await sessionPublicationService.publishSession({
-        i18n,
+      const session = await sessionPublicationService.publishSession({
         sessionId,
+        publishedAt,
         certificationRepository,
-        certificationCenterRepository,
         finalizedSessionRepository,
         sessionRepository,
+      });
+
+      await sessionPublicationService.manageEmails({
+        i18n,
+        session,
         publishedAt,
+        certificationCenterRepository,
+        sessionRepository,
       });
     } catch (error) {
       result.addPublicationError(sessionId, error);

--- a/api/tests/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/unit/domain/usecases/publish-session_test.js
@@ -8,6 +8,7 @@ describe('Unit | UseCase | publish-session', function () {
     const sessionId = Symbol('a session id');
     const session = Symbol('a session');
     const certificationRepository = Symbol('the certification repository');
+    const certificationCenterRepository = Symbol('the certification center repository');
     const finalizedSessionRepository = Symbol('the finalizedSessionRepository');
     const publishedAt = Symbol('a publication date');
 
@@ -18,11 +19,9 @@ describe('Unit | UseCase | publish-session', function () {
 
     const sessionPublicationService = {
       publishSession: sinon.stub(),
+      manageEmails: sinon.stub(),
     };
-
-    const certificationCenterRepository = {
-      getRefererEmails: sinon.stub(),
-    };
+    sessionPublicationService.publishSession.resolves(session);
 
     // when
     const result = await publishSession({
@@ -38,13 +37,18 @@ describe('Unit | UseCase | publish-session', function () {
 
     // then
     expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
-      i18n,
       sessionId,
+      publishedAt,
       certificationRepository,
-      certificationCenterRepository,
       finalizedSessionRepository,
       sessionRepository,
+    });
+    expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
+      i18n,
+      session,
       publishedAt,
+      certificationCenterRepository,
+      sessionRepository,
     });
     expect(result).to.equal(session);
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans ce ticket de création de script pour l’envoi des résultats de certif https://github.com/1024pix/pix/pull/6297, on a choisir d'extraire l’envoi des mails de la méthode `publishSession` pour en faire une méthode à part `manageEmails`.

En effet, la publication de session et l'envoi de mail étant deux choses différentes, ils doivent être séparés et visible dans le usecase.

## :robot: Proposition
Appeler la nouvelle méthode dans les usecases utilisant la méthode `publishSession` ( 2 usecases concernés ).

<img width="1402" alt="Capture d’écran 2023-09-01 à 15 50 40" src="https://github.com/1024pix/pix/assets/58915422/6043d59e-3162-4b14-8f4f-0637b8d96239">

## :100: Pour tester

- Se connecter sur Pix Admin avec superadmin@example.net
- https://admin-pr6979.review.pix.fr/sessions/list/to-be-published?version=2
- en BDD, changer l'info du referer avec son adresse e-mail 
- Publier une seule session 
- Constater que la session est publié et que le mail à été reçu
- Réitérer en publiant en masse les sessions (bien changer le referer avant) 
- Constater que les sessions sont publiés et que les mails ont été reçu

