### PR TITLE
[TECH] Supprimer la colonne "lastLoggedAt" de la table "Users" (PIX-9032)

### DIFF
--- a/api/db/migrations/20230914093838_remove-last-logged-at-column-from-users-table.js
+++ b/api/db/migrations/20230914093838_remove-last-logged-at-column-from-users-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'lastLoggedAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## ⚠️ Ne pas merger

En attente de l'exécution en production de ces PRs suivantes :
1. #6952
2. #6958
3. #6977
4. #7022 

Une fois que la PR #7022 sera mergée, il faudra supprimer puis créer de nouveau le fichier de migration de cette PR ci

## :unicorn: Problème

Cette PR est la dernière étape de la tâche demandant de déplacer la colonne lastLoggedAt depuis la table users vers la table user-logins.

1. Ajout de la colonne lastLoggedAt dans la table user-logins et alimentation de cette nouvelle colonne #6952 
2. Ajout d'un script à faire tourner en production pour synchroniser l'ancienne colonne (users.lastLoggedAt) vers la nouvelle (user-logins.lastLoggedAt) uniquement si aucune valeur existe sur cette dernière #6958 
3. Ne plus mettre à jour la colonne lastLoggedAt de la table users #6977 
6. Ajout d'un script de migration de base de données (cette PR)

## :robot: Proposition

Supprimer la colonne **lastLoggedAt** de la table **users**.

## :rainbow: Remarques

RAS

## :100: Pour tester

Test à faire sur votre machine

- **Exécuter la commande `npm run db:reset` sur la branche `dev` avant de continuer**
- Exécuter la commande de migration `npm run db:migrate`
- Constater en base de données que le schema de la table users a bien été modifié (colonne lastLoggedAt supprimée)
- Exécuter la commande de rollback `npm run db:rollback:latest`
- Constater en base de données que le schema de la table users a bien été modifié (colonne lastLoggedAt ajoutée)
- Vérifier que le script `npm run db:reset` reste bien toujours fonctionnel, c'est à dire s'exécute sans erreur
