### PR TITLE
[BUGFIX] Corriger l'affichage du menu dans Pix Orga (Pix-9066)

### DIFF
--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -1,4 +1,5 @@
 .topbar {
+  position: relative;
   display: flex;
   flex-shrink: 0;
   align-items: center;


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'affichage d'un bandeau sur PixOrga le menu qui déroule n'est pas correctement placé

## :robot: Proposition
Fixer sa position par rapport à son parent

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que le menu s'affiche correctement tout simplement