### PR TITLE
[FEATURE] Ajoute la colonne propriétaire dans la création de campagne en masse (PIX-9069).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-creator-repository.js
@@ -2,9 +2,11 @@ import { knex } from '../../../db/knex-database-connection.js';
 import { CampaignCreator } from '../../../lib/domain/models/CampaignCreator.js';
 import { UserNotAuthorizedToCreateCampaignError } from '../../domain/errors.js';
 
-async function get({ userId, organizationId, ownerId }) {
+async function get({ userId, organizationId, ownerId, shouldOwnerBeFromOrganization = true }) {
   await _checkUserIsAMemberOfOrganization({ organizationId, userId });
-  await _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId });
+  if (shouldOwnerBeFromOrganization) {
+    await _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId });
+  }
 
   const availableTargetProfileIds = await knex('target-profiles')
     .leftJoin('target-profile-shares', 'targetProfileId', 'target-profiles.id')

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -184,9 +184,12 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
         value = value.trim();
       }
       if (
-        ["Identifiant de l'organisation*", 'Identifiant du profil cible*', 'Identifiant du créateur*'].includes(
-          columnName,
-        )
+        [
+          "Identifiant de l'organisation*",
+          'Identifiant du profil cible*',
+          'Identifiant du créateur*',
+          'Identifiant du propriétaire',
+        ].includes(columnName)
       ) {
         value = parseInt(value, 10);
       }
@@ -210,6 +213,7 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     title: data['Titre du parcours'],
     customLandingPageText: data['Descriptif du parcours'],
     multipleSendings: data['Envoi multiple'].toLowerCase() === 'oui' ? true : false,
+    ownerId: data['Identifiant du propriétaire'] || null,
   }));
 }
 

--- a/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -2,6 +2,7 @@ import { expect, databaseBuilder, catchErr } from '../../../test-helper.js';
 import * as campaignCreatorRepository from '../../../../lib/infrastructure/repositories/campaign-creator-repository.js';
 import { UserNotAuthorizedToCreateCampaignError } from '../../../../lib/domain/errors.js';
 import * as apps from '../../../../lib/domain/constants.js';
+import { CampaignCreator } from '../../../../lib/domain/models/CampaignCreator.js';
 
 describe('Integration | Repository | CampaignCreatorRepository', function () {
   describe('#get', function () {
@@ -162,6 +163,28 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
         // then
         expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
         expect(error.message).to.equal(`Owner does not have an access to the organization ${organizationId}`);
+      });
+
+      it('return the campaign creator', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const shouldOwnerBeFromOrganization = false;
+        databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignCreatorRepository.get({
+          userId,
+          organizationId,
+          ownerId,
+          shouldOwnerBeFromOrganization,
+        });
+
+        // then
+        expect(result).to.be.instanceOf(CampaignCreator);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1065,17 +1065,17 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
-      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple\n";
+      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire\n";
 
     it('should return parsed campaign data', async function () {
       // given
-      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non`;
+      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non;`;
 
       // when
-      const [firstCampaign, secondCampaign] = await csvSerializer.parseForCampaignsImport(csv);
+      const parsedData = await csvSerializer.parseForCampaignsImport(csv);
 
       // then
-      const parsedData = [
+      const expectedParsedData = [
         {
           organizationId: 1,
           name: 'chaussette',
@@ -1085,6 +1085,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           customLandingPageText: 'descriptif 1',
           creatorId: 789,
           multipleSendings: true,
+          ownerId: 45,
         },
         {
           organizationId: 2,
@@ -1095,10 +1096,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           customLandingPageText: 'descriptif 2',
           creatorId: 666,
           multipleSendings: false,
+          ownerId: null,
         },
       ];
-      expect(firstCampaign).to.deep.equal(parsedData[0]);
-      expect(secondCampaign).to.deep.equal(parsedData[1]);
+      expect(parsedData).to.have.deep.members(expectedParsedData);
     });
 
     describe('when organizationId field is not valid', function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la création en masse de campagne Pix+ Edu, on veut pouvoir mettre un utilisateur générique en propriétaire de campagne.

## :robot: Proposition
Ajouter la colonne "Identifiant du propripétaire" dans le template du CSV 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que l'import fonctionne toujours sans la colonne propriétaire :
```
Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple
6000;chaussette;1000000;numéro étudiant;6000;titre 1;descriptif 1;Oui
6002;chapeau;1000000;identifiant;6002;titre 2;descriptif 2;non
```
Vérifier que l'import fonctionne toujours avec colonne propriétaire (partiellement remplie) :
```
Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire
6000;chaussette2;1000000;numéro étudiant;6000;titre 1;descriptif 1;Oui;90000
6002;chapeau2;1000000;identifiant;6002;titre 2;descriptif 2;non;
```