### PR TITLE
[FEATURE] Diminution de la capacité initiale en certif V3 (PIX-9072).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -316,6 +316,7 @@ const configuration = (function () {
     v3Certification: {
       numberOfChallengesPerCourse: process.env.V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE || 20,
       defaultProbabilityToPickChallenge: parseInt(process.env.DEFAULT_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
+      defaultCandidateCapacity: -3,
     },
     version: process.env.CONTAINER_VERSION || 'development',
   };

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -13,7 +13,11 @@ class FlashAssessmentAlgorithm {
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
   }
 
-  getPossibleNextChallenges({ allAnswers, challenges, initialCapacity }) {
+  getPossibleNextChallenges({
+    allAnswers,
+    challenges,
+    initialCapacity = config.v3Certification.defaultCandidateCapacity,
+  }) {
     if (allAnswers.length >= this.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -26,7 +26,7 @@ const getNextChallengeForCertification = async function ({
       return challengeRepository.get(lastNonAnsweredCertificationChallenge.challengeId);
     }
 
-    const { allAnswers, challenges, estimatedLevel } = await algorithmDataFetcherService.fetchForFlashCampaigns({
+    const { allAnswers, challenges } = await algorithmDataFetcherService.fetchForFlashCampaigns({
       assessmentId: assessment.id,
       answerRepository,
       challengeRepository,
@@ -41,7 +41,6 @@ const getNextChallengeForCertification = async function ({
     const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({
       allAnswers,
       challenges,
-      estimatedLevel,
     });
 
     const challenge = pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -179,7 +179,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
 
           chooseNextChallenge
             .withArgs({
-              possibleChallenges: [thirdChallenge, secondChallenge],
+              possibleChallenges: [secondChallenge, thirdChallenge],
             })
             .returns(secondChallenge);
 


### PR DESCRIPTION
## :unicorn: Problème

Suite aux premiers tests en interne qui ont été réalisés, il en est sorti que le niveau de difficulté des questions est trop important.

## :robot: Proposition

Afin d’améliorer l’expérience des candidats, nous choisissons de commencer la session de certification avec une capacité initiale de -3 (nombre choisi de façon totalement arbitraire)

## :rainbow: Remarques

Nous décidons de ne pas passer par une variable d'environnement pour ce paramètre.

## :100: Pour tester

- Créer une session de certif dans un CDC taggué “isV3Pilot” (login: certifv3@example.net)
- Inscrire un candidat à cette session
- Rejoindre la session avec ce candidat et commencer le test

Récupérer les ids des premières questions passées (environ 4-5) et vérifier que la difficulté de celles-ci commence environ à -3 et diminue ou augmente en fonction de l'exactitude de vos réponses.
