### PR TITLE
[FEATURE] Changer l'url de la bannière de l'ouverture du niveau 7 (PIX-8651)

### DIFF
--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -83,10 +83,9 @@ export default class Url extends Service {
   get levelSevenNewsUrl() {
     const currentLanguage = this.intl.t('current-lang');
 
-    // TODO change these url when they are available
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return 'https://pix.org/en/news/european-commission-pix-wins-european-digital-skills-awards';
+      return 'https://pix.org/en/news/discover-level-7-on-pix';
     }
-    return 'https://pix.fr/actualites/commission-europeenne-pix-remporte-european-digital-skills-awards';
+    return 'https://pix.fr/actualites/decouvrez-le-niveau-7-des-maintenant-sur-pix';
   }
 }

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -292,8 +292,7 @@ module('Unit | Service | locale', function (hooks) {
       const service = this.owner.lookup('service:url');
       service.currentDomain = { isFranceDomain: true };
       service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
-      const expectedLevelSevenNewsUrl =
-        'https://pix.fr/actualites/commission-europeenne-pix-remporte-european-digital-skills-awards';
+      const expectedLevelSevenNewsUrl = 'https://pix.fr/actualites/decouvrez-le-niveau-7-des-maintenant-sur-pix';
 
       // when
       const levelSevenNewsUrl = service.levelSevenNewsUrl;
@@ -308,8 +307,7 @@ module('Unit | Service | locale', function (hooks) {
         const service = this.owner.lookup('service:url');
         service.currentDomain = { isFranceDomain: false };
         service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
-        const expectedLevelSevenNewsUrl =
-          'https://pix.org/en/news/european-commission-pix-wins-european-digital-skills-awards';
+        const expectedLevelSevenNewsUrl = 'https://pix.org/en/news/discover-level-7-on-pix';
 
         // when
         const levelSevenNewsUrl = service.levelSevenNewsUrl;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les liens de la bannière d'information du niveau 7 ne sont pas les bons.

## :robot: Proposition
Les mettre à jour

## :rainbow: Remarques
RAS

## :100: Pour tester
mettre à jour la variable d'env MAX_REACHABLE_LEVEL à 7 sur scalingo
se rendre sur pix app
constater que la bannière est présente et que les liens fonctionnent