### PR TITLE
[FEATURE] Ajout d'une colonne "role" sur la table certification-center-memberships (PIX-4994)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center-membership.js
+++ b/api/db/database-builder/factory/build-certification-center-membership.js
@@ -11,6 +11,7 @@ const buildCertificationCenterMembership = function ({
   createdAt = new Date('2020-01-01'),
   disabledAt,
   isReferer = false,
+  role = 'MEMBER',
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   certificationCenterId = _.isUndefined(certificationCenterId) ? buildCertificationCenter().id : certificationCenterId;
@@ -23,6 +24,7 @@ const buildCertificationCenterMembership = function ({
     createdAt,
     disabledAt,
     isReferer,
+    role,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-center-memberships',

--- a/api/db/migrations/20230905084838_update-certification-center-memberships.js
+++ b/api/db/migrations/20230905084838_update-certification-center-memberships.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'certification-center-memberships';
+const COLUMN_NAME = 'role';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.enum(COLUMN_NAME, ['MEMBER', 'ADMIN']).defaultTo('MEMBER');
+  });
+  await knex(TABLE_NAME).update({ [COLUMN_NAME]: 'MEMBER' });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
> Cette modification est liée à l'Epix [PIX-1704] Pix Certif : Ajout de rôles et envoi d'invitations

Il n'y a pas de colonne `role` sur la table `certification-center-memberships`



## :robot: Proposition
Ajouter la colonne `role` avec les valeurs `MEMBER` (par défaut) ou `ADMIN` à la table `certification-center-memberships`

## :rainbow: Remarques
RAS

## :100: Pour tester

exécuter la commande : 
```sh
npm run db:migrate
```

Vérifier en base de donnée que le rôle est bien ajouté avec la bonne valeur par défaut "MEMBER" pour toutes les entrées de la table 

```sh
psql postgresql://postgres@localhost/pix 
# psql: \d certification-center-memberships
# psql: select * FROM   certification-center-memberships;
```

Vérifier que le rollback s'est bien fait : 

```sh
npm run db:rollback:latest
```



[PIX-1704]: https://1024pix.atlassian.net/browse/PIX-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ