### PR TITLE
[FEATURE] Ajout du scoring pour les certifications V3 (PIX-9050).

### DIFF
--- a/api/db/database-builder/factory/build-answered-not-completed-certification-assessment.js
+++ b/api/db/database-builder/factory/build-answered-not-completed-certification-assessment.js
@@ -8,11 +8,12 @@ const buildAnsweredNotCompletedCertificationAssessment = function ({
   certifiableUserId,
   competenceIdSkillIdPairs,
   limitDate,
+  version = 2,
 }) {
   const certificationCourseId = buildCertificationCourse({
     userId: certifiableUserId,
     createdAt: limitDate,
-    version: 2,
+    version,
   }).id;
   const certificationAssessment = buildAssessment({
     certificationCourseId,

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import perf_hooks from 'perf_hooks';
 import * as eventBusBuilder from '../../infrastructure/events/EventBusBuilder.js';
 
+import * as answerRepository from '../../infrastructure/repositories/answer-repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method-repository.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
@@ -19,6 +20,7 @@ import * as certificationAssessmentRepository from '../../infrastructure/reposit
 import * as certificationCenterRepository from '../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../infrastructure/repositories/certification-issue-report-repository.js';
+import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
 import * as competenceMarkRepository from '../../infrastructure/repositories/competence-mark-repository.js';
 import * as competenceRepository from '../../infrastructure/repositories/competence-repository.js';
 import * as complementaryCertificationScoringCriteriaRepository from '../../infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';
@@ -33,7 +35,6 @@ import * as userRepository from '../../../src/shared/infrastructure/repositories
 import { participantResultsSharedRepository } from '../../infrastructure/repositories/participant-results-shared-repository.js';
 import * as juryCertificationSummaryRepository from '../../infrastructure/repositories/jury-certification-summary-repository.js';
 import * as finalizedSessionRepository from '../../infrastructure/repositories/sessions/finalized-session-repository.js';
-import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
 import { logger } from '../../infrastructure/logger.js';
 import * as poleEmploiNotifier from '../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
 import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js';
@@ -57,9 +58,10 @@ function requirePoleEmploiNotifier() {
 }
 
 const dependencies = {
-  authenticationMethodRepository,
+  answerRepository,
   assessmentRepository,
   assessmentResultRepository,
+  authenticationMethodRepository,
   badgeAcquisitionRepository,
   badgeRepository,
   campaignRepository,
@@ -69,23 +71,23 @@ const dependencies = {
   certificationCenterRepository,
   certificationCourseRepository,
   certificationIssueReportRepository,
+  challengeRepository,
   competenceMarkRepository,
   competenceRepository,
   complementaryCertificationScoringCriteriaRepository,
+  finalizedSessionRepository,
+  juryCertificationSummaryRepository,
   knowledgeElementRepository,
+  logger,
   organizationRepository,
+  participantResultsSharedRepository,
+  poleEmploiNotifier: requirePoleEmploiNotifier(),
   poleEmploiSendingRepository,
   scoringCertificationService,
   skillRepository,
   supervisorAccessRepository,
   targetProfileRepository,
   userRepository,
-  participantResultsSharedRepository,
-  poleEmploiNotifier: requirePoleEmploiNotifier(),
-  juryCertificationSummaryRepository,
-  finalizedSessionRepository,
-  challengeRepository,
-  logger,
 };
 
 const partnerCertificationScoringRepository = injectDependencies(dependency, dependencies);

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,0 +1,95 @@
+import { status } from './AssessmentResult.js';
+import { FlashAssessmentAlgorithm } from './FlashAssessmentAlgorithm.js';
+
+/*
+Score should not be totally linear. It should be piecewise linear, so we define
+here the different intervals. See documentation here :
+https://1024pix.atlassian.net/wiki/spaces/DD/pages/3835133953/Vulgarisation+score+2023
+ */
+const scoreIntervals = [
+  {
+    start: -8,
+    end: -6,
+  },
+  {
+    start: -6,
+    end: -4,
+  },
+  {
+    start: -4,
+    end: -2,
+  },
+  {
+    start: -2,
+    end: 0,
+  },
+  {
+    start: 0,
+    end: 2,
+  },
+  {
+    start: 2,
+    end: 4,
+  },
+  {
+    start: 4,
+    end: 6,
+  },
+  {
+    start: 6,
+    end: 8,
+  },
+];
+
+const MAX_PIX_SCORE = 1024;
+const INTERVAL_HEIGHT = MAX_PIX_SCORE / scoreIntervals.length;
+
+class CertificationAssessmentScoreV3 {
+  constructor({ nbPix, percentageCorrectAnswers = 100 }) {
+    this.nbPix = nbPix;
+    this.percentageCorrectAnswers = percentageCorrectAnswers;
+  }
+
+  static fromChallengesAndAnswers({ challenges, allAnswers }) {
+    const algorithm = new FlashAssessmentAlgorithm();
+    const { estimatedLevel } = algorithm.getEstimatedLevelAndErrorRate({
+      challenges,
+      allAnswers,
+    });
+
+    const nbPix = _computeScore(estimatedLevel);
+
+    return new CertificationAssessmentScoreV3({
+      nbPix,
+    });
+  }
+
+  get status() {
+    return status.VALIDATED;
+  }
+
+  get competenceMarks() {
+    return [];
+  }
+
+  getPercentageCorrectAnswers() {
+    return this.percentageCorrectAnswers;
+  }
+}
+
+const _findIntervalIndex = (estimatedLevel) =>
+  scoreIntervals.findIndex(({ start, end }) => estimatedLevel < end && estimatedLevel >= start);
+
+const _computeScore = (estimatedLevel) => {
+  const intervalIndex = _findIntervalIndex(estimatedLevel);
+
+  const intervalMaxValue = scoreIntervals[intervalIndex].end;
+  const intervalWidth = scoreIntervals[intervalIndex].end - scoreIntervals[intervalIndex].start;
+
+  // Formula is defined here : https://1024pix.atlassian.net/wiki/spaces/DD/pages/3835133953/Vulgarisation+score+2023#Le-score
+  const score = INTERVAL_HEIGHT * (intervalIndex + 1 + (estimatedLevel - intervalMaxValue) / intervalWidth);
+
+  return Math.round(score);
+};
+
+export { CertificationAssessmentScoreV3 };

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -77,7 +77,7 @@ const challengeDatasource = datasource.extend({
 
     return challenges.filter(
       (challengeData) =>
-        _.includes(challengeData.locales, locale) &&
+        (!locale || _.includes(challengeData.locales, locale)) &&
         challengeData.alpha != null &&
         challengeData.delta != null &&
         challengeData.skillId &&

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -197,7 +197,7 @@ const findOperativeFlashCompatible = async function ({
   return _toDomainCollection({ challengeDataObjects, skills, successProbabilityThreshold });
 };
 
-const findFlashCompatible = async function ({ locale, useObsoleteChallenges }) {
+const findFlashCompatible = async function ({ locale, useObsoleteChallenges } = {}) {
   const challengeDataObjects = await challengeDatasource.findFlashCompatible({ locale, useObsoleteChallenges });
   const skills = await skillDatasource.list();
   return _toDomainCollection({ challengeDataObjects, skills });

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -10,11 +10,20 @@ import {
 import { Assessment, TrainingTrigger } from '../../../../lib/domain/models/index.js';
 import * as badgeAcquisitionRepository from '../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
 import { createServer } from '../../../../server.js';
+import _ from 'lodash';
 
 describe('Acceptance | Controller | assessment-controller-complete-assessment', function () {
   let options;
   let server;
   let user, assessment;
+  const easyChallengeParams = {
+    alpha: 1,
+    delta: -3,
+  };
+  const hardChallengeParams = {
+    alpha: 1,
+    delta: 3,
+  };
   const learningContent = [
     {
       id: 'recArea0',
@@ -29,17 +38,17 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
                   id: 'recSkill0_0',
                   nom: '@recSkill0_0',
                   level: 2,
-                  challenges: [{ id: 'recChallenge0_0_0' }],
+                  challenges: [{ id: 'recChallenge0_0_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill0_1',
                   nom: '@recSkill0_1',
-                  challenges: [{ id: 'recChallenge0_1_0' }],
+                  challenges: [{ id: 'recChallenge0_1_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill0_2',
                   nom: '@recSkill0_2',
-                  challenges: [{ id: 'recChallenge0_2_0' }],
+                  challenges: [{ id: 'recChallenge0_2_0', ...hardChallengeParams }],
                 },
               ],
             },
@@ -54,17 +63,17 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
                 {
                   id: 'recSkill1_0',
                   nom: '@recSkill1_0',
-                  challenges: [{ id: 'recChallenge1_0_0' }],
+                  challenges: [{ id: 'recChallenge1_0_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill1_1',
                   nom: '@recSkill1_1',
-                  challenges: [{ id: 'recChallenge1_1_0' }],
+                  challenges: [{ id: 'recChallenge1_1_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill1_2',
                   nom: '@recSkill1_2',
-                  challenges: [{ id: 'recChallenge1_2_0' }],
+                  challenges: [{ id: 'recChallenge1_2_0', ...hardChallengeParams }],
                 },
               ],
             },
@@ -79,17 +88,17 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
                 {
                   id: 'recSkill2_0',
                   nom: '@recSkill2_0',
-                  challenges: [{ id: 'recChallenge2_0_0' }],
+                  challenges: [{ id: 'recChallenge2_0_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill2_1',
                   nom: '@recSkill2_1',
-                  challenges: [{ id: 'recChallenge2_1_0' }],
+                  challenges: [{ id: 'recChallenge2_1_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill2_2',
                   nom: '@recSkill2_2',
-                  challenges: [{ id: 'recChallenge2_2_0' }],
+                  challenges: [{ id: 'recChallenge2_2_0', ...hardChallengeParams }],
                 },
               ],
             },
@@ -104,17 +113,17 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
                 {
                   id: 'recSkill3_0',
                   nom: '@recSkill3_0',
-                  challenges: [{ id: 'recChallenge3_0_0' }],
+                  challenges: [{ id: 'recChallenge3_0_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill3_1',
                   nom: '@recSkill3_1',
-                  challenges: [{ id: 'recChallenge3_1_0' }],
+                  challenges: [{ id: 'recChallenge3_1_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill3_2',
                   nom: '@recSkill3_2',
-                  challenges: [{ id: 'recChallenge3_2_0' }],
+                  challenges: [{ id: 'recChallenge3_2_0', ...hardChallengeParams }],
                 },
               ],
             },
@@ -129,17 +138,17 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
                 {
                   id: 'recSkill4_0',
                   nom: '@recSkill4_0',
-                  challenges: [{ id: 'recChallenge4_0_0' }],
+                  challenges: [{ id: 'recChallenge4_0_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill4_1',
                   nom: '@recSkill4_1',
-                  challenges: [{ id: 'recChallenge4_1_0' }],
+                  challenges: [{ id: 'recChallenge4_1_0', ...easyChallengeParams }],
                 },
                 {
                   id: 'recSkill4_2',
                   nom: '@recSkill4_2',
-                  challenges: [{ id: 'recChallenge4_2_0' }],
+                  challenges: [{ id: 'recChallenge4_2_0', ...hardChallengeParams }],
                 },
               ],
             },
@@ -323,51 +332,135 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
   });
 
   context('when assessment is of type certification', function () {
-    let certifiableUserId;
-    let certificationAssessmentId;
+    context('when certification is v2', function () {
+      let certifiableUserId;
+      let certificationAssessmentId;
 
-    beforeEach(function () {
-      const limitDate = new Date('2020-01-01T00:00:00Z');
-      const dateAfterLimitDate = new Date('2020-01-02T00:00:00Z');
-      certifiableUserId = databaseBuilder.factory.buildUser().id;
+      beforeEach(function () {
+        const limitDate = new Date('2020-01-01T00:00:00Z');
+        const dateAfterLimitDate = new Date('2020-01-02T00:00:00Z');
+        certifiableUserId = databaseBuilder.factory.buildUser().id;
 
-      const competenceIdSkillIdPairs =
-        databaseBuilder.factory.buildCorrectAnswersAndKnowledgeElementsForLearningContent.fromAreas({
-          learningContent,
+        const competenceIdSkillIdPairs =
+          databaseBuilder.factory.buildCorrectAnswersAndKnowledgeElementsForLearningContent.fromAreas({
+            learningContent,
+            userId: certifiableUserId,
+            placementDate: limitDate,
+            earnedPix: 8,
+          });
+
+        certificationAssessmentId = databaseBuilder.factory.buildAnsweredNotCompletedCertificationAssessment({
+          certifiableUserId,
+          competenceIdSkillIdPairs,
+          limitDate: dateAfterLimitDate,
+        }).id;
+
+        return databaseBuilder.commit();
+      });
+
+      afterEach(async function () {
+        await knex('certification-courses-last-assessment-results').delete();
+        await knex('competence-marks').delete();
+        await knex('assessment-results').delete();
+      });
+
+      it('should complete the certification assessment', async function () {
+        // given
+        options.url = `/api/assessments/${certificationAssessmentId}/complete-assessment`;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(certifiableUserId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    context('when certification is v3', function () {
+      let certifiableUserId;
+      let certificationAssessment;
+
+      beforeEach(function () {
+        const limitDate = new Date('2020-01-01T00:00:00Z');
+        certifiableUserId = databaseBuilder.factory.buildUser().id;
+
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
           userId: certifiableUserId,
-          placementDate: limitDate,
-          earnedPix: 8,
+          createdAt: limitDate,
+          version: 3,
+        }).id;
+        certificationAssessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId,
+          userId: certifiableUserId,
+          state: Assessment.states.STARTED,
+          type: Assessment.types.CERTIFICATION,
+          createdAt: limitDate,
         });
 
-      certificationAssessmentId = databaseBuilder.factory.buildAnsweredNotCompletedCertificationAssessment({
-        certifiableUserId,
-        competenceIdSkillIdPairs,
-        limitDate: dateAfterLimitDate,
-      }).id;
-      databaseBuilder.factory.buildBadge().id;
+        _buildValidAnswersAndCertificationChallenges({
+          assessmentId: certificationAssessment.id,
+          certificationCourseId,
+        });
+        databaseBuilder.factory.buildBadge();
 
-      return databaseBuilder.commit();
-    });
+        return databaseBuilder.commit();
+      });
 
-    afterEach(async function () {
-      await knex('certification-courses-last-assessment-results').delete();
-      await knex('competence-marks').delete();
-      await knex('assessment-results').delete();
-    });
+      afterEach(async function () {
+        await knex('certification-courses-last-assessment-results').delete();
+        await knex('competence-marks').delete();
+        await knex('assessment-results').delete();
+      });
 
-    it('should complete the certification assessment', async function () {
-      // given
-      options.url = `/api/assessments/${certificationAssessmentId}/complete-assessment`;
-      options.headers.authorization = generateValidRequestAuthorizationHeader(certifiableUserId);
+      it('should complete the certification assessment', async function () {
+        // given
+        options.url = `/api/assessments/${certificationAssessment.id}/complete-assessment`;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(certifiableUserId);
 
-      // when
-      const response = await server.inject(options);
+        // when
+        const response = await server.inject(options);
 
-      // then
-      expect(response.statusCode).to.equal(204);
+        // then
+        expect(response.statusCode).to.equal(204);
+
+        const assessmentResult = await knex('assessment-results')
+          .where({
+            assessmentId: certificationAssessment.id,
+          })
+          .first();
+
+        expect(assessmentResult.pixScore).to.exist;
+      });
     });
   });
 });
+
+function _buildValidAnswersAndCertificationChallenges({ certificationCourseId, assessmentId }) {
+  const answers = _.flatten(
+    _.range(0, 3).map((skillIndex) =>
+      _.range(0, 3).map((level) => {
+        return databaseBuilder.factory.buildAnswer({
+          challengeId: `recChallenge${skillIndex}_${level}_0`,
+          result: 'ok',
+          assessmentId: assessmentId,
+        });
+      }),
+    ),
+  );
+
+  const certificationChallenges = answers.map(({ challengeId }) =>
+    databaseBuilder.factory.buildCertificationChallenge({
+      challengeId,
+      courseId: certificationCourseId,
+    }),
+  );
+
+  return {
+    answers,
+    certificationChallenges,
+  };
+}
 
 async function _createAndCompleteCampaignParticipation({ user, campaign, badge, options, server }) {
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment-score-v3.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment-score-v3.js
@@ -1,0 +1,9 @@
+import { CertificationAssessmentScoreV3 } from '../../../../lib/domain/models/CertificationAssessmentScoreV3.js';
+
+const buildCertificationAssessmentScoreV3 = function ({ nbPix = 100 } = {}) {
+  return new CertificationAssessmentScoreV3({
+    nbPix,
+  });
+};
+
+export { buildCertificationAssessmentScoreV3 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -27,6 +27,7 @@ import { buildCampaignToStartParticipation } from './build-campaign-to-start-par
 import { buildCertifiableBadgeAcquisition } from './build-certifiable-badge-acquisition.js';
 import { buildCertificationAssessment } from './build-certification-assessment.js';
 import { buildCertificationAssessmentScore } from './build-certification-assessment-score.js';
+import { buildCertificationAssessmentScoreV3 } from './build-certification-assessment-score-v3.js';
 import { buildCertificationCandidate } from './build-certification-candidate.js';
 import { buildCertificationCandidateForSupervising } from './build-certification-candidate-for-supervising.js';
 import { buildCertificationCandidateSubscription } from './build-certification-candidate-subscription.js';
@@ -182,6 +183,7 @@ export {
   buildCertifiableBadgeAcquisition,
   buildCertificationAssessment,
   buildCertificationAssessmentScore,
+  buildCertificationAssessmentScoreV3,
   buildCertificationCandidate,
   buildCertificationCandidateForSupervising,
   buildCertificationCandidateSubscription,

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -1,0 +1,125 @@
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { AnswerStatus } from '../../../../lib/domain/models/index.js';
+import { CertificationAssessmentScoreV3 } from '../../../../lib/domain/models/CertificationAssessmentScoreV3.js';
+
+describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function () {
+  const assessmentId = 1234;
+  const secondAssessmentId = 456;
+
+  let answerRepository;
+  let challengeRepository;
+
+  let baseChallenges;
+  let baseAnswers;
+  let challenge4;
+
+  beforeEach(function () {
+    answerRepository = {
+      findByAssessment: sinon.stub(),
+    };
+    challengeRepository = {
+      findFlashCompatible: sinon.stub(),
+    };
+
+    const challenge1 = domainBuilder.buildChallenge({
+      id: 'recCHAL1',
+      discriminant: 1,
+      difficulty: 0,
+    });
+    const challenge2 = domainBuilder.buildChallenge({
+      id: 'recCHAL2',
+      discriminant: 1,
+      difficulty: 4,
+    });
+    const challenge3 = domainBuilder.buildChallenge({
+      id: 'recCHAL3',
+      discriminant: 1,
+      difficulty: 2,
+    });
+
+    challenge4 = domainBuilder.buildChallenge({
+      id: 'recCHAL4',
+      discriminant: 1,
+      difficulty: 2,
+    });
+
+    const answer1 = domainBuilder.buildAnswer({
+      id: 'ans1',
+      challengeId: challenge1.id,
+    });
+
+    const answer2 = domainBuilder.buildAnswer({
+      id: 'ans2',
+      challengeId: challenge2.id,
+      result: AnswerStatus.KO,
+    });
+
+    const answer3 = domainBuilder.buildAnswer({
+      id: 'ans3',
+      challengeId: challenge3.id,
+    });
+
+    baseChallenges = [challenge1, challenge2, challenge3, challenge4];
+    baseAnswers = [answer1, answer3, answer2];
+  });
+
+  it('should return the score', async function () {
+    answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
+    challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
+
+    const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+      challenges: baseChallenges,
+      allAnswers: baseAnswers,
+    });
+
+    expect(score.nbPix).to.equal(658);
+  });
+
+  describe('when a wrong answer is added', function () {
+    it('should decrease the score', async function () {
+      const wrongAnswer = domainBuilder.buildAnswer({
+        result: AnswerStatus.KO,
+        challengeId: challenge4.id,
+      });
+      answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
+      answerRepository.findByAssessment.withArgs(secondAssessmentId).resolves([...baseAnswers, wrongAnswer]);
+      challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
+
+      const baseScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+        challenges: baseChallenges,
+        allAnswers: baseAnswers,
+      });
+
+      const newScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+        challenges: baseChallenges,
+        allAnswers: [...baseAnswers, wrongAnswer],
+      });
+
+      expect(newScore.nbPix).to.be.lessThan(baseScore.nbPix);
+    });
+  });
+
+  describe('when a correct answer is added', function () {
+    it('should increase the score', async function () {
+      const correctAnswer = domainBuilder.buildAnswer({
+        result: AnswerStatus.OK,
+        challengeId: challenge4.id,
+      });
+      answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
+      answerRepository.findByAssessment.withArgs(secondAssessmentId).resolves([...baseAnswers, correctAnswer]);
+      challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
+
+      const baseScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+        challenges: baseChallenges,
+        allAnswers: baseAnswers,
+      });
+
+      const newScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+        challenges: baseChallenges,
+        allAnswers: [...baseAnswers, correctAnswer],
+      });
+
+      expect(newScore.nbPix).to.be.greaterThan(baseScore.nbPix);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -137,7 +137,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       const result = await challengeDatasource.findOperativeBySkillIds(skillIds);
 
       // then
-      expect(lcms.getLatestRelease).to.have.been.called;
       expect(_.map(result, 'id')).to.deep.equal(['challenge-web1', 'challenge-web2']);
     });
   });
@@ -162,7 +161,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
 
     it('should resolve to an array of matching Challenges from learning content', function () {
       // then
-      expect(lcms.getLatestRelease).to.have.been.called;
       expect(_.map(result, 'id')).to.deep.equal(['challenge-competence1']);
     });
   });
@@ -179,7 +177,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       const result = await challengeDatasource.findOperative();
 
       // then
-      expect(lcms.getLatestRelease).to.have.been.called;
       expect(_.map(result, 'id')).to.deep.equal(['challenge-web1', 'challenge-web2', 'challenge-web3-archived']);
     });
   });
@@ -212,7 +209,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       const result = await challengeDatasource.findValidated();
 
       // then
-      expect(lcms.getLatestRelease).to.have.been.called;
       expect(_.map(result, 'id')).to.deep.equal(['challenge-web1', 'challenge-web2']);
     });
   });
@@ -242,7 +238,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
         const result = await challengeDatasource.findFlashCompatible({ locale });
 
         // then
-        expect(lcms.getLatestRelease).to.have.been.called;
         expect(_.map(result, 'id').sort()).to.deep.equal(
           [challenge_competence1.id, challenge_competence2.id, challenge_web3.id, challenge_web3_archived.id].sort(),
         );
@@ -256,7 +251,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
         const result = await challengeDatasource.findFlashCompatible({ locale, useObsoleteChallenges: true });
 
         // then
-        expect(lcms.getLatestRelease).to.have.been.called;
         expect(_.map(result, 'id').sort()).to.deep.equal(
           [
             challenge_competence1.id,
@@ -286,18 +280,34 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       });
     });
 
-    it('should resolve an array of matching Challenges from learning content', async function () {
-      // when
-      const locale = 'fr-fr';
-      const result = await challengeDatasource.findActiveFlashCompatible(locale);
+    describe('when no locale is set', function () {
+      it('should resolve an array of matching Challenges from learning content', async function () {
+        // when
+        const result = await challengeDatasource.findActiveFlashCompatible();
 
-      // then
-      expect(lcms.getLatestRelease).to.have.been.called;
-      expect(_.map(result, 'id')).to.deep.equal([
-        challenge_competence1.id,
-        challenge_competence2.id,
-        challenge_web3.id,
-      ]);
+        // then
+        expect(_.map(result, 'id')).to.deep.equal([
+          challenge_competence1.id,
+          challenge_competence2.id,
+          challenge_web2_en.id,
+          challenge_web3.id,
+        ]);
+      });
+    });
+
+    describe('when a locale is set', function () {
+      it('should resolve an array of matching Challenges from learning content containing the locale', async function () {
+        // when
+        const locale = 'fr-fr';
+        const result = await challengeDatasource.findActiveFlashCompatible(locale);
+
+        // then
+        expect(_.map(result, 'id')).to.deep.equal([
+          challenge_competence1.id,
+          challenge_competence2.id,
+          challenge_web3.id,
+        ]);
+      });
     });
   });
 
@@ -323,7 +333,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       const result = await challengeDatasource.findOperativeFlashCompatible(locale);
 
       // then
-      expect(lcms.getLatestRelease).to.have.been.called;
       expect(_.map(result, 'id')).to.deep.equal([
         challenge_competence1.id,
         challenge_competence2.id,
@@ -344,7 +353,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       const result = await challengeDatasource.findValidatedBySkillId('skill-web1');
 
       // then
-      expect(lcms.getLatestRelease).to.have.been.called;
       expect(result).to.deep.equal([challenge_web1, challenge_competence2]);
     });
   });
@@ -377,19 +385,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     });
 
     context('when there are several challenges for the skillId', function () {
-      // it('should return a challenge randomly if the alternativeVersion is not provided', async function () {
-      //   // when
-      //   sinon.stub(lcms, 'getLatestRelease').resolves({
-      //     challenges: [challenge_web1, challenge_competence2, challenge_pix1d1, challenge_pix1d2],
-      //   });
-      //   const result = await challengeDatasource.getBySkillId(skillId);
-      //
-      //   // then
-      //   expect(lcms.getLatestRelease).to.have.been.called;
-      //
-      //   expect([result]).to.contain.oneOf(expectedChallenges);
-      // });
-
       it('should return an array of validated or proposed challenges', async function () {
         // when
         sinon.stub(lcms, 'getLatestRelease').resolves({
@@ -417,7 +412,6 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
         const result = await challengeDatasource.getBySkillId(skillId);
 
         // then
-        expect(lcms.getLatestRelease).to.have.been.called;
         expect(result).to.deep.equal([validated_challenge_pix1d]);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

La certif v3 ne propose actuellement pas de score puisque l’ancienne formule n’a pas été validée en comité sponsor.

## :robot: Proposition

Ajout d'une nouvelle méthode de scoring

## :rainbow: Remarques

Nous ne disposons à l'heure actuelle d'aucune information concernant la gestion des erreurs.
Nous settons la variable `reproducibilityRate` à `100` par défaut dans le cadre de la certif V3 afin de ne pas être gêné lors de l'ajout en base mais cette valeur n'a aucun intérêt à l'heure actuelle.

## :100: Pour tester

• Créer une session de certif dans un CDC taggué “isV3Pilot” (login: [certifv3@example.net](mailto:certifv3@example.
• Inscrire un candidat à cette 
• Rejoindre la session avec ce candidat et terminer le test
• Vérifier qu'un score a bien été enregistré en BDD dans la table `assessment-results`

⚠️ Vérifier qu’il n’y a pas eu de régression pour les sessions v2
