### PR TITLE
[BUGFIX] Exclure les participations qui ne sont pas liés aux participants par le userId (Pix-9068)

### DIFF
--- a/api/lib/infrastructure/repositories/organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/organization-participant-repository.js
@@ -69,21 +69,22 @@ async function getParticipantsByOrganizationId({ organizationId, page, filters =
       ),
     ])
     .from('view-active-organization-learners')
-    .join(
-      'campaign-participations',
-      'campaign-participations.organizationLearnerId',
-      'view-active-organization-learners.id',
-    )
+    .join('campaign-participations', function () {
+      this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
+        .andOnVal('campaign-participations.isImproved', false)
+        .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
+    })
     .join('campaigns', function () {
-      this.on('campaign-participations.campaignId', 'campaigns.id');
-      this.on('campaigns.organizationId', organizationId);
+      this.on('campaign-participations.campaignId', 'campaigns.id').andOnVal(
+        'campaigns.organizationId',
+        organizationId,
+      );
     })
     .leftJoin('subquery', 'subquery.organizationLearnerId', 'view-active-organization-learners.id')
-    .leftJoin('users', 'view-active-organization-learners.userId', 'users.id')
+    .join('users', function () {
+      this.on('view-active-organization-learners.userId', 'users.id').andOnVal('users.isAnonymous', false);
+    })
     .where('view-active-organization-learners.organizationId', organizationId)
-    .where('users.isAnonymous', '=', false)
-    .whereNull('campaign-participations.deletedAt')
-    .where('campaign-participations.isImproved', '=', false)
     .orderBy(orderByClause)
     .distinct('view-active-organization-learners.id')
     .modify(_filterBySearch, filters)

--- a/api/lib/infrastructure/repositories/organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/organization-participant-repository.js
@@ -16,13 +16,12 @@ async function getParticipantsByOrganizationId({ organizationId, page, filters =
         knex.raw('false'),
       );
     })
-    .join(
-      'campaign-participations',
-      'campaign-participations.organizationLearnerId',
-      'view-active-organization-learners.id',
-    )
+    .join('campaign-participations', function () {
+      this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
+        .andOn('campaign-participations.userId', 'view-active-organization-learners.userId')
+        .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
+    })
     .where({ organizationId: organizationId, isDisabled: false })
-    .where({ 'campaign-participations.deletedAt': null })
     .first();
   const totalParticipants = count ?? 0;
 
@@ -72,7 +71,8 @@ async function getParticipantsByOrganizationId({ organizationId, page, filters =
     .join('campaign-participations', function () {
       this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
         .andOnVal('campaign-participations.isImproved', false)
-        .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
+        .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'))
+        .andOn('campaign-participations.userId', 'view-active-organization-learners.userId');
     })
     .join('campaigns', function () {
       this.on('campaign-participations.campaignId', 'campaigns.id').andOnVal(

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -69,6 +69,7 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
     .from('view-active-organization-learners')
     .join('campaign-participations', function () {
       this.on('view-active-organization-learners.id', 'campaign-participations.organizationLearnerId')
+        .andOn('view-active-organization-learners.userId', 'campaign-participations.userId')
         .andOnVal('campaign-participations.status', CampaignParticipationStatuses.SHARED)
         .andOn('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
     })
@@ -152,6 +153,7 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
     .leftJoin('users', 'users.id', 'view-active-organization-learners.userId')
     .leftJoin('campaign-participations', function () {
       this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
+        .andOn('campaign-participations.userId', 'view-active-organization-learners.userId')
         .andOnVal('campaign-participations.isImproved', false)
         .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
     })

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -67,17 +67,17 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
       ),
     ])
     .from('view-active-organization-learners')
-    .join(
-      'campaign-participations',
-      'view-active-organization-learners.id',
-      'campaign-participations.organizationLearnerId',
-    )
-    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .where('campaign-participations.status', CampaignParticipationStatuses.SHARED)
-    .where('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
-    .where('view-active-organization-learners.organizationId', organizationId)
-    .where('campaigns.organizationId', organizationId)
-    .where('campaign-participations.deletedAt', null);
+    .join('campaign-participations', function () {
+      this.on('view-active-organization-learners.id', 'campaign-participations.organizationLearnerId')
+        .andOnVal('campaign-participations.status', CampaignParticipationStatuses.SHARED)
+        .andOn('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
+    })
+    .join('campaigns', function () {
+      this.on('campaigns.id', 'campaign-participations.campaignId')
+        .andOnVal('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
+        .andOnVal('campaigns.organizationId', organizationId);
+    })
+    .where('view-active-organization-learners.organizationId', organizationId);
 }
 
 const findPaginatedFilteredScoParticipants = async function ({ organizationId, filter, page = {}, sort = {} }) {
@@ -149,12 +149,12 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
     ])
     .from('view-active-organization-learners')
     .leftJoin('subquery', 'subquery.organizationLearnerId', 'view-active-organization-learners.id')
+    .leftJoin('users', 'users.id', 'view-active-organization-learners.userId')
     .leftJoin('campaign-participations', function () {
       this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
-        .andOn('campaign-participations.isImproved', '=', knex.raw('false'))
-        .andOn('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
+        .andOnVal('campaign-participations.isImproved', false)
+        .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
     })
-    .leftJoin('users', 'users.id', 'view-active-organization-learners.userId')
     .leftJoin('authentication-methods', function () {
       this.on('users.id', 'authentication-methods.userId').andOnVal(
         'authentication-methods.identityProvider',

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -46,8 +46,10 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
       ),
     ])
     .from('view-active-organization-learners')
+    .leftJoin('users', 'view-active-organization-learners.userId', 'users.id')
     .join('campaign-participations', function () {
       this.on('view-active-organization-learners.id', 'campaign-participations.organizationLearnerId')
+        .andOn('view-active-organization-learners.userId', 'campaign-participations.userId')
         .andOnVal('campaign-participations.status', CampaignParticipationStatuses.SHARED)
         .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
     })
@@ -116,9 +118,11 @@ const findPaginatedFilteredSupParticipants = async function ({ organizationId, f
       ),
     ])
     .from('view-active-organization-learners')
+    .leftJoin('users', 'view-active-organization-learners.userId', 'users.id')
     .leftJoin('subquery', 'subquery.organizationLearnerId', 'view-active-organization-learners.id')
     .leftJoin('campaign-participations', function () {
       this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
+        .andOn('view-active-organization-learners.userId', 'campaign-participations.userId')
         .andOnVal('campaign-participations.isImproved', false)
         .andOnVal('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
     })

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -46,17 +46,17 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
       ),
     ])
     .from('view-active-organization-learners')
-    .join(
-      'campaign-participations',
-      'view-active-organization-learners.id',
-      'campaign-participations.organizationLearnerId',
-    )
-    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .where('campaign-participations.status', CampaignParticipationStatuses.SHARED)
-    .where('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
-    .where('view-active-organization-learners.organizationId', organizationId)
-    .where('campaigns.organizationId', organizationId)
-    .where('campaign-participations.deletedAt', null);
+    .join('campaign-participations', function () {
+      this.on('view-active-organization-learners.id', 'campaign-participations.organizationLearnerId')
+        .andOnVal('campaign-participations.status', CampaignParticipationStatuses.SHARED)
+        .andOnVal('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
+    })
+    .join('campaigns', function () {
+      this.on('campaigns.id', 'campaign-participations.campaignId')
+        .andOnVal('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
+        .andOnVal('campaigns.organizationId', organizationId);
+    })
+    .where('view-active-organization-learners.organizationId', organizationId);
 }
 
 const findPaginatedFilteredSupParticipants = async function ({ organizationId, filter, page = {}, sort = {} }) {
@@ -119,8 +119,8 @@ const findPaginatedFilteredSupParticipants = async function ({ organizationId, f
     .leftJoin('subquery', 'subquery.organizationLearnerId', 'view-active-organization-learners.id')
     .leftJoin('campaign-participations', function () {
       this.on('campaign-participations.organizationLearnerId', 'view-active-organization-learners.id')
-        .andOn('campaign-participations.isImproved', '=', knex.raw('false'))
-        .andOn('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
+        .andOnVal('campaign-participations.isImproved', false)
+        .andOnVal('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
     })
     .leftJoin('campaigns', function () {
       this.on('campaigns.id', 'campaign-participations.campaignId').andOn(

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -824,6 +824,7 @@ describe('Acceptance | Application | organization-controller', function () {
         participation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: organizationLearner.id,
+          userId: user.id,
           isCertifiable: true,
         });
 

--- a/api/tests/integration/domain/usecases/get-paginated-participants-for-an-organization_test.js
+++ b/api/tests/integration/domain/usecases/get-paginated-participants-for-an-organization_test.js
@@ -6,13 +6,14 @@ describe('Integration | UseCases | get-paginated-participants-for-an-organizatio
   it('should get all participations for an organization', async function () {
     // given
     const organizationId = databaseBuilder.factory.buildOrganization().id;
-    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+    const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
       firstName: 'Ah',
       organizationId,
-    }).id;
+    });
     const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
     databaseBuilder.factory.buildCampaignParticipation({
       organizationLearnerId,
+      userId,
       campaignId,
     });
 

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -369,12 +369,17 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
               organizationId,
               type: CampaignTypes.PROFILES_COLLECTION,
             }).id;
-            const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-            const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+            const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
+            const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
 
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId,
               organizationLearnerId: organizationLearnerId1,
+              userId: userId1,
               status: CampaignParticipationStatuses.SHARED,
               sharedAt: new Date('2022-01-01'),
               isCertifiable: true,
@@ -382,6 +387,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId,
               organizationLearnerId: organizationLearnerId2,
+              userId: userId2,
               status: CampaignParticipationStatuses.SHARED,
               sharedAt: new Date('2022-01-01'),
               isCertifiable: false,
@@ -405,13 +411,20 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
               organizationId,
               type: CampaignTypes.PROFILES_COLLECTION,
             }).id;
-            const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-            const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-            const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+            const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
+            const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
+            const { id: organizationLearnerId3, userId: userId3 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+            });
 
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId,
               organizationLearnerId: organizationLearnerId1,
+              userId: userId1,
               status: CampaignParticipationStatuses.SHARED,
               sharedAt: new Date('2022-01-01'),
               isCertifiable: true,
@@ -419,6 +432,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId,
               organizationLearnerId: organizationLearnerId2,
+              userId: userId2,
               status: CampaignParticipationStatuses.SHARED,
               sharedAt: new Date('2022-01-01'),
               isCertifiable: false,
@@ -426,6 +440,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId,
               organizationLearnerId: organizationLearnerId3,
+              userId: userId3,
               status: CampaignParticipationStatuses.STARTED,
               sharedAt: null,
               isCertifiable: null,
@@ -586,7 +601,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         }).id;
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId }).id;
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, userId });
         await databaseBuilder.commit();
 
         const expectedAttributes = {
@@ -657,11 +672,13 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           name: 'some campaign name',
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const userId = databaseBuilder.factory.buildUser().id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.TO_SHARE,
         });
         await databaseBuilder.commit();
@@ -702,10 +719,16 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId: otherCampaignId, organizationLearnerId });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, userId });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId,
+          userId,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -725,17 +748,21 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           deletedAt: null,
           deletedBy: null,
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           deletedAt: new Date(),
           deletedBy,
         });
@@ -756,10 +783,51 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, isImproved: true });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, isImproved: false });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+          isImproved: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+          isImproved: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ participationCount }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(participationCount).to.deep.equal(1);
+      });
+
+      it('should count only participations associated to same user id', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          organizationLearnerId,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -851,87 +919,82 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
 
     describe('When sco participants are sorted', function () {
       describe('by participation count', function () {
-        it('should return sco participants sorted by ascendant', async function () {
-          const organizationId = databaseBuilder.factory.buildOrganization().id;
-          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        context('participant sort', function () {
+          let organizationId, organizationLearnerId1, organizationLearnerId2, organizationLearnerId3;
+          beforeEach(async function () {
+            organizationId = databaseBuilder.factory.buildOrganization().id;
+            const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+            const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
 
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId,
-            organizationLearnerId: organizationLearnerId1,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: otherCampaignId,
-            organizationLearnerId: organizationLearnerId1,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId,
-            organizationLearnerId: organizationLearnerId3,
-          });
-          await databaseBuilder.commit();
-          // when
-          const { data: participants } =
-            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-              organizationId,
-              sort: {
-                participationCount: 'asc',
-              },
+            const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+            const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+            const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+
+            organizationLearnerId1 = organizationLearner1.id;
+            organizationLearnerId2 = organizationLearner2.id;
+            organizationLearnerId3 = organizationLearner3.id;
+
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId,
+              organizationLearnerId: organizationLearnerId1,
+              userId: organizationLearner1.userId,
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: otherCampaignId,
+              organizationLearnerId: organizationLearnerId1,
+              userId: organizationLearner1.userId,
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId,
+              organizationLearnerId: organizationLearnerId3,
+              userId: organizationLearner3.userId,
             });
 
-          // then
-          expect(participants.length).to.equal(3);
-          expect(participants[0].id).to.equal(organizationLearnerId2);
-          expect(participants[1].id).to.equal(organizationLearnerId3);
-          expect(participants[2].id).to.equal(organizationLearnerId1);
-        });
-
-        it('should return sco participants sorted by descendant', async function () {
-          const organizationId = databaseBuilder.factory.buildOrganization().id;
-          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId,
-            organizationLearnerId: organizationLearnerId1,
+            await databaseBuilder.commit();
           });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: otherCampaignId,
-            organizationLearnerId: organizationLearnerId1,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId,
-            organizationLearnerId: organizationLearnerId3,
-          });
-          await databaseBuilder.commit();
-          // when
-          const { data: participants } =
-            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
-              organizationId,
-              sort: {
-                participationCount: 'desc',
-              },
-            });
 
-          // then
-          expect(participants.length).to.equal(3);
-          expect(participants[0].id).to.equal(organizationLearnerId1);
-          expect(participants[1].id).to.equal(organizationLearnerId3);
-          expect(participants[2].id).to.equal(organizationLearnerId2);
+          it('should return sco participants sorted by ascendant', async function () {
+            // when
+            const { data: participants } =
+              await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+                organizationId,
+                sort: {
+                  participationCount: 'asc',
+                },
+              });
+
+            // then
+            expect(participants.length).to.equal(3);
+            expect(participants[0].id).to.equal(organizationLearnerId2);
+            expect(participants[1].id).to.equal(organizationLearnerId3);
+            expect(participants[2].id).to.equal(organizationLearnerId1);
+          });
+
+          it('should return sco participants sorted by descendant', async function () {
+            // when
+            const { data: participants } =
+              await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+                organizationId,
+                sort: {
+                  participationCount: 'desc',
+                },
+              });
+
+            // then
+            expect(participants.length).to.equal(3);
+            expect(participants[0].id).to.equal(organizationLearnerId1);
+            expect(participants[1].id).to.equal(organizationLearnerId3);
+            expect(participants[2].id).to.equal(organizationLearnerId2);
+          });
         });
 
         it('should return sco participants sorted by name if identical participation count', async function () {
           const organizationId = databaseBuilder.factory.buildOrganization().id;
           const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
+          const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
             organizationId,
             lastName: 'Aaaah',
-          }).id;
+          });
           const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
             organizationId,
             lastName: 'Dupont',
@@ -944,6 +1007,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId: campaignId,
             organizationLearnerId: organizationLearnerId1,
+            userId: userId1,
           });
           await databaseBuilder.commit();
           // when
@@ -1108,16 +1172,20 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           createdAt: new Date('2022-01-01'),
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           createdAt: new Date('2021-01-01'),
         });
         await databaseBuilder.commit();
@@ -1139,11 +1207,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           deletedAt: null,
           deletedBy: null,
           createdAt: new Date('2021-02-01'),
@@ -1151,6 +1222,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           deletedAt: new Date(),
           deletedBy,
           createdAt: new Date('2022-01-01'),
@@ -1172,17 +1244,21 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           isImproved: true,
           createdAt: new Date('2022-01-01'),
         });
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           isImproved: false,
           createdAt: new Date('2021-01-01'),
         });
@@ -1229,11 +1305,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: false,
@@ -1241,6 +1320,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.STARTED,
           sharedAt: null,
           isCertifiable: true,
@@ -1269,11 +1349,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: false,
@@ -1282,6 +1365,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: true,
@@ -1311,11 +1395,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId,
           type: CampaignTypes.ASSESSMENT,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: profileCollectionCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,
@@ -1323,6 +1410,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: assessmentCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: false,
@@ -1352,11 +1440,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,
@@ -1364,6 +1455,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: false,
@@ -1390,11 +1482,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: true,
@@ -1403,6 +1498,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: false,
@@ -1432,11 +1528,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId: otherOrganizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,
@@ -1468,11 +1567,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -211,6 +211,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: expectedOrganizationLearner.id,
+          userId: expectedOrganizationLearner.userId,
           status: CampaignParticipationStatuses.SHARED,
           isCertifiable: true,
         });
@@ -223,6 +224,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: otherOrganizationLearner.id,
+          userId: otherOrganizationLearner.userId,
           status: CampaignParticipationStatuses.SHARED,
           isCertifiable: false,
         });
@@ -256,6 +258,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: eligibleOrganizationLearner.id,
+          userId: eligibleOrganizationLearner.userId,
           status: CampaignParticipationStatuses.SHARED,
           isCertifiable: true,
         });
@@ -268,6 +271,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: notEligibleOrganizationLearner.id,
+          userId: notEligibleOrganizationLearner.userId,
           status: CampaignParticipationStatuses.SHARED,
           isCertifiable: false,
         });
@@ -280,6 +284,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: notCommunicatedOrganizationLearner.id,
+          userId: notCommunicatedOrganizationLearner.userId,
           status: CampaignParticipationStatuses.STARTED,
           isCertifiable: null,
         });
@@ -401,9 +406,10 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           name: 'some campaign name',
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const userId = databaseBuilder.factory.buildUser().id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId }).id;
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId });
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, userId });
         await databaseBuilder.commit();
 
         const expectedAttributes = {
@@ -474,11 +480,13 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           name: 'some campaign name',
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const userId = databaseBuilder.factory.buildUser().id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.TO_SHARE,
         });
         await databaseBuilder.commit();
@@ -519,10 +527,16 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId: otherCampaignId, organizationLearnerId });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, userId });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId,
+          userId,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -542,17 +556,21 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           deletedAt: null,
           deletedBy: null,
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           deletedAt: new Date(),
           deletedBy,
         });
@@ -573,10 +591,22 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, isImproved: true });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, isImproved: false });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+          isImproved: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          userId,
+          isImproved: false,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -609,96 +639,94 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
     });
 
     describe('When sup participants are sorted', function () {
-      it('should return sup participants sorted by ascendant participation count', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+      context('sorting participation count', function () {
+        let organizationId, organizationLearnerId1, organizationLearnerId2, organizationLearnerId3;
+        beforeEach(async function () {
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
 
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: otherCampaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId3,
-        });
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId,
-          sort: {
-            participationCount: 'asc',
-          },
-        });
+          const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+          const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+          const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
 
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(organizationLearnerId2);
-        expect(participants[1].id).to.equal(organizationLearnerId3);
-        expect(participants[2].id).to.equal(organizationLearnerId1);
-      });
-      it('should return sup participants sorted by descendant participation count', async function () {
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
-        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          organizationLearnerId1 = organizationLearner1.id;
+          organizationLearnerId2 = organizationLearner2.id;
+          organizationLearnerId3 = organizationLearner3.id;
 
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: otherCampaignId,
-          organizationLearnerId: organizationLearnerId1,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaignId,
-          organizationLearnerId: organizationLearnerId3,
-        });
-        await databaseBuilder.commit();
-        // when
-        const { data: participants } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId,
-          sort: {
-            participationCount: 'desc',
-          },
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId1,
+            userId: organizationLearner1.userId,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: otherCampaignId,
+            organizationLearnerId: organizationLearnerId1,
+            userId: organizationLearner1.userId,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId3,
+            userId: organizationLearner3.userId,
+          });
+          await databaseBuilder.commit();
         });
 
-        // then
-        expect(participants.length).to.equal(3);
-        expect(participants[0].id).to.equal(organizationLearnerId1);
-        expect(participants[1].id).to.equal(organizationLearnerId3);
-        expect(participants[2].id).to.equal(organizationLearnerId2);
+        it('should return sup participants sorted by ascendant participation count', async function () {
+          // when
+          const { data: participants } =
+            await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+              organizationId,
+              sort: {
+                participationCount: 'asc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(organizationLearnerId2);
+          expect(participants[1].id).to.equal(organizationLearnerId3);
+          expect(participants[2].id).to.equal(organizationLearnerId1);
+        });
+
+        it('should return sup participants sorted by descendant participation count', async function () {
+          // when
+          const { data: participants } =
+            await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+              organizationId,
+              sort: {
+                participationCount: 'desc',
+              },
+            });
+
+          // then
+          expect(participants.length).to.equal(3);
+          expect(participants[0].id).to.equal(organizationLearnerId1);
+          expect(participants[1].id).to.equal(organizationLearnerId3);
+          expect(participants[2].id).to.equal(organizationLearnerId2);
+        });
       });
 
       it('should return sup participants sorted by name if participation count are identical', async function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
+        const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
           lastName: 'Aaaah',
-        }).id;
-        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+        });
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
           lastName: 'Dupont',
-        }).id;
-        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({
+        });
+        const { id: organizationLearnerId3 } = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
           lastName: 'Dupond',
-        }).id;
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaignId,
           organizationLearnerId: organizationLearnerId1,
+          userId: userId1,
         });
         await databaseBuilder.commit();
         // when
@@ -849,16 +877,20 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           createdAt: new Date('2022-01-01'),
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           createdAt: new Date('2021-01-01'),
         });
         await databaseBuilder.commit();
@@ -880,11 +912,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           deletedAt: null,
           deletedBy: null,
           createdAt: new Date('2021-02-01'),
@@ -892,6 +927,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           deletedAt: new Date(),
           deletedBy,
           createdAt: new Date('2022-01-01'),
@@ -914,17 +950,21 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           isImproved: true,
           createdAt: new Date('2022-01-01'),
         });
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           isImproved: false,
           createdAt: new Date('2021-01-01'),
         });
@@ -972,11 +1012,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: false,
@@ -985,6 +1028,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.STARTED,
           sharedAt: null,
           isCertifiable: true,
@@ -1041,11 +1085,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: true,
@@ -1054,6 +1101,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: false,
@@ -1083,11 +1131,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId,
           type: CampaignTypes.ASSESSMENT,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: profileCollectionCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,
@@ -1095,6 +1146,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: assessmentCampaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: false,
@@ -1124,11 +1176,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,
@@ -1162,11 +1217,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),
           isCertifiable: true,
@@ -1204,11 +1262,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId: otherOrganizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+        });
 
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
+          userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2021-01-01'),
           isCertifiable: true,
@@ -1242,11 +1303,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
             organizationId,
             type: CampaignTypes.PROFILES_COLLECTION,
           }).id;
-          const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+          });
 
           const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             organizationLearnerId,
+            userId,
             status: CampaignParticipationStatuses.SHARED,
             sharedAt: new Date('2021-01-01'),
             isCertifiable: true,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous ne faisons pas de restrictions sur les campaign-participations par rapport aux userId . De ce fait lorsqu'un learner est dissocié de son user, nous continuons d'afficher la certificabilité de ce leaner. Ce qui n'est pas correcte.

## :robot: Proposition
Ajouter la restriction sur le userId sur les routes sco sup sco

## :rainbow: Remarques
Bien qu'ayant peu d'impact pour la route pro, nous le prenons en compte afin de rester cohérent sur la liaison enter un learner participation user.

## :100: Pour tester
- Se connecter à PixOrga sur une organisation SCO
- Repérer un prescrit avec la certificabilité affichée
- Se connecter à Pix Admin et dissocier cet utilisateur de l'orga
- Constater sur PixOrga que la colonne certificabilité s'est vidé pour ce prescrit