### PR TITLE
[TECH] Retirer les mentions à l'attribut "imageUrl" des tests statiques, l'attribut est déprécié (PIX-9079)

### DIFF
--- a/api/lib/domain/models/Course.js
+++ b/api/lib/domain/models/Course.js
@@ -1,10 +1,9 @@
 class Course {
-  constructor({ id, description, isActive, imageUrl, name, challenges = [], competences = [] } = {}) {
+  constructor({ id, description, isActive, name, challenges = [], competences = [] } = {}) {
     this.id = id;
     this.name = name;
     this.description = description;
     this.isActive = isActive;
-    this.imageUrl = imageUrl;
     this.challenges = challenges; // Array of Record IDs
     this.competences = competences; // Array of Record IDs
   }

--- a/api/lib/infrastructure/repositories/course-repository.js
+++ b/api/lib/infrastructure/repositories/course-repository.js
@@ -9,7 +9,6 @@ function _toDomain(courseDataObject) {
     name: courseDataObject.name,
     description: courseDataObject.description,
     isActive: courseDataObject.isActive,
-    imageUrl: courseDataObject.imageUrl,
     challenges: courseDataObject.challenges,
     competences: courseDataObject.competences,
   });

--- a/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (courses) {
   return new Serializer('course', {
-    attributes: ['name', 'description', 'nbChallenges', 'imageUrl'],
+    attributes: ['name', 'description', 'nbChallenges'],
   }).serialize(courses);
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-course.js
@@ -4,7 +4,6 @@ const buildCourse = function ({
   id = 'recCOUR123',
   description = 'description',
   isActive = true,
-  imageUrl = 'imageURL',
   name = 'name',
   assessment,
   challenges = [],
@@ -17,7 +16,6 @@ const buildCourse = function ({
     // attributes
     description,
     isActive,
-    imageUrl,
     name,
     // relations
     assessment,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
@@ -9,7 +9,6 @@ describe('Unit | Serializer | JSONAPI | course-serializer', function () {
         id: 'course_id',
         name: 'Name of the course',
         description: 'Description of the course',
-        imageUrl: 'http://image.url',
         challenges: ['rec_challenge_1', 'rec_challenge_2', 'rec_challenge_3', 'rec_challenge_4', 'rec_challenge_5'],
       });
 
@@ -24,7 +23,6 @@ describe('Unit | Serializer | JSONAPI | course-serializer', function () {
           attributes: {
             name: course.name,
             description: course.description,
-            'image-url': 'http://image.url',
             'nb-challenges': 5,
           },
         },

--- a/mon-pix/app/models/course.js
+++ b/mon-pix/app/models/course.js
@@ -1,9 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class Course extends Model {
-  // attributes
   @attr('string') description;
-  @attr('string') imageUrl;
   @attr('string') name;
   @attr('number') nbChallenges;
 }


### PR DESCRIPTION
## :unicorn: Problème
La colonne imageUrl de la table des tests statiques côté LCMS n'est pas utilisée, elle va donc être supprimée.

## :robot: Proposition
On retire toutes les mentions à cet attribut dans le code de Pix.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Non régression autour des tests statiques
exemple de test statique :
https://app-pr7003.review.pix.fr/courses/receWeUsoGqhkgGTd
