### PR TITLE
[FEATURE] Ajouter l'INE dans les messages d'erreurs lors d'un import SIECLE (PIX-9094)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1080,6 +1080,13 @@ class CsvImportError extends DomainError {
   }
 }
 
+const SIECLE_ERRORS = {
+  INE_REQUIRED: 'INE_REQUIRED',
+  INE_UNIQUE: 'INE_UNIQUE',
+  SEX_CODE_REQUIRED: 'SEX_CODE_REQUIRED',
+  BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT: 'BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT',
+};
+
 class SiecleXmlImportError extends DomainError {
   constructor(code, meta) {
     super('An error occurred during Siecle XML import');
@@ -1467,4 +1474,5 @@ export {
   UserShouldNotBeReconciledOnAnotherAccountError,
   WrongDateFormatError,
   YamlParsingError,
+  SIECLE_ERRORS,
 };

--- a/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
+++ b/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
@@ -3,14 +3,8 @@ import lodash from 'lodash';
 
 const { isEmpty, isNil, each } = lodash;
 
-import { SiecleXmlImportError } from '../../../domain/errors.js';
+import { SiecleXmlImportError, SIECLE_ERRORS } from '../../../domain/errors.js';
 
-const ERRORS = {
-  INE_REQUIRED: 'INE_REQUIRED',
-  INE_UNIQUE: 'INE_UNIQUE',
-  SEX_CODE_REQUIRED: 'SEX_CODE_REQUIRED',
-  BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT: 'BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT',
-};
 const DIVISION = 'D';
 
 const FRANCE_COUNTRY_CODE = '100';
@@ -48,16 +42,16 @@ class XMLOrganizationLearnersSet {
     const birthCityCode = _getValueFromParsedElement(xmlNode.CODE_COMMUNE_INSEE_NAISS);
 
     if (_frenchBornHasEmptyCityCode({ birthCountryCode, birthCityCode })) {
-      throw new SiecleXmlImportError(ERRORS.BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT);
+      throw new SiecleXmlImportError(SIECLE_ERRORS.BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT, { nationalStudentId });
     }
     if (isEmpty(sexCode)) {
-      throw new SiecleXmlImportError(ERRORS.SEX_CODE_REQUIRED);
+      throw new SiecleXmlImportError(SIECLE_ERRORS.SEX_CODE_REQUIRED);
     }
     if (isEmpty(nationalStudentId)) {
-      throw new SiecleXmlImportError(ERRORS.INE_REQUIRED);
+      throw new SiecleXmlImportError(SIECLE_ERRORS.INE_REQUIRED);
     }
     if (this.studentIds.includes(nationalStudentId)) {
-      throw new SiecleXmlImportError(ERRORS.INE_UNIQUE, { nationalStudentId });
+      throw new SiecleXmlImportError(SIECLE_ERRORS.INE_UNIQUE, { nationalStudentId });
     }
   }
 

--- a/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
+++ b/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
@@ -45,7 +45,7 @@ class XMLOrganizationLearnersSet {
       throw new SiecleXmlImportError(SIECLE_ERRORS.BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT, { nationalStudentId });
     }
     if (isEmpty(sexCode)) {
-      throw new SiecleXmlImportError(SIECLE_ERRORS.SEX_CODE_REQUIRED);
+      throw new SiecleXmlImportError(SIECLE_ERRORS.SEX_CODE_REQUIRED, { nationalStudentId });
     }
     if (isEmpty(nationalStudentId)) {
       throw new SiecleXmlImportError(SIECLE_ERRORS.INE_REQUIRED);

--- a/api/tests/integration/domain/services/organization-learners-xml-service_test.js
+++ b/api/tests/integration/domain/services/organization-learners-xml-service_test.js
@@ -161,6 +161,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
     it('should abort parsing and reject with missing sex ', async function () {
       // given
       const validUAIFromSIECLE = '123ABC';
+      const nationalStudentIdFromFile = '12345';
       const organization = { externalId: validUAIFromSIECLE };
       const path = `${fixturesDirPath}/siecle-file/siecle-student-with-no-sex.xml`;
       // when
@@ -171,6 +172,8 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
 
       //then
       expect(error).to.be.instanceof(SiecleXmlImportError);
+      expect(error.code).to.be.equal(SIECLE_ERRORS.SEX_CODE_REQUIRED);
+      expect(error.meta).to.contains({ nationalStudentId: nationalStudentIdFromFile });
     });
     context('when student is born in France', function () {
       it('should abort parsing and reject with missing birth city code ', async function () {

--- a/api/tests/integration/domain/services/organization-learners-xml-service_test.js
+++ b/api/tests/integration/domain/services/organization-learners-xml-service_test.js
@@ -1,6 +1,6 @@
 import * as url from 'url';
 import { expect, catchErr } from '../../../test-helper.js';
-import { SiecleXmlImportError } from '../../../../lib/domain/errors.js';
+import { SiecleXmlImportError, SIECLE_ERRORS } from '../../../../lib/domain/errors.js';
 import * as organizationLearnersXmlService from '../../../../lib/domain/services/organization-learners-xml-service.js';
 
 const fixturesDirPath = `${url.fileURLToPath(new URL('../../../', import.meta.url))}tooling/fixtures/`;
@@ -176,6 +176,7 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
       it('should abort parsing and reject with missing birth city code ', async function () {
         // given
         const validUAIFromSIECLE = '123ABC';
+        const nationalStudentIdFromFile = '1234';
         const organization = { externalId: validUAIFromSIECLE };
         const path = `${fixturesDirPath}/siecle-file/siecle-french-student-with-no-birth-city-code.xml`;
         // when
@@ -186,6 +187,8 @@ describe('Integration | Services | organization-learnerz-xml-service', function 
 
         //then
         expect(error).to.be.instanceof(SiecleXmlImportError);
+        expect(error.code).to.be.equal(SIECLE_ERRORS.BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT);
+        expect(error.meta).to.contains({ nationalStudentId: nationalStudentIdFromFile });
       });
     });
   });

--- a/orga/tests/unit/services/error-messages_test.js
+++ b/orga/tests/unit/services/error-messages_test.js
@@ -37,10 +37,11 @@ module('Unit | Service | Error messages', function (hooks) {
     test('should return the message when error code is found', function (assert) {
       // Given
       const errorMessages = this.owner.lookup('service:errorMessages');
+      const nationalStudentId = '1234';
       // When
-      const message = errorMessages.getErrorMessage('SEX_CODE_REQUIRED');
+      const message = errorMessages.getErrorMessage('SEX_CODE_REQUIRED', { nationalStudentId });
       // Then
-      assert.strictEqual(message, t('api-error-messages.student-xml-import.sex-code-required'));
+      assert.strictEqual(message, t('api-error-messages.student-xml-import.sex-code-required', { nationalStudentId }));
     });
   });
 
@@ -48,12 +49,13 @@ module('Unit | Service | Error messages', function (hooks) {
     test('should return the message when error code is found', function (assert) {
       // Given
       const errorMessages = this.owner.lookup('service:errorMessages');
+      const nationalStudentId = '1234';
       // When
-      const message = errorMessages.getErrorMessage('BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT');
+      const message = errorMessages.getErrorMessage('BIRTH_CITY_CODE_REQUIRED_FOR_FR_STUDENT', { nationalStudentId });
       // Then
       assert.strictEqual(
         message,
-        t('api-error-messages.student-xml-import.birth-city-code-required-for-french-student'),
+        t('api-error-messages.student-xml-import.birth-city-code-required-for-french-student', { nationalStudentId }),
       );
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -40,7 +40,7 @@
       "user-does-not-belong-to-organization-error": "You no longer have the rights for this organisation."
     },
     "student-xml-import": {
-      "birth-city-code-required-for-french-student": "The field birth city code is mandatory for each student born in France.",
+      "birth-city-code-required-for-french-student": "Student with {nationalStudentId} INE has no birth city code filled out. This field is mandatory for each student born in France.",
       "empty": "Each student must have an INE and a class.",
       "encoding-not-supported": "File encoding not supported.",
       "ine-required": "INE is mandatory for each student.",
@@ -48,7 +48,7 @@
       "invalid-file": "File does not match the requirements.",
       "invalid-file-extension": "File with extension {fileExtension} not supported.",
       "payload-too-large": "The file must be less than {maxSize}MB.",
-      "sex-code-required": "The field sex is mandatory for each student.",
+      "sex-code-required": "Student with {nationalStudentId} INE has no sex code filled out. This field is mandatory for each student.",
       "uai-mismatched": "The UAI of your SIECLE file does not match your school."
     }
   },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -40,7 +40,7 @@
       "user-does-not-belong-to-organization-error": "Vous n'avez plus les droits pour cette organisation."
     },
     "student-xml-import": {
-      "birth-city-code-required-for-french-student": "Le champ code commune de naissance est obligatoire pour chaque élève née en France.",
+      "birth-city-code-required-for-french-student": "L'élève ayant pour INE {nationalStudentId} n'a pas de champ code commune de naissance renseigné. Il est obligatoire pour chaque élève né en France.",
       "empty": "Les élèves doivent posséder un INE ainsi qu'une classe.",
       "encoding-not-supported": "Encodage du fichier non supporté.",
       "ine-required": "Le champ INE est obligatoire pour chaque élève.",
@@ -48,7 +48,7 @@
       "invalid-file": "Le fichier n’est pas conforme.",
       "invalid-file-extension": "Extension {fileExtension} non supportée.",
       "payload-too-large": "La taille du fichier doit être inférieure à {maxSize}Mo.",
-      "sex-code-required": "Le champ sexe est obligatoire pour chaque élève.",
+      "sex-code-required": "L’élève ayant pour INE {nationalStudentId} n’a pas le champ sexe renseigné. Il est obligatoire pour chaque élève.",
       "uai-mismatched": "L’UAI du fichier SIECLE ne correspond pas à celui de votre établissement."
     }
   },


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un import SIECLE il y a des messages d'erreurs qui sont envoyés si une ligne ne remplit pas les conditions de validité. Cependant il est difficile d'identifier la ligne responsable de l'erreur. Pour l'erreur des doublons on précise l'INE pour aider l'utilisateur a effectué une correction ce qui n'est pas le cas pour les autres erreurs.

## :robot: Proposition
On a ajoute l'INE dans les messages d'erreurs lié au sexe ou à la commune de naissance.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Ces cas de figure sont bien couverts par des tests