### PR TITLE
[FEATURE] Afficher la nouvelle colonne "rôle" sur le tableau listant les membres d'un centre de certification (PIX-4995)

### DIFF
--- a/admin/app/components/certification-centers/memberships-section.hbs
+++ b/admin/app/components/certification-centers/memberships-section.hbs
@@ -13,6 +13,7 @@
             <th class="table__column table__column--wide">Prénom</th>
             <th class="table__column table__column--wide">Nom</th>
             <th class="table__column table__column--wide">Adresse e-mail</th>
+            <th class="table__column table__column--wide">Rôle</th>
             <th class="table__column table__column--wide">Date de rattachement</th>
             <th class="table__column table__column--wide">Actions</th>
           </tr>
@@ -36,6 +37,7 @@
                 <td class="member-information">{{certificationCenterMembership.user.firstName}}</td>
                 <td class="member-information">{{certificationCenterMembership.user.lastName}}</td>
                 <td class="member-information">{{certificationCenterMembership.user.email}}</td>
+                <td class="member-information">{{t certificationCenterMembership.roleLabelKey}}</td>
                 <td>
                   {{dayjs-format certificationCenterMembership.createdAt "DD-MM-YYYY - HH:mm:ss"}}
                 </td>

--- a/admin/app/components/certification-centers/memberships-section.hbs
+++ b/admin/app/components/certification-centers/memberships-section.hbs
@@ -9,7 +9,6 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--id">ID Membre</th>
             <th class="table__column table__column--id">ID Utilisateur</th>
             <th class="table__column table__column--wide">Prénom</th>
             <th class="table__column table__column--wide">Nom</th>
@@ -29,7 +28,6 @@
                   {{certificationCenterMembership.user.lastName}}
                 "
               >
-                <td>{{certificationCenterMembership.id}}</td>
                 <td>
                   <LinkTo @route="authenticated.users.get" @model={{certificationCenterMembership.user.id}}>
                     {{certificationCenterMembership.user.id}}

--- a/admin/app/models/certification-center-membership.js
+++ b/admin/app/models/certification-center-membership.js
@@ -1,8 +1,17 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+const ROLE_LABEL_KEYS = {
+  ADMIN: 'components.memberships-section.roles.admin',
+  MEMBER: 'components.memberships-section.roles.member',
+};
+
 export default class CertificationCenterMembership extends Model {
   @attr('date') createdAt;
-
+  @attr() role;
   @belongsTo('certification-center') certificationCenter;
   @belongsTo('user') user;
+
+  get roleLabelKey() {
+    return ROLE_LABEL_KEYS[this.role];
+  }
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -224,6 +224,7 @@ function routes() {
     return schema.certificationCenterMemberships.create({
       certificationCenter,
       createdAt: new Date(),
+      role: 'MEMBER',
       user,
     });
   });

--- a/admin/tests/acceptance/authenticated/certification-centers/get/team_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get/team_test.js
@@ -4,10 +4,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import setupIntl from '../../../../helpers/setup-intl';
 
 module('Acceptance | authenticated/certification-centers/get/team', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   test('should display Certification center memberships', async function (assert) {
     // given
@@ -20,11 +22,13 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
     const user1 = server.create('user', { firstName: 'Eric', lastName: 'Hochet' });
     server.create('certification-center-membership', {
       certificationCenter,
+      role: 'MEMBER',
       user: user1,
     });
     const user2 = server.create('user', { firstName: 'Gilles', lastName: 'Parbal' });
     server.create('certification-center-membership', {
       certificationCenter,
+      role: 'MEMBER',
       user: user2,
     });
 
@@ -39,7 +43,7 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
     assert.dom(screen.getByRole('link', { name: user2.id })).exists();
   });
 
-  test('should be possible to desactive a certification center membership', async function (assert) {
+  test('should be possible to deactivate a certification center membership', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const user = server.create('user', { firstName: 'Lili' });
@@ -52,6 +56,7 @@ module('Acceptance | authenticated/certification-centers/get/team', function (ho
       createdAt: new Date('2018-02-15T05:06:07Z'),
       certificationCenter,
       user,
+      role: 'MEMBER',
     });
 
     // when

--- a/admin/tests/integration/components/certification-centers/memberships-section_test.js
+++ b/admin/tests/integration/components/certification-centers/memberships-section_test.js
@@ -1,25 +1,31 @@
 import dayjs from 'dayjs';
 import { render } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import EmberObject from '@ember/object';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certification-centers/memberships-section', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
 
   test('it should display certification center membership details', async function (assert) {
     // given
-    const user = EmberObject.create({
+    const user = store.createRecord('user', {
       id: 123,
       firstName: 'Jojo',
       lastName: 'La Gringue',
       email: 'jojo@example.net',
     });
-    const certificationCenterMembership = EmberObject.create({
+    const certificationCenterMembership = store.createRecord('certification-center-membership', {
       id: 1,
       user,
+      role: 'MEMBER',
       createdAt: new Date('2018-02-15T05:06:07Z'),
     });
     this.set('certificationCenterMemberships', [certificationCenterMembership]);
@@ -43,22 +49,33 @@ module('Integration | Component | certification-centers/memberships-section', fu
     assert
       .dom(screen.getByLabelText('Informations du membre Jojo La Gringue'))
       .containsText(certificationCenterMembership.id);
+    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText('Membre');
   });
 
   test('it should display a list of certification center memberships', async function (assert) {
     // given
-    const user1 = EmberObject.create({
+    const user1 = store.createRecord('user', {
       firstName: 'Jojo',
       lastName: 'La Gringue',
       email: 'jojo@example.net',
     });
-    const user2 = EmberObject.create({
+    const user2 = store.createRecord('user', {
       firstName: 'Froufrou',
       lastName: 'Le froussard',
       email: 'froufrou@example.net',
     });
-    const certificationCenterMembership1 = EmberObject.create({ id: 1, user: user1 });
-    const certificationCenterMembership2 = EmberObject.create({ id: 2, user: user2 });
+    const certificationCenterMembership1 = store.createRecord('certification-center-membership', {
+      id: 1,
+      user: user1,
+      role: 'ADMIN',
+      createdAt: new Date('2018-02-15T05:06:07Z'),
+    });
+    const certificationCenterMembership2 = store.createRecord('certification-center-membership', {
+      id: 2,
+      user: user2,
+      role: 'MEMBER',
+      createdAt: new Date('2018-02-15T05:06:07Z'),
+    });
     const certificationCenterMemberships = [certificationCenterMembership1, certificationCenterMembership2];
     this.set('certificationCenterMemberships', certificationCenterMemberships);
     this.set('disableCertificationCenterMembership', sinon.stub());

--- a/admin/tests/integration/components/certification-centers/memberships-section_test.js
+++ b/admin/tests/integration/components/certification-centers/memberships-section_test.js
@@ -36,7 +36,6 @@ module('Integration | Component | certification-centers/memberships-section', fu
     );
 
     // then
-    assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.id);
     assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.email);
     assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.firstName);
     assert.dom(screen.getByLabelText('Informations du membre Jojo La Gringue')).containsText(user.lastName);

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -39,6 +39,12 @@
         }
       }
     },
+    "memberships-section": {
+      "roles": {
+        "admin": "Administrator",
+        "member": "Member"
+      }
+    },
     "organizations": {
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -47,6 +47,12 @@
         }
       }
     },
+    "memberships-section": {
+      "roles": {
+        "admin": "Administrateur",
+        "member": "Membre"
+      }
+    },
     "organizations": {
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"

--- a/api/db/seeds/data/common/tooling/certification-center-tooling.js
+++ b/api/db/seeds/data/common/tooling/certification-center-tooling.js
@@ -11,7 +11,7 @@ export { createCertificationCenter };
  * @param {string} externalId
  * @param {Date} createdAt
  * @param {Date} updatedAt
- * @param {Array<number>} memberIds
+ * @param {Array<{id: number, role: string}>} members
  * @param {boolean} isV3Pilot
  * @param {Array<number>} complementaryCertificationIds
  * @returns {Promise<{certificationCenterId: number}>}
@@ -24,9 +24,9 @@ async function createCertificationCenter({
   externalId,
   createdAt,
   updatedAt,
-  memberIds = [],
+  members = [],
   isV3Pilot = false,
-  complementaryCertificationIds,
+  complementaryCertificationIds = [],
 }) {
   _buildCertificationCenter({
     databaseBuilder,
@@ -42,7 +42,7 @@ async function createCertificationCenter({
   _buildCertificationCenterMemberships({
     databaseBuilder,
     certificationCenterId,
-    memberIds,
+    members,
   });
 
   _buildCertificationCenterHabilitations({
@@ -68,10 +68,11 @@ function _buildCertificationCenterHabilitations({
   );
 }
 
-function _buildCertificationCenterMemberships({ databaseBuilder, certificationCenterId, memberIds }) {
-  memberIds.forEach((memberId) =>
+function _buildCertificationCenterMemberships({ databaseBuilder, certificationCenterId, members }) {
+  members.forEach(({ id, role }) =>
     databaseBuilder.factory.buildCertificationCenterMembership({
-      userId: memberId,
+      userId: id,
+      role,
       certificationCenterId,
       createdAt: new Date(),
       isReferer: false,

--- a/api/db/seeds/data/team-acces/build-certification-centers.js
+++ b/api/db/seeds/data/team-acces/build-certification-centers.js
@@ -1,0 +1,16 @@
+import { createCertificationCenter } from '../common/tooling/certification-center-tooling.js';
+
+const CERTIFICATION_CENTER_OFFSET_ID = 8000;
+
+export async function buildCertificationCenters(databaseBuilder) {
+  const firstUser = databaseBuilder.factory.buildUser({ firstName: 'James', lastName: 'Palédroits' });
+  const secondUser = databaseBuilder.factory.buildUser({ firstName: 'Marc-Alex', lastName: 'Terrieur' });
+
+  await createCertificationCenter({
+    name: 'Accèssorium',
+    certificationCenterId: CERTIFICATION_CENTER_OFFSET_ID,
+    databaseBuilder,
+    members: [{ id: firstUser.id, role: 'ADMIN' }, { id: secondUser.id }],
+    externalId: 'TEAM_ACCES_123',
+  });
+}

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -6,6 +6,7 @@ import { buildUsers } from './build-users.js';
 import { buildOrganizationUsers } from './build-organization-users.js';
 import { buildArchivedOrganizations } from './build-archived-organizations.js';
 import { buildScoOrganizationLearners } from './build-sco-organization-learners.js';
+import { buildCertificationCenters } from './build-certification-centers.js';
 
 async function teamAccesDataBuilder(databaseBuilder) {
   buildPixAdminRoles(databaseBuilder);
@@ -16,6 +17,7 @@ async function teamAccesDataBuilder(databaseBuilder) {
   buildScoOrganizations(databaseBuilder);
   buildArchivedOrganizations(databaseBuilder);
   buildScoOrganizationLearners(databaseBuilder);
+  await buildCertificationCenters(databaseBuilder);
 }
 
 export { teamAccesDataBuilder };

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -87,7 +87,7 @@ async function _createScoCertificationCenter({ databaseBuilder }) {
     externalId: CERTIFICATION_SCO_MANAGING_STUDENTS_EXTERNAL_ID,
     createdAt: new Date(),
     updatedAt: new Date(),
-    memberIds: [SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID],
+    members: [{ id: SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID }],
     complementaryCertificationIds: [],
   });
 }
@@ -118,7 +118,7 @@ async function _createV3PilotCertificationCenter({ databaseBuilder }) {
     externalId: null,
     createdAt: new Date(),
     updatedAt: new Date(),
-    memberIds: [V3_CERTIFICATION_CENTER_USER_ID],
+    members: [{ id: V3_CERTIFICATION_CENTER_USER_ID }],
     isV3Pilot: true,
     complementaryCertificationIds: [],
   });
@@ -150,7 +150,7 @@ async function _createProCertificationCenter({ databaseBuilder }) {
     externalId: PRO_EXTERNAL_ID,
     createdAt: new Date(),
     updatedAt: new Date(),
-    memberIds: [PRO_CERTIFICATION_CENTER_USER_ID],
+    members: [{ id: PRO_CERTIFICATION_CENTER_USER_ID }],
     complementaryCertificationIds,
   });
 }

--- a/api/lib/domain/models/CertificationCenterMembership.js
+++ b/api/lib/domain/models/CertificationCenterMembership.js
@@ -1,11 +1,12 @@
 class CertificationCenterMembership {
-  constructor({ id, certificationCenter, user, createdAt, disabledAt, isReferer } = {}) {
+  constructor({ id, certificationCenter, user, createdAt, disabledAt, isReferer, role } = {}) {
     this.id = id;
     this.certificationCenter = certificationCenter;
     this.user = user;
     this.createdAt = createdAt;
     this.disabledAt = disabledAt;
     this.isReferer = isReferer;
+    this.role = role;
   }
 }
 

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -40,6 +40,7 @@ function _toDomain(certificationCenterMembershipDTO) {
     user,
     createdAt: certificationCenterMembershipDTO.createdAt,
     updatedAt: certificationCenterMembershipDTO.updatedAt,
+    role: certificationCenterMembershipDTO.role,
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -8,7 +8,7 @@ const serialize = function (certificationCenterMemberships) {
       record.certificationCenter.sessions = [];
       return record;
     },
-    attributes: ['createdAt', 'certificationCenter', 'user'],
+    attributes: ['createdAt', 'certificationCenter', 'user', 'role'],
     certificationCenter: {
       ref: 'id',
       included: true,

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -507,11 +507,13 @@ describe('Acceptance | API | Certification Center', function () {
         expect(response.result.data[0].attributes['created-at']).to.deep.equal(
           certificationCenterMembership1.createdAt,
         );
+        expect(response.result.data[0].attributes['role']).to.deep.equal(certificationCenterMembership1.role);
 
         expect(response.result.data[1].id).to.equal(certificationCenterMembership2.id.toString());
         expect(response.result.data[1].attributes['created-at']).to.deep.equal(
           certificationCenterMembership2.createdAt,
         );
+        expect(response.result.data[1].attributes['role']).to.deep.equal(certificationCenterMembership2.role);
 
         const expectedIncluded = [
           {

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -114,7 +114,7 @@ describe('Integration | Repository | Certification Center Membership', function 
 
       const certificationCenterMembership = certificationCenterMemberships[0];
       expect(certificationCenterMembership).to.be.an.instanceof(CertificationCenterMembership);
-      expect(certificationCenterMembership.id).to.equal(expectedCertificationCenterMembership.id);
+      expect(certificationCenterMembership.id).to.deep.equal(expectedCertificationCenterMembership.id);
 
       const associatedCertificationCenter = certificationCenterMembership.certificationCenter;
       expect(associatedCertificationCenter).to.be.an.instanceof(CertificationCenter);

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
@@ -18,6 +18,7 @@ const buildCertificationCenterMembership = function ({
   createdAt = new Date('2020-01-01'),
   disabledAt,
   isReferer = false,
+  role = 'MEMBER',
 } = {}) {
   return new CertificationCenterMembership({
     id,
@@ -26,6 +27,7 @@ const buildCertificationCenterMembership = function ({
     createdAt,
     disabledAt,
     isReferer,
+    role,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
             type: 'certificationCenterMemberships',
             attributes: {
               'created-at': certificationCenterMembership.createdAt,
+              role: certificationCenterMembership.role,
             },
             relationships: {
               'certification-center': {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, sur Pix Admin, nous ne pouvons pas connaître le rôle d'un membre d'un centre de certification.

## :robot: Proposition

Afficher le rôle des membres d'un centre de certification.

## :rainbow: Remarques

Nous avons modifié le tooling `api/db/seeds/data/common/tooling/certification-center-tooling.js` pour la création d'un centre de certification pour permettre l'ajout d'un membre avec un rôle.

**Quickwin** : Supprimer la colonne ID Membre qui n'est pas utile car c'est une information technique.

## :100: Pour tester

- Se connecter à [PixAdmin](https://admin-pr7008.review.pix.fr/) avec le compte superadmin@example.net
- Ouvrir la liste des centres de certifications
- Ouvrir la page de détails du centre de certification `Accèssorium`
- Vérifier l'affichage de 2 utilisateurs dans la liste des membres
  - **James** avec le rôle **Administrateur**
  - **Marc-Alex** avec le rôle **Membre**
- Vérifier que la colonne ID Membre n'existe plus dans la liste des membres du centre de certification
