### PR TITLE
[BUGFIX] Le niveau des sujets disponible pouvaient être incorrect lorsqu'on créé un nouveau profil cible (PIX-9043)

### DIFF
--- a/admin/app/components/common/tubes-selection/tube.js
+++ b/admin/app/components/common/tubes-selection/tube.js
@@ -11,7 +11,7 @@ export default class Tube extends Component {
   }
 
   get _maxLevel() {
-    return this.args.tube.level ?? 8;
+    return this.args.tube.level;
   }
 
   get state() {

--- a/admin/mirage/helpers/create-learning-content.js
+++ b/admin/mirage/helpers/create-learning-content.js
@@ -66,6 +66,7 @@ function _createTube(variableName, mobile, tablet, thematic, server) {
     practicalDescription: `${variableName} practicalDescription`,
     mobile,
     tablet,
+    level: 8,
     skills: [],
     competenceId: null,
   });

--- a/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
@@ -20,7 +20,7 @@ const serialize = function (framework, { withoutThematics = false } = {}) {
         tubes: {
           include: true,
           ref: 'id',
-          attributes: ['name', 'practicalTitle', 'practicalDescription', 'mobile', 'tablet'],
+          attributes: ['name', 'practicalTitle', 'practicalDescription', 'mobile', 'tablet', 'level'],
         },
       },
     },
@@ -41,7 +41,7 @@ const serialize = function (framework, { withoutThematics = false } = {}) {
                 .filter(({ id }) => {
                   return thematic.tubeIds.includes(id);
                 })
-                .map((tube) => ({ ...tube, mobile: tube.isMobileCompliant, tablet: tube.isTabletCompliant })),
+                .map((tube) => ({ ...tube, mobile: tube.isMobileCompliant, tablet: tube.isTabletCompliant, level: 8 })),
             };
           })
           .filter((thematic) => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
@@ -57,6 +57,7 @@ describe('Unit | Serializer | JSONAPI | pix-framework-serializer', function () {
               'practical-description': 'description pratique',
               mobile: true,
               tablet: false,
+              level: 8,
             },
           },
           {


### PR DESCRIPTION
## :unicorn: Problème
Bug :
https://github.com/1024pix/pix/assets/48727874/eb9c33c4-aa45-4f34-a76d-37d8993c37ac

## :robot: Proposition
Côté front, le ember-model tube est utilisé à deux fins :
- pour représenter un sujet du référentiel
- pour représenter un sujet cappé niveau d'un profil cible

Quand on créé un profil cible pour la première fois :
- La page de formulaire charge le référentiel, prenons comme référence le tube tubeABC123
- Le tube, à ce stade, a un attribut level à undefined. Donc, le formulaire comprend qu'il doit plafonner le niveau à 8
- Cochons le tube, et fixons son level à 3
- On enregistre le PC, on est redirigé sur la page de détails du PC. Côté ember-data, tubeABC123 est donc rechargé via le profil cible, et cette fois-ci avec un level défini, en l'occurrence 3
- On retourne sur la page de création car on souhaite créer un deuxième PC. Tout le référentiel est rechargé de force, MAIS comme la valeur level est undefined depuis l'API, la valeur 3 résiduelle reste dans le modèle.
- De fait, quand on veut cocher et changer le niveau du tube, on est limité au niveau 3.

SOLUTION :
- Standardiser la sérialisation de tube côté API. Y'a pas de raison qu'on attende un level et que parfois il soit undefined. Du coup, quand il s'agit d'un tube du réf, on met level = 8
- Ainsi, on dégage le fait que le front sait que si y'a pas de level, il faut mettre 8

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de reproduire le bug.
Vidéo résolution : 

https://github.com/1024pix/pix/assets/48727874/79f62415-9fc1-46f4-b8f9-879df03763ef

