### PR TITLE
[FEATURE] Ajouter la date de certificabilité même si l'apprenant n'est pas certifiable (PIX-9119)

### DIFF
--- a/api/lib/domain/models/OrganizationLearner.js
+++ b/api/lib/domain/models/OrganizationLearner.js
@@ -52,12 +52,7 @@ class OrganizationLearner {
   }
 
   updateCertificability(placementProfile) {
-    if (placementProfile.isCertifiable()) {
-      this.certifiableAt = placementProfile.profileDate;
-    } else {
-      this.certifiableAt = null;
-    }
-
+    this.certifiableAt = placementProfile.profileDate;
     this.isCertifiable = placementProfile.isCertifiable();
   }
 }

--- a/api/tests/unit/domain/models/OrganizationLearner_test.js
+++ b/api/tests/unit/domain/models/OrganizationLearner_test.js
@@ -5,7 +5,7 @@ import range from 'lodash/range.js';
 
 describe('Unit | Domain | Models | OrganizationLearner', function () {
   describe('#updateCertificability', function () {
-    it('should update certificability', function () {
+    it('should update certificability if certifiable', function () {
       // given
       const certifiableDate = new Date('2023-01-01');
       const organizationLearner = new OrganizationLearner({ isCertifiable: false });
@@ -26,7 +26,7 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
       expect(new Date(organizationLearner.certifiableAt)).to.deep.equal(placementProfile.profileDate);
     });
 
-    it('should not update certifiableAt if not certifiable', function () {
+    it('should update certifiableAt if not certifiable', function () {
       // given
       const profileDate = new Date('2023-01-01');
       const organizationLearner = new OrganizationLearner({ isCertifiable: false });
@@ -41,7 +41,7 @@ describe('Unit | Domain | Models | OrganizationLearner', function () {
 
       //then
       expect(organizationLearner.isCertifiable).to.be.false;
-      expect(organizationLearner.certifiableAt).to.be.null;
+      expect(new Date(organizationLearner.certifiableAt)).to.deep.equal(placementProfile.profileDate);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Nous n’avons pensé que, dans le cas d’un certificabilité fausse venant du learner et d’une certificabilité vrai provenant de la campagne, on ne peux pas savoir laquelle est la plus récente puisqu'à partir du moment où le learner n’est pas certifiable, on ne stock pas la date du dernier calcul.

## :robot: Proposition
Toujours enregistrer le `certifiableAt` que le `isCertifiable` soit `true` ou `false`

## :rainbow: Remarques
RAS

## :100: Pour tester
lancer le cron et vérifier que le `certifiableAt` est bien renseigné pour un apprenant sco managing student non certifiable