### PR TITLE
[BUGFIX] Ajoute la synchronisation manquante pour users.lastLoggedAt (PIX-9121)

### DIFF
--- a/api/scripts/team-acces/sync-user-logins-last-logged-at-missing-part.js
+++ b/api/scripts/team-acces/sync-user-logins-last-logged-at-missing-part.js
@@ -1,0 +1,40 @@
+import { fileURLToPath } from 'node:url';
+
+import { knex, disconnect } from '../../db/knex-database-connection.js';
+
+const modulePath = fileURLToPath(import.meta.url);
+const IS_LAUNCHED_FROM_CLI = process.argv[1] === modulePath;
+
+const TIMER_NAME = 'user-logins-last-logged-at-missing-part-syncing';
+
+async function main() {
+  console.time(TIMER_NAME);
+  console.log('Starting user-logins-last-logged-at syncing for non-existent user-logins …');
+
+  await syncUserLoginsLastLoggedAt();
+
+  console.timeEnd(TIMER_NAME);
+}
+
+async function syncUserLoginsLastLoggedAt() {
+  await knex.raw(`
+  INSERT INTO "user-logins"
+  ("userId", "lastLoggedAt")
+  SELECT "id", "lastLoggedAt"
+  FROM "users"
+  WHERE "lastLoggedAt" IS NOT NULL
+  ON CONFLICT ("userId") DO NOTHING
+  ;
+  `);
+}
+
+if (IS_LAUNCHED_FROM_CLI) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème

Les users qui ont bien un `users.lastLoggedAt` mais qui n'ont pas d'enregistrement dans user-logins n'ont pas de `lastLoggedAt` dans `user-logins`. C'est un manque dans la PR #6958.

## :robot: Proposition

Exécuter un script SQL en production pour créer les enregistrements manquants.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

1. Préparer certains users facilement identifiables en leur un `lastLoggedAt` non-null

```sql
pix=# update "users" set "lastLoggedAt"='1980-12-01' where "email" in ('temporary-blocked@example.net', 'blocked@example.net', 'gaal.dornick@foundation.verse', 'salvor.hardin@foundation.verse', 'allorga@example.net');
```

2. Constater qu'il y a seulement 3 enregistrements dans `user-logins` :
```sql
pix=# select * from "user-logins";
   id   | userId |         createdAt          |         updatedAt          | blockedAt | temporaryBlockedUntil | failureCount |      lastLoggedAt      
--------+--------+----------------------------+----------------------------+-----------+-----------------------+--------------+------------------------
 101603 | 101601 | 2023-09-07 11:42:15.327+00 | 2023-09-07 11:42:15.327+00 |           |                       |            0 | 1970-01-01 00:00:00+00
 101612 | 101610 | 2023-09-07 11:42:15.377+00 | 2023-09-07 11:42:15.377+00 |           |                       |           49 | 
 101615 | 101613 | 2023-09-07 11:42:15.426+00 | 2023-09-07 11:42:15.426+00 |           |                       |            9 | 
```

3. Exécuter le script : 

```shell
node api/scripts/team-acces/sync-user-logins-last-logged-at-missing-part.js
```

4. Constater qu'il y a maintenant 5 enregistrements dans `user-logins` et que les 2 enregistrements ajoutés proviennent de la table `users` et qui n'existaient pas déjà dans `user-logins` :

```sql
   id   | userId |           createdAt           |           updatedAt           | blockedAt | temporaryBlockedUntil | failureCount |      lastLoggedAt      
--------+--------+-------------------------------+-------------------------------+-----------+-----------------------+--------------+------------------------
 101603 | 101601 | 2023-09-07 11:42:15.327+00    | 2023-09-07 11:42:15.327+00    |           |                       |            0 | 1970-01-01 00:00:00+00
 101612 | 101610 | 2023-09-07 11:42:15.377+00    | 2023-09-07 11:42:15.377+00    |           |                       |           49 | 
 101615 | 101613 | 2023-09-07 11:42:15.426+00    | 2023-09-07 11:42:15.426+00    |           |                       |            9 | 
 101616 | 101599 | 2023-09-07 11:42:39.675414+00 | 2023-09-07 11:42:39.675414+00 |           |                       |            0 | 1980-12-01 00:00:00+00
 101620 |  10001 | 2023-09-07 11:42:39.675414+00 | 2023-09-07 11:42:39.675414+00 |           |                       |            0 | 1980-12-01 00:00:00+00

```