### PR TITLE
[FEATURE] Ajoute une option pour calculer la certificabilité de tous les prescrits du SCO (PIX-9062).

### DIFF
--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -386,7 +386,7 @@ async function countByOrganizationsWhichNeedToComputeCertificability({ skipLogge
 }
 
 function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset, skipLoggedLastDayCheck = false } = {}) {
-  const queryBuilder = knex('view-active-organization-learners')
+  return knex('view-active-organization-learners')
     .join(
       'organization-features',
       'view-active-organization-learners.organizationId',
@@ -407,17 +407,14 @@ function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset, s
           );
         });
       }
-    });
-
-  if (limit) {
-    queryBuilder.limit(limit);
-  }
-
-  if (offset) {
-    queryBuilder.offset(offset);
-  }
-
-  return queryBuilder.pluck('view-active-organization-learners.id');
+      if (limit) {
+        queryBuilder.limit(limit);
+      }
+      if (offset) {
+        queryBuilder.offset(offset);
+      }
+    })
+    .pluck('view-active-organization-learners.id');
 }
 
 export {

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2227,6 +2227,34 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       expect(result).to.deep.equal([organizationLearnerRecentlyConnecterId]);
     });
 
+    it('should return all organization learners if "skippLoggedLastDayCheck" option is passed', async function () {
+      // given
+      const userRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserLogin({ userId: userRecentlyConnectedId, lastLoggedAt: new Date('2023-07-01') });
+      const userNotRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUser({
+        userId: userNotRecentlyConnectedId,
+      });
+
+      const { id: organizationLearnerRecentlyConnecterId, organizationId } =
+        databaseBuilder.factory.buildOrganizationLearner({ userId: userRecentlyConnectedId });
+      const { id: organizationLearnerNotRecentlyConnectedId } = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userNotRecentlyConnectedId,
+        organizationId,
+      });
+
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+        skipLoggedLastDayCheck: true,
+      });
+
+      // then
+      expect(result).to.deep.equal([organizationLearnerRecentlyConnecterId, organizationLearnerNotRecentlyConnectedId]);
+    });
+
     it('should not return a disabled organization learner id for organizations that cannot compute certificability', async function () {
       // given
       const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ isDisabled: true });

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2154,6 +2154,30 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       // then
       expect(result).to.equal(1);
     });
+
+    it('should return count of all organization learners if "skipLoggedLastDayCheck" option is passed', async function () {
+      // given
+      const userRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserLogin({ userId: userRecentlyConnectedId, lastLoggedAt: new Date() });
+      const userNotRecentlyConnectedId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUser({
+        userId: userNotRecentlyConnectedId,
+      });
+
+      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ userId: userRecentlyConnectedId });
+      databaseBuilder.factory.buildOrganizationLearner({ userId: userNotRecentlyConnectedId, organizationId });
+
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+        skipLoggedLastDayCheck: true,
+      });
+
+      // then
+      expect(result).to.equal(2);
+    });
   });
 
   describe('#findByOrganizationsWhichNeedToComputeCertificability', function () {

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -62,15 +62,6 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           on_complete: true,
         },
       ]);
-      expect(pgBossRepository.insert.getCall(1).args[0]).to.be.deep.equal([
-        {
-          name: 'ComputeCertificabilityJob',
-          data: { organizationLearnerId: 3 },
-          retrylimit: 0,
-          retrydelay: 30,
-          on_complete: true,
-        },
-      ]);
     });
   });
 });

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -5,6 +5,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
   context('#handle', function () {
     it('should schedule multiple ComputeCertificabilityJob', async function () {
       // given
+      const skipLoggedLastDayCheck = false;
       const pgBossRepository = {
         insert: sinon.stub(),
       };
@@ -19,12 +20,14 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           },
         },
       };
-      organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability.resolves(3);
+      organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
+        .withArgs({ skipLoggedLastDayCheck })
+        .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 0 })
+        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 2 })
+        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
         new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
@@ -34,7 +37,71 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         });
 
       // when
-      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle();
+      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle(null);
+
+      // then
+      expect(pgBossRepository.insert.getCall(0).args[0]).to.be.deep.equal([
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 1 },
+          retrylimit: 0,
+          retrydelay: 30,
+          on_complete: true,
+        },
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 2 },
+          retrylimit: 0,
+          retrydelay: 30,
+          on_complete: true,
+        },
+      ]);
+      expect(pgBossRepository.insert.getCall(1).args[0]).to.be.deep.equal([
+        {
+          name: 'ComputeCertificabilityJob',
+          data: { organizationLearnerId: 3 },
+          retrylimit: 0,
+          retrydelay: 30,
+          on_complete: true,
+        },
+      ]);
+    });
+
+    it('should schedule ComputeCertificabilityJob for all learners', async function () {
+      // given
+      const skipLoggedLastDayCheck = true;
+      const pgBossRepository = {
+        insert: sinon.stub(),
+      };
+      const organizationLearnerRepository = {
+        findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
+        countByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
+      };
+      const config = {
+        features: {
+          scheduleComputeOrganizationLearnersCertificability: {
+            chunkSize: 2,
+          },
+        },
+      };
+      organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
+        .withArgs({ skipLoggedLastDayCheck })
+        .resolves(3);
+      organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
+        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck })
+        .resolves([1, 2]);
+      organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
+        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck })
+        .resolves([3]);
+      const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
+        new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
+          pgBossRepository,
+          organizationLearnerRepository,
+          config,
+        });
+
+      // when
+      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({ skipLoggedLastDayCheck });
 
       // then
       expect(pgBossRepository.insert.getCall(0).args[0]).to.be.deep.equal([


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix sur la remontée automatique de la certificabilité (RAC) pour les prescrits du SCO qui gèrent des élèves, on a ajouté une tâche CRON qui, tous les soirs à 21h, calcule la certificabilité des élèves s'étant connectés ces dernières 24 heures. Cependant pour le lancement de cette fonctionnalité on a besoin de calculer une première fois pour tous les élèves sans quoi il y aura des données anciennes affichées dans PixOrga.

## :robot: Proposition
On ajoute une option `skipLoggedLastDayCheck` qui permet de lancer le job `ScheduleComputeOrganizationLearnersCertificability` en ignorant la condition qui limite le calcul de la certificabilité aux prescrits connectés la veille. Cette option n'est pas prise en compte dans le code de l'API elle est utilisable uniquement si on insert le job à la main en DB.

## :rainbow: Remarques
Cette option permet aussi de tester plus facilement la RAC en local, recette et integration.
## :100: Pour tester
- Insérer le job ScheduleComputeOrganizationLearnersJob avec l'option et constater que ça calcule bien la certificabilité pour tous les prescrits du SCO avec import.
```sql
INSERT INTO "pgboss"."job" (name, retrylimit, retrydelay, on_complete, data) VALUES('ScheduleComputeOrganizationLearnersCertificabilityJob', 0, 30, true, '{"skipLoggedLastDayCheck":"true"}');
```
- _optionnel_ : Vérifier que si on insert le job sans l'option, c'est bien uniquement les learners récemment connectés qui sont pris en compte. C'est le fonctionnement par défaut
