### PR TITLE
[FEATURE] Mettre à jour la route de récupération de stages dans orga (PIX-8914) 

### DIFF
--- a/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
+++ b/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
@@ -1,46 +1,62 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable import/no-restricted-paths */
-import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
+import * as defaultStageRepository from '../../infrastructure/repositories/stage-repository.js';
+import * as defaultStageAcquisitionRepository from '../../infrastructure/repositories/stage-acquisition-repository.js';
 import { UserNotAuthorizedToAccessEntityError, NoStagesForCampaign } from '../errors.js';
+import * as defaultStageAndStageAcquisitionComparisonService from '../services/stages/stage-and-stage-acquisition-comparison-service.js';
 
 const getCampaignParticipationsCountByStage = async function ({
   userId,
   campaignId,
   campaignRepository,
-  campaignParticipationRepository,
+  stageRepository = defaultStageRepository,
+  stageAndStageAcquisitionComparisonService = defaultStageAndStageAcquisitionComparisonService,
+  stageAcquisitionRepository = defaultStageAcquisitionRepository,
 }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
   }
 
-  const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId });
+  const stages = await stageRepository.getByCampaignId(campaignId);
 
-  if (!stageCollection.hasStage) {
+  if (!stages.length) {
     throw new NoStagesForCampaign();
   }
 
-  const participantsResults = await campaignParticipationRepository.getAllParticipationsByCampaignId(campaignId);
+  const stageAcquisitions = await stageAcquisitionRepository.getByCampaignId(campaignId);
 
-  const participantsByStage = stageCollection.stages.map((stage, index) => ({
+  const uniqueCampaignParticipationIds = [
+    ...new Set(stageAcquisitions.map((stageAcquisition) => stageAcquisition.campaignParticipationId)),
+  ];
+
+  const stagesInfos = stages.map((stage, index) => ({
     id: stage.id,
     value: 0,
     reachedStage: index + 1,
-    totalStage: stageCollection.totalStages,
+    totalStage: stages.length,
     title: stage.prescriberTitle,
     description: stage.prescriberDescription,
   }));
 
-  participantsResults.forEach((participantResult) => {
-    const stageReached = stageCollection.getReachedStage(
-      participantResult.validatedSkillsCount,
-      participantResult.masteryRate * 100,
+  uniqueCampaignParticipationIds.forEach((campaignParticipationId) => {
+    const stageAcquisitionForCampaignParticipation = stageAcquisitions.filter(
+      (stageAcquisition) => stageAcquisition.campaignParticipationId === campaignParticipationId,
     );
 
-    const stageIndex = participantsByStage.findIndex((data) => data.id === stageReached.id);
-    participantsByStage[stageIndex].value++;
+    const stagesInformation = stageAndStageAcquisitionComparisonService.compare(
+      stages,
+      stageAcquisitionForCampaignParticipation,
+    );
+
+    const stageReached = stagesInformation.reachedStage;
+
+    if (!stageReached) return;
+
+    const stageIndex = stagesInfos.findIndex((data) => data.id === stageReached.id);
+    stagesInfos[stageIndex].value++;
   });
 
-  return participantsByStage;
+  return stagesInfos;
 };
 
 export { getCampaignParticipationsCountByStage };

--- a/api/lib/infrastructure/repositories/stage-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/stage-acquisition-repository.js
@@ -29,7 +29,6 @@ const toDomain = (stageAcquisitionData) =>
 
 /**
  * @param {Knex} knexConnection
- * @param {string[]} selectedFields
  *
  * @returns {*}
  */
@@ -91,6 +90,25 @@ const getByCampaignIdAndUserId = async (campaignId, userId, knexConnection = kne
   );
 
 /**
+ * @param {number} campaignId
+ * @param {Knex} knexConnection
+ *
+ * @returns {Promise<StageAcquisition[]>}
+ */
+const getByCampaignId = async (campaignId, knexConnection = knex) =>
+  toDomain(
+    await buildSelectAllQuery(knexConnection)
+      .join(
+        'campaign-participations',
+        'campaign-participations.id',
+        `${STAGE_ACQUISITIONS_TABLE_NAME}.${CAMPAIGN_PARTICIPATION_ID_COLUMN}`,
+      )
+      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .where('campaigns.id', campaignId)
+      .orderBy(`${STAGE_ACQUISITIONS_TABLE_NAME}.id`),
+  );
+
+/**
  * @param {Stage[]} stages
  * @param {number} userId
  * @param {number} campaignParticipationId
@@ -108,9 +126,10 @@ const saveStages = async (stages, userId, campaignParticipationId, knexConnectio
 };
 
 export {
-  getByCampaignParticipations,
+  getByCampaignId,
   getByCampaignIdAndUserId,
-  saveStages,
   getByCampaignParticipation,
+  getByCampaignParticipations,
   getStageIdsByCampaignParticipation,
+  saveStages,
 };

--- a/api/tests/integration/infrastructure/repositories/stage-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-acquisition-repository_test.js
@@ -1,5 +1,6 @@
 import { expect, databaseBuilder, knex } from '../../../test-helper.js';
 import {
+  getByCampaignId,
   getByCampaignIdAndUserId,
   getByCampaignParticipation,
   getByCampaignParticipations,
@@ -108,6 +109,8 @@ describe('Integration | Repository | Stage Acquisition', function () {
 
       // then
       expect(result.length).to.deep.equal(2);
+      expect(result[0].campaignParticipationId).to.equal(firstStage.campaignParticipationId);
+      expect(result[1].campaignParticipationId).to.equal(secondStage.campaignParticipationId);
     });
   });
 
@@ -150,6 +153,62 @@ describe('Integration | Repository | Stage Acquisition', function () {
     it('should return the expected stages', async function () {
       // when
       const result = await getByCampaignIdAndUserId(campaign.id, user.id);
+
+      // then
+      expect(result[0].stageId).to.deep.equal(stage.id);
+    });
+  });
+
+  describe('getByCampaignId', function () {
+    let stage;
+    let campaign;
+    let campaignParticipation, campaignParticipation2, campaignParticipation3;
+    let targetProfile;
+
+    beforeEach(async function () {
+      // given
+      targetProfile = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
+      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      stage = databaseBuilder.factory.buildStage({ campaignId: campaign.id });
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+      campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+      campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: campaignParticipation.id,
+        stageId: stage.id,
+      });
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: campaignParticipation2.id,
+        stageId: stage.id,
+      });
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: campaignParticipation3.id,
+        stageId: stage.id,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('stage-acquisitions').delete();
+    });
+
+    it('should return StageAcquisition instances', async function () {
+      // when
+      const stageAcquisitions = await getByCampaignId(campaign.id);
+
+      // then
+      expect(stageAcquisitions[0]).to.be.instanceof(StageAcquisition);
+      expect(stageAcquisitions.length).to.equal(3);
+      expect(stageAcquisitions[0].campaignParticipationId).to.equal(campaignParticipation.id);
+      expect(stageAcquisitions[1].campaignParticipationId).to.equal(campaignParticipation2.id);
+      expect(stageAcquisitions[2].campaignParticipationId).to.equal(campaignParticipation3.id);
+    });
+
+    it('should return the expected stages', async function () {
+      // when
+      const result = await getByCampaignId(campaign.id);
 
       // then
       expect(result[0].stageId).to.deep.equal(stage.id);


### PR DESCRIPTION
## :unicorn: Problème
Suite à une précédente PR, les acquisitions de paliers sont maintenant stockées en base, il faut maintenant modifier les routes qui retournent des paliers pour utiliser les acquisitions persistées en base et éviter de recalculer à chaque appel.
Cette PR modifie la route qui retourne les informations sur l'obtention des badges sur orga.

## :robot: Proposition
Mettre à jour le usecase pour aller chercher les information en base.

## :100: Pour tester
- Créer ou utiliser une campagne existante dans orga.
- Passer cette campagne avec un utilisateur.
- Sur orga, dans la page de la campagne, dans l'onglet "Résultats", s'assurer que les paliers apparaissent correctement.