### PR TITLE
[FEATURE] Afficher une bannière informant que la certificabilité remonte automatiquement pours les SCO isManagingStudent (PIX-8873)

### DIFF
--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -6,6 +6,9 @@
     @participantCount={{@model.meta.participantCount}}
     @isLoading={{this.isLoading}}
   />
+  <PixBanner @type="information">
+    {{t "pages.sco-organization-participants.banner"}}
+  </PixBanner>
   <ScoOrganizationParticipant::List
     @students={{@model}}
     @searchFilter={{this.search}}

--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -71,6 +71,14 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
         assert.strictEqual(currentURL(), '/eleves');
       });
 
+      test('it should display a banner fot automatic certificability calculation', async function (assert) {
+        // when
+        await visit('/eleves');
+
+        // then
+        assert.contains(this.intl.t('pages.sco-organization-participants.banner'));
+      });
+
       module('when admin uploads a file', function (hooks) {
         hooks.beforeEach(async function () {
           user = createUserManagingStudents('ADMIN');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -923,6 +923,7 @@
         "manage-account": "Manage the account",
         "show-actions": "Show actions"
       },
+      "banner": "Students' status is updated automatically to display eligibility for certification.",
       "connection-types": {
         "email": "Email address",
         "empty": "–",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -926,6 +926,7 @@
         "manage-account": "Gérer le compte",
         "show-actions": "Afficher les actions"
       },
+      "banner": "Le statut Certificabilité des élèves est actualisé automatiquement.",
       "connection-types": {
         "email": "Adresse e-mail",
         "empty": "–",


### PR DESCRIPTION
## :unicorn: Problème
Il est actuellement nécessaire de réaliser une campagne de collecte de profil pour connaître le statut “Certifiable” des prescrits.

Cela pose en particulier problème au SCO (isManagingStudent / ceux qui ont l’import uniquement) car les élèves ne répondent pas toujours aux campagnes. 

Cependant, ce problème ne sera plus rencontré après la mise en place de la nouvelle certification, la réponse à ce besoin est donc provisoire.

## :robot: Proposition
Mettre en place la remontée automatique et quotidienne du statut de certificabilité.

Dans ce ticket, nous souhaitons indiquer aux professeurs que l’information dans la colonne Certificabilité est automatiquement mise à jour. 

Pour cela, il faut ajouter dans la page Élèves un bandeau d’information. Celui-ci pourra contenir un lien vers une documentation fournie par le pôle SCO.

## :rainbow: Remarques
⚠️ MERGE DANS UNE FEATURE BRANCHE
## :100: Pour tester
- se connecter à PixOrga en tant que SCO isManagingStudent
- aller sur la page élèves
- observer la présence de la bannière
- 🎉 