### PR TITLE
[FEATURE] Mettre à jour la tooltip sur la remontée de la certificabilité pour les organisations SCO avec import (PIX-8874)

### DIFF
--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -676,11 +676,19 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @certificabilityFilter={{this.certificabilityFilter}}
 />`,
     );
+
+    await click(
+      screen.getByLabelText(
+        this.intl.t('pages.organization-participants.table.column.is-certifiable.tooltip.aria-label'),
+      ),
+    );
+
+    // then
     assert
       .dom(
-        screen.getByLabelText(
-          this.intl.t('pages.organization-participants.table.column.is-certifiable.tooltip.aria-label'),
-        ),
+        await screen.findByRole('tooltip', {
+          name: this.intl.t('pages.organization-participants.table.column.is-certifiable.tooltip.content'),
+        }),
       )
       .exists();
   });

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -1016,12 +1016,18 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   @onResetFilter={{this.noop}}
 />`);
 
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.tooltip.aria-label'),
+        ),
+      );
+
       // then
       assert
         .dom(
-          screen.getByLabelText(
-            this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.tooltip.aria-label'),
-          ),
+          await screen.findByRole('tooltip', {
+            name: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.tooltip.content'),
+          }),
         )
         .exists();
     });

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -302,11 +302,18 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     );
 
     // then
+    await click(
+      screen.getByLabelText(
+        this.intl.t('pages.sup-organization-participants.table.column.is-certifiable.tooltip.aria-label'),
+      ),
+    );
+
+    // then
     assert
       .dom(
-        screen.getByLabelText(
-          this.intl.t('pages.sup-organization-participants.table.column.is-certifiable.tooltip.aria-label'),
-        ),
+        await screen.findByRole('tooltip', {
+          name: this.intl.t('pages.sup-organization-participants.table.column.is-certifiable.tooltip.content'),
+        }),
       )
       .exists();
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1038,7 +1038,7 @@
             "not-available": "Unavailable",
             "tooltip": {
               "aria-label": "How to know if a student is eligible for certification and what does it mean?",
-              "content": "To know if a student is eligible for certification (meaning they have reached the level 1 in at least 5 different competences), their Pix profile needs to be submitted through a profile collection campaign. If the student has already submitted their profile, the date and status of the last submission are displayed."
+              "content": "To be eligible for certification, the student must have achieved level 1 in at least 5 different competences. This status is updated both automatically and during profile collection campaigns."
             }
           },
           "last-name": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1038,7 +1038,7 @@
             "not-available": "Unavailable",
             "tooltip": {
               "aria-label": "How to know if a student is eligible for certification and what does it mean?",
-              "content": "To be eligible for certification, the student must have achieved level 1 in at least 5 different competences. This status is updated both automatically and during profile collection campaigns."
+              "content": "To be eligible for certification, the student must have achieved level 1 in at least 5 different competences. This status is updated both automatically (every 24 hours) and during profile collection campaigns."
             }
           },
           "last-name": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1041,7 +1041,7 @@
             "not-available": "Non communiqué",
             "tooltip": {
               "aria-label": "Explication sur la certificabilité",
-              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. L'information provient des campagnes de collecte de profil réalisées par ce dernier. Si l'élève a déjà envoyé son profil, on affiche la date ainsi que le statut du dernier envoi."
+              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. Ce statut est mis à jour automatiquement et lors des campagnes de collectes de profils."
             }
           },
           "last-name": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1041,7 +1041,7 @@
             "not-available": "Non communiqué",
             "tooltip": {
               "aria-label": "Explication sur la certificabilité",
-              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. Ce statut est mis à jour automatiquement et lors des campagnes de collectes de profils."
+              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. Ce statut est mis à jour automatiquement (toutes les 24h) et lors des campagnes de collectes de profils."
             }
           },
           "last-name": {


### PR DESCRIPTION
## :unicorn: Problème
le fait que la certificabilité soit remonté automatiquement n'est pas mentionné dans la tooltip de la certificabilité

## :robot: Proposition
Mettre à jour le texte de la tooltip afin d'avoir l'information sur la remontée de la certificabilité auto

## :rainbow: Remarques
Ajout d'un BSR pour tester correctement les tooltip

## :100: Pour tester
Se connecter sur Pix Orga, vérifier que pour les orga sco managing student la tooltip est bien à jour. et qu'elle reste comme avant sur les non managing student

sco-orga@example.net , et faire la vérifiaction sur les deux organisations