### PR TITLE
[BUGFIX] Pix Admin - Dans la recherche d'utilisateur permettre à nouveau la saisie de texte dans le champ « Adresse e-mail »  (PIX-9112)

### DIFF
--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -32,7 +32,7 @@
         {{on "change" this.onChangeEmail}}
         placeholder="Adresse e-mail"
         @ariaLabel="Adresse e-mail"
-        type="email"
+        type="text"
       />
       <PixInput
         @id="username"

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -54,7 +54,7 @@ const register = async function (server) {
             'filter[id]': identifiersType.userId.empty('').allow(null).optional(),
             'filter[firstName]': Joi.string().empty('').allow(null).optional(),
             'filter[lastName]': Joi.string().empty('').allow(null).optional(),
-            'filter[email]': Joi.string().email().empty('').allow(null).optional(),
+            'filter[email]': Joi.string().empty('').allow(null).optional(),
             'filter[username]': Joi.string().empty('').allow(null).optional(),
             'page[number]': Joi.number().integer().empty('').allow(null).optional(),
             'page[size]': Joi.number().integer().empty('').allow(null).optional(),

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -613,17 +613,19 @@ describe('Unit | Router | user-router', function () {
         expect(response.statusCode).to.equal(403);
       });
 
-      describe('when the email provided in users filter is not valid', function () {
-        it('returns a BadRequest error (400)', async function () {
+      describe('when the search value in the search email field in users filter is a string and not a full email', function () {
+        it('is accepted and the search is performed', async function () {
           // given
+          sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+          sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
 
           // when
-          const response = await httpTestServer.request('GET', '/api/admin/users?filter[email]=999');
+          const response = await httpTestServer.request('GET', '/api/admin/users?filter[email]=some-value');
 
           // then
-          expect(response.statusCode).to.equal(400);
+          expect(response.statusCode).to.equal(200);
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème

#6954 a modifié le formulaire de recherche d'utilisateurs dans Pix Admin pour n'autoriser la recherche qu'avec des adresses email valides. Or quand on cherche des utilisateurs par email on les cherche souvent sur des « bouts d'adresse email » comme par exemple sur le domaine (ex : `@example.net`).

## :robot: Proposition

Restaurer le fonctionnement d'avant #6954 en ce qui concerne les recherches par email dans Pix Admin, c'est à dire autoriser l'utilisation de texte sans contrainte.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter avec Firefox (c'est important car Firefox est strict sur son interprétation de l'attribut `type="email"`) dans Pix Admin https://admin-pr7020.review.pix.fr/ avec utilisateur autorisé (par exemple `superadmin@example.net`)
2. Exécuter une recherche en spécifiant dans le champ « Adresse e-mail » la valeur `@example.net`
3. Constater que la recherche renvoie au moins un utilisateur
