### PR TITLE
[FEATURE] Afficher la date de certificabilité même si le prescrit SCO est non certifiable (PIX-9128)

### DIFF
--- a/api/lib/domain/read-models/ScoOrganizationParticipant.js
+++ b/api/lib/domain/read-models/ScoOrganizationParticipant.js
@@ -54,10 +54,10 @@ class ScoOrganizationParticipant {
 
     if (isCertifiableFromCampaignMostRecent) {
       this.isCertifiable = isCertifiableFromCampaign;
-      this.certifiableAt = this.isCertifiable ? certifiableAtFromCampaign : null;
+      this.certifiableAt = certifiableAtFromCampaign;
     } else {
       this.isCertifiable = isCertifiableFromLearner;
-      this.certifiableAt = this.isCertifiable ? certifiableAtFromLearner : null;
+      this.certifiableAt = certifiableAtFromLearner;
     }
   }
 }

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -1378,6 +1378,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
     context('#isCertifiable', function () {
       it('should take the learner certifiable value', async function () {
         // given
+        const certifiableDate = '2023-01-01';
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({
           organizationId,
@@ -1385,7 +1386,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         }).id;
         const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
-          certifiableAt: new Date('2023-01-01'),
+          certifiableAt: new Date(certifiableDate),
           isCertifiable: false,
         });
 
@@ -1409,7 +1410,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
 
         // then
         expect(isCertifiable).to.be.false;
-        expect(certifiableAt).to.be.null;
+        expect(certifiableAt).to.be.deep.equal(certifiableDate);
       });
 
       it('should take the shared participation', async function () {

--- a/api/tests/unit/domain/read-models/ScoOrganizationParticipant_test.js
+++ b/api/tests/unit/domain/read-models/ScoOrganizationParticipant_test.js
@@ -31,7 +31,7 @@ describe('Unit | Domain | Read-models | ScoOrganizationParticipant', function ()
 
     // then
     expect(organizationParticipant.isCertifiable).to.be.false;
-    expect(organizationParticipant.certifiableAt).to.be.null;
+    expect(organizationParticipant.certifiableAt).to.be.deep.equal(new Date('2023-01-01'));
   });
 
   it('should return certificability from learner when campaign is null', function () {


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que l'on calcule automatiquement la certificabilitée chaque jour, l'affichage de la date pour les prescrits non certifiable devient pertinente. 

## :robot: Proposition
Uniformiser l'affichage dans la colonne de certificabilité avec la date même si le prescrit n'est pas certifiable, afin de savoir à quelle date le dernier calcul de la certificabilité remonte. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga avec une organization SCO is Managing Students.
- Inserer le job `ScheduleComputeOrganizationLearnersCertificabilityJob`: 
```sql
INSERT INTO "pgboss"."job" (name, retrylimit, retrydelay, on_complete, data) VALUES('ScheduleComputeOrganizationLearnersCertificabilityJob', 0, 30, true, '{"skipLoggedLastDayCheck":"true"}');
```
- Verifier que tous les prescrits ont une date de certificabilité peut importe le statut de celui ci
- 🐱 
