### PR TITLE
[BUGFIX] Réparer le cas nominal de la recherche de profils cibles pour une complémentaire (PIX-9130).

### DIFF
--- a/api/db/database-builder/factory/build-badge.js
+++ b/api/db/database-builder/factory/build-badge.js
@@ -1,6 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
 import { buildTargetProfile } from './build-target-profile.js';
 import _ from 'lodash';
+import { randomUUID } from 'crypto';
 
 function buildBadge({
   id = databaseBuffer.getNextId(),
@@ -8,11 +9,12 @@ function buildBadge({
   imageUrl = '/img_funny.svg',
   message = 'message',
   title = 'title',
-  key = 'key',
+  key,
   isCertifiable = false,
   targetProfileId,
   isAlwaysVisible = false,
 } = {}) {
+  key = _.isUndefined(key) ? `key_${randomUUID()}` : key;
   targetProfileId = !_.isUndefined(targetProfileId) ? targetProfileId : buildTargetProfile().id;
 
   const values = {

--- a/api/lib/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/lib/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -3,56 +3,46 @@ import { knex } from '../../../db/knex-database-connection.js';
 import { AttachableTargetProfile } from '../../domain/models/AttachableTargetProfile.js';
 
 const find = async function ({ searchTerm } = {}) {
-  const targetProfilesSearchQuery = knex('target-profiles')
+  const targetProfiles = await knex('target-profiles')
     .select('target-profiles.id', 'target-profiles.name')
     .leftJoin('badges', 'target-profiles.id', 'badges.targetProfileId')
     .leftJoin('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
     .orderBy('target-profiles.name', 'ASC')
-    .orderBy('target-profiles.id', 'DESC');
+    .orderBy('target-profiles.id', 'DESC')
+    .where('target-profiles.outdated', false)
+    .where((builder) => _includeNeverAttachedTargetProfile(builder).orWhere(_includeDetachedTargetProfile))
+    .where((builder) => _searchByCritieria({ builder, searchTerm }));
 
-  targetProfilesSearchQuery.andWhere((queryBuilder) => {
-    return _excludeAllOutdatedTargetProfiles(queryBuilder).andWhere((queryBuilder) => {
-      return _includeAllTargetProfilesNotLinkedToAComplementaryCertification(queryBuilder).orWhere(
-        _includeTargetProfileLinkedToAComplementaryOnlyWhenDetached,
-      );
-    });
-  });
-
-  if (!_.isBlank(searchTerm)) {
-    targetProfilesSearchQuery.andWhere((builder) => {
-      return _searchByTargetProfileName({ builder, searchTerm }).orWhere((builder) => {
-        _searchOnIdColumnWhenSearchTermsContainsOnlyNumbers({ builder, searchTerm });
-      });
-    });
-  }
-
-  const targetProfiles = await targetProfilesSearchQuery;
   return _toDomain(targetProfiles);
 };
 
 export { find };
 
+function _searchByCritieria({ builder, searchTerm }) {
+  if (!_.isBlank(searchTerm)) {
+    const filteredBuilder = _searchByTargetProfileName({ builder, searchTerm });
+    const isNumberOnly = /^\d+$/.test(searchTerm);
+    if (isNumberOnly) {
+      return filteredBuilder.orWhere((builder) => _searchOnId({ builder, searchTerm }));
+    }
+
+    return filteredBuilder;
+  }
+  return builder;
+}
 function _searchByTargetProfileName({ builder, searchTerm }) {
   return builder.whereILike('target-profiles.name', `%${searchTerm}%`);
 }
 
-function _searchOnIdColumnWhenSearchTermsContainsOnlyNumbers({ builder, searchTerm }) {
-  if (/^\d+$/.test(searchTerm)) {
-    return builder.whereRaw('CAST("target-profiles"."id" AS TEXT) LIKE ?', [`%${searchTerm}%`]);
-  }
-
-  return builder;
+function _searchOnId({ builder, searchTerm }) {
+  return builder.whereRaw('CAST("target-profiles"."id" AS TEXT) LIKE ?', [`%${searchTerm}%`]);
 }
 
-function _excludeAllOutdatedTargetProfiles(builder) {
-  return builder.where('target-profiles.outdated', false);
-}
-
-function _includeAllTargetProfilesNotLinkedToAComplementaryCertification(builder) {
+function _includeNeverAttachedTargetProfile(builder) {
   return builder.whereNull('complementary-certification-badges.badgeId');
 }
 
-function _includeTargetProfileLinkedToAComplementaryOnlyWhenDetached(builder) {
+function _includeDetachedTargetProfile(builder) {
   return builder
     .whereNotNull('badges.targetProfileId')
     .andWhereNot('complementary-certification-badges.detachedAt', null);

--- a/api/lib/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/lib/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -49,7 +49,7 @@ function _excludeAllOutdatedTargetProfiles(builder) {
 }
 
 function _includeAllTargetProfilesNotLinkedToAComplementaryCertification(builder) {
-  return builder.whereNull('badges.targetProfileId');
+  return builder.whereNull('complementary-certification-badges.badgeId');
 }
 
 function _includeTargetProfileLinkedToAComplementaryOnlyWhenDetached(builder) {

--- a/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
@@ -5,29 +5,9 @@ describe('Integration | Repository | attachable-target-profiles', function () {
   describe('#find', function () {
     it('should return attachable target profiles ordered by name asc, then id desc', async function () {
       // given
-      const firstResult = {
-        id: 100,
-        name: 'AAA',
-        isPublic: false,
-        outdated: false,
-      };
-      databaseBuilder.factory.buildTargetProfile(firstResult);
-
-      const secondResult = {
-        id: 300,
-        name: 'BBB',
-        isPublic: true,
-        outdated: false,
-      };
-      databaseBuilder.factory.buildTargetProfile(secondResult);
-      const thirdResult = {
-        id: 200,
-        name: 'BBB',
-        isPublic: false,
-        outdated: false,
-      };
-      databaseBuilder.factory.buildTargetProfile(thirdResult);
-
+      new TargetProfileFactory({ id: 100, name: 'AAA' }).withBadge();
+      new TargetProfileFactory({ id: 300, name: 'BBB' }).withBadge();
+      new TargetProfileFactory({ id: 200, name: 'BBB' }).withBadge();
       await databaseBuilder.commit();
 
       // when
@@ -43,19 +23,8 @@ describe('Integration | Repository | attachable-target-profiles', function () {
 
     it('should not return outdated target profiles', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfile({
-        id: 100,
-        name: 'NOTOUTDATED',
-        isPublic: false,
-        outdated: false,
-      });
-
-      databaseBuilder.factory.buildTargetProfile({
-        id: 300,
-        name: 'OUTDATED',
-        isPublic: true,
-        outdated: true,
-      });
+      new TargetProfileFactory({ id: 100, name: 'NOTOUTDATED' }).withBadge();
+      new TargetProfileFactory({ id: 300, name: 'OUTDATED', outdated: true }).withBadge();
       await databaseBuilder.commit();
 
       // when
@@ -65,40 +34,40 @@ describe('Integration | Repository | attachable-target-profiles', function () {
       expect(results).to.deep.equal([{ id: 100, name: 'NOTOUTDATED' }]);
     });
 
-    context('when the target profiles is not linked to any badges', function () {
-      it('should return attachable target profiles', async function () {
+    context('when the target profile has no link to a complementary', function () {
+      it('should return it as an attachable target profile', async function () {
         // given
-        databaseBuilder.factory.buildTargetProfile({
-          id: 100,
-          name: 'Not tied to a complementary',
-          isPublic: false,
-          outdated: false,
-        });
-
+        new TargetProfileFactory({ id: 200, name: 'Target profile with a badge' }).withBadge();
         await databaseBuilder.commit();
 
         // when
         const results = await attachableTargetProfileRepository.find();
 
         // then
-        expect(results).to.deep.equal([{ id: 100, name: 'Not tied to a complementary' }]);
+        expect(results).to.deep.equal([{ id: 200, name: 'Target profile with a badge' }]);
       });
     });
 
-    context('when the target profiles has been linked to a complementary certification', function () {
+    context('when the target profile is not linked to any badges', function () {
+      it('should return it as an attachable target profiles', async function () {
+        // given
+        new TargetProfileFactory({ id: 100, name: 'Not tied to a badge' });
+        await databaseBuilder.commit();
+
+        // when
+        const results = await attachableTargetProfileRepository.find();
+
+        // then
+        expect(results).to.deep.equal([{ id: 100, name: 'Not tied to a badge' }]);
+      });
+    });
+
+    context('when the target profile has been linked to a complementary certification', function () {
       it('should not return target profiles currently attached to a complementary', async function () {
         // given
-        const targetProfile = databaseBuilder.factory.buildTargetProfile({
-          id: 100,
-          name: 'currentlyAttachedToATargetProfile',
-          isPublic: false,
-          outdated: false,
-        });
-        _createComplementaryCertificationBadge({
-          targetProfileId: targetProfile.id,
-          detachedAt: null,
-        });
-
+        new TargetProfileFactory({ id: 100, name: 'currentlyAttachedToATargetProfile' })
+          .withBadge()
+          .withComplementaryCertificationBadge({ detachedAt: null });
         await databaseBuilder.commit();
 
         // when
@@ -110,17 +79,9 @@ describe('Integration | Repository | attachable-target-profiles', function () {
 
       it('should return attached target profiles detached from a complementary', async function () {
         // given
-        const targetProfile = databaseBuilder.factory.buildTargetProfile({
-          id: 100,
-          name: 'currentlyDetached',
-          isPublic: false,
-          outdated: false,
-        });
-        _createComplementaryCertificationBadge({
-          targetProfileId: targetProfile.id,
-          detachedAt: new Date(),
-        });
-
+        new TargetProfileFactory({ id: 100, name: 'currentlyDetached' })
+          .withBadge()
+          .withComplementaryCertificationBadge({ detachedAt: new Date() });
         await databaseBuilder.commit();
 
         // when
@@ -135,36 +96,11 @@ describe('Integration | Repository | attachable-target-profiles', function () {
       context('when I am searching for a target profile by its name', function () {
         it('should return attachable target profiles matching the search term in their name', async function () {
           // given
-          databaseBuilder.factory.buildTargetProfile({
-            id: 1,
-            name: 'notAValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 11,
-            name: 'notAValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 2,
-            name: 'CLEA aValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 3,
-            name: 'aValidResult CLEA',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 4,
-            name: 'aValidCLEAResult',
-            isPublic: false,
-            outdated: false,
-          });
+          new TargetProfileFactory({ id: 1, name: 'notAValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 11, name: 'notAValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 2, name: 'CLEA aValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 3, name: 'aValidResult CLEA' }).withBadge();
+          new TargetProfileFactory({ id: 4, name: 'aValidCLEAResult' }).withBadge();
           await databaseBuilder.commit();
 
           const searchTerm = 'CLEA';
@@ -182,30 +118,10 @@ describe('Integration | Repository | attachable-target-profiles', function () {
 
         it('should not be case sensitive', async function () {
           // given
-          databaseBuilder.factory.buildTargetProfile({
-            id: 2,
-            name: 'CLÉA aValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 3,
-            name: 'aValidResult CléA',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 4,
-            name: 'aValidCLéAResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 5,
-            name: 'cléa',
-            isPublic: false,
-            outdated: false,
-          });
+          new TargetProfileFactory({ id: 2, name: 'CLÉA aValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 3, name: 'aValidResult CléA' }).withBadge();
+          new TargetProfileFactory({ id: 4, name: 'aValidCLéAResult' }).withBadge();
+          new TargetProfileFactory({ id: 5, name: 'cléa' }).withBadge();
           await databaseBuilder.commit();
 
           const searchTerm = 'cléa';
@@ -226,30 +142,10 @@ describe('Integration | Repository | attachable-target-profiles', function () {
       context('when I am searching for a target profile by its ID', function () {
         it('should return attachable target profiles matching the search term in their id', async function () {
           // given
-          databaseBuilder.factory.buildTargetProfile({
-            id: 1,
-            name: 'notAValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 2,
-            name: 'aValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 12,
-            name: 'aValidResult',
-            isPublic: false,
-            outdated: false,
-          });
-          databaseBuilder.factory.buildTargetProfile({
-            id: 21,
-            name: 'aValidResult',
-            isPublic: false,
-            outdated: false,
-          });
+          new TargetProfileFactory({ id: 1, name: 'notAValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 2, name: 'aValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 12, name: 'aValidResult' }).withBadge();
+          new TargetProfileFactory({ id: 21, name: 'aValidResult' }).withBadge();
           await databaseBuilder.commit();
 
           const searchTerm = '2';
@@ -269,16 +165,39 @@ describe('Integration | Repository | attachable-target-profiles', function () {
   });
 });
 
-function _createComplementaryCertificationBadge({ targetProfileId, detachedAt }) {
-  const badgeId = databaseBuilder.factory.buildBadge({
-    targetProfileId,
-  }).id;
+class TargetProfileFactory {
+  #targetProfile;
+  #badge;
+  #complementaryCertificationBadge;
 
-  databaseBuilder.factory.buildComplementaryCertificationBadge({
-    badgeId,
-    complementaryCertificationId: null,
-    detachedAt,
-  });
+  constructor(targetProfileOpts = {}) {
+    const _targetProfileOpts = { isPublic: true, outdated: false, ...targetProfileOpts };
+    this.withTargetProfile(_targetProfileOpts);
+  }
 
-  return badgeId;
+  withTargetProfile(targetProfileOpts) {
+    const _targetProfileOpts = { isPublic: true, outdated: false, ...targetProfileOpts };
+    this.#targetProfile = databaseBuilder.factory.buildTargetProfile(_targetProfileOpts);
+    return this;
+  }
+
+  withBadge(badgeOpts) {
+    const _badgeOpts = { targetProfileId: this.#targetProfile.id, ...badgeOpts };
+    this.#badge = databaseBuilder.factory.buildBadge(_badgeOpts);
+    return this;
+  }
+
+  withComplementaryCertificationBadge(complementaryCertificationBadgeOpts) {
+    const _badgeId = this.#badge?.id ?? this.withBadge();
+    const _complementaryCertificationBadgeOpts = {
+      badgeId: _badgeId,
+      complementaryCertificationId: null,
+      detachedAt: null,
+      ...complementaryCertificationBadgeOpts,
+    };
+    this.#complementaryCertificationBadge = databaseBuilder.factory.buildComplementaryCertificationBadge(
+      _complementaryCertificationBadgeOpts,
+    );
+    return this;
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
Le cas nominal de recherche de profils cibles attachables pour l'association à une complémentaire ne fonctionne pas.

## :robot: Proposition
Corriger la recherche.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Tout est sur Pix Admin, utilisateur `superadmin@example.net`

### Cas nominal

* Onglet profil cible
  * Créer un novueau profil cible
  * Lui associer au moins un badge certifiant
* Onglet certification complémentaire
  * Ouvrir une complémentaire, faire "rattacher un nouveau profil cible"
  * Rechercher le nouveau profil cible par nom ou par id
  * Vérifier qu'il apparait dans la recherche

### Tester la non régression

#### Obsolète

* Repérer ou créer un profil cible **NON** obsolète, vérifier qu'il apparait dans la recherche des PC complémentaires
* Le passer en obsolète
* Vérifier qu'il n'apparait plus dans la recherche

#### Pas de badge

* Repérer ou créer un profil cible sans badge
* Vérfier qu'il apparait dans la recherche

#### Déjà attaché

* Ouvrir une complémentaire, notez le profil attaché
* Ouvrir une autre complémentaire de la liste, essayer de faire une recherche sur le nom du profil cible précèdemment noté
* Il ne doit pas apparaitre dans la recherche
*
#### Détacher

* Ouvrir une complémentaire, par exemple Clé
* Regarder l'historique des profil cibles, repérer un profil cible **détaché**, notez le
* Faire une recherche, essayer de rechercher le profil cible détaché précèdemment noté
* Il doit apparaitre dans la recherche