### PR TITLE
[BUGFIX] Fixer la récupération d'infos d'un profil cible détaché puis rattaché à la même certification complémentaire (PIX-9131).

### DIFF
--- a/api/lib/domain/models/ComplementaryCertificationTargetProfileHistory.js
+++ b/api/lib/domain/models/ComplementaryCertificationTargetProfileHistory.js
@@ -1,9 +1,8 @@
 class ComplementaryCertificationTargetProfileHistory {
-  constructor({ id, label, key, currentTargetProfileBadges, targetProfilesHistory }) {
+  constructor({ id, label, key, targetProfilesHistory }) {
     this.id = id;
     this.label = label;
     this.key = key;
-    this.currentTargetProfileBadges = currentTargetProfileBadges;
     this.targetProfilesHistory = targetProfilesHistory;
   }
 }

--- a/api/lib/domain/usecases/get-complementary-certification-target-profile-history.js
+++ b/api/lib/domain/usecases/get-complementary-certification-target-profile-history.js
@@ -1,9 +1,34 @@
-const getComplementaryCertificationTargetProfileHistory = function ({
+import { ComplementaryCertificationTargetProfileHistory } from '../../domain/models/ComplementaryCertificationTargetProfileHistory.js';
+
+const getComplementaryCertificationTargetProfileHistory = async function ({
   complementaryCertificationId,
   complementaryCertificationTargetProfileHistoryRepository,
+  complementaryCertificationRepository,
 }) {
-  return complementaryCertificationTargetProfileHistoryRepository.getByComplementaryCertificationId({
+  const currentsTargetProfileHistoryWithBadgesByComplementaryCertification =
+    await complementaryCertificationTargetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId(
+      {
+        complementaryCertificationId,
+      },
+    );
+
+  const detachedTargetProfileHistoryByComplementaryCertification =
+    await complementaryCertificationTargetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId(
+      {
+        complementaryCertificationId,
+      },
+    );
+
+  const complementaryCertification = await complementaryCertificationRepository.getById({
     complementaryCertificationId,
+  });
+
+  return new ComplementaryCertificationTargetProfileHistory({
+    ...complementaryCertification,
+    targetProfilesHistory: [
+      ...currentsTargetProfileHistoryWithBadgesByComplementaryCertification,
+      ...detachedTargetProfileHistoryByComplementaryCertification,
+    ],
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-target-profile-history-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-target-profile-history-for-admin.js
@@ -4,14 +4,12 @@ const buildComplementaryCertificationTargetProfileHistory = function ({
   id = 1,
   label = 'Complementary certification name',
   key = 'COMPLEMENTARY_CERTIFICATION_KEY',
-  currentTargetProfileBadges = [],
   targetProfilesHistory = [],
 } = {}) {
   return new ComplementaryCertificationTargetProfileHistory({
     id,
     label,
     key,
-    currentTargetProfileBadges,
     targetProfilesHistory,
   });
 };

--- a/api/tests/unit/domain/usecases/get-complementary-certification-target-profile-history_test.js
+++ b/api/tests/unit/domain/usecases/get-complementary-certification-target-profile-history_test.js
@@ -3,27 +3,60 @@ import { getComplementaryCertificationTargetProfileHistory } from '../../../../l
 
 describe('Unit | UseCase | get-complementary-certification-target-profile-history', function () {
   let complementaryCertificationTargetProfileHistoryRepository;
+  let complementaryCertificationRepository;
 
   beforeEach(function () {
     complementaryCertificationTargetProfileHistoryRepository = {
-      getByComplementaryCertificationId: sinon.stub(),
+      getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId: sinon.stub(),
+      getDetachedTargetProfilesHistoryByComplementaryCertificationId: sinon.stub(),
+    };
+    complementaryCertificationRepository = {
+      getById: sinon.stub(),
     };
   });
 
   it('should get the complementary certification', async function () {
     // given
-    const complementaryCertification = domainBuilder.buildComplementaryCertificationTargetProfileHistory();
-    complementaryCertificationTargetProfileHistoryRepository.getByComplementaryCertificationId.resolves(
-      complementaryCertification,
-    );
+    const complementaryCertification = domainBuilder.buildComplementaryCertification();
+    const complementaryCertificationId = complementaryCertification.id;
+    complementaryCertificationRepository.getById
+      .withArgs({ complementaryCertificationId })
+      .resolves(complementaryCertification);
+
+    const attachedTargetProfileHistoryForAdmin = domainBuilder.buildTargetProfileHistoryForAdmin({
+      detachedAt: null,
+    });
+    const detachedTargetProfileHistoryForAdmin1 = domainBuilder.buildTargetProfileHistoryForAdmin({
+      detachedAt: new Date('2022-01-01'),
+    });
+    const detachedTargetProfileHistoryForAdmin2 = domainBuilder.buildTargetProfileHistoryForAdmin({
+      detachedAt: new Date('2021-01-01'),
+    });
+
+    complementaryCertificationTargetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId
+      .withArgs({ complementaryCertificationId })
+      .resolves([attachedTargetProfileHistoryForAdmin]);
+    complementaryCertificationTargetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId
+      .withArgs({ complementaryCertificationId })
+      .resolves([detachedTargetProfileHistoryForAdmin1, detachedTargetProfileHistoryForAdmin2]);
 
     // when
     const result = await getComplementaryCertificationTargetProfileHistory({
-      complementaryCertificationId: 1,
+      complementaryCertificationId,
       complementaryCertificationTargetProfileHistoryRepository,
+      complementaryCertificationRepository,
     });
 
     // then
-    expect(result).to.deep.equal(complementaryCertification);
+    expect(result).to.deepEqualInstance(
+      domainBuilder.buildComplementaryCertificationTargetProfileHistory({
+        ...complementaryCertification,
+        targetProfilesHistory: [
+          attachedTargetProfileHistoryForAdmin,
+          detachedTargetProfileHistoryForAdmin1,
+          detachedTargetProfileHistoryForAdmin2,
+        ],
+      }),
+    );
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, lorsqu'on procède au rattachement d'un profil cible ayant déjà été anciennement rattaché à cette même certification complémentaire, la page de détails rend une page blanche.
Ember attend des badges à afficher qui ne sont pas retournés par l'API. 
En effet, la méthode de repository qui retourne les bonnes infos ne prenait pas en compte ce genre de cas particulier.

## :robot: Proposition
Modifier la méthode de repository pour qu'elle retourne un historique de profil cible cohérent et les bon badges.

## :rainbow: Remarques
On décide de scinder la récupération des informations en deux méthodes de repo.

## :100: Pour tester

- Se connecter sur Pix Admin avec superadmin@example.net
- aller sur la page des certifications complémentaires
- Aller sur CléA et rattacher un nouveau profil cible (V1)
- remplir les badges et valider
- (pas de retour automatique sur la page de détails après validation) donc revenir à la page précédente et faire F5
- Constater que les infos sont les bonnes 

<img width="1656" alt="Capture d’écran 2023-09-12 à 10 45 44" src="https://github.com/1024pix/pix/assets/58915422/5fc6c6a4-5d28-4550-a2a6-6a0cc4e50065">
