### PR TITLE
[BUGFIX] Gérer les erreurs d'emailing qui ne suivent pas le format d'erreur Brevo

### DIFF
--- a/api/lib/infrastructure/mailers/BrevoProvider.js
+++ b/api/lib/infrastructure/mailers/BrevoProvider.js
@@ -55,9 +55,11 @@ class BrevoProvider extends MailingProvider {
     try {
       return await this._client.sendTransacEmail(payload);
     } catch (err) {
-      const responseText = JSON.parse(err.response.text);
-      if (responseText.code === 'invalid_parameter') {
-        throw new MailingProviderInvalidEmailError(responseText.message);
+      if (err?.response?.text) {
+        const responseText = JSON.parse(err.response.text);
+        if (responseText.code === 'invalid_parameter') {
+          throw new MailingProviderInvalidEmailError(responseText.message);
+        }
       }
 
       throw err;

--- a/api/tests/unit/infrastructure/mailers/BrevoProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/BrevoProvider_test.js
@@ -168,6 +168,26 @@ describe('Unit | Class | BrevoProvider', function () {
           expect(error.message).to.equal('email is not valid in to');
         });
       });
+
+      context('when an underlying infrascture error is thrown', function () {
+        it('should throw an error with the message', async function () {
+          // given
+          const options = {
+            from: senderEmailAddress,
+            to: userEmailAddress,
+            fromName: 'Ne pas repondre',
+            subject: 'Creation de compte',
+            template: templateId,
+          };
+          stubbedBrevoSMTPApi.sendTransacEmail.rejects(new Error('Error: write EPROTO routines:ssl3_read_bytes:tlsv1'));
+
+          // when
+          const error = await catchErr(mailingProvider.sendEmail, mailingProvider)(options);
+
+          // then
+          expect(error.message).to.equal('Error: write EPROTO routines:ssl3_read_bytes:tlsv1');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'une erreur survient à l'envoi d'un email pour une raison ne relevant pas d'une erreur Brevo (ex: Erreur DNS, de certificats, etc ...), l'erreur retournée par le code est une erreur de parsing.

## :robot: Proposition

Renvoyer la véritable erreur lorsque celle ci ne semble pas être une erreur Brevo

## :100: Pour tester

Modifier ses hosts : 

```
127.0.0.1 api.brevo.com
``` 
Activer le mailing via les variables d'environnement.

Tenter de lancer un reset de mot de passe et voir l'erreur correctement renvoyée.
