### PR TITLE
[TECH] Corrige la corruption de cache du npm ci de l'admin sur CircleCi.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,10 +459,10 @@ jobs:
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:
-            - v7-admin-npm-{{ checksum "cachekey" }}
+            - v8-admin-npm-{{ checksum "cachekey" }}
       - run: npm ci
       - save_cache:
-          key: v7-admin-npm-{{ checksum "cachekey" }}
+          key: v8-admin-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
       - run:


### PR DESCRIPTION
## :unicorn: Problème
Tous les jobs `npm ci` de l'admin fail depuis un bump du package-lock. Cela semble venir d'un cache corrompu.

## :robot: Proposition
Bumper la version du cache.

## :100: Pour tester
La ci de l'admin fonctionne