### PR TITLE
[TECH] Récupérer les paliers acquis dans la page "Mes parcours" (PIX-8912)

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -10,39 +10,33 @@ class CampaignParticipationOverview {
     sharedAt,
     organizationName,
     status,
+    campaignId,
+    targetProfileId,
     campaignCode,
     campaignTitle,
     campaignArchivedAt,
     deletedAt,
     masteryRate,
+    totalStagesCount,
+    validatedStagesCount,
     validatedSkillsCount,
-    stageCollection,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
+    this.targetProfileId = targetProfileId;
     this.isShared = status === SHARED;
     this.sharedAt = sharedAt;
     this.organizationName = organizationName;
     this.status = status;
+    this.campaignId = campaignId;
     this.campaignCode = campaignCode;
     this.campaignTitle = campaignTitle;
-    this.stageCollection = stageCollection;
     this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
     this.validatedSkillsCount = validatedSkillsCount;
-
     const dates = [deletedAt, campaignArchivedAt].filter((a) => a != null);
-
+    this.totalStagesCount = totalStagesCount;
+    this.validatedStagesCount = validatedStagesCount;
     this.disabledAt = _.min(dates) || null;
-  }
-
-  get validatedStagesCount() {
-    if (this.stageCollection.totalStages === 0 || !this.isShared) return null;
-
-    return this.stageCollection.getReachedStage(this.validatedSkillsCount, this.masteryRate * 100).reachedStage;
-  }
-
-  get totalStagesCount() {
-    return this.stageCollection.totalStages;
   }
 }
 

--- a/api/lib/domain/services/stages/stage-and-stage-acquisition-comparison-service.js
+++ b/api/lib/domain/services/stages/stage-and-stage-acquisition-comparison-service.js
@@ -1,0 +1,79 @@
+/**
+ * This service compares available and acquired stages for a campaign participation.
+ */
+class StagesAndAcquiredStagesComparison {
+  /**
+   * @type {Stage[]}
+   */
+  #acquiredStages = [];
+
+  /**
+   * @type {number}
+   */
+  #totalNumberOfStages;
+
+  /**
+   * @param {Stage[]} availableStages
+   * @param {StageAcquisition[]} stageAcquisitions
+   */
+  constructor(availableStages, stageAcquisitions) {
+    this.#totalNumberOfStages = availableStages.length;
+    this.#acquiredStages = availableStages
+      .sort(this.#sortByLevelOrThreshold)
+      .filter((availableStage) => stageAcquisitions.find(({ stageId }) => stageId === availableStage.id));
+  }
+
+  /**
+   * @param {Stage} previousStage
+   * @param {Stage} currentStage
+   *
+   * @returns {-1, 0, 1}
+   */
+  #sortByLevelOrThreshold(previousStage, currentStage) {
+    if (currentStage.isFirstSkill) {
+      return previousStage.isZeroStage ? -1 : 1;
+    }
+    return currentStage.level
+      ? previousStage.level - currentStage.level
+      : previousStage.threshold - currentStage.threshold;
+  }
+
+  /**
+   * @returns {number}
+   */
+  get reachedStageNumber() {
+    return this.#acquiredStages.length;
+  }
+
+  /**
+   * @returns {number}
+   */
+  get totalNumberOfStages() {
+    return this.#totalNumberOfStages;
+  }
+
+  /**
+   * @returns {Stage}
+   */
+  get reachedStage() {
+    return this.#acquiredStages[this.#acquiredStages.length - 1];
+  }
+}
+
+/**
+ * Compare stages and stages acquisitions to
+ * build stages information for a campaign.
+ *
+ * @param {Stage[]} availableStages
+ * @param {StageAcquisition[]} stageAcquisitions
+ * @returns {{reachedStage: Stage, reachedStageNumber: number, totalNumberOfStages: number}}
+ */
+export const compare = (availableStages, stageAcquisitions) => {
+  const stageComparison = new StagesAndAcquiredStagesComparison(availableStages, stageAcquisitions);
+
+  return {
+    reachedStageNumber: stageComparison.reachedStageNumber,
+    totalNumberOfStages: stageComparison.totalNumberOfStages,
+    reachedStage: stageComparison.reachedStage,
+  };
+};

--- a/api/lib/domain/usecases/find-user-campaign-participation-overviews.js
+++ b/api/lib/domain/usecases/find-user-campaign-participation-overviews.js
@@ -2,17 +2,50 @@ const findUserCampaignParticipationOverviews = async function ({
   userId,
   states,
   page,
+  stageRepository,
+  stageAcquisitionRepository,
   campaignParticipationOverviewRepository,
+  stageAndStageAcquisitionComparisonService,
 }) {
   const concatenatedStates = states ? [].concat(states) : undefined;
 
-  const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
-    userId,
-    states: concatenatedStates,
-    page,
-  });
+  const { campaignParticipationOverviews, pagination } =
+    await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+      userId,
+      states: concatenatedStates,
+      page,
+    });
 
-  return campaignParticipationOverviews;
+  // We deduplicate targetProfileIds in the case where several campaigns belong to the same target profile
+  const targetProfileIds = [...new Set(campaignParticipationOverviews.map(({ targetProfileId }) => targetProfileId))];
+  const campaignParticipationIds = campaignParticipationOverviews.map(({ id }) => id);
+
+  const [stages, acquiredStages] = await Promise.all([
+    stageRepository.getByTargetProfileIds(targetProfileIds),
+    stageAcquisitionRepository.getByCampaignParticipations(campaignParticipationIds),
+  ]);
+
+  const campaignParticipationOverviewsWithStages = campaignParticipationOverviews.map(
+    (campaignParticipationOverview) => {
+      const stagesForThisCampaign = stages.filter(
+        ({ targetProfileId }) => targetProfileId === campaignParticipationOverview.targetProfileId,
+      );
+      const acquiredStagesForThisCampaign = acquiredStages.filter(
+        ({ campaignParticipationId }) => campaignParticipationId === campaignParticipationOverview.id,
+      );
+      const stagesComparison = stageAndStageAcquisitionComparisonService.compare(
+        stagesForThisCampaign,
+        acquiredStagesForThisCampaign,
+      );
+
+      campaignParticipationOverview.totalStagesCount = stagesComparison.totalNumberOfStages;
+      campaignParticipationOverview.validatedStagesCount = stagesComparison.reachedStageNumber;
+
+      return campaignParticipationOverview;
+    },
+  );
+
+  return { campaignParticipationOverviews: campaignParticipationOverviewsWithStages, pagination };
 };
 
 export { findUserCampaignParticipationOverviews };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -160,6 +160,8 @@ import * as skillRepository from '../../infrastructure/repositories/skill-reposi
 import * as smartRandom from '../../domain/services/algorithm-methods/smart-random.js';
 import * as stageCollectionForTargetProfileRepository from '../../infrastructure/repositories/target-profile-management/stage-collection-repository.js';
 import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
+import * as stageRepository from '../../infrastructure/repositories/stage-repository.js';
+import * as stageAcquisitionRepository from '../../infrastructure/repositories/stage-acquisition-repository.js';
 import * as studentRepository from '../../infrastructure/repositories/student-repository.js';
 import * as supervisorAccessRepository from '../../infrastructure/repositories/supervisor-access-repository.js';
 import * as supOrganizationLearnerRepository from '../../../src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js';
@@ -187,6 +189,8 @@ import * as userToCreateRepository from '../../infrastructure/repositories/user-
 import * as userValidator from '../validators/user-validator.js';
 import * as verifyCertificateCodeService from '../../domain/services/verify-certificate-code-service.js';
 import * as writeCsvUtils from '../../infrastructure/utils/csv/write-csv-utils.js';
+import * as writeOdsUtils from '../../infrastructure/utils/ods/write-ods-utils.js';
+import * as stageAndStageAcquisitionComparisonService from '../../domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
 import { CampaignParticipationsStatsRepository as campaignParticipationsStatsRepository } from '../../infrastructure/repositories/campaign-participations-stats-repository.js';
 import { campaignParticipantActivityRepository } from '../../infrastructure/repositories/campaign-participant-activity-repository.js';
 import { campaignParticipationResultRepository } from '../../infrastructure/repositories/campaign-participation-result-repository.js';
@@ -212,7 +216,6 @@ function requirePoleEmploiNotifier() {
 }
 
 const dependencies = {
-  TargetProfileForSpecifierRepository,
   accountRecoveryDemandRepository,
   activityAnswerRepository,
   activityRepository,
@@ -222,6 +225,7 @@ const dependencies = {
   areaRepository,
   assessmentRepository,
   assessmentResultRepository,
+  attachableTargetProfileRepository,
   authenticationMethodRepository,
   authenticationServiceRegistry,
   authenticationSessionService,
@@ -234,7 +238,6 @@ const dependencies = {
   campaignAssessmentParticipationRepository,
   campaignAssessmentParticipationResultListRepository,
   campaignAssessmentParticipationResultRepository,
-  codeGenerator,
   campaignCollectiveResultRepository,
   campaignCreatorRepository,
   campaignCsvExportService,
@@ -282,6 +285,7 @@ const dependencies = {
   certificationResultRepository,
   challengeRepository,
   cleaCertifiedCandidateRepository,
+  codeGenerator,
   codeUtils,
   competenceEvaluationRepository,
   competenceMarkRepository,
@@ -334,9 +338,9 @@ const dependencies = {
   organizationPlacesCapacityRepository,
   organizationPlacesLotRepository,
   organizationRepository,
+  organizationsToAttachToTargetProfileRepository,
   organizationTagRepository,
   organizationValidator,
-  organizationsToAttachToTargetProfileRepository,
   participantResultRepository,
   participantResultsSharedRepository,
   participationsForCampaignManagementRepository,
@@ -371,15 +375,18 @@ const dependencies = {
   sessionsImportValidationService,
   skillRepository,
   smartRandom,
-  stageCollectionRepository,
+  stageAndStageAcquisitionComparisonService,
   stageCollectionForTargetProfileRepository,
+  stageCollectionRepository,
+  stageRepository,
+  stageAcquisitionRepository,
   studentRepository,
+  supervisorAccessRepository,
   supOrganizationLearnerRepository,
   supOrganizationParticipantRepository,
-  supervisorAccessRepository,
   tagRepository,
-  attachableTargetProfileRepository,
   targetProfileForAdminRepository,
+  TargetProfileForSpecifierRepository,
   targetProfileForUpdateRepository,
   targetProfileRepository,
   targetProfileShareRepository,
@@ -395,8 +402,8 @@ const dependencies = {
   tutorialRepository: repositories.tutorialRepository,
   userEmailRepository,
   userLoginRepository,
-  userOrgaSettingsRepository,
   userOrganizationsForAdminRepository,
+  userOrgaSettingsRepository,
   userRecommendedTrainingRepository: repositories.userRecommendedTrainingRepository,
   userReconciliationService,
   userRepository,
@@ -406,6 +413,7 @@ const dependencies = {
   userValidator,
   verifyCertificateCodeService,
   writeCsvUtils,
+  writeOdsUtils,
   attendanceSheetPdfUtils,
 };
 

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -1,10 +1,8 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { CampaignTypes } from '../../domain/models/CampaignTypes.js';
-import { CampaignParticipationOverview } from '../../domain/read-models/CampaignParticipationOverview.js';
 import { fetchPage } from '../utils/knex-utils.js';
-import bluebird from 'bluebird';
 import { CampaignParticipationStatuses } from '../../domain/models/CampaignParticipationStatuses.js';
-import * as stageCollectionRepository from './user-campaign-results/stage-collection-repository.js';
+import { CampaignParticipationOverview } from '../../domain/read-models/CampaignParticipationOverview.js';
 
 const findByUserIdWithFilters = async function ({ userId, states, page }) {
   const queryBuilder = _findByUserId({ userId });
@@ -15,10 +13,10 @@ const findByUserIdWithFilters = async function ({ userId, states, page }) {
 
   const { results, pagination } = await fetchPage(queryBuilder, page);
 
-  const campaignParticipationOverviews = await _toReadModel(results);
-
   return {
-    campaignParticipationOverviews,
+    campaignParticipationOverviews: results.map(
+      (campaignParticipationOverview) => new CampaignParticipationOverview(campaignParticipationOverview),
+    ),
     pagination,
   };
 };
@@ -92,15 +90,4 @@ function _sortEndedBySharedAt() {
 
 function _filterByStates(queryBuilder, states) {
   queryBuilder.whereIn('participationState', states);
-}
-
-function _toReadModel(campaignParticipationOverviews) {
-  return bluebird.mapSeries(campaignParticipationOverviews, async (data) => {
-    const stageCollection = await stageCollectionRepository.findStageCollection({ campaignId: data.campaignId });
-
-    return new CampaignParticipationOverview({
-      ...data,
-      stageCollection,
-    });
-  });
 }

--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -71,4 +71,16 @@ const getByCampaignParticipationId = async (campaignParticipationId, knexConnect
       .where('campaign-participations.id', campaignParticipationId),
   );
 
-export { getByCampaignIds, getByCampaignId, getByCampaignParticipationId };
+/**
+ * Return campaign stages for several target profile ids,
+ * this is convenient for campaign overviews
+ *
+ * @param {[number]} targetProfileIds
+ * @param knexConnection
+ *
+ * @returns Promise<Stage[]>
+ */
+const getByTargetProfileIds = async (targetProfileIds, knexConnection = knex) =>
+  toDomain(await knexConnection('stages').select('stages.*').whereIn('stages.targetProfileId', targetProfileIds));
+
+export { getByCampaignIds, getByCampaignId, getByCampaignParticipationId, getByTargetProfileIds };

--- a/api/tests/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -1,0 +1,144 @@
+import { databaseBuilder, expect } from '../../../test-helper.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+describe('Integration | UseCase | find-user-campaign-participation-overviews_test', function () {
+  describe('when there are several campaigns for several target profiles', function () {
+    let user;
+
+    beforeEach(async function () {
+      // given
+      user = databaseBuilder.factory.buildUser();
+
+      const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+      const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+
+      const targetProfile1Stage1 = databaseBuilder.factory.buildStage({ targetProfileId: targetProfile1.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile1.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile1.id });
+
+      const targetProfile2Stage2 = databaseBuilder.factory.buildStage({ targetProfileId: targetProfile2.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile2.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile2.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile2.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile2.id });
+
+      const campaign1 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile1.id });
+      const campaign2 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile2.id });
+
+      const campaign1Participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign1.id,
+        userId: user.id,
+      });
+      const campaign2Participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign2.id,
+        userId: user.id,
+      });
+
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: targetProfile1Stage1.id,
+        userId: user.id,
+        campaignParticipationId: campaign1Participation1.id,
+      });
+
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: targetProfile2Stage2.id,
+        userId: user.id,
+        campaignParticipationId: campaign2Participation2.id,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return campaign participations for a given user', async function () {
+      // when
+      const result = await usecases.findUserCampaignParticipationOverviews({
+        userId: user.id,
+      });
+
+      // then
+      expect(result.campaignParticipationOverviews.length).to.equal(2);
+    });
+
+    it('should return acquired stages', async function () {
+      // when
+      const result = await usecases.findUserCampaignParticipationOverviews({
+        userId: user.id,
+      });
+
+      // then
+      expect(result.campaignParticipationOverviews[0].totalStagesCount).to.equal(3);
+      expect(result.campaignParticipationOverviews[0].validatedStagesCount).to.equal(1);
+      expect(result.campaignParticipationOverviews[1].totalStagesCount).to.equal(5);
+      expect(result.campaignParticipationOverviews[1].validatedStagesCount).to.equal(1);
+    });
+  });
+
+  describe('when there are several campaigns for one target profile', function () {
+    let user;
+
+    beforeEach(async function () {
+      // given
+      user = databaseBuilder.factory.buildUser();
+
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+
+      const stage1 = databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
+      const stage2 = databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
+
+      const campaign1 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const campaign2 = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+
+      const campaign1Participation1 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign1.id,
+        userId: user.id,
+      });
+      const campaign2Participation2 = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign2.id,
+        userId: user.id,
+      });
+
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: stage1.id,
+        userId: user.id,
+        campaignParticipationId: campaign1Participation1.id,
+      });
+
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: stage1.id,
+        userId: user.id,
+        campaignParticipationId: campaign2Participation2.id,
+      });
+
+      databaseBuilder.factory.buildStageAcquisition({
+        stageId: stage2.id,
+        userId: user.id,
+        campaignParticipationId: campaign2Participation2.id,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return campaign participations for a given user', async function () {
+      // when
+      const result = await usecases.findUserCampaignParticipationOverviews({
+        userId: user.id,
+      });
+
+      // then
+      expect(result.campaignParticipationOverviews.length).to.equal(2);
+    });
+
+    it('should return acquired stages', async function () {
+      // when
+      const result = await usecases.findUserCampaignParticipationOverviews({
+        userId: user.id,
+      });
+
+      // then
+      expect(result.campaignParticipationOverviews[0].totalStagesCount).to.equal(3);
+      expect(result.campaignParticipationOverviews[0].validatedStagesCount).to.equal(1);
+      expect(result.campaignParticipationOverviews[1].totalStagesCount).to.equal(3);
+      expect(result.campaignParticipationOverviews[1].validatedStagesCount).to.equal(2);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -1,10 +1,4 @@
-import {
-  expect,
-  databaseBuilder,
-  mockLearningContent,
-  learningContentBuilder,
-  domainBuilder,
-} from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent, learningContentBuilder } from '../../../test-helper.js';
 
 const { campaignParticipationOverviewFactory } = databaseBuilder.factory;
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
@@ -86,8 +80,8 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           campaignTitle: 'Campaign ABCD',
           organizationName: 'Organization ABCD',
           masteryRate: 0.1,
-          totalStagesCount: 1,
-          validatedStagesCount: 1,
+          totalStagesCount: undefined,
+          validatedStagesCount: undefined,
           status: 'SHARED',
         });
       });
@@ -577,9 +571,10 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
 
         // then
-        const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({ campaignId, stages: [] });
         expect(campaignParticipationOverviews).to.deep.equal([
           {
+            campaignId,
+            targetProfileId: null,
             campaignCode: 'FLASH',
             campaignTitle: 'Campaign FLASH',
             createdAt: new Date('2020-01-01T00:00:00Z'),
@@ -590,8 +585,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
             sharedAt: new Date('2020-01-02T00:00:00Z'),
             status: 'SHARED',
             disabledAt: null,
-            stageCollection,
             validatedSkillsCount: 3,
+            totalStagesCount: undefined,
+            validatedStagesCount: undefined,
           },
         ]);
       });

--- a/api/tests/integration/infrastructure/repositories/target-profile-management/stage-collection-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-management/stage-collection-repository_test.js
@@ -123,7 +123,9 @@ describe('Integration | Infrastructure | Repository | target-profile-management 
       // then
       const savedStages = await knex.from('stages');
       expect(savedStages).to.have.lengthOf(2);
-      expect(_.omit(savedStages[0], ['id', 'createdAt', 'updatedAt'])).to.deep.include(_.omit(newStage, ['id']));
+      expect(_.omit(savedStages[0], ['id', 'createdAt', 'updatedAt'])).to.deep.include(
+        _.omit(newStage, ['id', 'campaignId']),
+      );
       expect(_.omit(savedStages[1], ['createdAt', 'updatedAt'])).to.deep.include(existingStage);
     });
 

--- a/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -2,7 +2,7 @@ import { CampaignParticipationOverview } from '../../../../lib/domain/read-model
 import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
 import { expect, domainBuilder } from '../../../test-helper.js';
 
-const { SHARED, STARTED } = CampaignParticipationStatuses;
+const { SHARED } = CampaignParticipationStatuses;
 
 describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function () {
   describe('constructor', function () {
@@ -26,7 +26,6 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
       expect(campaignParticipationOverview.createdAt).to.deep.equal(new Date('2020-02-15T15:00:34Z'));
       expect(campaignParticipationOverview.sharedAt).to.deep.equal(new Date('2020-03-15T15:00:34Z'));
       expect(campaignParticipationOverview.isShared).to.be.true;
-      expect(campaignParticipationOverview.stageCollection).to.deep.equal(stageCollection);
       expect(campaignParticipationOverview.organizationName).to.equal('Pix');
       expect(campaignParticipationOverview.status).to.equal(SHARED);
       expect(campaignParticipationOverview.campaignCode).to.equal('campaignCode');
@@ -100,138 +99,6 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
           // then
           expect(campaignParticipationOverview.masteryRate).to.equal(0.75);
         });
-      });
-    });
-  });
-
-  describe('#validatedStagesCount', function () {
-    context('when the participation is shared', function () {
-      context('when the campaign has stages', function () {
-        it('should return validated stages count', function () {
-          const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
-            campaignId: 3,
-            stages: [
-              {
-                threshold: 0,
-              },
-              {
-                threshold: 10,
-              },
-              {
-                threshold: 30,
-              },
-              {
-                threshold: 70,
-              },
-            ],
-          });
-          const campaignParticipationOverview = new CampaignParticipationOverview({
-            status: SHARED,
-            validatedSkillsCount: 1,
-            stageCollection,
-            masteryRate: '0.5',
-          });
-
-          expect(campaignParticipationOverview.validatedStagesCount).to.equal(3);
-        });
-      });
-
-      context("when the campaign doesn't have stages", function () {
-        it('should return null', function () {
-          const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
-            campaignId: 3,
-            stages: [],
-          });
-          const campaignParticipationOverview = new CampaignParticipationOverview({
-            status: SHARED,
-            validatedSkillsCount: 2,
-            totalSkillsCount: 3,
-            stageCollection,
-          });
-
-          expect(campaignParticipationOverview.validatedStagesCount).to.equal(null);
-        });
-      });
-    });
-
-    context('when the participation is not shared', function () {
-      it('should return null', function () {
-        const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
-          campaignId: 3,
-          stages: [
-            {
-              threshold: 0,
-            },
-            {
-              threshold: 10,
-            },
-            {
-              threshold: 30,
-            },
-            {
-              threshold: 70,
-            },
-          ],
-        });
-        const campaignParticipationOverview = new CampaignParticipationOverview({
-          status: STARTED,
-          validatedSkillsCount: 2,
-          totalSkillsCount: 3,
-          stageCollection,
-        });
-
-        expect(campaignParticipationOverview.validatedStagesCount).to.equal(null);
-      });
-    });
-  });
-
-  describe('#totalStagesCount', function () {
-    context('the campaign has stages', function () {
-      it('should return the count of stages with a threshold over 0', function () {
-        const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
-          campaignId: 3,
-          stages: [
-            {
-              threshold: 0,
-            },
-            {
-              threshold: 3,
-            },
-            {
-              threshold: 5,
-            },
-            {
-              threshold: 8,
-            },
-            {
-              threshold: 11,
-            },
-            {
-              threshold: 14,
-            },
-          ],
-        });
-        const campaignParticipationOverview = new CampaignParticipationOverview({
-          status: SHARED,
-          stageCollection,
-        });
-
-        expect(campaignParticipationOverview.totalStagesCount).to.equal(6);
-      });
-    });
-
-    context("campaign doesn't have stages", function () {
-      it('should return 0', function () {
-        const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
-          campaignId: 3,
-          stages: [],
-        });
-        const campaignParticipationOverview = new CampaignParticipationOverview({
-          status: SHARED,
-          stageCollection,
-        });
-
-        expect(campaignParticipationOverview.totalStagesCount).to.equal(0);
       });
     });
   });

--- a/api/tests/unit/domain/services/stages/stage-and-stage-acquisition-comparison-service_test.js
+++ b/api/tests/unit/domain/services/stages/stage-and-stage-acquisition-comparison-service_test.js
@@ -1,0 +1,92 @@
+import { expect } from '../../../../test-helper.js';
+import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { compare } from '../../../../../lib/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
+import { Stage } from '../../../../../lib/domain/models/Stage.js';
+
+describe('Unit | Service | Stages acquisition', function () {
+  context('Stages are defined by thresholds', function () {
+    let availableStages;
+    let stagesAcquisitions;
+    let stagesFormatService;
+
+    before(function () {
+      availableStages = [
+        { id: 50, threshold: 30 },
+        { id: 10, threshold: null, level: null, isFirstSkill: true },
+        { id: 40, threshold: 0 },
+        { id: 1, threshold: 10 },
+        { id: 2, threshold: 20 },
+        { id: 4, threshold: 40 },
+        { id: 6, threshold: 60 },
+        { id: 5, threshold: 50 },
+      ].map(domainBuilder.buildStage);
+
+      stagesAcquisitions = [
+        { id: 3, stageId: 50 },
+        { id: 2, stageId: 2 },
+        { id: 1, stageId: 1 },
+        { id: 4, stageId: 10 },
+        { id: 5, stageId: 40 },
+      ].map(domainBuilder.buildStageAcquisition);
+
+      stagesFormatService = compare(availableStages, stagesAcquisitions);
+    });
+
+    describe('totalNumberOfStages', function () {
+      it('should return the correct number of stages', function () {
+        expect(stagesFormatService.totalNumberOfStages).to.deep.equal(availableStages.length);
+      });
+    });
+    describe('reachedStageNumber', function () {
+      it('should return the correct number of stages', function () {
+        expect(stagesFormatService.reachedStageNumber).to.deep.equal(5);
+      });
+    });
+    describe('reachedStage', function () {
+      it('should return the correct number of stages', function () {
+        expect(stagesFormatService.reachedStage).to.be.an.instanceOf(Stage);
+        expect(stagesFormatService.reachedStage.id).to.deep.equal(50);
+      });
+    });
+  });
+  context('Stages are defined by levels', function () {
+    let availableStages;
+    let stagesAcquisitions;
+    let stagesFormatService;
+
+    before(function () {
+      availableStages = [
+        { id: 4, level: 2 },
+        { id: 1, level: 5 },
+        { id: 6, level: 3 },
+        { id: 5, level: 8 },
+        { id: 2, level: 1 },
+        { id: 50, level: 0 },
+      ].map(domainBuilder.buildStage);
+
+      stagesAcquisitions = [
+        { id: 3, stageId: 4 },
+        { id: 1, stageId: 50 },
+      ].map(domainBuilder.buildStageAcquisition);
+
+      stagesFormatService = compare(availableStages, stagesAcquisitions);
+    });
+
+    describe('totalNumberOfStages', function () {
+      it('should return the correct number of stages', function () {
+        expect(stagesFormatService.totalNumberOfStages).to.deep.equal(availableStages.length);
+      });
+    });
+    describe('reachedStageNumber', function () {
+      it('should return the correct number of stages', function () {
+        expect(stagesFormatService.reachedStageNumber).to.deep.equal(2);
+      });
+    });
+    describe('reachedStage', function () {
+      it('should return the correct number of stages', function () {
+        expect(stagesFormatService.reachedStage).to.be.an.instanceOf(Stage);
+        expect(stagesFormatService.reachedStage.id).to.deep.equal(4);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/unit/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -1,15 +1,23 @@
 import { sinon } from '../../../test-helper.js';
 import { findUserCampaignParticipationOverviews } from '../../../../lib/domain/usecases/find-user-campaign-participation-overviews.js';
 describe('Unit | UseCase | find-user-campaign-participation-overviews', function () {
-  let campaignParticipationOverviewRepository;
+  let compareStagesAndAcquiredStagesService,
+    campaignParticipationOverviewRepository,
+    stageRepository,
+    stageAcquisitionRepository;
 
   beforeEach(function () {
+    compareStagesAndAcquiredStagesService = {
+      compare: sinon.stub().returns([]),
+    };
     campaignParticipationOverviewRepository = {
       findByUserIdWithFilters: sinon.stub().resolves({
         campaignParticipationOverviews: [],
         pagination: {},
       }),
     };
+    stageRepository = { getByTargetProfileIds: sinon.stub().resolves([]) };
+    stageAcquisitionRepository = { getByCampaignParticipations: sinon.stub().resolves([]) };
   });
 
   context('when states is undefined', function () {
@@ -22,7 +30,10 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
       await findUserCampaignParticipationOverviews({
         userId,
         states,
+        compareStagesAndAcquiredStagesService,
         campaignParticipationOverviewRepository,
+        stageRepository,
+        stageAcquisitionRepository,
       });
 
       // then
@@ -45,8 +56,11 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
       await findUserCampaignParticipationOverviews({
         userId,
         states,
-        campaignParticipationOverviewRepository,
         page,
+        compareStagesAndAcquiredStagesService,
+        campaignParticipationOverviewRepository,
+        stageRepository,
+        stageAcquisitionRepository,
       });
 
       // then
@@ -69,8 +83,11 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
       await findUserCampaignParticipationOverviews({
         userId,
         states,
-        campaignParticipationOverviewRepository,
         page,
+        compareStagesAndAcquiredStagesService,
+        campaignParticipationOverviewRepository,
+        stageRepository,
+        stageAcquisitionRepository,
       });
 
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -1,4 +1,4 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
 import { CampaignParticipationOverview } from '../../../../../lib/domain/read-models/CampaignParticipationOverview.js';
 import { CampaignParticipationStatuses } from '../../../../../lib/domain/models/CampaignParticipationStatuses.js';
@@ -10,20 +10,6 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
     let campaignParticipationOverview, expectedSerializedCampaignParticipationOverview;
 
     beforeEach(function () {
-      const stageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({
-        campaignId: 3,
-        stages: [
-          {
-            threshold: 0,
-          },
-          {
-            threshold: 30,
-          },
-          {
-            threshold: 70,
-          },
-        ],
-      });
       campaignParticipationOverview = new CampaignParticipationOverview({
         id: 5,
         sharedAt: new Date('2018-02-06T14:12:44Z'),
@@ -33,9 +19,11 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
         campaignCode: '1234',
         campaignTitle: 'My campaign',
         campaignArchivedAt: new Date('2021-01-01'),
-        stageCollection,
         masteryRate: 0.5,
+        totalStagesCount: 3,
+        validatedStagesCount: 2,
       });
+
       expectedSerializedCampaignParticipationOverview = {
         data: {
           type: 'campaign-participation-overviews',
@@ -69,7 +57,6 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
   describe('#serializeForPaginatedList', function () {
     it('should call serialize method by destructuring passed parameter', function () {
       // given
-      const emptyStageCollection = domainBuilder.buildStageCollectionForUserCampaignResults({ stages: [] });
       const campaignParticipationOverviews = [
         new CampaignParticipationOverview({
           id: 6,
@@ -81,8 +68,10 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           campaignTitle: 'My campaign 1',
           campaignArchivedAt: null,
           masteryRate: null,
-          stageCollection: emptyStageCollection,
+          totalStagesCount: 0,
+          validatedStagesCount: null,
         }),
+
         new CampaignParticipationOverview({
           id: 7,
           status: STARTED,
@@ -93,7 +82,8 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           campaignTitle: 'My campaign 2',
           campaignArchivedAt: null,
           masteryRate: null,
-          stageCollection: emptyStageCollection,
+          totalStagesCount: 0,
+          validatedStagesCount: null,
         }),
       ];
       const pagination = {


### PR DESCRIPTION
## :unicorn: Problème
Les données relatives aux paliers acquis ont été persistées mais ne sont toujours pas utilisées pour l'affichage de l'aperçu des campagnes en cours.

## :robot: Proposition
Cette PR a pour objet de récupérer les informations en base pour fournir les informations relatives à l'aperçu des campagnes en cours.

## :100: Pour tester
**Dans Admin**: créez un profil cible public avec paliers
**Dans Orga**: créez une campagne liée à ce profil cible
**Dans Pix app**: passez la campagne mais n'envoyez pas les résultats. Vérifiez que l'aperçu de la campagne est bien présent dans la page "Mes parcours" avec les paliers obtenus.