### PR TITLE
[FEATURE]  Suggérer d'aller sur l'onglet Élèves au lieu de créer une campagne de collecte de profil sur la page de création de campagne (PIX-8875)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -261,7 +261,6 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
       describe('#participantCount', function () {
         it('should only count learners in currentOrganization', async function () {
           // given
-          expectedPrescriber.userOrgaSettings = userOrgaSettings;
           databaseBuilder.factory.buildOrganizationLearner({
             organizationId: organization.id,
           });
@@ -278,7 +277,6 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
         it('should not count anonymous users', async function () {
           // given
           const userId = databaseBuilder.factory.buildUser({ isAnonymous: true }).id;
-          expectedPrescriber.userOrgaSettings = userOrgaSettings;
           databaseBuilder.factory.buildOrganizationLearner({
             userId,
             organizationId: organization.id,
@@ -294,7 +292,6 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
 
         it('should not count disabled organization learners', async function () {
           // given
-          expectedPrescriber.userOrgaSettings = userOrgaSettings;
           databaseBuilder.factory.buildOrganizationLearner({
             organizationId: organization.id,
             isDisabled: true,
@@ -310,7 +307,6 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
 
         it('should count all organization learners when several exists', async function () {
           // given
-          expectedPrescriber.userOrgaSettings = userOrgaSettings;
           databaseBuilder.factory.buildOrganizationLearner({
             organizationId: organization.id,
           });

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -14,7 +14,7 @@
       class="input"
       maxlength="255"
       {{on "change" (fn this.onChangeCampaignValue "name")}}
-      @value={{this.campaign.name}}
+      @value={{@campaign.name}}
       required={{true}}
       aria-required={{true}}
     />
@@ -32,7 +32,7 @@
         class="pix-select-owner"
         @options={{this.campaignOwnerOptions}}
         @onChange={{this.onChangeCampaignOwner}}
-        @value="{{this.campaign.ownerId}}"
+        @value="{{@campaign.ownerId}}"
         @isSearchable={{true}}
         @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
         @searchLabel={{t "pages.campaign-creation.owner.search-placeholder"}}
@@ -116,12 +116,12 @@
         <PixFilterableAndSearchableSelect
           @label={{t "pages.campaign-creation.target-profiles-list-label"}}
           @placeholder={{t "pages.campaign-creation.target-profiles-label"}}
-          @options={{this.targetProfilesOptions}}
+          @options={{this.targetOwnerOptions}}
           @hideDefaultOption={{true}}
           @onChange={{this.selectTargetProfile}}
           @categoriesLabel={{t "pages.campaign-creation.target-profiles-category-label"}}
           @categoriesPlaceholder={{t "pages.campaign-creation.target-profiles-category-placeholder"}}
-          @value={{this.campaign.targetProfile.id}}
+          @value={{@campaign.targetProfile.id}}
           @requiredText={{t "common.form.mandatory-fields-title"}}
           @errorMessage={{if @errors.targetProfile (t "api-error-messages.campaign-creation.target-profile-required")}}
           @isSearchable={{true}}
@@ -129,18 +129,18 @@
         />
       </:default>
       <:information>
-        {{#if this.campaign.targetProfile}}
+        {{#if @campaign.targetProfile}}
           <Ui::ExplanationCard id="target-profile-info">
-            <:title>{{this.campaign.targetProfile.name}}</:title>
+            <:title>{{@campaign.targetProfile.name}}</:title>
 
             <:message>
               <Campaign::TargetProfileDetails
                 class="form__field-info-message"
-                @targetProfileDescription={{this.campaign.targetProfile.description}}
-                @hasStages={{this.campaign.targetProfile.hasStage}}
-                @hasBadges={{gt this.campaign.targetProfile.thematicResultCount 0}}
-                @targetProfileTubesCount={{this.campaign.targetProfile.tubeCount}}
-                @targetProfileThematicResultCount={{this.campaign.targetProfile.thematicResultCount}}
+                @targetProfileDescription={{@campaign.targetProfile.description}}
+                @hasStages={{@campaign.targetProfile.hasStage}}
+                @hasBadges={{gt @campaign.targetProfile.thematicResultCount 0}}
+                @targetProfileTubesCount={{@campaign.targetProfile.tubeCount}}
+                @targetProfileThematicResultCount={{@campaign.targetProfile.thematicResultCount}}
               />
             </:message>
           </Ui::ExplanationCard>
@@ -160,7 +160,7 @@
               @value="false"
               {{on "change" (fn this.selectMultipleSendingsStatus false)}}
               aria-describedby="multiple-sendings-info"
-              checked={{not this.campaign.multipleSendings}}
+              checked={{not @campaign.multipleSendings}}
             >
               {{t "pages.campaign-creation.no"}}
             </PixRadioButton>
@@ -170,7 +170,7 @@
               @value="true"
               {{on "change" (fn this.selectMultipleSendingsStatus true)}}
               aria-describedby="multiple-sendings-info"
-              checked={{this.campaign.multipleSendings}}
+              checked={{@campaign.multipleSendings}}
             >
               {{t "pages.campaign-creation.yes"}}
             </PixRadioButton>
@@ -183,7 +183,7 @@
 
           <:message>
             {{t this.multipleSendingWording.info}}
-            {{#if this.campaign.targetProfile.areKnowledgeElementsResettable}}
+            {{#if @campaign.targetProfile.areKnowledgeElementsResettable}}
               {{t "pages.campaign-creation.multiple-sendings.knowledge-elements-resettable"}}
             {{/if}}
           </:message>
@@ -226,7 +226,7 @@
         maxlength="255"
         @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
         {{on "change" (fn this.onChangeCampaignValue "idPixLabel")}}
-        @value={{this.campaign.idPixLabel}}
+        @value={{@campaign.idPixLabel}}
       />
       {{#if @errors.idPixLabel}}
         <div class="form__error error-message">
@@ -244,7 +244,7 @@
         @name="campaign-title"
         maxlength="50"
         {{on "change" (fn this.onChangeCampaignValue "title")}}
-        @value={{this.campaign.title}}
+        @value={{@campaign.title}}
       />
     </Ui::FormField>
   {{/if}}
@@ -254,7 +254,7 @@
       @label={{t "pages.campaign-creation.landing-page-text.label"}}
       @id="custom-landing-page-text"
       @maxlength="5000"
-      @value={{this.campaign.customLandingPageText}}
+      @value={{@campaign.customLandingPageText}}
       {{on "change" this.onChangeCampaignCustomLandingPageText}}
       rows="8"
     />

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -95,7 +95,16 @@
         <Ui::ExplanationCard id="campaign-goal-profiles-collection-info">
           <:title>{{t "pages.campaign-creation.purpose.profiles-collection"}}</:title>
 
-          <:message>{{t "pages.campaign-creation.purpose.profiles-collection-info"}}</:message>
+          <:message>
+            {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
+            {{#if this.isComputeLearnerCertificabilityEnabled}}
+              {{t
+                "pages.campaign-creation.purpose.profiles-collection-info-certificability-calculation"
+                linkClasses="link link--banner link--bold link--underlined"
+                htmlSafe=true
+              }}
+            {{/if}}
+          </:message>
         </Ui::ExplanationCard>
       {{/if}}
     </:information>

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -8,20 +8,18 @@ export default class CreateForm extends Component {
   @service currentUser;
   @service intl;
 
-  @tracked campaign;
-  @tracked wantIdPix = Boolean(this.campaign.idPixLabel);
-  @tracked targetProfilesOptions = [];
+  @tracked wantIdPix = Boolean(this.args.campaign.idPixLabel);
 
-  constructor() {
-    super(...arguments);
-    this.campaign = this.args.campaign;
-    this._setTargetProfilesOptions(this.args.targetProfiles);
-    this.isMultipleSendingAssessmentEnabled = this.currentUser.prescriber.enableMultipleSendingAssessment;
-    this.isComputeLearnerCertificabilityEnabled = this.currentUser.prescriber.computeOrganizationLearnerCertificability;
+  get isMultipleSendingAssessmentEnabled() {
+    return this.currentUser.prescriber.enableMultipleSendingAssessment;
   }
 
-  _setTargetProfilesOptions(targetProfiles) {
-    const options = targetProfiles.map((targetProfile) => {
+  get isComputeLearnerCertificabilityEnabled() {
+    return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
+  }
+
+  get targetOwnerOptions() {
+    const options = this.args.targetProfiles.map((targetProfile) => {
       return {
         value: targetProfile.id,
         label: targetProfile.name,
@@ -29,7 +27,7 @@ export default class CreateForm extends Component {
         order: 'OTHER' === targetProfile.category ? 1 : 0,
       };
     });
-    this.targetProfilesOptions = _orderBy(options, ['order', 'category', 'label']);
+    return _orderBy(options, ['order', 'category', 'label']);
   }
 
   get campaignOwnerOptions() {
@@ -59,15 +57,15 @@ export default class CreateForm extends Component {
   }
 
   get isCampaignGoalAssessment() {
-    return this.campaign.type === 'ASSESSMENT';
+    return this.args.campaign.type === 'ASSESSMENT';
   }
 
   get isCampaignGoalProfileCollection() {
-    return this.campaign.type === 'PROFILES_COLLECTION';
+    return this.args.campaign.type === 'PROFILES_COLLECTION';
   }
 
   get isExternalIdNotSelectedChecked() {
-    return this.campaign.idPixLabel === null;
+    return this.args.campaign.idPixLabel === null;
   }
 
   get isExternalIdSelectedChecked() {
@@ -77,46 +75,46 @@ export default class CreateForm extends Component {
   @action
   askLabelIdPix() {
     this.wantIdPix = true;
-    this.campaign.idPixLabel = '';
+    this.args.campaign.idPixLabel = '';
   }
 
   @action
   doNotAskLabelIdPix() {
     this.wantIdPix = false;
-    this.campaign.idPixLabel = null;
+    this.args.campaign.idPixLabel = null;
   }
 
   @action
   selectTargetProfile(targetProfileId) {
-    this.campaign.targetProfile = this.args.targetProfiles.find(
+    this.args.campaign.targetProfile = this.args.targetProfiles.find(
       (targetProfile) => targetProfile.id === targetProfileId,
     );
   }
 
   @action
   selectMultipleSendingsStatus(value) {
-    this.campaign.multipleSendings = value;
+    this.args.campaign.multipleSendings = value;
   }
 
   @action
   setCampaignGoal(event) {
     if (event.target.value === 'collect-participants-profile') {
-      this.campaign.setType('PROFILES_COLLECTION');
+      this.args.campaign.setType('PROFILES_COLLECTION');
     } else {
-      this.campaign.setType('ASSESSMENT');
+      this.args.campaign.setType('ASSESSMENT');
     }
   }
 
   @action
   onChangeCampaignValue(key, event) {
-    this.campaign[key] = event.target.value;
+    this.args.campaign[key] = event.target.value;
   }
 
   @action
   onChangeCampaignOwner(newOwnerId) {
     const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
     if (selectedMember) {
-      this.campaign.ownerId = selectedMember.id;
+      this.args.campaign.ownerId = selectedMember.id;
     }
   }
 
@@ -128,6 +126,6 @@ export default class CreateForm extends Component {
   @action
   onSubmit(event) {
     event.preventDefault();
-    this.args.onSubmit(this.campaign);
+    this.args.onSubmit(this.args.campaign);
   }
 }

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -17,6 +17,7 @@ export default class CreateForm extends Component {
     this.campaign = this.args.campaign;
     this._setTargetProfilesOptions(this.args.targetProfiles);
     this.isMultipleSendingAssessmentEnabled = this.currentUser.prescriber.enableMultipleSendingAssessment;
+    this.isComputeLearnerCertificabilityEnabled = this.currentUser.prescriber.computeOrganizationLearnerCertificability;
   }
 
   _setTargetProfilesOptions(targetProfiles) {

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -94,9 +94,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
     );
-
     // then
-    assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.owner.info'))).exists();
+    assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.owner.info'), { exact: true })).exists();
     assert.dom(screen.getAllByText(this.intl.t('pages.campaign-creation.owner.title'))[0]).exists();
   });
 
@@ -133,14 +132,19 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     // then
-    assert.dom(screen.getByText(this.intl.t('common.form.mandatory-fields'))).exists();
+    assert
+      .dom(
+        screen.getByText(this.intl.t('common.form.mandatory-fields'), {
+          exact: false,
+        }),
+      )
+      .exists();
   });
 
   module('when campaign is of type ASSESSMENT', function () {
     test('it should have checked ASSESSMENT', async function (assert) {
       // given
       this.campaign.type = 'ASSESSMENT';
-
       // when
       const screen = await render(
         hbs`<Campaign::CreateForm

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -1003,6 +1003,44 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.ok(true);
   });
 
+  test('it should not display the explanation of automatic compute certificability if the feature is not activated', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @targetProfiles={{this.targetProfiles}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+    );
+    await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
+
+    // then
+    assert.dom(screen.queryByRole('link', { name: 'Élèves' })).doesNotExist();
+  });
+
+  test('it should display the explanation of automatic compute certificability if the feature is activated', async function (assert) {
+    // when
+    prescriber.set('computeOrganizationLearnerCertificability', true);
+
+    const screen = await render(
+      hbs`<Campaign::CreateForm
+  @campaign={{this.campaign}}
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @targetProfiles={{this.targetProfiles}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`,
+    );
+    await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Élèves' })).exists();
+  });
+
   module('when there are errors', function () {
     test('it should display errors messages when the name, the campaign purpose and the external user id fields are empty', async function (assert) {
       // given

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -28,7 +28,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       await component.onChangeCampaignOwner(newOwnerId);
 
       //then
-      assert.deepEqual(component.campaign.ownerId, 7);
+      assert.deepEqual(component.args.campaign.ownerId, 7);
     });
   });
 
@@ -49,7 +49,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       await component.selectMultipleSendingsStatus(true);
 
       //then
-      assert.true(component.campaign.multipleSendings);
+      assert.true(component.args.campaign.multipleSendings);
     });
 
     test('set to false', async function (assert) {
@@ -68,7 +68,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       await component.selectMultipleSendingsStatus(false);
 
       //then
-      assert.false(component.campaign.multipleSendings);
+      assert.false(component.args.campaign.multipleSendings);
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -393,7 +393,8 @@
         "assessment-info": "An assessment campaign tests participants on specific topics.",
         "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
-        "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score."
+        "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score.",
+        "profiles-collection-info-certificability-calculation": "The “Eligible for certification” status is updated automatically in the '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Students'</a>' tab."
       },
       "tags": {
         "COMPETENCES": "Pix Competences",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -396,7 +396,8 @@
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
         "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
-        "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
+        "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix.",
+        "profiles-collection-info-certificability-calculation": "Le statut Certifiable est mis à jour automatiquement dans l’onglet '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Élèves'</a>'."
       },
       "tags": {
         "COMPETENCES": "Les 16 compétences",


### PR DESCRIPTION
## :unicorn: Problème
Il est actuellement nécessaire de réaliser une campagne de collecte de profil pour connaître le statut “Certifiable” des prescrits.

Cela pose en particulier problème au SCO (ismanagingStudent / ceux qui ont l’import uniquement) car les élèves ne répondent pas toujours aux campagnes. 

Cependant, ce problème ne sera plus rencontré après la mise en place de la nouvelle certification, la réponse à ce besoin est donc provisoire.
## :robot: Proposition
Mettre en place la remontée automatique et quotidienne du statut de certificabilité.

Dans ce ticket, **réorienter le prescripteur vers l’onglet élèves** si celui essaie de créer une campagne de collecte de profil avec pour seule intention de connaître le statut Certificabilité de ses élèves.

Pour cela, il faut compléter la bulle d’information qui s’affiche lors de la sélection de l’option “Collecte de profil” dans la page de création de campagne.


## :rainbow: Remarques
Texte à ajouter : 

En français : “Le statut Certifiable est mis à jour automatiquement dans l’onglet Élèves.” (Le mot Certifiable étant le label que l’on retrouve dans l’onglet Élèves (voir la maquette)

En anglais : “The “Eligible for certification” status is updated automatically in the Students tab.

## :100: Pour tester
- Se connecter à Pix Orga en tant que SCO Users (ismanagingStudent / ceux qui ont l’import uniquement)
- Vérifier l'info-bulle sur la page de création de campagne
- Se déconnecter et se reconnecter avec une autre typologie d'Orga
- Vérifier que l'info-bulle ne contienne pas le texte ci-dessus
- 🎉 