### PR TITLE
[TECH] Corriger un test flacky sur organization learner repository (PIX-9150)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2252,7 +2252,10 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       });
 
       // then
-      expect(result).to.deep.equal([organizationLearnerRecentlyConnecterId, organizationLearnerNotRecentlyConnectedId]);
+      expect(result).to.deep.include.members([
+        organizationLearnerNotRecentlyConnectedId,
+        organizationLearnerRecentlyConnecterId,
+      ]);
     });
 
     it('should not return a disabled organization learner id for organizations that cannot compute certificability', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Un test flacky à été découvert sur la méthode findByOrganizationsWhichNeedToComputeCertificability. On vérifiait la présence d'ID, sans faire attention à ce que l'ordre puisse être différent. L'ordre ici n'est pas important, seul la présence des IDS l'est.

## :robot: Proposition
Vérifier uniquement la présence des IDS sans prendre en compte l'ordre de ceux ci.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Vérifier que les tests passent
- 🐱 
