### PR TITLE
[TECH] Appeler la route /identity-providers sur Pix Admin uniquement quand nécessaire (PIX-9152).

### DIFF
--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -8,15 +8,12 @@ export default class ApplicationRoute extends Route {
   @service intl;
   @service currentUser;
   @service featureToggles;
-  @service oidcIdentityProviders;
 
   async beforeModel() {
     await this.session.setup();
     this.intl.setLocale([defaultLocale]);
 
     await this.featureToggles.load();
-
-    await this.oidcIdentityProviders.load().catch();
 
     return this._loadCurrentUser();
   }

--- a/admin/app/routes/authenticated.js
+++ b/admin/app/routes/authenticated.js
@@ -3,8 +3,13 @@ import { service } from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
   @service session;
+  @service oidcIdentityProviders;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  async model() {
+    await this.oidcIdentityProviders.loadAllAvailableIdentityProviders();
   }
 }

--- a/admin/app/services/oidc-identity-providers.js
+++ b/admin/app/services/oidc-identity-providers.js
@@ -7,7 +7,7 @@ export default class OidcIdentityProviders extends Service {
     return this.store.peekAll('oidc-identity-provider').toArray();
   }
 
-  async load() {
+  async loadAllAvailableIdentityProviders() {
     const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider');
     oidcIdentityProviders.map((oidcIdentityProvider) => (this[oidcIdentityProvider.id] = oidcIdentityProvider));
   }

--- a/admin/tests/unit/routes/authenticated_test.js
+++ b/admin/tests/unit/routes/authenticated_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | authenticated', function (hooks) {
   setupTest(hooks);
@@ -7,5 +8,21 @@ module('Unit | Route | authenticated', function (hooks) {
   test('it exists', function (assert) {
     const route = this.owner.lookup('route:authenticated');
     assert.ok(route);
+  });
+
+  module('model', function () {
+    test('loads all available identity providers', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated');
+
+      sinon.stub(route.oidcIdentityProviders, 'loadAllAvailableIdentityProviders');
+      route.oidcIdentityProviders.loadAllAvailableIdentityProviders.resolves();
+
+      // when
+      await route.model();
+
+      // then
+      assert.ok(route.oidcIdentityProviders.loadAllAvailableIdentityProviders.called);
+    });
   });
 });

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         auth: false,
         handler: oidcController.getAllIdentityProvidersForAdmin,
         notes: [
-          'Cette route renvoie un objet contenant les informations requises par le front pour les partenaires oidc',
+          "Cette route renvoie un objet contenant tous les fournisseurs d'identité OIDC (même désactivés) pour leur gestion dans Pix Admin",
         ],
         tags: ['api', 'oidc'],
       },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, lorsqu'on est sur la page de connexion, on peut voir que la route `api/admin/oidc/identity-providers` est appelé. Or ce qu'elle retourne n'est nécessaire que pour deux besoins uniquement lorsque l'utilisateur est authentifié : 
- Afficher les partenaires oidc dans la page de détails d'un utilisateur
- Afficher les partenaires lors d'une création ou d'un update d'une organisation

## :robot: Proposition
Appeler la route uniquement lorsque l'utilisateur est authentifié .

## :rainbow: Remarques
Cette PR provient d'un besoin pour le SSO Admin. Sur la page de connexion, on souhaiterait contacter `api/oidc/identity-providers` pour avoir accès uniquement aux partenaires oidc que l'on a enabled (ce qui se passe sur pix-app)

## :100: Pour tester
Tester la non régression des fonctionnalités existantes : 
- Se connecter sur Pix Admin avec superadmin
- Dans le menu, aller sur Utilisateurs et choisir un utilisateur au hasard 
- Dans l'onglet Détails, s'assurer que les partenaires oidc s'affichent toujours
- Dans le menu, aller sur organisation et choisir une orga
- Lors d'une édition, dans le champ sso, cliquer et s'assurer que les partenaires oidc s'affichent
- Lors de la création d'une orga (retourner dans la liste des orgas, bouton en haut à droite) s'assurer qu'ils s'affichent
