### PR TITLE
[BUGFIX] Fixer une largeur pour les badges des RT certifiants (PIX-9151).

### DIFF
--- a/api/db/seeds/data/team-evaluation/users/eval-campaign-with-badges.js
+++ b/api/db/seeds/data/team-evaluation/users/eval-campaign-with-badges.js
@@ -116,7 +116,7 @@ export default async function initUser(teamOffset, databaseBuilder) {
     // Acquired + Certifiables
     {
       altMessage: '1 RT certifiable, acquis et valide',
-      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+      imageUrl: 'https://images.pix.fr/badges/Badge_Pixome%CC%80tre-plane%CC%80te.svg',
       message: '1 RT certifiable, acquis et valide',
       title: '1 RT certifiable, acquis et valide',
       isCertifiable: true,

--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -40,6 +40,8 @@
   }
 
   &__image {
+    width: 130px;
+
     &--not-acquired {
       filter: grayscale(1);
     }


### PR DESCRIPTION
## :unicorn: Problème

Si le SVG du badge n'a pas d'attributs de taille prédéfinis (width / height), l'image ne s'affiche pas bien dans la page des résultats de campagne.

## :robot: Proposition

Définir une largeur fixe pour ces images (130px).

## :rainbow: Remarques

Il est aussi nécessaire que les fichiers SVG soient bien nommés.
Dans le cas précisé dans le ticket, le fichier comporte des accents, ce qui pose des problèmes de lecture dans les différents navigateurs (Chrome / FF).

## :100: Pour tester

- Aller sur PixApp
- Se connecter avec l'utilisateur `eval-campaign-with-badges@example.net`
- Visiter la page [`/campagnes/EVALBADGE/evaluation/resultats`](https://app-pr7064.review.pix.fr/campagnes/EVALBADGE/evaluation/resultats)
- Constater que le badge "_1 RT certifiable, acquis et valide_" s'affiche bien
