### PR TITLE
[FEATURE] Envoyer un email aux organisations avec une campagne basée sur l’ancien PC (PIX-8932)

### DIFF
--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -11,31 +11,26 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
     return `${this.host}/${this.namespace}/complementary-certifications/${id}/badges`;
   }
 
-  async updateRecord(_, type, complementaryCertification) {
-    if (complementaryCertification.adapterOptions?.attachBadges) {
-      const payload = this.serialize(complementaryCertification);
+  async updateRecord(_, type, snapshot) {
+    if (snapshot.adapterOptions?.attachBadges) {
+      const payload = this.serialize(snapshot);
       delete payload.data.attributes['key'];
       delete payload.data.attributes['label'];
       delete payload.data.attributes['has-external-jury'];
       delete payload.data.attributes['target-profiles-history'];
 
-      const { targetProfileId, notifyOrganizations } = complementaryCertification.adapterOptions;
+      const { targetProfileId, notifyOrganizations } = snapshot.adapterOptions;
       payload.data.attributes['target-profile-id'] = targetProfileId;
       payload.data.attributes['notify-organizations'] = notifyOrganizations;
 
-      const complementaryCertificationBadges =
-        complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];
+      const complementaryCertificationBadges = snapshot.hasMany('complementaryCertificationBadges') ?? [];
       payload.data.attributes['complementary-certification-badges'] = complementaryCertificationBadges.map(
         (complementaryCertificationBadge) => {
           return this.serialize(complementaryCertificationBadge, { includeId: true });
         },
       );
 
-      return this.ajax(
-        this.urlForUpdateRecord(complementaryCertification.id, type.modelName, complementaryCertification),
-        'PUT',
-        { data: payload },
-      );
+      return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PUT', { data: payload });
     }
 
     return super.updateRecord(...arguments);

--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -11,7 +11,7 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
     return `${this.host}/${this.namespace}/complementary-certifications/${id}/badges`;
   }
 
-  async updateRecord(store, type, complementaryCertification) {
+  async updateRecord(_, type, complementaryCertification) {
     if (complementaryCertification.adapterOptions?.attachBadges) {
       const payload = this.serialize(complementaryCertification);
       delete payload.data.attributes['key'];
@@ -19,8 +19,9 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
       delete payload.data.attributes['has-external-jury'];
       delete payload.data.attributes['target-profiles-history'];
 
-      const { targetProfileId } = complementaryCertification.adapterOptions;
+      const { targetProfileId, notifyOrganizations } = complementaryCertification.adapterOptions;
       payload.data.attributes['target-profile-id'] = targetProfileId;
+      payload.data.attributes['notify-organizations'] = notifyOrganizations;
 
       const complementaryCertificationBadges =
         complementaryCertification.hasMany('complementaryCertificationBadges') ?? [];

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -11,6 +11,8 @@ export default class AttachTargetProfileController extends Controller {
   @tracked isSubmitDisabled = true;
   @tracked isSubmitting = false;
   @tracked selectedTargetProfile;
+
+  #notifyOrganizations = true;
   #targetProfileBadges = new Map();
 
   get hasExternalJury() {
@@ -37,6 +39,7 @@ export default class AttachTargetProfileController extends Controller {
   onReset() {
     this.selectedTargetProfile = undefined;
     this.#targetProfileBadges = new Map();
+    this.#notifyOrganizations = true;
     this.isSubmitDisabled = true;
     this.isSubmitting = false;
   }
@@ -44,6 +47,11 @@ export default class AttachTargetProfileController extends Controller {
   @action
   onBadgeUpdated({ update: { badgeId, fieldName, fieldValue } }) {
     this.#updateBadge({ badgeId, fieldName, fieldValue });
+  }
+
+  @action
+  onNotificationUpdated({ target }) {
+    this.#notifyOrganizations = target.checked;
   }
 
   @action
@@ -82,6 +90,7 @@ export default class AttachTargetProfileController extends Controller {
         adapterOptions: {
           attachBadges: true,
           targetProfileId: this.model.currentTargetProfile.id,
+          notifyOrganizations: this.#notifyOrganizations,
         },
       });
 

--- a/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
@@ -14,6 +14,16 @@
     margin-bottom: $pix-spacing-l;
   }
 
+  &__checkbox {
+    display: flex;
+
+    .pix-tooltip__trigger-element{
+      margin: 0 8px;
+    }
+
+
+  }
+
   &__card-badges {
     .card__content {
       position: relative;

--- a/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
+++ b/admin/app/styles/components/complementary-certifications/attach-target-profile.scss
@@ -14,14 +14,16 @@
     margin-bottom: $pix-spacing-l;
   }
 
-  &__checkbox {
+  &__notification {
     display: flex;
+
+    &__checkbox {
+      margin-right: 8px;
+    }
 
     .pix-tooltip__trigger-element{
       margin: 0 8px;
     }
-
-
   }
 
   &__card-badges {

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -27,9 +27,9 @@
         />
       </Card>
 
-      <div class="badge-edit-form__field attach-target-profile__checkbox">
+      <div class="badge-edit-form__field attach-target-profile__notification">
         <Input
-          class="badge-edit-form__control"
+          class="badge-edit-form__control attach-target-profile__notification__checkbox"
           @type="checkbox"
           @checked="false"
           {{on "change" this.onNotificationUpdated}}

--- a/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/complementary-certification/attach-target-profile.hbs
@@ -26,6 +26,25 @@
           @hasExternalJury={{this.hasExternalJury}}
         />
       </Card>
+
+      <div class="badge-edit-form__field attach-target-profile__checkbox">
+        <Input
+          class="badge-edit-form__control"
+          @type="checkbox"
+          @checked="false"
+          {{on "change" this.onNotificationUpdated}}
+          id="notification-checkbox"
+        />
+        <label for="notification-checkbox">Notifier les organisations avec une campagne basée sur l’ancien PC</label>
+        <PixTooltip @position="top-left" @isLight={{true}} @isWide={{true}}>
+          <:triggerElement>
+            <FaIcon @icon="circle-question" tabindex="0" />
+          </:triggerElement>
+          <:tooltip>
+            Un email sera envoyé à chaque membre de l'organisation
+          </:tooltip>
+        </PixTooltip>
+      </div>
     {{/if}}
 
     <div class="attach-target-profile__actions">

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -196,9 +196,14 @@ module(
             screen.getByRole('textbox', { name: '200 Badge Arène Feu Message temporaire certificat' }),
             'TEMP MESSAGE',
           );
+          await click(
+            screen.getByRole('checkbox', {
+              name: 'Notifier les organisations avec une campagne basée sur l’ancien PC',
+            }),
+          );
+
           // when
           await clickByName('Rattacher le profil cible');
-
           // then
           assert
             .dom(

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -453,6 +453,18 @@ function sendNotificationToCertificationCenterRefererForCleaResults({ email, ses
   return mailer.sendEmail(options);
 }
 
+function sendNotificationToOrganizationMembersForTargetProfileDetached({ email, complementaryCertificationName }) {
+  const options = {
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME_FR,
+    to: email,
+    template: mailer.targetProfileNotCertifiableTemplateId,
+    variables: { complementaryCertificationName },
+  };
+
+  return mailer.sendEmail(options);
+}
+
 const mailService = {
   sendAccountCreationEmail,
   sendAccountRecoveryEmail,
@@ -464,6 +476,7 @@ const mailService = {
   sendVerificationCodeEmail,
   sendCpfEmail,
   sendNotificationToCertificationCenterRefererForCleaResults,
+  sendNotificationToOrganizationMembersForTargetProfileDetached,
 };
 export {
   sendAccountCreationEmail,
@@ -476,5 +489,6 @@ export {
   sendVerificationCodeEmail,
   sendCpfEmail,
   sendNotificationToCertificationCenterRefererForCleaResults,
+  sendNotificationToOrganizationMembersForTargetProfileDetached,
   mailService,
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -236,6 +236,14 @@ PGBOSS_CONNECTION_POOL_MAX_SIZE=
 # default: none
 # BREVO_CLEA_ACQUIRED_RESULT_TEMPLATE_ID=
 
+# ID of the template used to notify the organization members when their campaign's target profile unlinked from a complementary certificartion
+#
+# presence: required only if emailing is enabled and provider is Brevo
+# type: Number
+# default: none
+# BREVO_TARGET_PROFILE_NOT_CERTIFIABLE_TEMPLATE_ID=
+
+
 # String for links in emails redirect to a specific domain when user comes from french domain
 #
 # presence: optional

--- a/api/src/certification/complementary-certification/application/attach-target-profile-controller.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-controller.js
@@ -6,13 +6,23 @@ const attachTargetProfile = async function (request, h, dependencies = { complem
   const { complementaryCertificationId } = request.params;
   const { targetProfileId, notifyOrganizations, complementaryCertificationBadges } =
     await dependencies.complementaryCertificationBadgeSerializer.deserialize(request.payload);
+  const complementaryCertification = await usecases.getComplementaryCertificationForTargetProfileAttachmentRepository({
+    complementaryCertificationId,
+  });
+
   await usecases.attachBadges({
     userId,
-    complementaryCertificationId,
+    complementaryCertification,
     targetProfileIdToDetach: targetProfileId,
-    notifyOrganizations,
     complementaryCertificationBadgesToAttachDTO: complementaryCertificationBadges,
   });
+
+  if (notifyOrganizations) {
+    usecases.sendTargetProfileNotifications({
+      targetProfileIdToDetach: targetProfileId,
+      complementaryCertification,
+    });
+  }
 
   return h.response().code(204);
 };

--- a/api/src/certification/complementary-certification/application/attach-target-profile-controller.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-controller.js
@@ -4,12 +4,13 @@ import { usecases } from '../../shared/domain/usecases/index.js';
 const attachTargetProfile = async function (request, h, dependencies = { complementaryCertificationBadgeSerializer }) {
   const { userId } = request.auth.credentials;
   const { complementaryCertificationId } = request.params;
-  const { targetProfileId, complementaryCertificationBadges } =
+  const { targetProfileId, notifyOrganizations, complementaryCertificationBadges } =
     await dependencies.complementaryCertificationBadgeSerializer.deserialize(request.payload);
   await usecases.attachBadges({
     userId,
     complementaryCertificationId,
     targetProfileIdToDetach: targetProfileId,
+    notifyOrganizations,
     complementaryCertificationBadgesToAttachDTO: complementaryCertificationBadges,
   });
 

--- a/api/src/certification/complementary-certification/application/attach-target-profile-route.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-route.js
@@ -33,7 +33,8 @@ const register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                'target-profile-id': identifiersType.targetProfileId,
+                'target-profile-id': identifiersType.targetProfileId.required(),
+                'notify-organizations': Joi.boolean().required(),
                 'complementary-certification-badges': Joi.array()
                   .items(
                     Joi.object({

--- a/api/src/certification/complementary-certification/domain/usecases/attach-badges.js
+++ b/api/src/certification/complementary-certification/domain/usecases/attach-badges.js
@@ -108,7 +108,7 @@ async function sendNotification({
       { concurrency: CONCURRENCY_HEAVY_OPERATIONS },
     );
     logger.info(
-      `${emails.length} emails sent to notify organisation users of ${complementaryCertificationName}'s target profile change`,
+      `${emails.length} email(s) sent to notify organisation users of ${complementaryCertificationName}'s target profile change`,
     );
   }
 }

--- a/api/src/certification/complementary-certification/domain/usecases/get-complementary-certification-for-target-profile-attachment.js
+++ b/api/src/certification/complementary-certification/domain/usecases/get-complementary-certification-for-target-profile-attachment.js
@@ -1,0 +1,10 @@
+const getComplementaryCertificationForTargetProfileAttachmentRepository = async function ({
+  complementaryCertificationId,
+  complementaryCertificationForTargetProfileAttachmentRepository,
+}) {
+  return complementaryCertificationForTargetProfileAttachmentRepository.getById({
+    complementaryCertificationId,
+  });
+};
+
+export { getComplementaryCertificationForTargetProfileAttachmentRepository };

--- a/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
+++ b/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
@@ -1,0 +1,45 @@
+import bluebird from 'bluebird';
+import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
+import { logger } from '../../../../../lib/infrastructure/logger.js';
+const EVENT_NAME = 'attach-target-profile-certif';
+
+export { sendTargetProfileNotifications };
+
+async function sendTargetProfileNotifications({
+  targetProfileIdToDetach,
+  complementaryCertification,
+  organizationRepository,
+  mailService,
+}) {
+  const complementaryCertificationName = complementaryCertification.label;
+  const emails =
+    await organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId(targetProfileIdToDetach);
+
+  if (emails.length) {
+    let sucessCounter = 0;
+    await bluebird.map(
+      emails,
+      async (email) => {
+        const result = await mailService.sendNotificationToOrganizationMembersForTargetProfileDetached({
+          complementaryCertificationName,
+          email,
+        });
+        if (result.hasFailed()) {
+          logger.error({
+            event: EVENT_NAME,
+            message: `Failed to send email to notify organisation user "${email}" of ${complementaryCertificationName}'s target profile change`,
+          });
+
+          return;
+        }
+        sucessCounter++;
+      },
+      { concurrency: CONCURRENCY_HEAVY_OPERATIONS },
+    );
+
+    logger.info({
+      event: EVENT_NAME,
+      message: `${sucessCounter} email(s) sent to notify organisation users of ${complementaryCertificationName}'s target profile change`,
+    });
+  }
+}

--- a/api/src/certification/complementary-certification/infrastructure/repositories/organization-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/organization-repository.js
@@ -1,12 +1,13 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 
-const getOrganizationUserEmailsFromTargetProfileId = async function ({ targetProfileId }) {
+const getOrganizationUserEmailByCampaignTargetProfileId = async function (targetProfileId) {
   return knex('campaigns')
-    .innerJoin('organization', 'campaigns.organizationId', 'organization.id')
-    .innerJoin('memberships', 'organization.id', 'memberships.organizationId')
+    .innerJoin('organizations', 'campaigns.organizationId', 'organizations.id')
+    .innerJoin('memberships', 'organizations.id', 'memberships.organizationId')
     .innerJoin('users', 'users.id', 'memberships.userId')
     .where({ targetProfileId })
-    .pluck('email');
+    .distinct()
+    .pluck('users.email');
 };
 
-export { getOrganizationUserEmailsFromTargetProfileId };
+export { getOrganizationUserEmailByCampaignTargetProfileId };

--- a/api/src/certification/complementary-certification/infrastructure/repositories/organization-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/organization-repository.js
@@ -1,0 +1,12 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+
+const getOrganizationUserEmailsFromTargetProfileId = async function ({ targetProfileId }) {
+  return knex('campaigns')
+    .innerJoin('organization', 'campaigns.organizationId', 'organization.id')
+    .innerJoin('memberships', 'organization.id', 'memberships.organizationId')
+    .innerJoin('users', 'users.id', 'memberships.userId')
+    .where({ targetProfileId })
+    .pluck('email');
+};
+
+export { getOrganizationUserEmailsFromTargetProfileId };

--- a/api/src/certification/shared/domain/services/mail-service.js
+++ b/api/src/certification/shared/domain/services/mail-service.js
@@ -1,0 +1,21 @@
+import { mailer } from '../../../../shared/mail/infrastructure/services/mailer.js';
+
+const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
+const PIX_NAME_FR = 'PIX - Ne pas répondre';
+
+function sendNotificationToOrganizationMembersForTargetProfileDetached({ email, complementaryCertificationName }) {
+  const options = {
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME_FR,
+    to: email,
+    template: mailer.targetProfileNotCertifiableTemplateId,
+    variables: { complementaryCertificationName },
+  };
+
+  return mailer.sendEmail(options);
+}
+
+const mailService = {
+  sendNotificationToOrganizationMembersForTargetProfileDetached,
+};
+export { sendNotificationToOrganizationMembersForTargetProfileDetached, mailService };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -6,6 +6,8 @@ import * as complementaryCertificationBadgesRepository from '../../../complement
 import * as complementaryCertificationRepository from '../../../../../lib/infrastructure/repositories/complementary-certification-repository.js';
 import * as complementaryCertificationForTargetProfileAttachmentRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js';
 import * as complementaryCertificationTargetProfileHistoryRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js';
+import * as mailService from '../services/mail-service.js';
+import * as organizationRepository from '../../../complementary-certification/infrastructure/repositories/organization-repository.js';
 import * as sessionCodeService from '../../../session/domain/services/session-code-service.js';
 import * as sessionValidator from '../../../session/domain/validators/session-validator.js';
 import * as userRepository from '../../../../../src/shared/infrastructure/repositories/user-repository.js';
@@ -23,7 +25,9 @@ const dependencies = {
   complementaryCertificationRepository,
   complementaryCertificationForTargetProfileAttachmentRepository,
   complementaryCertificationTargetProfileHistoryRepository,
+  organizationRepository,
   sessionCodeService,
+  mailService,
   sessionRepository,
   sessionValidator,
   userRepository,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -249,6 +249,7 @@ const configuration = (function () {
           emailVerificationCodeTemplateId: process.env.BREVO_EMAIL_VERIFICATION_CODE_TEMPLATE_ID,
           cpfEmailTemplateId: process.env.BREVO_CPF_TEMPLATE_ID,
           acquiredCleaResultTemplateId: process.env.BREVO_CLEA_ACQUIRED_RESULT_TEMPLATE_ID,
+          targetProfileNotCertifiableTemplateId: process.env.BREVO_TARGET_PROFILE_NOT_CERTIFIABLE_TEMPLATE_ID,
         },
       },
     },
@@ -374,6 +375,8 @@ const configuration = (function () {
     config.mailing.brevo.templates.emailVerificationCodeTemplateId = 'test-email-verification-code-template-id';
     config.mailing.brevo.templates.cpfEmailTemplateId = 'test-cpf-email-template-id';
     config.mailing.brevo.templates.acquiredCleaResultTemplateId = 'test-acquired-clea-result-template-id';
+    config.mailing.brevo.templates.targetProfileNotCertifiableTemplateId =
+      'test-target-profile-no-certifiable-template-id';
 
     config.bcryptNumberOfSaltRounds = 1;
 

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -94,6 +94,10 @@ class Mailer {
   get acquiredCleaResultTemplateId() {
     return mailing[this._providerName].templates.acquiredCleaResultTemplateId;
   }
+
+  get targetProfileNotCertifiableTemplateId() {
+    return mailing[this._providerName].templates.targetProfileNotCertifiableTemplateId;
+  }
 }
 
 const mailer = new Mailer();

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -32,6 +32,15 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
       const targetProfile = databaseBuilder.factory.buildTargetProfile({
         id: 12,
       });
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: superAdmin.id,
+      });
+      databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+      });
       const badge = databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 3,
@@ -47,6 +56,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
           data: {
             attributes: {
               'target-profile-id': 12,
+              'notify-organizations': true,
               'complementary-certification-badges': [
                 {
                   data: {

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -4,7 +4,7 @@ const { omit } = lodash;
 import * as complementaryCertificationBadgeRepository from '../../../../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
 
-describe('Integration | Infrastructure | Repository | complementary-certification-badge-repository', function () {
+describe('Integration | Infrastructure | Repository | Certification | Complementary-certification | complementary-certification-badge-repository', function () {
   context('#getAllIdsByTargetProfileId', function () {
     context('when complementary certification badges are linked to a target profile', function () {
       it('should return complementary certification badge ids', async function () {

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/organization-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/organization-repository_test.js
@@ -1,0 +1,107 @@
+import { expect, databaseBuilder } from '../../../../../test-helper.js';
+import * as organizationRepository from '../../../../../../src/certification/complementary-certification/infrastructure/repositories/organization-repository.js';
+
+describe('Integration | Repository | Certification | Complementary-certification | Organization', function () {
+  describe('#getOrganizationUserEmailByCampaignTargetProfileId', function () {
+    context('when there are no campaign for this target profile', function () {
+      it('should return an empty array', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const otherTargetProfile = databaseBuilder.factory.buildTargetProfile();
+
+        const createCampaignWithUser = ({ targetProfileId }) => {
+          const organization = databaseBuilder.factory.buildOrganization();
+          databaseBuilder.factory.buildCampaign({
+            organizationId: organization.id,
+            targetProfileId,
+          });
+
+          const user = databaseBuilder.factory.buildUser();
+          databaseBuilder.factory.buildMembership({
+            organizationId: organization.id,
+            userId: user.id,
+          });
+        };
+
+        createCampaignWithUser({ targetProfileId: otherTargetProfile.id });
+
+        await databaseBuilder.commit();
+        // when
+        const organizationSaved = await organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId(
+          targetProfile.id,
+        );
+
+        // then
+        expect(organizationSaved).to.be.empty;
+      });
+    });
+
+    context('where there are organization users for the campaigns linked to the target profile', function () {
+      it('should return emails', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+
+        const createCampaignWithUser = ({ userEmail }) => {
+          const organization = databaseBuilder.factory.buildOrganization();
+          databaseBuilder.factory.buildCampaign({
+            organizationId: organization.id,
+            targetProfileId: targetProfile.id,
+          });
+
+          const user = databaseBuilder.factory.buildUser({ email: userEmail });
+          databaseBuilder.factory.buildMembership({
+            organizationId: organization.id,
+            userId: user.id,
+          });
+        };
+
+        createCampaignWithUser({ userEmail: 'lady.orgaga@example.net' });
+        createCampaignWithUser({ userEmail: 'lady.orgougou@example.net' });
+
+        await databaseBuilder.commit();
+        // when
+        const organizationSaved = await organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId(
+          targetProfile.id,
+        );
+
+        // then
+        expect(organizationSaved).to.exactlyContain(['lady.orgaga@example.net', 'lady.orgougou@example.net']);
+      });
+    });
+    context('where there are multiple campaigns linked to the target profile', function () {
+      it('should return only distinct emails', async function () {
+        // given
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+
+        const createCampaignWithUser = ({ userEmail }) => {
+          const organization = databaseBuilder.factory.buildOrganization();
+          databaseBuilder.factory.buildCampaign({
+            organizationId: organization.id,
+            targetProfileId: targetProfile.id,
+          });
+          databaseBuilder.factory.buildCampaign({
+            organizationId: organization.id,
+            targetProfileId: targetProfile.id,
+          });
+
+          const user = databaseBuilder.factory.buildUser({ email: userEmail });
+          databaseBuilder.factory.buildMembership({
+            organizationId: organization.id,
+            userId: user.id,
+          });
+        };
+
+        createCampaignWithUser({ userEmail: 'lady.orgaga@example.net' });
+
+        await databaseBuilder.commit();
+        // when
+        const organizationSaved = await organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId(
+          targetProfile.id,
+        );
+
+        // then
+        expect(organizationSaved).to.have.length(1);
+      });
+    });
+  });
+});

--- a/api/tests/certification/complementary-certification/unit/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/unit/application/attach-target-profile-controller_test.js
@@ -1,0 +1,101 @@
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+import { attachTargetProfileController } from '../../../../../src/certification/complementary-certification/application/attach-target-profile-controller.js';
+import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+
+describe('Unit | Application | Certification | ComplementaryCertification | attach-target-profile-controller', function () {
+  describe('#attachTargetProfile', function () {
+    context('when there is no notification', function () {
+      it('should call the usecase and serialize the response', async function () {
+        // given
+        const request = {
+          payload: Symbol('args'),
+          auth: { credentials: { userId: 99 } },
+          params: { complementaryCertificationId: 101 },
+        };
+
+        const complementaryCertification = Symbol('certification');
+        const complementaryCertificationBadges = Symbol('complementaryCertificationBadges');
+
+        sinon.stub(usecases, 'getComplementaryCertificationForTargetProfileAttachmentRepository');
+        sinon.stub(usecases, 'attachBadges');
+        sinon.stub(usecases, 'sendTargetProfileNotifications');
+        const complementaryCertificationBadgeSerializerStub = {
+          deserialize: sinon.stub(),
+        };
+
+        usecases.getComplementaryCertificationForTargetProfileAttachmentRepository.resolves(complementaryCertification);
+        complementaryCertificationBadgeSerializerStub.deserialize.withArgs(request.payload).returns({
+          targetProfileId: 1,
+          notifyOrganizations: false,
+          complementaryCertificationBadges,
+        });
+
+        const dependencies = {
+          complementaryCertificationBadgeSerializer: complementaryCertificationBadgeSerializerStub,
+        };
+
+        // when
+        const result = await attachTargetProfileController.attachTargetProfile(request, hFake, dependencies);
+
+        // then
+        expect(result.statusCode).to.equal(204);
+        expect(usecases.attachBadges).to.have.been.calledWith({
+          userId: 99,
+          complementaryCertification,
+          targetProfileIdToDetach: 1,
+          complementaryCertificationBadgesToAttachDTO: complementaryCertificationBadges,
+        });
+        expect(usecases.sendTargetProfileNotifications).not.to.have.been.called;
+      });
+    });
+
+    context('when there are notifications', function () {
+      it('should call the usecase and serialize the response', async function () {
+        // given
+        const request = {
+          payload: Symbol('args'),
+          auth: { credentials: { userId: 99 } },
+          params: { complementaryCertificationId: 101 },
+        };
+
+        const complementaryCertification = Symbol('certification');
+        const complementaryCertificationBadges = Symbol('complementaryCertificationBadges');
+
+        sinon.stub(usecases, 'getComplementaryCertificationForTargetProfileAttachmentRepository');
+        sinon.stub(usecases, 'attachBadges');
+        sinon.stub(usecases, 'sendTargetProfileNotifications');
+        const complementaryCertificationBadgeSerializerStub = {
+          deserialize: sinon.stub(),
+        };
+
+        usecases.getComplementaryCertificationForTargetProfileAttachmentRepository.resolves(complementaryCertification);
+        complementaryCertificationBadgeSerializerStub.deserialize.withArgs(request.payload).returns({
+          targetProfileId: 1,
+          notifyOrganizations: true,
+          complementaryCertificationBadges,
+        });
+
+        const dependencies = {
+          complementaryCertificationBadgeSerializer: complementaryCertificationBadgeSerializerStub,
+        };
+
+        // when
+        const result = await attachTargetProfileController.attachTargetProfile(request, hFake, dependencies);
+
+        // then
+        expect(result.statusCode).to.equal(204);
+        expect(usecases.attachBadges).to.have.been.calledWith({
+          userId: 99,
+          complementaryCertification,
+          targetProfileIdToDetach: 1,
+          complementaryCertificationBadgesToAttachDTO: complementaryCertificationBadges,
+        });
+        expect(usecases.sendTargetProfileNotifications).to.have.been.calledWith({
+          targetProfileIdToDetach: 1,
+          complementaryCertification,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -118,14 +118,10 @@ describe('Unit | UseCase | attach-badges', function () {
   context('when complementary certification has external jury and one required attributes is missing', function () {
     it('should return MissingAttributesError', async function () {
       // given
-      complementaryCertificationForTargetProfileAttachmentRepository.getById
-        .withArgs({ complementaryCertificationId: 123 })
-        .resolves(
-          domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
-            id: 123,
-            hasExternalJury: true,
-          }),
-        );
+      const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
+        id: 123,
+        hasExternalJury: true,
+      });
       badgeRepository.findAllByIds.resolves([{ badgeId: 1 }, { badgeId: 2 }]);
 
       // when
@@ -134,7 +130,7 @@ describe('Unit | UseCase | attach-badges', function () {
           { badgeId: 1, level: 1, certificateMessage: 'message', temporaryCertificateMessage: 'temporary message' },
           { badgeId: 2, level: 2, certificateMessage: null, temporaryCertificateMessage: 'temporary message' },
         ],
-        complementaryCertificationId: 123,
+        complementaryCertification,
         badgeRepository,
         complementaryCertificationForTargetProfileAttachmentRepository,
       });
@@ -191,14 +187,10 @@ describe('Unit | UseCase | attach-badges', function () {
         const badge1 = domainBuilder.buildBadge({ id: 123 });
         const badge2 = domainBuilder.buildBadge({ id: 456 });
 
-        complementaryCertificationForTargetProfileAttachmentRepository.getById
-          .withArgs({ complementaryCertificationId: 123 })
-          .resolves(
-            domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
-              id: 123,
-              hasExternalJury: false,
-            }),
-          );
+        const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
+          id: 123,
+          hasExternalJury: false,
+        });
         badgeRepository.findAllByIds.resolves([badge1, badge2]);
         const complementaryCertificationBadgesRepository = {
           attach: sinon.stub().resolves(),
@@ -218,7 +210,7 @@ describe('Unit | UseCase | attach-badges', function () {
             { badgeId: 456, level: 1, label: 'badge_2' },
           ],
           targetProfileIdToDetach: 789,
-          complementaryCertificationId: 123,
+          complementaryCertification,
           badgeRepository,
           complementaryCertificationForTargetProfileAttachmentRepository,
           complementaryCertificationBadgesRepository,
@@ -251,14 +243,10 @@ describe('Unit | UseCase | attach-badges', function () {
           temporaryCertificateMessage: null,
         };
 
-        complementaryCertificationForTargetProfileAttachmentRepository.getById
-          .withArgs({ complementaryCertificationId: 123 })
-          .resolves(
-            domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
-              id: 123,
-              hasExternalJury: false,
-            }),
-          );
+        const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
+          id: 123,
+          hasExternalJury: false,
+        });
         badgeRepository.findAllByIds.resolves([badge1]);
         const complementaryCertificationBadgesRepository = {
           attach: sinon.stub(),
@@ -278,7 +266,7 @@ describe('Unit | UseCase | attach-badges', function () {
           userId: 1234,
           complementaryCertificationBadgesToAttachDTO: [complementaryCertificationBadge],
           targetProfileIdToDetach: 456,
-          complementaryCertificationId: 123,
+          complementaryCertification,
           badgeRepository,
           complementaryCertificationForTargetProfileAttachmentRepository,
           complementaryCertificationBadgesRepository,
@@ -296,151 +284,6 @@ describe('Unit | UseCase | attach-badges', function () {
         });
       });
     });
-
-    context('when notifyOrganizations is true', function () {
-      it('should send an email to members', async function () {
-        // given
-        const domainTransaction = {
-          knexTransaction: Symbol('transaction'),
-        };
-        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback(domainTransaction);
-        });
-        const badge1 = domainBuilder.buildBadge({ id: 123 });
-
-        const complementaryCertificationForTargetProfileAttachmentRepository = {
-          getById: sinon.stub().resolves(
-            domainBuilder.buildComplementaryCertification({
-              id: 123,
-              label: 'complementary certification label',
-            }),
-          ),
-        };
-        const badgeRepository = {
-          findAllByIds: sinon.stub().withArgs([123]).resolves([badge1]),
-        };
-        const complementaryCertificationBadgesRepository = {
-          attach: sinon.stub().resolves(),
-          detachByIds: sinon.stub(),
-          getAllIdsByTargetProfileId: sinon.stub(),
-        };
-
-        complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId
-          .withArgs({ targetProfileId: 789 })
-          .resolves([1]);
-
-        const organizationRepository = {
-          getOrganizationUserEmailByCampaignTargetProfileId: sinon.stub(),
-        };
-        organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId
-          .withArgs(789)
-          .resolves(['toto@gmail.com', 'tata@gmail.com']);
-
-        const mailService = {
-          sendNotificationToOrganizationMembersForTargetProfileDetached: sinon.stub().resolves(),
-        };
-
-        // when
-        await attachBadges({
-          userId: 1234,
-          complementaryCertificationBadgesToAttachDTO: [{ badgeId: 123, level: 1, label: 'badge_1' }],
-          targetProfileIdToDetach: 789,
-          complementaryCertificationId: 123,
-          notifyOrganizations: true,
-          badgeRepository,
-          complementaryCertificationForTargetProfileAttachmentRepository,
-          complementaryCertificationBadgesRepository,
-          organizationRepository,
-          mailService,
-        });
-
-        // then
-        expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWith({
-          complementaryCertificationBadgeIds: [1],
-          domainTransaction,
-        });
-
-        expect(
-          mailService.sendNotificationToOrganizationMembersForTargetProfileDetached.withArgs({
-            email: 'toto@gmail.com',
-            complementaryCertificationName: 'complementary certification label',
-          }),
-        ).to.have.been.calledOnce;
-        expect(
-          mailService.sendNotificationToOrganizationMembersForTargetProfileDetached.withArgs({
-            email: 'tata@gmail.com',
-            complementaryCertificationName: 'complementary certification label',
-          }),
-        ).to.have.been.calledOnce;
-      });
-    });
-
-    context('when notifyOrganizations is false', function () {
-      it('should not send an email to members', async function () {
-        // given
-        const domainTransaction = {
-          knexTransaction: Symbol('transaction'),
-        };
-        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-          return callback(domainTransaction);
-        });
-        const badge1 = domainBuilder.buildBadge({ id: 123 });
-
-        const complementaryCertificationForTargetProfileAttachmentRepository = {
-          getById: sinon.stub().resolves(
-            domainBuilder.buildComplementaryCertification({
-              id: 123,
-              label: 'complementary certification label',
-            }),
-          ),
-        };
-        const badgeRepository = {
-          findAllByIds: sinon.stub().withArgs([123]).resolves([badge1]),
-        };
-        const complementaryCertificationBadgesRepository = {
-          attach: sinon.stub().resolves(),
-          detachByIds: sinon.stub(),
-          getAllIdsByTargetProfileId: sinon.stub(),
-        };
-
-        complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId
-          .withArgs({ targetProfileId: 789 })
-          .resolves([1]);
-
-        const organizationRepository = {
-          getOrganizationUserEmailByCampaignTargetProfileId: sinon.stub(),
-        };
-        organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId
-          .withArgs(789)
-          .resolves(['toto@gmail.com', 'tata@gmail.com']);
-
-        const mailService = {
-          sendNotificationToOrganizationMembersForTargetProfileDetached: sinon.stub().resolves(),
-        };
-
-        // when
-        await attachBadges({
-          userId: 1234,
-          complementaryCertificationBadgesToAttachDTO: [{ badgeId: 123, level: 1, label: 'badge_1' }],
-          targetProfileIdToDetach: 789,
-          complementaryCertificationId: 123,
-          notifyOrganizations: false,
-          badgeRepository,
-          complementaryCertificationForTargetProfileAttachmentRepository,
-          complementaryCertificationBadgesRepository,
-          organizationRepository,
-          mailService,
-        });
-
-        // then
-        expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWith({
-          complementaryCertificationBadgeIds: [1],
-          domainTransaction,
-        });
-
-        expect(mailService.sendNotificationToOrganizationMembersForTargetProfileDetached).not.to.have.been.called;
-      });
-    });
   });
 
   context('when there is no badges associated to target profile', function () {
@@ -455,14 +298,10 @@ describe('Unit | UseCase | attach-badges', function () {
       const badge1 = domainBuilder.buildBadge({ id: 123 });
       const badge2 = domainBuilder.buildBadge({ id: 456 });
 
-      complementaryCertificationForTargetProfileAttachmentRepository.getById
-        .withArgs({ complementaryCertificationId: 123 })
-        .resolves(
-          domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
-            id: 123,
-            hasExternalJury: false,
-          }),
-        );
+      const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
+        id: 123,
+        hasExternalJury: false,
+      });
       badgeRepository.findAllByIds.resolves([badge1, badge2]);
       const complementaryCertificationBadgesRepository = {
         attach: sinon.stub().resolves(),
@@ -484,7 +323,7 @@ describe('Unit | UseCase | attach-badges', function () {
           { badgeId: 456, level: 1, label: 'badge_2' },
         ],
         targetProfileIdToDetach: 789,
-        complementaryCertificationId: 123,
+        complementaryCertification,
         BadgeToAttachValidator,
         badgeRepository,
         complementaryCertificationForTargetProfileAttachmentRepository,

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -296,6 +296,151 @@ describe('Unit | UseCase | attach-badges', function () {
         });
       });
     });
+
+    context('when notifyOrganizations is true', function () {
+      it('should send an email to members', async function () {
+        // given
+        const domainTransaction = {
+          knexTransaction: Symbol('transaction'),
+        };
+        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+          return callback(domainTransaction);
+        });
+        const badge1 = domainBuilder.buildBadge({ id: 123 });
+
+        const complementaryCertificationForTargetProfileAttachmentRepository = {
+          getById: sinon.stub().resolves(
+            domainBuilder.buildComplementaryCertification({
+              id: 123,
+              label: 'complementary certification label',
+            }),
+          ),
+        };
+        const badgeRepository = {
+          findAllByIds: sinon.stub().withArgs([123]).resolves([badge1]),
+        };
+        const complementaryCertificationBadgesRepository = {
+          attach: sinon.stub().resolves(),
+          detachByIds: sinon.stub(),
+          getAllIdsByTargetProfileId: sinon.stub(),
+        };
+
+        complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId
+          .withArgs({ targetProfileId: 789 })
+          .resolves([1]);
+
+        const organizationRepository = {
+          getOrganizationUserEmailByCampaignTargetProfileId: sinon.stub(),
+        };
+        organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId
+          .withArgs(789)
+          .resolves(['toto@gmail.com', 'tata@gmail.com']);
+
+        const mailService = {
+          sendNotificationToOrganizationMembersForTargetProfileDetached: sinon.stub().resolves(),
+        };
+
+        // when
+        await attachBadges({
+          userId: 1234,
+          complementaryCertificationBadgesToAttachDTO: [{ badgeId: 123, level: 1, label: 'badge_1' }],
+          targetProfileIdToDetach: 789,
+          complementaryCertificationId: 123,
+          notifyOrganizations: true,
+          badgeRepository,
+          complementaryCertificationForTargetProfileAttachmentRepository,
+          complementaryCertificationBadgesRepository,
+          organizationRepository,
+          mailService,
+        });
+
+        // then
+        expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWith({
+          complementaryCertificationBadgeIds: [1],
+          domainTransaction,
+        });
+
+        expect(
+          mailService.sendNotificationToOrganizationMembersForTargetProfileDetached.withArgs({
+            email: 'toto@gmail.com',
+            complementaryCertificationName: 'complementary certification label',
+          }),
+        ).to.have.been.calledOnce;
+        expect(
+          mailService.sendNotificationToOrganizationMembersForTargetProfileDetached.withArgs({
+            email: 'tata@gmail.com',
+            complementaryCertificationName: 'complementary certification label',
+          }),
+        ).to.have.been.calledOnce;
+      });
+    });
+
+    context('when notifyOrganizations is false', function () {
+      it('should not send an email to members', async function () {
+        // given
+        const domainTransaction = {
+          knexTransaction: Symbol('transaction'),
+        };
+        sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+          return callback(domainTransaction);
+        });
+        const badge1 = domainBuilder.buildBadge({ id: 123 });
+
+        const complementaryCertificationForTargetProfileAttachmentRepository = {
+          getById: sinon.stub().resolves(
+            domainBuilder.buildComplementaryCertification({
+              id: 123,
+              label: 'complementary certification label',
+            }),
+          ),
+        };
+        const badgeRepository = {
+          findAllByIds: sinon.stub().withArgs([123]).resolves([badge1]),
+        };
+        const complementaryCertificationBadgesRepository = {
+          attach: sinon.stub().resolves(),
+          detachByIds: sinon.stub(),
+          getAllIdsByTargetProfileId: sinon.stub(),
+        };
+
+        complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId
+          .withArgs({ targetProfileId: 789 })
+          .resolves([1]);
+
+        const organizationRepository = {
+          getOrganizationUserEmailByCampaignTargetProfileId: sinon.stub(),
+        };
+        organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId
+          .withArgs(789)
+          .resolves(['toto@gmail.com', 'tata@gmail.com']);
+
+        const mailService = {
+          sendNotificationToOrganizationMembersForTargetProfileDetached: sinon.stub().resolves(),
+        };
+
+        // when
+        await attachBadges({
+          userId: 1234,
+          complementaryCertificationBadgesToAttachDTO: [{ badgeId: 123, level: 1, label: 'badge_1' }],
+          targetProfileIdToDetach: 789,
+          complementaryCertificationId: 123,
+          notifyOrganizations: false,
+          badgeRepository,
+          complementaryCertificationForTargetProfileAttachmentRepository,
+          complementaryCertificationBadgesRepository,
+          organizationRepository,
+          mailService,
+        });
+
+        // then
+        expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWith({
+          complementaryCertificationBadgeIds: [1],
+          domainTransaction,
+        });
+
+        expect(mailService.sendNotificationToOrganizationMembersForTargetProfileDetached).not.to.have.been.called;
+      });
+    });
   });
 
   context('when there is no badges associated to target profile', function () {

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/get-complementary-certification-for-target-profile-attachment_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/get-complementary-certification-for-target-profile-attachment_test.js
@@ -1,0 +1,26 @@
+import { expect, domainBuilder, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | get-complementary-certification-for-target-profile-attachment', function () {
+  it('should get the complementary certification', async function () {
+    // given
+    const complementaryCertificationForTargetProfileAttachmentRepository = {
+      getById: sinon.stub(),
+    };
+    const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment({
+      id: 123,
+      hasExternalJury: true,
+    });
+    complementaryCertificationForTargetProfileAttachmentRepository.getById
+      .withArgs({ complementaryCertificationId: 5, complementaryCertificationForTargetProfileAttachmentRepository })
+      .resolves(complementaryCertification);
+
+    // when
+    const result = await complementaryCertificationForTargetProfileAttachmentRepository.getById({
+      complementaryCertificationId: 5,
+      complementaryCertificationForTargetProfileAttachmentRepository,
+    });
+
+    // then
+    expect(result).to.deepEqualInstance(complementaryCertification);
+  });
+});

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/send-target-profile-notifications_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/send-target-profile-notifications_test.js
@@ -1,0 +1,42 @@
+import { expect, sinon } from '../../../../../test-helper.js';
+import { sendTargetProfileNotifications } from '../../../../../../src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js';
+import { EmailingAttempt } from '../../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
+
+describe('Unit | UseCase |send-target-profile-notifications', function () {
+  it('should send an email to members', async function () {
+    // given
+    const organizationRepository = {
+      getOrganizationUserEmailByCampaignTargetProfileId: sinon.stub(),
+    };
+    organizationRepository.getOrganizationUserEmailByCampaignTargetProfileId
+      .withArgs(789)
+      .resolves(['toto@gmail.com', 'tata@gmail.com']);
+
+    const success = EmailingAttempt.success();
+    const mailService = {
+      sendNotificationToOrganizationMembersForTargetProfileDetached: sinon.stub().resolves(success),
+    };
+
+    // when
+    await sendTargetProfileNotifications({
+      targetProfileIdToDetach: 789,
+      complementaryCertification: { label: 'complementary certification label' },
+      organizationRepository,
+      mailService,
+    });
+
+    // then
+    expect(
+      mailService.sendNotificationToOrganizationMembersForTargetProfileDetached.withArgs({
+        email: 'toto@gmail.com',
+        complementaryCertificationName: 'complementary certification label',
+      }),
+    ).to.have.been.calledOnce;
+    expect(
+      mailService.sendNotificationToOrganizationMembersForTargetProfileDetached.withArgs({
+        email: 'tata@gmail.com',
+        complementaryCertificationName: 'complementary certification label',
+      }),
+    ).to.have.been.calledOnce;
+  });
+});

--- a/api/tests/certification/shared/unit/domain/services/mail-service_test.js
+++ b/api/tests/certification/shared/unit/domain/services/mail-service_test.js
@@ -1,0 +1,36 @@
+import { sinon, expect } from '../../../../../test-helper.js';
+
+import * as mailService from '../../../../../../src/certification/shared/domain/services/mail-service.js';
+import { mailer } from '../../../../../../src/shared/mail/infrastructure/services/mailer.js';
+
+describe('Unit | Service | Certification | MailService', function () {
+  const senderEmailAddress = 'ne-pas-repondre@pix.fr';
+  const userEmailAddress = 'user@example.net';
+
+  beforeEach(function () {
+    sinon.stub(mailer, 'sendEmail').resolves();
+  });
+
+  describe('#sendNotificationToOrganizationMembersForTargetProfileDetached', function () {
+    it(`should call sendEmail with the right options`, async function () {
+      // given
+      const email = userEmailAddress;
+      const complementaryCertificationName = 'what a complementary';
+
+      // when
+      await mailService.sendNotificationToOrganizationMembersForTargetProfileDetached({
+        email,
+        complementaryCertificationName,
+      });
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWith({
+        from: senderEmailAddress,
+        fromName: 'PIX - Ne pas répondre',
+        to: email,
+        template: mailer.targetProfileNotCertifiableTemplateId,
+        variables: { complementaryCertificationName },
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -1,6 +1,6 @@
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
-import { NotFoundError, EntityValidationError } from '../../../../src/shared/domain/errors.js';
+import { EntityValidationError, NotFoundError } from '../../../../src/shared/domain/errors.js';
 
 import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { handle } from '../../../../src/shared/application/error-manager.js';

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -791,4 +791,27 @@ describe('Unit | Service | MailService', function () {
       });
     });
   });
+
+  describe('#sendNotificationToOrganizationMembersForTargetProfileDetached', function () {
+    it(`should call sendEmail with the right options`, async function () {
+      // given
+      const email = 'user@example.net';
+      const complementaryCertificationName = 'what a complementary';
+
+      // when
+      await mailService.sendNotificationToOrganizationMembersForTargetProfileDetached({
+        email,
+        complementaryCertificationName,
+      });
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWith({
+        from: 'ne-pas-repondre@pix.fr',
+        fromName: 'PIX - Ne pas répondre',
+        to: email,
+        template: mailer.targetProfileNotCertifiableTemplateId,
+        variables: { complementaryCertificationName },
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Un prescripteur ayant fait passer des campagnes basées sur une ancienne version du PC pour la certification complémentaire concernée ne pourra plus faire certifier ses prescrits en l'état.

Il devra refaire passer de nouvelles campagnes à ses prescrits basées sur la nouvelle version du PC pour obtenir le nouveau RT certifiant.

## :robot: Proposition
Création de la case “Notifier les organisations avec une campagne basée sur l’ancien PC.”

Dans le tooltip à côté de la case, faire apparaître le texte du mail :

> Evolution des conditions de certificabilité pour la certification complémentaire <NomDeLaCertif>:
> Bonjour,
> Suite à l'évolution des conditions de certificabilité pour la certification <NomDeLaCertif>, vos publics ayant passé ou allant passer une campagne établie sur l'ancienne version du parcours ne sont plus certifiables.
> Si vos publics souhaitent se présenter à une session de certification ils doivent donc participer à une nouvelle campagne basée sur la nouvelle version du parcours. Cela leur permettra d’obtenir la nouvelle version du “badge” ou “résultat thématique certifiant

## :rainbow: Remarques
Ajout d'une VAR ENV ~~BREVO_TARGET_PROFILE_NOT_CERTIFIABLE_ID~~ 
BREVO_TARGET_PROFILE_NOT_CERTIFIABLE_TEMPLATE_ID

Lors de l'echec d'email, on log l'erreur avec un event specifique 'attach-target-profile-certif' (qui pourra etre filtré/notifié via datadog)
Pour tester ce comportement, il suffit de supprimer la var env de l'id du template (cela renverra une erreur)

⚠️ Ne pas oublier de mettre cette VARENV sur tout les environnements

## :100: Pour tester
Mettre à jour un email d'utilisateur de l'organisation pour recevoir la notification: 
```sql
update users set email = 'monemail+test7065@pix.fr' where id = 1000;
```
ajouter l'utilisateur pour l'orga liée au profile cible cléA
```sql
insert into memberships ("userId", "organizationId") values (1000, 
(select distinct o.id from "target-profiles" tp 
inner join campaigns c on c."targetProfileId" = tp."id"
inner join organizations o on o.id = c."organizationId"
where tp.id in (56, 78))
)
```
Retirer les "detachedAt" pour pouvoir reattacher
```sql 
update "complementary-certification-badges" set "detachedAt" = null;
```

Remplacer un target profile en cochant la case et s'assurer recevoir l'email.

Refaire la meme operation sans cocher la case et s'assurer de ne pas recevoir l'email

