### PR TITLE
[FEATURE] Afficher un message dans le champ de recherche des profils cibles attachables lorsqu'il n'y a aucun résultat - Pix Admin (PIX-8948).

### DIFF
--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/index.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/index.hbs
@@ -9,5 +9,6 @@
     @onSearch={{this.onSearch}}
     @options={{this.attachableTargetProfiles}}
     @isLoading={{this.isAttachableTargetProfilesLoading}}
+    @isNoResult={{this.isNoResult}}
   />
 {{/if}}

--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/index.js
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/index.js
@@ -7,19 +7,22 @@ export default class TargetProfileSelectorComponent extends Component {
   @service notifications;
   @service store;
 
-  @tracked attachableTargetProfiles = [];
+  @tracked attachableTargetProfiles = undefined;
   @tracked isAttachableTargetProfilesLoading = false;
   @tracked selectedTargetProfile;
+  @tracked isNoResult = false;
 
   @action
   onChange() {
     this.selectedTargetProfile = undefined;
-    this.attachableTargetProfiles = [];
+    this.attachableTargetProfiles = undefined;
     this.args.onChange();
   }
 
   @action
   async onSearch(value) {
+    this.isNoResult = false;
+    this.attachableTargetProfiles = undefined;
     const searchTerm = value?.trim();
     const isSearchById = searchTerm && /^\d+$/.test(searchTerm);
     const isSearchByName = searchTerm?.length >= 2;
@@ -28,6 +31,12 @@ export default class TargetProfileSelectorComponent extends Component {
       try {
         this.isAttachableTargetProfilesLoading = true;
         const attachableTargetProfiles = await this.store.query('attachable-target-profile', { searchTerm });
+
+        if (attachableTargetProfiles.length === 0) {
+          this.isNoResult = true;
+          return;
+        }
+
         this.attachableTargetProfiles = attachableTargetProfiles.map((attachableTargetProfile) => ({
           label: `${attachableTargetProfile.id} - ${attachableTargetProfile.name}`,
           value: attachableTargetProfile,
@@ -37,8 +46,6 @@ export default class TargetProfileSelectorComponent extends Component {
       } finally {
         this.isAttachableTargetProfilesLoading = false;
       }
-    } else {
-      this.attachableTargetProfiles = [];
     }
   }
 

--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.hbs
@@ -9,13 +9,26 @@
       @triggerFiltering={{this.onSearchValueInput}}
       autocomplete="off"
     />
-    {{#if (or @isLoading @options.length)}}
-      <ul role="listbox" class="attach-target-profile-search__results" aria-busy="{{@isLoading}}">
-        {{#if @isLoading}}
-          <li class="attach-target-profile-search__results__loader" role="progressbar">
-            Recherche en cours...
-          </li>
-        {{/if}}
+
+    {{#if @isLoading}}
+      <span class="attach-target-profile-search__loader" role="progressbar">
+        Recherche en cours...
+      </span>
+    {{/if}}
+
+    {{#if @isNoResult}}
+      <span class="attach-target-profile-search__no-result">
+        Aucun résultat
+      </span>
+    {{/if}}
+
+    {{#if @options.length}}
+      <ul
+        id="target-profiles-list"
+        role="listbox"
+        class="attach-target-profile-search__results"
+        aria-busy="{{@isLoading}}"
+      >
         {{#each @options as |option|}}
           <li
             class="attach-target-profile-search__results__option"

--- a/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.js
+++ b/admin/app/components/complementary-certifications/attach-badges/target-profile-selector/searchbar.js
@@ -1,9 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import ENV from 'pix-admin/config/environment';
 
 export default class SearchBar extends Component {
   get debounce() {
-    return 0;
+    return ENV.searchTargetProfiles.debounce;
   }
 
   @action

--- a/admin/app/styles/components/complementary-certifications/search-bar.scss
+++ b/admin/app/styles/components/complementary-certifications/search-bar.scss
@@ -9,13 +9,14 @@
     min-width: 40%;
   }
 
-  &__results {
+  &__results, &__loader, &__no-result {
     position: absolute;
     z-index: 200;
     width: inherit;
     max-height: 12.5rem;
     padding: $pix-spacing-xs $pix-spacing-s;
     overflow-y: auto;
+    color: $pix-neutral-50;
     white-space: nowrap;
     list-style-type: none;
     background-color: $pix-neutral-0;
@@ -24,8 +25,8 @@
     box-shadow: 0 6px 12px rgb(7 20 46 / 8%);
     transition: all 0.1s ease-in-out;
 
-    &__loader {
-      color: $pix-neutral-30;
+    &__option {
+      color: $pix-neutral-80;
     }
 
     &__option:hover,

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -101,6 +101,14 @@ module.exports = function (environment) {
         minValue: 250,
       }),
     },
+
+    searchTargetProfiles: {
+      debounce: _getEnvironmentVariableAsNumber({
+        environmentVariableName: 'SEARCH_TARGET_PROFILE_DEBOUNCE_TIMEOUT',
+        defaultValue: 250,
+        minValue: 0,
+      }),
+    },
   };
 
   if (environment === 'development') {
@@ -133,6 +141,7 @@ module.exports = function (environment) {
     };
 
     ENV.pagination.debounce = 0;
+    ENV.searchTargetProfiles.debounce = 0;
   }
 
   if (environment === 'production') {

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -97,7 +97,7 @@ module(
           await fillIn(input, '3');
 
           await screen.findByRole('listbox');
-          const targetProfileSelectable = screen.getByRole('option', { name: '3 - ALEX TARGET' });
+          const targetProfileSelectable = await screen.findByRole('option', { name: '3 - ALEX TARGET' });
 
           // when
           await targetProfileSelectable.click();
@@ -133,7 +133,7 @@ module(
           const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
           await fillIn(input, '5');
           await screen.findByRole('listbox');
-          const targetProfileSelectable = screen.getByRole('option', { name: '5 - ALEX TARGET' });
+          const targetProfileSelectable = await screen.findByRole('option', { name: '5 - ALEX TARGET' });
 
           // when
           await targetProfileSelectable.click();

--- a/admin/tests/integration/components/complementary-certifications/attach-form/target-profile-selector/searchbar_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/target-profile-selector/searchbar_test.js
@@ -28,12 +28,24 @@ module(
 
       // when
       const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::TargetProfileSelector::Searchbar
-      @options={{this.options}}
-    />`);
+        @options={{this.options}}
+      />`);
 
       // then
       const searchResult = await screen.findByRole('option', { name: '3 - ALEX TARGET' });
       assert.dom(searchResult).exists();
+    });
+
+    module('when the search returns no results', function () {
+      test('it should display the no results message', async function (assert) {
+        // given & when
+        const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::TargetProfileSelector::Searchbar
+         @isNoResult={{true}}
+        />`);
+
+        // then
+        assert.dom(screen.getByText('Aucun résultat')).exists();
+      });
     });
 
     module('when the search is in progress', function () {
@@ -43,8 +55,8 @@ module(
         this.set('isLoading', isLoading);
         // when
         const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::TargetProfileSelector::Searchbar
-        @isLoading={{this.isLoading}}
-      />`);
+          @isLoading={{this.isLoading}}
+        />`);
 
         // then
         assert.dom(screen.getByRole('progressbar', { value: { text: 'Recherche en cours...' } })).exists();
@@ -58,8 +70,8 @@ module(
         this.set('isLoading', isLoading);
         // when
         const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::TargetProfileSelector::Searchbar
-        @isLoading={{this.isLoading}}
-      />`);
+          @isLoading={{this.isLoading}}
+        />`);
 
         // then
         assert.dom(screen.queryByRole('progressbar')).doesNotExist();
@@ -74,8 +86,8 @@ module(
 
         // when
         const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::TargetProfileSelector::Searchbar
-        @onSearch={{this.onSearchStub}}
-      />`);
+          @onSearch={{this.onSearchStub}}
+        />`);
         const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
         await fillIn(input, '3');
 
@@ -96,9 +108,9 @@ module(
 
         // when
         const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::TargetProfileSelector::Searchbar
-        @onSelection={{this.onSelection}}
-        @options={{this.options}}
-    />`);
+            @onSelection={{this.onSelection}}
+            @options={{this.options}}
+        />`);
         const targetProfileSelectable = await screen.findByRole('option', { name: '3 - ALEX TARGET' });
         await targetProfileSelectable.click();
 

--- a/admin/tests/unit/components/complementary-certifications/attach-form/target-profile-selector/index_test.js
+++ b/admin/tests/unit/components/complementary-certifications/attach-form/target-profile-selector/index_test.js
@@ -8,7 +8,7 @@ module('Unit | Component | complementary-certifications/attach-badges/target-pro
 
   module('#onSearch', function () {
     module('when there is no searchTerm', function () {
-      test('it should update attachableTargetProfiles options with an empty array', async function (assert) {
+      test('it should not have attachable target profiles options yet', async function (assert) {
         const store = this.owner.lookup('service:store');
         store.query = sinon.stub();
         const component = createGlimmerComponent(
@@ -20,7 +20,7 @@ module('Unit | Component | complementary-certifications/attach-badges/target-pro
 
         // then
         sinon.assert.notCalled(store.query);
-        assert.deepEqual(component.attachableTargetProfiles, []);
+        assert.deepEqual(component.attachableTargetProfiles, undefined);
       });
     });
 
@@ -74,7 +74,7 @@ module('Unit | Component | complementary-certifications/attach-badges/target-pro
       });
 
       module('when there is a searchTerm with less than 2 characters other than number', function () {
-        test('it should update searchResults with the list of attachable target profiles', async function (assert) {
+        test('it should not trigger a search', async function (assert) {
           const store = this.owner.lookup('service:store');
           store.query = sinon.stub();
           const component = createGlimmerComponent(
@@ -86,7 +86,7 @@ module('Unit | Component | complementary-certifications/attach-badges/target-pro
 
           // then
           assert.notOk(store.query.called);
-          assert.deepEqual(component.attachableTargetProfiles, []);
+          assert.deepEqual(component.attachableTargetProfiles, undefined);
         });
       });
 
@@ -162,7 +162,7 @@ module('Unit | Component | complementary-certifications/attach-badges/target-pro
 
       // then
       assert.strictEqual(component.selectedTargetProfile, undefined);
-      assert.deepEqual(component.attachableTargetProfiles, []);
+      assert.deepEqual(component.attachableTargetProfiles, undefined);
       assert.ok(component.args.onChange.calledWithExactly());
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Quand on recherche des profils cibles attachables, et que on obitent aucun résultat, il n'y a pas de retour utilisateur.

## :robot: Proposition
Ajouter un message quand il n'y a pas de résultats

## :rainbow: Remarques

Le debounce aussi était à zéro, surement un oubli lors du dev précèdent. J'ai corrigé cela.

## :100: Pour tester
* Pix admin, superadmin@example.net
* Onglet complémentaires > sélectionner une complémentaire > Rattacher
* Taper 'qsdfghjkl'
* Observer le message "Aucun résultat..."
