### PR TITLE
[TECH] Définir une valeur de MAX_REACHABLE_LEVEL pour les tests

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -342,6 +342,7 @@ const configuration = (function () {
     config.features.dayBeforeImproving = 4;
     config.features.dayBeforeCompetenceResetV2 = 7;
     config.features.garAccessV2 = false;
+    config.features.maxReachableLevel = 5;
     config.features.numberOfChallengesForFlashMethod = 10;
     config.features.pixCertifScoBlockedAccessDateLycee = null;
     config.features.pixCertifScoBlockedAccessDateCollege = null;


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la valeur de la variable `MAX_REACHABLE_LEVEL` est changée dans le fichier .env, les tests du `scoring-certification-service` ne fonctionnent plus.

## :robot: Proposition
Définir cette valeur dans la section test de config.js

## :100: Pour tester
Lancer les tests en local avec une valeur de `MAX_REACHABLE_LEVEL` différente de `5`