### PR TITLE
[TECH] Ajouter un test manquant pour le calcul de la certificabilitée auto (PIX-9169)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2178,6 +2178,36 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       // then
       expect(result).to.equal(2);
     });
+
+    it('should not count organization learners not reconciliated', async function () {
+      // given
+      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ userId: null });
+
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability();
+
+      // then
+      expect(result).to.equal(0);
+    });
+
+    it('should not count organization learners not reconciliated with option skipLoggedLastDayCheck', async function () {
+      // given
+      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ userId: null });
+
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+        skipLoggedLastDayCheck: true,
+      });
+
+      // then
+      expect(result).to.equal(0);
+    });
   });
 
   describe('#findByOrganizationsWhichNeedToComputeCertificability', function () {
@@ -2268,7 +2298,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
 
       // then
-      expect(result).to.deep.equal([]);
+      expect(result).to.be.empty;
     });
 
     it('should not return an organization learner id for organizations that cannot compute certificability', async function () {
@@ -2280,7 +2310,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
 
       // then
-      expect(result).to.deep.equal([]);
+      expect(result).to.be.empty;
     });
 
     it('should not return an organization learner id for organizations with other features', async function () {
@@ -2295,6 +2325,36 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
 
       // then
       expect(result).to.deep.equal([]);
+    });
+
+    it('should not return an organization learner not reconciliated', async function () {
+      // given
+      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ userId: null });
+
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+
+      // then
+      expect(result).to.be.empty;
+    });
+
+    it('should not return an organization learner not reconciliated with option skipLoggedLastDayCheck', async function () {
+      // given
+      const { organizationId } = databaseBuilder.factory.buildOrganizationLearner({ userId: null });
+
+      databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+        skipLoggedLastDayCheck: true,
+      });
+
+      // then
+      expect(result).to.be.empty;
     });
 
     it('should limit ids returned', async function () {


### PR DESCRIPTION
## :unicorn: Problème
On s'est rendus compte à la suite de tests fonctionnels, que le cas d'un learner non reconcilié n'était pas pris en compte pour le calcul de la certificabilité automatique. 

## :robot: Proposition
Ajout d'un test sur le repository pour le cas d'un learner non reconcilié (sans userId), qui vérifie que celui ci n'est pas pris en compte dans le calcul de la remontée auto de la certif.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- ( Les tests passent )

- Supprimer le userId d'un organization learner appartenant à une organization ayant la feature d'activée (SCO isManagingStudent) OU Faire un import dans une orga ayant la feature activée
- Inserer le job : 
```sql
INSERT INTO "pgboss"."job" (name, retrylimit, retrydelay, on_complete, data) VALUES('ScheduleComputeOrganizationLearnersCertificabilityJob', 0, 30, true, '{"skipLoggedLastDayCheck":"true"}');
```
- Vérifier que les learners concernés (sans userId) n'ont pas eu le calcul de la certificabilitée
- :cat:
