### PR TITLE
[FEATURE] Afficher les invitations en attente d'une équipe sur Pix Certif (PIX-138)

### DIFF
--- a/api/db/seeds/data/team-acces/build-certification-centers.js
+++ b/api/db/seeds/data/team-acces/build-certification-centers.js
@@ -30,7 +30,7 @@ export async function buildCertificationCenters(databaseBuilder) {
       email: 'lee-tige@example.net',
       username: 'lee.tige',
     },
-  ].map((user) => _buildUsersWithRawPassword({ databaseBuilder, ...user }));
+  ].map((user) => _buildUsersWithDefaultPassword({ databaseBuilder, ...user }));
 
   const { certificationCenterId } = await createCertificationCenter({
     name: 'Accèssorium',
@@ -47,7 +47,7 @@ export async function buildCertificationCenters(databaseBuilder) {
   });
 }
 
-function _buildUsersWithRawPassword({
+function _buildUsersWithDefaultPassword({
   databaseBuilder,
   firstName,
   lastName,

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -137,6 +137,15 @@ const createCertificationCenterMembershipByEmail = async function (
     .created();
 };
 
+const findPendingInvitations = async function (request, h) {
+  const certificationCenterId = request.params.certificationCenterId;
+
+  const certificationCenterInvitations = await usecases.findPendingCertificationCenterInvitations({
+    certificationCenterId,
+  });
+  return h.response(certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitations));
+};
+
 const findPendingInvitationsForAdmin = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
 
@@ -240,6 +249,7 @@ const certificationCenterController = {
   findCertificationCenterMembershipsByCertificationCenter,
   findCertificationCenterMemberships,
   createCertificationCenterMembershipByEmail,
+  findPendingInvitations,
   findPendingInvitationsForAdmin,
   updateReferer,
   sendInvitationForAdmin,

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -146,15 +146,6 @@ const findPendingInvitations = async function (request, h) {
   return h.response(certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitations));
 };
 
-const findPendingInvitationsForAdmin = async function (request, h) {
-  const certificationCenterId = request.params.certificationCenterId;
-
-  const certificationCenterInvitations = await usecases.findPendingCertificationCenterInvitations({
-    certificationCenterId,
-  });
-  return h.response(certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitations));
-};
-
 const updateReferer = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
   const { userId, isReferer } = request.payload.data.attributes;
@@ -250,7 +241,6 @@ const certificationCenterController = {
   findCertificationCenterMemberships,
   createCertificationCenterMembershipByEmail,
   findPendingInvitations,
-  findPendingInvitationsForAdmin,
   updateReferer,
   sendInvitationForAdmin,
   getSessionsImportTemplate,

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -355,7 +355,7 @@ const register = async function (server) {
             certificationCenterId: identifiersType.certificationCenterId,
           }),
         },
-        handler: certificationCenterController.findPendingInvitationsForAdmin,
+        handler: certificationCenterController.findPendingInvitations,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés et ayant accès à Pix Admin**\n' +
             '- Récupération de la liste des invitations en attente liée un centre de certification',

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -312,6 +312,30 @@ const register = async function (server) {
 
     {
       method: 'GET',
+      path: '/api/certification-centers/{certificationCenterId}/invitations',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenter,
+            assign: 'isAdminOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: certificationCenterController.findPendingInvitations,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification**\n' +
+            '- Récupération de la liste des invitations en attente liée un centre de certification',
+        ],
+        tags: ['api', 'certification-center', 'invitations'],
+      },
+    },
+
+    {
+      method: 'GET',
       path: '/api/admin/certification-centers/{certificationCenterId}/invitations',
       config: {
         pre: [

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -17,6 +17,7 @@ import * as checkUserBelongsToOrganizationUseCase from './usecases/checkUserBelo
 import * as checkUserCanDisableHisOrganizationMembershipUseCase from './usecases/checkUserCanDisableHisOrganizationMembership.js';
 import * as checkUserIsAdminAndManagingStudentsForOrganization from './usecases/checkUserIsAdminAndManagingStudentsForOrganization.js';
 import * as checkUserIsMemberOfAnOrganizationUseCase from './usecases/checkUserIsMemberOfAnOrganization.js';
+import * as checkUserIsAdminOfCertificationCenterUsecase from './usecases/checkUserIsAdminOfCertificationCenter.js';
 import * as checkUserIsMemberOfCertificationCenterUsecase from './usecases/checkUserIsMemberOfCertificationCenter.js';
 import * as checkUserIsMemberOfCertificationCenterSessionUsecase from './usecases/checkUserIsMemberOfCertificationCenterSession.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
@@ -181,6 +182,28 @@ function checkUserIsAdminInOrganization(request, h, dependencies = { checkUserIs
     .catch(() => _replyForbiddenError(h));
 }
 
+function checkUserIsAdminOfCertificationCenter(
+  request,
+  h,
+  dependencies = { checkUserIsAdminOfCertificationCenterUsecase },
+) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const certificationCenterId = request.params.certificationCenterId;
+
+  return dependencies.checkUserIsAdminOfCertificationCenterUsecase
+    .execute(userId, certificationCenterId)
+    .then((isAdminInCertificationCenter) => {
+      if (isAdminInCertificationCenter) {
+        return h.response(true);
+      }
+      return _replyForbiddenError(h);
+    })
+    .catch(() => _replyForbiddenError(h));
+}
 function checkUserIsMemberOfCertificationCenter(
   request,
   h,
@@ -616,6 +639,7 @@ const securityPreHandlers = {
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserIsMemberOfAnOrganization,
+  checkUserIsAdminOfCertificationCenter,
   checkUserIsMemberOfCertificationCenter,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,

--- a/api/lib/application/usecases/checkUserIsAdminOfCertificationCenter.js
+++ b/api/lib/application/usecases/checkUserIsAdminOfCertificationCenter.js
@@ -1,0 +1,14 @@
+import * as certificationCenterMembershipRepository from '../../infrastructure/repositories/certification-center-membership-repository.js';
+
+const execute = async function (
+  userId,
+  certificationCenterId,
+  dependencies = { certificationCenterMembershipRepository },
+) {
+  return await dependencies.certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+    userId,
+    certificationCenterId,
+  });
+};
+
+export { execute };

--- a/api/lib/domain/read-models/CertificationPointOfContact.js
+++ b/api/lib/domain/read-models/CertificationPointOfContact.js
@@ -7,6 +7,7 @@ class CertificationPointOfContact {
     lang,
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
+    certificationCenterMemberships,
   }) {
     this.id = id;
     this.firstName = firstName;
@@ -15,6 +16,7 @@ class CertificationPointOfContact {
     this.lang = lang;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
     this.allowedCertificationCenterAccesses = allowedCertificationCenterAccesses;
+    this.certificationCenterMemberships = certificationCenterMemberships;
   }
 }
 

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -123,6 +123,20 @@ const save = async function ({ userId, certificationCenterId }) {
   }
 };
 
+const isAdminOfCertificationCenter = async function ({ userId, certificationCenterId }) {
+  const certificationCenterMembershipId = await knex('certification-center-memberships')
+    .select('id')
+    .where({
+      userId,
+      certificationCenterId,
+      disabledAt: null,
+      role: 'ADMIN',
+    })
+    .first();
+
+  return Boolean(certificationCenterMembershipId);
+};
+
 const isMemberOfCertificationCenter = async function ({ userId, certificationCenterId }) {
   const certificationCenterMembershipId = await knex('certification-center-memberships')
     .select('id')
@@ -226,6 +240,7 @@ export {
   findByUserId,
   findActiveByCertificationCenterIdSortedById,
   save,
+  isAdminOfCertificationCenter,
   isMemberOfCertificationCenter,
   disableById,
   updateRefererStatusByUserIdAndCertificationCenterId,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -3,6 +3,12 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
+const ALLOWED_CERTIFICATION_CENTER_ACCESS_ATTRIBUTE = 'allowedCertificationCenterAccesses';
+const ALLOWED_CERTIFICATION_CENTER_ACCESS_TYPE = 'allowed-certification-center-access';
+
+const CERTIFICATION_CENTER_MEMBERSHIP_ATTRIBUTE = 'certificationCenterMemberships';
+const CERTIFICATION_CENTER_MEMBERSHIP_TYPE = 'certification-center-membership';
+
 const serialize = function (certificationPointOfContact) {
   return new Serializer('certification-point-of-contact', {
     attributes: [
@@ -12,6 +18,7 @@ const serialize = function (certificationPointOfContact) {
       'lang',
       'pixCertifTermsOfServiceAccepted',
       'allowedCertificationCenterAccesses',
+      CERTIFICATION_CENTER_MEMBERSHIP_ATTRIBUTE,
     ],
     allowedCertificationCenterAccesses: {
       ref: 'id',
@@ -31,11 +38,20 @@ const serialize = function (certificationPointOfContact) {
         'pixCertifScoBlockedAccessDateCollege',
       ],
     },
+    certificationCenterMemberships: {
+      ref: 'id',
+      included: true,
+      attributes: ['certificationCenterId', 'userId', 'role'],
+    },
     typeForAttribute: function (attribute) {
-      if (attribute === 'allowedCertificationCenterAccesses') {
-        return 'allowed-certification-center-access';
+      switch (attribute) {
+        case ALLOWED_CERTIFICATION_CENTER_ACCESS_ATTRIBUTE:
+          return ALLOWED_CERTIFICATION_CENTER_ACCESS_TYPE;
+        case CERTIFICATION_CENTER_MEMBERSHIP_ATTRIBUTE:
+          return CERTIFICATION_CENTER_MEMBERSHIP_TYPE;
+        default:
+          return attribute;
       }
-      return attribute;
     },
     transform(certificationPointOfContact) {
       const transformedCertificationPointOfContact = _.clone(certificationPointOfContact);

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -606,6 +606,72 @@ describe('Acceptance | API | Certification Center', function () {
     });
   });
 
+  describe('GET /api/certifications-centers/{certificationCenterId}/invitations', function () {
+    let certificationCenterId, userId;
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser().id;
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    });
+
+    context('When user is admin of the certification center', function () {
+      it('returns pending invitations from certification center', async function () {
+        // given
+        const invitation = databaseBuilder.factory.buildCertificationCenterInvitation({ certificationCenterId });
+        const invitation2 = databaseBuilder.factory.buildCertificationCenterInvitation({
+          certificationCenterId,
+          code: 'WXCVBN',
+          email: 'test@example.net',
+        });
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'ADMIN' });
+
+        await databaseBuilder.commit();
+
+        request = {
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          method: 'GET',
+          url: `/api/certification-centers/${certificationCenterId}/invitations`,
+          payload: { certificationCenterId },
+        };
+
+        // when
+        const response = await server.inject(request);
+        const responseIds = response.result.data.map(
+          (certificationCenterInvitation) => certificationCenterInvitation.id,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(responseIds).to.deep.equal([invitation.id.toString(), invitation2.id.toString()]);
+      });
+    });
+
+    context('When user is not admin of the certification center', function () {
+      it('returns an 403 HTTP error code', async function () {
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'MEMBER' });
+
+        await databaseBuilder.commit();
+
+        request = {
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          method: 'GET',
+          url: `/api/certification-centers/${certificationCenterId}/invitations`,
+          payload: { certificationCenterId },
+        };
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+
   describe('POST /api/admin/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
     let certificationCenterId;
     let email;

--- a/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
+++ b/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
@@ -13,10 +13,10 @@ describe('Acceptance | Route | CertificationPointOfContact', function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({
+      const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
         userId,
         certificationCenterId,
-      });
+      }).id;
       await databaseBuilder.commit();
       const options = {
         method: 'GET',
@@ -31,6 +31,27 @@ describe('Acceptance | Route | CertificationPointOfContact', function () {
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.id).to.equal(userId.toString());
       expect(response.result.data.attributes.lang).to.equal('fr');
+
+      expect(response.result.data.relationships).to.to.deep.include({
+        'certification-center-memberships': {
+          data: [
+            {
+              id: certificationCenterMembershipId.toString(),
+              type: 'certification-center-membership',
+            },
+          ],
+        },
+      });
+
+      expect(response.result.included).to.deep.include({
+        id: certificationCenterMembershipId.toString(),
+        type: 'certification-center-membership',
+        attributes: {
+          'certification-center-id': certificationCenterId,
+          'user-id': userId,
+          role: 'MEMBER',
+        },
+      });
     });
   });
 });

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -388,7 +388,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
       expect(response.statusCode).to.equal(200);
     });
 
-    it('returns an 403 HTTP error when user is not admin of the certification-center', async function () {
+    it('returns 403 when user is not admin of the certification-center', async function () {
       // given
       databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'MEMBER' });
 

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -333,6 +333,75 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkUserIsAdminOfCertificationCenter', function () {
+    let userId;
+    let certificationCenterId;
+    let options;
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser().id;
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+      databaseBuilder.factory.options = {
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        method: 'GET',
+        url: `/api/organizations/${certificationCenterId}/invitations`,
+      };
+
+      await databaseBuilder.commit();
+
+      server.route({
+        method: 'GET',
+        path: '/test_route/certification-centers/admin/{certificationCenterId}',
+        handler: (r, h) => h.response({}).code(200),
+        config: {
+          pre: [
+            {
+              method: securityPreHandlers.checkUserIsAdminOfCertificationCenter,
+            },
+          ],
+        },
+      });
+
+      options = {
+        method: 'GET',
+        url: `/test_route/certification-centers/admin/${certificationCenterId}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+    });
+
+    it('returns 200 when user is admin of the certification-center', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+        role: 'ADMIN',
+        disabledAt: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('returns an 403 HTTP error when user is not admin of the certification-center', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'MEMBER' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
   describe('#checkUserIsMemberOfAnOrganization', function () {
     it('should return a well formed JSON API error when user is not authorized', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -270,6 +270,88 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
   });
 
+  describe('#isAdminOfCertificationCenter', function () {
+    let certificationCenterId, userId;
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser().id;
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+      await databaseBuilder.commit();
+    });
+
+    it('returns false if user has no membership in given certification center', async function () {
+      // when
+      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+        userId,
+        certificationCenterId,
+      });
+
+      // then
+      expect(hasMembership).to.be.false;
+    });
+
+    it('returns false if user has a role "MEMBER" in given certification center', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+        disabledAt: null,
+        role: 'MEMBER',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+        userId,
+        certificationCenterId,
+      });
+
+      // then
+      expect(hasMembership).to.be.false;
+    });
+
+    it('returns false if user has a role "ADMIN" and a disabled membership in given certification center', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+        disabledAt: new Date(),
+        role: 'ADMIN',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+        userId,
+        certificationCenterId,
+      });
+
+      // then
+      expect(hasMembership).to.be.false;
+    });
+
+    it('returns true if user has a role "ADMIN" in given certification center and no disabled membership', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+        disabledAt: null,
+        role: 'ADMIN',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+        userId,
+        certificationCenterId,
+      });
+
+      // then
+      expect(hasMembership).to.be.true;
+    });
+  });
+
   describe('#isMemberOfCertificationCenter', function () {
     it('should return false if user has no membership in given certification center', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -282,13 +282,13 @@ describe('Integration | Repository | Certification Center Membership', function 
 
     it('returns false if user has no membership in given certification center', async function () {
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+      const isAdminOfCertificationCenter = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
         userId,
         certificationCenterId,
       });
 
       // then
-      expect(hasMembership).to.be.false;
+      expect(isAdminOfCertificationCenter).to.be.false;
     });
 
     it('returns false if user has a role "MEMBER" in given certification center', async function () {
@@ -302,13 +302,13 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
 
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+      const isAdminOfCertificationCenter = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
         userId,
         certificationCenterId,
       });
 
       // then
-      expect(hasMembership).to.be.false;
+      expect(isAdminOfCertificationCenter).to.be.false;
     });
 
     it('returns false if user has a role "ADMIN" and a disabled membership in given certification center', async function () {
@@ -322,13 +322,13 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
 
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+      const isAdminOfCertificationCenter = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
         userId,
         certificationCenterId,
       });
 
       // then
-      expect(hasMembership).to.be.false;
+      expect(isAdminOfCertificationCenter).to.be.false;
     });
 
     it('returns true if user has a role "ADMIN" in given certification center and no disabled membership', async function () {
@@ -342,13 +342,13 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
 
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+      const isAdminOfCertificationCenter = await certificationCenterMembershipRepository.isAdminOfCertificationCenter({
         userId,
         certificationCenterId,
       });
 
       // then
-      expect(hasMembership).to.be.true;
+      expect(isAdminOfCertificationCenter).to.be.true;
     });
   });
 
@@ -365,13 +365,15 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
 
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
-        userId,
-        certificationCenterId: otherCertificationCenterId,
-      });
+      const isMemberOfCertificationCenter = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+        {
+          userId,
+          certificationCenterId: otherCertificationCenterId,
+        },
+      );
 
       // then
-      expect(hasMembership).to.be.false;
+      expect(isMemberOfCertificationCenter).to.be.false;
     });
 
     it('should return false if user has a disabled membership in given certification center', async function () {
@@ -386,13 +388,15 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
 
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
-        userId,
-        certificationCenterId,
-      });
+      const isMemberOfCertificationCenter = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+        {
+          userId,
+          certificationCenterId,
+        },
+      );
 
       // then
-      expect(hasMembership).to.be.false;
+      expect(isMemberOfCertificationCenter).to.be.false;
     });
 
     it('should return true if user has a not disabled membership in given certification center', async function () {
@@ -407,13 +411,15 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
 
       // when
-      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
-        userId,
-        certificationCenterId,
-      });
+      const isMemberOfCertificationCenter = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+        {
+          userId,
+          certificationCenterId,
+        },
+      );
 
       // then
-      expect(hasMembership).to.be.true;
+      expect(isMemberOfCertificationCenter).to.be.true;
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -40,6 +40,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         lang: 'fr',
         pixCertifTermsOfServiceAccepted: true,
         allowedCertificationCenterAccesses: [],
+        certificationCenterMemberships: [],
       });
       expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
     });
@@ -73,7 +74,8 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             email: 'jean.acajou@example.net',
             pixCertifTermsOfServiceAccepted: true,
           });
-          databaseBuilder.factory.buildCertificationCenterMembership({
+
+          const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
             certificationCenterId: 123,
             userId: 456,
           });
@@ -92,6 +94,16 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             relatedOrganizationTags: [],
             habilitations: [],
           });
+
+          const expectedCertificationCenterMemberships = [
+            {
+              id: certificationCenterMembership.id,
+              certificationCenterId: 123,
+              userId: 456,
+              role: 'MEMBER',
+            },
+          ];
+
           const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
             id: 456,
             firstName: 'Jean',
@@ -99,6 +111,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             email: 'jean.acajou@example.net',
             pixCertifTermsOfServiceAccepted: true,
             allowedCertificationCenterAccesses: [expectedAllowedCertificationCenterAccess],
+            certificationCenterMemberships: expectedCertificationCenterMemberships,
           });
           expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
         });
@@ -163,29 +176,55 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
           email: 'jean.acajou@example.net',
           pixCertifTermsOfServiceAccepted: true,
         });
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          certificationCenterId: 1,
-          userId: 123,
-        });
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          certificationCenterId: 2,
-          userId: 123,
-        });
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          certificationCenterId: 3,
-          userId: 123,
-        });
+
+        const [firstMembership, secondMembership, thirdMembership] = [
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            certificationCenterId: 1,
+            userId: 123,
+          }),
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            certificationCenterId: 2,
+            userId: 123,
+          }),
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            certificationCenterId: 3,
+            userId: 123,
+          }),
+        ];
+
         databaseBuilder.factory.buildCertificationCenterMembership({
           certificationCenterId: 4,
           userId: 123,
           disabledAt: now,
         });
+
         await databaseBuilder.commit();
 
         // when
         const certificationPointOfContact = await certificationPointOfContactRepository.get(123);
 
         // then
+        const expectedCertificationCenterMemberships = [
+          {
+            id: firstMembership.id,
+            certificationCenterId: 1,
+            userId: 123,
+            role: 'MEMBER',
+          },
+          {
+            id: secondMembership.id,
+            certificationCenterId: 2,
+            userId: 123,
+            role: 'MEMBER',
+          },
+          {
+            id: thirdMembership.id,
+            certificationCenterId: 3,
+            userId: 123,
+            role: 'MEMBER',
+          },
+        ];
+
         const expectedFirstAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
           id: 1,
           name: 'Centre de certif sans orga reliée',
@@ -224,6 +263,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             expectedSecondAllowedCertificationCenterAccess,
             expectedThirdAllowedCertificationCenterAccess,
           ],
+          certificationCenterMemberships: expectedCertificationCenterMemberships,
         });
         expect(expectedCertificationPointOfContact).to.deepEqualInstance(certificationPointOfContact);
       });
@@ -265,20 +305,39 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         email: 'jean.acajou@example.net',
         pixCertifTermsOfServiceAccepted: true,
       });
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 1,
-        userId: 123,
-      });
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        certificationCenterId: 2,
-        userId: 123,
-      });
+
+      const [firstMembership, secondMembership] = [
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: 1,
+          userId: 123,
+        }),
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: 2,
+          userId: 123,
+        }),
+      ];
+
       await databaseBuilder.commit();
 
       // when
       const certificationPointOfContact = await certificationPointOfContactRepository.get(123);
 
       // then
+      const expectedCertificationCenterMemberships = [
+        {
+          id: firstMembership.id,
+          userId: 123,
+          certificationCenterId: 1,
+          role: 'MEMBER',
+        },
+        {
+          id: secondMembership.id,
+          userId: 123,
+          certificationCenterId: 2,
+          role: 'MEMBER',
+        },
+      ];
+
       const expectedFirstAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 1,
         name: 'Centre de certif sans orga reliée',
@@ -300,6 +359,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         relatedOrganizationTags: [],
         habilitations: [{ id: 3, label: 'Certif comp 3', key: 'COMP_3' }],
       });
+
       const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 123,
         firstName: 'Jean',
@@ -310,6 +370,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
           expectedFirstAllowedCertificationCenterAccess,
           expectedSecondAllowedCertificationCenterAccess,
         ],
+        certificationCenterMemberships: expectedCertificationCenterMemberships,
       });
       expect(certificationPointOfContact).to.deepEqualInstance(expectedCertificationPointOfContact);
     });
@@ -364,7 +425,8 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             email: 'jean.acajou@example.net',
             pixCertifTermsOfServiceAccepted: true,
           });
-          databaseBuilder.factory.buildCertificationCenterMembership({
+
+          const membership = databaseBuilder.factory.buildCertificationCenterMembership({
             certificationCenterId: 1,
             userId: 123,
           });
@@ -374,6 +436,15 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
           const certificationPointOfContact = await certificationPointOfContactRepository.get(123);
 
           // then
+          const expectedCertificationCenterMemberships = [
+            {
+              id: membership.id,
+              certificationCenterId: 1,
+              userId: 123,
+              role: 'MEMBER',
+            },
+          ];
+
           const expectedAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
             id: 1,
             name: 'Centre de certif',
@@ -393,10 +464,113 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             email: 'jean.acajou@example.net',
             pixCertifTermsOfServiceAccepted: true,
             allowedCertificationCenterAccesses: [expectedAllowedCertificationCenterAccess],
+            certificationCenterMemberships: expectedCertificationCenterMemberships,
           });
           expect(certificationPointOfContact).to.deepEqualInstance(expectedCertificationPointOfContact);
         });
       },
     );
+
+    context('when user is linked and has an "ADMIN" role of an certification center', function () {
+      const userId = 123;
+      const certificationCenterId = 1;
+
+      let certificationCenter, user;
+
+      beforeEach(async function () {
+        user = databaseBuilder.factory.buildUser({
+          id: userId,
+          firstName: 'Jean',
+          lastName: 'Acajou',
+          email: 'jean.acajou@example.net',
+          pixCertifTermsOfServiceAccepted: true,
+        });
+
+        certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+          id: certificationCenterId,
+          name: 'Centre de certif Pro',
+          type: CertificationCenter.types.PRO,
+          externalId: 'Centre1',
+        });
+      });
+
+      context("when user's membership is not disabled", function () {
+        it('returns a certification-point-of-contact object with a certification-center-membership having "ADMIN" role', async function () {
+          // given
+          const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+            certificationCenterId: certificationCenterId,
+            userId: userId,
+            disabledAt: null,
+            role: 'ADMIN',
+          });
+
+          await databaseBuilder.commit();
+
+          const expectedCertificationCenterMembership = {
+            id: certificationCenterMembership.id,
+            userId,
+            certificationCenterId,
+            role: 'ADMIN',
+          };
+
+          const expectedAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+            id: certificationCenterId,
+            name: certificationCenter.name,
+            externalId: certificationCenter.externalId,
+            type: certificationCenter.type,
+            isRelatedToManagingStudentsOrganization: false,
+            relatedOrganizationTags: [],
+            habilitations: [],
+          });
+
+          const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
+            id: 123,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            email: user.email,
+            pixCertifTermsOfServiceAccepted: user.pixCertifTermsOfServiceAccepted,
+            allowedCertificationCenterAccesses: [expectedAllowedCertificationCenterAccess],
+            certificationCenterMemberships: [expectedCertificationCenterMembership],
+          });
+
+          // when
+          const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
+
+          // then
+
+          expect(certificationPointOfContact).to.deepEqualInstance(expectedCertificationPointOfContact);
+        });
+      });
+
+      context("when user's membership is disabled", function () {
+        it('returns a certification-point-of-contact object without a certification-center-membership having "ADMIN" role', async function () {
+          // given
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            certificationCenterId: certificationCenterId,
+            userId: userId,
+            disabledAt: new Date(),
+          });
+
+          await databaseBuilder.commit();
+
+          const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
+            id: 123,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            email: user.email,
+            pixCertifTermsOfServiceAccepted: user.pixCertifTermsOfServiceAccepted,
+            allowedCertificationCenterAccesses: [],
+            certificationCenterMemberships: [],
+          });
+
+          // when
+          const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
+
+          // then
+
+          expect(certificationPointOfContact).to.deepEqualInstance(expectedCertificationPointOfContact);
+        });
+      });
+    });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -1,5 +1,7 @@
 import { AllowedCertificationCenterAccess } from '../../../../lib/domain/read-models/AllowedCertificationCenterAccess.js';
 
+const ALLOWED_CERTIFICATION_CENTER_ACCESS_BUILDER_DEFAULT_ID = 123;
+
 function buildAllowedCertificationCenterAccess({
   id = 123,
   name = 'Sunnydale Center',
@@ -30,4 +32,4 @@ buildAllowedCertificationCenterAccess.notSco = function ({
   });
 };
 
-export { buildAllowedCertificationCenterAccess };
+export { ALLOWED_CERTIFICATION_CENTER_ACCESS_BUILDER_DEFAULT_ID, buildAllowedCertificationCenterAccess };

--- a/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
@@ -1,5 +1,10 @@
 import { CertificationPointOfContact } from '../../../../lib/domain/read-models/CertificationPointOfContact.js';
-import { buildAllowedCertificationCenterAccess } from './build-allowed-certification-center-access.js';
+import {
+  ALLOWED_CERTIFICATION_CENTER_ACCESS_BUILDER_DEFAULT_ID,
+  buildAllowedCertificationCenterAccess,
+} from './build-allowed-certification-center-access.js';
+
+const CERTIFICATION_POINT_OF_CONTACT_BUILDER_MEMBERSHIP_DEFAULT_ID = 1231;
 
 const buildCertificationPointOfContact = function ({
   id = 123,
@@ -9,6 +14,7 @@ const buildCertificationPointOfContact = function ({
   lang = 'fr',
   pixCertifTermsOfServiceAccepted = true,
   allowedCertificationCenterAccesses = [buildAllowedCertificationCenterAccess()],
+  certificationCenterMemberships = [_buildCertificationCenterMembership({ userId: id })],
 } = {}) {
   return new CertificationPointOfContact({
     id,
@@ -18,7 +24,22 @@ const buildCertificationPointOfContact = function ({
     lang,
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
+    certificationCenterMemberships,
   });
 };
 
-export { buildCertificationPointOfContact };
+function _buildCertificationCenterMembership({
+  id = CERTIFICATION_POINT_OF_CONTACT_BUILDER_MEMBERSHIP_DEFAULT_ID,
+  certificationCenterId = ALLOWED_CERTIFICATION_CENTER_ACCESS_BUILDER_DEFAULT_ID,
+  userId,
+  role = 'MEMBER',
+}) {
+  return {
+    id,
+    certificationCenterId,
+    userId,
+    role,
+  };
+}
+
+export { CERTIFICATION_POINT_OF_CONTACT_BUILDER_MEMBERSHIP_DEFAULT_ID, buildCertificationPointOfContact };

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -18,6 +18,16 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
       });
+
+      const certificationCenterMemberships = [
+        {
+          id: '1231',
+          certificationCenterId: 123,
+          userId: 789,
+          role: 'MEMBER',
+        },
+      ];
+
       const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 789,
         firstName: 'Buffy',
@@ -25,12 +35,15 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
         email: 'buffy.summers@example.net',
         pixCertifTermsOfServiceAccepted: true,
         allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
+        certificationCenterMemberships,
       });
+
       const request = {
         auth: {
           credentials: { userId: 123 },
         },
       };
+
       usecases.getCertificationPointOfContact.withArgs({ userId: 123 }).resolves(certificationPointOfContact);
 
       // when
@@ -57,6 +70,14 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
                 },
               ],
             },
+            'certification-center-memberships': {
+              data: [
+                {
+                  id: '1231',
+                  type: 'certification-center-membership',
+                },
+              ],
+            },
           },
         },
         included: [
@@ -76,6 +97,15 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
               'pix-certif-sco-blocked-access-date-lycee': null,
               'related-organization-tags': [],
               habilitations: [],
+            },
+          },
+          {
+            id: '1231',
+            type: 'certification-center-membership',
+            attributes: {
+              'certification-center-id': 123,
+              'user-id': 789,
+              role: 'MEMBER',
             },
           },
         ],

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -1045,7 +1045,7 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
   describe('#checkUserIsAdminOfCertificationCenter', function () {
     context('Successful case', function () {
-      it('authorizes access to resource when the user is authenticated and is admin in certification center', async function () {
+      it('authorizes access to resource when the user is authenticated and is admin of the certification center', async function () {
         // given
         const user = domainBuilder.buildUser();
         const certificationCenter = domainBuilder.buildCertificationCenter();

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -1043,6 +1043,63 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkUserIsAdminOfCertificationCenter', function () {
+    context('Successful case', function () {
+      it('authorizes access to resource when the user is authenticated and is admin in certification center', async function () {
+        // given
+        const user = domainBuilder.buildUser();
+        const certificationCenter = domainBuilder.buildCertificationCenter();
+        const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+          user,
+          certificationCenter,
+          role: 'ADMIN',
+        });
+        const request = {
+          auth: { credentials: { accessToken: 'valid.access.token', userId: certificationCenterMembership.user.id } },
+          params: { certificationCenterId: certificationCenterMembership.certificationCenter.id },
+        };
+
+        sinon.stub(tokenService, 'extractTokenFromAuthChain');
+        const checkUserIsAdminOfCertificationCenterUsecaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
+
+        // when
+        const response = await securityPreHandlers.checkUserIsAdminOfCertificationCenter(request, hFake, {
+          checkUserIsAdminOfCertificationCenterUsecase: checkUserIsAdminOfCertificationCenterUsecaseStub,
+        });
+
+        // then
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('Error cases', function () {
+      it('forbids resource access when user is not admin in certification center', async function () {
+        // given
+        const user = domainBuilder.buildUser();
+        const certificationCenter = domainBuilder.buildCertificationCenter();
+        const request = {
+          auth: { credentials: { accessToken: 'valid.access.token', userId: user.id } },
+          params: { certificationCenterId: certificationCenter.id },
+        };
+
+        sinon.stub(tokenService, 'extractTokenFromAuthChain');
+        const checkUserIsAdminOfCertificationCenterUsecaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
+
+        // when
+        const response = await securityPreHandlers.checkUserIsAdminOfCertificationCenter(request, hFake, {
+          checkUserIsAdminOfCertificationCenterUsecase: checkUserIsAdminOfCertificationCenterUsecaseStub,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+
   describe('#checkUserIsMemberOfCertificationCenter', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is authenticated and is member in certification center', async function () {

--- a/api/tests/unit/application/usecases/checkUserIsAdminOfCertificationCenter_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsAdminOfCertificationCenter_test.js
@@ -1,0 +1,44 @@
+import { expect, sinon, domainBuilder } from '../../../test-helper.js';
+import * as usecase from '../../../../lib/application/usecases/checkUserIsAdminOfCertificationCenter.js';
+
+describe('Unit | Application | Use Case | CheckUserIsAdminOfCertificationCenter', function () {
+  let certificationCenter, certificationCenterMembershipRepositoryStub, user;
+
+  beforeEach(function () {
+    certificationCenter = domainBuilder.buildCertificationCenter();
+    certificationCenterMembershipRepositoryStub = {
+      isAdminOfCertificationCenter: sinon.stub(),
+    };
+    user = domainBuilder.buildUser();
+  });
+
+  context('When user is admin of the certification center', function () {
+    it('returns true', async function () {
+      // given
+      certificationCenterMembershipRepositoryStub.isAdminOfCertificationCenter.resolves(true);
+
+      // when
+      const response = await usecase.execute(user.id, certificationCenter.id, {
+        certificationCenterMembershipRepository: certificationCenterMembershipRepositoryStub,
+      });
+
+      // then
+      expect(response).to.equal(true);
+    });
+  });
+
+  context('When user is not admin of the certification center', function () {
+    it('returns false', async function () {
+      // given
+      certificationCenterMembershipRepositoryStub.isAdminOfCertificationCenter.resolves(false);
+
+      // when
+      const response = await usecase.execute(user.id, certificationCenter.id, {
+        certificationCenterMembershipRepository: certificationCenterMembershipRepositoryStub,
+      });
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -10,6 +10,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
       sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value('2022-08-01');
 
       settings.features.pixCertifScoBlockedAccessDateLycee = '2022-08-01';
+
       const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 123,
         name: 'Sunnydale Center',
@@ -22,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
           { id: 2, name: 'Certif comp 2' },
         ],
       });
+
       const allowedCertificationCenterAccess2 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 456,
         name: 'Hellmouth',
@@ -31,6 +33,22 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         relatedOrganizationTags: ['tag1'],
         habilitations: [],
       });
+
+      const certificationCenterMemberships = [
+        {
+          id: 1231,
+          certificationCenterId: 123,
+          userId: 789,
+          role: 'ADMIN',
+        },
+        {
+          id: 1232,
+          certificationCenterId: 456,
+          userId: 789,
+          role: 'MEMBER',
+        },
+      ];
+
       const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 789,
         firstName: 'Buffy',
@@ -38,6 +56,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         email: 'buffy.summers@example.net',
         pixCertifTermsOfServiceAccepted: true,
         allowedCertificationCenterAccesses: [allowedCertificationCenterAccess1, allowedCertificationCenterAccess2],
+        certificationCenterMemberships,
       });
 
       // when
@@ -65,6 +84,18 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 {
                   id: '456',
                   type: 'allowed-certification-center-access',
+                },
+              ],
+            },
+            'certification-center-memberships': {
+              data: [
+                {
+                  id: '1231',
+                  type: 'certification-center-membership',
+                },
+                {
+                  id: '1232',
+                  type: 'certification-center-membership',
                 },
               ],
             },
@@ -108,6 +139,24 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'pix-certif-sco-blocked-access-date-lycee': '2022-08-01',
               'related-organization-tags': ['tag1'],
               habilitations: [],
+            },
+          },
+          {
+            id: '1231',
+            type: 'certification-center-membership',
+            attributes: {
+              'certification-center-id': 123,
+              'user-id': 789,
+              role: 'ADMIN',
+            },
+          },
+          {
+            id: '1232',
+            type: 'certification-center-membership',
+            attributes: {
+              'certification-center-id': 456,
+              'user-id': 789,
+              role: 'MEMBER',
             },
           },
         ],

--- a/certif/app/adapters/certification-center-invitation.js
+++ b/certif/app/adapters/certification-center-invitation.js
@@ -1,6 +1,12 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCenterInvitationAdapter extends ApplicationAdapter {
+  urlForFindAll(modelName, { adapterOptions }) {
+    const { certificationCenterId } = adapterOptions;
+
+    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/invitations`;
+  }
+
   urlForQueryRecord(query) {
     if (query.invitationId && query.code) {
       const { invitationId } = query;

--- a/certif/app/components/team/invitations-list-item.hbs
+++ b/certif/app/components/team/invitations-list-item.hbs
@@ -1,0 +1,6 @@
+<tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
+  <td>{{@invitation.email}}</td>
+  <td>
+    {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
+  </td>
+</tr>

--- a/certif/app/components/team/invitations-list.hbs
+++ b/certif/app/components/team/invitations-list.hbs
@@ -1,0 +1,17 @@
+<div class="panel table content-text content-text--small">
+  <table>
+    <thead>
+      <tr>
+        <th class="table__column table__column--medium">{{t "pages.team-invitations.table.labels.email-address"}}</th>
+        <th class="table__column table__column--medium">{{t
+            "pages.team-invitations.table.labels.last-sending-date"
+          }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @invitations as |invitation|}}
+        <Team::InvitationsListItem @invitation={{invitation}} />
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/certif/app/controllers/authenticated/team.js
+++ b/certif/app/controllers/authenticated/team.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class Team extends Controller {
+  @service currentUser;
   @service featureToggles;
   @service router;
   @service notifications;
@@ -11,6 +12,10 @@ export default class Team extends Controller {
 
   @tracked shouldShowRefererSelectionModal = false;
   @tracked selectedReferer = '';
+
+  get shouldDisplayNavbarSection() {
+    return this.currentUser.isAdminOfCurrentCertificationCenter;
+  }
 
   get shouldDisplayNoRefererSection() {
     return this.model.hasCleaHabilitation && _hasAtLeastOneMemberAndNoReferer(this.model.members);

--- a/certif/app/models/certification-center-membership.js
+++ b/certif/app/models/certification-center-membership.js
@@ -1,0 +1,11 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CertificationCenterMembership extends Model {
+  @attr('number') userId;
+  @attr('number') certificationCenterId;
+  @attr('string') role;
+
+  get isAdmin() {
+    return this.role === 'ADMIN';
+  }
+}

--- a/certif/app/models/certification-point-of-contact.js
+++ b/certif/app/models/certification-point-of-contact.js
@@ -7,6 +7,7 @@ export default class CertificationPointOfContact extends Model {
   @attr() lang;
   @attr() pixCertifTermsOfServiceAccepted;
   @hasMany('allowed-certification-center-access') allowedCertificationCenterAccesses;
+  @hasMany('certification-center-membership') certificationCenterMemberships;
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -35,7 +35,11 @@ Router.map(function () {
       });
       this.route('add-student', { path: '/:session_id/inscription-eleves' });
     });
-    this.route('team', { path: '/equipe' });
+    this.route('team', { path: '/equipe' }, function () {
+      this.route('list', { path: '/' }, function () {
+        this.route('members', { path: '/membres' });
+      });
+    });
   });
 
   this.route('logout');

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -38,6 +38,7 @@ Router.map(function () {
     this.route('team', { path: '/equipe' }, function () {
       this.route('list', { path: '/' }, function () {
         this.route('members', { path: '/membres' });
+        this.route('invitations');
       });
     });
   });

--- a/certif/app/routes/authenticated/team.js
+++ b/certif/app/routes/authenticated/team.js
@@ -6,14 +6,23 @@ export default class AuthenticatedTeamRoute extends Route {
   @service currentUser;
   @service store;
 
-  model() {
+  async model() {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    let invitations = [];
     const members = this.store.query('member', { certificationCenterId });
+
+    if (this.currentUser.isAdminOfCurrentCertificationCenter) {
+      invitations = await this.store.findAll('certification-center-invitation', {
+        adapterOptions: { certificationCenterId },
+      });
+    }
+
     const hasCleaHabilitation = this.store
       .peekRecord('allowed-certification-center-access', certificationCenterId)
       .habilitations?.some((habilitation) => habilitation.key === 'CLEA');
 
     return {
+      invitations,
       members,
       hasCleaHabilitation,
     };

--- a/certif/app/routes/authenticated/team/list/index.js
+++ b/certif/app/routes/authenticated/team/list/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.replaceWith('authenticated.team.list.members');
+  }
+}

--- a/certif/app/routes/authenticated/team/list/invitations.js
+++ b/certif/app/routes/authenticated/team/list/invitations.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AuthenticatedTeamListInvitationsRoute extends Route {
+  @service currentUser;
+  @service router;
+
+  beforeModel() {
+    if (!this.currentUser.isAdminOfCurrentCertificationCenter) {
+      this.router.replaceWith('authenticated.team.list.members');
+    }
+  }
+
+  model() {
+    return this.modelFor('authenticated.team').invitations;
+  }
+}

--- a/certif/app/routes/authenticated/team/list/members.js
+++ b/certif/app/routes/authenticated/team/list/members.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+
+export default class MembersRoute extends Route {
+  model() {
+    return {
+      members: this.modelFor('authenticated.team').members,
+      hasCleaHabilitation: this.modelFor('authenticated.team').hasCleaHabilitation,
+    };
+  }
+}

--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -6,6 +6,12 @@
     align-items:center;
   }
 
+  &__tabs {
+    display: flex;
+    margin-bottom: $pix-spacing-m;
+    border-bottom: 1px solid $pix-neutral-20;
+  }
+
   &__update-referer-button {
     width: 180px;
     height: 50px;

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -39,6 +39,9 @@
     <LinkTo @route="authenticated.team.list.members" class="navbar-item">
       {{t "pages.team.tabs.member" count=@model.members.length}}
     </LinkTo>
+    <LinkTo @route="authenticated.team.list.invitations" class="navbar-item">
+      {{t "pages.team.tabs.invitation" count=@model.invitations.length}}
+    </LinkTo>
   </nav>
   {{outlet}}
 

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -34,6 +34,18 @@
   </div>
 {{/if}}
 
+{{#if this.shouldDisplayNavbarSection}}
+  <nav class="panel navbar team__tabs" aria-label="A ajouter">
+    <LinkTo @route="authenticated.team.list.members" class="navbar-item">
+      {{t "pages.team.tabs.member" count=@model.members.length}}
+    </LinkTo>
+  </nav>
+  {{outlet}}
+
+{{else}}
+  <MembersList @members={{@model.members}} @hasCleaHabilitation={{this.model.hasCleaHabilitation}} />
+{{/if}}
+
 <SelectRefererModal
   @showModal={{this.shouldShowRefererSelectionModal}}
   @toggleRefererModal={{this.toggleRefererModal}}
@@ -43,4 +55,3 @@
   @options={{this.membersSelectOptionsSortedByLastName}}
   @selectedReferer={{this.selectedReferer}}
 />
-<MembersList @members={{@model.members}} @hasCleaHabilitation={{this.model.hasCleaHabilitation}} />

--- a/certif/app/templates/authenticated/team/list/invitations.hbs
+++ b/certif/app/templates/authenticated/team/list/invitations.hbs
@@ -1,0 +1,3 @@
+{{page-title "Invitations"}}
+
+<Team::InvitationsList @invitations={{@model}} />

--- a/certif/app/templates/authenticated/team/list/members.hbs
+++ b/certif/app/templates/authenticated/team/list/members.hbs
@@ -1,0 +1,1 @@
+<MembersList @members={{@model.members}} @hasCleaHabilitation={{@model.hasCleaHabilitation}} />

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -279,6 +279,11 @@ function routes() {
     return new Response(204);
   });
 
+  this.get('/certification-centers/:id/invitations', async (schema, request) => {
+    const certificationCenterId = request.params.id;
+    return schema.certificationCenterInvitations.where({ certificationCenterId });
+  });
+
   this.get('/certification-center-invitations/:id', (schema, request) => {
     const certificationCenterInvitationId = request.params.id;
     const code = request.queryParams?.code;

--- a/certif/mirage/serializers/certification-point-of-contact.js
+++ b/certif/mirage/serializers/certification-point-of-contact.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const include = ['allowedCertificationCenterAccesses'];
+const include = ['allowedCertificationCenterAccesses', 'certificationCenterMemberships'];
 
 export default ApplicationSerializer.extend({
   include,

--- a/certif/tests/acceptance/team/invitations_test.js
+++ b/certif/tests/acceptance/team/invitations_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupIntl from '../../helpers/setup-intl';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import {
+  authenticateSession,
+  createCertificationPointOfContactWithTermsOfServiceAccepted,
+} from '../../helpers/test-init';
+
+module('Acceptance | Team | Invitations', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('When user is member', function () {
+    test('redirects to team members page', async function (assert) {
+      // given
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+
+      await authenticateSession(certificationPointOfContact.id);
+
+      // when
+      await visit('/equipe');
+
+      // then
+      assert.strictEqual(currentURL(), '/equipe/membres');
+    });
+  });
+
+  module('When user is admin', function () {
+    test('displays invitations list', async function (assert) {
+      // given
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+        undefined,
+        'Centre de certification du pix',
+        false,
+        'ADMIN',
+      );
+
+      server.create('certification-center-invitation', {
+        certificationCenterId: 123,
+        email: 'camile.onette@example.net',
+        updatedAt: new Date('2023-09-20'),
+      });
+
+      server.create('certification-center-invitation', {
+        certificationCenterId: 123,
+        email: 'camile.onette@example.net',
+        updatedAt: new Date('2023-09-19'),
+      });
+
+      await authenticateSession(certificationPointOfContact.id);
+
+      // when
+      await visit('/equipe/invitations');
+
+      // then
+      assert.strictEqual(currentURL(), '/equipe/invitations');
+    });
+  });
+});

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -19,70 +19,132 @@ module('Acceptance | authenticated | team', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  module('when user go to members list', function () {
-    module('when certification center has "CLEA" habilitation', function () {
-      module('when there is at least one member', function () {
-        module('when there is no referer', function () {
-          test('it should be possible to see the "no referer" section', async function (assert) {
-            // given
-            const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-            server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-            server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-            await authenticateSession(certificationPointOfContact.id);
+  module('when user is admin', function () {
+    test('displays navbar with "members" and "invitations" links', async function (assert) {
+      // given
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+        undefined,
+        'Centre de certification du pix',
+        false,
+        'ADMIN',
+      );
 
-            // when
-            const screen = await visitScreen('/equipe');
+      server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+      server.create('member', { firstName: 'Lee', lastName: 'Tige', isReferer: false });
+      await authenticateSession(certificationPointOfContact.id);
 
-            // then
-            assert.dom(screen.getByText(this.intl.t('pages.team.no-referer-section.title'))).exists();
-            assert
-              .dom(
-                screen.getByRole('button', {
-                  name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
-                }),
-              )
-              .exists();
-          });
+      // when
+      const screen = await visitScreen('/equipe');
 
-          test('it should be possible to select a referer', async function (assert) {
-            // given
-            const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-            server.create('member', {
-              id: 102,
-              firstName: 'Lili',
-              lastName: 'Dupont',
-              isReferer: false,
+      // then
+      assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Lee' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Tige' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Membres (2)' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Invitations (-)' })).exists();
+    });
+
+    module('when user clicks on invitations link', function () {
+      test('displays invitations list', async function (assert) {
+        // given
+        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+          undefined,
+          'Centre de certification du pix',
+          false,
+          'ADMIN',
+        );
+
+        server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+        server.create('member', { firstName: 'Lee', lastName: 'Tige', isReferer: false });
+
+        server.create('certification-center-invitation', {
+          certificationCenterId: 1,
+          email: 'camile.onette@example.net',
+          updatedAt: new Date('2023-09-20'),
+        });
+
+        server.create('certification-center-invitation', {
+          certificationCenterId: 1,
+          email: 'camile.onette@example.net',
+          updatedAt: new Date('2023-09-19'),
+        });
+
+        await authenticateSession(certificationPointOfContact.id);
+
+        // when
+        const screen = await visitScreen('/equipe');
+
+        await click(
+          screen.getByRole('link', {
+            name: 'Invitations (2)',
+          }),
+        );
+        // then
+        assert.strictEqual(currentURL(), '/equipe/invitations');
+        assert.strictEqual(screen.getAllByLabelText('Invitations en attente').length, 2);
+      });
+    });
+  });
+
+  module('when user is member', function () {
+    module('when visiting "/equipe/" url', function () {
+      test('redirects to "/equipe/membres" url', async function (assert) {
+        // given
+        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        await authenticateSession(certificationPointOfContact.id);
+
+        // when
+        await visitScreen('/equipe');
+
+        // then
+        assert.strictEqual(currentURL(), '/equipe/membres');
+      });
+    });
+
+    test('display only member list on the page', async function (assert) {
+      // given
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+
+      server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+      await authenticateSession(certificationPointOfContact.id);
+
+      // when
+      const screen = await visitScreen('/equipe');
+
+      // then
+      assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
+      assert.dom(screen.queryByRole('link', { name: 'Membres (1)' })).doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: 'Invitations (-)' })).doesNotExist();
+    });
+
+    module('when user go to members list', function () {
+      module('when certification center has "CLEA" habilitation', function () {
+        module('when there is at least one member', function () {
+          module('when there is no referer', function () {
+            test('it should be possible to see the "no referer" section', async function (assert) {
+              // given
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+              server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              await authenticateSession(certificationPointOfContact.id);
+
+              // when
+              const screen = await visitScreen('/equipe');
+
+              // then
+              assert.dom(screen.getByText(this.intl.t('pages.team.no-referer-section.title'))).exists();
+              assert
+                .dom(
+                  screen.getByRole('button', {
+                    name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
+                  }),
+                )
+                .exists();
             });
-            server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-            await authenticateSession(certificationPointOfContact.id);
 
-            // when
-            const screen = await visitScreen('/equipe');
-
-            assert.dom(screen.queryByRole('cell', { name: 'Référent Pix' })).doesNotExist();
-
-            await click(
-              screen.getByRole('button', { name: this.intl.t('pages.team.no-referer-section.select-referer-button') }),
-            );
-            await screen.findByRole('dialog');
-            await click(screen.getByLabelText(this.intl.t('pages.team.select-referer-modal.label')));
-            await click(
-              await screen.findByRole('option', {
-                name: 'Lili Dupont',
-              }),
-            );
-            await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
-            await waitForDialogClose();
-
-            // then
-            assert
-              .dom(screen.queryByRole('dialog', { name: this.intl.t('pages.team.select-referer-modal.title') }))
-              .doesNotExist();
-            assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).exists();
-          });
-
-          module('when no referer is selected', function () {
-            test('it should not be possible to validate', async function (assert) {
+            test('it should be possible to select a referer', async function (assert) {
               // given
               const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
               server.create('member', {
@@ -97,111 +159,152 @@ module('Acceptance | authenticated | team', function (hooks) {
               // when
               const screen = await visitScreen('/equipe');
 
+              assert.dom(screen.queryByRole('cell', { name: 'Référent Pix' })).doesNotExist();
+
               await click(
                 screen.getByRole('button', {
                   name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
                 }),
               );
               await screen.findByRole('dialog');
+              await click(screen.getByLabelText(this.intl.t('pages.team.select-referer-modal.label')));
+              await click(
+                await screen.findByRole('option', {
+                  name: 'Lili Dupont',
+                }),
+              );
+              await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
+              await waitForDialogClose();
 
               // then
-              assert.dom(screen.getByRole('button', { name: 'Valider la sélection de référent' })).isDisabled();
+              assert
+                .dom(screen.queryByRole('dialog', { name: this.intl.t('pages.team.select-referer-modal.title') }))
+                .doesNotExist();
+              assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).exists();
             });
 
-            module('when referer registration failed', function () {
-              test('it should return error message', async function (assert) {
+            module('when no referer is selected', function () {
+              test('it should not be possible to validate', async function (assert) {
                 // given
-                await _createAndAuthenticateMember();
-                const screen = await visitScreen('/equipe');
-                this.server.post('certif/certification-centers/:id/update-referer', () => {
-                  return new Response(500, {}, { errors: [{ status: '500' }] });
+                const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+                server.create('member', {
+                  id: 102,
+                  firstName: 'Lili',
+                  lastName: 'Dupont',
+                  isReferer: false,
                 });
-
-                await click(screen.getByRole('button', { name: 'Désigner un référent' }));
-                await screen.findByRole('dialog');
-                await click(screen.getByLabelText('Sélectionner le référent Pix'));
-                await click(
-                  await screen.findByRole('option', {
-                    name: 'Lili Dupont',
-                  }),
-                );
+                server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+                await authenticateSession(certificationPointOfContact.id);
 
                 // when
-                await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
+                const screen = await visitScreen('/equipe');
+
+                await click(
+                  screen.getByRole('button', {
+                    name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
+                  }),
+                );
+                await screen.findByRole('dialog');
 
                 // then
-                assert
-                  .dom(
-                    screen.getByText(
-                      'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
-                    ),
-                  )
-                  .exists();
+                assert.dom(screen.getByRole('button', { name: 'Valider la sélection de référent' })).isDisabled();
+              });
+
+              module('when referer registration failed', function () {
+                test('it should return error message', async function (assert) {
+                  // given
+                  await _createAndAuthenticateMember();
+                  const screen = await visitScreen('/equipe');
+                  this.server.post('certif/certification-centers/:id/update-referer', () => {
+                    return new Response(500, {}, { errors: [{ status: '500' }] });
+                  });
+
+                  await click(screen.getByRole('button', { name: 'Désigner un référent' }));
+                  await screen.findByRole('dialog');
+                  await click(screen.getByLabelText('Sélectionner le référent Pix'));
+                  await click(
+                    await screen.findByRole('option', {
+                      name: 'Lili Dupont',
+                    }),
+                  );
+
+                  // when
+                  await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
+
+                  // then
+                  assert
+                    .dom(
+                      screen.getByText(
+                        'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+                      ),
+                    )
+                    .exists();
+                });
               });
             });
           });
         });
       });
-    });
 
-    test('it should be possible to see members list', async function (assert) {
-      // given
-      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
-      await authenticateSession(certificationPointOfContact.id);
-
-      // when
-      const screen = await visitScreen('/equipe');
-
-      // then
-      assert.strictEqual(currentURL(), '/equipe');
-      assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
-    });
-
-    module('when user switch to see another certification center', function () {
-      test('it should be possible to see the other members list', async function (assert) {
+      test('it should be possible to see members list', async function (assert) {
         // given
-        const certificationCenterName = 'Centre de certif des Anne-atole';
-        const otherCertificationCenterName = 'Centre de certif de 7 Anne-néla';
-        const certificationPointOfContact = createAllowedCertificationCenterAccess({
-          certificationCenterName,
-          certificationCenterType: 'SCO',
-          isRelatedOrganizationManagingStudents: true,
-        });
-        const certificationPointOfContact2 = createAllowedCertificationCenterAccess({
-          certificationCenterName: otherCertificationCenterName,
-          certificationCenterType: 'SCO',
-          isRelatedOrganizationManagingStudents: true,
-        });
-        createCertificationPointOfContactWithCustomCenters({
-          pixCertifTermsOfServiceAccepted: true,
-          allowedCertificationCenterAccesses: [certificationPointOfContact, certificationPointOfContact2],
-        });
+        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
         server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
-        const memberOfTheFirstCertificationCenter = server.create('member', { firstName: 'Jack', lastName: 'Adit' });
         await authenticateSession(certificationPointOfContact.id);
-        const screen = await visitScreen('/equipe');
 
         // when
-        await click(screen.getByText(`${certificationCenterName} (${certificationPointOfContact.externalId})`));
-        await click(screen.getByText(`${otherCertificationCenterName}`));
-        memberOfTheFirstCertificationCenter.destroy();
-        await visitScreen('/equipe');
+        const screen = await visitScreen('/equipe');
 
         // then
+        assert.strictEqual(currentURL(), '/equipe/membres');
         assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
         assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
-        assert.dom(screen.queryByRole('cell', { name: 'Jack' })).doesNotExist();
-        assert.dom(screen.queryByRole('cell', { name: 'Adit' })).doesNotExist();
+      });
+
+      module('when user switch to see another certification center', function () {
+        test('it should be possible to see the other members list', async function (assert) {
+          // given
+          const certificationCenterName = 'Centre de certif des Anne-atole';
+          const otherCertificationCenterName = 'Centre de certif de 7 Anne-néla';
+          const certificationPointOfContact = createAllowedCertificationCenterAccess({
+            certificationCenterName,
+            certificationCenterType: 'SCO',
+            isRelatedOrganizationManagingStudents: true,
+          });
+          const certificationPointOfContact2 = createAllowedCertificationCenterAccess({
+            certificationCenterName: otherCertificationCenterName,
+            certificationCenterType: 'SCO',
+            isRelatedOrganizationManagingStudents: true,
+          });
+          createCertificationPointOfContactWithCustomCenters({
+            pixCertifTermsOfServiceAccepted: true,
+            allowedCertificationCenterAccesses: [certificationPointOfContact, certificationPointOfContact2],
+          });
+          server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
+          const memberOfTheFirstCertificationCenter = server.create('member', { firstName: 'Jack', lastName: 'Adit' });
+          await authenticateSession(certificationPointOfContact.id);
+          const screen = await visitScreen('/equipe');
+
+          // when
+          await click(screen.getByText(`${certificationCenterName} (${certificationPointOfContact.externalId})`));
+          await click(screen.getByText(`${otherCertificationCenterName}`));
+          memberOfTheFirstCertificationCenter.destroy();
+          await visitScreen('/equipe');
+
+          // then
+          assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
+          assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
+          assert.dom(screen.queryByRole('cell', { name: 'Jack' })).doesNotExist();
+          assert.dom(screen.queryByRole('cell', { name: 'Adit' })).doesNotExist();
+        });
       });
     });
-  });
 
-  async function _createAndAuthenticateMember() {
-    const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-    server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-    server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-    await authenticateSession(certificationPointOfContact.id);
-  }
+    async function _createAndAuthenticateMember() {
+      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+      server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+      server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+      await authenticateSession(certificationPointOfContact.id);
+    }
+  });
 });

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -12,21 +12,36 @@ export function createCertificationPointOfContact(
   certificationCenterName = 'Centre de certification du pix',
   isRelatedOrganizationManagingStudents = false,
   certificationCenterCount = 1,
+  certificationCenterRole = 'MEMBER',
 ) {
   const allowedCertificationCenterAccesses = _createCertificationCenters(certificationCenterCount, {
     certificationCenterName,
     certificationCenterType,
     isRelatedOrganizationManagingStudents,
   });
+
+  const certificationCenterIds = allowedCertificationCenterAccesses.map(
+    (certificationCenter) => certificationCenter.id,
+  );
+
+  const certificationCenterMemberships = _createCertificationCenterMemberships({
+    certificationCenterIds,
+    userId: 1,
+    role: certificationCenterRole,
+  });
+
   return createCertificationPointOfContactWithCustomCenters({
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
+    certificationCenterRole,
+    certificationCenterMemberships,
   });
 }
 
 export function createCertificationPointOfContactWithCustomCenters({
   pixCertifTermsOfServiceAccepted = false,
   allowedCertificationCenterAccesses = [],
+  certificationCenterMemberships = [],
 }) {
   return server.create('certification-point-of-contact', {
     firstName: 'Harry',
@@ -35,6 +50,7 @@ export function createCertificationPointOfContactWithCustomCenters({
     lang: 'fr',
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
+    certificationCenterMemberships,
   });
 }
 
@@ -45,6 +61,16 @@ function _createCertificationCenters(certificationCenterCount, certificationCent
     certificationCenters.push(certificationCenter);
   });
   return certificationCenters;
+}
+
+function _createCertificationCenterMemberships({ certificationCenterIds, userId, role }) {
+  return certificationCenterIds.map((certificationCenterId) =>
+    createCertificationCenterMembership({
+      certificationCenterId,
+      userId,
+      role,
+    }),
+  );
 }
 
 export function createAllowedCertificationCenterAccess({
@@ -64,6 +90,14 @@ export function createAllowedCertificationCenterAccess({
   });
 }
 
+export function createCertificationCenterMembership({ certificationCenterId, userId, role = 'MEMBER' }) {
+  return server.create('certification-center-membership', {
+    userId,
+    certificationCenterId,
+    role,
+  });
+}
+
 export function createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted() {
   return createCertificationPointOfContactWithTermsOfServiceAccepted('SCO', 'Centre de certification SCO du pix', true);
 }
@@ -72,12 +106,15 @@ export function createCertificationPointOfContactWithTermsOfServiceAccepted(
   certificationCenterType = undefined,
   certificationCenterName = 'Centre de certification du pix',
   isRelatedOrganizationManagingStudents = false,
+  certificationCenterRole = 'MEMBER',
 ) {
   return createCertificationPointOfContact(
     true,
     certificationCenterType,
     certificationCenterName,
     isRelatedOrganizationManagingStudents,
+    1,
+    certificationCenterRole,
   );
 }
 

--- a/certif/tests/integration/components/team/invitations-list-item_test.js
+++ b/certif/tests/integration/components/team/invitations-list-item_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import dayjs from 'dayjs';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  team/invitation-list-item', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  test('displays a pending invitation table row item', async function (assert) {
+    // given
+    const invitation = store.createRecord('certification-center-invitation', {
+      id: 1,
+      email: 'camille.onette@example.net',
+      updatedAt: new Date('2023-09-21T16:21:12Z'),
+    });
+
+    this.set('invitation', invitation);
+
+    //  when
+    const screen = await renderScreen(hbs`<Team::InvitationsListItem @invitation={{this.invitation}} />`);
+
+    // then
+    const expectedDate = dayjs(invitation.updatedAt).format('DD/MM/YYYY - HH:mm');
+
+    assert.dom(screen.getByLabelText('Invitations en attente')).containsText(invitation.email);
+    assert.dom(screen.getByLabelText('Invitations en attente')).containsText(expectedDate);
+  });
+});

--- a/certif/tests/integration/components/team/invitations-list_test.js
+++ b/certif/tests/integration/components/team/invitations-list_test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  team/invitation-list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  test('displays pending invitations list ', async function (assert) {
+    // given
+    const invitation = store.createRecord('certification-center-invitation', {
+      id: 1,
+      email: 'camille.onette@example.net',
+      updatedAt: new Date('2023-09-21T16:21:12Z'),
+    });
+
+    const secondInvitation = store.createRecord('certification-center-invitation', {
+      id: 2,
+      email: 'lee.tige@example.net',
+      updatedAt: new Date('2023-09-20T16:21:12Z'),
+    });
+
+    this.set('invitations', [invitation, secondInvitation]);
+
+    //  when
+    const screen = await renderScreen(hbs`<Team::InvitationsList @invitations={{this.invitations}} />`);
+
+    // then
+
+    assert.strictEqual(screen.getAllByLabelText('Invitations en attente').length, 2);
+  });
+});

--- a/certif/tests/unit/adapters/certification-center-invitation_test.js
+++ b/certif/tests/unit/adapters/certification-center-invitation_test.js
@@ -4,6 +4,22 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Adapter | certification-center-invitation', function (hooks) {
   setupTest(hooks);
 
+  module('#urlForFindAll', function () {
+    test('builds request pending invitations url with dynamic certification-center-id param', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:certification-center-invitation');
+      const certificationCenterId = 123;
+
+      // when
+      const url = await adapter.urlForFindAll('certification-center-invitation', {
+        adapterOptions: { certificationCenterId },
+      });
+
+      // then
+      assert.true(url.endsWith(`/certification-centers/${certificationCenterId}/invitations`));
+    });
+  });
+
   module('#urlForQueryRecord', function () {
     module('when there is an "invitationId" and a "code" attributes in query', function () {
       test('builds certification-center-invitation url with dynamic invitationId', async function (assert) {

--- a/certif/tests/unit/adapters/certification-center-invitation_test.js
+++ b/certif/tests/unit/adapters/certification-center-invitation_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | certification-center-invitation', function (hooks) {
+  setupTest(hooks);
+
+  module('#urlForQueryRecord', function () {
+    module('when there is an "invitationId" and a "code" attributes in query', function () {
+      test('builds certification-center-invitation url with dynamic invitationId', async function (assert) {
+        // given
+        const adapter = this.owner.lookup('adapter:certification-center-invitation');
+        const invitationId = 123;
+        const query = { code: 'ABCDEF', invitationId };
+
+        // when
+        const url = await adapter.urlForQueryRecord(query);
+
+        // then
+        assert.true(url.endsWith(`/certification-center-invitations/${invitationId}`));
+      });
+    });
+
+    module('when there is no "invitationId" attribute in query', function () {
+      test('builds default url', async function (assert) {
+        // given
+        const adapter = this.owner.lookup('adapter:certification-center-invitation');
+
+        // when
+        const url = await adapter.urlForQueryRecord({});
+
+        // then
+        assert.true(url.endsWith('api'));
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -870,7 +870,22 @@
         "empty-option": "--Sélectionner--",
         "label": "Sélectionner un référent Pix"
       },
+      "tabs": {
+        "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",
+        "member": "Members ({count, plural, =0 {-} other {{count}}})"
+      },
       "update-referer-button": "Changer de référent"
+    },
+    "team-invitations": {
+      "table": {
+        "labels": {
+          "email-address": "Email address",
+          "last-sending-date": "Last sending date"
+        },
+        "row": {
+          "aria-label": "Pending invitations"
+        }
+      }
     },
     "terms-of-service": {
       "title": "Terms and conditions of use of the Pix Certif platform",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -870,7 +870,22 @@
         "empty-option": "--Sélectionner--",
         "label": "Sélectionner le référent Pix"
       },
+      "tabs": {
+        "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",
+        "member": "Membres ({count, plural, =0 {-} other {{count}}})"
+      },
       "update-referer-button": "Changer de référent"
+    },
+    "team-invitations": {
+      "table": {
+        "labels": {
+          "email-address": "Adresse email",
+          "last-sending-date": "Date de dernier envoi"
+        },
+        "row": {
+          "aria-label": "Invitations en attente"
+        }
+      }
     },
     "terms-of-service": {
       "title": "Conditions générales d'utilisation de la plateforme Pix Certif",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la liste des membres d'un centre de certif n'est que consultable et non éditable.
Cela les empêche de pouvoir administrer, de manière autonome, leurs membres comme sur Pix Orga.

## :robot: Proposition
Afficher la liste des invitations en attente sur la page, 1ère étape pour la gestion autonome des membres. 
Cette liste n'est consultable uniquement si la personne connectée est admin.

## :rainbow: Remarques 
- Le fichier `certification-point-of-contact.repository.js` est assez verbeux, avec des requêtes sur plusieurs tables, ce qui ne facilite pas la maintenance. Peut être faire une refacto lors de la migration dans `src` ?

- Sur le fichier `test-init.js` pour les tests d'acceptance, les fonctions `createCertificationPointOfContact` et `createCertificationPointOfContactWithTermsOfServiceAccepted` prennent plusieurs paramètres alors que la signature semble présumer un objet. Il faudrait améliorer la lisibilité en passant uniquement un objet en paramètre.


## :100: Pour tester
### Test avec un utilisateur ayant le rôle **Membre** dans le centre de certif.
- Se connecter, sur la review app https://certif-pr7073.review.pix.fr/, avec le compte `marc-alex-terrieur@example.net` (mdp par défaut).
- Aller sur la page Equipe en cliquant sur le lien dans le menu.
- Vérifier que le chemin dans l'URL est maintenant `/equipe/membres`
- Vérifier que la page affiche exactement le même contenu qu'avant (uniquement la liste des membres).

### Test avec un utilisateur ayant le rôle **Admin** dans le centre de certif.
- Se connecter, sur la review app https://certif-pr7073.review.pix.fr/, avec le compte `james-paledroits@example.net` (mdp par défaut).
- Aller sur la page Equipe en cliquant sur le lien dans le menu.
- Vérifier que le chemin dans l'url est `/equipe/membres`
- Vérifier qu'il y a bien 2 membres affichés avec une nouvelle section ayant comme lien Membres (2) et Invitations (2)
- Cliquer sur le lien Invitations (2)
- Vérifier que le chemin dans l'URL est maintenant `/equipe/invitations`
- Vérifier que la liste des invitations en attente s'affiche bien avec l'email et la dernière date d'envoi.
