### PR TITLE
[TECH] ajoute les learners dans les seeds de devcomp (Pix-9158)

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -127,8 +127,8 @@ async function createAssessmentCampaign({
   );
 
   for (const { userId, organizationLearnerId } of userAndLearnerIds) {
-    const createdDate = dayjs(createdAt).subtract(30, 'days').add(_.random(2, 10), 'day').toDate();
-    const sharedDate = dayjs(createdDate).add(_.random(2, 20), 'day').toDate();
+    const createdDate = dayjs(createdAt).subtract(30, 'days').add(_.random(2, 10), 'days').toDate();
+    const sharedDate = dayjs(createdDate).add(_.random(2, 20), 'days').toDate();
 
     const { status, answersAndKnowledgeElements, validatedSkillsCount, masteryRate, pixScore, buildBadges } =
       await _getCompletionCampaignParticipationData(completionDistribution.shift(), campaignSkills, sharedDate);

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -127,7 +127,7 @@ async function createAssessmentCampaign({
   );
 
   for (const { userId, organizationLearnerId } of userAndLearnerIds) {
-    const createdDate = dayjs(createdAt).add(_.random(2, 10), 'day').toDate();
+    const createdDate = dayjs(createdAt).subtract(30, 'days').add(_.random(2, 10), 'day').toDate();
     const sharedDate = dayjs(createdDate).add(_.random(2, 20), 'day').toDate();
 
     const { status, answersAndKnowledgeElements, validatedSkillsCount, masteryRate, pixScore, buildBadges } =

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -86,7 +86,7 @@ async function createAssessmentCampaign({
     completionDistribution.push(
       ...Array(configCampaign.participantCount - completionDistribution.length).fill('SHARED'),
     );
-  const { realCampaignId, realOrganizationId } = _buildCampaign({
+  const { realCampaignId, realOrganizationId, realCreatedAt } = _buildCampaign({
     databaseBuilder,
     campaignId,
     name,
@@ -127,8 +127,12 @@ async function createAssessmentCampaign({
   );
 
   for (const { userId, organizationLearnerId } of userAndLearnerIds) {
-    const createdDate = dayjs(createdAt).subtract(30, 'days').add(_.random(2, 10), 'days').toDate();
-    const sharedDate = dayjs(createdDate).add(_.random(2, 20), 'days').toDate();
+    const createdDate = dayjs(realCreatedAt)
+      .add(_.random(0, _numberOfDaysBetweenNowAndCreationDate(realCreatedAt)), 'days')
+      .toDate();
+    const sharedDate = dayjs(createdDate)
+      .add(_.random(0, _numberOfDaysBetweenNowAndCreationDate(createdDate)), 'days')
+      .toDate();
 
     const { status, answersAndKnowledgeElements, validatedSkillsCount, masteryRate, pixScore, buildBadges } =
       await _getCompletionCampaignParticipationData(completionDistribution.shift(), campaignSkills, sharedDate);
@@ -203,6 +207,10 @@ async function createAssessmentCampaign({
 
   await databaseBuilder.commit();
   return { campaignId: realCampaignId };
+}
+
+function _numberOfDaysBetweenNowAndCreationDate(date) {
+  return dayjs().diff(date, 'day');
 }
 
 /**
@@ -399,7 +407,11 @@ function _buildCampaign({
   multipleSendings,
   assessmentMethod,
 }) {
-  const { id: realCampaignId, organizationId: realOrganizationId } = databaseBuilder.factory.buildCampaign({
+  const {
+    id: realCampaignId,
+    organizationId: realOrganizationId,
+    createdAt: realCreatedAt,
+  } = databaseBuilder.factory.buildCampaign({
     id: campaignId,
     name,
     code,
@@ -423,7 +435,7 @@ function _buildCampaign({
     multipleSendings,
     assessmentMethod,
   });
-  return { realCampaignId, realOrganizationId };
+  return { realCampaignId, realOrganizationId, realCreatedAt };
 }
 
 let emailIndex = 0;

--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -10,7 +10,7 @@ async function _createScoCampaigns(databaseBuilder) {
     name: 'PIX+ EDU - SCO - envoi simple',
     code: 'EDUSIMPLE',
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
-    configCampaign: { participantCount: 0 },
+    configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
   });
   await createAssessmentCampaign({
     databaseBuilder,
@@ -20,7 +20,7 @@ async function _createScoCampaigns(databaseBuilder) {
     code: 'EDUMULTIP',
     multipleSendings: true,
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
-    configCampaign: { participantCount: 0 },
+    configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
   });
 }
 

--- a/api/db/seeds/data/team-devcomp/build-target-profiles.js
+++ b/api/db/seeds/data/team-devcomp/build-target-profiles.js
@@ -1,7 +1,7 @@
 import { SCO_ORGANIZATION_ID } from '../common/constants.js';
 import { PIX_EDU_SMALL_TARGET_PROFILE_ID } from './constants.js';
 
-export function buildTargetProfiles(databaseBuilder) {
+export async function buildTargetProfiles(databaseBuilder) {
   databaseBuilder.factory.buildTargetProfile({
     id: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     ownerOrganizationId: SCO_ORGANIZATION_ID,
@@ -24,4 +24,5 @@ export function buildTargetProfiles(databaseBuilder) {
       level,
     });
   });
+  await databaseBuilder.commit();
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans devcomp on a pas les learners qui ont finalisé leur parcours pour une organisation

## :robot: Proposition
On ajoute les learners qui ont partargé leur resultat à leur orga

## :rainbow: Remarques
On a aussi corrigé les seeds de createCampaignParticipation pour que le date `createdAt` ne soit pas dans le future

## :100: Pour tester
Verifier que pour un organisation SCO on a 3 participants qui ont partargé leur resultats pour les compagnes: `EDUMULTIP` et `EDUSIMPLE`
