### PR TITLE
[FEATURE] Ajouter une route de monitoring sur Audit-logger (PIX-9129)

### DIFF
--- a/audit-logger/src/lib/controllers/healthcheck.controller.ts
+++ b/audit-logger/src/lib/controllers/healthcheck.controller.ts
@@ -1,0 +1,20 @@
+import { type Request, type ResponseObject, type ResponseToolkit, type ServerRoute } from '@hapi/hapi';
+
+
+export class HealthcheckController {
+  async handle(_request: Request, h: ResponseToolkit): Promise<ResponseObject> {
+    return h.response('ok').code(200);
+  }
+
+}
+
+const healthcheckController=  new HealthcheckController();
+
+export const HEALTHCHECK_ROUTE: ServerRoute = {
+  method: 'GET',
+  path: '/health',
+  options: {
+    handler: healthcheckController.handle.bind(healthcheckController),
+    auth:false
+  }
+};

--- a/audit-logger/src/lib/routes.ts
+++ b/audit-logger/src/lib/routes.ts
@@ -1,5 +1,6 @@
 import { CREATE_AUDIT_LOG_ROUTE } from './controllers/create-audit-log.controller.js';
-
+import { HEALTHCHECK_ROUTE } from './controllers/healthcheck.controller.js';
 export const ROUTES = [
   CREATE_AUDIT_LOG_ROUTE,
+  HEALTHCHECK_ROUTE,
 ];

--- a/audit-logger/tests/acceptance/controllers/healthcheck.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/healthcheck.controller.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { type Server, type ServerInjectOptions } from '@hapi/hapi';
+
+import { HapiServer } from '../../../src/lib/server';
+
+describe('Acceptance | Controllers | HealthcheckController', () => {
+  let server: Server;
+
+  beforeEach(async function (): Promise<void> {
+    const hapiServer = await HapiServer.createServer();
+    server = hapiServer.server;
+  });
+
+  afterEach(async function (): Promise<void> {
+    await server.stop();
+  });
+
+  test("returns a 200 HTTP status code", async () => {
+    // given
+    const options: ServerInjectOptions = {
+      method: 'GET',
+      url: '/health',
+    };
+
+    // when
+    const response = await server.inject(options);
+
+    // then
+    expect(response.statusCode).toEqual(200);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous n'avons actuellement aucun moyen de vérifier que l'API est disponible.

## :robot: Proposition
Ajouter une nouvelle route /health pour vérifier le bon fonctionnement de cette API depuis des outils de monitoring comme Freshping.

## :rainbow: Remarques
RAS

## :100: Pour tester
1. Ouvrir un nouvel onglet avec l'adresse https://pix-audit-logger-review-pr7077.osc-fr1.scalingo.io/health.
2. Vérifier que le message `ok` s'affiche et que le status code HTTP est `200`.
