### PR TITLE
[TECH] Mise à jour des regles d'envoi de champs CPF. (PIX-9176)

### DIFF
--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -41,7 +41,7 @@ class CpfCertificationResult {
 
   get countryCode() {
     if (!this.birthINSEECode) return null;
-    if (!this.birthINSEECode.startsWith('99')) return null;
+    if (_isAFrenchBirthINSEECode(this.birthINSEECode)) return null;
     return this.birthINSEECode.slice(2);
   }
 
@@ -50,6 +50,10 @@ class CpfCertificationResult {
     if (this.birthPostalCode.length !== 5) return null;
     return this.birthPostalCode;
   }
+}
+
+function _isAFrenchBirthINSEECode(birthINSEECode) {
+  return !birthINSEECode.startsWith('99');
 }
 
 export { CpfCertificationResult };

--- a/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
@@ -66,7 +66,7 @@ class EuropeanNumericLevelFactory {
       );
     }
 
-    remove(europeanNumericLevels, ({ level }) => level === 0);
+    remove(europeanNumericLevels, ({ level }) => level < 1);
 
     return europeanNumericLevels;
   }

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -1,45 +1,46 @@
 import { config } from '../../config.js';
 import xmlbuilder2 from 'xmlbuilder2';
-
-const { create, fragment } = xmlbuilder2;
-
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 import timezone from 'dayjs/plugin/timezone.js';
+
+const { create, fragment } = xmlbuilder2;
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
 const schemaVersion = '1.0.0';
 const { cpf } = config;
+
 // prettier-ignore
-async function buildXmlExport({ cpfCertificationResults, writableStream, opts = {}, uuidService}) {
-  const overrideOpts = { allowEmptyTags: true, };
+async function buildXmlExport({ cpfCertificationResults, writableStream, opts = {}, uuidService }) {
+  const overrideOpts = { allowEmptyTags: true };
   const PLACEHOLDER = 'PLACEHOLDER';
   const formatedDate = dayjs().tz('Europe/Paris').format('YYYY-MM-DDThh:mm:ss') + '+01:00';
   const root = create()
     .ele('cpf:flux', {
       'xmlns:cpf': `urn:cdc:cpf:pc5:schema:${schemaVersion}`,
-      'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance'
     })
-      .ele('cpf:idFlux').txt(uuidService.randomUUID()).up()
-      .ele('cpf:horodatage').txt(formatedDate).up()
-      .ele('cpf:emetteur')
-        .ele('cpf:idClient').txt(cpf.idClient).up()
-        .ele('cpf:certificateurs')
-          .ele('cpf:certificateur')
-            .ele('cpf:idClient').txt(cpf.idClient).up()
-            .ele('cpf:idContrat').txt(cpf.idContrat).up()
-            .ele('cpf:certifications')
-              .ele('cpf:certification')
-                .ele('cpf:type').txt('RS').up()
-                .ele('cpf:code').txt(cpf.codeFranceConnect).up()
-                .ele('cpf:natureDeposant').txt('CERTIFICATEUR').up()
-                .ele('cpf:passageCertifications').txt(PLACEHOLDER);
-  const [headerOpeningTag, headerClosingTag] = root.end( {...opts, ...overrideOpts}).split(PLACEHOLDER);
+    .ele('cpf:idFlux').txt(uuidService.randomUUID()).up()
+    .ele('cpf:horodatage').txt(formatedDate).up()
+    .ele('cpf:emetteur')
+    .ele('cpf:idClient').txt(cpf.idClient).up()
+    .ele('cpf:certificateurs')
+    .ele('cpf:certificateur')
+    .ele('cpf:idClient').txt(cpf.idClient).up()
+    .ele('cpf:idContrat').txt(cpf.idContrat).up()
+    .ele('cpf:certifications')
+    .ele('cpf:certification')
+    .ele('cpf:type').txt('RS').up()
+    .ele('cpf:code').txt(cpf.codeFranceConnect).up()
+    .ele('cpf:natureDeposant').txt('CERTIFICATEUR').up()
+    .ele('cpf:passageCertifications').txt(PLACEHOLDER);
+  const [headerOpeningTag, headerClosingTag] = root.end({ ...opts, ...overrideOpts }).split(PLACEHOLDER);
 
   await _write(writableStream, headerOpeningTag);
 
-  for(const {
+  for (const {
     id,
     publishedAt,
     pixScore,
@@ -53,116 +54,118 @@ async function buildXmlExport({ cpfCertificationResults, writableStream, opts = 
     countryCode,
     birthCountry,
     europeanNumericLevels,
-  } of  cpfCertificationResults) {
+  } of cpfCertificationResults) {
     const [yearOfBirth, monthOfBirth, dayOfBirth] = birthdate.split('-');
     const line = fragment()
       .ele('cpf:passageCertification')
-        .ele('cpf:idTechnique').txt(id)
-        .up()
-        .ele('cpf:obtentionCertification').txt('PAR_SCORING')
-        .up()
-        .ele('cpf:donneeCertifiee').txt(true)
-        .up()
-        .ele('cpf:dateDebutValidite').txt(dayjs(publishedAt).format('YYYY-MM-DD'))
-        .up()
-        .ele('cpf:dateFinValidite', { 'xsi:nil': true })
-        .up()
-        .ele('cpf:presenceNiveauLangueEuro').txt(false)
-        .up()
-        .ele('cpf:presenceNiveauNumeriqueEuro').txt(true)
-        .up();
+      .ele('cpf:idTechnique').txt(id)
+      .up()
+      .ele('cpf:obtentionCertification').txt('PAR_SCORING')
+      .up()
+      .ele('cpf:donneeCertifiee').txt(true)
+      .up()
+      .ele('cpf:dateDebutValidite').txt(dayjs(publishedAt).format('YYYY-MM-DD'))
+      .up()
+      .ele('cpf:dateFinValidite', { 'xsi:nil': true })
+      .up()
+      .ele('cpf:presenceNiveauLangueEuro').txt(false)
+      .up()
+      .ele('cpf:presenceNiveauNumeriqueEuro').txt(true)
+      .up();
     const niveauNumeriqueEuropeen = line
-        .ele('cpf:niveauNumeriqueEuropeen')
-          .ele('cpf:scoreGeneral').txt(pixScore)
-          .up();
+      .ele('cpf:niveauNumeriqueEuropeen')
+      .ele('cpf:scoreGeneral').txt(pixScore)
+      .up();
     const resultats = niveauNumeriqueEuropeen
-          .ele('cpf:resultats');
+      .ele('cpf:resultats');
 
     europeanNumericLevels.forEach(({ domainCompetenceId, competenceId, level }) => {
       resultats
-            .ele('cpf:resultat')
-              .ele('cpf:niveau').txt(level)
-              .up()
-              .ele('cpf:domaineCompetenceId').txt(domainCompetenceId)
-              .up()
-              .ele('cpf:competenceId').txt(competenceId)
-              .up()
-            .up();
+        .ele('cpf:resultat')
+        .ele('cpf:niveau').txt(level)
+        .up()
+        .ele('cpf:domaineCompetenceId').txt(domainCompetenceId)
+        .up()
+        .ele('cpf:competenceId').txt(competenceId)
+        .up()
+        .up();
     });
 
     resultats
-          .up();
+      .up();
     niveauNumeriqueEuropeen
-        .up();
+      .up();
 
     const details = line
-        .ele('cpf:scoring').txt(pixScore)
-        .up()
-        .ele('cpf:mentionValidee', { 'xsi:nil': true })
-        .up()
-        .ele('cpf:modalitesInscription')
-          .ele('cpf:modaliteAcces', { 'xsi:nil': true })
-          .up()
-        .up()
-        .ele('cpf:identificationTitulaire')
-          .ele('cpf:titulaire')
-            .ele('cpf:nomNaissance').txt(lastName)
-            .up()
-            .ele('cpf:nomUsage', { 'xsi:nil': true })
-            .up()
-            .ele('cpf:prenom1').txt(firstName)
-            .up()
-            .ele('cpf:anneeNaissance').txt(yearOfBirth)
-            .up()
-            .ele('cpf:moisNaissance').txt(monthOfBirth)
-            .up()
-            .ele('cpf:jourNaissance').txt(dayOfBirth)
-            .up()
-            .ele('cpf:sexe').txt(sex)
-            .up()
+      .ele('cpf:scoring').txt(pixScore)
+      .up()
+      .ele('cpf:mentionValidee', { 'xsi:nil': true })
+      .up()
+      .ele('cpf:modalitesInscription')
+      .ele('cpf:modaliteAcces', { 'xsi:nil': true })
+      .up()
+      .up()
+      .ele('cpf:identificationTitulaire')
+      .ele('cpf:titulaire')
+      .ele('cpf:nomNaissance').txt(lastName)
+      .up()
+      .ele('cpf:nomUsage', { 'xsi:nil': true })
+      .up()
+      .ele('cpf:prenom1').txt(firstName)
+      .up()
+      .ele('cpf:anneeNaissance').txt(yearOfBirth)
+      .up()
+      .ele('cpf:moisNaissance').txt(monthOfBirth)
+      .up()
+      .ele('cpf:jourNaissance').txt(dayOfBirth)
+      .up()
+      .ele('cpf:sexe').txt(sex)
+      .up();
 
     const communeNaissance = details
-            .ele('cpf:codeCommuneNaissance');
+      .ele('cpf:codeCommuneNaissance');
 
     if (inseeCode) {
       communeNaissance
-              .ele('cpf:codeInseeNaissance')
-                .ele('cpf:codeInsee').txt(inseeCode)
-                .up()
-              .up();
+        .ele('cpf:codeInseeNaissance')
+        .ele('cpf:codeInsee').txt(inseeCode)
+        .up()
+        .up();
     } else if (postalCode) {
       communeNaissance
-              .ele('cpf:codePostalNaissance')
-                .ele('cpf:codePostal').txt(postalCode)
-                .up()
-              .up();
+        .ele('cpf:codePostalNaissance')
+        .ele('cpf:codePostal').txt(postalCode)
+        .up()
+        .up();
     } else {
       communeNaissance
-              .ele('cpf:codePostalNaissance')
-                .ele('cpf:codePostal', { 'xsi:nil': true })
-                .up()
-              .up();
+        .ele('cpf:codePostalNaissance')
+        .ele('cpf:codePostal', { 'xsi:nil': true })
+        .up()
+        .up();
     }
     communeNaissance
-            .up()
+      .up();
     if (birthplace) {
       details
-            .ele('cpf:libelleCommuneNaissance').txt(birthplace)
-            .up()
-          .up()
+        .ele('cpf:libelleCommuneNaissance').txt(birthplace)
+        .up()
+        .up();
     }
     if (countryCode) {
       details
         .ele('cpf:codePaysNaissance').txt(countryCode)
         .up();
     }
-    details
+    if (birthCountry) {
+      details
         .ele('cpf:libellePaysNaissance').txt(birthCountry)
         .up();
+    }
 
     line
       .up();
-    await _write(writableStream, line.end({ ...opts, ...overrideOpts,  }));
+    await _write(writableStream, line.end({ ...opts, ...overrideOpts }));
   }
 
   await _write(writableStream, headerClosingTag);

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -145,11 +145,12 @@ async function buildXmlExport({ cpfCertificationResults, writableStream, opts = 
     }
     communeNaissance
             .up()
-
-    details
-          .ele('cpf:libelleCommuneNaissance').txt(birthplace)
+    if (birthplace) {
+      details
+            .ele('cpf:libelleCommuneNaissance').txt(birthplace)
+            .up()
           .up()
-        .up()
+    }
     if (countryCode) {
       details
         .ele('cpf:codePaysNaissance').txt(countryCode)

--- a/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
+++ b/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
@@ -311,13 +311,13 @@ describe('Unit | Domain | Read-models | EuropeanNumericLevelFactory', function (
       });
     });
 
-    context('when there is european numeric levels with a level of 0 after computing', function () {
+    context('when there is european numeric levels with a level < 1 after computing', function () {
       it('should remove these european numeric levels', function () {
         // given
         const competenceMarks = [
           { competenceCode: '1.1', level: 0 },
-          { competenceCode: '2.1', level: 0 },
-          { competenceCode: '3.1', level: 0 },
+          { competenceCode: '2.1', level: -1 },
+          { competenceCode: '3.1', level: -1 },
           { competenceCode: '3.2', level: 0 },
         ];
 

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -124,11 +124,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
           uuidService,
         });
 
-        const xmlExport = await streamToPromise(writableStream);
-
-        const parsedXsd = parseXml(cpfXsd);
-        const parsedXmlToExport = parseXml(xmlExport);
-        parsedXmlToExport.validate(parsedXsd);
+        const parsedXmlToExport = await _parseAndValidateXmlWithXsd({ writableStream, cpfXsd });
 
         // then
         expect(parsedXmlToExport.validationErrors).to.be.empty;
@@ -165,11 +161,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
           uuidService,
         });
 
-        const xmlExport = await streamToPromise(writableStream);
-
-        const parsedXsd = parseXml(cpfXsd);
-        const parsedXmlToExport = parseXml(xmlExport);
-        parsedXmlToExport.validate(parsedXsd);
+        const parsedXmlToExport = await _parseAndValidateXmlWithXsd({ writableStream, cpfXsd });
 
         // then
         expect(parsedXmlToExport.validationErrors[0].message).to.equal(
@@ -177,7 +169,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         );
       });
 
-      context('when there is no birthPlace for the candidate', function () {
+      context('when there is no birthplace for the candidate', function () {
         it('it should generate a valid XML', async function () {
           // given
           uuidService.randomUUID.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
@@ -209,11 +201,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
             uuidService,
           });
 
-          const xmlExport = await streamToPromise(writableStream);
-
-          const parsedXsd = parseXml(cpfXsd);
-          const parsedXmlToExport = parseXml(xmlExport);
-          parsedXmlToExport.validate(parsedXsd);
+          const parsedXmlToExport = await _parseAndValidateXmlWithXsd({ writableStream, cpfXsd });
 
           // then
           expect(parsedXmlToExport.validationErrors).to.be.empty;
@@ -252,11 +240,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
             uuidService,
           });
 
-          const xmlExport = await streamToPromise(writableStream);
-
-          const parsedXsd = parseXml(cpfXsd);
-          const parsedXmlToExport = parseXml(xmlExport);
-          parsedXmlToExport.validate(parsedXsd);
+          const parsedXmlToExport = await _parseAndValidateXmlWithXsd({ writableStream, cpfXsd });
 
           // then
           expect(parsedXmlToExport.validationErrors).to.be.empty;
@@ -506,4 +490,14 @@ function _getExpectedXmlExport() {
     </cpf:certificateurs>
   </cpf:emetteur>
 </cpf:flux>`;
+}
+
+async function _parseAndValidateXmlWithXsd({ writableStream, cpfXsd }) {
+  const xmlExport = await streamToPromise(writableStream);
+
+  const parsedXsd = parseXml(cpfXsd);
+  const parsedXmlToExport = parseXml(xmlExport);
+  parsedXmlToExport.validate(parsedXsd);
+
+  return parsedXmlToExport;
 }

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -178,6 +178,49 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
           "Element '{urn:cdc:cpf:pc5:schema:1.0.0}sexe': [facet 'enumeration'] The value '' is not an element of the set {'M', 'F'}.\n",
         );
       });
+
+      context('when there is no birthPlace for the candidate', function () {
+        it('it should generate a valid XML', async function () {
+          // given
+          uuidService.randomUUID.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
+
+          const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({
+            id: 1234,
+            firstName: 'Bart',
+            lastName: 'Haba',
+            birthdate: '1993-05-23',
+            sex: 'M',
+            birthINSEECode: null,
+            birthPostalCode: '75002',
+            birthplace: null,
+            birthCountry: 'FRANCE',
+            publishedAt: '2022-01-03',
+            pixScore: 324,
+            competenceMarks: [
+              { competenceCode: '2.1', level: 4 },
+              { competenceCode: '3.2', level: 3 },
+            ],
+          });
+
+          const writableStream = new PassThrough();
+
+          // when
+          cpfCertificationXmlExportService.buildXmlExport({
+            cpfCertificationResults: [cpfCertificationResult],
+            writableStream,
+            uuidService,
+          });
+
+          const xmlExport = await streamToPromise(writableStream);
+
+          const parsedXsd = parseXml(cpfXsd);
+          const parsedXmlToExport = parseXml(xmlExport);
+          parsedXmlToExport.validate(parsedXsd);
+
+          // then
+          expect(parsedXmlToExport.validationErrors).to.be.empty;
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les fichiers que l'ont génère pour le CPF échouent à la validation sur la plateforme. En effet, plusieurs paramètres transmis ne respectent plus les attentes.

Les paramètres non valides :
- `niveau` = -1 alors qu’il doivent etre > 0
- `libelleCommuneNaissance` est souvent vide alors qu’il doit être renseigné ou absent
- `libellePaysNaissance` est souvent vide alors qu’il doit être renseigné ou absent

## :robot: Proposition
Ajouter des conditions autour de ces valeurs 

## :100: Pour tester
Les tests passent ✅ 