### PR TITLE
[TECH] Création d'un script pour valider un fichier XML via XSD pour le CPF. (PIX-9095)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -97,6 +97,7 @@
         "eslint-plugin-unicorn": "^48.0.0",
         "form-data": "^4.0.0",
         "inquirer": "^9.0.0",
+        "libxmljs2": "^0.32.0",
         "mocha": "^10.0.0",
         "mocha-junit-reporter": "^2.0.2",
         "mockdate": "^3.0.5",
@@ -3531,6 +3532,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -6095,6 +6105,12 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7813,6 +7829,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libxmljs2": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.10",
+        "bindings": "~1.5.0",
+        "nan": "~2.17.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -8568,6 +8599,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.3",

--- a/api/package.json
+++ b/api/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-unicorn": "^48.0.0",
     "form-data": "^4.0.0",
     "inquirer": "^9.0.0",
+    "libxmljs2": "^0.32.0",
     "mocha": "^10.0.0",
     "mocha-junit-reporter": "^2.0.2",
     "mockdate": "^3.0.5",

--- a/api/scripts/certification/validate-cpf-xml.js
+++ b/api/scripts/certification/validate-cpf-xml.js
@@ -1,0 +1,43 @@
+// eslint-disable-next-line n/no-unpublished-import
+import { parseXml } from 'libxmljs2';
+import { readFile } from 'fs/promises';
+import * as url from 'url';
+import { logger } from '../../lib/infrastructure/logger.js';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+async function main() {
+  const xmlPath = process.argv[2];
+
+  logger.info('Starting script validate-cpf-xml');
+
+  logger.trace(`Checking data file...`);
+  const generatedCpfXml = await readFile(xmlPath, 'utf8');
+  const cpfXsd = await readFile(`${__dirname}../../tests/unit/domain/services/cpf/cpf.xsd`, 'utf8');
+  const parsedXmlToExport = parseXml(generatedCpfXml);
+  const parsedXsd = parseXml(cpfXsd);
+
+  parsedXmlToExport.validate(parsedXsd);
+
+  if (parsedXmlToExport.validationErrors.length > 0) {
+    const set = new Set();
+    const extractMessage = ({ message }) =>
+      message.replace(/Element '\{urn:cdc:cpf:pc5:schema:1.0.0\}(.*)'/, '$1').replace('\n', '');
+    parsedXmlToExport.validationErrors.forEach((error) => set.add(extractMessage(error)));
+
+    set.forEach((errorSet) => logger.error(errorSet));
+
+    logger.warn(`${parsedXmlToExport.validationErrors.length} erreurs dans le fichier`);
+  }
+  logger.info('✅ ');
+}
+
+(async () => {
+  try {
+    await main();
+    logger.s;
+  } catch (error) {
+    logger.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -140,7 +140,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         // given
         uuidService.randomUUID.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
 
-        const sexIsBad = domainBuilder.buildCpfCertificationResult({
+        const incorrectCpfCertificationResult = domainBuilder.buildCpfCertificationResult({
           id: 1234,
           firstName: 'Bart',
           lastName: 'Haba',
@@ -162,7 +162,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
 
         // when
         cpfCertificationXmlExportService.buildXmlExport({
-          cpfCertificationResults: [sexIsBad],
+          cpfCertificationResults: [incorrectCpfCertificationResult],
           writableStream,
           uuidService,
         });
@@ -174,7 +174,6 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         parsedXmlToExport.validate(parsedXsd);
 
         // then
-        expect(parsedXmlToExport.validationErrors).not.to.be.empty;
         expect(parsedXmlToExport.validationErrors[0].message).to.equal(
           "Element '{urn:cdc:cpf:pc5:schema:1.0.0}sexe': [facet 'enumeration'] The value '' is not an element of the set {'M', 'F'}.\n",
         );

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -1,7 +1,13 @@
-import { expect, domainBuilder, sinon, streamToPromise } from '../../../test-helper.js';
+import { expect, domainBuilder, sinon, streamToPromise } from '../../../../test-helper.js';
 import stream from 'stream';
+// eslint-disable-next-line n/no-unpublished-import
+import { parseXml } from 'libxmljs2';
+import { readFile } from 'fs/promises';
+import * as url from 'url';
 
 const { PassThrough } = stream;
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
@@ -10,7 +16,7 @@ import timezone from 'dayjs/plugin/timezone.js';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-import * as cpfCertificationXmlExportService from '../../../../lib/domain/services/cpf-certification-xml-export-service.js';
+import * as cpfCertificationXmlExportService from '../../../../../lib/domain/services/cpf-certification-xml-export-service.js';
 
 describe('Unit | Services | cpf-certification-xml-export-service', function () {
   let clock;
@@ -80,6 +86,99 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
       const expectedXmlExport = _getExpectedXmlExport();
       const xmlExport = await streamToPromise(writableStream);
       expect(xmlExport).to.equal(expectedXmlExport.replace(/\n| {2}/g, ''));
+    });
+
+    describe('CPF XSD validation', function () {
+      let cpfXsd;
+
+      before(async function () {
+        cpfXsd = await readFile(`${__dirname}/cpf.xsd`, 'utf8');
+      });
+
+      it('it should validate our generated XML', async function () {
+        // given
+        uuidService.randomUUID.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
+
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({
+          id: 1234,
+          firstName: 'Bart',
+          lastName: 'Haba',
+          birthdate: '1993-05-23',
+          sex: 'M',
+          birthINSEECode: null,
+          birthPostalCode: '75002',
+          birthplace: 'PARIS',
+          birthCountry: 'FRANCE',
+          publishedAt: '2022-01-03',
+          pixScore: 324,
+          competenceMarks: [
+            { competenceCode: '2.1', level: 4 },
+            { competenceCode: '3.2', level: 3 },
+          ],
+        });
+
+        const writableStream = new PassThrough();
+
+        // when
+        cpfCertificationXmlExportService.buildXmlExport({
+          cpfCertificationResults: [cpfCertificationResult],
+          writableStream,
+          uuidService,
+        });
+
+        const xmlExport = await streamToPromise(writableStream);
+
+        const parsedXsd = parseXml(cpfXsd);
+        const parsedXmlToExport = parseXml(xmlExport);
+        parsedXmlToExport.validate(parsedXsd);
+
+        // then
+        expect(parsedXmlToExport.validationErrors).to.be.empty;
+      });
+
+      it('it should detect CPF schema errors', async function () {
+        // given
+        uuidService.randomUUID.returns('5d079a5d-0a4d-45ac-854d-256b01cacdfe');
+
+        const sexIsBad = domainBuilder.buildCpfCertificationResult({
+          id: 1234,
+          firstName: 'Bart',
+          lastName: 'Haba',
+          birthdate: '1993-05-23',
+          sex: null,
+          birthINSEECode: null,
+          birthPostalCode: '75002',
+          birthplace: 'PARIS',
+          birthCountry: 'FRANCE',
+          publishedAt: '2022-01-03',
+          pixScore: 324,
+          competenceMarks: [
+            { competenceCode: '2.1', level: 4 },
+            { competenceCode: '3.2', level: 3 },
+          ],
+        });
+
+        const writableStream = new PassThrough();
+
+        // when
+        cpfCertificationXmlExportService.buildXmlExport({
+          cpfCertificationResults: [sexIsBad],
+          writableStream,
+          uuidService,
+        });
+
+        const xmlExport = await streamToPromise(writableStream);
+
+        const parsedXsd = parseXml(cpfXsd);
+        const parsedXmlToExport = parseXml(xmlExport);
+        parsedXmlToExport.validate(parsedXsd);
+
+        // then
+        expect(parsedXmlToExport.validationErrors).not.to.be.empty;
+        expect(parsedXmlToExport.validationErrors[0].message).to.equal(
+          "Element '{urn:cdc:cpf:pc5:schema:1.0.0}sexe': [facet 'enumeration'] The value '' is not an element of the set {'M', 'F'}.\n",
+        );
+      });
     });
   });
 });

--- a/api/tests/unit/domain/services/cpf/cpf.xsd
+++ b/api/tests/unit/domain/services/cpf/cpf.xsd
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:cpf="urn:cdc:cpf:pc5:schema:1.0.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:cdc:cpf:pc5:schema:1.0.0" elementFormDefault="qualified" version="1.1.2">
+   <xsd:complexType name="flux">
+      <xsd:all>
+         <xsd:element name="idFlux">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="50"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="horodatage">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:dateTime">
+                  <xsd:pattern value="(19|20)[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9](\+|-)(:2[0-3]|[01][0-9]):[0-5][0-9]"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="emetteur" type="cpf:emetteur"/>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="emetteur">
+      <xsd:all>
+         <xsd:element name="idClient">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:length value="8"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="certificateurs" type="cpf:certificateurs"/>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="certificateurs">
+      <xsd:all>
+         <xsd:element name="certificateur" type="cpf:certificateur"/>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="certificateur">
+      <xsd:all>
+         <xsd:element name="idClient">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:length value="8"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="idContrat">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="20"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="certifications">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:choice maxOccurs="unbounded">
+                     <xsd:element name="certification" type="cpf:certification"/>
+                  </xsd:choice>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="certification">
+      <xsd:all>
+         <xsd:element name="type">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="255"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="code">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="100"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="natureDeposant" type="cpf:natureDeposant" minOccurs="0"/>
+         <xsd:element name="passageCertifications">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:choice maxOccurs="unbounded">
+                     <xsd:element name="passageCertification" type="cpf:passageCertification"/>
+                  </xsd:choice>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="passageCertification">
+      <xsd:all>
+         <xsd:element name="idTechnique">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="255"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="urlPreuve" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="255"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="libelleOption" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="255"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="obtentionCertification" type="cpf:obtentionCertification"/>
+         <xsd:element name="donneeCertifiee" type="xsd:boolean"/>
+         <xsd:element name="dateDebutExamen" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:date">
+                  <xsd:pattern value="(19|20)[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="dateFinExamen" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:date">
+                  <xsd:pattern value="(19|20)[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="modalitePassageExamen" type="cpf:modalitePassageExamen" minOccurs="0"/>
+         <xsd:element name="codePostalCentreExamen" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="9"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="dateDebutValidite">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:date">
+                  <xsd:pattern value="(19|20)[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="dateFinValidite" nillable="true">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:date">
+                  <xsd:pattern value="(19|20)[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="presenceNiveauLangueEuro" type="xsd:boolean"/>
+         <xsd:element name="niveauLangueEuropeen" type="cpf:niveauCECRL" minOccurs="0"/>
+         <xsd:element name="presenceNiveauNumeriqueEuro" type="xsd:boolean"/>
+         <xsd:element name="niveauNumeriqueEuropeen" type="cpf:niveauNumeriqueEuropeen" minOccurs="0"/>
+         <xsd:element name="scoring" nillable="true">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="255"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="mentionValidee" type="cpf:mention" nillable="true"/>
+         <xsd:element name="modalitesInscription" type="cpf:modalitesInscription"/>
+         <xsd:element name="identificationTitulaire" type="cpf:identificationTitulaire"/>
+         <xsd:element name="verbatim" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="255"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="niveauNumeriqueEuropeen">
+      <xsd:all>
+         <xsd:element name="scoreGeneral" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:int">
+                  <xsd:minInclusive value="1"/>
+                  <xsd:maxInclusive value="1000"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="resultats" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:choice maxOccurs="unbounded">
+                     <xsd:element name="resultat" type="cpf:resultat" minOccurs="0"/>
+                  </xsd:choice>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="resultat">
+      <xsd:all>
+         <xsd:element name="niveau" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:int">
+                  <xsd:minInclusive value="1"/>
+                  <xsd:maxInclusive value="8"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="domaineCompetenceId" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:length value="1"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="competenceId" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:length value="1"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="modalitesInscription">
+      <xsd:all>
+         <xsd:element name="modaliteAcces" type="cpf:modaliteAcces" nillable="true"/>
+         <xsd:element name="voieAccessVAE" type="cpf:voieAccesVAE" minOccurs="0"/>
+         <xsd:element name="initiativeInscription" type="cpf:initiativeInscription" minOccurs="0"/>
+         <xsd:element name="dateInscription" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:date">
+                  <xsd:pattern value="(19|20)[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="identificationTitulaire">
+      <xsd:sequence>
+         <xsd:choice>
+            <xsd:element name="dossierFormation" type="cpf:dossierFormation"/>
+            <xsd:element name="titulaire" type="cpf:titulaire"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="dossierFormation">
+      <xsd:all>
+         <xsd:element name="idDossier">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="13"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="nomTitulaire">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="30"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="prenom1Titulaire">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="20"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="titulaire">
+      <xsd:all>
+         <xsd:element name="nomNaissance">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="nomUsage" nillable="true">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="prenom1">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="prenom2" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="prenom3" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="anneeNaissance">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:int">
+                  <xsd:minInclusive value="1900"/>
+                  <xsd:maxInclusive value="2099"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="moisNaissance" nillable="true">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:int">
+                  <xsd:minInclusive value="1"/>
+                  <xsd:maxInclusive value="12"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="jourNaissance" nillable="true">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:int">
+                  <xsd:minInclusive value="1"/>
+                  <xsd:maxInclusive value="31"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="sexe" type="cpf:genre"/>
+         <xsd:element name="codeCommuneNaissance" type="cpf:codeCommuneNaissance"/>
+         <xsd:element name="libelleCommuneNaissance" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="codePaysNaissance" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:length value="3"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="libellePaysNaissance" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="60"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="commentairesMEN" minOccurs="0">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="250"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+   <xsd:complexType name="codeCommuneNaissance">
+      <xsd:sequence>
+         <xsd:choice>
+            <xsd:element name="codeInseeNaissance" type="cpf:codeInsee"/>
+            <xsd:element name="codePostalNaissance" type="cpf:codePostal"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="codeInsee">
+      <xsd:sequence>
+         <xsd:element name="codeInsee">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:length value="5"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="codePostal">
+      <xsd:sequence>
+         <xsd:element name="codePostal" nillable="true">
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:minLength value="1"/>
+                  <xsd:maxLength value="9"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="flux" type="cpf:flux"/>
+   <xsd:simpleType name="natureDeposant">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="CERTIFICATEUR"/>
+         <xsd:enumeration value="TIERS_CONFIANCE"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="obtentionCertification">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="PAR_ADMISSION"/>
+         <xsd:enumeration value="PAR_SCORING"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="modalitePassageExamen">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="A_DISTANCE"/>
+         <xsd:enumeration value="EN_PRESENTIEL"/>
+         <xsd:enumeration value="MIXTE"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="niveauCECRL">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="A1"/>
+         <xsd:enumeration value="A2"/>
+         <xsd:enumeration value="B1"/>
+         <xsd:enumeration value="B2"/>
+         <xsd:enumeration value="C1"/>
+         <xsd:enumeration value="C2"/>
+         <xsd:enumeration value="INSUFFISANT"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="mention">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="SANS_MENTION"/>
+         <xsd:enumeration value="MENTION_ASSEZ_BIEN"/>
+         <xsd:enumeration value="MENTION_BIEN"/>
+         <xsd:enumeration value="MENTION_TRES_BIEN"/>
+         <xsd:enumeration value="MENTION_TRES_BIEN_AVEC_FELICITATIONS_DU_JURY"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="modaliteAcces">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="FORMATION_INITIALE_HORS_APPRENTISSAGE"/>
+         <xsd:enumeration value="FORMATION_INITIALE_APPRENTISSAGE"/>
+         <xsd:enumeration value="FORMATION_CONTINUE_HORS_CONTRAT_DE_PROFESSIONNALISATION"/>
+         <xsd:enumeration value="FORMATION_CONTINUE_CONTRAT_DE_PROFESSIONNALISATION"/>
+         <xsd:enumeration value="VAE"/>
+         <xsd:enumeration value="EQUIVALENCE_DIPLOME_ETRANGER"/>
+         <xsd:enumeration value="CANDIDAT_LIBRE"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="voieAccesVAE">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="CONGES_VAE"/>
+         <xsd:enumeration value="VAE_CLASSIQUE"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="initiativeInscription">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="CERTIFIE"/>
+         <xsd:enumeration value="OF"/>
+         <xsd:enumeration value="POLE_EMPLOI"/>
+         <xsd:enumeration value="EMPLOYEUR"/>
+         <xsd:enumeration value="AUTRE"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="genre">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="M"/>
+         <xsd:enumeration value="F"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
## :unicorn: Problème
L’objectif est de nous assurer que nos fichiers XML sont aux normes pour le CPF en les validant via le fichier .xsd (disponible sur le site [mon compte formation](https://certificateurs.moncompteformation.gouv.fr/espace-public/page-guide#ctg14) ou depuis la page https://1024pix.atlassian.net/wiki/spaces/DEV/pages/3549462542 en version 2.0.0)

## :robot: Proposition
https://github.com/oozcitak/xmlbuilder2/blob/master/test/xsd/simple.test.ts 
https://certificateurs.moncompteformation.gouv.fr/espace-public/aide/peut-tester-le-fichier-xml-avec-le-xsd-meme-si-ne-dispose-pas-encore-des-identifiants 
https://certificateurs.moncompteformation.gouv.fr/espace-public/aide/que-faire-quand-ne-dispose-pas-de-toutes-les-donnees-obligatoires-type-date-de-naissance-lieu 

## :rainbow: Remarques
Utilisation de la lib https://www.npmjs.com/package/libxmljs

## :100: Pour tester
- télécharger un fichier d'export xml CPF sur le bucket OVH
- lancer le script `node scripts/certification/validate-cpf-xml.js <CHEMIN_VERS_XML>.xml`
- voir le rapport d'erreurs