### PR TITLE
[FEATURE] Rediriger vers la liste des certifications complémentaire après le rattachement d'un profil cible sur Pix Admin (PIX-9022).

### DIFF
--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -80,9 +80,13 @@ export default class AttachTargetProfileController extends Controller {
           targetProfileId: this.model.currentTargetProfile.id,
         },
       });
-      this.notifications.success('Profil cible rattaché avec succès');
+
+      this.router.transitionTo('authenticated.complementary-certifications.list');
+
+      this.notifications.success(
+        `Profil cible rattaché à la certification ${complementaryCertification.label} mis à jour avec succès !`,
+      );
     } catch (error) {
-      console.log(error);
       await this.onError("Une erreur est survenue lors de l'enregistrement du profil cible.");
     } finally {
       this.isSubmitting = false;

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -150,7 +150,7 @@ module(
       });
 
       module('when user submits the form', function () {
-        test('it should save the new attached target profile', async function (assert) {
+        test('it should save the new attached target profile and redirect to complementary certification list', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           server.create('complementary-certification', {
@@ -199,7 +199,14 @@ module(
           await clickByName('Rattacher le profil cible');
 
           // then
-          assert.dom(await screen.findByText('Profil cible rattaché avec succès')).exists();
+          assert
+            .dom(
+              await screen.findByText(
+                'Profil cible rattaché à la certification MARIANNE CERTIF mis à jour avec succès !',
+              ),
+            )
+            .exists();
+          assert.strictEqual(currentURL(), '/complementary-certifications/list');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, lorsqu'on rattache un nouveau profil cible, un toaster nous indique que tout s'est bien passé mais on reste sur la page de rattachement.

## :robot: Proposition
Etre redirigé vers la liste des certification complémentaires et modifier le message de succès pour plus de précision

## :100: Pour tester

- Se connecter sur Admin
- Aller dans les certifications complémentaire
- Aller sur CléA, et rattacher la V1
- remplir les champs de la table et cliquer sur Rattacher
- Constater que l'on est redirigé et qu'un toaster de succès s'affiche.
- (non régression) : Echouer lors du remplissage des champs lors du rattachement et constater que le toaster d'erreur s'affiche mais que l'on est pas redirigé.
- 