### PR TITLE
[FEATURE] Ajouter une variable au script de mise à jour des acquisitions de paliers (PIX-9125)

### DIFF
--- a/api/scripts/add-existing-stage-acquisitions.js
+++ b/api/scripts/add-existing-stage-acquisitions.js
@@ -49,13 +49,19 @@ function getAllArgs() {
       demand: true,
       description: 'id du dernier assessment',
     })
+    .option('maxRangeSize', {
+      type: 'number',
+      demand: true,
+      description: `taille de la plage d'assessments à parcourir`,
+    })
     .help().argv;
 }
 
-function normalizeRange({ idMin, idMax }) {
+function normalizeRange({ idMin, idMax, maxRangeSize }) {
   const rangeSize = idMax - idMin;
-  if (rangeSize > MAX_RANGE_SIZE) {
-    const newIdMax = idMin + MAX_RANGE_SIZE;
+  const range = maxRangeSize || MAX_RANGE_SIZE;
+  if (rangeSize > range) {
+    const newIdMax = idMin + range;
     logger.info(`Max range size exceeded : new idMax is ${newIdMax}`);
     return { idMin, idMax: newIdMax };
   }
@@ -66,8 +72,8 @@ async function main() {
   const startTime = performance.now();
 
   logger.info('\n---\n* Starting existing stage-acquisitions insertions.\n---\n');
-  const { idMin, idMax } = getAllArgs();
-  const range = normalizeRange({ idMin, idMax });
+  const { idMin, idMax, maxRangeSize } = getAllArgs();
+  const range = normalizeRange({ idMin, idMax, maxRangeSize });
 
   await handleStageAcquisitions({ ...range, throwError: false });
   logger.info('\n---\n* Done.\n---\n');


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le script de mise à jour des paliers est borné à 100 000 assessments que l'on peut parcourir.

## :robot: Proposition
Ajouter une variable au script pour pouvoir le lancer sur plus d'enregistrements.

## :rainbow: Remarques

## :100: Pour tester
En local :

🧹 Faire un npm run db:reset pour avoir une BDD clean
🚀 Lancer le nouveau script à partir du dossier api :
node scripts/add-existing-stage-acquisitions.js --idMin=100000 --idMax=300000 --maxRangeSize=1000000
✅ Attester que la table stage-acquisitions est remplie par les données souhaitées