### PR TITLE
[FEATURE] Ajouter une bordure autour des simulateurs d'épreuve (PIX-9198).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -1,6 +1,8 @@
 .challenge-embed-simulator {
-  width: calc(100% + 8px);
+  width: calc(100% + 10px);
   margin: 35px 0 50px -4px;
+  border-top: 1px solid var(--pix-neutral-22, #c1c7d0);
+  border-bottom: 1px solid var(--pix-neutral-22, #c1c7d0);
 }
 
 .embed {


### PR DESCRIPTION
## :unicorn: Problème

Depuis le dernier changement d'affichage des embeds sur les pages d'épreuve, on ne voit plus bien la délimitation lorsque l'embed est "blanc" comme c'est le cas pour le simulateur de calendrier, d'agenda, le file manager.

![image](https://github.com/1024pix/pix/assets/7335131/21eb5b58-b55e-415d-86d5-8665eced849a)

## :robot: Proposition

Ajouter une bordure haut et bas aux embeds pour améliorer la séparation visuelle. 

## :100: Pour tester

Visiter [cette épreuve](https://app-pr7090.review.pix.fr/challenges/challenge29tPnCHpMMvpd1/preview) et constater l'ajout des bordures
