### PR TITLE
[TECH] Ajoute une option onlyNotComputed sur le CRON du calcul de la certificabilité (PIX-9227).

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1265,6 +1265,12 @@ class AuditLoggerApiError extends DomainError {
   }
 }
 
+class OrganizationLearnerCertificabilityNotUpdatedError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 export {
   AuditLoggerApiError,
   LocaleFormatError,
@@ -1386,6 +1392,7 @@ export {
   OrganizationLearnerAlreadyLinkedToUserError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
   OrganizationLearnerCannotBeDissociatedError,
+  OrganizationLearnerCertificabilityNotUpdatedError,
   OrganizationLearnerDisabledError,
   OrganizationLearnerNotFound,
   OrganizationLearnersCouldNotBeSavedError,

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
@@ -10,12 +10,13 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
   }
 
   async handle(event = {}) {
-    let skipLoggedLastDayCheck = false;
-    if (event) skipLoggedLastDayCheck = event.skipLoggedLastDayCheck;
+    const skipLoggedLastDayCheck = event?.skipLoggedLastDayCheck;
+    const onlyNotComputed = event?.onlyNotComputed;
     const chunkSize = this.config.features.scheduleComputeOrganizationLearnersCertificability.chunkSize;
     await DomainTransaction.execute(async (domainTransaction) => {
       const count = await this.organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
         skipLoggedLastDayCheck,
+        onlyNotComputed,
         domainTransaction,
       });
       const chunkCount = Math.ceil(count / chunkSize);
@@ -26,6 +27,7 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
             limit: chunkSize,
             offset: index * chunkSize,
             skipLoggedLastDayCheck,
+            onlyNotComputed,
             domainTransaction,
           });
         await this.pgBossRepository.insert(

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -6,6 +6,7 @@ import {
   OrganizationLearnersCouldNotBeSavedError,
   UserCouldNotBeReconciledError,
   UserNotFoundError,
+  OrganizationLearnerCertificabilityNotUpdatedError,
 } from '../../domain/errors.js';
 import { OrganizationLearner } from '../../domain/models/OrganizationLearner.js';
 import { OrganizationLearnerForAdmin } from '../../domain/read-models/OrganizationLearnerForAdmin.js';
@@ -357,10 +358,15 @@ const isActive = async function ({ userId, campaignId }) {
 };
 
 async function updateCertificability(organizationLearner) {
-  await knex('organization-learners').where({ id: organizationLearner.id }).update({
+  const result = await knex('organization-learners').where({ id: organizationLearner.id }).update({
     isCertifiable: organizationLearner.isCertifiable,
     certifiableAt: organizationLearner.certifiableAt,
   });
+  if (result === 0) {
+    throw new OrganizationLearnerCertificabilityNotUpdatedError(
+      `Could not update certificability for OrganizationLearner with ID ${organizationLearner.id}.`,
+    );
+  }
 }
 
 async function countByOrganizationsWhichNeedToComputeCertificability({

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -363,14 +363,22 @@ async function updateCertificability(organizationLearner) {
   });
 }
 
-async function countByOrganizationsWhichNeedToComputeCertificability({ skipLoggedLastDayCheck = false } = {}) {
-  const queryBuilder = _queryBuilderForCertificability(skipLoggedLastDayCheck);
+async function countByOrganizationsWhichNeedToComputeCertificability({
+  skipLoggedLastDayCheck = false,
+  domainTransaction,
+} = {}) {
+  const queryBuilder = _queryBuilderForCertificability({ skipLoggedLastDayCheck, domainTransaction });
   const [{ count }] = await queryBuilder.count('view-active-organization-learners.id');
   return count;
 }
 
-function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset, skipLoggedLastDayCheck = false } = {}) {
-  const queryBuilder = _queryBuilderForCertificability(skipLoggedLastDayCheck);
+function findByOrganizationsWhichNeedToComputeCertificability({
+  limit,
+  offset,
+  skipLoggedLastDayCheck = false,
+  domainTransaction,
+} = {}) {
+  const queryBuilder = _queryBuilderForCertificability({ skipLoggedLastDayCheck, domainTransaction });
 
   return queryBuilder
     .modify(function (qB) {
@@ -384,8 +392,9 @@ function findByOrganizationsWhichNeedToComputeCertificability({ limit, offset, s
     .pluck('view-active-organization-learners.id');
 }
 
-function _queryBuilderForCertificability(skipLoggedLastDayCheck) {
-  return knex('view-active-organization-learners')
+function _queryBuilderForCertificability({ skipLoggedLastDayCheck, domainTransaction }) {
+  const knexConn = domainTransaction.knexTransaction || knex;
+  return knexConn('view-active-organization-learners')
     .join(
       'organization-features',
       'view-active-organization-learners.organizationId',

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -11,6 +11,7 @@ import {
   OrganizationLearnerNotFound,
   UserCouldNotBeReconciledError,
   UserNotFoundError,
+  OrganizationLearnerCertificabilityNotUpdatedError,
 } from '../../../../lib/domain/errors.js';
 
 import * as organizationLearnerRepository from '../../../../lib/infrastructure/repositories/organization-learner-repository.js';
@@ -2158,6 +2159,21 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         .first();
       expect(isCertifiable).to.be.true;
       expect(new Date(certifiableAt)).to.deep.equal(organizationLearner.certifiableAt);
+    });
+
+    it('should throw an error if it does not update anything', async function () {
+      // given
+      const notExistingOrganizationLearner = new OrganizationLearner({ id: 1 });
+      await databaseBuilder.commit();
+
+      // when
+      notExistingOrganizationLearner.isCertifiable = true;
+      notExistingOrganizationLearner.certifiableAt = new Date('2023-01-01');
+
+      const error = await catchErr(organizationLearnerRepository.updateCertificability)(notExistingOrganizationLearner);
+
+      // then
+      expect(error).to.be.instanceof(OrganizationLearnerCertificabilityNotUpdatedError);
     });
   });
   describe('#countByOrganizationsWhichNeedToComputeCertificability', function () {

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2185,7 +2185,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability();
+      const result = await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.equal(2);
@@ -2208,7 +2212,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability();
+      const result = await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.equal(1);
@@ -2230,8 +2238,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
-        skipLoggedLastDayCheck: true,
+      const result = await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+          skipLoggedLastDayCheck: true,
+          domainTransaction,
+        });
       });
 
       // then
@@ -2246,7 +2257,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability();
+      const result = await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.equal(0);
@@ -2260,8 +2275,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
-        skipLoggedLastDayCheck: true,
+      const result = await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability({
+          skipLoggedLastDayCheck: true,
+          domainTransaction,
+        });
       });
 
       // then
@@ -2286,7 +2304,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.deep.equal([organizationLearnerId]);
@@ -2310,7 +2332,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.deep.equal([organizationLearnerRecentlyConnecterId]);
@@ -2336,8 +2362,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-        skipLoggedLastDayCheck: true,
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          skipLoggedLastDayCheck: true,
+          domainTransaction,
+        });
       });
 
       // then
@@ -2354,7 +2383,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.be.empty;
@@ -2366,7 +2399,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.be.empty;
@@ -2380,7 +2417,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.deep.equal([]);
@@ -2394,7 +2435,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability();
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          domainTransaction,
+        });
+      });
 
       // then
       expect(result).to.be.empty;
@@ -2408,8 +2453,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-        skipLoggedLastDayCheck: true,
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          skipLoggedLastDayCheck: true,
+          domainTransaction,
+        });
       });
 
       // then
@@ -2426,8 +2474,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-        limit: 1,
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          limit: 1,
+          domainTransaction,
+        });
       });
 
       // then
@@ -2446,8 +2497,11 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       await databaseBuilder.commit();
 
       // when
-      const result = await organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
-        offset: 1,
+      const result = await await DomainTransaction.execute(async (domainTransaction) => {
+        return organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
+          offset: 1,
+          domainTransaction,
+        });
       });
 
       // then

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -14,7 +14,8 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
 
     it('should schedule multiple ComputeCertificabilityJob', async function () {
       // given
-      const skipLoggedLastDayCheck = false;
+      const skipLoggedLastDayCheck = undefined;
+      const onlyNotComputed = undefined;
       const pgBossRepository = {
         insert: sinon.stub(),
       };
@@ -30,13 +31,13 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         },
       };
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
         new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
@@ -76,9 +77,10 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
       ]);
     });
 
-    it('should schedule ComputeCertificabilityJob for all learners', async function () {
+    it('should take options from event', async function () {
       // given
       const skipLoggedLastDayCheck = true;
+      const onlyNotComputed = true;
       const pgBossRepository = {
         insert: sinon.stub(),
       };
@@ -94,13 +96,13 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         },
       };
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
         new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
@@ -110,7 +112,10 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         });
 
       // when
-      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({ skipLoggedLastDayCheck });
+      await scheduleComputeOrganizationLearnersCertificabilityJobHandler.handle({
+        skipLoggedLastDayCheck,
+        onlyNotComputed,
+      });
 
       // then
       expect(pgBossRepository.insert.getCall(0).args[0]).to.be.deep.equal([
@@ -142,7 +147,8 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
 
     it('should test pagination with a lot of results', async function () {
       // given
-      const skipLoggedLastDayCheck = false;
+      const skipLoggedLastDayCheck = undefined;
+      const onlyNotComputed = undefined;
       const pgBossRepository = {
         insert: sinon.stub(),
       };
@@ -160,12 +166,12 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         },
       };
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ skipLoggedLastDayCheck, domainTransaction })
+        .withArgs({ skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves(30);
 
       for (let index = 0; index < chunkCount; index++) {
         organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-          .withArgs({ limit, offset: index * limit, skipLoggedLastDayCheck, domainTransaction })
+          .withArgs({ limit, offset: index * limit, skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
           .resolves([index * limit + 1, index * limit + 2, index * limit + 3]);
       }
 

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -1,8 +1,17 @@
 import { expect, sinon } from '../../../../test-helper.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from '../../../../../lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 
 describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCertificabilityJobHandler', function () {
   context('#handle', function () {
+    let domainTransaction;
+    beforeEach(function () {
+      domainTransaction = Symbol('domainTransaction');
+      DomainTransaction.execute = (lambda) => {
+        return lambda(domainTransaction);
+      };
+    });
+
     it('should schedule multiple ComputeCertificabilityJob', async function () {
       // given
       const skipLoggedLastDayCheck = false;
@@ -21,13 +30,13 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         },
       };
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ skipLoggedLastDayCheck })
+        .withArgs({ skipLoggedLastDayCheck, domainTransaction })
         .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck })
+        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck, domainTransaction })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck })
+        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck, domainTransaction })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
         new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
@@ -85,13 +94,13 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         },
       };
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ skipLoggedLastDayCheck })
+        .withArgs({ skipLoggedLastDayCheck, domainTransaction })
         .resolves(3);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck })
+        .withArgs({ limit: 2, offset: 0, skipLoggedLastDayCheck, domainTransaction })
         .resolves([1, 2]);
       organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck })
+        .withArgs({ limit: 2, offset: 2, skipLoggedLastDayCheck, domainTransaction })
         .resolves([3]);
       const scheduleComputeOrganizationLearnersCertificabilityJobHandler =
         new ScheduleComputeOrganizationLearnersCertificabilityJobHandler({
@@ -151,12 +160,12 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         },
       };
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
-        .withArgs({ skipLoggedLastDayCheck })
+        .withArgs({ skipLoggedLastDayCheck, domainTransaction })
         .resolves(30);
 
       for (let index = 0; index < chunkCount; index++) {
         organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability
-          .withArgs({ limit, offset: index * limit, skipLoggedLastDayCheck })
+          .withArgs({ limit, offset: index * limit, skipLoggedLastDayCheck, domainTransaction })
           .resolves([index * limit + 1, index * limit + 2, index * limit + 3]);
       }
 


### PR DESCRIPTION
## :unicorn: Problème
Afin de pouvoir faire un rattrapage et anticiper l’ajout de la feature pour les AEFE, on veut pouvoir ajouter une option à l’insertion du job pour calculer la certificabilitée uniquement pour les learners n’ayant jamais eu ce calcul d'éffectué.

## :robot: Proposition
Ajout d'une option "onlyNotComputed" qui n'est prise en compte uniquement si l'option "skipLoggedLastDayCheck" est passée à true, afin de permettre de calculer le statut de certificabilitée pour les learners ne l'ayant jamais eu.

## :rainbow: Remarques
- Ajoute toutes les requêtes SQL dans la transaction
- Ajoute un test sur la pagination (10 pages)
- Déclenche une erreur si la certificabilité n'a pas pu être mise à jour pour un prescrit

## :100: Pour tester
- Avoir une organization ayant la feature d'activée avec au moins 2 learners actifs
- Modifier sur la table "organization-learners" les colonnes isCertifiable et certifiableAt (avec une date passée) pour un learner des deux learners de l'orga précedemment citée
- Insérer le job ScheduleComputeOrganizationLearnersJob avec les deux options "skipLoggedLastDayCheck" ET "onlyNotComputed" à true : 
```sql
INSERT INTO "pgboss"."job" (name, data) VALUES('ScheduleComputeOrganizationLearnersCertificabilityJob', '{"skipLoggedLastDayCheck":"true", "onlyNotComputed":"true"}');
```
- Vérifier que seul les learners avec le statut isCertifiable à null ont maintenant eu leurs calculs. Et le learner ayant été modifié à l'étape 2 à lui toujours l'ancienne date en certifiableAt
- 🐱 