### PR TITLE
[BUGFIX] ajoute le statut « en construction » au filtre des « skills » pris en compte pour pix1d

### DIFF
--- a/api/lib/infrastructure/datasources/learning-content/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/skill-datasource.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import * as datasource from './datasource.js';
 
 const ACTIVE_STATUS = 'actif';
+const IN_BUILD_STATUS = 'en construction';
 const OPERATIVE_STATUSES = ['actif', 'archivé'];
 
 const skillDatasource = datasource.extend({
@@ -34,6 +35,14 @@ const skillDatasource = datasource.extend({
     const skills = await this.list();
     return skills.filter(
       (skillData) => _.includes(OPERATIVE_STATUSES, skillData.status) && _.includes(skillIds, skillData.id),
+    );
+  },
+
+  async findByTubeIdFor1d(tubeId) {
+    const skills = await this.list();
+    return skills.filter(
+      (skillData) =>
+        _.includes([ACTIVE_STATUS, IN_BUILD_STATUS], skillData.status) && _.includes(tubeId, skillData.tubeId),
     );
   },
 

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -78,7 +78,7 @@ const getActivityChallengesFor1d = async function ({ missionId, activityLevel })
   if (activityLevelTube === undefined) {
     _throwNotFoundError(activityLevel, missionId);
   }
-  const skills = await skillDatasource.findActiveByTubeId(activityLevelTube.id);
+  const skills = await skillDatasource.findByTubeIdFor1d(activityLevelTube.id);
 
   let allLevelChallenges;
   try {

--- a/api/tests/unit/infrastructure/datasources/learning-content/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/skill-datasource_test.js
@@ -198,6 +198,41 @@ describe('Unit | Infrastructure | Datasource | LearningContent | SkillDatasource
     });
   });
 
+  describe('#findByTubeIdFor1d', function () {
+    beforeEach(function () {
+      const acquixActive = { id: 'recSkillActive', status: 'actif', competenceId: 'recCompetence', tubeId: 'recTube' };
+      const acquixInBuild = {
+        id: 'recSkillInBuild',
+        status: 'en construction',
+        competenceId: 'recCompetence',
+        tubeId: 'recTube',
+      };
+      const acquixExpired = {
+        id: 'recSkillExpired',
+        status: 'périmé',
+        competenceId: 'recCompetence',
+        tubeId: 'recTube',
+      };
+      const acquixOtherTube = {
+        id: 'recSkillOtherTube',
+        status: 'actif',
+        competenceId: 'recOtherCompetence',
+        tubeId: 'recOtherTube',
+      };
+      sinon
+        .stub(lcms, 'getLatestRelease')
+        .resolves({ skills: [acquixActive, acquixInBuild, acquixExpired, acquixOtherTube] });
+    });
+
+    it('should retrieve all skills from learning content for one competence', async function () {
+      // when
+      const skills = await skillDatasource.findByTubeIdFor1d('recTube');
+
+      // then
+      expect(_.map(skills, 'id')).to.have.members(['recSkillActive', 'recSkillInBuild']);
+    });
+  });
+
   describe('#findOperativeByCompetenceId', function () {
     beforeEach(function () {
       const acquix1 = { id: 'recSkill1', status: 'actif', competenceId: 'recCompetence' };


### PR DESCRIPTION
## :unicorn: Problème

Nous avons des acquis « en construction » sur Pix1D.
Nous voulons quand même les afficher (pour nos tests et panel).

## :robot: Proposition

Ajouter un filtre **temporaire** spécial pour Pix1d qui prend en compte les acquis en construction.

## :rainbow: Remarques


## :100: Pour tester

cf RA en faisant la première mission.