### PR TITLE
[BUGFIX] Eliminer les doublons de recherches de profils cibles attachables (PIX-9165).

### DIFF
--- a/api/lib/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/lib/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -8,17 +8,16 @@ const find = async function ({ searchTerm } = {}) {
       queryBuilder
         .select('complementary-certification-badges.badgeId')
         .from('complementary-certification-badges')
-        .whereNull('complementary-certification-badges.detachedAt')
-        .distinct();
+        .whereNull('complementary-certification-badges.detachedAt');
     })
     .select('target-profiles.id', 'target-profiles.name')
-    .from('target-profiles')
+    .distinct()
     .leftJoin('badges', 'target-profiles.id', 'badges.targetProfileId')
     .leftJoin('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
     .orderBy('target-profiles.name', 'ASC')
     .orderBy('target-profiles.id', 'DESC')
     .where('target-profiles.outdated', false)
-    .where((builder) => _includeNeverAttachedTargetProfile(builder).orWhere(_includeDetachedTargetProfile))
+    .where((builder) => _includeNeverAttachedTargetProfile(builder).orWhere(_includeNotAttachedTargetProfile))
     .where((builder) => _searchByCritieria({ builder, searchTerm }));
 
   return _toDomain(targetProfiles);
@@ -50,7 +49,7 @@ function _includeNeverAttachedTargetProfile(builder) {
   return builder.whereNull('complementary-certification-badges.badgeId');
 }
 
-function _includeDetachedTargetProfile(builder) {
+function _includeNotAttachedTargetProfile(builder) {
   return builder.whereNotNull('badges.targetProfileId').whereNotExists((queryBuilder) => {
     queryBuilder
       .select(1)

--- a/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
@@ -90,6 +90,28 @@ describe('Integration | Repository | attachable-target-profiles', function () {
         // then
         expect(results).to.deep.equal([{ id: 100, name: 'currentlyDetached' }]);
       });
+
+      context('when the target profile has an history where it has been detached', function () {
+        it('should not return a target profile even if it was detached in the past', async function () {
+          // given
+          new TargetProfileFactory({ id: 100, name: 'a_PC_attached_now_but_who_got_detached_also_in_the_past' })
+            .withBadge({ id: 876, title: 'this_badge_will_be_both_linked_to_an_attached_and_detached_ccbadge' })
+            .withComplementaryCertificationBadge({ detachedAt: null });
+
+          databaseBuilder.factory.buildComplementaryCertificationBadge({
+            badgeId: 876,
+            complementaryCertificationId: null,
+            detachedAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const results = await attachableTargetProfileRepository.find();
+
+          // then
+          expect(results).to.deep.equal([]);
+        });
+      });
     });
 
     context('when there is a term to search for', function () {

--- a/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
@@ -91,8 +91,31 @@ describe('Integration | Repository | attachable-target-profiles', function () {
         expect(results).to.deep.equal([{ id: 100, name: 'currentlyDetached' }]);
       });
 
+      context('when the target profile has been multiple times detached', function () {
+        it('should appear only once in the results', async function () {
+          // given
+          new TargetProfileFactory({ id: 100, name: 'currentlyDetached' })
+            .withBadge({ id: 875, title: 'this_badge_has_been_detached_twice' })
+            .withComplementaryCertificationBadge({ detachedAt: new Date() });
+
+          databaseBuilder.factory.buildComplementaryCertificationBadge({
+            badgeId: 875,
+            complementaryCertificationId: null,
+            detachedAt: new Date(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const results = await attachableTargetProfileRepository.find();
+
+          // then
+          expect(results).to.deep.equal([{ id: 100, name: 'currentlyDetached' }]);
+        });
+      });
+
       context('when the target profile has an history where it has been detached', function () {
-        it('should not return a target profile even if it was detached in the past', async function () {
+        it('should not be returned', async function () {
           // given
           new TargetProfileFactory({ id: 100, name: 'a_PC_attached_now_but_who_got_detached_also_in_the_past' })
             .withBadge({ id: 876, title: 'this_badge_will_be_both_linked_to_an_attached_and_detached_ccbadge' })
@@ -101,7 +124,7 @@ describe('Integration | Repository | attachable-target-profiles', function () {
           databaseBuilder.factory.buildComplementaryCertificationBadge({
             badgeId: 876,
             complementaryCertificationId: null,
-            detachedAt: new Date(),
+            detachedAt: new Date('2021-01-01'),
           });
           await databaseBuilder.commit();
 
@@ -109,7 +132,7 @@ describe('Integration | Repository | attachable-target-profiles', function () {
           const results = await attachableTargetProfileRepository.find();
 
           // then
-          expect(results).to.deep.equal([]);
+          expect(results).to.be.empty;
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Certains profils apparaissent plusieurs fois (ou apparaissent tout court) en tant que attachables alors qu'ils ne sont pas éligibles (ou alors en doublons).

## :robot: Proposition
Prendre en compte le fait qu'un profil cibles peut être à la fois attaché mais avoir été détaché dans le passé aussi.
Prendre en compte que un profil cible peut avoir été détaché un nombre N de fois.

## :rainbow: Remarques

⚠️ Bien faire de la non régression !

## :100: Pour tester

Tout est sur Pix Admin, utilisateur `superadmin@example.net`

### Cas réparé

* Onglet certification complémentaire
  * Ouvrir une complémentaire, faire "rattacher un nouveau profil cible", **noter le profil cible actuel** (A)
  * Rechercher un profil cible
  * Le rattacher, noter le nouveau profil cible (B)
  * Revenir sur la même complémentaire
  * Rechercher un des profils dible de son historique (le A)
  * Le rattacher à nouveau
  * Revenir sur la même complémentaire
  * Rechercher le profil cible actuellement attaché (le A) : il ne doit pas apparaitre (bien que détaché précèdemment)
  * Rechercher le profil cible B, le voir apparaitre une seule et unique fois
  * Re-rattacher le B
  * Re-rechercher le A, il ne doit apparaitre q'une seule et unique fois (bien que détaché du coup deux fois)

### Non reg 

#### Cas nominal

* Onglet profil cible
  * Créer un novueau profil cible
  * Lui associer au moins un badge certifiant
* Onglet certification complémentaire
  * Ouvrir une complémentaire, faire "rattacher un nouveau profil cible"
  * Rechercher le nouveau profil cible par nom ou par id
  * Vérifier qu'il apparait dans la recherche

#### Cas obsolète

* Repérer ou créer un profil cible **NON** obsolète, vérifier qu'il apparait dans la recherche des PC complémentaires
* Le passer en obsolète
* Vérifier qu'il n'apparait plus dans la recherche

#### Pas de badge

* Repérer ou créer un profil cible sans badge
* Vérfier qu'il apparait dans la recherche

#### Déjà attaché

* Ouvrir une complémentaire, notez le profil attaché
* Ouvrir une autre complémentaire de la liste, essayer de faire une recherche sur le nom du profil cible précèdemment noté
* Il ne doit pas apparaitre dans la recherche
*
#### Détacher

* Ouvrir une complémentaire, par exemple Clé
* Regarder l'historique des profil cibles, repérer un profil cible **détaché**, notez le
* Faire une recherche, essayer de rechercher le profil cible détaché précèdemment noté
* Il doit apparaitre dans la recherche
