### PR TITLE
[FEATURE] Ajouter un loading state au bouton d'import et informer pour le SCO (PIX-9276)

### DIFF
--- a/orga/app/components/sco-organization-participant/header-actions.hbs
+++ b/orga/app/components/sco-organization-participant/header-actions.hbs
@@ -2,9 +2,15 @@
   <h1 class="page__title page-title">{{t "pages.sco-organization-participants.title" count=@participantCount}}</h1>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="organization-participant-list-page__import-students-button hide-on-mobile">
-      <PixButtonUpload @id="students-file-upload" @onChange={{@onImportStudents}} accept={{this.acceptedFileType}}>
-        {{this.importButtonLabel}}
-      </PixButtonUpload>
+      {{#if @isLoading}}
+        <PixButton @id="students-file-upload" @onChange={{@onImportStudents}} @isDisabled="true" @isLoading="true">
+          {{this.importButtonLabel}}
+        </PixButton>
+      {{else}}
+        <PixButtonUpload @id="students-file-upload" @onChange={{@onImportStudents}} accept={{this.acceptedFileType}}>
+          {{this.importButtonLabel}}
+        </PixButtonUpload>
+      {{/if}}
     </div>
   {{/if}}
 </div>

--- a/orga/app/components/sco-organization-participant/header-actions.hbs
+++ b/orga/app/components/sco-organization-participant/header-actions.hbs
@@ -1,6 +1,11 @@
 <div class="organization-participant-list-page__header">
   <h1 class="page__title page-title">{{t "pages.sco-organization-participants.title" count=@participantCount}}</h1>
   {{#if this.currentUser.isAdminInOrganization}}
+    {{#if @isLoading}}
+      <PixMessage @type="information" @withIcon="true">
+        {{t "pages.sco-organization-participants.actions.import-file.information"}}
+      </PixMessage>
+    {{/if}}
     <div class="organization-participant-list-page__import-students-button hide-on-mobile">
       {{#if @isLoading}}
         <PixButton @id="students-file-upload" @onChange={{@onImportStudents}} @isDisabled="true" @isLoading="true">

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -73,7 +73,11 @@ export default class ListController extends Controller {
     const adapter = this.store.adapterFor('students-import');
     const organizationId = this.currentUser.organization.id;
     const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
-
+    const confirmBeforeClose = (event) => {
+      event.preventDefault();
+      return (event.returnValue = '');
+    };
+    window.addEventListener('beforeunload', confirmBeforeClose);
     this.isLoading = true;
     this.notifications.clearAll();
     try {
@@ -85,6 +89,7 @@ export default class ListController extends Controller {
       this.isLoading = false;
       this._handleError(errorResponse);
     }
+    window.removeEventListener('beforeunload', confirmBeforeClose);
   }
 
   _handleError(errorResponse) {

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -4,6 +4,7 @@
   <ScoOrganizationParticipant::HeaderActions
     @onImportStudents={{this.importStudents}}
     @participantCount={{@model.meta.participantCount}}
+    @isLoading={{this.isLoading}}
   />
   <ScoOrganizationParticipant::List
     @students={{@model}}
@@ -21,8 +22,4 @@
     @divisionSort={{this.divisionSort}}
     @lastnameSort={{this.lastnameSort}}
   />
-
-  {{#if this.isLoading}}
-    <Ui::PixLoader />
-  {{/if}}
 </div>

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -54,6 +54,19 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
 
           assert.dom(screen.getByRole('button', { hidden: true })).exists();
         });
+
+        test('a message should be display when importing ', async function (assert) {
+          screen = await render(
+            hbs`<ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudentsSpy}} @isLoading={{true}} />`,
+          );
+          assert
+            .dom(
+              await screen.findByText(
+                this.intl.t('pages.sco-organization-participants.actions.import-file.information'),
+              ),
+            )
+            .exists();
+        });
       });
 
       module('when organization is SCO and tagged as Agriculture and CFA', (hooks) => {
@@ -78,6 +91,19 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
           );
 
           assert.dom(screen.getByRole('button', { hidden: true })).exists();
+        });
+
+        test('a message should be display when importing ', async function (assert) {
+          screen = await render(
+            hbs`<ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudentsSpy}} @isLoading={{true}} />`,
+          );
+          assert
+            .dom(
+              await screen.findByText(
+                this.intl.t('pages.sco-organization-participants.actions.import-file.information'),
+              ),
+            )
+            .exists();
         });
       });
     });

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
@@ -14,7 +13,7 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
       this.set('participantCount', 0);
 
       // when
-      const screen = await renderScreen(
+      const screen = await render(
         hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{this.participantCount}} />`,
       );
 
@@ -27,7 +26,7 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
       this.set('participantCount', 5);
 
       // when
-      const screen = await renderScreen(
+      const screen = await render(
         hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{this.participantCount}} />`,
       );
 
@@ -39,24 +38,27 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
   module('user rights', () => {
     module('when user is admin in organization', () => {
       module('when organization is SCO', (hooks) => {
-        hooks.beforeEach(function () {
+        let screen;
+        hooks.beforeEach(async function () {
           class CurrentUserStub extends Service {
             isAdminInOrganization = true;
           }
           this.owner.register('service:current-user', CurrentUserStub);
           this.set('importStudentsSpy', () => {});
-          return render(
-            hbs`<ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudentsSpy}} />`,
-          );
         });
 
-        test('it should display import XML file button', async function (assert) {
-          assert.contains('Importer (.xml ou .zip)');
+        test('the import button should be in loading state when importing', async function (assert) {
+          screen = await render(
+            hbs`<ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudentsSpy}} @isLoading={{true}} />`,
+          );
+
+          assert.dom(screen.getByRole('button', { hidden: true })).exists();
         });
       });
 
       module('when organization is SCO and tagged as Agriculture and CFA', (hooks) => {
-        hooks.beforeEach(function () {
+        let screen;
+        hooks.beforeEach(async function () {
           class CurrentUserStub extends Service {
             isAdminInOrganization = true;
             isAgriculture = true;
@@ -68,13 +70,14 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
 
           this.set('importStudentsSpy', () => {});
           this.owner.register('service:current-user', CurrentUserStub);
-          return render(
-            hbs`<ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudentsSpy}} />`,
-          );
         });
 
-        test('it should still display import CSV file button', async function (assert) {
-          assert.contains('Importer (.csv)');
+        test('the import button should be in loading state when importing', async function (assert) {
+          screen = await render(
+            hbs`<ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudentsSpy}} @isLoading={{true}} />`,
+          );
+
+          assert.dom(screen.getByRole('button', { hidden: true })).exists();
         });
       });
     });

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -82,18 +82,26 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
       });
     });
 
-    module('when user is not admin in organization', (hooks) => {
-      hooks.beforeEach(function () {
+    module('when user is not admin in organization', () => {
+      test('it should not display import button', async function (assert) {
         class CurrentUserStub extends Service {
           isAdminInOrganization = false;
         }
         this.owner.register('service:current-user', CurrentUserStub);
-        return render(hbs`<ScoOrganizationParticipant::HeaderActions />`);
-      });
+        const screen = await render(hbs`<ScoOrganizationParticipant::HeaderActions />`);
 
-      test('it should not display import button', async function (assert) {
-        assert.notContains('Importer (.xml)');
-        assert.notContains('Importer (.csv)');
+        assert.strictEqual(
+          screen.queryByLabelText(
+            this.intl.t('pages.sco-organization-participants.actions.import-file.label', { types: '.csv' }),
+          ),
+          null,
+        );
+        assert.strictEqual(
+          screen.queryByLabelText(
+            this.intl.t('pages.sco-organization-participants.actions.import-file.label', { types: '.xml ou .zip' }),
+          ),
+          null,
+        );
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -919,7 +919,9 @@
       "actions": {
         "import-file": {
           "file-type-separator": " or ",
+          "information": "Importing your file may take a few minutes. Some features may be temporarily inaccessible.",
           "label": "Import ({types})"
+
         },
         "manage-account": "Manage the account",
         "show-actions": "Show actions"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -922,6 +922,7 @@
       "actions": {
         "import-file": {
           "file-type-separator": " ou ",
+          "information": "L'import de votre fichier peut prendre quelques minutes. Certaines fonctionnalités sont temporairement inaccessibles.",
           "label": "Importer ({types})"
         },
         "manage-account": "Gérer le compte",


### PR DESCRIPTION
## :unicorn: Problème
Quand l'utilisateur importe des élèves, tout le long de l'import, il ne peut pas quitter la page ou faire une quelconque action. Cependant l'utilisateur n'en est pas informé et a l'impression que la plateforme plante.
Également, rien de visuel n'informait l'utilisateur que l'import était en cours (sauf si il scrollait vers le bas pour voir un loader qui se balade en fin de page 😬 

## :robot: Proposition
- Ajouter un loading state sur le bouton et le disable le temps de l'import
- Ajouter un encart d'information  pour que l'utilisateur soit au courant que d'autres features de l'application ne seraient pas disponibles le temps de l'import
- Ajouter une confirmation quand le utilisateur sont en train d'importer et souhaite fermer leur page de navigateur (car dans ce cas cela couperait l'import.

## :rainbow: Remarques
Ceci est une première solution pour répondre aux latences suite aux imports siecles en masse de la rentrée

## :100: Pour tester
- se connecter à Pix Orga en tant que SCO
- Se mettre en slow 3G
- Importer un document
- Remarquer le loading du bouton et l'encart d'information
- Recommencer l'import si il s'est terminé
- Essayer de quitter la page
- Remarquer la pop-in du navigateur qui te demande si tu es sûr de ce que tu veux faire
- 🎉 