### PR TITLE
[FEATURE] Espacer les questions de même compétence dans la certif v3 (PIX-9213)

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -11,6 +11,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   forcedCompetencies: Joi.array().items(Joi.string()),
   useObsoleteChallenges: Joi.boolean(),
   challengePickProbability: Joi.number().min(0).max(100),
+  challengesBetweenSameCompetence: Joi.number().min(0),
 });
 
 const register = async (server) => {

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -28,6 +28,7 @@ async function simulateFlashAssessmentScenario(
     forcedCompetences,
     useObsoleteChallenges,
     challengePickProbability,
+    challengesBetweenSameCompetence,
   } = request.payload;
 
   const pickAnswerStatus = _getPickAnswerStatusMethod(dependencies.pickAnswerStatusService, request.payload);
@@ -51,6 +52,7 @@ async function simulateFlashAssessmentScenario(
           warmUpLength,
           forcedCompetences,
           useObsoleteChallenges,
+          challengesBetweenSameCompetence,
         },
         _.isUndefined,
       );

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -317,6 +317,7 @@ const configuration = (function () {
       numberOfChallengesPerCourse: process.env.V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE || 20,
       defaultProbabilityToPickChallenge: parseInt(process.env.DEFAULT_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
       defaultCandidateCapacity: -3,
+      challengesBetweenSameCompetence: 2,
     },
     version: process.env.CONTAINER_VERSION || 'development',
   };

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -32,8 +32,10 @@ class FlashAssessmentAlgorithm {
       allAnswers,
       challenges,
       estimatedLevel,
-      warmUpLength: this.warmUpLength,
-      forcedCompetences: this.forcedCompetences,
+      options: {
+        warmUpLength: this.warmUpLength,
+        forcedCompetences: this.forcedCompetences,
+      },
     });
 
     if (hasAssessmentEnded) {

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -7,10 +7,18 @@ import {
 import { config } from '../../config.js';
 
 class FlashAssessmentAlgorithm {
-  constructor({ warmUpLength, forcedCompetences, maximumAssessmentLength } = {}) {
+  /**
+   * Model to interact with the flash algorithm
+   * @param warmUpLength - define a warmup when the algorithm do not go through the competences
+   * @param forcedCompetences - force the algorithm to ask questions on the specified competences
+   * @param maximumAssessmentLength - override the default limit for an assessment length
+   * @param challengesBetweenSameCompetence - define a number of questions between the same competence
+   */
+  constructor({ warmUpLength, forcedCompetences, maximumAssessmentLength, challengesBetweenSameCompetence } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
+    this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
   }
 
   getPossibleNextChallenges({
@@ -35,6 +43,7 @@ class FlashAssessmentAlgorithm {
       options: {
         warmUpLength: this.warmUpLength,
         forcedCompetences: this.forcedCompetences,
+        challengesBetweenSameCompetence: this.challengesBetweenSameCompetence,
       },
     });
 

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -14,7 +14,12 @@ class FlashAssessmentAlgorithm {
    * @param maximumAssessmentLength - override the default limit for an assessment length
    * @param challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    */
-  constructor({ warmUpLength, forcedCompetences, maximumAssessmentLength, challengesBetweenSameCompetence } = {}) {
+  constructor({
+    warmUpLength,
+    forcedCompetences,
+    maximumAssessmentLength,
+    challengesBetweenSameCompetence = config.v3Certification.challengesBetweenSameCompetence,
+  } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;

--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -12,7 +12,7 @@ class FlashAssessmentAlgorithm {
    * @param warmUpLength - define a warmup when the algorithm do not go through the competences
    * @param forcedCompetences - force the algorithm to ask questions on the specified competences
    * @param maximumAssessmentLength - override the default limit for an assessment length
-   * @param challengesBetweenSameCompetence - define a number of questions between the same competence
+   * @param challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    */
   constructor({ warmUpLength, forcedCompetences, maximumAssessmentLength, challengesBetweenSameCompetence } = {}) {
     this.warmUpLength = warmUpLength;

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -25,8 +25,7 @@ function getPossibleNextChallenges({
   allAnswers,
   challenges,
   estimatedLevel = DEFAULT_ESTIMATED_LEVEL,
-  warmUpLength = 0,
-  forcedCompetences = [],
+  options: { warmUpLength = 0, forcedCompetences = [] } = {},
 } = {}) {
   let nonAnsweredChallenges = getChallengesForNonAnsweredSkills({ allAnswers, challenges });
 

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -10,6 +10,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   warmUpLength,
   forcedCompetences,
   useObsoleteChallenges,
+  challengesBetweenSameCompetence,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -17,6 +18,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     warmUpLength,
     forcedCompetences,
     maximumAssessmentLength: stopAtChallenge,
+    challengesBetweenSameCompetence,
   });
 
   const simulator = new AssessmentSimulator({

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -2,9 +2,29 @@ import { expect, domainBuilder } from '../../../../test-helper.js';
 import * as flash from '../../../../../lib/domain/services/algorithm-methods/flash.js';
 import { AnswerStatus } from '../../../../../lib/domain/models/AnswerStatus.js';
 import { config } from '../../../../../lib/config.js';
+import { getPossibleNextChallenges } from '../../../../../lib/domain/services/algorithm-methods/flash.js';
 
 describe('Integration | Domain | Algorithm-methods | Flash', function () {
   describe('#getPossibleNextChallenge', function () {
+    let listSkills;
+
+    beforeEach(function () {
+      listSkills = {
+        url5: domainBuilder.buildSkill({ id: 'url5', competenceId: 'url' }),
+        web3: domainBuilder.buildSkill({ id: 'web3', competenceId: 'web' }),
+        sourceinfo5: domainBuilder.buildSkill({ id: 'sourceinfo5', competenceId: 'sourceinfo' }),
+        installogiciel2: domainBuilder.buildSkill({ id: 'installogiciel2', competenceId: 'installogiciel' }),
+        fichier4: domainBuilder.buildSkill({ id: 'fichier4', competenceId: 'fichier' }),
+        sauvegarde5: domainBuilder.buildSkill({ id: 'sauvegarde5', competenceId: 'sauvegarde' }),
+        langbalise6: domainBuilder.buildSkill({ id: 'langbalise6', competenceId: 'langbalise' }),
+        pratiquesinternet4: domainBuilder.buildSkill({
+          id: 'pratiquesinternet4',
+          competenceId: 'pratiquesinternet4',
+        }),
+        langbalise7: domainBuilder.buildSkill({ id: 'langbalise7', competenceId: 'langbalise' }),
+      };
+    });
+
     context('when there is no challenge', function () {
       it('should return hasAssessmentEnded as true and possibleChallenges is empty', function () {
         // given
@@ -184,25 +204,9 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
 
     context('when the user answers a lot of challenges', function () {
-      let listSkills;
       let listChallenges;
 
       beforeEach(function () {
-        listSkills = {
-          url5: domainBuilder.buildSkill({ id: 'url5', competenceId: 'url' }),
-          web3: domainBuilder.buildSkill({ id: 'web3', competenceId: 'web' }),
-          sourceinfo5: domainBuilder.buildSkill({ id: 'sourceinfo5', competenceId: 'sourceinfo' }),
-          installogiciel2: domainBuilder.buildSkill({ id: 'installogiciel2', competenceId: 'installogiciel' }),
-          fichier4: domainBuilder.buildSkill({ id: 'fichier4', competenceId: 'fichier' }),
-          sauvegarde5: domainBuilder.buildSkill({ id: 'sauvegarde5', competenceId: 'sauvegarde' }),
-          langbalise6: domainBuilder.buildSkill({ id: 'langbalise6', competenceId: 'langbalise' }),
-          pratiquesinternet4: domainBuilder.buildSkill({
-            id: 'pratiquesinternet4',
-            competenceId: 'pratiquesinternet4',
-          }),
-          langbalise7: domainBuilder.buildSkill({ id: 'langbalise7', competenceId: 'langbalise' }),
-        };
-
         listChallenges = [
           domainBuilder.buildChallenge({
             id: 'recA',
@@ -499,6 +503,150 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
               allAnswers.push(answer);
             }
           });
+        });
+      });
+    });
+
+    describe('when you space competences', function () {
+      let challenges;
+
+      beforeEach(function () {
+        challenges = [
+          domainBuilder.buildChallenge({
+            id: 'recCHAL1',
+            competenceId: 'compId1',
+            skill: listSkills.langbalise6,
+            difficulty: 3,
+            discriminant: 1,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recCHAL2',
+            competenceId: 'compId1',
+            skill: listSkills.langbalise7,
+            difficulty: 3,
+            discriminant: 1,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recCHAL3',
+            competenceId: 'compId2',
+            skill: listSkills.fichier4,
+            difficulty: -3,
+            discriminant: 1,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recCHAL4',
+            competenceId: 'compId2',
+            skill: listSkills.sauvegarde5,
+            difficulty: -3,
+            discriminant: 1,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recCHAL5',
+            competenceId: 'compId3',
+            skill: listSkills.url5,
+            difficulty: -3,
+            discriminant: 1,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recCHAL6',
+            competenceId: 'compId3',
+            skill: listSkills.web3,
+            difficulty: -3,
+            discriminant: 1,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recCHAL7',
+            competenceId: 'compId3',
+            skill: listSkills.sourceinfo5,
+            difficulty: -3,
+            discriminant: 1,
+          }),
+        ];
+      });
+      describe('when there is not enough answers since last answer on the competence', function () {
+        it('should not offer a challenge for this competence', function () {
+          const answers = [
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL3',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL7',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL1',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL6',
+            }),
+          ];
+
+          const { possibleChallenges } = getPossibleNextChallenges({
+            allAnswers: answers,
+            challenges,
+            estimatedLevel: 3,
+            options: {
+              challengesBetweenSameCompetence: 3,
+            },
+          });
+          expect(possibleChallenges).not.to.include(challenges[1]);
+        });
+      });
+
+      describe('when there is enough answers since last answer on the competence', function () {
+        it('can offer a challenge for this competence', function () {
+          const answers = [
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL1',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL3',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL7',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL6',
+            }),
+          ];
+
+          const { possibleChallenges } = getPossibleNextChallenges({
+            allAnswers: answers,
+            challenges,
+            estimatedLevel: 3,
+            options: {
+              challengesBetweenSameCompetence: 3,
+            },
+          });
+          expect(possibleChallenges).to.include(challenges[1]);
+        });
+      });
+
+      describe('when there is no challenge with enough space', function () {
+        it('can offer any challenge', function () {
+          const answers = [
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL6',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL1',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL3',
+            }),
+            domainBuilder.buildAnswer({
+              challengeId: 'recCHAL7',
+            }),
+          ];
+
+          const { possibleChallenges } = getPossibleNextChallenges({
+            allAnswers: answers,
+            challenges,
+            estimatedLevel: 3,
+            options: {
+              challengesBetweenSameCompetence: 3,
+            },
+          });
+          expect(possibleChallenges).to.include(challenges[1]);
         });
       });
     });

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -431,7 +431,9 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
                 challenges: listChallenges,
                 allAnswers,
                 estimatedLevel,
-                forcedCompetences,
+                options: {
+                  forcedCompetences,
+                },
               });
 
               // then
@@ -485,8 +487,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
                 challenges: listChallenges,
                 allAnswers,
                 estimatedLevel,
-                forcedCompetences,
-                warmUpLength,
+                options: {
+                  forcedCompetences,
+                  warmUpLength,
+                },
               });
 
               // then


### PR DESCRIPTION
## :unicorn: Problème
Il arrive parfois d’enchaîner 2 questions de même compétence. Sur des compétences particulières (programmer, par exemple), il arrive que l’utilisateur ne soit pas du tout compétent, malgré sa compétence sur le reste, ce qui peut provoquer une sensation de “matraquage” par l’algorithme.
## :robot: Proposition
Espacer les questions de même compétence dans la certif v3

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer une certification v3.
Vérifier que la même compétence n'est pas proposée à espace trop rapproché (2 questions minimum entre 2 challenges de même compétence)