### PR TITLE
[FEATURE] Modification de design pour le details d'une complementaire (PIX-9146).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
@@ -7,20 +7,18 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column--id">{{t
-                "components.complementary-certifications.target-profiles.badges-list.header.id"
-              }}</th>
             <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}</th>
             <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}</th>
+            <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.id"}}</th>
           </tr>
         </thead>
 
         <tbody>
           {{#each this.currentTargetProfileBadges as |badge|}}
             <tr>
-              <td>{{badge.id}}</td>
               <td>{{badge.label}}</td>
               <td>{{badge.level}}</td>
+              <td>{{badge.id}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -31,10 +31,10 @@ module('Integration | Component | complementary-certifications/target-profiles/b
     );
 
     // then
-    assert.dom(screen.getByRole('columnheader', { name: 'ID' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Nom du résultat thématique' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
-    assert.dom(screen.getByRole('row', { name: '1023 Badge Cascade 3' })).exists();
-    assert.dom(screen.getByRole('row', { name: '1025 Badge Volcan 1' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom du badge certifié' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Niveau du badge certifié' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'ID du RT certifiant' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Badge Cascade 3 1023' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Badge Volcan 1 1025' })).exists();
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -30,11 +30,11 @@
     "complementary-certifications": {
       "target-profiles": {
         "badges-list": {
-          "title": "Résultats thématiques certifiants du profil cible actuel",
+          "title": "Badges certifiés du profil cible actuel",
           "header": {
-            "id": "ID",
-            "level": "Niveau",
-            "name": "Nom du résultat thématique"
+            "id": "ID du RT certifiant",
+            "level": "Niveau du badge certifié",
+            "name": "Nom du badge certifié"
           }
         }
       }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -38,11 +38,11 @@
     "complementary-certifications": {
       "target-profiles": {
         "badges-list": {
-          "title": "Résultats thématiques certifiants du profil cible actuel",
+          "title": "Badges certifiés du profil cible actuel",
           "header": {
-            "id": "ID",
-            "level": "Niveau",
-            "name": "Nom du résultat thématique"
+            "id": "ID du RT certifiant",
+            "level": "Niveau du badge certifié",
+            "name": "Nom du badge certifié"
           }
         }
       }


### PR DESCRIPTION
## :unicorn: Problème
Le nom des colonnes peut entrainer de l’incompréhension dans la lecture de ce tableau.

## :robot: Proposition

- renommer le tableau comme suit : “Badges certifiés du profil cible actuel”
- renommer la colonne “ID” en “ID du RT certifiant”
- renommer la colonne “Nom du résultat thématique” en “Nom du badge certifié”
- renommer la colonne “Niveau” en “Niveau du badge certifié”
- déplacer la colonne “ID” en dernière colonne du tableau

## :rainbow: Remarques

J'ai modifié le CSS de la colonne ID, car sinon ça donne une truc un peu moche
![image](https://github.com/1024pix/pix/assets/170271/7ff74fd7-a922-4242-aab6-b3cd4401aa1b)

## :100: Pour tester

Pix Admin avec `superadmin@example.net` > Certifications complémentaires > Ouvrir une certif complémentaire
