### PR TITLE
[FEATURE] Augmenter le taux de réussite estimé au début de la certif v3

### DIFF
--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -5,6 +5,25 @@ import {
   getReward,
 } from '../services/algorithm-methods/flash.js';
 import { config } from '../../config.js';
+import { FlashAssessmentSuccessRateHandler } from './FlashAssessmentSuccessRateHandler.js';
+
+const defaultMinimumEstimatedSuccessRateRanges = [
+  // Between question 1 and question 8 included, we set the minimum estimated
+  // success rate to 80%
+  FlashAssessmentSuccessRateHandler.createFixed({
+    startingChallengeIndex: 0,
+    endingChallengeIndex: 7,
+    value: 0.8,
+  }),
+  // Between question 9 and question 16 included, we linearly decrease the
+  // minimum estimated success rate from 80% to 50%
+  FlashAssessmentSuccessRateHandler.createLinear({
+    startingChallengeIndex: 8,
+    endingChallengeIndex: 15,
+    startingValue: 0.8,
+    endingValue: 0.5,
+  }),
+];
 
 class FlashAssessmentAlgorithm {
   /**
@@ -13,17 +32,20 @@ class FlashAssessmentAlgorithm {
    * @param forcedCompetences - force the algorithm to ask questions on the specified competences
    * @param maximumAssessmentLength - override the default limit for an assessment length
    * @param challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
+   * @param minimumEstimatedSuccessRateRanges - force a minimal estimated success rate for challenges chosen at specific indexes
    */
   constructor({
     warmUpLength,
     forcedCompetences,
     maximumAssessmentLength,
     challengesBetweenSameCompetence = config.v3Certification.challengesBetweenSameCompetence,
+    minimumEstimatedSuccessRateRanges = defaultMinimumEstimatedSuccessRateRanges,
   } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
     this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
+    this.minimumEstimatedSuccessRateRanges = minimumEstimatedSuccessRateRanges;
   }
 
   getPossibleNextChallenges({
@@ -41,6 +63,8 @@ class FlashAssessmentAlgorithm {
       initialCapacity,
     });
 
+    const minimalSuccessRate = this._computeMinimalSuccessRate(allAnswers.length);
+
     const { possibleChallenges, hasAssessmentEnded } = getPossibleNextChallenges({
       allAnswers,
       challenges,
@@ -49,6 +73,7 @@ class FlashAssessmentAlgorithm {
         warmUpLength: this.warmUpLength,
         forcedCompetences: this.forcedCompetences,
         challengesBetweenSameCompetence: this.challengesBetweenSameCompetence,
+        minimalSuccessRate,
       },
     });
 
@@ -57,6 +82,22 @@ class FlashAssessmentAlgorithm {
     }
 
     return possibleChallenges;
+  }
+
+  _computeMinimalSuccessRate(questionIndex) {
+    const filterConfiguration = this._findApplicableSuccessRateConfiguration(questionIndex);
+
+    if (!filterConfiguration) {
+      return 0;
+    }
+
+    return filterConfiguration.getMinimalSuccessRate(questionIndex);
+  }
+
+  _findApplicableSuccessRateConfiguration(questionIndex) {
+    return this.minimumEstimatedSuccessRateRanges.find((successRateRange) =>
+      successRateRange.isApplicable(questionIndex),
+    );
   }
 
   getEstimatedLevelAndErrorRate({ allAnswers, challenges, initialCapacity }) {

--- a/api/lib/domain/models/FlashAssessmentSuccessRateHandler.js
+++ b/api/lib/domain/models/FlashAssessmentSuccessRateHandler.js
@@ -1,0 +1,42 @@
+import { FlashAssessmentSuccessRateHandlerFixedStrategy } from './FlashAssessmentSuccessRateHandlerFixedStrategy.js';
+import { FlashAssessmentSuccessRateHandlerLinearStrategy } from './FlashAssessmentSuccessRateHandlerLinearStrategy.js';
+
+class FlashAssessmentSuccessRateHandler {
+  constructor({ startingChallengeIndex, endingChallengeIndex, strategy }) {
+    this.startingChallengeIndex = startingChallengeIndex;
+    this.endingChallengeIndex = endingChallengeIndex;
+
+    this._strategy = strategy;
+  }
+
+  isApplicable(questionIndex) {
+    return this.startingChallengeIndex <= questionIndex && this.endingChallengeIndex >= questionIndex;
+  }
+
+  getMinimalSuccessRate(questionIndex) {
+    return this._strategy.getMinimalSuccessRate(this.startingChallengeIndex, this.endingChallengeIndex, questionIndex);
+  }
+
+  static createFixed({ startingChallengeIndex, endingChallengeIndex, value }) {
+    return new FlashAssessmentSuccessRateHandler({
+      startingChallengeIndex,
+      endingChallengeIndex,
+      strategy: new FlashAssessmentSuccessRateHandlerFixedStrategy({
+        value,
+      }),
+    });
+  }
+
+  static createLinear({ startingChallengeIndex, endingChallengeIndex, startingValue, endingValue }) {
+    return new FlashAssessmentSuccessRateHandler({
+      startingChallengeIndex,
+      endingChallengeIndex,
+      strategy: new FlashAssessmentSuccessRateHandlerLinearStrategy({
+        startingValue,
+        endingValue,
+      }),
+    });
+  }
+}
+
+export { FlashAssessmentSuccessRateHandler };

--- a/api/lib/domain/models/FlashAssessmentSuccessRateHandlerFixedStrategy.js
+++ b/api/lib/domain/models/FlashAssessmentSuccessRateHandlerFixedStrategy.js
@@ -1,0 +1,9 @@
+export class FlashAssessmentSuccessRateHandlerFixedStrategy {
+  constructor({ value }) {
+    this.value = value;
+  }
+
+  getMinimalSuccessRate() {
+    return this.value;
+  }
+}

--- a/api/lib/domain/models/FlashAssessmentSuccessRateHandlerLinearStrategy.js
+++ b/api/lib/domain/models/FlashAssessmentSuccessRateHandlerLinearStrategy.js
@@ -1,0 +1,14 @@
+export class FlashAssessmentSuccessRateHandlerLinearStrategy {
+  constructor({ startingValue, endingValue }) {
+    this.startingValue = startingValue;
+    this.endingValue = endingValue;
+  }
+
+  // Computes a linear success rate variation between startingChallengeIndex and endingChallengeIndex
+  // It varies from this.startingValue to this.endingValue
+  getMinimalSuccessRate(startingChallengeIndex, endingChallengeIndex, challengeIndex) {
+    const successRateSlope = (this.endingValue - this.startingValue) / (endingChallengeIndex - startingChallengeIndex);
+
+    return this.startingValue + successRateSlope * (challengeIndex - startingChallengeIndex);
+  }
+}

--- a/api/tests/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -3,6 +3,7 @@ import { domainBuilder, expect } from '../../../test-helper.js';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
 import _ from 'lodash';
 import { config } from '../../../../lib/config.js';
+import { FlashAssessmentSuccessRateHandler } from '../../../../lib/domain/models/FlashAssessmentSuccessRateHandler.js';
 
 function initializeTestChallenges(hardAnsweredChallengesCount, difficulty, answerStatus) {
   const defaultDiscriminantValue = 0.5;
@@ -43,7 +44,7 @@ function initializeTestChallenges(hardAnsweredChallengesCount, difficulty, answe
   return { expectedUnansweredChallenge, mediumUnansweredChallenge, challenges, allAnswers };
 }
 
-describe('FlashAssessmentAlgorithm', function () {
+describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
   describe('#getPossibleNextChallenges', function () {
     context('when enough challenges have been answered', function () {
       it('should throw an AssessmentEndedError', function () {
@@ -95,7 +96,7 @@ describe('FlashAssessmentAlgorithm', function () {
       });
 
       context('when user has a weak level', function () {
-        it('should choose a hard challenge', function () {
+        it('should choose a weak challenge', function () {
           const weakLevel = -6;
           const { expectedUnansweredChallenge, mediumUnansweredChallenge, challenges, allAnswers } =
             initializeTestChallenges(alreadyAnsweredChallengesCount, weakLevel, AnswerStatus.KO);
@@ -104,6 +105,147 @@ describe('FlashAssessmentAlgorithm', function () {
             expectedUnansweredChallenge,
             mediumUnansweredChallenge,
           ]);
+        });
+      });
+    });
+    context('when specifying a minimal success rate', function () {
+      context('when a fixed minimal success rate has been set', function () {
+        it('should choose a challenge that has the required success rate first', function () {
+          // Given
+          const easyDifficulty = -3;
+          const hardDifficulty = 3;
+          const discriminant = 1;
+          const initialCapacity = 3;
+
+          const easyChallenge = domainBuilder.buildChallenge({
+            id: 'easyChallenge',
+            skill: domainBuilder.buildSkill({
+              id: 'skillEasy',
+            }),
+            competenceId: 'compEasy',
+            discriminant,
+            difficulty: easyDifficulty,
+          });
+
+          const hardChallenge = domainBuilder.buildChallenge({
+            id: 'hardChallenge',
+            skill: domainBuilder.buildSkill({
+              id: 'skillHard',
+            }),
+            competenceId: 'compHard',
+            discriminant,
+            difficulty: hardDifficulty,
+          });
+
+          const challenges = [hardChallenge, easyChallenge];
+          const answers = [];
+
+          // when
+          const algorithm = new FlashAssessmentAlgorithm({
+            minimumEstimatedSuccessRateRanges: [
+              FlashAssessmentSuccessRateHandler.createFixed({
+                startingChallengeIndex: 0,
+                endingChallengeIndex: 1,
+                value: 0.8,
+              }),
+            ],
+          });
+          const nextChallenges = algorithm.getPossibleNextChallenges({
+            allAnswers: answers,
+            challenges,
+            initialCapacity,
+          });
+
+          expect(nextChallenges).to.deep.equal([easyChallenge, hardChallenge]);
+        });
+      });
+
+      context('when a linear minimal success rate has been set', function () {
+        it('should choose a challenge that has the required success rate first', function () {
+          // Given
+          const easyDifficulty = -3;
+          const hardDifficulty = 3;
+
+          const challengeWithRightSuccessRateDifficulty = 2.2;
+          const challengeWithRightSuccessRateDiscriminant = 1;
+
+          const discriminant = 1;
+          const initialCapacity = 2;
+
+          const easyChallenge = domainBuilder.buildChallenge({
+            id: 'easyChallenge',
+            skill: domainBuilder.buildSkill({
+              id: 'skillEasy',
+            }),
+            competenceId: 'compEasy',
+            discriminant,
+            difficulty: easyDifficulty,
+          });
+
+          // A challenge with an estimated success rate over 0.6, which is
+          // the lower limit of our linear configuration
+          const challengeWithRightSuccessRate = domainBuilder.buildChallenge({
+            id: 'challengeWithRightSuccessRate',
+            skill: domainBuilder.buildSkill({
+              id: 'skillMedium',
+            }),
+            competenceId: 'compMedium',
+            discriminant: challengeWithRightSuccessRateDiscriminant,
+            difficulty: challengeWithRightSuccessRateDifficulty,
+          });
+
+          const takenChallenge = domainBuilder.buildChallenge({
+            id: 'hardChallenge2',
+            skill: domainBuilder.buildSkill({
+              id: 'skillHard2',
+            }),
+            competenceId: 'compHard2',
+            discriminant,
+            difficulty: hardDifficulty,
+          });
+
+          const hardChallenge = domainBuilder.buildChallenge({
+            id: 'hardChallenge',
+            skill: domainBuilder.buildSkill({
+              id: 'skillHard',
+            }),
+            competenceId: 'compHard',
+            discriminant,
+            difficulty: hardDifficulty,
+          });
+
+          const challenges = [hardChallenge, challengeWithRightSuccessRate, takenChallenge, easyChallenge];
+          const answers = [
+            domainBuilder.buildAnswer({
+              challengeId: takenChallenge.id,
+            }),
+          ];
+
+          // when
+          const algorithm = new FlashAssessmentAlgorithm({
+            minimumEstimatedSuccessRateRanges: [
+              FlashAssessmentSuccessRateHandler.createLinear({
+                startingChallengeIndex: 0,
+                endingChallengeIndex: 2,
+                startingValue: 0.8,
+                endingValue: 0.4,
+              }),
+            ],
+          });
+
+          //when
+          const nextChallenges = algorithm.getPossibleNextChallenges({
+            allAnswers: answers,
+            challenges,
+            initialCapacity,
+          });
+
+          // then
+          const expectedChallenges = [challengeWithRightSuccessRate, easyChallenge, hardChallenge];
+          const expectedChallengeIds = expectedChallenges.map(({ id }) => id);
+          const challengeIds = nextChallenges.map(({ id }) => id);
+          expect(challengeIds).to.deep.equal(expectedChallengeIds);
+          expect(nextChallenges).to.deep.equal(expectedChallenges);
         });
       });
     });

--- a/api/tests/unit/domain/models/FlashAssessmentSuccessRateHandler_test.js
+++ b/api/tests/unit/domain/models/FlashAssessmentSuccessRateHandler_test.js
@@ -1,0 +1,81 @@
+import { FlashAssessmentSuccessRateHandler } from '../../../../lib/domain/models/FlashAssessmentSuccessRateHandler.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | Domain | Models | FlashAssessmentAlgorithmSuccessRateHandler', function () {
+  describe('#isApplicable', function () {
+    let flashAssessmentSuccessRateHandler;
+    beforeEach(function () {
+      const fixedConfig = {
+        startingChallengeIndex: 0,
+        endingChallengeIndex: 7,
+        value: 0.8,
+      };
+
+      flashAssessmentSuccessRateHandler = FlashAssessmentSuccessRateHandler.createFixed(fixedConfig);
+    });
+
+    describe('when currentIndex is inside the application range', function () {
+      it('should return true', function () {
+        const currentIndex = 5;
+
+        const isApplicable = flashAssessmentSuccessRateHandler.isApplicable(currentIndex);
+
+        expect(isApplicable).to.be.true;
+      });
+    });
+
+    describe('when filter is outside the application range', function () {
+      it('should return false', function () {
+        const currentIndex = 8;
+
+        const isApplicable = flashAssessmentSuccessRateHandler.isApplicable(currentIndex);
+
+        expect(isApplicable).to.be.false;
+      });
+    });
+  });
+
+  describe('#getMinimalSuccessRate', function () {
+    describe('when strategy is fixed', function () {
+      let flashAssessmentSuccessRateHandler;
+      const configSuccessRate = 0.8;
+      beforeEach(function () {
+        const fixedConfig = {
+          startingChallengeIndex: 0,
+          endingChallengeIndex: 7,
+          value: configSuccessRate,
+        };
+
+        flashAssessmentSuccessRateHandler = FlashAssessmentSuccessRateHandler.createFixed(fixedConfig);
+      });
+
+      it('should return the fixed value', function () {
+        const questionIndex = 5;
+        const successRate = flashAssessmentSuccessRateHandler.getMinimalSuccessRate(questionIndex);
+
+        expect(successRate).to.equal(configSuccessRate);
+      });
+    });
+
+    describe('when strategy is linear', function () {
+      let flashAssessmentSuccessRateHandler;
+      beforeEach(function () {
+        const linearConfig = {
+          startingChallengeIndex: 0,
+          endingChallengeIndex: 4,
+          startingValue: 0.8,
+          endingValue: 0.6,
+        };
+
+        flashAssessmentSuccessRateHandler = FlashAssessmentSuccessRateHandler.createLinear(linearConfig);
+      });
+
+      it('should return the computed linear value', function () {
+        const questionIndex = 2;
+        const successRate = flashAssessmentSuccessRateHandler.getMinimalSuccessRate(questionIndex);
+
+        expect(successRate).to.equal(0.7);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -112,23 +112,9 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         challengeRepository.findFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
 
-        pickChallenge
-          .withArgs({
-            possibleChallenges: [thirdChallenge, secondChallenge, firstChallenge],
-          })
-          .returns(firstChallenge)
-          .withArgs({
-            possibleChallenges: [thirdChallenge, secondChallenge],
-          })
-          .returns(secondChallenge)
-          .withArgs({
-            possibleChallenges: [thirdChallenge],
-          })
-          .returns(thirdChallenge);
+        pickChallenge.callsFake(({ possibleChallenges }) => possibleChallenges.at(-1));
 
-        pickAnswerStatus.withArgs(sinon.match({ nextChallenge: firstChallenge })).returns(AnswerStatus.OK);
-        pickAnswerStatus.withArgs(sinon.match({ nextChallenge: secondChallenge })).returns(AnswerStatus.OK);
-        pickAnswerStatus.withArgs(sinon.match({ nextChallenge: thirdChallenge })).returns(AnswerStatus.OK);
+        pickAnswerStatus.callsFake(() => AnswerStatus.OK);
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({


### PR DESCRIPTION
## :unicorn: Problème
Des premiers tests ont été faits par des membres de la startup certif nextGen. L’un des points qui en est ressorti est le manque de bienveillance et le sentiment de mise en échec ressentie dès les premières questions du test.

## :robot: Proposition
Augmenter le taux de réussite de l'utilisateur en proposant des questions plus simples afin d'améliorer le ressenti.

## :100: Pour tester
Test plutôt compliqué à évaluer. Vérifier que la certification fonctionne est un bon début.