### PR TITLE
[FEATURE] Ajout d'un lien direct vers le badge d'un target profile de complémentaire (PIX-9149).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
@@ -18,7 +18,15 @@
             <tr>
               <td>{{badge.label}}</td>
               <td>{{badge.level}}</td>
-              <td>{{badge.id}}</td>
+              <td>
+                <LinkTo
+                  @route="authenticated.target-profiles.target-profile.badges.badge"
+                  @models={{array @currentTargetProfile.id badge.id}}
+                  target="_blank"
+                >
+                  {{badge.id}}
+                </LinkTo>
+              </td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -37,4 +37,29 @@ module('Integration | Component | complementary-certifications/target-profiles/b
     assert.dom(screen.getByRole('row', { name: 'Badge Cascade 3 1023' })).exists();
     assert.dom(screen.getByRole('row', { name: 'Badge Volcan 1 1025' })).exists();
   });
+
+  test('it should contain a link for each target profile badge', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const complementaryCertification = store.createRecord('complementary-certification', {
+      label: 'CERTIF',
+      targetProfilesHistory: [
+        {
+          detachedAt: null,
+          name: 'TARGET PROFILE',
+          id: 85,
+          badges: [{ id: 75, label: 'Badge Feu', level: 3 }],
+        },
+      ],
+    });
+    this.currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
+
+    // when
+    const screen = await render(
+      hbs`<ComplementaryCertifications::TargetProfiles::BadgesList @currentTargetProfile={{this.currentTargetProfile}} />`,
+    );
+
+    // then
+    assert.dom(screen.getByRole('link', { name: '75' })).hasAttribute('href', '/target-profiles/85/badges/75');
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
L’ID des RT certifiants sont affichés dans la liste des badges certifiés d’une certification complémentaire. Cela permet notamment aux pôles métiers concernés de faire le lien entre un RT certifiant, et un badge certifié (pour une certif complémentaire avec plusieurs niveaux telle que Pix+ Edu ou Droit).

## :robot: Proposition

Mettre un lien direct vers la page du RT certifiant depuis la liste des badges certifiés : 
rendre cliquable l’ID du RT certifiant
cliquer dessus ouvre un nouvel onglet, avec la page de détails du RT certifiant concerné 
URL : https://admin.pix.fr/target-profiles/%idTargetProfile%/%idBadge% (ex en recette : https://admin.recette.pix.fr/target-profiles/118/badges/85)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Pix admin, superadmin@example.net > certif complémentaire > details > cliquer sur le lien de l'ID dans les détails
Vérifier que ça pointe sur le bon badge
