### PR TITLE
[FEATURE] Afficher la nouvelle colonne "rôle" sur le tableau listant les centres de certification d'un utilisateur (PIX-9231). 

### DIFF
--- a/admin/app/components/users/certification-center-memberships.hbs
+++ b/admin/app/components/users/certification-center-memberships.hbs
@@ -11,6 +11,7 @@
           <th>Nom</th>
           <th>Type</th>
           <th>Identifiant externe</th>
+          <th>{{t "components.certification-centers.table-headers.roleLabel"}}</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -31,6 +32,7 @@
               <td>{{certificationCenterMembership.certificationCenter.name}}</td>
               <td>{{certificationCenterMembership.certificationCenter.type}}</td>
               <td>{{certificationCenterMembership.certificationCenter.externalId}}</td>
+              <td>{{t certificationCenterMembership.roleLabelKey}}</td>
               <td>
                 <PixButton
                   @size="small"

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -32,7 +32,7 @@
       aria-label="Organisations de l’utilisateur"
       class="navbar-item"
     >
-      Organisations
+      {{t "pages.user-details.navbar.organizations-list"}}
     </LinkTo>
 
     <LinkTo
@@ -40,7 +40,7 @@
       class="navbar-item certification-center-navbar"
       aria-label="Centres de certification auxquels appartient l´utilisateur"
     >
-      Centres de certification
+      {{t "pages.user-details.navbar.certification-centers-list"}}
     </LinkTo>
   </nav>
 

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -319,6 +319,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       });
       const certificationCenterMembership = this.server.create('certification-center-membership', {
         certificationCenter,
+        role: 'MEMBER',
       });
       const user = this.server.create('user', {
         email: 'john.harry@example.net',

--- a/admin/tests/integration/components/users/certification-center-memberships_test.js
+++ b/admin/tests/integration/components/users/certification-center-memberships_test.js
@@ -1,16 +1,21 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | users | certification-center-memberships', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
 
   module('When user isn’t member of any certification center', function () {
-    test('it should display an empty table', async function (assert) {
+    test('displays an empty table', async function (assert) {
       // given
       this.set('certificationCenterMemberships', []);
 
@@ -25,17 +30,18 @@ module('Integration | Component | users | certification-center-memberships', fun
   });
 
   module('When user is member of some certification centers', function () {
-    test('it should display a table of the certification centers the user is member of', async function (assert) {
+    test('displays a table of the certification centers the user is member of', async function (assert) {
       // given
-      const certificationCenter = EmberObject.create('certification-center', {
+      const certificationCenter = store.createRecord('certification-center', {
         id: '123',
         name: 'Centre Kaede',
         externalId: 'ABCDEF12345',
         type: 'SCO',
       });
-      const certificationCenterMembership = EmberObject.create('certification-center-membership', {
+      const certificationCenterMembership = store.createRecord('certification-center-membership', {
         id: '456',
         certificationCenter,
+        role: 'MEMBER',
       });
 
       this.set('certificationCenterMemberships', [certificationCenterMembership]);
@@ -47,12 +53,12 @@ module('Integration | Component | users | certification-center-memberships', fun
 
       // then
       assert.dom(screen.getByText('Centre Kaede')).exists();
+      assert.dom(screen.getByText('Membre')).exists();
     });
   });
 
-  test('it should be possible to deactivate a certification center membership from a pix certification center user', async function (assert) {
+  test('deactivates a certification center membership from a pix certification center user', async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
     const pixCertifUser = store.createRecord('user', { firstName: 'Gaara' });
     const certificationCenter = store.createRecord('certification-center', {
       id: 123,
@@ -65,6 +71,7 @@ module('Integration | Component | users | certification-center-memberships', fun
       id: 456789,
       certificationCenter,
       user: pixCertifUser,
+      role: 'MEMBER',
       destroyRecord: sinon.stub().resolves(),
     });
     this.set('certificationCenterMemberships', [certificationCenterMembership]);
@@ -87,9 +94,8 @@ module('Integration | Component | users | certification-center-memberships', fun
     sinon.assert.calledWith(notificationSuccessStub, 'Le membre a correctement été désactivé.');
   });
 
-  test('it should display an error message when it is not possible to deactivate a certification center membership from a pix certification center user', async function (assert) {
+  test('displays an error message when it is not possible to deactivate a certification center membership from a pix certification center user', async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
     const pixCertifUser = store.createRecord('user', { firstName: 'Nagato' });
     const certificationCenter = store.createRecord('certification-center', {
       id: '123',
@@ -102,6 +108,7 @@ module('Integration | Component | users | certification-center-memberships', fun
       id: 456789,
       certificationCenter,
       user: pixCertifUser,
+      role: 'MEMBER',
       destroyRecord: sinon.stub().rejects(),
     });
     this.set('certificationCenterMemberships', [certificationCenterMembership]);

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -118,6 +118,12 @@
           "tabName": "Triggers"
         }
       }
+    },
+    "user-details": {
+      "navbar": {
+        "certification-centers-list": "Pix Certif",
+        "organizations-list": "Pix Orga"
+      }
     }
   }
 }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -44,6 +44,9 @@
       },
       "membership-item-role": {
         "select-role": "Select role"
+      },
+      "table-headers" : {
+        "roleLabel": "Role"
       }
     },
     "complementary-certifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -140,6 +140,12 @@
           "tabName": "Déclencheurs"
         }
       }
+    },
+    "user-details": {
+      "navbar": {
+        "certification-centers-list": "Pix Certif",
+        "organizations-list": "Pix Orga"
+      }
     }
   }
 }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -52,6 +52,9 @@
       },
       "membership-item-role": {
         "select-role": "Sélectionner un rôle"
+      },
+      "table-headers" : {
+        "roleLabel": "Rôle"
       }
     },
     "complementary-certifications": {


### PR DESCRIPTION
## :unicorn: Problème
Nous n'affichons pas le rôle de l'utilisateur dans le tableau listant les centres de certification dont il fait partit

## :robot: Proposition
Ajouter une colonne rôle dans le tableau

## :rainbow: Remarques
Les onglets "Organisations et "Centre de certifications" ont respectivement été renommés en "Pix Orga" et "Pix Certif" pour raisons de cohérence et a la demande de la team certif 

## :100: Pour tester
- Se rendre https://admin-pr7120.review.pix.fr/
- Se connecter a l'aide de l'utilisateur: superadmin@example.net
- Chercher l'utilisateur: James Palédroits
- Constater que les noms des ongles "Organisations et "Centre de certifications" ont respectivement été renommés en "Pix Orga" et "Pix Certif"
- Sur l'onglet "Pix Certif", constater le bon affichage du rôle "Administrateur" pour l'organisation dont il fait parti
