### PR TITLE
[FEATURE] Ordonner les badges des certifications complementaires par niveaux (PIX-9308)

### DIFF
--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
@@ -67,7 +67,8 @@ async function _getBadgesForCurrentTargetProfiles({ targetProfile }) {
     })
     .leftJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
     .where('targetProfileId', targetProfile.id)
-    .whereNull('complementary-certification-badges.detachedAt');
+    .whereNull('complementary-certification-badges.detachedAt')
+    .orderBy('level', 'asc');
 
   return badgesDTO.map((badge) => new ComplementaryCertificationBadgeForAdmin({ ...badge }));
 }

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-target-profile-history-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-target-profile-history-repository_test.js
@@ -24,18 +24,18 @@ describe('Integration | Repository | complementary-certification-target-profile-
 
         const oldTargetProfile = databaseBuilder.factory.buildTargetProfile({ id: 222, name: 'oldTarget' });
 
-        const currentBadgeId = _createComplementaryCertificationBadge({
-          targetProfileId: currentTarget.id,
-          complementaryCertificationId: complementaryCertification.id,
-          createdAt: new Date('2023-10-10'),
-          label: 'goodBadge',
-          level: 1,
-        });
         const currentBadgeId2 = _createComplementaryCertificationBadge({
           targetProfileId: currentTarget.id,
           complementaryCertificationId: complementaryCertification.id,
           createdAt: new Date('2023-10-10'),
           label: 'goodBadge2',
+          level: 2,
+        });
+        const currentBadgeId = _createComplementaryCertificationBadge({
+          targetProfileId: currentTarget.id,
+          complementaryCertificationId: complementaryCertification.id,
+          createdAt: new Date('2023-10-10'),
+          label: 'goodBadge',
           level: 1,
         });
         _createComplementaryCertificationBadge({
@@ -66,7 +66,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
             detachedAt: null,
             badges: [
               new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId, level: 1, label: 'goodBadge' }),
-              new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId2, level: 1, label: 'goodBadge2' }),
+              new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId2, level: 2, label: 'goodBadge2' }),
             ],
           }),
         ]);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les badges d’une certification complémentaire sont affichés mais pas ordonnés.

## :robot: Proposition
Trier les badges par niveau

## :100: Pour tester
Aller dans admin sur la certification complementaire pix+droit. S'assurer que les badges sont trié par niveaux
<img width="1061" alt="image" src="https://github.com/1024pix/pix/assets/3769147/d8974b7b-3091-4603-a1ed-3b4c16ae6920">

