### PR TITLE
[TECH] Exclure les learners toujours présent de la liste à désactiver (PIX-9345)

### DIFF
--- a/api/lib/domain/usecases/import-organization-learners-from-siecle.js
+++ b/api/lib/domain/usecases/import-organization-learners-from-siecle.js
@@ -51,10 +51,13 @@ const importOrganizationLearnersFromSIECLEFormat = async function ({
 
   const organizationLearnersChunks = chunk(organizationLearnerData, ORGANIZATION_LEARNER_CHUNK_SIZE);
 
+  const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);
+
   return DomainTransaction.execute(async (domainTransaction) => {
     await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
       domainTransaction,
       organizationId,
+      nationalStudentIds: nationalStudentIdData,
     });
 
     await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -102,10 +102,15 @@ const isOrganizationLearnerIdLinkedToUserAndSCOOrganization = async function ({ 
   return Boolean(exist);
 };
 
-const disableAllOrganizationLearnersInOrganization = async function ({ domainTransaction, organizationId }) {
+const disableAllOrganizationLearnersInOrganization = async function ({
+  domainTransaction,
+  organizationId,
+  nationalStudentIds,
+}) {
   const knexConn = domainTransaction.knexTransaction;
   await knexConn('organization-learners')
     .where({ organizationId, isDisabled: false })
+    .whereNotIn('nationalStudentId', nationalStudentIds)
     .update({ isDisabled: true, updatedAt: knexConn.raw('CURRENT_TIMESTAMP') });
 };
 

--- a/api/tests/unit/domain/usecases/import-organization-learners-from-siecle_test.js
+++ b/api/tests/unit/domain/usecases/import-organization-learners-from-siecle_test.js
@@ -183,7 +183,7 @@ describe('Unit | UseCase | import-organization-learners-from-siecle', function (
       // then
       expect(
         organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization,
-      ).to.have.been.calledWithExactly({ domainTransaction, organizationId });
+      ).to.have.been.calledWithExactly({ domainTransaction, organizationId, nationalStudentIds: ['INE1'] });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous désactivons tout les learners d'une orga avant de les réactiver. Ce qui n'est pas optimum

## :robot: Proposition
Ajouter une liste de nationalStudentIds à ne pas désactiver .

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire des tests imports Siecle