### PR TITLE
[FEATURE] Changement du texte et du lien quand un candidat n'a pas pu rejoindre une session (PIX-6678).

### DIFF
--- a/certif/app/components/session-finalization/complementary-information-step.hbs
+++ b/certif/app/components/session-finalization/complementary-information-step.hbs
@@ -23,7 +23,11 @@
 
     {{#if this.displayJoiningIssue}}
       <PixMessage @type="info" @withIcon={{true}}>
-        {{t "pages.session-finalization.complementary-information.candidates-joining-issue.link" htmlSafe=true}}
+        {{t
+          "pages.session-finalization.complementary-information.candidates-joining-issue.link"
+          htmlSafe=true
+          joiningIssueSheetUrl=this.joiningIssueSheetUrl
+        }}
       </PixMessage>
     {{/if}}
   </div>

--- a/certif/app/components/session-finalization/complementary-information-step.js
+++ b/certif/app/components/session-finalization/complementary-information-step.js
@@ -1,8 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 export default class CompletedReportsInformationStep extends Component {
+  @service url;
+
   @tracked displayIncidentDuringCertificationSession = false;
   @tracked displayJoiningIssue = false;
 
@@ -16,5 +19,9 @@ export default class CompletedReportsInformationStep extends Component {
   onCheckIssueWithJoiningSession(event) {
     this.displayJoiningIssue = event.target.checked;
     this.args.toggleSessionJoiningIssue(this.displayJoiningIssue);
+  }
+
+  get joiningIssueSheetUrl() {
+    return this.url.joiningIssueSheetUrl;
   }
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -56,4 +56,13 @@ export default class Url extends Service {
     const currentLanguage = this.intl.t('current-lang');
     return currentLanguage === 'fr' ? 'https://support.pix.org' : 'https://support.pix.org/en/support/home';
   }
+
+  get joiningIssueSheetUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'fr') {
+      return 'https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf';
+    }
+
+    return 'https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download';
+  }
 }

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -346,7 +346,7 @@
         "title": "Additional information (optional)",
         "candidates-joining-issue": {
           "label": "At least one candidate was present during the certification session but couldn’t join the session.",
-          "link": "You will find '<a class=\"link\" href=\"https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download\" target=\"_blank\" rel=\"noreferrer noopener\">'here a document to help you solve this kind of connexion difficulty for the next sessions. (PDF, 66ko).'</a>'"
+          "link": "You will find '<'a class=\"link\" href=\"{joiningIssueSheetUrl}\" target=\"_blank\" rel=\"noreferrer noopener\"'>'here a document to help you solve this kind of connexion difficulty for the next sessions. (PDF, 66ko).'</a>'"
         },
         "description": "You may indicate, if need be, the events that occurred during the session. It isn’t necessary to report any missing candidates.",
         "incident": "Despite an incident having occurred during the session, the candidates have been able to finish their Pix certification exam. Additional time has been granted to at least one of the candidates."

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -346,7 +346,7 @@
         "title": "Additional information (optional)",
         "candidates-joining-issue": {
           "label": "At least one candidate was present during the certification session but couldn’t join the session.",
-          "link": "You may find '<a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">'here a document to help you solve this kind of connection problem for the following sessions (PDF, 131ko).'</a>'"
+          "link": "You will find '<a class=\"link\" href=\"https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download\" target=\"_blank\" rel=\"noreferrer noopener\">'here a document to help you solve this kind of connexion difficulty for the next sessions. (PDF, 66ko).'</a>'"
         },
         "description": "You may indicate, if need be, the events that occurred during the session. It isn’t necessary to report any missing candidates.",
         "incident": "Despite an incident having occurred during the session, the candidates have been able to finish their Pix certification exam. Additional time has been granted to at least one of the candidates."

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -346,7 +346,7 @@
         "title": "Informations complémentaires (facultatif)",
         "candidates-joining-issue": {
           "label": "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.",
-          "link": "Vous trouverez '<a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">'ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions (PDF, 131ko).'</a>'"
+          "link": "Vous trouverez '<'a class=\"link\" href=\"{joiningIssueSheetUrl}\" target=\"_blank\" rel=\"noreferrer noopener\"'>'ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions (PDF, 131ko).'</a>'"
         },
         "description": "Vous pouvez indiquer, le cas échéant, les événements survenus lors de la session. Il n'est pas nécessaire de renseigner les candidats absents.",
         "incident": "Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats."


### PR DESCRIPTION
## :unicorn: Problème
Une fois sur la page de finalisation d’une session de certification Pix, un utilisateur anglophone de Pix Certif pour lequel un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session peut cocher la case correspondante “Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.”

Le texte est actuellement en français.

## :robot: Proposition
Traduire en anglais le texte dans l’encadré bleu : Vous trouverez ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions. => You will find here a document to help you solve this kind of connexion difficulty for the next sessions.

Rediriger l’utilisateur vers le document d’aide en anglais : https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download

## :rainbow: Remarques
Il y avait déjà une traduction tout de même, mais pas le fichier sous-jacent en anglais

## :100: Pour tester
* Pix Certif, utilisateur certif-pro@example.net
* Vérifier que http://localhost:4203/sessions/7005/finalisation en FR est toujours OK
* Vérifier que la version anglaise est désormais disponible http://localhost:4203/sessions/7005/finalisation?lang=en
