### PR TITLE
[BUGFIX] Ne plus activer tout les learners lors d'une nouvelle participation à une campagne (PIX-9353)

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -41,8 +41,14 @@ async function _createNewOrganizationLearner(organizationLearner, queryBuilder) 
       .first();
 
     if (existingOrganizationLearner) {
-      const [{ id }] = await queryBuilder('organization-learners').update({ isDisabled: false }).returning('id');
-      return id;
+      if (existingOrganizationLearner.isDisabled) {
+        await queryBuilder('organization-learners')
+          .update({ isDisabled: false })
+          .where({ id: existingOrganizationLearner.id })
+          .returning('id');
+      }
+
+      return existingOrganizationLearner.id;
     } else {
       const [{ id }] = await queryBuilder('organization-learners').insert(
         {


### PR DESCRIPTION
## :unicorn: Problème
Les captains ont vu une route `api/campaign-participations` qui faisait un appel sur organization-learners pour activer TOUT les learners de la table. 

## :robot: Proposition
Ajouter la condition au learner que l'on a précédement identifié

## :rainbow: Remarques
RAS

## :100: Pour tester
Lorsque l'on participe à une campagne PRO vérifier que les autres learners reste desactivé