### PR TITLE
[HOTFIX] Hotfix v4.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
 ### :coffee: Autre
 - [#6986](https://github.com/1024pix/pix/pull/6986) [ADR] Compatibilité avec les différents navigateurs web (browser support).
 
+## v4.36.1 (22/09/2023)
+
+### :bug: Correction
+- [#7133](https://github.com/1024pix/pix/pull/7133) [BUGFIX] Ne plus activer tous les learners lors d'une nouvelle participation à une campagne (PIX-9353).
+
+
 ## v4.36.0 (20/09/2023)
 
 


### PR DESCRIPTION
## :unicorn: Problème
Les captains ont vu une route `api/campaign-participations` qui faisait un appel sur organization-learners pour activer TOUT les learners de la table. 

## :robot: Proposition
Ajouter la condition au learner que l'on a précédement identifié

## :rainbow: Remarques
RAS

## :100: Pour tester
Lorsque l'on participe à une campagne PRO vérifier que les autres learners reste desactivé