### PR TITLE
[BUGFIX] Réparer l'affichage du sélecteur de langue sur la page de connexion de Pix Certif (PIX-9350).

### DIFF
--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -1,5 +1,6 @@
 .login {
   max-width: 500px;
+  margin-bottom: $pix-spacing-s;
   padding: 20px 30px;
   background-color: $pix-neutral-0;
   border-radius: 10px;

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -1,14 +1,9 @@
 .login-page {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
   min-height: 100vh;
   background: $pix-primary-certif-gradient;
-
-  &__container {
-    display: flex;
-    flex-direction: column;
-    gap: $pix-spacing-s;
-  }
 }

--- a/certif/app/templates/login.hbs
+++ b/certif/app/templates/login.hbs
@@ -1,6 +1,6 @@
 {{page-title (t "pages.login.title")}}
 <main class="login-page">
-  <div class="login-page__container">
+  <div>
     <LoginForm
       @hasInvitationAlreadyBeenAccepted={{this.hasInvitationAlreadyBeenAccepted}}
       @isInvitationCancelled={{this.isInvitationCancelled}}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur la page de connexion de Pix Certif en .org, on peut voir ça 
<img width="435" alt="Capture d’écran 2023-09-22 à 09 41 11" src="https://github.com/1024pix/pix/assets/58915422/019f566b-a196-4589-923c-7647ab988ce1">

Le sélecteur de langue s'étend sur la largeur de l'élément au dessus. Le bug à été introduit lors de la montée de version de Pix UI en v40 fait par Renovate qui touche au composant PixSelect.

## :robot: Proposition
Modifier le css pour réparer l'affichage.

## :100: Pour tester
Aller sur Pix Certif en .org et constater que le sélecteur s'affiche correctement.
<img width="587" alt="Capture d’écran 2023-09-22 à 16 04 27" src="https://github.com/1024pix/pix/assets/58915422/3e0220d1-6c39-4c9f-91c2-732fbba1d1aa">
