### PR TITLE
[FEATURE] Mettre à jour les dates de certification pour les lycées et collèges sur Pix Certif (PIX-9314).

### DIFF
--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -106,7 +106,7 @@ module('Acceptance | authenticated', function (hooks) {
       assert
         .dom(
           screen.getByText(
-            'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la',
+            'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
           ),
         )
         .exists();
@@ -123,7 +123,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // then
       const certificationBannerMessage = screen.queryByText(
-        'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la',
+        'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
       );
       assert.dom(certificationBannerMessage).doesNotExist();
     });

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -163,7 +163,7 @@ module('Acceptance | Session List', function (hooks) {
         assert
           .dom(
             screen.queryByText(
-              'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la',
+              'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
             ),
           )
           .doesNotExist();
@@ -183,7 +183,7 @@ module('Acceptance | Session List', function (hooks) {
         assert
           .dom(
             screen.getByText(
-              'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la',
+              'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
             ),
           )
           .exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -249,7 +249,7 @@
     },
     "sco": {
       "banner": {
-        "information": "La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la",
+        "information": "La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la",
         "url-label": "documentation pour voir les nouveautés."
       },
       "enrol-candidates-in-session": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -249,7 +249,7 @@
     },
     "sco": {
       "banner": {
-        "information": "La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la",
+        "information": "La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la",
         "url-label": "documentation pour voir les nouveautés."
       },
       "enrol-candidates-in-session": {


### PR DESCRIPTION
## :unicorn: Problème
Les dates officielles de certification pour les collèges et lycées ont été définies avec le MEN. Il faut les mettre à jour.

## :robot: Proposition
Mettre à jour les dates pour la certification Pix

## :rainbow: Remarques
On reste sur le texte en dur à modifier, une épix sera prévu pour refacto cette affichage pour donner la main au métier de changer eux même les dates

## :100: Pour tester
Se connecter sur Pix Certif en .fr avec certif-sco@example.net
Constater que les dates sur le bandeau sont corrects
