### PR TITLE
[FEATURE] Afficher l'image du badge certifié dans la page de détails d'une certification complémentaire sur Pix Admin (PIX-9148).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
@@ -7,7 +7,10 @@
       <table>
         <thead>
           <tr>
-            <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}</th>
+            <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.image-url"}}</th>
+            <th class="complementary-certification-details-table__complementary-certification-badge-name">
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}
+            </th>
             <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}</th>
             <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.id"}}</th>
           </tr>
@@ -16,6 +19,13 @@
         <tbody>
           {{#each this.currentTargetProfileBadges as |badge|}}
             <tr>
+              <td>
+                <img
+                  class="complementary-certification-details-table__complementary-certification-badge-image-url"
+                  src={{badge.imageUrl}}
+                  alt="{{badge.label}}"
+                />
+              </td>
               <td>{{badge.label}}</td>
               <td>{{badge.level}}</td>
               <td>

--- a/admin/app/styles/components/complementary-certifications/details.scss
+++ b/admin/app/styles/components/complementary-certifications/details.scss
@@ -38,3 +38,14 @@
     width: fit-content;
   }
 }
+
+.complementary-certification-details-table {
+
+  &__complementary-certification-badge-name {
+    width: 50%;
+  }
+
+  &__complementary-certification-badge-image-url {
+    width: 80px;
+  }
+}

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -17,8 +17,8 @@ module('Integration | Component | complementary-certifications/target-profiles/b
           name: 'ALEX TARGET',
           id: 3,
           badges: [
-            { id: 1023, label: 'Badge Cascade', level: 3 },
-            { id: 1025, label: 'Badge Volcan', level: 1 },
+            { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
+            { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
           ],
         },
       ],
@@ -31,11 +31,12 @@ module('Integration | Component | complementary-certifications/target-profiles/b
     );
 
     // then
+    assert.dom(screen.getByRole('columnheader', { name: 'Image du badge certifié' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Nom du badge certifié' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Niveau du badge certifié' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'ID du RT certifiant' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Badge Cascade 3 1023' })).exists();
-    assert.dom(screen.getByRole('row', { name: 'Badge Volcan 1 1025' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Badge Cascade Badge Cascade 3 1023' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Badge Volcan Badge Volcan 1 1025' })).exists();
   });
 
   test('it should contain a link for each target profile badge', async function (assert) {

--- a/admin/tests/unit/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/unit/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -10,10 +10,16 @@ module('Unit | Component | complementary-certifications/target-profiles/badges-l
     const component = createGlimmerComponent('component:complementary-certifications/target-profiles/badges-list');
 
     component.args = {
-      currentTargetProfile: { id: 1, name: 'current target', badges: [{ id: 1, level: 2, label: 'badge Pluie' }] },
+      currentTargetProfile: {
+        id: 1,
+        name: 'current target',
+        badges: [{ id: 1, level: 2, label: 'badge Pluie', imageUrl: 'http://badge-pluie.net' }],
+      },
     };
 
     // when & then
-    assert.deepEqual(component.currentTargetProfileBadges, [{ id: 1, level: 2, label: 'badge Pluie' }]);
+    assert.deepEqual(component.currentTargetProfileBadges, [
+      { id: 1, level: 2, label: 'badge Pluie', imageUrl: 'http://badge-pluie.net' },
+    ]);
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -55,6 +55,7 @@
           "title": "Badges certifiés du profil cible actuel",
           "header": {
             "id": "ID du RT certifiant",
+            "image-url": "Image du badge certifié",
             "level": "Niveau du badge certifié",
             "name": "Nom du badge certifié"
           }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -63,6 +63,7 @@
           "title": "Badges certifiés du profil cible actuel",
           "header": {
             "id": "ID du RT certifiant",
+            "image-url": "Image du badge certifié",
             "level": "Niveau du badge certifié",
             "name": "Nom du badge certifié"
           }

--- a/api/lib/domain/models/ComplementaryCertificationBadgeForAdmin.js
+++ b/api/lib/domain/models/ComplementaryCertificationBadgeForAdmin.js
@@ -1,8 +1,9 @@
 class ComplementaryCertificationBadgeForAdmin {
-  constructor({ id, label, level }) {
+  constructor({ id, label, level, imageUrl }) {
     this.id = id;
     this.label = label;
     this.level = level;
+    this.imageUrl = imageUrl;
   }
 }
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
@@ -64,6 +64,7 @@ async function _getBadgesForCurrentTargetProfiles({ targetProfile }) {
       id: 'badges.id',
       label: 'complementary-certification-badges.label',
       level: 'complementary-certification-badges.level',
+      imageUrl: 'complementary-certification-badges.imageUrl',
     })
     .leftJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
     .where('targetProfileId', targetProfile.id)

--- a/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -3,15 +3,16 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serializeForAdmin = function (complementaryCertification) {
-  return new Serializer('complementary-certification', {
+  const tutu = new Serializer('complementary-certification', {
     attributes: ['label', 'hasExternalJury', 'targetProfilesHistory'],
     targetProfilesHistory: {
       attributes: ['id', 'name', 'attachedAt', 'detachedAt', 'badges'],
       badges: {
-        attributes: ['id', 'label', 'level'],
+        attributes: ['id', 'label', 'level', 'imageUrl'],
       },
     },
   }).serialize(complementaryCertification);
+  return tutu;
 };
 
 export { serializeForAdmin };

--- a/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -3,7 +3,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serializeForAdmin = function (complementaryCertification) {
-  const tutu = new Serializer('complementary-certification', {
+  return new Serializer('complementary-certification', {
     attributes: ['label', 'hasExternalJury', 'targetProfilesHistory'],
     targetProfilesHistory: {
       attributes: ['id', 'name', 'attachedAt', 'detachedAt', 'badges'],
@@ -12,7 +12,6 @@ const serializeForAdmin = function (complementaryCertification) {
       },
     },
   }).serialize(complementaryCertification);
-  return tutu;
 };
 
 export { serializeForAdmin };

--- a/api/tests/certification/complementary-certification/acceptance/application/complementary-certification-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/complementary-certification-controller_test.js
@@ -88,11 +88,13 @@ describe('Acceptance | API | complementary-certification-controller', function (
                     id: 198,
                     level: 1,
                     label: 'another badge label',
+                    imageUrl: 'http://badge-image-url.fr',
                   },
                   {
                     id: 298,
                     level: 1,
                     label: 'badge label',
+                    imageUrl: 'http://badge-image-url.fr',
                   },
                 ],
               },

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-target-profile-history-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-target-profile-history-repository_test.js
@@ -30,6 +30,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           createdAt: new Date('2023-10-10'),
           label: 'goodBadge2',
           level: 2,
+          imageUrl: 'http://good-badge-2-url.net',
         });
         const currentBadgeId = _createComplementaryCertificationBadge({
           targetProfileId: currentTarget.id,
@@ -37,6 +38,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           createdAt: new Date('2023-10-10'),
           label: 'goodBadge',
           level: 1,
+          imageUrl: 'http://good-badge-url.net',
         });
         _createComplementaryCertificationBadge({
           targetProfileId: oldTargetProfile.id,
@@ -65,8 +67,18 @@ describe('Integration | Repository | complementary-certification-target-profile-
             attachedAt: new Date('2023-10-10'),
             detachedAt: null,
             badges: [
-              new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId, level: 1, label: 'goodBadge' }),
-              new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId2, level: 2, label: 'goodBadge2' }),
+              new ComplementaryCertificationBadgeForAdmin({
+                id: currentBadgeId,
+                level: 1,
+                label: 'goodBadge',
+                imageUrl: 'http://good-badge-url.net',
+              }),
+              new ComplementaryCertificationBadgeForAdmin({
+                id: currentBadgeId2,
+                level: 2,
+                label: 'goodBadge2',
+                imageUrl: 'http://good-badge-2-url.net',
+              }),
             ],
           }),
         ]);
@@ -138,7 +150,12 @@ describe('Integration | Repository | complementary-certification-target-profile-
             attachedAt: new Date('2023-10-10'),
             detachedAt: null,
             badges: [
-              new ComplementaryCertificationBadgeForAdmin({ id: newBadgeId1, level: 1, label: 'badgeReattached' }),
+              new ComplementaryCertificationBadgeForAdmin({
+                id: newBadgeId1,
+                level: 1,
+                label: 'badgeReattached',
+                imageUrl: 'http://badge-image-url.fr',
+              }),
             ],
           }),
         ]);
@@ -207,8 +224,18 @@ describe('Integration | Repository | complementary-certification-target-profile-
             attachedAt: new Date('2023-10-10'),
             detachedAt: null,
             badges: [
-              new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId, level: 1, label: 'badgeGood' }),
-              new ComplementaryCertificationBadgeForAdmin({ id: currentBadgeId2, level: 1, label: 'badgeGood2' }),
+              new ComplementaryCertificationBadgeForAdmin({
+                id: currentBadgeId,
+                level: 1,
+                label: 'badgeGood',
+                imageUrl: 'http://badge-image-url.fr',
+              }),
+              new ComplementaryCertificationBadgeForAdmin({
+                id: currentBadgeId2,
+                level: 1,
+                label: 'badgeGood2',
+                imageUrl: 'http://badge-image-url.fr',
+              }),
             ],
           }),
           new TargetProfileHistoryForAdmin({
@@ -221,6 +248,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
                 id: currentBadgeId3,
                 level: 1,
                 label: 'anotherCurrentBadge',
+                imageUrl: 'http://badge-image-url.fr',
               }),
             ],
           }),
@@ -392,6 +420,7 @@ function _createComplementaryCertificationBadge({
   detachedAt,
   label,
   level,
+  imageUrl,
 }) {
   const badgeId = databaseBuilder.factory.buildBadge({
     targetProfileId,
@@ -405,6 +434,7 @@ function _createComplementaryCertificationBadge({
     detachedAt,
     label,
     level,
+    imageUrl,
   });
 
   return badgeId;

--- a/api/tests/certification/complementary-certification/unit/infrastructure/serializers/complementary-certification-serializer_test.js
+++ b/api/tests/certification/complementary-certification/unit/infrastructure/serializers/complementary-certification-serializer_test.js
@@ -6,8 +6,18 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
     it('should convert a ComplementaryCertificationTargetProfileHistory model object into JSON API data', function () {
       // given
       const badges = [
-        domainBuilder.buildComplementaryCertificationBadgeForAdmin({ id: 1, label: 'badge 1', level: 1 }),
-        domainBuilder.buildComplementaryCertificationBadgeForAdmin({ id: 2, label: 'badge 2', level: 2 }),
+        domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+          id: 1,
+          label: 'badge 1',
+          level: 1,
+          imageUrl: 'http://badge-image-url.fr',
+        }),
+        domainBuilder.buildComplementaryCertificationBadgeForAdmin({
+          id: 2,
+          label: 'badge 2',
+          level: 2,
+          imageUrl: 'http://badge-image-url.fr',
+        }),
       ];
 
       const currentTargetProfile = domainBuilder.buildTargetProfileHistoryForAdmin({
@@ -53,8 +63,8 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
                 attachedAt: new Date('2023-10-10'),
                 detachedAt: null,
                 badges: [
-                  { id: 1, label: 'badge 1', level: 1 },
-                  { id: 2, label: 'badge 2', level: 2 },
+                  { id: 1, label: 'badge 1', level: 1, imageUrl: 'http://badge-image-url.fr' },
+                  { id: 2, label: 'badge 2', level: 2, imageUrl: 'http://badge-image-url.fr' },
                 ],
               },
               {

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-badge-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-badge-for-admin.js
@@ -1,7 +1,12 @@
 import { ComplementaryCertificationBadgeForAdmin } from '../../../../lib/domain/models/ComplementaryCertificationBadgeForAdmin.js';
 
-const buildComplementaryCertificationBadgeForAdmin = function ({ id = 1, label = 'badge Cascade', level = 1 }) {
-  return new ComplementaryCertificationBadgeForAdmin({ id, label, level });
+const buildComplementaryCertificationBadgeForAdmin = function ({
+  id = 1,
+  label = 'badge Cascade',
+  level = 1,
+  imageUrl = 'http://badge-image-url.fr',
+}) {
+  return new ComplementaryCertificationBadgeForAdmin({ id, label, level, imageUrl });
 };
 
 export { buildComplementaryCertificationBadgeForAdmin };


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, il est aujourd’hui possible pour le métier de visualiser l’image d’un RT depuis sa page de détail dans Pix Admin, mais pas possible de faire de même pour un badge certifié (complementary certification badge).

Pour plusieurs raisons, notamment en cas de question au support sur l’affichage erroné d’un badge certifié sur le certificat d’un candidat, le métier souhaite pouvoir visualiser l’image du badge certifié.

## :robot: Proposition
Afficher pour chaque badge certifié de la certif complémentaire concernée l’image correspondante

## :rainbow: Remarques
- Ajouter une colonne “Image du badge certifié” dans le tableau
- A positionner en 1ère colonne du tableau

---

J'ai donné 50% de place au nom du badge certifié qui aura besoin de plus de place que les autres.

## :100: Pour tester

- Hop hop hop on se connecte sur Pix Admin
- Tu vois le menu à gauche ? Clique sur celui des certifications complémentaire
- Maintenant tu cliques sur la certif' comp' que tu veux
- Et là dans le tableau, tu vois de belles images
- Tu coches ✅  et za paaaart en prod ! 
🚀

<img width="1648" alt="Capture d’écran 2023-09-22 à 18 02 07" src="https://github.com/1024pix/pix/assets/58915422/04cfb6fc-e0d9-49b4-9c24-9db483c14dfd">
