### PR TITLE
[BUGFIX] Afficher les styles de liste dans la correction (PIX-9034)

### DIFF
--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -21,7 +21,7 @@
       }
     }
 
-    li {
+    ul, li {
       list-style: unset;
     }
   }


### PR DESCRIPTION
## :unicorn: Problème
Les styles de liste disparaissent dans la correction.

## :robot: Proposition
Rajouter une propriété CSS pour éviter de cacher les puces des listes dans les corrections

## :100: Pour tester
TBA