### PR TITLE
[BUGFIX] Afficher les styles de liste dans la correction (PIX-9193)

### DIFF
--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -12,6 +12,10 @@
   &__instruction {
     font-size: 1rem;
 
+    ul, li {
+      list-style: unset;
+    }
+
     ul,
     ol {
       padding-left: 2em;
@@ -21,9 +25,6 @@
       }
     }
 
-    li {
-      list-style: unset;
-    }
   }
 
   &__default-message-container {


### PR DESCRIPTION
## :unicorn: Problème
Les styles de liste disparaissent dans la correction.

## :robot: Proposition
Rajouter une propriété CSS pour éviter de cacher les puces des listes dans les corrections

## :100: Pour tester
TBA