### PR TITLE
[FEATURE] Suspicion de fraude en anglais (PIX-7766).

### DIFF
--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -12,7 +12,12 @@
   </div>
   {{#if @fraudCategory.isChecked}}
     <div class="fraud-certification-issue-report-fields__details">
-      <p>{{t "pages.session-finalization.add-issue-modal.actions.transmit-report" htmlSafe=true}}
+      <p>
+        {{t
+          "pages.session-finalization.add-issue-modal.actions.transmit-report"
+          htmlSafe=true
+          fraudFormUrl=this.fraudFormUrl
+        }}
         <FaIcon @icon="up-right-from-square" aria-hidden="true" />
         <span class="sr-only">{{t "navigation.external-link-title"}}</span>
       </p>

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+export default class FraudCertificationIssueReportFields extends Component {
+  @service url;
+
+  get fraudFormUrl() {
+    return this.url.fraudFormUrl;
+  }
+}

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -14,21 +14,18 @@ export default class Url extends Service {
   }
 
   get cguUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') return 'https://pix.org/en-gb/terms-and-conditions';
+    if (this.#isEnglishSpoken()) return 'https://pix.org/en-gb/terms-and-conditions';
     return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
   }
 
   get dataProtectionPolicyUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') return 'https://pix.org/en-gb/personal-data-protection-policy';
+    if (this.#isEnglishSpoken()) return 'https://pix.org/en-gb/personal-data-protection-policy';
     return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
   }
 
   get forgottenPasswordUrl() {
-    const currentLanguage = this.intl.t('current-lang');
     let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
-    if (currentLanguage === 'en') {
+    if (this.#isEnglishSpoken()) {
       url += '?lang=en';
     }
     return url;
@@ -37,15 +34,13 @@ export default class Url extends Service {
   get legalNoticeUrl() {
     if (this.currentDomain.isFranceDomain) return 'https://pix.fr/mentions-legales';
 
-    const currentLanguage = this.intl.t('current-lang');
-    return currentLanguage === 'fr' ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
+    return this.#isFrenchSpoken() ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
   }
 
   get accessibilityUrl() {
     if (this.currentDomain.isFranceDomain) return 'https://pix.fr/accessibilite-pix-certif';
 
-    const currentLanguage = this.intl.t('current-lang');
-    return currentLanguage === 'fr'
+    return this.#isFrenchSpoken()
       ? 'https://pix.org/fr/accessibilite-pix-certif'
       : 'https://pix.org/en-gb/accessibility-pix-certif';
   }
@@ -53,13 +48,11 @@ export default class Url extends Service {
   get supportUrl() {
     if (this.currentDomain.isFranceDomain) return 'https://support.pix.fr';
 
-    const currentLanguage = this.intl.t('current-lang');
-    return currentLanguage === 'fr' ? 'https://support.pix.org' : 'https://support.pix.org/en/support/home';
+    return this.#isFrenchSpoken() ? 'https://support.pix.org' : 'https://support.pix.org/en/support/home';
   }
 
   get joiningIssueSheetUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'fr') {
+    if (this.#isFrenchSpoken()) {
       return 'https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf';
     }
 
@@ -67,11 +60,26 @@ export default class Url extends Service {
   }
 
   get urlToDownloadSessionIssueReportSheet() {
-    const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'fr') {
+    if (this.#isFrenchSpoken()) {
       return 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download';
     }
 
     return 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download';
+  }
+
+  get fraudFormUrl() {
+    if (this.#isFrenchSpoken()) {
+      return 'https://form-eu.123formbuilder.com/41052/form';
+    }
+
+    return 'https://cloud.pix.fr/s/6Ltnqkf4emQEooS/download';
+  }
+
+  #isFrenchSpoken() {
+    return this.intl.t('current-lang') === 'fr';
+  }
+
+  #isEnglishSpoken() {
+    return this.intl.t('current-lang') === 'en';
   }
 }

--- a/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields_test.js
@@ -49,6 +49,8 @@ module('Integration | Component | issue-report-modal/fraud-certification-issue-r
         ),
       )
       .exists();
-    assert.dom(screen.getByText('ce formulaire')).exists();
+    assert
+      .dom(screen.getByRole('link', { name: 'ce formulaire' }))
+      .hasAttribute('href', 'https://form-eu.123formbuilder.com/41052/form');
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -303,7 +303,7 @@
           "select-subcategory": "Select a subcategory:",
           "select-subcategory-label": "Select a subcategory",
           "specify": "Specify",
-          "transmit-report": "Please transmit the fraud report filled in during the certification session by using '<span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer\">'this form'</a></span>'"
+          "transmit-report": "Please transmit the fraud report filled in during the certification session by using '<span><'a class=\"link\" href=\"{fraudFormUrl}\" target=\"_blank\" rel=\"noreferrer\"'>'this form'</a></span>'"
         },
         "category-labels": {
           "candidate-informations-changes": "Edit the candidate’s details",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -303,7 +303,7 @@
           "select-subcategory": "Sélectionnez une sous-catégorie :",
           "select-subcategory-label": "Sélectionner la sous-catégorie",
           "specify": "Précisez",
-          "transmit-report": "Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant '<span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer\">'ce formulaire'</a></span>'"
+          "transmit-report": "Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant '<span><'a class=\"link\" href=\"{fraudFormUrl}\" target=\"_blank\" rel=\"noreferrer\"'>'ce formulaire'</></span>'"
         },
         "category-labels": {
           "candidate-informations-changes": "Modification infos candidat",


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Une fois sur la page de finalisation d’une session de certification Pix, un utilisateur anglophone peut remonter un signalement C6 “Suspicion de fraude” et en cliquant sur le lien vers le formulaire approprié.

Le lien se fait actuellement vers le formulaire en français.

## :robot: Proposition
Modifier le lien pour rediriger vers la version anglaise du formulaire de déclaration de suspicion de fraude : https://cloud.pix.fr/s/6Ltnqkf4emQEooS/download

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Sur Pix Certif avec `certifpro@example.net`, pour la session http://localhost:4203/sessions/7005/ , se mettre ne surveillant et confirmer une présence pour un des candidats
* Sur Pix App, passer une certif pour un des candidats de  la session http://localhost:4203/sessions/7005/
* Ensuite sur Pix, finaliser la session sur http://localhost:4203/sessions/7005/finalisation
* Introduire une suspicion de fraude 
![image](https://github.com/1024pix/pix/assets/170271/b5d7f72e-30dd-4342-9f99-88c8716f2562)
* Vérifier que ce même comportement en version anglaise sur http://localhost:4203/sessions/7005/finalisation?lang=en
