### PR TITLE
[FEATURE] Ajout du nombre d'organisations, centres de certif et participations sur la page users de pix-admin 

### DIFF
--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -39,4 +39,14 @@ export default class User extends Model {
   get language() {
     return this.lang?.toUpperCase();
   }
+
+  get organizationMembershipsCount() {
+    return this.organizationMemberships.length;
+  }
+  get certificationCenterMembershipsCount() {
+    return this.certificationCenterMemberships.length;
+  }
+  get participationsCount() {
+    return this.participations.length;
+  }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -72,7 +72,6 @@
 @import 'components/users/user-profile';
 @import 'components/users/user-overview';
 @import 'components/users/organization-learners-table';
-@import 'components/users/get';
 @import 'components/users/authentication-method';
 @import 'components/target-profiles/badges';
 @import 'components/target-profiles/target-profile';

--- a/admin/app/styles/components/users/get.scss
+++ b/admin/app/styles/components/users/get.scss
@@ -1,3 +1,0 @@
-.certification-center-navbar {
-  width: 200px;
-}

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -15,15 +15,16 @@
 
   <nav class="navbar" aria-label="Navigation de la section détails d'un utilisateur">
     <LinkTo @route="authenticated.users.get.information" @model={{@model}} class="navbar-item">
-      Détails
+      {{t "pages.user-details.navbar.details"}}
     </LinkTo>
 
     <LinkTo @route="authenticated.users.get.profile" @model={{@model}} class="navbar-item">
-      Profil
+      {{t "pages.user-details.navbar.profile"}}
     </LinkTo>
 
     <LinkTo @route="authenticated.users.get.campaign-participations" @model={{@model}} class="navbar-item">
-      Participations
+      {{t "pages.user-details.navbar.participations-list"}}
+      ({{@model.participationsCount}})
     </LinkTo>
 
     <LinkTo
@@ -33,14 +34,15 @@
       class="navbar-item"
     >
       {{t "pages.user-details.navbar.organizations-list"}}
+      ({{@model.organizationMembershipsCount}})
     </LinkTo>
 
     <LinkTo
       @route="authenticated.users.get.certification-center-memberships"
-      class="navbar-item certification-center-navbar"
       aria-label="Centres de certification auxquels appartient l´utilisateur"
     >
       {{t "pages.user-details.navbar.certification-centers-list"}}
+      ({{@model.certificationCenterMembershipsCount}})
     </LinkTo>
   </nav>
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -123,7 +123,10 @@
     "user-details": {
       "navbar": {
         "certification-centers-list": "Pix Certif",
-        "organizations-list": "Pix Orga"
+        "details": "Details",
+        "organizations-list": "Pix Orga",
+        "participations-list": "Participations",
+        "profile": "Profile"
       }
     }
   }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -145,7 +145,10 @@
     "user-details": {
       "navbar": {
         "certification-centers-list": "Pix Certif",
-        "organizations-list": "Pix Orga"
+        "details" : "Détails",
+        "organizations-list": "Pix Orga",
+        "participations-list": "Participations",
+        "profile" : "Profil"
       }
     }
   }


### PR DESCRIPTION
## :unicorn: Problème
Sur pix Admin, dans la catégorie users, les onglets Organisations, Centre de certif et Participations ne donnent pas d'apperçu du nombre d'éléments qu'ils contiennent.

## :robot: Proposition
Ajouter un nombre entre parenthèses à côté du titre de l'onglet afin d'afficher le nombre d'éléments que cette catégories contient

## :rainbow: Remarques
On a étendu le scope à l'onglet participation + les 3 modifications étant très proches, elles ont été regroupées dans une seule PR.

## :100: Pour tester
- Se connecter sur Pix Admin avec l'utilisateur: superadmin@example.net
- Chercher un utilisateur, par exemple: screen si dessous
- Vérfier que les numéros s'affichent bien entre parenthèse lorsque l'onglet dispose d'une entrée ou non

<img width="1074" alt="image" src="https://github.com/1024pix/pix/assets/3486537/3caf471b-279b-463a-b34b-0da6a9241e53">
