### PR TITLE
[FEATURE] Ajouter le SSO Pays de la Loire (PIX-9309)

### DIFF
--- a/api/lib/domain/constants/oidc-identity-providers.js
+++ b/api/lib/domain/constants/oidc-identity-providers.js
@@ -11,8 +11,13 @@ const FWB = {
   configKey: 'fwb',
 };
 
+const PAYSDELALOIRE = {
+  code: 'PAYSDELALOIRE',
+  configKey: 'paysdelaloire',
+};
+
 function getValidOidcProviderCodes() {
-  return [POLE_EMPLOI.code, CNAV.code, FWB.code];
+  return [POLE_EMPLOI.code, CNAV.code, FWB.code, PAYSDELALOIRE.code];
 }
 
-export { getValidOidcProviderCodes, POLE_EMPLOI, CNAV, FWB };
+export { getValidOidcProviderCodes, POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE };

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -2,11 +2,13 @@ import { InvalidIdentityProviderError } from '../../errors.js';
 import { PoleEmploiOidcAuthenticationService } from './pole-emploi-oidc-authentication-service.js';
 import { CnavOidcAuthenticationService } from './cnav-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
+import { PaysdelaloireOidcAuthenticationService } from './paysdelaloire-oidc-authentication-service.js';
 
 const allOidcProviderServices = [
   new PoleEmploiOidcAuthenticationService(),
   new CnavOidcAuthenticationService(),
   new FwbOidcAuthenticationService(),
+  new PaysdelaloireOidcAuthenticationService(),
 ];
 
 const readyOidcProviderServices = allOidcProviderServices.filter((oidcProvider) => oidcProvider.isReady);

--- a/api/lib/domain/services/authentication/paysdelaloire-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/paysdelaloire-oidc-authentication-service.js
@@ -1,0 +1,28 @@
+import { config } from '../../../../src/shared/config.js';
+
+import { OidcAuthenticationService } from './oidc-authentication-service.js';
+import { PAYSDELALOIRE } from '../../constants/oidc-identity-providers.js';
+
+const configKey = PAYSDELALOIRE.configKey;
+
+class PaysdelaloireOidcAuthenticationService extends OidcAuthenticationService {
+  constructor() {
+    super({
+      identityProvider: PAYSDELALOIRE.code,
+      configKey,
+      source: 'paysdelaloire',
+      slug: 'pays-de-la-loire',
+      organizationName: 'Pays de la Loire',
+      hasLogoutUrl: false,
+      jwtOptions: { expiresIn: config.paysdelaloire.accessTokenLifespanMs / 1000 },
+      clientSecret: config.paysdelaloire.clientSecret,
+      clientId: config.paysdelaloire.clientId,
+      tokenUrl: config.paysdelaloire.tokenUrl,
+      authenticationUrl: config.paysdelaloire.authenticationUrl,
+      authenticationUrlParameters: [{ key: 'scope', value: 'openid profile' }],
+      userInfoUrl: config.paysdelaloire.userInfoUrl,
+    });
+  }
+}
+
+export { PaysdelaloireOidcAuthenticationService };

--- a/api/sample.env
+++ b/api/sample.env
@@ -663,6 +663,54 @@ AUTH_SECRET=Change me!
 # default: 7d
 # sample: FWB_ID_TOKEN_LIFESPAN=
 
+# ==============================
+# PAYS DE LA LOIRE CONFIGURATION
+# ==============================
+
+# Enable connection to the OIDC provider
+#
+# presence: optional
+# type: boolean
+# default: `false`
+# PAYSDELALOIRE_ENABLED=false
+
+# Client ID
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: string
+# sample: PAYSDELALOIRE_CLIENT_ID=
+
+# Client secret
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: string
+# sample: PAYSDELALOIRE_CLIENT_SECRET=
+
+# Token URL
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: URL
+# sample: PAYSDELALOIRE_TOKEN_URL=
+
+# Authentication URL
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: URL
+# sample: PAYSDELALOIRE_AUTHENTICATION_URL=
+
+# User info URL
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: URL
+# sample: PAYSDELALOIRE_USER_INFO_URL=
+
+# Temporary storage idToken expiration delay in milliseconds
+#
+# presence: optional
+# type: Integer
+# default: 7d
+# sample: PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN=
+
 # ===================
 # AUTHENTICATION SESSION CONFIGURATION
 # ===================

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -255,6 +255,15 @@ const configuration = (function () {
     partner: {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
+    paysdelaloire: {
+      isEnabled: isFeatureEnabled(process.env.PAYSDELALOIRE_ENABLED),
+      clientId: process.env.PAYSDELALOIRE_CLIENT_ID,
+      clientSecret: process.env.PAYSDELALOIRE_CLIENT_SECRET,
+      tokenUrl: process.env.PAYSDELALOIRE_TOKEN_URL,
+      userInfoUrl: process.env.PAYSDELALOIRE_USER_INFO_URL,
+      authenticationUrl: process.env.PAYSDELALOIRE_AUTHENTICATION_URL,
+      accessTokenLifespanMs: ms(process.env.PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN || '7d'),
+    },
     pgBoss: {
       connexionPoolMaxSize: _getNumber(process.env.PGBOSS_CONNECTION_POOL_MAX_SIZE, 2),
       teamSize: _getNumber(process.env.PG_BOSS_TEAM_SIZE, 1),


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons ajouter Pays de la Loire comme SSO

## :robot: Proposition
Créer un nouveau service OIDC et ajouter les variables d'environnements dans les environnements de recette d'intégration.

## :rainbow: Remarques
- [x] Penser à ajouter les variables d'environnements en recette et intégration

## :100: Pour tester

Tester en local car il n'est pas possible de tester le SSO via les RA.
Il faut attendre que la PR soit mergé pour le faire intégration et en recette.
