### PR TITLE
[FEATURE] Ne pas poser 2 question sur le même sujet dans la certif v3 (PIX-9293)

### DIFF
--- a/api/lib/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/FlashAssessmentAlgorithm.js
@@ -33,6 +33,7 @@ class FlashAssessmentAlgorithm {
    * @param maximumAssessmentLength - override the default limit for an assessment length
    * @param challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    * @param minimumEstimatedSuccessRateRanges - force a minimal estimated success rate for challenges chosen at specific indexes
+   * @param limitToOneQuestionPerTube - limits questions to one per tube
    */
   constructor({
     warmUpLength,
@@ -40,12 +41,14 @@ class FlashAssessmentAlgorithm {
     maximumAssessmentLength,
     challengesBetweenSameCompetence = config.v3Certification.challengesBetweenSameCompetence,
     minimumEstimatedSuccessRateRanges = defaultMinimumEstimatedSuccessRateRanges,
+    limitToOneQuestionPerTube = true,
   } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
     this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
     this.minimumEstimatedSuccessRateRanges = minimumEstimatedSuccessRateRanges;
+    this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
   }
 
   getPossibleNextChallenges({
@@ -74,6 +77,7 @@ class FlashAssessmentAlgorithm {
         forcedCompetences: this.forcedCompetences,
         challengesBetweenSameCompetence: this.challengesBetweenSameCompetence,
         minimalSuccessRate,
+        limitToOneQuestionPerTube: this.limitToOneQuestionPerTube,
       },
     });
 

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -32,9 +32,12 @@ function getPossibleNextChallenges({
     forcedCompetences = [],
     challengesBetweenSameCompetence = 0,
     minimalSuccessRate = 0,
+    limitToOneQuestionPerTube = false,
   } = {},
 } = {}) {
-  let nonAnsweredChallenges = getChallengesForNonAnsweredSkills({ allAnswers, challenges });
+  let nonAnsweredChallenges = limitToOneQuestionPerTube
+    ? getChallengesForNonAnsweredTubes({ allAnswers, challenges })
+    : getChallengesForNonAnsweredSkills({ allAnswers, challenges });
 
   if (allAnswers.length >= warmUpLength) {
     const answersAfterWarmup = _getAnswersAfterWarmup({ answers: allAnswers, warmUpLength });
@@ -132,6 +135,15 @@ function getEstimatedLevelAndErrorRate({ allAnswers, challenges, estimatedLevel 
   const correctedErrorRate = Math.sqrt(rawErrorRate - (ERROR_RATE_CLASS_INTERVAL ** 2) / 12.0); // prettier-ignore
 
   return { estimatedLevel: latestEstimatedLevel, errorRate: correctedErrorRate };
+}
+
+function getChallengesForNonAnsweredTubes({ allAnswers, challenges }) {
+  const alreadyAnsweredTubeIds = allAnswers.map((answer) => _findChallengeForAnswer(challenges, answer).skill.tubeId);
+
+  const isNonAnsweredTube = (skill) => !alreadyAnsweredTubeIds.includes(skill.tubeId);
+  const challengesForNonAnsweredTubes = challenges.filter((challenge) => isNonAnsweredTube(challenge.skill));
+
+  return challengesForNonAnsweredTubes;
 }
 
 function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -187,7 +187,7 @@ ko,aband,ok`;
         const response = await server.inject(options);
         // then
         expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(3);
+        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
       });
     });
 
@@ -202,7 +202,7 @@ ko,aband,ok`;
 
         // then
         expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(5);
+        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
       });
     });
 
@@ -217,7 +217,7 @@ ko,aband,ok`;
 
         // then
         expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(5);
+        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
       });
     });
 

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -650,6 +650,69 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         });
       });
     });
+
+    describe('when we limit to one question per tube', function () {
+      describe('when a tube has already been answered', function () {
+        it('should choose the challenge from an unanswered tube', function () {
+          // Given
+          const answeredTubeId = 'answeredTubeId';
+          const firstSkillWithAnsweredTube = domainBuilder.buildSkill({
+            id: 'skill1',
+            tubeId: answeredTubeId,
+          });
+
+          const secondSkillWithAnsweredTube = domainBuilder.buildSkill({
+            id: 'skill2',
+            tubeId: answeredTubeId,
+          });
+
+          const skillForUnansweredTube = domainBuilder.buildSkill({
+            id: 'skill3',
+            tubeId: 'unansweredTubeId',
+          });
+
+          const answeredChallenge = domainBuilder.buildChallenge({
+            id: 'recCHAL1',
+            skill: firstSkillWithAnsweredTube,
+          });
+
+          const unansweredChallengeAnsweredTube = domainBuilder.buildChallenge({
+            id: 'recCHAL2',
+            skill: secondSkillWithAnsweredTube,
+            difficulty: 2,
+            discriminant: 1,
+          });
+
+          const unansweredChallengeUnansweredTube = domainBuilder.buildChallenge({
+            id: 'recCHAL3',
+            skill: skillForUnansweredTube,
+            difficulty: -2,
+            discriminant: 1,
+          });
+
+          const challenges = [answeredChallenge, unansweredChallengeAnsweredTube, unansweredChallengeUnansweredTube];
+
+          const answers = [
+            domainBuilder.buildAnswer({
+              challengeId: answeredChallenge.id,
+            }),
+          ];
+
+          // when
+          const nextChallenges = getPossibleNextChallenges({
+            allAnswers: answers,
+            challenges,
+            estimatedLevel: 2,
+            options: {
+              limitToOneQuestionPerTube: true,
+            },
+          }).possibleChallenges;
+
+          // then
+          expect(nextChallenges).to.deep.equal([unansweredChallengeUnansweredTube]);
+        });
+      });
+    });
   });
 
   describe('#getEstimatedLevelAndErrorRate', function () {

--- a/api/tests/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -9,6 +9,7 @@ function initializeTestChallenges(hardAnsweredChallengesCount, difficulty, answe
   const defaultDiscriminantValue = 0.5;
   const defaultSkill = domainBuilder.buildSkill({
     id: 'recSK456',
+    tubeId: 'tube456',
   });
   const hardAnsweredChallenges = _.range(0, hardAnsweredChallengesCount).map((index) =>
     domainBuilder.buildChallenge({
@@ -36,7 +37,10 @@ function initializeTestChallenges(hardAnsweredChallengesCount, difficulty, answe
     id: 'recUnansweredMedium',
     difficulty: 0,
     discriminant: defaultDiscriminantValue,
-    skill: defaultSkill,
+    skill: domainBuilder.buildSkill({
+      id: `skill2`,
+      tubeId: 'tube2',
+    }),
   });
 
   const challenges = [...hardAnsweredChallenges, expectedUnansweredChallenge, mediumUnansweredChallenge];
@@ -176,6 +180,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             id: 'easyChallenge',
             skill: domainBuilder.buildSkill({
               id: 'skillEasy',
+              tubeId: 'tube4',
             }),
             competenceId: 'compEasy',
             discriminant,
@@ -188,6 +193,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             id: 'challengeWithRightSuccessRate',
             skill: domainBuilder.buildSkill({
               id: 'skillMedium',
+              tubeId: 'tube3',
             }),
             competenceId: 'compMedium',
             discriminant: challengeWithRightSuccessRateDiscriminant,
@@ -198,6 +204,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             id: 'hardChallenge2',
             skill: domainBuilder.buildSkill({
               id: 'skillHard2',
+              tubeId: 'tube2',
             }),
             competenceId: 'compHard2',
             discriminant,
@@ -208,6 +215,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm', function () {
             id: 'hardChallenge',
             skill: domainBuilder.buildSkill({
               id: 'skillHard',
+              tubeId: 'tube1',
             }),
             competenceId: 'compHard',
             discriminant,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -80,8 +80,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
       let locale;
 
       beforeEach(function () {
-        firstSkill = domainBuilder.buildSkill({ id: 'First' });
-        secondSkill = domainBuilder.buildSkill({ id: 'Second' });
+        firstSkill = domainBuilder.buildSkill({ id: 'First', tubeId: '1' });
+        secondSkill = domainBuilder.buildSkill({ id: 'Second', tubeId: '2' });
         firstChallenge = domainBuilder.buildChallenge({
           id: '1234',
           difficulty: -5,

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -9,9 +9,9 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
     context('when no initial capacity is provided', function () {
       it('should return an array of estimated level, challenge, reward and error rate for each answer', async function () {
         // given
-        const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill' });
-        const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill' });
-        const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill' });
+        const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill', tubeId: '1' });
+        const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill', tubeId: '2' });
+        const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill', tubeId: '3' });
         const firstChallenge = domainBuilder.buildChallenge({
           id: 'one',
           skill: firstSkill,
@@ -82,9 +82,9 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         // given
         const initialCapacity = 7;
 
-        const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill' });
-        const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill' });
-        const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill' });
+        const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill', tubeId: '1' });
+        const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill', tubeId: '2' });
+        const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill', tubeId: '3' });
         const firstChallenge = domainBuilder.buildChallenge({
           id: 'one',
           skill: firstSkill,


### PR DESCRIPTION
## :unicorn: Problème
Dans la certif v3, il arrive que l'algorithme retombe toujours sur les mêmes sujets, surtout à des niveaux de difficulté élevés.

## :robot: Proposition
Afin d'éviter cela, nous instaurons une limite d'une question par sujet. Cela permet également de plus diversifier les sujets.

## :100: Pour tester
Tester un parcours complet pour être certain qu'il n'y ait pas d'erreur.