### PR TITLE
[TECH] Favoriser l'utilisation de calledWithExactly au lieu de calledWith

### DIFF
--- a/api/tests/acceptance/scripts/certification/update-certification-infos_test.js
+++ b/api/tests/acceptance/scripts/certification/update-certification-infos_test.js
@@ -144,7 +144,7 @@ describe('Acceptance | Scripts | update-certification-infos', function () {
         await updateCertificationInfos(dataFile, sessionIdsFile);
 
         // then
-        expect(logger.warn).to.have.been.calledWith('Certification for external id 123 not found');
+        expect(logger.warn).to.have.been.calledWithExactly('Certification for external id 123 not found');
       });
     });
 
@@ -247,7 +247,7 @@ describe('Acceptance | Scripts | update-certification-infos', function () {
         await updateCertificationInfos(dataFile, sessionIdsFile);
 
         // then
-        expect(logger.warn).to.have.been.calledWith('Certification for external id 123 not found');
+        expect(logger.warn).to.have.been.calledWithExactly('Certification for external id 123 not found');
       });
     });
   });

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -225,7 +225,7 @@ describe('Unit | UseCase | attach-badges', function () {
         });
 
         // then
-        expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWith({
+        expect(complementaryCertificationBadgesRepository.detachByIds).to.have.been.calledWithExactly({
           complementaryCertificationBadgeIds: [1, 2],
           domainTransaction,
         });
@@ -290,7 +290,7 @@ describe('Unit | UseCase | attach-badges', function () {
           complementaryCertificationId: 123,
           createdBy: 1234,
         });
-        expect(complementaryCertificationBadgesRepository.attach).to.have.been.calledWith({
+        expect(complementaryCertificationBadgesRepository.attach).to.have.been.calledWithExactly({
           complementaryCertificationBadges: [newComplementaryCertificationBadge],
           domainTransaction,
         });

--- a/api/tests/certification/session/unit/application/create-session-controller_test.js
+++ b/api/tests/certification/session/unit/application/create-session-controller_test.js
@@ -57,7 +57,7 @@ describe('Unit | Controller | create-session-controller', function () {
       await createSessionController.createSession(request, hFake, { sessionSerializer: sessionSerializerStub });
 
       // then
-      expect(usecases.createSession).to.have.been.calledWith({ userId, session: expectedSession });
+      expect(usecases.createSession).to.have.been.calledWithExactly({ userId, session: expectedSession });
     });
 
     it('should return the saved session in JSON API', async function () {
@@ -84,7 +84,7 @@ describe('Unit | Controller | create-session-controller', function () {
 
       // then
       expect(response).to.deep.equal(jsonApiSession);
-      expect(sessionSerializerStub.serialize).to.have.been.calledWith({ session: savedSession });
+      expect(sessionSerializerStub.serialize).to.have.been.calledWithExactly({ session: savedSession });
     });
   });
 });

--- a/api/tests/certification/session/unit/domain/usecases/dismiss-live-alert_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/dismiss-live-alert_test.js
@@ -64,7 +64,7 @@ describe('Unit | UseCase | dismiss-live-alert', function () {
       });
 
       // then
-      expect(certificationChallengeLiveAlertRepository.save).to.have.been.calledWith({
+      expect(certificationChallengeLiveAlertRepository.save).to.have.been.calledWithExactly({
         certificationChallengeLiveAlert: domainBuilder.buildCertificationChallengeLiveAlert(dismissedLiveAlert),
       });
     });

--- a/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -56,7 +56,7 @@ describe('Integration | Application | Scoring-simulator | scoring-simulator-cont
             datasetId: 'datasetId',
             results: simulationResults,
           });
-          expect(usecases.simulateOldScoring).to.have.been.calledWith({
+          expect(usecases.simulateOldScoring).to.have.been.calledWithExactly({
             simulations: [
               new ScoringSimulation({
                 answers: [new Answer({ challengeId: 'okChallengeId', result: 'ok' })],
@@ -120,7 +120,7 @@ describe('Integration | Application | Scoring-simulator | scoring-simulator-cont
             datasetId: 'datasetId',
             results: simulationResults,
           });
-          expect(usecases.simulateFlashScoring).to.have.been.calledWith({
+          expect(usecases.simulateFlashScoring).to.have.been.calledWithExactly({
             simulations: [
               new ScoringSimulation({
                 user: {

--- a/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -124,7 +124,7 @@ describe('Integration | UseCase | create-or-update-certification-center-invitati
     });
 
     // then
-    expect(mailService.sendCertificationCenterInvitationEmail).to.has.been.calledWith({
+    expect(mailService.sendCertificationCenterInvitationEmail).to.has.been.calledWithExactly({
       email: 'some.user@example.net',
       certificationCenterName: 'Pixar',
       certificationCenterInvitationId,

--- a/api/tests/integration/infrastructure/event-dispatcher-logger_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher-logger_test.js
@@ -17,7 +17,7 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchStarted(event, eventHandlerName);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
         metrics: {
           event_name: 'TestEvent',
           event_content: event,
@@ -64,7 +64,7 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
         metrics: {
           event_name: 'TestEvent',
           event_content: event,
@@ -91,7 +91,7 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchFailure(event, eventHandlerName, anError);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
         metrics: {
           event_name: 'TestEvent',
           event_content: event,
@@ -159,7 +159,7 @@ describe('Integration | Infrastructure | EventHandlerLogger', function () {
       eventDispatcherLogger.onEventDispatchSuccess(event, eventHandlerName, context);
 
       // then
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
         metrics: {
           event_name: 'TestEvent',
           event_content: event,

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -23,7 +23,7 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
+    expect(eventHandler).to.have.been.calledWithExactly({ domainTransaction, event });
   });
 
   it('throws when duplicate subscription', async function () {
@@ -56,8 +56,8 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(eventHandler_1).to.have.been.calledWith({ domainTransaction, event });
-    expect(eventHandler_2).to.have.been.calledWith({ domainTransaction, event });
+    expect(eventHandler_1).to.have.been.calledWithExactly({ domainTransaction, event });
+    expect(eventHandler_2).to.have.been.calledWithExactly({ domainTransaction, event });
   });
 
   it('calls handler only for subscribed events', async function () {
@@ -76,8 +76,8 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(otherEvent, domainTransaction);
 
     // then
-    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
-    expect(eventHandler).not.to.have.been.calledWith({ domainTransaction, otherEvent });
+    expect(eventHandler).to.have.been.calledWithExactly({ domainTransaction, event });
+    expect(eventHandler).not.to.have.been.calledWithExactly({ domainTransaction, otherEvent });
   });
 
   it('dispatches event returned by eventHandlers', async function () {
@@ -96,7 +96,7 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event: returnedEvent });
+    expect(eventHandler).to.have.been.calledWithExactly({ domainTransaction, event: returnedEvent });
   });
 
   it('dispatches events returned by eventHandlers', async function () {
@@ -116,8 +116,8 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event: returnedEvent1 });
-    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event: returnedEvent2 });
+    expect(eventHandler).to.have.been.calledWithExactly({ domainTransaction, event: returnedEvent1 });
+    expect(eventHandler).to.have.been.calledWithExactly({ domainTransaction, event: returnedEvent2 });
   });
 
   it('logs when dispatch starts', async function () {
@@ -134,7 +134,7 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(logger.onEventDispatchStarted).to.have.been.calledWith(event, 'handler 1');
+    expect(logger.onEventDispatchStarted).to.have.been.calledWithExactly(event, 'handler 1');
   });
 
   it('logs when a dispatch is successful', async function () {
@@ -151,7 +151,7 @@ describe('Integration | Infrastructure | EventHandler', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(logger.onEventDispatchSuccess).to.have.been.calledWith(event, 'handler 1');
+    expect(logger.onEventDispatchSuccess).to.have.been.calledWithExactly(event, 'handler 1', 'Started Job Name');
   });
 
   it('logs and rethrow when a dispatch fails', async function () {
@@ -174,13 +174,13 @@ describe('Integration | Infrastructure | EventHandler', function () {
       error = e;
     }
     expect(error).to.equal(anError);
-    expect(logger.onEventDispatchFailure).to.have.been.calledWith(event, 'handler 1', anError);
+    expect(logger.onEventDispatchFailure).to.have.been.calledWithExactly(event, 'handler 1', anError);
   });
 });
 
 function _buildLoggerMock() {
   return {
-    onEventDispatchStarted: sinon.stub(),
+    onEventDispatchStarted: sinon.stub().returns('Started Job Name'),
     onEventDispatchSuccess: sinon.stub(),
     onEventDispatchFailure: sinon.stub(),
   };

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -82,7 +82,7 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
     });
 
     // then
-    expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
+    expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWithExactly({
       certificationCourseIds: [12, 20],
       filename: expectedFileName,
     });

--- a/api/tests/integration/scripts/populate-organizations-email_test.js
+++ b/api/tests/integration/scripts/populate-organizations-email_test.js
@@ -32,7 +32,7 @@ describe('Integration | Scripts | populate-organizations-email.js', function () 
       expect(organizations).to.deep.include(csvData[1]);
       expect(organizations).to.not.deep.include(csvData[2]);
       // eslint-disable-next-line no-console
-      expect(console.error).to.have.been.calledWith('Organization not found for External ID unknown');
+      expect(console.error).to.have.been.calledWithExactly('Organization not found for External ID unknown');
     });
   });
 });

--- a/api/tests/integration/scripts/toggle-is-for-absolute-novice-campaign-attribute_test.js
+++ b/api/tests/integration/scripts/toggle-is-for-absolute-novice-campaign-attribute_test.js
@@ -13,7 +13,7 @@ describe('Toggle isForAbsoluteNovice campaign attribute', function () {
         await toggleIsForAbsoluteNoviceCampaignAttribute(1234);
 
         // then
-        expect(logger.error).to.have.been.calledWith('Campaign not found for id 1234');
+        expect(logger.error).to.have.been.calledWithExactly('Campaign not found for id 1234');
       });
     });
 

--- a/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
@@ -77,10 +77,10 @@ describe('Unit | Controller | account-recovery-controller', function () {
       await accountRecoveryController.checkAccountRecoveryDemand(request, hFake, dependencies);
 
       // then
-      expect(usecases.getAccountRecoveryDetails).to.have.been.calledWith({ temporaryKey });
-      expect(studentInformationForAccountRecoverySerializerStub.serializeAccountRecovery).to.have.been.calledWith(
-        studentInformation,
-      );
+      expect(usecases.getAccountRecoveryDetails).to.have.been.calledWithExactly({ temporaryKey });
+      expect(
+        studentInformationForAccountRecoverySerializerStub.serializeAccountRecovery,
+      ).to.have.been.calledWithExactly(studentInformation);
     });
   });
 

--- a/api/tests/unit/application/activity-answers/activity-answer-controller_test.js
+++ b/api/tests/unit/application/activity-answers/activity-answer-controller_test.js
@@ -54,7 +54,7 @@ describe('Unit | Controller | activity-answer-controller', function () {
       });
 
       // then
-      expect(usecases.correctAnswer).to.have.been.calledWith({
+      expect(usecases.correctAnswer).to.have.been.calledWithExactly({
         activityAnswer: deserializedPayload.activityAnswer,
         assessmentId,
       });

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -128,7 +128,7 @@ describe('Unit | Controller | answer-controller', function () {
 
       it('should call the usecase to save the answer', function () {
         // then
-        expect(usecases.correctAnswerThenUpdateAssessment).to.have.been.calledWith({
+        expect(usecases.correctAnswerThenUpdateAssessment).to.have.been.calledWithExactly({
           answer: deserializedAnswer,
           userId,
           locale,
@@ -137,7 +137,7 @@ describe('Unit | Controller | answer-controller', function () {
 
       it('should serialize the answer', function () {
         // then
-        expect(answerSerializerStub.serialize).to.have.been.calledWith(createdAnswer);
+        expect(answerSerializerStub.serialize).to.have.been.calledWithExactly(createdAnswer);
       });
       it('should return the serialized answer', function () {
         // then

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -179,7 +179,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
 
         // then
         expect(usecases.getNextChallengeForCertification).to.have.been.calledOnce;
-        expect(usecases.getNextChallengeForCertification).to.have.been.calledWith({
+        expect(usecases.getNextChallengeForCertification).to.have.been.calledWithExactly({
           assessment: certificationAssessment,
           locale,
         });
@@ -215,7 +215,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         await assessmentController.getNextChallenge({ params: { id: 1 } }, null, dependencies);
 
         // then
-        expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWith({
+        expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWithExactly({
           assessment,
           locale: defaultLocale,
         });
@@ -238,7 +238,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         );
 
         // then
-        expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWith({
+        expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWithExactly({
           assessment,
           locale,
         });
@@ -274,7 +274,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
           await assessmentController.getNextChallenge(request, null, dependencies);
 
           // then
-          expect(usecases.getNextChallengeForCompetenceEvaluation).to.have.been.calledWith({
+          expect(usecases.getNextChallengeForCompetenceEvaluation).to.have.been.calledWithExactly({
             assessment,
             userId,
             locale,

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -49,7 +49,7 @@ describe('Unit | Controller | assessment-controller-save', function () {
         await controller.save(request, hFake, { assessmentRepository: assessmentRepositoryStub });
 
         // then
-        expect(assessmentRepositoryStub.save).to.have.been.calledWith({ assessment: expected });
+        expect(assessmentRepositoryStub.save).to.have.been.calledWithExactly({ assessment: expected });
       });
     });
   });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -21,7 +21,7 @@ describe('Unit | Controller | assessment-controller', function () {
       });
 
       expect(result.statusCode).to.be.equal(201);
-      expect(assessmentSerializer.serialize).to.have.been.calledWith(createdAssessment);
+      expect(assessmentSerializer.serialize).to.have.been.calledWithExactly(createdAssessment);
     });
   });
   describe('#createAssessmentPreviewForPix1d', function () {
@@ -36,7 +36,7 @@ describe('Unit | Controller | assessment-controller', function () {
       });
 
       expect(result.statusCode).to.be.equal(201);
-      expect(assessmentSerializer.serialize).to.have.been.calledWith(createdAssessment);
+      expect(assessmentSerializer.serialize).to.have.been.calledWithExactly(createdAssessment);
     });
   });
   describe('#get', function () {
@@ -191,7 +191,7 @@ describe('Unit | Controller | assessment-controller', function () {
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(assessmentCompletedEvent);
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(assessmentCompletedEvent);
     });
   });
 

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -123,7 +123,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         await oidcController.getRedirectLogoutUrl(request, hFake, dependencies);
 
         // then
-        expect(oidcAuthenticationService.getRedirectLogoutUrl).to.have.been.calledWith({
+        expect(oidcAuthenticationService.getRedirectLogoutUrl).to.have.been.calledWithExactly({
           userId: '123',
           logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
         });
@@ -156,7 +156,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       await oidcController.getAuthenticationUrl(request, hFake, dependencies);
 
       //then
-      expect(oidcAuthenticationService.getAuthenticationUrl).to.have.been.calledWith({
+      expect(oidcAuthenticationService.getAuthenticationUrl).to.have.been.calledWithExactly({
         redirectUri: 'http:/exemple.net/',
       });
     });
@@ -212,7 +212,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       await oidcController.authenticateUser(request, hFake, dependencies);
 
       // then
-      expect(usecases.authenticateOidcUser).to.have.been.calledWith({
+      expect(usecases.authenticateOidcUser).to.have.been.calledWithExactly({
         code,
         redirectUri,
         stateReceived,

--- a/api/tests/unit/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaign-participations/campaign-participation-controller_test.js
@@ -76,7 +76,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       await campaignParticipationController.shareCampaignResult(request, hFake, dependencies);
 
       // then
-      expect(events.eventBus.publish).to.have.been.calledWith(
+      expect(events.eventBus.publish).to.have.been.calledWithExactly(
         campaignParticipationResultsSharedEvent,
         domainTransaction,
       );
@@ -183,7 +183,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       await campaignParticipationController.save(request, hFake, dependencies);
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(campaignParticipationStartedEvent);
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(campaignParticipationStartedEvent);
     });
 
     it('should return the serialized campaign participation when it has been successfully created', async function () {
@@ -205,7 +205,9 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const response = await campaignParticipationController.save(request, hFake, dependencies);
 
       // then
-      expect(dependencies.campaignParticipationSerializer.serialize).to.have.been.calledWith(campaignParticipation);
+      expect(dependencies.campaignParticipationSerializer.serialize).to.have.been.calledWithExactly(
+        campaignParticipation,
+      );
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCampaignParticipation);
     });
@@ -230,10 +232,12 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const response = await campaignParticipationController.save(request, hFake, dependencies);
 
       // then
-      expect(dependencies.monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+      expect(dependencies.monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
         message: errorInHandler,
       });
-      expect(dependencies.campaignParticipationSerializer.serialize).to.have.been.calledWith(campaignParticipation);
+      expect(dependencies.campaignParticipationSerializer.serialize).to.have.been.calledWithExactly(
+        campaignParticipation,
+      );
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCampaignParticipation);
     });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -459,7 +459,7 @@ describe('Unit | Application | Controller | Campaign', function () {
 
       // then
       expect(usecases.getCampaign).calledWith({ campaignId, userId });
-      expect(tokenServiceStub.createTokenForCampaignResults).to.have.been.calledWith({ userId, campaignId });
+      expect(tokenServiceStub.createTokenForCampaignResults).to.have.been.calledWithExactly({ userId, campaignId });
       expect(response).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/unit/application/campaigns-administration/index_test.js
+++ b/api/tests/unit/application/campaigns-administration/index_test.js
@@ -16,7 +16,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       await httpTestServer.request('POST', '/api/admin/campaigns/archive-campaigns', {});
 
       // then
-      expect(securityPreHandlers.adminMemberHasAtLeastOneAccessOf).to.have.been.calledWith([
+      expect(securityPreHandlers.adminMemberHasAtLeastOneAccessOf).to.have.been.calledWithExactly([
         securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
         securityPreHandlers.checkAdminMemberHasRoleMetier,
       ]);

--- a/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
+++ b/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
@@ -27,7 +27,7 @@ describe('Unit | Application | Certification-center-Invitations | Certification-
       );
 
       // then
-      expect(usecases.acceptCertificationCenterInvitation).to.have.been.calledWith({
+      expect(usecases.acceptCertificationCenterInvitation).to.have.been.calledWithExactly({
         certificationCenterInvitationId,
         code,
         email: notValidEmail.trim().toLowerCase(),

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -446,7 +446,7 @@ describe('Unit | Controller | certifications-center-controller', function () {
       });
 
       // then
-      expect(usecases.validateSessions).to.have.been.calledWith({
+      expect(usecases.validateSessions).to.have.been.calledWithExactly({
         sessions: ['session'],
         certificationCenterId: 123,
         userId: 2,
@@ -517,7 +517,7 @@ describe('Unit | Controller | certifications-center-controller', function () {
       await certificationCenterController.createSessionsForMassImport(request, hFake);
 
       // then
-      expect(usecases.createSessions).to.have.been.calledWith({
+      expect(usecases.createSessions).to.have.been.calledWithExactly({
         cachedValidatedSessionsKey: 'uuid',
         certificationCenterId: 123,
         userId: 2,

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -201,7 +201,7 @@ describe('Unit | Controller | certification-course-controller', function () {
       await certificationCourseController.update(options, hFake, { certificationSerializer });
 
       // then
-      expect(usecases.correctCandidateIdentityInCertificationCourse).to.have.been.calledWith({
+      expect(usecases.correctCandidateIdentityInCertificationCourse).to.have.been.calledWithExactly({
         command: {
           firstName: 'Phil',
           lastName: 'Defer',
@@ -413,7 +413,7 @@ describe('Unit | Controller | certification-course-controller', function () {
       await certificationCourseController.cancel(request, hFake);
 
       // then
-      expect(usecases.cancelCertificationCourse).to.have.been.calledWith({ certificationCourseId: 123 });
+      expect(usecases.cancelCertificationCourse).to.have.been.calledWithExactly({ certificationCourseId: 123 });
     });
   });
 
@@ -432,7 +432,7 @@ describe('Unit | Controller | certification-course-controller', function () {
       await certificationCourseController.uncancel(request, hFake);
 
       // then
-      expect(usecases.uncancelCertificationCourse).to.have.been.calledWith({ certificationCourseId: 123 });
+      expect(usecases.uncancelCertificationCourse).to.have.been.calledWithExactly({ certificationCourseId: 123 });
     });
   });
 });

--- a/api/tests/unit/application/certification-issue-reports/certification-issue-report-controller_test.js
+++ b/api/tests/unit/application/certification-issue-reports/certification-issue-report-controller_test.js
@@ -25,7 +25,7 @@ describe('Unit | Controller | certification-issue-report-controller', function (
 
       // then
       expect(response).to.be.null;
-      expect(usecases.deleteCertificationIssueReport).to.have.been.calledWith({ certificationIssueReportId });
+      expect(usecases.deleteCertificationIssueReport).to.have.been.calledWithExactly({ certificationIssueReportId });
     });
   });
 

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -259,7 +259,7 @@ describe('Unit | Controller | certifications-controller', function () {
       await certificationController.neutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
-      expect(usecases.neutralizeChallenge).to.have.been.calledWith({
+      expect(usecases.neutralizeChallenge).to.have.been.calledWithExactly({
         certificationCourseId: 1,
         challengeRecId: 'rec43mpMIR5dUzdjh',
         juryId: 7,
@@ -347,7 +347,7 @@ describe('Unit | Controller | certifications-controller', function () {
       await certificationController.deneutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
-      expect(usecases.deneutralizeChallenge).to.have.been.calledWith({
+      expect(usecases.deneutralizeChallenge).to.have.been.calledWithExactly({
         certificationCourseId: 1,
         challengeRecId: 'rec43mpMIR5dUzdjh',
         juryId: 7,
@@ -406,7 +406,7 @@ describe('Unit | Controller | certifications-controller', function () {
       await certificationController.deneutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
-      expect(eventsStub.eventDispatcher.dispatch).to.have.been.calledWith(eventToBeDispatched);
+      expect(eventsStub.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
     });
   });
 });

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -26,7 +26,7 @@ describe('Unit | Controller | challenge-controller', function () {
       });
 
       // then
-      expect(challengeRepository.get).to.have.been.calledWith(challengeId);
+      expect(challengeRepository.get).to.have.been.calledWithExactly(challengeId);
       expect(challengeSerializer.serialize).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
     });

--- a/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -54,7 +54,7 @@ describe('Unit | Application | Controller | Competence-Evaluation', function () 
       });
 
       // then
-      expect(competenceEvaluationSerializer.serialize).to.have.been.calledWith(competenceEvaluation);
+      expect(competenceEvaluationSerializer.serialize).to.have.been.calledWithExactly(competenceEvaluation);
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCompetenceEvaluation);
     });

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -27,7 +27,7 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
       await organizationInvitationController.acceptOrganizationInvitation(request);
 
       // then
-      expect(usecases.acceptOrganizationInvitation).to.have.been.calledWith({
+      expect(usecases.acceptOrganizationInvitation).to.have.been.calledWithExactly({
         organizationInvitationId: organizationInvitation.id,
         code,
         email,
@@ -58,7 +58,7 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
       await organizationInvitationController.acceptOrganizationInvitation(request);
 
       // then
-      expect(usecases.createCertificationCenterMembershipForScoOrganizationMember).to.have.been.calledWith({
+      expect(usecases.createCertificationCenterMembershipForScoOrganizationMember).to.have.been.calledWithExactly({
         membership,
       });
     });
@@ -85,7 +85,7 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
       });
 
       // then
-      expect(usecases.getOrganizationInvitation).to.have.been.calledWith({
+      expect(usecases.getOrganizationInvitation).to.have.been.calledWithExactly({
         organizationInvitationId,
         organizationInvitationCode,
       });

--- a/api/tests/unit/application/organization-learners/organization-learner-controller_test.js
+++ b/api/tests/unit/application/organization-learners/organization-learner-controller_test.js
@@ -31,8 +31,10 @@ describe('Unit | Application | Organization-Learner | organization-learner-contr
       });
 
       // then
-      expect(usecases.getOrganizationLearnerActivity).to.have.been.calledWith({ organizationLearnerId });
-      expect(organizationLearnerActivitySerializer.serialize).to.have.been.calledWith(organizationLearnerActivity);
+      expect(usecases.getOrganizationLearnerActivity).to.have.been.calledWithExactly({ organizationLearnerId });
+      expect(organizationLearnerActivitySerializer.serialize).to.have.been.calledWithExactly(
+        organizationLearnerActivity,
+      );
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.equal(serializedActivity);
     });
@@ -66,8 +68,8 @@ describe('Unit | Application | Organization-Learner | organization-learner-contr
       });
 
       // then
-      expect(usecases.getOrganizationLearner).to.have.been.calledWith({ organizationLearnerId });
-      expect(organizationLearnerSerializer.serialize).to.have.been.calledWith(organizationLearner);
+      expect(usecases.getOrganizationLearner).to.have.been.calledWithExactly({ organizationLearnerId });
+      expect(organizationLearnerSerializer.serialize).to.have.been.calledWithExactly(organizationLearner);
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.equal(serializedLearner);
     });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -325,7 +325,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredCampaigns(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredOrganizationCampaigns).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredOrganizationCampaigns).to.have.been.calledWithExactly({
         organizationId,
         filter: expectedFilter,
         page: expectedPage,
@@ -422,7 +422,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedCampaignManagements(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedCampaignManagements).to.have.been.calledWith({
+      expect(usecases.findPaginatedCampaignManagements).to.have.been.calledWithExactly({
         organizationId,
         filter: expectedFilter,
         page: expectedPage,
@@ -592,7 +592,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredScoParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: {},
         page: {},
@@ -617,7 +617,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredScoParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: { lastName: 'Bob', firstName: 'Tom', connectionTypes: ['email'], divisions: ['D1'] },
         page: {},
@@ -640,7 +640,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredScoParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: {},
         page: {},
@@ -661,7 +661,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredScoParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: {},
         page: { size: 10, number: 1 },
@@ -700,7 +700,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
 
       // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: { certificability: [true, false, null] },
         page: {},
@@ -754,7 +754,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredSupParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: {},
         page: {},
@@ -778,7 +778,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredSupParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: { lastName: 'Bob', firstName: 'Tom', group: 'L1' },
         page: {},
@@ -801,7 +801,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredSupParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: {},
         page: {},
@@ -820,7 +820,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredSupParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: {},
         page: { size: 10, number: 1 },
@@ -860,7 +860,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.findPaginatedFilteredSupParticipants(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWith({
+      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
         organizationId,
         filter: { certificability: [true, false, null] },
         page: {},
@@ -898,7 +898,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.importOrganizationLearnersFromSIECLE(request, hFake);
 
       // then
-      expect(usecases.importOrganizationLearnersFromSIECLEFormat).to.have.been.calledWith({
+      expect(usecases.importOrganizationLearnersFromSIECLEFormat).to.have.been.calledWithExactly({
         organizationId,
         payload,
         format,
@@ -939,7 +939,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.sendInvitations(request, hFake);
 
       // then
-      expect(usecases.createOrganizationInvitations).to.have.been.calledWith({ organizationId, emails, locale });
+      expect(usecases.createOrganizationInvitations).to.have.been.calledWithExactly({ organizationId, emails, locale });
     });
   });
 
@@ -1066,8 +1066,10 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const response = await organizationController.findPendingInvitations(request, hFake, dependencies);
 
       // then
-      expect(usecases.findPendingOrganizationInvitations).to.have.been.calledWith({ organizationId: organization.id });
-      expect(dependencies.organizationInvitationSerializer.serialize).to.have.been.calledWith(
+      expect(usecases.findPendingOrganizationInvitations).to.have.been.calledWithExactly({
+        organizationId: organization.id,
+      });
+      expect(dependencies.organizationInvitationSerializer.serialize).to.have.been.calledWithExactly(
         resolvedOrganizationInvitations,
       );
       expect(response).to.deep.equal(serializedOrganizationInvitations);
@@ -1373,7 +1375,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake, dependencies);
 
       // then
-      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWithExactly({
         organizationId,
         filters: {},
         page: {},
@@ -1400,7 +1402,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake, dependencies);
 
       // then
-      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWithExactly({
         organizationId,
         filters: { certificability: [true, false, null] },
         page: {},

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -50,11 +50,13 @@ describe('Unit | Controller | PasswordController', function () {
 
       // then
       expect(response.statusCode).to.equal(201);
-      expect(usecases.createPasswordResetDemand).to.have.been.calledWith({
+      expect(usecases.createPasswordResetDemand).to.have.been.calledWithExactly({
         email,
         locale,
       });
-      expect(dependencies.passwordResetSerializer.serialize).to.have.been.calledWith(resetPasswordDemand.attributes);
+      expect(dependencies.passwordResetSerializer.serialize).to.have.been.calledWithExactly(
+        resetPasswordDemand.attributes,
+      );
     });
   });
 
@@ -83,8 +85,8 @@ describe('Unit | Controller | PasswordController', function () {
       await passwordController.checkResetDemand(request, hFake, dependencies);
 
       // then
-      expect(usecases.getUserByResetPasswordDemand).to.have.been.calledWith({ temporaryKey });
-      expect(dependencies.userSerializer.serialize).to.have.been.calledWith({ email });
+      expect(usecases.getUserByResetPasswordDemand).to.have.been.calledWithExactly({ temporaryKey });
+      expect(dependencies.userSerializer.serialize).to.have.been.calledWithExactly({ email });
     });
   });
 

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -15,7 +15,10 @@ describe('Unit | Controller | pole-emploi-controller', function () {
         await poleEmploiController.getSendings(request, hFake);
 
         //then
-        expect(usecases.getPoleEmploiSendings).have.been.calledWith({ cursor: 'azefvbjljhgrEDJNH', filters: {} });
+        expect(usecases.getPoleEmploiSendings).have.been.calledWithExactly({
+          cursor: 'azefvbjljhgrEDJNH',
+          filters: {},
+        });
       });
     });
     context('when there are filters', function () {
@@ -30,7 +33,7 @@ describe('Unit | Controller | pole-emploi-controller', function () {
           await poleEmploiController.getSendings(request, hFake);
 
           //then
-          expect(usecases.getPoleEmploiSendings).have.been.calledWith({
+          expect(usecases.getPoleEmploiSendings).have.been.calledWithExactly({
             cursor: 'azefvbjljhgrEDJNH',
             filters: { isSuccessful: true },
           });
@@ -47,7 +50,7 @@ describe('Unit | Controller | pole-emploi-controller', function () {
           await poleEmploiController.getSendings(request, hFake);
 
           //then
-          expect(usecases.getPoleEmploiSendings).have.been.calledWith({
+          expect(usecases.getPoleEmploiSendings).have.been.calledWithExactly({
             cursor: 'azefvbjljhgrEDJNH',
             filters: { isSuccessful: false },
           });

--- a/api/tests/unit/application/progressions/progression-controller_test.js
+++ b/api/tests/unit/application/progressions/progression-controller_test.js
@@ -44,7 +44,7 @@ describe('Unit | Controller | progression-controller', function () {
           const response = await progressionController.get(request, hFake);
 
           // Then
-          expect(usecases.getProgression).to.have.been.calledWith({
+          expect(usecases.getProgression).to.have.been.calledWithExactly({
             progressionId,
             userId,
           });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -182,7 +182,7 @@ describe('Unit | Controller | sessionController', function () {
       await sessionController.importCertificationCandidatesFromCandidatesImportSheet(request);
 
       // then
-      expect(usecases.importCertificationCandidatesFromCandidatesImportSheet).to.have.been.calledWith({
+      expect(usecases.importCertificationCandidatesFromCandidatesImportSheet).to.have.been.calledWithExactly({
         sessionId,
         odsBuffer,
         i18n: request.i18n,
@@ -1080,7 +1080,7 @@ describe('Unit | Controller | sessionController', function () {
       });
 
       // then
-      expect(usecases.getSupervisorKitSessionInfo).to.have.been.calledWith({
+      expect(usecases.getSupervisorKitSessionInfo).to.have.been.calledWithExactly({
         userId,
         sessionId: sessionMainInfo.id,
       });

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -333,7 +333,7 @@ describe('Unit | Controller | target-profile-controller', function () {
       );
 
       // then
-      expect(usecases.findPaginatedTargetProfileTrainingSummaries).to.have.been.calledWith(useCaseParameters);
+      expect(usecases.findPaginatedTargetProfileTrainingSummaries).to.have.been.calledWithExactly(useCaseParameters);
       expect(queryParamsUtils.extractParameters).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
     });

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -36,7 +36,7 @@ describe('Unit | Controller | training-controller', function () {
       );
 
       // then
-      expect(usecases.findPaginatedTrainingSummaries).to.have.been.calledWith(useCaseParameters);
+      expect(usecases.findPaginatedTrainingSummaries).to.have.been.calledWithExactly(useCaseParameters);
       expect(trainingSummarySerializer.serialize).to.have.been.calledOnce;
       expect(queryParamsUtils.extractParameters).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
@@ -66,7 +66,7 @@ describe('Unit | Controller | training-controller', function () {
       );
 
       // then
-      expect(usecases.getTraining).to.have.been.calledWith({ trainingId });
+      expect(usecases.getTraining).to.have.been.calledWithExactly({ trainingId });
       expect(trainingSerializer.serializeForAdmin).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
     });
@@ -116,7 +116,7 @@ describe('Unit | Controller | training-controller', function () {
       await trainingController.create({ payload }, hFake, { trainingSerializer });
 
       // then
-      expect(trainingSerializer.deserialize).to.have.been.calledWith(payload);
+      expect(trainingSerializer.deserialize).to.have.been.calledWithExactly(payload);
       expect(usecases.createTraining).to.have.been.calledOnceWithExactly({ training: deserializedTraining });
     });
 
@@ -148,7 +148,7 @@ describe('Unit | Controller | training-controller', function () {
       );
 
       // then
-      expect(trainingSerializer.serialize).to.have.been.calledWith(createdTraining);
+      expect(trainingSerializer.serialize).to.have.been.calledWithExactly(createdTraining);
       expect(response.source).to.deep.equal(expectedSerializedTraining);
     });
   });
@@ -196,8 +196,8 @@ describe('Unit | Controller | training-controller', function () {
         );
 
         // then
-        expect(trainingSerializer.deserialize).to.have.been.calledWith(payload);
-        expect(usecases.updateTraining).to.have.been.calledWith(useCaseParameters);
+        expect(trainingSerializer.deserialize).to.have.been.calledWithExactly(payload);
+        expect(usecases.updateTraining).to.have.been.calledWithExactly(useCaseParameters);
       });
 
       it('should return a serialized training', async function () {
@@ -226,7 +226,7 @@ describe('Unit | Controller | training-controller', function () {
         );
 
         // then
-        expect(trainingSerializer.serialize).to.have.been.calledWith(updatedTraining);
+        expect(trainingSerializer.serialize).to.have.been.calledWithExactly(updatedTraining);
         expect(response).to.deep.equal(expectedSerializedUser);
       });
     });
@@ -297,7 +297,7 @@ describe('Unit | Controller | training-controller', function () {
       );
 
       // then
-      expect(usecases.createOrUpdateTrainingTrigger).to.have.been.calledWith({
+      expect(usecases.createOrUpdateTrainingTrigger).to.have.been.calledWithExactly({
         trainingId: 145,
         threshold: deserializedTrigger.threshold,
         type: deserializedTrigger.type,
@@ -329,7 +329,7 @@ describe('Unit | Controller | training-controller', function () {
       });
 
       // then
-      expect(usecases.findTargetProfileSummariesForTraining).to.have.been.calledWith({ trainingId });
+      expect(usecases.findTargetProfileSummariesForTraining).to.have.been.calledWithExactly({ trainingId });
       expect(result).to.be.equal(serializedTargetProfileSummaries);
     });
   });
@@ -352,7 +352,7 @@ describe('Unit | Controller | training-controller', function () {
 
       // then
       expect(response.statusCode).to.equal(204);
-      expect(usecases.attachTargetProfilesToTraining).to.have.been.calledWith({ trainingId, targetProfileIds });
+      expect(usecases.attachTargetProfilesToTraining).to.have.been.calledWithExactly({ trainingId, targetProfileIds });
     });
   });
 });

--- a/api/tests/unit/application/usecases/checkUserBelongsToLearnersOrganization_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToLearnersOrganization_test.js
@@ -37,7 +37,7 @@ describe('Unit | Application | Use Case | checkUserBelongsToLearnersOrganization
 
     // then
     expect(response).to.equal(true);
-    expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.have.been.calledWith({
+    expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.have.been.calledWithExactly({
       userId,
       organizationId: sharedOrganization.id,
     });
@@ -65,7 +65,7 @@ describe('Unit | Application | Use Case | checkUserBelongsToLearnersOrganization
 
     // then
     expect(response).to.equal(false);
-    expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.have.been.calledWith({
+    expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.have.been.calledWithExactly({
       userId,
       organizationId: anotherOrganization.id,
     });

--- a/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -67,12 +67,12 @@ describe('Unit | Controller | user-orga-settings-controller', function () {
 
     it('should call the usecase to update the userOrgaSetting', async function () {
       // then
-      expect(usecases.createOrUpdateUserOrgaSettings).to.have.been.calledWith({ userId, organizationId });
+      expect(usecases.createOrUpdateUserOrgaSettings).to.have.been.calledWithExactly({ userId, organizationId });
     });
 
     it('should serialize the userOrgaSettings', function () {
       // then
-      expect(userOrgaSettingsSerializer.serialize).to.have.been.calledWith(expectedUserOrgaSettings);
+      expect(userOrgaSettingsSerializer.serialize).to.have.been.calledWithExactly(expectedUserOrgaSettings);
     });
 
     it('should return the serialized userOrgaSettings', function () {

--- a/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
@@ -60,7 +60,7 @@ describe('Unit | Controller | User-tutorials', function () {
         expect(addTutorialToUserArgs).to.have.property('userId', userId);
         expect(addTutorialToUserArgs).to.have.property('tutorialId', tutorialId);
         expect(addTutorialToUserArgs).to.have.property('skillId', skillId);
-        expect(userSavedTutorialSerializer.deserialize).to.have.been.calledWith(request.payload);
+        expect(userSavedTutorialSerializer.deserialize).to.have.been.calledWithExactly(request.payload);
       });
     });
   });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -86,7 +86,7 @@ describe('Unit | Controller | user-controller', function () {
           );
 
           // then
-          expect(dependencies.userSerializer.serialize).to.have.been.calledWith(savedUser);
+          expect(dependencies.userSerializer.serialize).to.have.been.calledWithExactly(savedUser);
           expect(dependencies.localeService.getCanonicalLocale).to.not.have.been.called;
           expect(response.source).to.deep.equal(expectedSerializedUser);
           expect(response.statusCode).to.equal(201);
@@ -134,9 +134,9 @@ describe('Unit | Controller | user-controller', function () {
           );
 
           // then
-          expect(usecases.createUser).to.have.been.calledWith(useCaseParameters);
-          expect(dependencies.localeService.getCanonicalLocale).to.have.been.calledWith(localeFromCookie);
-          expect(dependencies.userSerializer.serialize).to.have.been.calledWith(savedUser);
+          expect(usecases.createUser).to.have.been.calledWithExactly(useCaseParameters);
+          expect(dependencies.localeService.getCanonicalLocale).to.have.been.calledWithExactly(localeFromCookie);
+          expect(dependencies.userSerializer.serialize).to.have.been.calledWithExactly(savedUser);
           expect(response.statusCode).to.equal(201);
         });
       });
@@ -840,7 +840,7 @@ describe('Unit | Controller | user-controller', function () {
       await userController.getProfile(request, hFake, { profileSerializer, requestResponseUtils });
 
       // then
-      expect(usecases.getUserProfile).to.have.been.calledWith({ userId, locale });
+      expect(usecases.getUserProfile).to.have.been.calledWithExactly({ userId, locale });
     });
   });
 
@@ -870,7 +870,7 @@ describe('Unit | Controller | user-controller', function () {
       await userController.getProfileForAdmin(request, hFake, { profileSerializer, requestResponseUtils });
 
       // then
-      expect(usecases.getUserProfile).to.have.been.calledWith({ userId, locale });
+      expect(usecases.getUserProfile).to.have.been.calledWithExactly({ userId, locale });
     });
   });
 
@@ -905,7 +905,7 @@ describe('Unit | Controller | user-controller', function () {
       await userController.resetScorecard(request, hFake, { scorecardSerializer, requestResponseUtils });
 
       // then
-      expect(usecases.resetScorecard).to.have.been.calledWith({ userId, competenceId, locale });
+      expect(usecases.resetScorecard).to.have.been.calledWithExactly({ userId, competenceId, locale });
     });
   });
 
@@ -986,10 +986,10 @@ describe('Unit | Controller | user-controller', function () {
       // then
       const expectedEvent = new UserAnonymized({ userId, updatedByUserId, role: 'SUPER_ADMIN' });
       expect(DomainTransaction.execute).to.have.been.called;
-      expect(usecases.anonymizeUser).to.have.been.calledWith({ userId, updatedByUserId, domainTransaction });
-      expect(usecases.getUserDetailsForAdmin).to.have.been.calledWith({ userId });
-      expect(eventBus.publish).to.have.been.calledWith(expectedEvent, domainTransaction);
-      expect(userAnonymizedDetailsForAdminSerializer.serialize).to.have.been.calledWith(userDetailsForAdmin);
+      expect(usecases.anonymizeUser).to.have.been.calledWithExactly({ userId, updatedByUserId, domainTransaction });
+      expect(usecases.getUserDetailsForAdmin).to.have.been.calledWithExactly({ userId });
+      expect(eventBus.publish).to.have.been.calledWithExactly(expectedEvent, domainTransaction);
+      expect(userAnonymizedDetailsForAdminSerializer.serialize).to.have.been.calledWithExactly(userDetailsForAdmin);
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal(anonymizedUserSerialized);
     });
@@ -1032,7 +1032,7 @@ describe('Unit | Controller | user-controller', function () {
       await userController.sendVerificationCode(request, hFake);
 
       // then
-      expect(usecases.sendVerificationCode).to.have.been.calledWith({
+      expect(usecases.sendVerificationCode).to.have.been.calledWithExactly({
         i18n,
         locale,
         newEmail,
@@ -1079,7 +1079,7 @@ describe('Unit | Controller | user-controller', function () {
       const response = await userController.updateUserEmailWithValidation(request, hFake, { updateEmailSerializer });
 
       // then
-      expect(usecases.updateUserEmailWithValidation).to.have.been.calledWith({
+      expect(usecases.updateUserEmailWithValidation).to.have.been.calledWithExactly({
         code,
         userId,
       });
@@ -1200,7 +1200,7 @@ describe('Unit | Controller | user-controller', function () {
         await userController.reassignAuthenticationMethods(request, hFake);
 
         // then
-        expect(usecases.reassignAuthenticationMethodToAnotherUser).to.have.been.calledWith({
+        expect(usecases.reassignAuthenticationMethodToAnotherUser).to.have.been.calledWithExactly({
           originUserId,
           targetUserId,
           authenticationMethodId,
@@ -1231,7 +1231,7 @@ describe('Unit | Controller | user-controller', function () {
       await userController.findUserOrganizationsForAdmin(request, hFake, { userOrganizationForAdminSerializer });
 
       // then
-      expect(usecases.findUserOrganizationsForAdmin).to.have.been.calledWith({ userId: 1 });
+      expect(usecases.findUserOrganizationsForAdmin).to.have.been.calledWithExactly({ userId: 1 });
     });
   });
 

--- a/api/tests/unit/domain/events/event-choreography-certification-rescoring-after-jury_test.js
+++ b/api/tests/unit/domain/events/event-choreography-certification-rescoring-after-jury_test.js
@@ -12,6 +12,9 @@ describe('Event Choreography | CertificationJuryDone', function () {
     await eventDispatcher.dispatch(event);
 
     // then
-    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ event, domainTransaction: undefined });
+    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWithExactly({
+      event,
+      domainTransaction: undefined,
+    });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-finalized-session_test.js
+++ b/api/tests/unit/domain/events/event-choreography-finalized-session_test.js
@@ -13,7 +13,7 @@ describe('Event Choreography | Finalized session', function () {
     await eventDispatcher.dispatch(event);
 
     // then
-    expect(handlerStubs.handleAutoJury).to.have.been.calledWith({ event, domainTransaction: undefined });
+    expect(handlerStubs.handleAutoJury).to.have.been.calledWithExactly({ event, domainTransaction: undefined });
   });
 
   it('Should trigger persisting a finalized session on Auto Jury Done event', async function () {
@@ -25,6 +25,6 @@ describe('Event Choreography | Finalized session', function () {
     await eventDispatcher.dispatch(event);
 
     // then
-    expect(handlerStubs.handleSessionFinalized).to.have.been.calledWith({ event, domainTransaction: undefined });
+    expect(handlerStubs.handleSessionFinalized).to.have.been.calledWithExactly({ event, domainTransaction: undefined });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/event-choreography-pole-emploi-participation-finished_test.js
@@ -13,6 +13,9 @@ describe('Event Choreography | Pole Emploi Participation Finished', function () 
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(handlerStubs.handlePoleEmploiParticipationFinished).to.have.been.calledWith({ event, domainTransaction });
+    expect(handlerStubs.handlePoleEmploiParticipationFinished).to.have.been.calledWithExactly({
+      event,
+      domainTransaction,
+    });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/event-choreography-pole-emploi-participation-started_test.js
@@ -13,6 +13,9 @@ describe('Event Choreography | Pole Emploi Participation Started', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(handlerStubs.handlePoleEmploiParticipationStarted).to.have.been.calledWith({ event, domainTransaction });
+    expect(handlerStubs.handlePoleEmploiParticipationStarted).to.have.been.calledWithExactly({
+      event,
+      domainTransaction,
+    });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-rescore-certification_test.js
+++ b/api/tests/unit/domain/events/event-choreography-rescore-certification_test.js
@@ -13,7 +13,10 @@ describe('Event Choreography | Rescore Certification', function () {
     await eventDispatcher.dispatch(event);
 
     // then
-    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ domainTransaction: undefined, event });
+    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWithExactly({
+      domainTransaction: undefined,
+      event,
+    });
   });
 
   it('Should trigger Certification Rescoring handler on ChallengeDeneutralized event', async function () {
@@ -25,6 +28,9 @@ describe('Event Choreography | Rescore Certification', function () {
     await eventDispatcher.dispatch(event);
 
     // then
-    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWith({ domainTransaction: undefined, event });
+    expect(handlerStubs.handleCertificationRescoring).to.have.been.calledWithExactly({
+      domainTransaction: undefined,
+      event,
+    });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-score-certification_test.js
+++ b/api/tests/unit/domain/events/event-choreography-score-certification_test.js
@@ -13,6 +13,6 @@ describe('Event Choreography | Score Certification', function () {
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(handlerStubs.handleCertificationScoring).to.have.been.calledWith({ domainTransaction, event });
+    expect(handlerStubs.handleCertificationScoring).to.have.been.calledWithExactly({ domainTransaction, event });
   });
 });

--- a/api/tests/unit/domain/events/event-choreography-score-pix-plus-certification_test.js
+++ b/api/tests/unit/domain/events/event-choreography-score-pix-plus-certification_test.js
@@ -21,7 +21,7 @@ describe('Event Choreography | Score Pix+ Certification', function () {
     await eventDispatcher.dispatch(certificationScoringCompleted);
 
     // then
-    expect(handlerStubs.handleComplementaryCertificationsScoring).to.have.been.calledWith({
+    expect(handlerStubs.handleComplementaryCertificationsScoring).to.have.been.calledWithExactly({
       event: certificationScoringCompleted,
       domainTransaction: undefined,
     });
@@ -43,7 +43,7 @@ describe('Event Choreography | Score Pix+ Certification', function () {
     await eventDispatcher.dispatch(certificationRescoringCompleted);
 
     // then
-    expect(handlerStubs.handleComplementaryCertificationsScoring).to.have.been.calledWith({
+    expect(handlerStubs.handleComplementaryCertificationsScoring).to.have.been.calledWithExactly({
       event: certificationRescoringCompleted,
       domainTransaction: undefined,
     });

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -90,7 +90,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
     // then
     expect(certificationIssueReport.isResolved()).to.be.true;
     expect(certificationIssueReport.hasBeenAutomaticallyResolved).to.be.true;
-    expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
+    expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(certificationAssessment);
   });
 
   it('returns an AutoJuryDone event as last event', async function () {
@@ -707,7 +707,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
 
       // then
       expect(certificationIssueReport2.isResolved()).to.be.true;
-      expect(logger.error).to.have.been.calledWith(anError);
+      expect(logger.error).to.have.been.calledWithExactly(anError);
     });
   });
 });

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -91,7 +91,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     });
 
     // then
-    expect(assessmentResultRepository.save).to.have.been.calledWith({
+    expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
       certificationCourseId: 123,
       assessmentResult: assessmentResultToBeSaved,
     });
@@ -481,7 +481,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         });
 
         // then
-        expect(assessmentResultRepository.save).to.have.been.calledWith({
+        expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
           certificationCourseId: 789,
           assessmentResult: assessmentResultToBeSaved,
         });

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
@@ -161,7 +161,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', f
         });
 
         // then
-        expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending });
+        expect(poleEmploiSendingRepository.create).to.have.been.calledWithExactly({ poleEmploiSending });
       });
     });
 

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
@@ -152,7 +152,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', fu
         });
 
         // then
-        expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending });
+        expect(poleEmploiSendingRepository.create).to.have.been.calledWithExactly({ poleEmploiSending });
       });
     });
 

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1509,7 +1509,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         await strategies.resolve({ certificationIssueReport, certificationAssessment });
 
         // then
-        expect(strategyStub).to.have.been.calledWith({
+        expect(strategyStub).to.have.been.calledWithExactly({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,

--- a/api/tests/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/unit/domain/models/UserDetailsForAdmin_test.js
@@ -33,7 +33,7 @@ describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
       const user = new UserDetailsForAdmin({ locale: 'fr-be' }, dependencies);
 
       // then
-      expect(localeService.getCanonicalLocale).to.have.been.calledWith('fr-be');
+      expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
       expect(user.locale).to.equal('fr-BE');
     });
   });

--- a/api/tests/unit/domain/models/UserToCreate_test.js
+++ b/api/tests/unit/domain/models/UserToCreate_test.js
@@ -23,7 +23,7 @@ describe('Unit | Domain | Models | UserToCreate', function () {
       const userToCreate = new UserToCreate({ locale: 'fr-be', dependencies: { localeService: localeServiceStub } });
 
       // then
-      expect(localeServiceStub.getCanonicalLocale).to.have.been.calledWith('fr-be');
+      expect(localeServiceStub.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
       expect(userToCreate.locale).to.equal('fr-BE');
     });
 

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -39,7 +39,7 @@ describe('Unit | Domain | Models | User', function () {
       const user = new User({ locale: 'fr-be' }, dependencies);
 
       // then
-      expect(localeService.getCanonicalLocale).to.have.been.calledWith('fr-be');
+      expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
       expect(user.locale).to.equal('fr-BE');
     });
   });
@@ -68,7 +68,7 @@ describe('Unit | Domain | Models | User', function () {
         user.setLocaleIfNotAlreadySet('fr-fr');
 
         // then
-        expect(localeService.getCanonicalLocale).to.have.been.calledWith('fr-fr');
+        expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-fr');
         expect(user.locale).to.equal('fr-FR');
         expect(user.hasBeenModified).to.be.true;
       });

--- a/api/tests/unit/domain/models/ValidatorQCM_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCM_test.js
@@ -34,7 +34,7 @@ describe('Unit | Domain | Models | ValidatorQCM', function () {
 
     it('should call solutionServiceQCU', function () {
       // then
-      expect(solutionServiceQcmStub.match).to.have.been.calledWith(uncorrectedAnswer.value, solution.value);
+      expect(solutionServiceQcmStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
     });
     it('should return a validation object with the returned status', function () {
       const expectedValidation = domainBuilder.buildValidation({

--- a/api/tests/unit/domain/models/ValidatorQCU_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCU_test.js
@@ -35,7 +35,7 @@ describe('Unit | Domain | Models | ValidatorQCU', function () {
 
     it('should call solutionServiceQCU', function () {
       // then
-      expect(solutionServiceQCUStub.match).to.have.been.calledWith(uncorrectedAnswer.value, solution.value);
+      expect(solutionServiceQCUStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
     });
     it('should return a validation object with the returned status', function () {
       const expectedValidation = domainBuilder.buildValidation({

--- a/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
@@ -42,7 +42,7 @@ describe('Unit | Domain | Models | ValidatorQROCMDep', function () {
 
     it('should call solutionServiceQROCMDep', function () {
       // then
-      expect(solutionServiceQROCMDepStub.match).to.have.been.calledWith({
+      expect(solutionServiceQROCMDepStub.match).to.have.been.calledWithExactly({
         answerValue: uncorrectedAnswer.value,
         solution,
       });

--- a/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
@@ -35,7 +35,7 @@ describe('Unit | Domain | Models | ValidatorQROCMInd', function () {
 
     it('should call solutionServiceQROCMInd', function () {
       // then
-      expect(solutionServiceQROCMIndStub.match).to.have.been.calledWith({
+      expect(solutionServiceQROCMIndStub.match).to.have.been.calledWithExactly({
         answerValue: uncorrectedAnswer.value,
         solution: solution,
       });

--- a/api/tests/unit/domain/models/ValidatorQROC_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROC_test.js
@@ -31,7 +31,7 @@ describe('Unit | Domain | Models | ValidatorQROC', function () {
 
     it('should call solutionServiceQROC', function () {
       // then
-      expect(solutionServiceQROCStub.match).to.have.been.calledWith({
+      expect(solutionServiceQROCStub.match).to.have.been.calledWithExactly({
         answer: uncorrectedAnswer.value,
         solution: solution,
         challengeFormat,

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -243,7 +243,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const expectedData = `client_secret=OIDC_CLIENT_SECRET&grant_type=authorization_code&code=AUTH_CODE&client_id=OIDC_CLIENT_ID&redirect_uri=pix.net%2Fconnexion%2Foidc`;
       const expectedHeaders = { 'content-type': 'application/x-www-form-urlencoded' };
 
-      expect(httpAgent.post).to.have.been.calledWith({
+      expect(httpAgent.post).to.have.been.calledWithExactly({
         url: 'http://oidc.net/api/token',
         payload: expectedData,
         headers: expectedHeaders,
@@ -286,7 +286,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.an.instanceOf(OidcInvokingTokenEndpointError);
         expect(error.message).to.equal('Erreur lors de la récupération des tokens du partenaire.');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
           message: {
             customMessage: 'Erreur lors de la récupération des tokens du partenaire.',
             errorDetails: JSON.stringify(errorResponse.data),
@@ -507,7 +507,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(errorResponse.message).to.be.equal(
           'Une erreur est survenue en récupérant les informations des utilisateurs.',
         );
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
           message: {
             customMessage: 'Une erreur est survenue en récupérant les informations des utilisateurs.',
             errorDetails: 'Pas de détails disponibles',
@@ -552,7 +552,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           `Les informations utilisateur renvoyées par votre fournisseur d'identité ${organizationName} ne sont pas au format attendu.`,
         );
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.badResponseFormat.code);
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
           message: {
             message: `Les informations utilisateur renvoyées par votre fournisseur d'identité ${organizationName} ne sont pas au format attendu.`,
             typeOfUserInfoContent: 'string',
@@ -599,7 +599,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcMissingFieldsError);
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
           message: errorMessage,
           missingFields: 'Champs manquants : family_name',
           userInfoContent: {
@@ -658,7 +658,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
 
       // then
-      expect(authenticationMethodRepository.create).to.have.been.calledWith({
+      expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
         authenticationMethod: expectedAuthenticationMethod,
         domainTransaction,
       });

--- a/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
@@ -55,7 +55,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
         });
 
         // then
-        expect(userRepository.getByUsernameOrEmailWithRolesAndPassword).to.has.been.calledWith(username);
+        expect(userRepository.getByUsernameOrEmailWithRolesAndPassword).to.has.been.calledWithExactly(username);
       });
 
       it('should call the encryptionService check function', async function () {
@@ -71,7 +71,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
         });
 
         // then
-        expect(encryptionService.checkPassword).to.has.been.calledWith({
+        expect(encryptionService.checkPassword).to.has.been.calledWithExactly({
           password,
           passwordHash: expectedPasswordHash,
         });
@@ -131,7 +131,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
 
           // then
           expect(resetUserTemporaryBlockingStub).to.have.been.calledOnce;
-          expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
+          expect(userLoginRepository.update).to.have.been.calledWithExactly(userLogin);
         });
       });
     });
@@ -178,11 +178,11 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             });
 
             // then
-            expect(userLoginRepository.create).to.have.been.calledWith({ userId: user.id });
+            expect(userLoginRepository.create).to.have.been.calledWithExactly({ userId: user.id });
             expect(userLoginCreated.incrementFailureCount).to.have.been.calledOnce;
             expect(userLoginCreated.markUserAsTemporarilyBlocked).to.not.have.been.called;
             expect(userLoginCreated.markUserAsBlocked).to.not.have.been.called;
-            expect(userLoginRepository.update).to.have.been.calledWith(userLoginCreated);
+            expect(userLoginRepository.update).to.have.been.calledWithExactly(userLoginCreated);
             expect(error).to.be.an.instanceof(PasswordNotMatching);
           });
         });
@@ -214,7 +214,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             expect(userLogin.incrementFailureCount).to.have.been.calledOnce;
             expect(userLogin.markUserAsTemporarilyBlocked).to.have.been.calledOnce;
             expect(userLogin.markUserAsBlocked).to.not.have.been.called;
-            expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
+            expect(userLoginRepository.update).to.have.been.calledWithExactly(userLogin);
             expect(error).to.be.an.instanceof(PasswordNotMatching);
           });
         });
@@ -247,7 +247,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             expect(userLogin.incrementFailureCount).to.have.been.calledOnce;
             expect(userLogin.markUserAsBlocked).to.have.been.calledOnce;
             expect(userLogin.markUserAsTemporarilyBlocked).to.not.have.been.called;
-            expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
+            expect(userLoginRepository.update).to.have.been.calledWithExactly(userLogin);
           });
         });
       });

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -422,7 +422,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(cpfBirthInformationValidation);
-            expect(certificationCpfCityRepository.findByINSEECode).to.have.been.calledWith({
+            expect(certificationCpfCityRepository.findByINSEECode).to.have.been.calledWithExactly({
               INSEECode: birthInformation.birthINSEECode,
             });
           });
@@ -534,7 +534,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(cpfBirthInformationValidation);
-            expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({
+            expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWithExactly({
               postalCode: birthInformation.birthPostalCode,
             });
           });
@@ -582,7 +582,7 @@ describe('Unit | Service | Certification CPF service', function () {
 
               // then
               expect(result).to.deep.equal(cpfBirthInformationValidation);
-              expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({
+              expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWithExactly({
                 postalCode: birthInformation.birthPostalCode,
               });
             });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -757,7 +757,7 @@ describe('Unit | Service | MailService', function () {
       });
 
       // then
-      expect(mailer.sendEmail).to.have.been.calledWith({
+      expect(mailer.sendEmail).to.have.been.calledWithExactly({
         from: 'ne-pas-repondre@pix.fr',
         fromName: 'PIX - Ne pas répondre',
         to: email,
@@ -782,7 +782,7 @@ describe('Unit | Service | MailService', function () {
       });
 
       // then
-      expect(mailer.sendEmail).to.have.been.calledWith({
+      expect(mailer.sendEmail).to.have.been.calledWithExactly({
         from: 'ne-pas-repondre@pix.fr',
         fromName: 'PIX - Ne pas répondre',
         to: email,

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -68,13 +68,13 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         });
 
         // then
-        expect(organizationInvitationRepository.create).to.has.been.calledWith({
+        expect(organizationInvitationRepository.create).to.has.been.calledWithExactly({
           organizationId: organization.id,
           email: userEmailAddress,
           code: sinon.match.string,
           role,
         });
-        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith({
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWithExactly({
           email: userEmailAddress,
           organizationName: organization.name,
           organizationInvitationId: organizationInvitation.id,
@@ -160,7 +160,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           tags,
         };
 
-        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWithExactly(expectedParameters);
       });
 
       it('should update organization-invitation modification date', async function () {
@@ -187,7 +187,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         });
 
         // then
-        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(
+        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWithExactly(
           organizationInvitation.id,
         );
       });
@@ -289,7 +289,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           locale,
           tags,
         };
-        expect(mailService.sendScoOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+        expect(mailService.sendScoOrganizationInvitationEmail).to.has.been.calledWithExactly(expectedParameters);
       });
 
       it('should send an email with organizationId, email, code and tags', async function () {
@@ -338,7 +338,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           locale,
           tags,
         };
-        expect(mailService.sendScoOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+        expect(mailService.sendScoOrganizationInvitationEmail).to.has.been.calledWithExactly(expectedParameters);
       });
     });
 
@@ -383,7 +383,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           tags,
         };
 
-        expect(mailService.sendScoOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+        expect(mailService.sendScoOrganizationInvitationEmail).to.has.been.calledWithExactly(expectedParameters);
       });
 
       it('should update organization-invitation modification date', async function () {
@@ -414,7 +414,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         });
 
         // then
-        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(
+        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWithExactly(
           organizationInvitation.id,
         );
       });
@@ -468,7 +468,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         });
 
         // then
-        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWithExactly(expectedParameters);
       });
     });
 
@@ -510,7 +510,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           tags,
         };
 
-        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWithExactly(expectedParameters);
       });
 
       it('should update organization-invitation modification date', async function () {
@@ -539,7 +539,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         });
 
         // then
-        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(
+        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWithExactly(
           organizationInvitation.id,
         );
       });

--- a/api/tests/unit/domain/services/password-generator_test.js
+++ b/api/tests/unit/domain/services/password-generator_test.js
@@ -43,7 +43,7 @@ describe('Unit | Service | password-generator', function () {
       generatedPassword = service.generateComplexPassword();
 
       // then
-      expect(randomString.generate).to.have.been.calledWith({
+      expect(randomString.generate).to.have.been.calledWithExactly({
         length: 32,
         charset: 'alphanumeric',
       });

--- a/api/tests/unit/domain/services/refresh-token-service_test.js
+++ b/api/tests/unit/domain/services/refresh-token-service_test.js
@@ -31,11 +31,11 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
       const result = await refreshTokenService.createRefreshTokenFromUserId({ userId, source, uuidGenerator });
 
       // then
-      expect(userRefreshTokensTemporaryStorage.lpush).to.have.been.calledWith({
+      expect(userRefreshTokensTemporaryStorage.lpush).to.have.been.calledWithExactly({
         key: 123,
         value: '123:aaaabbbb-1111-ffff-8888-7777dddd0000',
       });
-      expect(userRefreshTokensTemporaryStorage.expire).to.have.been.calledWith({
+      expect(userRefreshTokensTemporaryStorage.expire).to.have.been.calledWithExactly({
         key: 123,
         expirationDelaySeconds: settings.authentication.refreshTokenLifespanMs / 1000 + 60 * 60,
       });
@@ -101,8 +101,11 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
       await refreshTokenService.revokeRefreshToken({ refreshToken });
 
       // then
-      expect(userRefreshTokensTemporaryStorage.lrem).to.have.been.calledWith({ key: 123, valueToRemove: refreshToken });
-      expect(refreshTokenTemporaryStorage.delete).to.have.been.calledWith(refreshToken);
+      expect(userRefreshTokensTemporaryStorage.lrem).to.have.been.calledWithExactly({
+        key: 123,
+        valueToRemove: refreshToken,
+      });
+      expect(refreshTokenTemporaryStorage.delete).to.have.been.calledWithExactly(refreshToken);
     });
 
     it('should do nothing if the refresh token does not exist', async function () {
@@ -132,10 +135,10 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
       await refreshTokenService.revokeRefreshTokensForUserId({ userId: '123' });
 
       // then
-      expect(userRefreshTokensTemporaryStorage.lrange).to.have.been.calledWith('123');
-      expect(userRefreshTokensTemporaryStorage.delete).to.have.been.calledWith('123');
-      expect(refreshTokenTemporaryStorage.delete).to.have.been.calledWith('123:uuid1');
-      expect(refreshTokenTemporaryStorage.delete).to.have.been.calledWith('123:uuid2');
+      expect(userRefreshTokensTemporaryStorage.lrange).to.have.been.calledWithExactly('123');
+      expect(userRefreshTokensTemporaryStorage.delete).to.have.been.calledWithExactly('123');
+      expect(refreshTokenTemporaryStorage.delete).to.have.been.calledWithExactly('123:uuid1');
+      expect(refreshTokenTemporaryStorage.delete).to.have.been.calledWithExactly('123:uuid2');
     });
   });
 });

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -125,7 +125,7 @@ describe('Unit | UseCase | session-publication-service', function () {
 
           // then
           expect(finalizedSession.publishedAt).to.equal(now);
-          expect(finalizedSessionRepository.save).to.have.been.calledWith(finalizedSession);
+          expect(finalizedSessionRepository.save).to.have.been.calledWithExactly(finalizedSession);
         });
       });
     });
@@ -245,7 +245,7 @@ describe('Unit | UseCase | session-publication-service', function () {
         });
 
         // then
-        expect(sessionRepository.flagResultsAsSentToPrescriber).to.have.been.calledWith({
+        expect(sessionRepository.flagResultsAsSentToPrescriber).to.have.been.calledWithExactly({
           id: sessionId,
           resultsSentToPrescriberAt: now,
         });
@@ -387,7 +387,7 @@ describe('Unit | UseCase | session-publication-service', function () {
         });
 
         // then
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledWith({
+        expect(mailService.sendCertificationResultEmail).to.have.been.calledWithExactly({
           sessionId,
           resultRecipientEmail: 'email1@example.net',
           daysBeforeExpiration: 30,
@@ -396,7 +396,7 @@ describe('Unit | UseCase | session-publication-service', function () {
           email: 'email1@example.net',
           translate: i18n.__,
         });
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledWith({
+        expect(mailService.sendCertificationResultEmail).to.have.been.calledWithExactly({
           sessionId,
           resultRecipientEmail: 'email2@example.net',
           daysBeforeExpiration: 30,

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -33,9 +33,13 @@ describe('Unit | Domain | Service | Token Service', function () {
 
       // then
       expect(accessTokenForCampaignResults).to.equal(generatedAccessToken);
-      expect(jsonwebtoken.sign).to.have.been.calledWith({ access_id: userId, campaign_id: campaignId }, 'a secret', {
-        expiresIn: 10,
-      });
+      expect(jsonwebtoken.sign).to.have.been.calledWithExactly(
+        { access_id: userId, campaign_id: campaignId },
+        'a secret',
+        {
+          expiresIn: 10,
+        },
+      );
     });
   });
 

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -736,7 +736,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
           // then
           expect(error).to.be.instanceof(OrganizationLearnerAlreadyLinkedToUserError);
-          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
+          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWithExactly(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
           expect(error.code).to.equal('ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION');
           expect(error.meta.shortCode).to.equal('R32');
@@ -768,7 +768,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
           // then
           expect(error).to.be.instanceof(OrganizationLearnerAlreadyLinkedToUserError);
-          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
+          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWithExactly(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
           expect(error.code).to.equal('ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION');
           expect(error.meta.shortCode).to.equal('R33');
@@ -839,7 +839,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
           // then
           expect(error).to.be.instanceof(OrganizationLearnerAlreadyLinkedToUserError);
-          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
+          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWithExactly(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans un autre établissement.');
           expect(error.code).to.equal('ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION');
           expect(error.meta.shortCode).to.equal('R12');
@@ -874,7 +874,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
 
           // then
           expect(error).to.be.instanceof(OrganizationLearnerAlreadyLinkedToUserError);
-          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWith(user.id);
+          expect(userRepositoryStub.getForObfuscation).to.have.been.calledWithExactly(user.id);
           expect(error.message).to.equal('Un compte existe déjà pour l‘élève dans un autre établissement.');
           expect(error.code).to.equal('ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION');
           expect(error.meta.shortCode).to.equal('R13');

--- a/api/tests/unit/domain/usecases/accept-certification-center-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-certification-center-invitation_test.js
@@ -59,8 +59,10 @@ describe('Unit | UseCase | accept-certification-center-invitation', function () 
     });
 
     // then
-    expect(certificationCenterInvitedUserRepository.save).to.have.been.calledWith(certificationCenterInvitedUser);
-    expect(userRepository.update).to.have.been.calledWith({ id: user.id, locale: 'fr-BE' });
+    expect(certificationCenterInvitedUserRepository.save).to.have.been.calledWithExactly(
+      certificationCenterInvitedUser,
+    );
+    expect(userRepository.update).to.have.been.calledWithExactly({ id: user.id, locale: 'fr-BE' });
   });
 
   it('does not sets the user locale if there is not a localeFromCookie, updates the invitation status to accepted with date and creates a membership for the user', async function () {

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -55,7 +55,7 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
       });
 
       // then
-      expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitation.id);
+      expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWithExactly(organizationInvitation.id);
       expect(error).to.be.instanceOf(AlreadyExistingMembershipError);
     });
   });
@@ -86,7 +86,7 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
         });
 
         // then
-        expect(organizationInvitedUserRepository.save).to.have.been.calledWith({ organizationInvitedUser });
+        expect(organizationInvitedUserRepository.save).to.have.been.calledWithExactly({ organizationInvitedUser });
         expect(result).to.deep.equal({
           id: organizationInvitedUser.currentMembershipId,
           isAdmin: false,
@@ -142,7 +142,7 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
           });
 
           // then
-          expect(userRepository.update).to.have.have.been.calledWith({ id: user.id, locale: 'fr-BE' });
+          expect(userRepository.update).to.have.have.been.calledWithExactly({ id: user.id, locale: 'fr-BE' });
         });
       });
     });

--- a/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | accept-pix-certif-terms-of-service', function () {
     const actualUpdatedUser = await acceptPixCertifTermsOfService({ userId, userRepository });
 
     // then
-    expect(userRepository.updatePixCertifTermsOfServiceAcceptedToTrue).to.have.been.calledWith(userId);
+    expect(userRepository.updatePixCertifTermsOfServiceAcceptedToTrue).to.have.been.calledWithExactly(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 });

--- a/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | accept-pix-orga-terms-of-service', function () {
     const actualUpdatedUser = await acceptPixOrgaTermsOfService({ userId, userRepository });
 
     // then
-    expect(userRepository.updatePixOrgaTermsOfServiceAcceptedToTrue).to.have.been.calledWith(userId);
+    expect(userRepository.updatePixOrgaTermsOfServiceAcceptedToTrue).to.have.been.calledWithExactly(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 });

--- a/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | accept-pix-last-terms-of-service', function () {
     const actualUpdatedUser = await acceptPixLastTermsOfService({ userId, userRepository });
 
     // then
-    expect(userRepository.acceptPixLastTermsOfService).to.have.been.calledWith(userId);
+    expect(userRepository.acceptPixLastTermsOfService).to.have.been.calledWithExactly(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 });

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
@@ -79,7 +79,7 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
         }),
         userId: user.id,
       });
-      expect(authenticationMethodRepository.create).to.have.been.calledWith(
+      expect(authenticationMethodRepository.create).to.have.been.calledWithExactly(
         {
           authenticationMethod: expectedAuthenticationMethodFromPix,
         },
@@ -120,7 +120,7 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
       });
 
       // then
-      expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWith(
+      expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWithExactly(
         {
           userId: user.id,
           hashedPassword,
@@ -183,7 +183,10 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
     });
 
     // then
-    expect(accountRecoveryDemandRepository.markAsBeingUsed).to.have.been.calledWith(temporaryKey);
+    expect(accountRecoveryDemandRepository.markAsBeingUsed).to.have.been.calledWithExactly(
+      temporaryKey,
+      domainTransaction,
+    );
   });
 
   it('should save last terms of service validated at date', async function () {
@@ -239,6 +242,6 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
       },
       domainTransaction,
     };
-    expect(userRepository.updateWithEmailConfirmed).to.have.been.calledWith(expectedParams);
+    expect(userRepository.updateWithEmailConfirmed).to.have.been.calledWithExactly(expectedParams);
   });
 });

--- a/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
+++ b/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
@@ -82,7 +82,7 @@ describe('Unit | UseCase | add-pix-authentication-method-by-email', function () 
           shouldChangePassword: false,
         }),
       });
-      expect(authenticationMethodRepository.create).to.have.been.calledWith({
+      expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
         authenticationMethod: authenticationMethodFromPix,
       });
     });
@@ -110,7 +110,7 @@ describe('Unit | UseCase | add-pix-authentication-method-by-email', function () 
     });
 
     // then
-    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
       id: user.id,
       userAttributes: { email },
     });

--- a/api/tests/unit/domain/usecases/add-tutorial-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/add-tutorial-evaluation_test.js
@@ -32,7 +32,11 @@ describe('Unit | UseCase | add-tutorial-evaluation', function () {
       });
 
       // Then
-      expect(tutorialEvaluationRepository.createOrUpdate).to.have.been.calledWith({ userId, tutorialId, status });
+      expect(tutorialEvaluationRepository.createOrUpdate).to.have.been.calledWithExactly({
+        userId,
+        tutorialId,
+        status,
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/add-tutorial-to-user_test.js
+++ b/api/tests/unit/domain/usecases/add-tutorial-to-user_test.js
@@ -33,7 +33,7 @@ describe('Unit | UseCase | add-tutorial-to-user', function () {
         });
 
         // Then
-        expect(userSavedTutorialRepository.addTutorial).to.have.been.calledWith({ userId, tutorialId, skillId });
+        expect(userSavedTutorialRepository.addTutorial).to.have.been.calledWithExactly({ userId, tutorialId, skillId });
         expect(skillRepository.get).not.to.have.been.called;
       });
     });
@@ -58,8 +58,12 @@ describe('Unit | UseCase | add-tutorial-to-user', function () {
           });
 
           // Then
-          expect(userSavedTutorialRepository.addTutorial).to.have.been.calledWith({ userId, tutorialId, skillId });
-          expect(skillRepository.get).to.have.been.calledWith(skillId);
+          expect(userSavedTutorialRepository.addTutorial).to.have.been.calledWithExactly({
+            userId,
+            tutorialId,
+            skillId,
+          });
+          expect(skillRepository.get).to.have.been.calledWithExactly(skillId);
         });
       });
 
@@ -83,7 +87,7 @@ describe('Unit | UseCase | add-tutorial-to-user', function () {
 
           // Then
           expect(error).to.be.instanceOf(NotFoundError);
-          expect(skillRepository.get).to.have.been.calledWith(skillId);
+          expect(skillRepository.get).to.have.been.calledWithExactly(skillId);
         });
       });
     });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -76,12 +76,12 @@ describe('Unit | UseCase | anonymize-user', function () {
       domainTransaction,
     });
     expect(refreshTokenService.revokeRefreshTokensForUserId).to.have.been.calledWithExactly({ userId });
-    expect(membershipRepository.disableMembershipsByUserId).to.have.been.calledWith({
+    expect(membershipRepository.disableMembershipsByUserId).to.have.been.calledWithExactly({
       userId,
       updatedByUserId,
       domainTransaction,
     });
-    expect(certificationCenterMembershipRepository.disableMembershipsByUserId).to.have.been.calledWith({
+    expect(certificationCenterMembershipRepository.disableMembershipsByUserId).to.have.been.calledWithExactly({
       updatedByUserId,
       userId,
       domainTransaction,
@@ -95,6 +95,6 @@ describe('Unit | UseCase | anonymize-user', function () {
       userId,
       domainTransaction,
     });
-    expect(adminMemberRepository.get).to.have.been.calledWith({ userId: updatedByUserId });
+    expect(adminMemberRepository.get).to.have.been.calledWithExactly({ userId: updatedByUserId });
   });
 });

--- a/api/tests/unit/domain/usecases/archive-campaign-from-campaign-code_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign-from-campaign-code_test.js
@@ -30,6 +30,6 @@ describe('Unit | UseCase | archive-campaign', function () {
     await archiveCampaignFromCampaignCode({ userId, campaignCode, campaignForArchivingRepository });
 
     expect(campaignForArchivingRepository.getByCode).to.have.been.calledWithExactly(campaignCode);
-    expect(campaignForArchivingRepository.save).to.have.been.calledWith(expectedCampaign);
+    expect(campaignForArchivingRepository.save).to.have.been.calledWithExactly(expectedCampaign);
   });
 });

--- a/api/tests/unit/domain/usecases/archive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign_test.js
@@ -27,7 +27,7 @@ describe('Unit | UseCase | archive-campaign', function () {
 
     await archiveCampaign({ campaignId: 1, userId: 12, campaignForArchivingRepository });
 
-    expect(campaignForArchivingRepository.get).to.have.been.calledWith(1);
-    expect(campaignForArchivingRepository.save).to.have.been.calledWith(expectedCampaign);
+    expect(campaignForArchivingRepository.get).to.have.been.calledWithExactly(1);
+    expect(campaignForArchivingRepository.save).to.have.been.calledWithExactly(expectedCampaign);
   });
 });

--- a/api/tests/unit/domain/usecases/archive-organization_test.js
+++ b/api/tests/unit/domain/usecases/archive-organization_test.js
@@ -33,11 +33,11 @@ describe('Unit | UseCase | archive-organization', function () {
     });
 
     // then
-    expect(organizationForAdminRepository.archive).to.have.been.calledWith({
+    expect(organizationForAdminRepository.archive).to.have.been.calledWithExactly({
       id: organizationId,
       archivedBy: superAdminUser.id,
     });
-    expect(organizationForAdminRepository.get).to.have.been.calledWith(organizationId);
+    expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organizationId);
     expect(archivedOrganizationForAdmin).to.deep.equal(expectedArchivedOrganization);
     clock.restore();
   });

--- a/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
+++ b/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
@@ -36,11 +36,11 @@ describe('Unit | UseCase | assign-certification-officer-to-session', function ()
     });
 
     // then
-    expect(jurySessionRepository.assignCertificationOfficer).to.have.been.calledWith({
+    expect(jurySessionRepository.assignCertificationOfficer).to.have.been.calledWithExactly({
       id: finalizedSession.sessionId,
       assignedCertificationOfficerId: certificationOfficer.id,
     });
-    expect(finalizedSessionRepository.save).to.have.been.calledWith(finalizedSession);
+    expect(finalizedSessionRepository.save).to.have.been.calledWithExactly(finalizedSession);
     expect(actualSessionId).to.equal(returnedSessionId);
   });
 });

--- a/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
@@ -47,7 +47,7 @@ describe('Unit | UseCase | authenticate-anonymous-user', function () {
       lang: lang,
       hasSeenAssessmentInstructions: false,
     };
-    expect(campaignToJoinRepository.getByCode).to.have.been.calledWith(campaignCode);
+    expect(campaignToJoinRepository.getByCode).to.have.been.calledWithExactly(campaignCode);
     expect(userToCreateRepository.create).to.have.been.calledWithMatch({ user: expectedUser });
   });
 

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -121,7 +121,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
     });
 
     it("should throw an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {
@@ -244,7 +244,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
             lastName: 'Le Terrier',
           }),
         });
-        expect(authenticationMethodRepository.create).to.have.been.calledWith({
+        expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
           authenticationMethod: expectedAuthenticationMethod,
         });
       });
@@ -296,7 +296,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
             lastName: 'Samoëns',
           }),
         });
-        expect(authenticationMethodRepository.create).to.have.been.calledWith({
+        expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
           authenticationMethod: expectedAuthenticationMethod,
         });
       });

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
       // then
       expect(error).to.be.an.instanceOf(UnexpectedOidcStateError);
-      expect(logger.error).to.have.been.calledWith(
+      expect(logger.error).to.have.been.calledWithExactly(
         `State sent ${stateSent} did not match the state received ${stateReceived}`,
       );
     });
@@ -99,7 +99,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
     });
 
     // then
-    expect(oidcAuthenticationService.getUserInfo).to.have.been.calledWith({
+    expect(oidcAuthenticationService.getUserInfo).to.have.been.calledWithExactly({
       idToken: sessionContent.idToken,
       accessToken: sessionContent.accessToken,
     });
@@ -121,7 +121,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
     });
 
     // then
-    expect(userRepository.findByExternalIdentifier).to.have.been.calledWith({
+    expect(userRepository.findByExternalIdentifier).to.have.been.calledWithExactly({
       externalIdentityId,
       identityProvider: oidcAuthenticationService.identityProvider,
     });
@@ -149,7 +149,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       });
 
       // then
-      expect(authenticationSessionService.save).to.have.been.calledWith(sessionContent);
+      expect(authenticationSessionService.save).to.have.been.calledWithExactly(sessionContent);
       expect(result).to.deep.equal({ authenticationKey, givenName, familyName, isAuthenticationComplete: false });
     });
 
@@ -227,7 +227,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         // then
         expect(
           authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
-        ).to.have.been.calledWith({
+        ).to.have.been.calledWithExactly({
           authenticationComplement,
           userId: 1,
           identityProvider: oidcAuthenticationService.identityProvider,
@@ -297,7 +297,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       // then
       expect(
         authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
-      ).to.have.been.calledWith({
+      ).to.have.been.calledWithExactly({
         authenticationComplement,
         userId: 10,
         identityProvider: oidcAuthenticationService.identityProvider,

--- a/api/tests/unit/domain/usecases/authorize-certification-candidate-to-resume_test.js
+++ b/api/tests/unit/domain/usecases/authorize-certification-candidate-to-resume_test.js
@@ -23,7 +23,7 @@ describe('Unit | Domain | Use Cases | authorize-certification-candidate-to-resum
     });
 
     // then
-    expect(certificationCandidateForSupervisingRepository.update).to.have.been.calledWith(
+    expect(certificationCandidateForSupervisingRepository.update).to.have.been.calledWithExactly(
       domainBuilder.buildCertificationCandidateForSupervising({
         authorizedToStart: true,
       }),

--- a/api/tests/unit/domain/usecases/authorize-certification-candidate-to-start_test.js
+++ b/api/tests/unit/domain/usecases/authorize-certification-candidate-to-start_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Use Cases | authorize-certification-candidate-to-start
     });
 
     // then
-    expect(certificationCandidateForSupervisingRepository.update).to.have.been.calledWith({
+    expect(certificationCandidateForSupervisingRepository.update).to.have.been.calledWithExactly({
       id: updatedCertificationCandidateForSupervising.id,
       authorizedToStart: updatedCertificationCandidateForSupervising.authorizedToStart,
     });

--- a/api/tests/unit/domain/usecases/campaigns-administration/archive-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/campaigns-administration/archive-campaigns_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | archive-campaign', function () {
         campaignAdministrationRepository,
       });
 
-      expect(campaignAdministrationRepository.archiveCampaigns).to.have.been.calledWith(campaignIds, userId);
+      expect(campaignAdministrationRepository.archiveCampaigns).to.have.been.calledWithExactly(campaignIds, userId);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/cancel-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/cancel-certification-course_test.js
@@ -21,6 +21,6 @@ describe('Unit | UseCase | cancel-certification-course', function () {
 
     // then
     expect(certificationCourse.cancel).to.have.been.calledOnce;
-    expect(certificationCourseRepository.update).to.have.been.calledWith(certificationCourse);
+    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
   });
 });

--- a/api/tests/unit/domain/usecases/change-user-lang_test.js
+++ b/api/tests/unit/domain/usecases/change-user-lang_test.js
@@ -22,8 +22,8 @@ describe('Unit | UseCase | change-user-lang', function () {
     const actualUpdatedUser = await changeUserLang({ userId, lang, userRepository });
 
     // then
-    expect(userRepository.update).to.have.been.calledWith({ id: userId, lang });
-    expect(userRepository.getFullById).to.have.been.calledWith(userId);
+    expect(userRepository.update).to.have.been.calledWithExactly({ id: userId, lang });
+    expect(userRepository.getFullById).to.have.been.calledWithExactly(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 });

--- a/api/tests/unit/domain/usecases/compute-organization-learner-certificability_test.js
+++ b/api/tests/unit/domain/usecases/compute-organization-learner-certificability_test.js
@@ -41,7 +41,7 @@ describe('Unit | UseCase | compute-organization-learner-certificabilty', functio
     });
 
     // then
-    expect(organizationLearner.updateCertificability).to.have.been.calledWith(placementProfile);
-    expect(organizationLearnerRepository.updateCertificability).to.have.been.calledWith(organizationLearner);
+    expect(organizationLearner.updateCertificability).to.have.been.calledWithExactly(placementProfile);
+    expect(organizationLearnerRepository.updateCertificability).to.have.been.calledWithExactly(organizationLearner);
   });
 });

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -207,7 +207,10 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         });
 
         // then
-        expect(answerRepository.saveWithKnowledgeElements).to.have.been.calledWith(completedAnswer);
+        expect(answerRepository.saveWithKnowledgeElements).to.have.been.calledWithExactly(completedAnswer, [
+          firstCreatedKnowledgeElement,
+          secondCreatedKnowledgeElement,
+        ]);
       });
 
       it('should call repositories to get needed information', async function () {
@@ -219,8 +222,8 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         });
 
         // then
-        expect(skillRepository.findActiveByCompetenceId).to.have.been.calledWith(assessment.competenceId);
-        expect(knowledgeElementRepository.findUniqByUserIdAndAssessmentId).to.have.been.calledWith({
+        expect(skillRepository.findActiveByCompetenceId).to.have.been.calledWithExactly(assessment.competenceId);
+        expect(knowledgeElementRepository.findUniqByUserIdAndAssessmentId).to.have.been.calledWithExactly({
           userId: assessment.userId,
           assessmentId: assessment.id,
         });
@@ -366,7 +369,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         });
 
         // then
-        expect(campaignRepository.findSkillsByCampaignParticipationId).to.have.been.calledWith({
+        expect(campaignRepository.findSkillsByCampaignParticipationId).to.have.been.calledWithExactly({
           campaignParticipationId: assessment.campaignParticipationId,
         });
       });
@@ -381,7 +384,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
         // then
         const expectedArgument = answer.challengeId;
-        expect(challengeRepository.get).to.have.been.calledWith(expectedArgument);
+        expect(challengeRepository.get).to.have.been.calledWithExactly(expectedArgument);
       });
 
       it('should create the knowledge elements for the answer', async function () {
@@ -403,7 +406,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           targetSkills: skills,
           userId: assessment.userId,
         };
-        expect(KnowledgeElement.createKnowledgeElementsForAnswer).to.have.been.calledWith(expectedArgument);
+        expect(KnowledgeElement.createKnowledgeElementsForAnswer).to.have.been.calledWithExactly(expectedArgument);
       });
 
       it('should return the saved answer - with the id', async function () {
@@ -569,7 +572,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
         // then
         const expectedArgument = answer.challengeId;
-        expect(challengeRepository.get).to.have.been.calledWith(expectedArgument);
+        expect(challengeRepository.get).to.have.been.calledWithExactly(expectedArgument);
       });
 
       it('should not create the knowledge elements for the answer', async function () {
@@ -607,7 +610,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           ...dependencies,
         });
 
-        expect(algorithmDataFetcherService.fetchForFlashLevelEstimation).to.have.been.calledWith({
+        expect(algorithmDataFetcherService.fetchForFlashLevelEstimation).to.have.been.calledWithExactly({
           assessment,
           answerRepository,
           challengeRepository,
@@ -622,7 +625,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           ...dependencies,
         });
 
-        expect(flashAlgorithmService.getEstimatedLevelAndErrorRate).to.have.been.calledWith(flashData);
+        expect(flashAlgorithmService.getEstimatedLevelAndErrorRate).to.have.been.calledWithExactly(flashData);
       });
 
       it('should call the flash assessment result repository to save estimatedLevel and errorRate', async function () {
@@ -633,7 +636,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           ...dependencies,
         });
 
-        expect(flashAssessmentResultRepository.save).to.have.been.calledWith({
+        expect(flashAssessmentResultRepository.save).to.have.been.calledWithExactly({
           answerId: id,
           estimatedLevel,
           errorRate,
@@ -728,7 +731,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
         // then
         const expectedArgument = completedAnswer;
-        expect(answerRepository.saveWithKnowledgeElements).to.have.been.calledWith(expectedArgument);
+        expect(answerRepository.saveWithKnowledgeElements).to.have.been.calledWithExactly(expectedArgument, []);
       });
 
       it('should call the challenge repository to get the answer challenge', async function () {
@@ -741,7 +744,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
         // then
         const expectedArgument = answer.challengeId;
-        expect(challengeRepository.get).to.have.been.calledWith(expectedArgument);
+        expect(challengeRepository.get).to.have.been.calledWithExactly(expectedArgument);
       });
 
       it('should not call the compute scorecard method', async function () {

--- a/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
@@ -79,7 +79,7 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
     });
 
     // then
-    expect(certificationCourseRepository.update).to.have.been.calledWith(
+    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(
       new CertificationCourse({
         ...certificationCourseToBeModified.toDTO(),
         firstName: 'Maurice',

--- a/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -300,7 +300,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
           });
 
           // then
-          expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(
+          expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly(
             userAttributes.email,
             locale,
             expectedRedirectionUrl,

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -56,8 +56,8 @@ describe('Unit | UseCase | create-campaign', function () {
     });
 
     // then
-    expect(campaignCreator.createCampaign).to.have.been.calledWith({ ...campaignData, code });
-    expect(campaignRepository.save).to.have.been.calledWith(campaignToCreate);
+    expect(campaignCreator.createCampaign).to.have.been.calledWithExactly({ ...campaignData, code });
+    expect(campaignRepository.save).to.have.been.calledWithExactly(campaignToCreate);
     expect(campaign).to.deep.equal(savedCampaign);
   });
 });

--- a/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -34,12 +34,12 @@ describe('Unit | UseCase | create-certification-center-membership-by-email', fun
     });
 
     // then
-    expect(userRepository.getByEmail).has.been.calledWith(email);
-    expect(certificationCenterMembershipRepository.isMemberOfCertificationCenter).has.been.calledWith({
+    expect(userRepository.getByEmail).has.been.calledWithExactly(email);
+    expect(certificationCenterMembershipRepository.isMemberOfCertificationCenter).has.been.calledWithExactly({
       userId,
       certificationCenterId,
     });
-    expect(certificationCenterMembershipRepository.save).has.been.calledWith({ userId, certificationCenterId });
+    expect(certificationCenterMembershipRepository.save).has.been.calledWithExactly({ userId, certificationCenterId });
   });
 
   it('should throw UserNotFoundError if no user matches this email', async function () {

--- a/api/tests/unit/domain/usecases/create-certification-center-membership-for-sco-organization-member_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center-membership-for-sco-organization-member_test.js
@@ -96,7 +96,7 @@ describe('Unit | UseCase | create-certification-center-membership-for-sco-organi
             });
 
             // then
-            expect(certificationCenterMembershipRepository.save).to.have.been.calledWith({
+            expect(certificationCenterMembershipRepository.save).to.have.been.calledWithExactly({
               userId: userWhoseOrganizationRoleIsToUpdate.id,
               certificationCenterId: existingCertificationCenter.id,
             });

--- a/api/tests/unit/domain/usecases/create-lcms-release_test.js
+++ b/api/tests/unit/domain/usecases/create-lcms-release_test.js
@@ -25,6 +25,6 @@ describe('Unit | UseCase | create-lcms-release', function () {
     await createLcmsRelease();
 
     // then
-    expect(learningContentCache.set).to.have.been.calledWith(learningContent);
+    expect(learningContentCache.set).to.have.been.calledWithExactly(learningContent);
   });
 });

--- a/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
@@ -58,7 +58,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
       });
 
       // then
-      expect(trainingTriggerRepository.createOrUpdate).to.have.been.calledWith({
+      expect(trainingTriggerRepository.createOrUpdate).to.have.been.calledWithExactly({
         trainingId,
         triggerTubesForCreation: tubes,
         type,

--- a/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
@@ -29,7 +29,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
 
       // then
       expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledOnce;
-      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledWith({
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledWithExactly({
         organizationId: organization.id,
         email,
         locale,

--- a/api/tests/unit/domain/usecases/create-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitations_test.js
@@ -37,7 +37,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
 
       // then
       expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledOnce;
-      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledWith({
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledWithExactly({
         organizationId,
         email: emails[0],
         locale,

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -37,14 +37,14 @@ describe('Unit | UseCase | create-organization', function () {
     });
 
     // then
-    expect(organizationCreationValidator.validate).to.have.been.calledWith(organization);
-    expect(dataProtectionOfficerRepository.create).to.have.been.calledWith({
+    expect(organizationCreationValidator.validate).to.have.been.calledWithExactly(organization);
+    expect(dataProtectionOfficerRepository.create).to.have.been.calledWithExactly({
       organizationId: 1,
       firstName: '',
       lastName: '',
       email: 'justin.ptipeu@example.net',
     });
-    expect(organizationForAdminRepository.save).to.have.been.calledWith(organization);
+    expect(organizationForAdminRepository.save).to.have.been.calledWithExactly(organization);
   });
 
   context('Error cases', function () {

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -115,7 +115,7 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     });
 
     // then
-    expect(organizationValidator.validate).to.have.been.calledWith(organizations[0]);
+    expect(organizationValidator.validate).to.have.been.calledWithExactly(organizations[0]);
   });
 
   it('should throw an error when organization tags not exists', async function () {
@@ -428,7 +428,7 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     });
 
     // then
-    expect(organizationInvitationService.createProOrganizationInvitation).to.have.been.calledWith({
+    expect(organizationInvitationService.createProOrganizationInvitation).to.have.been.calledWithExactly({
       organizationRepository: organizationRepositoryStub,
       organizationInvitationRepository: organizationInvitationRepositoryStub,
       organizationId: firstOrganizationWithAdminRole.id,
@@ -437,7 +437,7 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       role: firstOrganizationWithAdminRole.organizationInvitationRole,
       locale: firstOrganizationWithAdminRole.locale,
     });
-    expect(organizationInvitationService.createProOrganizationInvitation).to.have.been.calledWith({
+    expect(organizationInvitationService.createProOrganizationInvitation).to.have.been.calledWithExactly({
       organizationRepository: organizationRepositoryStub,
       organizationInvitationRepository: organizationInvitationRepositoryStub,
       organizationId: secondOrganizationWithMemberRole.id,

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -68,7 +68,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
     });
 
     it('should return an access token', async function () {
@@ -141,7 +141,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: user.id });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
     });
 
     it('should return an access token', async function () {

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -88,7 +88,7 @@ describe('Unit | UseCase | create-user', function () {
       });
 
       // then
-      expect(userRepository.checkIfEmailIsAvailable).to.have.been.calledWith(userEmail);
+      expect(userRepository.checkIfEmailIsAvailable).to.have.been.calledWithExactly(userEmail);
     });
 
     it('should validate the user', async function () {
@@ -110,7 +110,7 @@ describe('Unit | UseCase | create-user', function () {
       });
 
       //then
-      expect(userValidator.validate).to.have.been.calledWith({ user });
+      expect(userValidator.validate).to.have.been.calledWithExactly({ user });
     });
 
     it('should validate the password', async function () {
@@ -132,7 +132,7 @@ describe('Unit | UseCase | create-user', function () {
       });
 
       // then
-      expect(passwordValidator.validate).to.have.been.calledWith(password);
+      expect(passwordValidator.validate).to.have.been.calledWithExactly(password);
     });
 
     context('when user email is already used', function () {
@@ -365,7 +365,7 @@ describe('Unit | UseCase | create-user', function () {
         });
 
         // then
-        expect(encryptionService.hashPassword).to.have.been.calledWith(password);
+        expect(encryptionService.hashPassword).to.have.been.calledWithExactly(password);
       });
 
       it('should throw Error when hash password function fails', async function () {
@@ -411,7 +411,7 @@ describe('Unit | UseCase | create-user', function () {
         });
 
         // then
-        expect(userService.createUserWithPassword).to.have.been.calledWith({
+        expect(userService.createUserWithPassword).to.have.been.calledWithExactly({
           user,
           hashedPassword,
           userToCreateRepository,
@@ -446,7 +446,7 @@ describe('Unit | UseCase | create-user', function () {
         });
 
         // then
-        expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(
+        expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly(
           userEmail,
           localeFromHeader,
           expectedRedirectionUrl,
@@ -478,7 +478,7 @@ describe('Unit | UseCase | create-user', function () {
           });
 
           // then
-          expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(
+          expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly(
             userEmail,
             localeFromHeader,
             expectedRedirectionUrl,
@@ -512,7 +512,7 @@ describe('Unit | UseCase | create-user', function () {
           });
 
           // then
-          expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(
+          expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly(
             userEmail,
             localeFromHeader,
             expectedRedirectionUrl,

--- a/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/deneutralize-challenge_test.js
@@ -38,10 +38,10 @@ describe('Unit | UseCase | deneutralize-challenge', function () {
     });
 
     // then
-    expect(certificationAssessment.deneutralizeChallengeByRecId).to.have.been.calledWith(
+    expect(certificationAssessment.deneutralizeChallengeByRecId).to.have.been.calledWithExactly(
       challengeToBeDeneutralized.challengeId,
     );
-    expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
+    expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(certificationAssessment);
   });
 
   it('return a ChallengeDeneutralized event', async function () {

--- a/api/tests/unit/domain/usecases/dissociate-user-from-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/dissociate-user-from-organization-learner_test.js
@@ -31,7 +31,7 @@ describe('Unit | UseCase | dissociate-user-from-organization-learner', function 
     });
 
     // then
-    expect(organizationLearnerRepositoryStub.dissociateUserFromOrganizationLearner).to.be.have.been.calledWith(
+    expect(organizationLearnerRepositoryStub.dissociateUserFromOrganizationLearner).to.be.have.been.calledWithExactly(
       organizationLearnerId,
     );
   });

--- a/api/tests/unit/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/unit/domain/usecases/find-assessment-participation-result-list_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | find-assessment-participation-result-list', function 
       campaignAssessmentParticipationResultListRepository: { findPaginatedByCampaignId },
     });
 
-    expect(findPaginatedByCampaignId).to.have.been.calledWith({ page, campaignId, filters });
+    expect(findPaginatedByCampaignId).to.have.been.calledWithExactly({ page, campaignId, filters });
     expect(results).to.equal(participations);
   });
 });

--- a/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -18,9 +18,9 @@ describe('Unit | UseCase | find-certification-center-memberships-by-certificatio
     });
 
     // then
-    expect(certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById).to.have.been.calledWith(
-      { certificationCenterId },
-    );
+    expect(
+      certificationCenterMembershipRepository.findActiveByCertificationCenterIdSortedById,
+    ).to.have.been.calledWithExactly({ certificationCenterId });
     expect(foundCertificationCenterMemberships).to.deep.equal(certificationCenterMemberships);
   });
 });

--- a/api/tests/unit/domain/usecases/find-latest-ongoing-user-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/find-latest-ongoing-user-campaign-participation_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | find-latest-user-campaign-participations', function (
     });
 
     // then
-    expect(campaignParticipationRepository.findLatestOngoingByUserId).to.have.been.calledWith(userId);
+    expect(campaignParticipationRepository.findLatestOngoingByUserId).to.have.been.calledWithExactly(userId);
   });
 
   it('should return user with his campaign participations', async function () {

--- a/api/tests/unit/domain/usecases/find-paginated-target-profile-training-summaries_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-target-profile-training-summaries_test.js
@@ -20,7 +20,7 @@ describe('Unit | UseCase | findPaginatedTargetProfileTrainingSummaries', functio
     });
 
     // then
-    expect(trainingRepository.findPaginatedSummariesByTargetProfileId).to.have.been.calledWith({
+    expect(trainingRepository.findPaginatedSummariesByTargetProfileId).to.have.been.calledWithExactly({
       targetProfileId,
       page,
     });

--- a/api/tests/unit/domain/usecases/find-pending-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/find-pending-organization-invitations_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | find-pending-organization-invitations', function () {
     });
 
     // then
-    expect(organizationInvitationRepositoryStub.findPendingByOrganizationId).to.have.been.calledWith({
+    expect(organizationInvitationRepositoryStub.findPendingByOrganizationId).to.have.been.calledWithExactly({
       organizationId,
     });
   });

--- a/api/tests/unit/domain/usecases/find-target-profile-summaries-for-training_test.js
+++ b/api/tests/unit/domain/usecases/find-target-profile-summaries-for-training_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | find-target-profile-summaries-for-training', function
     });
 
     // then
-    expect(targetProfileSummaryForAdminRepository.findByTraining).to.have.been.calledWith({ trainingId });
+    expect(targetProfileSummaryForAdminRepository.findByTraining).to.have.been.calledWithExactly({ trainingId });
     expect(result).to.equal(targetProfileSummaries);
   });
 });

--- a/api/tests/unit/domain/usecases/find-user-authentication-methods.js
+++ b/api/tests/unit/domain/usecases/find-user-authentication-methods.js
@@ -15,6 +15,6 @@ describe('Unit | UseCase | find-user-authentication-methods', function () {
     await findUserAuthenticationMethods({ userId: user.id, authenticationMethodRepository });
 
     // then
-    expect(authenticationMethodRepository.findByUserId).to.have.been.calledWith({ userId: user.id });
+    expect(authenticationMethodRepository.findByUserId).to.have.been.calledWithExactly({ userId: user.id });
   });
 });

--- a/api/tests/unit/domain/usecases/get-current-activity_test.js
+++ b/api/tests/unit/domain/usecases/get-current-activity_test.js
@@ -9,7 +9,7 @@ describe('Unit | Domain | Use Cases | get-current-activity', function () {
 
       await getCurrentActivity({ assessmentId, activityRepository });
 
-      expect(activityRepository.getLastActivity).to.have.been.calledWith(assessmentId);
+      expect(activityRepository.getLastActivity).to.have.been.calledWithExactly(assessmentId);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -140,7 +140,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: 777 });
     });
 
     context("when user's authentication method does not contain first and last name", function () {
@@ -180,7 +180,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLastName: 'Lisitsa',
           externalIdentifier: 'saml-id',
         });
-        expect(authenticationMethodRepository.update).to.have.been.calledWith(expectedAuthenticationMethod);
+        expect(authenticationMethodRepository.update).to.have.been.calledWithExactly(expectedAuthenticationMethod);
       });
     });
 
@@ -216,7 +216,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLastName: 'Lisitsa',
           externalIdentifier: 'saml-id',
         });
-        expect(authenticationMethodRepository.update).to.have.been.calledWith(expectedAuthenticationMethod);
+        expect(authenticationMethodRepository.update).to.have.been.calledWithExactly(expectedAuthenticationMethod);
       });
     });
 
@@ -252,7 +252,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLastName: 'Volk',
           externalIdentifier: 'saml-id',
         });
-        expect(authenticationMethodRepository.update).to.have.been.calledWith(expectedAuthenticationMethod);
+        expect(authenticationMethodRepository.update).to.have.been.calledWithExactly(expectedAuthenticationMethod);
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -35,7 +35,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
         });
 
         // then
-        expect(certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId).to.have.been.calledWith(
+        expect(certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId).to.have.been.calledWithExactly(
           156,
           54516,
         );
@@ -63,7 +63,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
 
         // then
         expect(challenge).to.equal(nextChallengeToAnswer);
-        expect(challengeRepository.get).to.have.been.calledWith(challengeId);
+        expect(challengeRepository.get).to.have.been.calledWithExactly(challengeId);
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-organization-details_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-details_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | get-organization-details', function () {
     const organization = await getOrganizationDetails({ organizationId, organizationForAdminRepository });
 
     // then
-    expect(organizationForAdminRepository.get).to.have.been.calledWith(organizationId);
+    expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(organizationId);
     expect(organization).to.be.an.instanceOf(Organization);
     expect(organization).to.deep.equal(foundOrganization);
   });

--- a/api/tests/unit/domain/usecases/get-organization-learner-activity_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-learner-activity_test.js
@@ -31,7 +31,7 @@ describe('Unit | UseCase | get-organisation-learner-activity', function () {
     });
 
     // then
-    expect(organizationLearnerActivityRepository.get).to.have.been.calledWith(organizationLearnerId);
+    expect(organizationLearnerActivityRepository.get).to.have.been.calledWithExactly(organizationLearnerId);
     expect(organizationLearnerActivity).to.be.an.instanceOf(OrganizationLearnerActivity);
     expect(organizationLearnerActivity.participations.length).to.equal(1);
     expect(organizationLearnerActivity.participations[0]).to.deep.equal(organizationLearnerParticipation);

--- a/api/tests/unit/domain/usecases/get-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-learner_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | get-organisation-learner', function () {
     });
 
     // then
-    expect(organizationLearnerRepository.get).to.have.been.calledWith(organizationLearnerId);
+    expect(organizationLearnerRepository.get).to.have.been.calledWithExactly(organizationLearnerId);
     expect(organizationLearner).to.be.an.instanceOf(OrganizationLearner);
     expect(organizationLearner.firstName).to.be.equal('Michael');
     expect(organizationLearner.lastName).to.be.equal('Jackson');

--- a/api/tests/unit/domain/usecases/get-progression_test.js
+++ b/api/tests/unit/domain/usecases/get-progression_test.js
@@ -106,7 +106,7 @@ describe('Unit | Domain | Use Cases | get-progression', function () {
           });
 
           // then
-          expect(improvementService.filterKnowledgeElementsIfImproving).to.have.been.calledWith({
+          expect(improvementService.filterKnowledgeElementsIfImproving).to.have.been.calledWithExactly({
             knowledgeElements,
             assessment,
             isRetrying: false,
@@ -170,7 +170,7 @@ describe('Unit | Domain | Use Cases | get-progression', function () {
           });
 
           // then
-          expect(improvementService.filterKnowledgeElementsIfImproving).to.have.been.calledWith({
+          expect(improvementService.filterKnowledgeElementsIfImproving).to.have.been.calledWithExactly({
             knowledgeElements,
             assessment,
             isRetrying: true,
@@ -294,7 +294,7 @@ describe('Unit | Domain | Use Cases | get-progression', function () {
         });
 
         // then
-        expect(competenceEvaluationRepository.getByAssessmentId).to.have.been.calledWith(assessmentId);
+        expect(competenceEvaluationRepository.getByAssessmentId).to.have.been.calledWithExactly(assessmentId);
       });
 
       it('should return the progression associated to the assessment', async function () {
@@ -352,7 +352,7 @@ describe('Unit | Domain | Use Cases | get-progression', function () {
           });
 
           // then
-          expect(improvementService.filterKnowledgeElementsIfImproving).to.have.been.calledWith({
+          expect(improvementService.filterKnowledgeElementsIfImproving).to.have.been.calledWithExactly({
             knowledgeElements,
             assessment: competenceEvaluationAssessment,
           });

--- a/api/tests/unit/domain/usecases/get-user-by-reset-password-demand_test.js
+++ b/api/tests/unit/domain/usecases/get-user-by-reset-password-demand_test.js
@@ -14,10 +14,12 @@ describe('Unit | UseCase | get-user-by-reset-password-demand', function () {
   const email = 'user@example.net';
 
   let resetPasswordService;
+  let resetPasswordDemandRepository;
   let tokenService;
   let userRepository;
 
   beforeEach(function () {
+    resetPasswordDemandRepository = sinon.stub();
     resetPasswordService = {
       verifyDemand: sinon.stub(),
     };
@@ -40,15 +42,19 @@ describe('Unit | UseCase | get-user-by-reset-password-demand', function () {
     const result = await getUserByResetPasswordDemand({
       temporaryKey,
       resetPasswordService,
+      resetPasswordDemandRepository,
       tokenService,
       userRepository,
     });
 
     // then
     expect(result).to.be.an.instanceOf(User);
-    expect(resetPasswordService.verifyDemand).to.have.been.calledWith(temporaryKey);
-    expect(tokenService.decodeIfValid).to.have.been.calledWith(temporaryKey);
-    expect(userRepository.getByEmail).to.have.been.calledWith(email);
+    expect(resetPasswordService.verifyDemand).to.have.been.calledWithExactly(
+      temporaryKey,
+      resetPasswordDemandRepository,
+    );
+    expect(tokenService.decodeIfValid).to.have.been.calledWithExactly(temporaryKey);
+    expect(userRepository.getByEmail).to.have.been.calledWithExactly(email);
   });
 
   it('should throw InvalidTemporaryKeyError if TemporaryKey is invalid', async function () {

--- a/api/tests/unit/domain/usecases/handle-training-recommendation_test.js
+++ b/api/tests/unit/domain/usecases/handle-training-recommendation_test.js
@@ -106,7 +106,7 @@ describe('Unit | UseCase | handle-training-recommendation', function () {
         });
 
         // then
-        expect(findWithTriggersByCampaignParticipationIdAndLocaleStub).to.have.been.calledWith({
+        expect(findWithTriggersByCampaignParticipationIdAndLocaleStub).to.have.been.calledWithExactly({
           campaignParticipationId,
           locale,
           domainTransaction,

--- a/api/tests/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -119,11 +119,11 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           });
 
           // then
-          expect(certificationCandidateRepository.deleteBySessionId).to.have.been.calledWith({
+          expect(certificationCandidateRepository.deleteBySessionId).to.have.been.calledWithExactly({
             sessionId,
             domainTransaction,
           });
-          expect(certificationCandidateRepository.saveInSession).to.have.been.calledWith({
+          expect(certificationCandidateRepository.saveInSession).to.have.been.calledWithExactly({
             certificationCandidate,
             sessionId,
             domainTransaction,

--- a/api/tests/unit/domain/usecases/import-organization-learners-from-siecle_test.js
+++ b/api/tests/unit/domain/usecases/import-organization-learners-from-siecle_test.js
@@ -148,11 +148,10 @@ describe('Unit | UseCase | import-organization-learners-from-siecle', function (
 
         expect(
           organizationLearnersXmlServiceStub.extractOrganizationLearnersInformationFromSIECLE,
-        ).to.have.been.calledWith(payload.path, { externalId: organizationUAI });
-        expect(organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners).to.have.been.calledWith(
-          organizationLearners,
-          organizationId,
-        );
+        ).to.have.been.calledWithExactly(payload.path, { externalId: organizationUAI });
+        expect(
+          organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners,
+        ).to.have.been.calledWithExactly(organizationLearners, organizationId, domainTransaction);
         expect(organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners).to.not.throw();
       });
     });

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -426,13 +426,13 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               });
 
               // then
-              expect(certificationCandidateRepository.linkToUser).to.have.been.calledWith({
+              expect(certificationCandidateRepository.linkToUser).to.have.been.calledWithExactly({
                 id: certificationCandidate.id,
                 userId,
               });
               expect(
                 organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization,
-              ).to.have.been.calledWith({ userId, organizationLearnerId: organizationLearner.id });
+              ).to.have.been.calledWithExactly({ userId, organizationLearnerId: organizationLearner.id });
               expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
             });
           });
@@ -508,7 +508,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               // then
               expect(
                 organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization,
-              ).to.have.been.calledWith({ userId, organizationLearnerId: organizationLearner.id });
+              ).to.have.been.calledWithExactly({ userId, organizationLearnerId: organizationLearner.id });
               expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
             });
           });

--- a/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
@@ -28,8 +28,8 @@ describe('Unit | UseCase | manually-resolve-certification-issue-report', functio
 
       // then
       expect(certificationIssueReportRepository.get).to.have.been.called;
-      expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
-      expect(expectedCertificationIssueReport.resolveManually).to.have.been.calledWith(resolution);
+      expect(certificationIssueReportRepository.save).to.have.been.calledWithExactly(expectedCertificationIssueReport);
+      expect(expectedCertificationIssueReport.resolveManually).to.have.been.calledWithExactly(resolution);
     });
   });
 
@@ -57,7 +57,9 @@ describe('Unit | UseCase | manually-resolve-certification-issue-report', functio
         });
 
         // then
-        expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
+        expect(certificationIssueReportRepository.save).to.have.been.calledWithExactly(
+          expectedCertificationIssueReport,
+        );
       });
     });
 

--- a/api/tests/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/neutralize-challenge_test.js
@@ -45,10 +45,10 @@ describe('Unit | UseCase | neutralize-challenge', function () {
     });
 
     // then
-    expect(certificationAssessment.neutralizeChallengeByRecId).to.have.been.calledWith(
+    expect(certificationAssessment.neutralizeChallengeByRecId).to.have.been.calledWithExactly(
       challengeToBeNeutralized.challengeId,
     );
-    expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
+    expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(certificationAssessment);
   });
 
   it('return a ChallengeNeutralized event', async function () {

--- a/api/tests/unit/domain/usecases/organization-learners-management/delete-organization-learners_test.js
+++ b/api/tests/unit/domain/usecases/organization-learners-management/delete-organization-learners_test.js
@@ -30,13 +30,13 @@ describe('Unit | UseCase | Organization Learners Management | Delete Organizatio
     });
 
     // then
-    expect(campaignParticipationRepository.removeByOrganizationLearnerIds).to.have.been.calledWith({
+    expect(campaignParticipationRepository.removeByOrganizationLearnerIds).to.have.been.calledWithExactly({
       organizationLearnerIds,
       userId,
       domainTransaction,
     });
 
-    expect(organizationLearnerRepository.removeByIds).to.have.been.calledWith({
+    expect(organizationLearnerRepository.removeByIds).to.have.been.calledWithExactly({
       organizationLearnerIds,
       userId,
       domainTransaction,

--- a/api/tests/unit/domain/usecases/organizations-administration/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/organizations-administration/update-organization-information_test.js
@@ -35,13 +35,13 @@ describe('Unit | UseCase | organizations-administration | update-organization-in
     });
 
     // then
-    expect(organizationForAdminRepository.get).to.have.been.calledWith(givenOrganization.id, domainTransaction);
-    expect(existingOrganizationForAdmin.updateWithDataProtectionOfficerAndTags).to.have.been.calledWith(
+    expect(organizationForAdminRepository.get).to.have.been.calledWithExactly(givenOrganization.id, domainTransaction);
+    expect(existingOrganizationForAdmin.updateWithDataProtectionOfficerAndTags).to.have.been.calledWithExactly(
       givenOrganization,
       givenOrganization.dataProtectionOfficer,
       givenOrganization.tags,
     );
-    expect(organizationForAdminRepository.update).to.have.been.calledWith(
+    expect(organizationForAdminRepository.update).to.have.been.calledWithExactly(
       existingOrganizationForAdmin,
       domainTransaction,
     );

--- a/api/tests/unit/domain/usecases/remember-user-has-seen-assessment-instructions_test.js
+++ b/api/tests/unit/domain/usecases/remember-user-has-seen-assessment-instructions_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | remember-user-has-seen-assessment-instructions', func
     const actualUpdatedUser = await rememberUserHasSeenAssessmentInstructions({ userId, userRepository });
 
     // then
-    expect(userRepository.updateHasSeenAssessmentInstructionsToTrue).to.have.been.calledWith(userId);
+    expect(userRepository.updateHasSeenAssessmentInstructionsToTrue).to.have.been.calledWithExactly(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 });

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -60,7 +60,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(userRepository.updateEmail).to.have.been.calledWith({ id: user.id, email: null });
+      expect(userRepository.updateEmail).to.have.been.calledWithExactly({ id: user.id, email: null });
     });
 
     context('When user does not have a username', function () {
@@ -75,7 +75,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
         // then
-        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
           userId: user.id,
           identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         });
@@ -113,7 +113,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(userRepository.updateUsername).to.have.been.calledWith({ id: user.id, username: null });
+      expect(userRepository.updateUsername).to.have.been.calledWithExactly({ id: user.id, username: null });
     });
 
     context('When user does not have an email', function () {
@@ -128,7 +128,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
         await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
         // then
-        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
           userId: user.id,
           identityProvider: NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
         });
@@ -166,7 +166,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
         userId: user.id,
         identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
       });
@@ -186,7 +186,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
         userId: user.id,
         identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
       });
@@ -206,7 +206,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
         userId: user.id,
         identityProvider: OidcIdentityProviders.CNAV.code,
       });
@@ -226,7 +226,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
         userId: user.id,
         identityProvider: OidcIdentityProviders.FWB.code,
       });

--- a/api/tests/unit/domain/usecases/reset-organization-learners-password_test.js
+++ b/api/tests/unit/domain/usecases/reset-organization-learners-password_test.js
@@ -67,9 +67,9 @@ describe('Unit | UseCases | Reset organization learners password', function () {
 
           // then
           expect(passwordGenerator.generateSimplePassword).to.have.been.callCount(2);
-          expect(encryptionService.hashPassword).to.have.been.calledWith(generatedPassword);
+          expect(encryptionService.hashPassword).to.have.been.calledWithExactly(generatedPassword);
           expect(encryptionService.hashPassword).to.have.been.callCount(2);
-          expect(authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged).to.have.been.calledWith({
+          expect(authenticationMethodRepository.batchUpdatePasswordThatShouldBeChanged).to.have.been.calledWithExactly({
             usersToUpdateWithNewPassword: userIdHashedPassword,
             domainTransaction,
           });
@@ -110,7 +110,7 @@ describe('Unit | UseCases | Reset organization learners password', function () {
         });
 
         // then
-        expect(organizationLearnerRepository.findByIds).to.have.been.calledWith({ ids: organizationLearnersId });
+        expect(organizationLearnerRepository.findByIds).to.have.been.calledWithExactly({ ids: organizationLearnersId });
         expect(error).to.be.instanceOf(UserNotAuthorizedToUpdatePasswordError);
         expect(error.code).to.equal(ORGANIZATION_LEARNER_DOES_NOT_BELONG_TO_ORGANIZATION_CODE);
       });
@@ -140,7 +140,7 @@ describe('Unit | UseCases | Reset organization learners password', function () {
           userRepository,
         });
         // then
-        expect(userRepository.getByIds).to.have.been.calledWith(studentIds);
+        expect(userRepository.getByIds).to.have.been.calledWithExactly(studentIds);
         expect(error).to.be.instanceOf(UserNotAuthorizedToUpdatePasswordError);
         expect(error.code).to.equal(ORGANIZATION_LEARNER_WITHOUT_USERNAME_CODE);
       });

--- a/api/tests/unit/domain/usecases/revoke-refresh-token_test.js
+++ b/api/tests/unit/domain/usecases/revoke-refresh-token_test.js
@@ -12,6 +12,6 @@ describe('Unit | UseCase | revoke-refresh-token', function () {
     await revokeRefreshToken({ refreshToken, refreshTokenService });
 
     // then
-    expect(refreshTokenService.revokeRefreshToken).to.have.been.calledWith({ refreshToken });
+    expect(refreshTokenService.revokeRefreshToken).to.have.been.calledWithExactly({ refreshToken });
   });
 });

--- a/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
@@ -17,7 +17,7 @@ describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', f
     });
 
     // then
-    expect(participantResultsSharedRepository.get).to.have.been.calledWith(1);
-    expect(participantResultsSharedRepository.save).to.have.been.calledWith(participationResultsShared);
+    expect(participantResultsSharedRepository.get).to.have.been.calledWithExactly(1);
+    expect(participantResultsSharedRepository.save).to.have.been.calledWithExactly(participationResultsShared);
   });
 });

--- a/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
+++ b/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
@@ -92,7 +92,7 @@ describe('Unit | UseCase | save-jury-complementary-certification-course-results'
           });
 
           // then
-          expect(complementaryCertificationCourseResultRepository.save).to.have.been.calledWith(
+          expect(complementaryCertificationCourseResultRepository.save).to.have.been.calledWithExactly(
             new ComplementaryCertificationCourseResult({
               partnerKey: 'KEY_2',
               source: ComplementaryCertificationCourseResult.sources.EXTERNAL,

--- a/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -215,7 +215,7 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
       });
 
       // then
-      expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending });
+      expect(poleEmploiSendingRepository.create).to.have.been.calledWithExactly({ poleEmploiSending });
     });
   });
 

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -127,7 +127,7 @@ describe('Unit | UseCase | send-verification-code', function () {
     });
 
     // then
-    expect(mailService.sendVerificationCodeEmail).to.have.been.calledWith({
+    expect(mailService.sendVerificationCodeEmail).to.have.been.calledWithExactly({
       code,
       locale,
       email: newEmail,

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -61,13 +61,13 @@ describe('Unit | UseCase | start-campaign-participation', function () {
     });
 
     // then
-    expect(campaignParticipant.start).to.have.been.calledWith({
+    expect(campaignParticipant.start).to.have.been.calledWithExactly({
       participantExternalId: 'YvoLoL',
       isReset: campaignParticipationAttributes.isReset,
     });
     expect(event).to.deep.equal(campaignParticipationStartedEvent);
     expect(campaignParticipation).to.deep.equal(expectedCampaignParticipation);
-    expect(campaignRepository.areKnowledgeElementsResettable).to.have.been.calledWith({
+    expect(campaignRepository.areKnowledgeElementsResettable).to.have.been.calledWithExactly({
       id: campaignParticipationAttributes.campaignId,
       domainTransaction,
     });
@@ -152,7 +152,7 @@ describe('Unit | UseCase | start-campaign-participation', function () {
         });
 
         // then
-        expect(campaignRepository.findAllSkills).to.have.been.calledWith({
+        expect(campaignRepository.findAllSkills).to.have.been.calledWithExactly({
           campaignId: campaignParticipationAttributes.campaignId,
           domainTransaction,
         });

--- a/api/tests/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/unit/domain/usecases/supervise-session_test.js
@@ -74,6 +74,6 @@ describe('Unit | UseCase | supervise-session', function () {
     });
 
     // then
-    expect(supervisorAccessRepository.create).to.have.been.calledWith({ sessionId, userId });
+    expect(supervisorAccessRepository.create).to.have.been.calledWithExactly({ sessionId, userId });
   });
 });

--- a/api/tests/unit/domain/usecases/unarchive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/unarchive-campaign_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | unarchive-campaign', function () {
 
     await unarchiveCampaign({ campaignId: 1, campaignForArchivingRepository });
 
-    expect(campaignForArchivingRepository.get).to.have.been.calledWith(1);
-    expect(campaignForArchivingRepository.save).to.have.been.calledWith(expectedCampaign);
+    expect(campaignForArchivingRepository.get).to.have.been.calledWithExactly(1);
+    expect(campaignForArchivingRepository.save).to.have.been.calledWithExactly(expectedCampaign);
   });
 });

--- a/api/tests/unit/domain/usecases/uncancel-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/uncancel-certification-course_test.js
@@ -21,6 +21,6 @@ describe('Unit | UseCase | uncancel-certification-course', function () {
 
     // then
     expect(certificationCourse.uncancel).to.have.been.calledOnce;
-    expect(certificationCourseRepository.update).to.have.been.calledWith(certificationCourse);
+    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
   });
 });

--- a/api/tests/unit/domain/usecases/update-certification-center-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-certification-center-membership_test.js
@@ -44,7 +44,7 @@ describe('Unit | UseCase | update-certification-center-membership', function () 
     // then
     expect(updatedCertificationCenterMembership).to.be.instanceof(CertificationCenterMembership);
     expect(certificationCenterMembershipRepository.findById).to.have.been.calledTwice;
-    expect(certificationCenterMembershipRepository.update).to.have.been.calledWith(
+    expect(certificationCenterMembershipRepository.update).to.have.been.calledWithExactly(
       expectedCertificationCenterMembership,
     );
   });

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -120,7 +120,7 @@ describe('Unit | UseCase | update-expired-password', function () {
       });
 
       // then
-      expect(logger.warn).to.have.been.calledWith('Trying to change his password with incorrect user id');
+      expect(logger.warn).to.have.been.calledWithExactly('Trying to change his password with incorrect user id');
     });
   });
 

--- a/api/tests/unit/domain/usecases/update-organization-learner-dependent-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-learner-dependent-user-password_test.js
@@ -70,7 +70,7 @@ describe('Unit | UseCase | update-organization-learner-dependent-user-password',
     });
 
     // then
-    expect(userRepository.getWithMemberships).to.have.been.calledWith(userId);
+    expect(userRepository.getWithMemberships).to.have.been.calledWithExactly(userId);
   });
 
   it('should get student by his id', async function () {
@@ -87,7 +87,7 @@ describe('Unit | UseCase | update-organization-learner-dependent-user-password',
     });
 
     // then
-    expect(organizationLearnerRepository.get).to.have.been.calledWith(organizationLearnerId);
+    expect(organizationLearnerRepository.get).to.have.been.calledWithExactly(organizationLearnerId);
   });
 
   it('should update user password with a hashed password', async function () {
@@ -104,8 +104,8 @@ describe('Unit | UseCase | update-organization-learner-dependent-user-password',
     });
 
     // then
-    expect(encryptionService.hashPassword).to.have.been.calledWith(generatedPassword);
-    expect(authenticationMethodRepository.updatePasswordThatShouldBeChanged).to.have.been.calledWith({
+    expect(encryptionService.hashPassword).to.have.been.calledWithExactly(generatedPassword);
+    expect(authenticationMethodRepository.updatePasswordThatShouldBeChanged).to.have.been.calledWithExactly({
       userId: userStudent.id,
       hashedPassword: encryptedPassword,
     });

--- a/api/tests/unit/domain/usecases/update-student-number_test.js
+++ b/api/tests/unit/domain/usecases/update-student-number_test.js
@@ -61,7 +61,7 @@ describe('Unit | UseCase | update-student-number', function () {
       });
 
       // then
-      expect(supOrganizationLearnerRepository.updateStudentNumber).to.have.been.calledWith(
+      expect(supOrganizationLearnerRepository.updateStudentNumber).to.have.been.calledWithExactly(
         organizationLearnerId,
         studentNumber,
       );

--- a/api/tests/unit/domain/usecases/update-user-details-for-administration_test.js
+++ b/api/tests/unit/domain/usecases/update-user-details-for-administration_test.js
@@ -37,7 +37,7 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
       await updateUserDetailsForAdministration({ userId, userDetailsForAdministration, userRepository });
 
       // then
-      expect(userRepository.findAnotherUserByEmail).to.have.been.calledWith(userId, email);
+      expect(userRepository.findAnotherUserByEmail).to.have.been.calledWithExactly(userId, email);
     });
 
     it('should not search existing users if email is empty', async function () {
@@ -68,7 +68,7 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
       await updateUserDetailsForAdministration({ userId, userDetailsForAdministration, userRepository });
 
       // then
-      expect(userRepository.findAnotherUserByUsername).to.have.been.calledWith(userId, username);
+      expect(userRepository.findAnotherUserByUsername).to.have.been.calledWithExactly(userId, username);
     });
 
     it('should not search existing user if username is empty', async function () {
@@ -110,7 +110,7 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
     });
 
     // then
-    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
       id: userId,
       userAttributes: attributesToUpdate,
     });
@@ -137,7 +137,7 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
 
       // then
       const expectedAttributes = { email, mustValidateTermsOfService: true };
-      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
         id: userId,
         userAttributes: expectedAttributes,
       });
@@ -163,7 +163,7 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
 
       // then
       const expectedAttributes = { email };
-      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
         id: userId,
         userAttributes: expectedAttributes,
       });

--- a/api/tests/unit/domain/usecases/update-user-email-with-validation_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email-with-validation_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | update-user-email-with-validation', function () {
     });
 
     // then
-    expect(userRepository.updateWithEmailConfirmed).to.have.been.calledWith({
+    expect(userRepository.updateWithEmailConfirmed).to.have.been.calledWithExactly({
       id: userId,
       userAttributes: { email: newEmail, emailConfirmedAt: now },
     });

--- a/api/tests/unit/domain/usecases/update-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-user-password_test.js
@@ -56,7 +56,7 @@ describe('Unit | UseCase | update-user-password', function () {
     });
 
     // then
-    expect(userRepository.get).to.have.been.calledWith(userId);
+    expect(userRepository.get).to.have.been.calledWithExactly(userId);
   });
 
   it('should throw a UserNotAuthorizedToUpdatePasswordError when user does not have an email', async function () {
@@ -91,7 +91,10 @@ describe('Unit | UseCase | update-user-password', function () {
     });
 
     // then
-    expect(resetPasswordService.hasUserAPasswordResetDemandInProgress).to.have.been.calledWith(user.email);
+    expect(resetPasswordService.hasUserAPasswordResetDemandInProgress).to.have.been.calledWithExactly(
+      user.email,
+      temporaryKey,
+    );
   });
 
   it('should update user password with a hashed password', async function () {
@@ -110,8 +113,8 @@ describe('Unit | UseCase | update-user-password', function () {
     });
 
     // then
-    expect(encryptionService.hashPassword).to.have.been.calledWith(password);
-    expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWith({
+    expect(encryptionService.hashPassword).to.have.been.calledWithExactly(password);
+    expect(authenticationMethodRepository.updateChangedPassword).to.have.been.calledWithExactly({
       userId,
       hashedPassword,
     });
@@ -130,7 +133,7 @@ describe('Unit | UseCase | update-user-password', function () {
     });
 
     // then
-    expect(resetPasswordService.invalidateOldResetPasswordDemand).to.have.been.calledWith(user.email);
+    expect(resetPasswordService.invalidateOldResetPasswordDemand).to.have.been.calledWithExactly(user.email);
   });
 
   describe('When user has not a current password reset demand', function () {

--- a/api/tests/unit/infrastructure/caches/RedisCache_test.js
+++ b/api/tests/unit/infrastructure/caches/RedisCache_test.js
@@ -81,7 +81,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
 
           // then
           return promise.then(() => {
-            return expect(redisCache.set).to.have.been.calledWith(CACHE_KEY, dataFromHandler);
+            return expect(redisCache.set).to.have.been.calledWithExactly(CACHE_KEY, dataFromHandler);
           });
         });
 
@@ -162,7 +162,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
       // then
       return expect(promise).to.have.been.fulfilled.then((result) => {
         expect(result).to.deep.equal(objectToCache);
-        expect(stubbedClient.set).to.have.been.calledWith(CACHE_KEY, JSON.stringify(objectToCache));
+        expect(stubbedClient.set).to.have.been.calledWithExactly(CACHE_KEY, JSON.stringify(objectToCache));
       });
     });
 

--- a/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -199,7 +199,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
       await dataSource.refreshLearningContentCacheRecords();
 
       // then
-      expect(learningContentCache.set).to.have.been.calledWith(learningContent);
+      expect(learningContentCache.set).to.have.been.calledWithExactly(learningContent);
     });
   });
 

--- a/api/tests/unit/infrastructure/events/handlers/LogEvent_test.js
+++ b/api/tests/unit/infrastructure/events/handlers/LogEvent_test.js
@@ -13,7 +13,7 @@ describe('Unit | Infrastructure | Events | Handler | LogEvent', function () {
       const handler = new LogEvent({ monitoringTools });
       await handler.handle(event);
 
-      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+      expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
         message: {
           type: 'EVENT_LOG',
           event: event.attributes,

--- a/api/tests/unit/infrastructure/events/handlers/ScheduleSendSharedParticipationResultsToPoleEmploiJob_test.js
+++ b/api/tests/unit/infrastructure/events/handlers/ScheduleSendSharedParticipationResultsToPoleEmploiJob_test.js
@@ -15,7 +15,7 @@ describe('Unit | Infrastructure | Events | Handler | SharedParticipationResultsT
       });
       await handler.handle(event);
 
-      expect(job.schedule).to.have.been.calledWith(event);
+      expect(job.schedule).to.have.been.calledWithExactly(event);
     });
   });
 });

--- a/api/tests/unit/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler_test.js
+++ b/api/tests/unit/infrastructure/events/subscribers/audit-log/UserAnonymizedEventLoggingJobScheduler_test.js
@@ -18,7 +18,7 @@ describe('Unit | Infrastructure | Events | Subscribers | UserAnonymizedEventLogg
         scheduler.handle(event);
 
         // then
-        expect(userAnonymizedEventLoggingJob.schedule).to.not.have.been.calledWith(event);
+        expect(userAnonymizedEventLoggingJob.schedule).to.not.have.been.calledWithExactly(event);
       });
     });
 
@@ -36,7 +36,7 @@ describe('Unit | Infrastructure | Events | Subscribers | UserAnonymizedEventLogg
         scheduler.handle(event);
 
         // then
-        expect(userAnonymizedEventLoggingJob.schedule).to.have.been.calledWith(event);
+        expect(userAnonymizedEventLoggingJob.schedule).to.have.been.calledWithExactly(event);
       });
     });
   });

--- a/api/tests/unit/infrastructure/external-storage/cpf-external-storage_test.js
+++ b/api/tests/unit/infrastructure/external-storage/cpf-external-storage_test.js
@@ -38,7 +38,7 @@ describe('Unit | Infrastructure | external-storage | cpf-external-storage', func
       await cpfExternalStorage.upload({ filename: '', readableStream, dependencies: { s3Utils, logger } });
 
       // then
-      expect(s3Utils.getS3Client).to.have.been.calledWith({
+      expect(s3Utils.getS3Client).to.have.been.calledWithExactly({
         accessKeyId: 'accessKeyId',
         secretAccessKey: 'secretAccessKey',
         endpoint: 'endpoint',
@@ -65,7 +65,7 @@ describe('Unit | Infrastructure | external-storage | cpf-external-storage', func
       await cpfExternalStorage.upload({ filename: 'filename.xml', readableStream, dependencies: { s3Utils, logger } });
 
       // then
-      expect(s3Utils.startUpload).to.have.been.calledWith({
+      expect(s3Utils.startUpload).to.have.been.calledWithExactly({
         client: s3ClientMock,
         filename: 'filename.xml',
         bucket: 'bucket',
@@ -108,7 +108,7 @@ describe('Unit | Infrastructure | external-storage | cpf-external-storage', func
       await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date: null, dependencies: { s3Utils } });
 
       // then
-      expect(s3Utils.getS3Client).to.have.been.calledWith({
+      expect(s3Utils.getS3Client).to.have.been.calledWithExactly({
         accessKeyId: 'accessKeyId',
         secretAccessKey: 'secretAccessKey',
         endpoint: 'endpoint',
@@ -133,7 +133,7 @@ describe('Unit | Infrastructure | external-storage | cpf-external-storage', func
       await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date: null, dependencies: { s3Utils } });
 
       // then
-      expect(s3Utils.listFiles).to.have.been.calledWith({ client: s3ClientMock, bucket: 'bucket' });
+      expect(s3Utils.listFiles).to.have.been.calledWithExactly({ client: s3ClientMock, bucket: 'bucket' });
     });
 
     it('should pre sign files modified after a date', async function () {
@@ -168,7 +168,7 @@ describe('Unit | Infrastructure | external-storage | cpf-external-storage', func
       await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date, dependencies: { s3Utils } });
 
       // then
-      expect(s3Utils.preSignFiles).to.have.been.calledWith({
+      expect(s3Utils.preSignFiles).to.have.been.calledWithExactly({
         client: s3ClientMock,
         bucket: 'bucket',
         keys: ['thirdFile', 'fourthFile'],

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -127,7 +127,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         await notify(userId, payload, { authenticationMethodRepository, httpAgent, httpErrorsHelper, monitoringTools });
 
         // then
-        expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+        expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
           event: 'participation-send-pole-emploi',
           'pole-emploi-action': 'send-results',
           'participation-state': 'PARTICIPATION_COMPLETED',
@@ -173,7 +173,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         await notify(userId, payload, { authenticationMethodRepository, httpAgent, httpErrorsHelper, monitoringTools });
 
         // then
-        expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+        expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWithExactly({
           event: 'participation-send-pole-emploi',
           'pole-emploi-action': 'refresh-token',
           'participation-state': 'PARTICIPATION_STARTED',
@@ -205,7 +205,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           // then
           expect(
             authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
-          ).to.have.been.calledWith({
+          ).to.have.been.calledWithExactly({
             authenticationComplement,
             userId,
             identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
@@ -300,7 +300,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           });
 
           // then
-          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
             event: 'participation-send-pole-emploi',
             'pole-emploi-action': 'refresh-token',
             'participation-state': 'PARTICIPATION_STARTED',
@@ -361,7 +361,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           });
 
           // then
-          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
             event: 'participation-send-pole-emploi',
             'pole-emploi-action': 'send-results',
             'participation-state': 'PARTICIPATION_SHARED',

--- a/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler_test.js
@@ -40,7 +40,7 @@ describe('Unit | Infrastructure | Jobs | audit-log | ', function () {
         action: 'ANONYMIZATION',
         client: 'PIX_ADMIN',
       };
-      expect(auditLoggerRepository.logEvent).to.have.been.calledWith(expectedEvent);
+      expect(auditLoggerRepository.logEvent).to.have.been.calledWithExactly(expectedEvent);
     });
   });
 });

--- a/api/tests/unit/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler_test.js
@@ -17,7 +17,9 @@ describe('Unit | Infrastructure | Jobs | saveComputedCampaignParticipationResult
       await participationResultCalculationJobHandler.handle(event);
 
       // then
-      expect(usecases.saveComputedCampaignParticipationResult).to.have.been.calledWith({ campaignParticipationId });
+      expect(usecases.saveComputedCampaignParticipationResult).to.have.been.calledWithExactly({
+        campaignParticipationId,
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler_test.js
@@ -24,7 +24,9 @@ describe('Unit | Infrastructure | Jobs | SendSharedParticipationResultsToPoleEmp
       await sendSharedParticipationResultsToPoleEmploiHandler.handle(event);
 
       // then
-      expect(usecases.sendSharedParticipationResultsToPoleEmploi).to.have.been.calledWith({ campaignParticipationId });
+      expect(usecases.sendSharedParticipationResultsToPoleEmploi).to.have.been.calledWithExactly({
+        campaignParticipationId,
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -68,16 +68,16 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
       });
 
       // then
-      expect(cpfCertificationXmlExportService.buildXmlExport).to.have.been.calledWith({
+      expect(cpfCertificationXmlExportService.buildXmlExport).to.have.been.calledWithExactly({
         cpfCertificationResults,
         writableStream: sinon.match(PassThrough),
         uuidService,
       });
-      expect(cpfExternalStorage.upload).to.have.been.calledWith({
+      expect(cpfExternalStorage.upload).to.have.been.calledWithExactly({
         filename: 'pix-cpf-export-20220101-114327.xml.gz',
         readableStream: sinon.match(Readable),
       });
-      expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
+      expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWithExactly({
         certificationCourseIds: [12, 20, 33, 98, 114],
         filename: 'pix-cpf-export-20220101-114327.xml.gz',
       });

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
@@ -64,7 +64,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
       offset: 4,
       batchId: '237584-7648#2',
     });
-    expect(cpfCertificationResultRepository.countByTimeRange).to.have.been.calledWith({ startDate, endDate });
+    expect(cpfCertificationResultRepository.countByTimeRange).to.have.been.calledWithExactly({ startDate, endDate });
     expect(pgBoss.insert).to.have.been.calledOnceWith([
       {
         name: 'CpfExportBuilderJob',

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
@@ -33,7 +33,9 @@ describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
     await sendEmail({ cpfExternalStorage, mailService });
 
     // then
-    expect(cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter).to.have.been.calledWith({ date: expectedDate });
+    expect(cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter).to.have.been.calledWithExactly({
+      date: expectedDate,
+    });
   });
 
   it('should send an email with a list of generated files url', async function () {
@@ -52,7 +54,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
     await sendEmail({ cpfExternalStorage, mailService });
 
     // then
-    expect(mailService.sendCpfEmail).to.have.been.calledWith({
+    expect(mailService.sendCpfEmail).to.have.been.calledWithExactly({
       email: 'teamcertif@example.net',
       generatedFiles: [
         'https://bucket.url.com/file1.xml',

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -87,7 +87,10 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
           const result = await mailer.sendEmail({ to: recipient });
 
           // then
-          expect(logger.warn).to.have.been.calledWith({ err: expectedError }, "Email is not valid 'test@example.net'");
+          expect(logger.warn).to.have.been.calledWithExactly(
+            { err: expectedError },
+            "Email is not valid 'test@example.net'",
+          );
           expect(result).to.deep.equal(
             EmailingAttempt.failure('test@example.net', EmailingAttempt.errorCode.INVALID_DOMAIN),
           );

--- a/api/tests/unit/infrastructure/repositories/audit-logger-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/audit-logger-repository_test.js
@@ -40,7 +40,7 @@ describe('Unit | Infrastructure | Repositories | audit-logger-repository', funct
         await auditLoggerRepository.logEvent(event);
 
         // then
-        expect(httpAgent.post).to.have.been.calledWith({ url, payload, headers });
+        expect(httpAgent.post).to.have.been.calledWithExactly({ url, payload, headers });
       });
     });
 

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -124,7 +124,7 @@ describe('Unit | Repository | correction-repository', function () {
         expect(getCorrectionStub).not.to.have.been.called;
         expect(result).to.be.an.instanceof(Correction);
         expect(result).to.deep.equal(expectedCorrection);
-        expect(challengeDatasource.get).to.have.been.calledWith(recordId);
+        expect(challengeDatasource.get).to.have.been.calledWithExactly(recordId);
         expect(expectedCorrection.tutorials.map(({ skillId }) => skillId)).to.deep.equal([
           'recSK0X22abcdefgh',
           'recSK0X22abcdefgh',

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -52,7 +52,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         sinon.stub(logger, 'error');
         csvSerializer.serializeLine([{}]);
         // then
-        expect(logger.error).to.have.been.calledWith(
+        expect(logger.error).to.have.been.calledWithExactly(
           'Unknown value type in _csvSerializeValue: object: [object Object]',
         );
       });
@@ -62,7 +62,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         sinon.stub(logger, 'error');
         csvSerializer.serializeLine([null]);
         // then
-        expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: object: null');
+        expect(logger.error).to.have.been.calledWithExactly('Unknown value type in _csvSerializeValue: object: null');
       });
 
       it('given undefined', async function () {
@@ -70,7 +70,9 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         sinon.stub(logger, 'error');
         csvSerializer.serializeLine([undefined]);
         // then
-        expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: undefined: undefined');
+        expect(logger.error).to.have.been.calledWithExactly(
+          'Unknown value type in _csvSerializeValue: undefined: undefined',
+        );
       });
     });
   });
@@ -1059,7 +1061,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       });
 
       // then
-      expect(checkCsvHeaderStub).to.have.been.calledWith({ filePath, requiredFieldNames });
+      expect(checkCsvHeaderStub).to.have.been.calledWithExactly({ filePath, requiredFieldNames });
     });
   });
 

--- a/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -85,7 +85,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       await redisTemporaryStorage.save({ value, expirationDelaySeconds });
 
       // then
-      expect(clientStub.set).to.have.been.calledWith(
+      expect(clientStub.set).to.have.been.calledWithExactly(
         sinon.match.any,
         JSON.stringify(value),
         EXPIRATION_PARAMETER,
@@ -123,7 +123,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       await redisTemporaryStorage.update(key, value);
 
       // then
-      expect(clientStub.set).to.have.been.calledWith(sinon.match.any, JSON.stringify(value), KEEPTTL_PARAMETER);
+      expect(clientStub.set).to.have.been.calledWithExactly(sinon.match.any, JSON.stringify(value), KEEPTTL_PARAMETER);
     });
   });
 
@@ -154,7 +154,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       await redisTemporaryStorage.expire({ key, expirationDelaySeconds });
 
       // then
-      expect(clientStub.expire).to.have.been.calledWith(key, expirationDelaySeconds);
+      expect(clientStub.expire).to.have.been.calledWithExactly(key, expirationDelaySeconds);
     });
   });
 
@@ -169,7 +169,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       const remainingTtl = await redisTemporaryStorage.ttl(key);
 
       // then
-      expect(clientStub.ttl).to.have.been.calledWith(key);
+      expect(clientStub.ttl).to.have.been.calledWithExactly(key);
       expect(remainingTtl).to.equal(12);
     });
   });
@@ -186,7 +186,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       await redisTemporaryStorage.lpush(key, value);
 
       // then
-      expect(clientStub.lpush).to.have.been.calledWith('key', 'valueToAdd');
+      expect(clientStub.lpush).to.have.been.calledWithExactly('key', 'valueToAdd');
     });
   });
 
@@ -202,7 +202,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       await redisTemporaryStorage.lrem(key, value);
 
       // then
-      expect(clientStub.lrem).to.have.been.calledWith('key', 0, 'valueToRemove');
+      expect(clientStub.lrem).to.have.been.calledWithExactly('key', 0, 'valueToRemove');
     });
   });
 
@@ -219,7 +219,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       await redisTemporaryStorage.lrange(key, start, stop);
 
       // then
-      expect(clientStub.lrange).to.have.been.calledWith('key', 0, -1);
+      expect(clientStub.lrange).to.have.been.calledWithExactly('key', 0, -1);
     });
   });
 });

--- a/api/tests/unit/scripts/delete-assessment_test.js
+++ b/api/tests/unit/scripts/delete-assessment_test.js
@@ -112,12 +112,16 @@ describe('Delete Assessment Script', function () {
         return promise.then(() => {
           sinon.assert.callCount(clientStub.query_and_log, 4);
 
-          expect(clientStub.query_and_log).to.have.been.calledWith('DELETE FROM feedbacks WHERE "assessmentId" = 1345');
-          expect(clientStub.query_and_log).to.have.been.calledWith('DELETE FROM answers WHERE "assessmentId" = 1345');
-          expect(clientStub.query_and_log).to.have.been.calledWith(
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
+            'DELETE FROM feedbacks WHERE "assessmentId" = 1345',
+          );
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
+            'DELETE FROM answers WHERE "assessmentId" = 1345',
+          );
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
             'DELETE FROM "competence-marks" WHERE "assessmentResultId" IN ( SELECT id from "assessment-results" WHERE "assessmentId" = 1345 )',
           );
-          expect(clientStub.query_and_log).to.have.been.calledWith(
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
             'DELETE FROM "assessment-results" WHERE "assessmentId" = 1345',
           );
         });

--- a/api/tests/unit/scripts/delete-user_test.js
+++ b/api/tests/unit/scripts/delete-user_test.js
@@ -337,16 +337,16 @@ describe('Delete User Script', function () {
         return promise.then(() => {
           sinon.assert.callCount(clientStub.query_and_log, 4);
 
-          expect(clientStub.query_and_log).to.have.been.calledWith(
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
             'DELETE FROM feedbacks WHERE "assessmentId" IN (123,456)',
           );
-          expect(clientStub.query_and_log).to.have.been.calledWith(
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
             'DELETE FROM answers WHERE "assessmentId" IN (123,456)',
           );
-          expect(clientStub.query_and_log).to.have.been.calledWith(
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
             'DELETE FROM "competence-marks" WHERE "assessmentResultId" IN ( SELECT id from "assessment-results" WHERE "assessmentId" IN (123,456) )',
           );
-          expect(clientStub.query_and_log).to.have.been.calledWith(
+          expect(clientStub.query_and_log).to.have.been.calledWithExactly(
             'DELETE FROM "assessment-results" WHERE "assessmentId" IN (123,456)',
           );
         });


### PR DESCRIPTION
## :unicorn: Problème
le fait d'utiliser calledWith dans les tests ne permet de de garantir que la signature ne change pas, ou n'a pas été changé

## :robot: Proposition
Modifier les calledWith en calledExactlyWith afin de vérifier la signature au complet

## :rainbow: Remarques
Seul un calledWith est resté dans le redis_test.js.

## :100: Pour tester
Vérifier que la CI passe