### PR TITLE
[FEATURE] Unifier la compatibilité des apps Ember.js avec les différents navigateurs web suivant l'ADR

### DIFF
--- a/1d/config/targets.js
+++ b/1d/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%', 'firefox 58'];
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/1d/config/targets.js
+++ b/1d/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['defaults', 'last 4 years'];
+const { browsers } = require('../../config/targets.js');
 
 module.exports = {
   browsers,

--- a/admin/config/targets.js
+++ b/admin/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%'];
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/admin/config/targets.js
+++ b/admin/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['defaults', 'last 4 years'];
+const { browsers } = require('../../config/targets.js');
 
 module.exports = {
   browsers,

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%', 'firefox 58'];
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['defaults', 'last 4 years'];
+const { browsers } = require('../../config/targets.js');
 
 module.exports = {
   browsers,

--- a/config/targets.js
+++ b/config/targets.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const browsers = ['defaults', 'last 4 years'];
+
+module.exports = {
+  browsers,
+};

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%', 'firefox 58'];
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['defaults', 'last 4 years'];
+const { browsers } = require('../../config/targets.js');
 
 module.exports = {
   browsers,

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%', 'firefox 58'];
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['defaults', 'last 4 years'];
+const { browsers } = require('../../config/targets.js');
 
 module.exports = {
   browsers,


### PR DESCRIPTION
## :unicorn: Problème

Les différentes applications Ember.js du monorepo ont des configurations de compatibilité avec les différents navigateurs web qui sont problématiques cf. _[ADR] Compatibilité avec les différents navigateurs web (browser support)_.

## :robot: Proposition

L'ADR sur la compatibilité des navigateurs ayant été validée avec #6986, on peut maintenant mettre à jour et unifier la compatibilité des front Pix avec les différents navigateurs web.

Cette PR ne fait que mettre à jour et unifier la configuration de compatibilité des navigateurs pour les apps Ember.js du monorepo. Il faudra continuer ce travail sur les autres front pix.

En pratique au moment où cette PR est faite, les artefacts produits sont identiques avant (sur `dev`) et après avec cette PR.

Le fait que les artefacts produits soient identiques avant et après éveille logiquement le doute 🤔 quant à la bonne prise en compte de ce changement de configuration et/ou quant à son efficacité. Pour valider que le fichier `config/targets.js` a bien un effet on peut faire 2 builds différents avec respectivement les configurations suivantes et on constate que les artefacts sont clairement différents : 

```javascript
const browsers = ['firefox 58']
```

```javascript
const browsers = ['firefox 110'];
```

L'explication du pourquoi les artefacts produits avant (sur `dev`) et après cette PR sont identiques tient au fait que les configurations BrowsersList `> 1%` et `defaults` offrent/recherchent un tel périmètre de compatibilité que le fait de supprimer la compatibilité avec Firefox 58 ne produit pas encore d'optimisation.


## :rainbow: Remarques

Les artefacts sont construits avec la commande suivante : 

```shell
BUILD_ENVIRONMENT=production npm run build
```

## :100: Pour tester

1. La CI doit passer
2. Les différentes apps Ember.js doivent bien fonctionner avec la plus vielle version de chaque navigateur listé dans la sortie de la commande suivante : 

   ```shell
   npx browserslist "defaults, last 4 years"
   ```

   Le service _LambdaTest_ peut être utilisé pour tester avec ces plus vieilles versions de navigateurs données.

   Sinon c'est avec Firefox qu'il est le plus aisé de tester avec des versions anciennes : https://ftp.mozilla.org/pub/firefox/releases/
   Ainsi au moment de la création de cette PR, la plus vieille version de Firefox retournée par la commande `npx browserslist "defaults, last 4 years"` est `firefox 70` et c'est avec celle-ci qu'il est recommandé de tester cette PR.
  
