### PR TITLE
[TECH] Utiliser uniquement le setupIntl qui provient des helpers (PIX-9392)

### DIFF
--- a/orga/app/components/campaign/target-profile-details.hbs
+++ b/orga/app/components/campaign/target-profile-details.hbs
@@ -14,7 +14,9 @@
       </li>
     {{/if}}
     <li class="target-profile-details__specificity__row target-profile-details__specificity__row--break-line">
-      {{t "common.target-profile-details.results.common"}}
+      <span class="target-profile-details__specificity__white-space">
+        {{t "common.target-profile-details.results.common"}}
+      </span>
       <FaIcon
         @fixedWidth={{true}}
         @aria-hidden={{false}}

--- a/orga/app/styles/components/campaign/target-profile-details.scss
+++ b/orga/app/styles/components/campaign/target-profile-details.scss
@@ -9,6 +9,10 @@
     margin: 0;
     padding: 0;
 
+    &__white-space {
+      padding-right: 5px;
+    }
+
     &__row {
       margin-bottom: 8px;
       font-size: 0.875rem;

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -128,6 +128,7 @@
   }
 
   abbr.mandatory-mark {
+    padding-right: 5px;
     color: $pix-error-70;
     text-decoration: none;
     border: none;

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -20,6 +20,7 @@ module('Integration | Component | Campaign::Cards::StageAverage', function (hook
     );
 
     assert.contains(this.intl.t('cards.participants-average-stages.title'));
+    assert.dom(screen.getByText(this.intl.t('cards.participants-average-stages.title'))).exists();
     assert.dom(screen.getByText(this.intl.t('common.result.stages', { count: 1, total: 2 }))).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl, t } from 'ember-intl/test-support';
 import { render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Cards::StageAverage', function (hooks) {
   setupIntlRenderingTest(hooks);
-  setupIntl(hooks);
 
   test('it should display average result card', async function (assert) {
     this.totalStage = 3;
@@ -21,7 +19,7 @@ module('Integration | Component | Campaign::Cards::StageAverage', function (hook
 />`,
     );
 
-    assert.contains(t('cards.participants-average-stages.title'));
-    assert.dom(screen.getByText(t('common.result.stages', { count: 1, total: 2 }))).exists();
+    assert.contains(this.intl.t('cards.participants-average-stages.title'));
+    assert.dom(screen.getByText(this.intl.t('common.result.stages', { count: 1, total: 2 }))).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -19,7 +19,6 @@ module('Integration | Component | Campaign::Cards::StageAverage', function (hook
 />`,
     );
 
-    assert.contains(this.intl.t('cards.participants-average-stages.title'));
     assert.dom(screen.getByText(this.intl.t('cards.participants-average-stages.title'))).exists();
     assert.dom(screen.getByText(this.intl.t('common.result.stages', { count: 1, total: 2 }))).exists();
   });

--- a/orga/tests/integration/components/campaign/copy-paste-button_test.js
+++ b/orga/tests/integration/components/campaign/copy-paste-button_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 
@@ -12,12 +12,12 @@ module('Integration | Component | Campaign::CopyPasteButton', function (hooks) {
     this.successMessage = successMessage;
     this.defaultMessage = defaultMessage;
 
-    await render(hbs`<Campaign::CopyPasteButton
+    const screen = await render(hbs`<Campaign::CopyPasteButton
   @clipboardText='textToCopy'
   @successMessage={{this.successMessage}}
   @defaultMessage={{this.defaultMessage}}
 />`);
 
-    assert.contains(defaultMessage);
+    assert.dom(screen.getByText(defaultMessage)).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/copy-paste-button_test.js
+++ b/orga/tests/integration/components/campaign/copy-paste-button_test.js
@@ -2,11 +2,9 @@ import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | Campaign::CopyPasteButton', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   const successMessage = 'Ouiiiiiii !';
   const defaultMessage = 'Ivre il clique sur le bouton et ....';

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -4,13 +4,11 @@ import { clickByName, fillByLabel, render, within } from '@1024pix/ember-testing
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { click } from '@ember/test-helpers';
 
 module('Integration | Component | Campaign::CreateForm', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntlRenderingTest(hooks);
 
   let prescriber;
   let defaultMembers;
@@ -57,7 +55,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     // then
-    assert.contains(t('pages.campaign-creation.name.label'));
+    assert.contains(this.intl.t('pages.campaign-creation.name.label'));
     assert.dom('button[type="submit"]').exists();
     assert.dom('input[type=text]').hasAttribute('maxLength', '255');
     assert.dom('textarea').hasAttribute('maxLength', '5000');
@@ -80,7 +78,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     assert
-      .dom(screen.getByRole('textbox', { name: t('pages.campaign-creation.name.label') }))
+      .dom(screen.getByRole('textbox', { name: this.intl.t('pages.campaign-creation.name.label') }))
       .hasValue('Campagne de test');
   });
 
@@ -98,8 +96,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     // then
-    assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
-    assert.dom(screen.getByText(t('pages.campaign-creation.owner.title'))).exists();
+    assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.owner.info'))).exists();
+    assert.dom(screen.getAllByText(this.intl.t('pages.campaign-creation.owner.title'))[0]).exists();
   });
 
   test("it should auto complete owner field with owner's full name", async function (assert) {
@@ -114,7 +112,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
     );
-    await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+    await click(screen.getByLabelText(this.intl.t('pages.campaign-creation.owner.label'), { exact: false }));
     await screen.findByRole('listbox');
 
     // then
@@ -135,7 +133,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     // then
-    assert.dom(screen.getByText(t('common.form.mandatory-fields'))).exists();
+    assert.dom(screen.getByText(this.intl.t('common.form.mandatory-fields'))).exists();
   });
 
   module('when campaign is of type ASSESSMENT', function () {
@@ -156,7 +154,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       );
 
       // then
-      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.assessment'))).isChecked();
+      assert.dom(screen.getByLabelText(this.intl.t('pages.campaign-creation.purpose.assessment'))).isChecked();
     });
 
     test('it should fill target-profile fields', async function (assert) {
@@ -185,7 +183,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       // then
       assert.strictEqual(
-        screen.getByRole('button', { name: t('pages.campaign-creation.target-profiles-list-label') }).innerText,
+        screen.getByRole('button', { name: this.intl.t('pages.campaign-creation.target-profiles-list-label') })
+          .innerText,
         targetProfile.name,
       );
     });
@@ -210,9 +209,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       // then
       const radiogroup = screen.getByRole('radiogroup', {
-        name: t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+        name: this.intl.t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
       });
-      assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+      assert.dom(within(radiogroup).getByLabelText(this.intl.t('pages.campaign-creation.yes'))).isChecked();
     });
   });
 
@@ -233,7 +232,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 />`,
       );
 
-      assert.dom(screen.getByLabelText(t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
+      assert.dom(screen.getByLabelText(this.intl.t('pages.campaign-creation.purpose.profiles-collection'))).isChecked();
     });
 
     test('it should fill multiple sendings fields', async function (assert) {
@@ -255,9 +254,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       // then
       const radiogroup = screen.getByRole('radiogroup', {
-        name: t('pages.campaign-creation.multiple-sendings.profiles.question-label'),
+        name: this.intl.t('pages.campaign-creation.multiple-sendings.profiles.question-label'),
       });
-      assert.dom(within(radiogroup).getByLabelText(t('pages.campaign-creation.yes'))).isChecked();
+      assert.dom(within(radiogroup).getByLabelText(this.intl.t('pages.campaign-creation.yes'))).isChecked();
     });
   });
 
@@ -274,11 +273,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.purpose.assessment'));
+      await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(t('pages.campaign-creation.test-title.label'));
-      assert.contains(t('pages.campaign-creation.purpose.label'));
+      assert.contains(this.intl.t('pages.campaign-creation.test-title.label'));
+      assert.contains(this.intl.t('pages.campaign-creation.purpose.label'));
     });
 
     test('it should display the purpose explanation of an assessment campaign', async function (assert) {
@@ -293,11 +292,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.purpose.assessment'));
+      await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(t('pages.campaign-creation.purpose.assessment-info'));
-      assert.notContains(t('pages.campaign-creation.purpose.profiles-collection-info'));
+      assert.contains(this.intl.t('pages.campaign-creation.purpose.assessment-info'));
+      assert.notContains(this.intl.t('pages.campaign-creation.purpose.profiles-collection-info'));
     });
 
     module('when the user chose a target profile', function () {
@@ -333,15 +332,17 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
         );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+        await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-        await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+        await click(
+          screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+        );
         await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
         // then
         assert.contains('description1');
-        assert.contains(t('common.target-profile-details.subjects', { value: 11 }));
-        assert.contains(t('common.target-profile-details.thematic-results', { value: 12 }));
+        assert.contains(this.intl.t('common.target-profile-details.subjects', { value: 11 }));
+        assert.contains(this.intl.t('common.target-profile-details.thematic-results', { value: 12 }));
       });
 
       test('it should display a message about result', async function (assert) {
@@ -376,13 +377,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
         );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+        await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-        await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+        await click(
+          screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+        );
         await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
         // then
-        assert.contains(t('common.target-profile-details.results.common'));
+        assert.contains(this.intl.t('common.target-profile-details.results.common'));
       });
 
       module('Displaying options and categories', function () {
@@ -438,9 +441,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
           );
-          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+          await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(
+            screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+          );
           let options = await screen.findAllByRole('option');
 
           // then
@@ -484,9 +489,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
           );
-          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+          await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(
+            screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+          );
           let options = await screen.findAllByRole('option');
 
           // then
@@ -523,11 +530,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
         );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+        await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
         // then
-        assert.notContains(t('pages.campaign-creation.multiple-sendings.assessments.question-label'));
-        assert.notContains(t('pages.campaign-creation.multiple-sendings.assessments.info'));
+        assert.notContains(this.intl.t('pages.campaign-creation.multiple-sendings.assessments.question-label'));
+        assert.notContains(this.intl.t('pages.campaign-creation.multiple-sendings.assessments.info'));
       });
 
       test('it should display multiple sendings field', async function (assert) {
@@ -563,13 +570,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
         );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+        await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-        await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+        await click(
+          screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+        );
         await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
         // then
-        assert.contains(t('common.target-profile-details.results.common'));
+        assert.contains(this.intl.t('common.target-profile-details.results.common'));
       });
 
       module('when target profile are knowledge elements resettable', function () {
@@ -607,13 +616,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
           );
-          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+          await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(
+            screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+          );
           await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
           // then
-          assert.contains(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
+          assert.contains(this.intl.t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
         });
       });
 
@@ -652,13 +663,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
           );
-          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+          await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
-          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          await click(
+            screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+          );
           await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
           // then
-          assert.notContains(t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
+          assert.notContains(this.intl.t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
         });
       });
     });
@@ -677,11 +690,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+      await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.notContains(t('pages.campaign-creation.test-title.label'));
-      assert.notContains(t('pages.campaign-creation.target-profiles-list-label'));
+      assert.notContains(this.intl.t('pages.campaign-creation.test-title.label'));
+      assert.notContains(this.intl.t('pages.campaign-creation.target-profiles-list-label'));
     });
 
     test('it should display fields for enabling multiple sendings', async function (assert) {
@@ -696,11 +709,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+      await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.contains(t('pages.campaign-creation.multiple-sendings.profiles.question-label'));
-      assert.contains(t('pages.campaign-creation.multiple-sendings.profiles.info'));
+      assert.contains(this.intl.t('pages.campaign-creation.multiple-sendings.profiles.question-label'));
+      assert.contains(this.intl.t('pages.campaign-creation.multiple-sendings.profiles.info'));
     });
 
     test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
@@ -715,11 +728,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
+      await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.contains(t('pages.campaign-creation.purpose.profiles-collection-info'));
-      assert.notContains(t('pages.campaign-creation.purpose.assessment-info'));
+      assert.contains(this.intl.t('pages.campaign-creation.purpose.profiles-collection-info'));
+      assert.notContains(this.intl.t('pages.campaign-creation.purpose.assessment-info'));
     });
   });
 
@@ -741,15 +754,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     // then
     const externalIdentifier = screen
-      .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
+      .getByText(this.intl.t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
       .closest('fieldset');
-    const element = within(externalIdentifier).getByRole('radio', { name: t('pages.campaign-creation.yes') });
+    const element = within(externalIdentifier).getByRole('radio', { name: this.intl.t('pages.campaign-creation.yes') });
 
     assert.dom(element).isChecked();
     assert
       .dom(
         screen.getByRole('textbox', {
-          name: `${t('pages.campaign-creation.external-id-label.label')} ${t(
+          name: `${this.intl.t('pages.campaign-creation.external-id-label.label')} ${this.intl.t(
             'pages.campaign-creation.external-id-label.suggestion',
           )}`,
         }),
@@ -775,9 +788,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     // then
     const externalIdentifier = screen
-      .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
+      .getByText(this.intl.t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
       .closest('fieldset');
-    const element = within(externalIdentifier).getByRole('radio', { name: t('pages.campaign-creation.no') });
+    const element = within(externalIdentifier).getByRole('radio', { name: this.intl.t('pages.campaign-creation.no') });
 
     assert.dom(element).isChecked();
   });
@@ -798,11 +811,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       // then
       const externalIdentifier = screen
-        .getByText(t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
+        .getByText(this.intl.t('pages.campaign-creation.external-id-label.question-label'), { selector: 'legend' })
         .closest('fieldset');
 
-      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.no'))).isNotChecked();
-      assert.dom(within(externalIdentifier).getByLabelText(t('pages.campaign-creation.yes'))).isNotChecked();
+      assert.dom(within(externalIdentifier).getByLabelText(this.intl.t('pages.campaign-creation.no'))).isNotChecked();
+      assert.dom(within(externalIdentifier).getByLabelText(this.intl.t('pages.campaign-creation.yes'))).isNotChecked();
     });
 
     test('it should not display gdpr footnote', async function (assert) {
@@ -819,7 +832,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       );
 
       // then
-      assert.notContains(t('pages.campaign-creation.legal-warning'));
+      assert.notContains(this.intl.t('pages.campaign-creation.legal-warning'));
     });
   });
 
@@ -836,10 +849,10 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.no'));
+      await clickByName(this.intl.t('pages.campaign-creation.no'));
 
       // then
-      assert.notContains(t('pages.campaign-creation.legal-warning'));
+      assert.notContains(this.intl.t('pages.campaign-creation.legal-warning'));
     });
   });
 
@@ -856,10 +869,10 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.yes'));
+      await clickByName(this.intl.t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains(t('pages.campaign-creation.legal-warning'));
+      assert.contains(this.intl.t('pages.campaign-creation.legal-warning'));
     });
 
     test('it set the external id as required', async function (assert) {
@@ -874,10 +887,10 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.yes'));
+      await clickByName(this.intl.t('pages.campaign-creation.yes'));
 
       // then
-      const label = screen.getByLabelText(new RegExp(t('pages.campaign-creation.external-id-label.label')));
+      const label = screen.getByLabelText(new RegExp(this.intl.t('pages.campaign-creation.external-id-label.label')));
       assert.true(label.hasAttribute('aria-required', false));
     });
   });
@@ -900,7 +913,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     assert
-      .dom(screen.getByRole('textbox', { name: t('pages.campaign-creation.test-title.label') }))
+      .dom(screen.getByRole('textbox', { name: this.intl.t('pages.campaign-creation.test-title.label') }))
       .hasValue('Mon titre de parcours');
   });
 
@@ -921,7 +934,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     assert
-      .dom(screen.getByRole('textbox', { name: t('pages.campaign-creation.landing-page-text.label') }))
+      .dom(screen.getByRole('textbox', { name: this.intl.t('pages.campaign-creation.landing-page-text.label') }))
       .hasValue('Mon texte de landing page');
   });
 
@@ -941,13 +954,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
     );
-    await fillByLabel(`* ${t('pages.campaign-creation.name.label')}`, 'Ma campagne');
-    await clickByName(t('pages.campaign-creation.purpose.assessment'));
-    await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+    await fillByLabel(`* ${this.intl.t('pages.campaign-creation.name.label')}`, 'Ma campagne');
+    await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
+    await click(
+      screen.getByLabelText(this.intl.t('pages.campaign-creation.target-profiles-list-label'), { exact: false }),
+    );
     await click(await screen.findByRole('option', { name: targetProfile.name }));
 
     // when
-    await clickByName(t('pages.campaign-creation.actions.create'));
+    await clickByName(this.intl.t('pages.campaign-creation.actions.create'));
 
     sinon.assert.calledWithExactly(this.createCampaignSpy, this.campaign);
     // then
@@ -990,12 +1005,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.yes'));
+      await clickByName(this.intl.t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains(t('api-error-messages.campaign-creation.name-required'));
-      assert.contains(t('api-error-messages.campaign-creation.purpose-required'));
-      assert.contains(t('api-error-messages.campaign-creation.external-user-id-required'));
+      assert.contains(this.intl.t('api-error-messages.campaign-creation.name-required'));
+      assert.contains(this.intl.t('api-error-messages.campaign-creation.purpose-required'));
+      assert.contains(this.intl.t('api-error-messages.campaign-creation.external-user-id-required'));
     });
 
     test('it should display errors messages when the target profile field is empty', async function (assert) {
@@ -1022,10 +1037,10 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   @membersSortedByFullName={{this.defaultMembers}}
 />`,
       );
-      await clickByName(t('pages.campaign-creation.purpose.assessment'));
+      await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(t('api-error-messages.campaign-creation.target-profile-required'));
+      assert.contains(this.intl.t('api-error-messages.campaign-creation.target-profile-required'));
     });
   });
 });

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -43,7 +43,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   test('it should contain inputs, attributes and validation button', async function (assert) {
     // when
-    await render(
+    const screen = await render(
       hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -55,7 +55,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     // then
-    assert.contains(this.intl.t('pages.campaign-creation.name.label'));
+    assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.name.label'))).exists();
     assert.dom('button[type="submit"]').exists();
     assert.dom('input[type=text]').hasAttribute('maxLength', '255');
     assert.dom('textarea').hasAttribute('maxLength', '5000');
@@ -263,7 +263,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   module('when user choose to create a campaign of type ASSESSMENT', function () {
     test('it should display fields for campaign title and target profile', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -276,13 +276,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(this.intl.t('pages.campaign-creation.test-title.label'));
-      assert.contains(this.intl.t('pages.campaign-creation.purpose.label'));
+      assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.test-title.label'))).exists();
+      assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.purpose.label'))).exists();
     });
 
     test('it should display the purpose explanation of an assessment campaign', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -295,8 +295,10 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(this.intl.t('pages.campaign-creation.purpose.assessment-info'));
-      assert.notContains(this.intl.t('pages.campaign-creation.purpose.profiles-collection-info'));
+      assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.purpose.assessment-info'))).exists();
+      assert
+        .dom(screen.queryByText(this.intl.t('pages.campaign-creation.purpose.profiles-collection-info')))
+        .doesNotExist();
     });
 
     module('when the user chose a target profile', function () {
@@ -340,9 +342,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
         // then
-        assert.contains('description1');
-        assert.contains(this.intl.t('common.target-profile-details.subjects', { value: 11 }));
-        assert.contains(this.intl.t('common.target-profile-details.thematic-results', { value: 12 }));
+        assert.dom(screen.getByText('description1')).exists();
+        assert.dom(screen.getByText(this.intl.t('common.target-profile-details.subjects', { value: 11 }))).exists();
+        assert
+          .dom(screen.getByText(this.intl.t('common.target-profile-details.thematic-results', { value: 12 })))
+          .exists();
       });
 
       test('it should display a message about result', async function (assert) {
@@ -385,7 +389,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
         // then
-        assert.contains(this.intl.t('common.target-profile-details.results.common'));
+        assert.dom(screen.getByText(this.intl.t('common.target-profile-details.results.common'))).exists();
       });
 
       module('Displaying options and categories', function () {
@@ -520,7 +524,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     module('multiple sending', function () {
       test('it should not display multiple sendings field', async function (assert) {
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -533,8 +537,16 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
         // then
-        assert.notContains(this.intl.t('pages.campaign-creation.multiple-sendings.assessments.question-label'));
-        assert.notContains(this.intl.t('pages.campaign-creation.multiple-sendings.assessments.info'));
+        assert
+          .dom(
+            screen.queryByLabelText(
+              this.intl.t('pages.campaign-creation.multiple-sendings.assessments.question-label'),
+            ),
+          )
+          .doesNotExist();
+        assert
+          .dom(screen.queryByLabelText(this.intl.t('pages.campaign-creation.multiple-sendings.assessments.info')))
+          .doesNotExist();
       });
 
       test('it should display multiple sendings field', async function (assert) {
@@ -578,12 +590,14 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
         // then
-        assert.contains(this.intl.t('common.target-profile-details.results.common'));
+        assert.dom(screen.getByText(this.intl.t('common.target-profile-details.results.common'))).exists();
       });
 
       module('when target profile are knowledge elements resettable', function () {
         test('it should display specific message', async function (assert) {
           // given
+          prescriber.enableMultipleSendingAssessment = true;
+
           this.targetProfiles = [
             store.createRecord('target-profile', {
               id: '1',
@@ -603,7 +617,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
               hasStage: false,
             }),
           ];
-          prescriber.enableMultipleSendingAssessment = true;
 
           // when
           const screen = await render(
@@ -624,7 +637,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
           // then
-          assert.contains(this.intl.t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
+          assert
+            .dom(
+              screen.getByText(this.intl.t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'), {
+                exact: false,
+              }),
+            )
+            .exists();
         });
       });
 
@@ -671,7 +690,16 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           await click(await screen.findByRole('option', { name: 'targetProfile1' }));
 
           // then
-          assert.notContains(this.intl.t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'));
+          assert
+            .dom(
+              screen.queryByText(
+                this.intl.t('pages.campaign-creation.multiple-sendings.knowledge-elements-resettable'),
+                {
+                  exact: false,
+                },
+              ),
+            )
+            .doesNotExist();
         });
       });
     });
@@ -680,7 +708,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   module('when user choose to create a campaign of type PROFILES_COLLECTION', () => {
     test('it should not display fields for campaign title and target profile', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -693,13 +721,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.notContains(this.intl.t('pages.campaign-creation.test-title.label'));
-      assert.notContains(this.intl.t('pages.campaign-creation.target-profiles-list-label'));
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign-creation.test-title.label'))).doesNotExist();
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign-creation.target-profiles-list-label'))).doesNotExist();
     });
 
     test('it should display fields for enabling multiple sendings', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -712,13 +740,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.contains(this.intl.t('pages.campaign-creation.multiple-sendings.profiles.question-label'));
-      assert.contains(this.intl.t('pages.campaign-creation.multiple-sendings.profiles.info'));
+      assert
+        .dom(screen.getByText(this.intl.t('pages.campaign-creation.multiple-sendings.profiles.question-label')))
+        .exists();
+      assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.multiple-sendings.profiles.info'))).exists();
     });
 
     test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -731,8 +761,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.contains(this.intl.t('pages.campaign-creation.purpose.profiles-collection-info'));
-      assert.notContains(this.intl.t('pages.campaign-creation.purpose.assessment-info'));
+      assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.purpose.profiles-collection-info'))).exists();
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign-creation.purpose.assessment-info'))).doesNotExist();
     });
   });
 
@@ -820,7 +850,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     test('it should not display gdpr footnote', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -832,14 +862,14 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       );
 
       // then
-      assert.notContains(this.intl.t('pages.campaign-creation.legal-warning'));
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign-creation.legal-warning'))).doesNotExist();
     });
   });
 
   module('when user choose not to ask an external user ID', function () {
     test('it should not display gdpr footnote either', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -852,14 +882,14 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.no'));
 
       // then
-      assert.notContains(this.intl.t('pages.campaign-creation.legal-warning'));
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign-creation.legal-warning'))).doesNotExist();
     });
   });
 
   module('when user choose to ask an external user ID', function () {
     test('it should display gdpr footnote', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -872,7 +902,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains(this.intl.t('pages.campaign-creation.legal-warning'));
+      assert.dom(screen.getByText(this.intl.t('pages.campaign-creation.legal-warning'))).exists();
     });
 
     test('it set the external id as required', async function (assert) {
@@ -995,7 +1025,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       this.errors = campaign.errors;
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -1008,9 +1038,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains(this.intl.t('api-error-messages.campaign-creation.name-required'));
-      assert.contains(this.intl.t('api-error-messages.campaign-creation.purpose-required'));
-      assert.contains(this.intl.t('api-error-messages.campaign-creation.external-user-id-required'));
+      assert.dom(screen.getByText(this.intl.t('api-error-messages.campaign-creation.name-required'))).exists();
+      assert.dom(screen.getByText(this.intl.t('api-error-messages.campaign-creation.purpose-required'))).exists();
+      assert
+        .dom(screen.getByText(this.intl.t('api-error-messages.campaign-creation.external-user-id-required')))
+        .exists();
     });
 
     test('it should display errors messages when the target profile field is empty', async function (assert) {
@@ -1027,7 +1059,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       this.errors = campaign.errors;
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::CreateForm
   @campaign={{this.campaign}}
   @onSubmit={{this.createCampaignSpy}}
@@ -1040,7 +1072,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(this.intl.t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(this.intl.t('api-error-messages.campaign-creation.target-profile-required'));
+      assert
+        .dom(screen.getByText(this.intl.t('api-error-messages.campaign-creation.target-profile-required')))
+        .exists();
     });
   });
 });

--- a/orga/tests/integration/components/campaign/empty-state_test.js
+++ b/orga/tests/integration/components/campaign/empty-state_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -7,8 +7,8 @@ module('Integration | Component | Campaign::EmptyState', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it displays the empty message', async function (assert) {
-    await render(hbs`<Campaign::EmptyState @campaignCode='ABDC123' />`);
+    const screen = await render(hbs`<Campaign::EmptyState @campaignCode='ABDC123' />`);
 
-    assert.contains(this.intl.t('pages.campaign.empty-state'));
+    assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state'))).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/empty-state_test.js
+++ b/orga/tests/integration/components/campaign/empty-state_test.js
@@ -1,16 +1,14 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::EmptyState', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it displays the empty message', async function (assert) {
     await render(hbs`<Campaign::EmptyState @campaignCode='ABDC123' />`);
 
-    assert.contains(t('pages.campaign.empty-state'));
+    assert.contains(this.intl.t('pages.campaign.empty-state'));
   });
 });

--- a/orga/tests/integration/components/campaign/filter/campaign-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/campaign-filters_test.js
@@ -3,7 +3,6 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
-import { t } from 'ember-intl/test-support';
 
 module('Integration | Component | Campaign::Filter::CampaignFilters', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -24,12 +23,12 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
     );
 
     // then
-    assert.dom(screen.getByText('Filtres')).exists();
-    assert.dom(screen.getByLabelText('Rechercher une campagne')).exists();
-    assert.dom(screen.getByLabelText('Rechercher un propriétaire')).exists();
-    assert.dom(screen.getByLabelText('Archivées')).exists();
-    assert.dom(screen.getByLabelText('Actives')).exists();
-    assert.dom(screen.getByText('1 campagne')).exists();
+    assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.title'))).exists();
+    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-name'))).exists();
+    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner'))).exists();
+    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.action.archived.label'))).exists();
+    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.action.ongoing.label'))).exists();
+    assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.results', { total: 1 }))).exists();
   });
 
   module('With clear all filters button', function () {
@@ -68,7 +67,7 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
       );
 
       // then
-      assert.dom(screen.queryByLabelText('Rechercher un propriétaire')).doesNotExist();
+      assert.dom(screen.queryByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner'))).doesNotExist();
     });
   });
 
@@ -86,7 +85,7 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
 />`,
     );
 
-    await fillByLabel(t('pages.campaigns-list.filter.by-name'), 'Sal');
+    await fillByLabel(this.intl.t('pages.campaigns-list.filter.by-name'), 'Sal');
 
     // then
     assert.ok(triggerFiltering.calledWith('name', 'Sal'));
@@ -106,7 +105,7 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
 />`,
     );
 
-    await fillByLabel(t('pages.campaigns-list.filter.by-owner'), 'Sal');
+    await fillByLabel(this.intl.t('pages.campaigns-list.filter.by-owner'), 'Sal');
 
     // then
     assert.ok(triggerFiltering.calledWith('ownerName', 'Sal'));

--- a/orga/tests/integration/components/campaign/no-campaign-panel_test.js
+++ b/orga/tests/integration/components/campaign/no-campaign-panel_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -7,9 +7,9 @@ module('Integration | Component | Campaign::NoCampaignPanel', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it displays the empty message', async function (assert) {
-    await render(hbs`<Campaign::NoCampaignPanel />`);
+    const screen = await render(hbs`<Campaign::NoCampaignPanel />`);
 
-    assert.contains(this.intl.t('pages.campaigns-list.no-campaign'));
+    assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign'))).exists();
   });
 
   test('it displays the empty image', async function (assert) {

--- a/orga/tests/integration/components/campaign/no-campaign-panel_test.js
+++ b/orga/tests/integration/components/campaign/no-campaign-panel_test.js
@@ -1,17 +1,15 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::NoCampaignPanel', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it displays the empty message', async function (assert) {
     await render(hbs`<Campaign::NoCampaignPanel />`);
 
-    assert.contains(t('pages.campaigns-list.no-campaign'));
+    assert.contains(this.intl.t('pages.campaigns-list.no-campaign'));
   });
 
   test('it displays the empty image', async function (assert) {

--- a/orga/tests/integration/components/campaign/results/assessment-cards_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-cards_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Results::AssessmentCards', function (hooks) {
@@ -12,10 +12,10 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
       this.averageResult = 0.9;
 
       //when
-      await render(hbs`<Campaign::Results::AssessmentCards @averageResult={{this.averageResult}} />`);
+      const screen = await render(hbs`<Campaign::Results::AssessmentCards @averageResult={{this.averageResult}} />`);
 
       //then
-      assert.contains(this.intl.t('cards.participants-average-results.title'));
+      assert.dom(screen.getByText(this.intl.t('cards.participants-average-results.title'))).exists();
     });
   });
 
@@ -27,7 +27,7 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
       this.averageResult = 0.5;
 
       //when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::AssessmentCards
   @averageResult={{this.averageResult}}
   @hasStages={{this.hasStages}}
@@ -36,7 +36,7 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
       );
 
       //then
-      assert.contains(this.intl.t('cards.participants-average-stages.title'));
+      assert.dom(screen.getByText(this.intl.t('cards.participants-average-stages.title'))).exists();
     });
   });
 
@@ -45,11 +45,11 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
     this.sharedParticipationsCount = 10;
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Campaign::Results::AssessmentCards @sharedParticipationsCount={{this.sharedParticipationsCount}} />`,
     );
 
     //then
-    assert.contains(this.intl.t('cards.submitted-count.title'));
+    assert.dom(screen.getByText(this.intl.t('cards.submitted-count.title'))).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/results/assessment-cards_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-cards_test.js
@@ -2,11 +2,9 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl, t } from 'ember-intl/test-support';
 
 module('Integration | Component | Campaign::Results::AssessmentCards', function (hooks) {
   setupIntlRenderingTest(hooks);
-  setupIntl(hooks);
 
   module('When the campaign has no stages', function () {
     test('It should display average result card', async function (assert) {
@@ -17,7 +15,7 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
       await render(hbs`<Campaign::Results::AssessmentCards @averageResult={{this.averageResult}} />`);
 
       //then
-      assert.contains(t('cards.participants-average-results.title'));
+      assert.contains(this.intl.t('cards.participants-average-results.title'));
     });
   });
 
@@ -38,7 +36,7 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
       );
 
       //then
-      assert.contains(t('cards.participants-average-stages.title'));
+      assert.contains(this.intl.t('cards.participants-average-stages.title'));
     });
   });
 
@@ -52,6 +50,6 @@ module('Integration | Component | Campaign::Results::AssessmentCards', function 
     );
 
     //then
-    assert.contains(t('cards.submitted-count.title'));
+    assert.contains(this.intl.t('cards.submitted-count.title'));
   });
 });

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -21,35 +21,35 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
     this.campaign = {};
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
     );
 
     // then
-    assert.contains('Jean La fripouille');
+    assert.dom(screen.getByText('Jean La fripouille')).exists();
   });
 
   test('it displays campaign participation creation date', async function (assert) {
     this.participation = { createdAt: '2020-01-01' };
     this.campaign = {};
 
-    await render(
+    const screen = await render(
       hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
     );
 
-    assert.contains('01 janv. 2020');
+    assert.dom(screen.getByText('01 janv. 2020')).exists();
   });
 
   test('it displays campaign participation progression', async function (assert) {
     this.participation = { progression: 0.75 };
     this.campaign = {};
 
-    await render(
+    const screen = await render(
       hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
     );
 
-    assert.contains(this.intl.t('pages.assessment-individual-results.progression'));
-    assert.contains('75 %');
+    assert.dom(screen.getByText(this.intl.t('pages.assessment-individual-results.progression'))).exists();
+    assert.dom(screen.getByText('75 %')).exists();
   });
 
   module('is shared', function () {
@@ -62,12 +62,12 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         };
         this.campaign = {};
 
-        await render(
+        const screen = await render(
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.contains(this.intl.t('pages.campaign-individual-results.shared-date'));
-        assert.contains('02 janv. 2020');
+        assert.dom(screen.getByText(this.intl.t('pages.campaign-individual-results.shared-date'))).exists();
+        assert.dom(screen.getByText('02 janv. 2020')).exists();
       });
     });
 
@@ -76,11 +76,11 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         this.participation = { isShared: false };
         this.campaign = {};
 
-        await render(
+        const screen = await render(
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.notContains(this.intl.t('pages.campaign-individual-results.shared-date'));
+        assert.dom(screen.queryByText(this.intl.t('pages.campaign-individual-results.shared-date'))).doesNotExist();
       });
     });
   });
@@ -94,12 +94,12 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         };
         this.campaign = { idPixLabel: 'identifiant de l’élève' };
 
-        await render(
+        const screen = await render(
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.contains('identifiant de l’élève');
-        assert.contains('i12345');
+        assert.dom(screen.getByText('identifiant de l’élève')).exists();
+        assert.dom(screen.getByText('i12345')).exists();
       });
     });
     module('when the external id is not present', function () {
@@ -110,11 +110,11 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         };
         this.campaign = {};
 
-        await render(
+        const screen = await render(
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.notContains('identifiant de l’élève');
+        assert.dom(screen.queryByText('identifiant de l’élève')).doesNotExist();
       });
     });
   });
@@ -125,12 +125,14 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         this.participation = { progression: 1, isShared: true, masteryRate: 0.85 };
         this.campaign = {};
 
-        await render(
+        const screen = await render(
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.notContains(this.intl.t('pages.assessment-individual-results.progression'));
-        assert.notContains(this.intl.t('common.result.percentage', { value: this.participation.progression }));
+        assert.dom(screen.queryByText(this.intl.t('pages.assessment-individual-results.progression'))).doesNotExist();
+        assert
+          .dom(screen.queryByText(this.intl.t('common.result.percentage', { value: this.participation.progression })))
+          .doesNotExist();
       });
 
       module('when the campaign has stages', function () {
@@ -163,11 +165,11 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           this.participation = { masteryRate: 0.65, isShared: true };
           this.campaign = {};
 
-          await render(
+          const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.contains('65%');
+          assert.dom(screen.getAllByText('65%')[0]).exists();
         });
       });
 

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { t } from 'ember-intl/test-support';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -49,7 +48,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
       hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
     );
 
-    assert.contains(t('pages.assessment-individual-results.progression'));
+    assert.contains(this.intl.t('pages.assessment-individual-results.progression'));
     assert.contains('75 %');
   });
 
@@ -67,7 +66,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.contains(t('pages.campaign-individual-results.shared-date'));
+        assert.contains(this.intl.t('pages.campaign-individual-results.shared-date'));
         assert.contains('02 janv. 2020');
       });
     });
@@ -81,7 +80,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.notContains(t('pages.campaign-individual-results.shared-date'));
+        assert.notContains(this.intl.t('pages.campaign-individual-results.shared-date'));
       });
     });
   });
@@ -130,8 +129,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.notContains(t('pages.assessment-individual-results.progression'));
-        assert.notContains(t('common.result.percentage', { value: this.participation.progression }));
+        assert.notContains(this.intl.t('pages.assessment-individual-results.progression'));
+        assert.notContains(this.intl.t('common.result.percentage', { value: this.participation.progression }));
       });
 
       module('when the campaign has stages', function () {
@@ -154,8 +153,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.dom(`[aria-label="${t('pages.assessment-individual-results.result')}"]`).exists();
-          assert.dom(screen.getByText(t('common.result.stages', { count: 1, total: 2 }))).exists();
+          assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.result'))).exists();
+          assert.dom(screen.getByText(this.intl.t('common.result.stages', { count: 1, total: 2 }))).exists();
         });
       });
 
@@ -177,11 +176,13 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           this.campaign = { hasBadges: true };
           this.participation = { isShared: true, masteryRate: 0.85, badges: [{ id: 1, title: 'Les bases' }] };
 
-          await render(
+          const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.dom(`[aria-label="${t('pages.assessment-individual-results.badges')}"]`).containsText('Les bases');
+          assert
+            .dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges')))
+            .containsText('Les bases');
         });
       });
 
@@ -190,11 +191,11 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           this.campaign = { hasBadges: false };
           this.participation = { isShared: true, masteryRate: 0.85, badges: [{ id: 1, title: 'Les bases' }] };
 
-          await render(
+          const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.dom(`[aria-label="${t('pages.assessment-individual-results.badges')}"]`).doesNotExist();
+          assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges'))).doesNotExist();
         });
       });
 
@@ -203,11 +204,10 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           this.campaign = { hasBadges: true };
           this.participation = { isShared: true, masteryRate: 0.85, badges: [] };
 
-          await render(
+          const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
-
-          assert.dom(`[aria-label="${t('pages.assessment-individual-results.badges')}"]`).doesNotExist();
+          assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges'))).doesNotExist();
         });
       });
     });
@@ -217,11 +217,11 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         this.participation = { isShared: false };
         this.campaign = {};
 
-        await render(
+        const screen = await render(
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(`[aria-label="${t('pages.assessment-individual-results.result')}"]`).doesNotExist();
+        assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.result'))).doesNotExist();
       });
     });
   });

--- a/orga/tests/integration/components/participant/assessment/results_test.js
+++ b/orga/tests/integration/components/participant/assessment/results_test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { setupIntl, t } from 'ember-intl/test-support';
 
 module('Integration | Component | Participant::Assessment::Results', function (hooks) {
   setupIntlRenderingTest(hooks);
-  setupIntl(hooks);
 
   let store;
 
@@ -16,10 +14,10 @@ module('Integration | Component | Participant::Assessment::Results', function (h
 
   test('it should display a sentence when displayResults is false', async function (assert) {
     // when
-    await render(hbs`<Participant::Assessment::Results @displayResults={{false}} />`);
+    const screen = await render(hbs`<Participant::Assessment::Results @displayResults={{false}} />`);
 
     // then
-    assert.contains('En attente de résultats');
+    assert.dom(screen.getByText(this.intl.t('pages.assessment-individual-results.table.empty'))).exists();
   });
 
   test('it should display results when displayResults is true', async function (assert) {
@@ -38,15 +36,19 @@ module('Integration | Component | Participant::Assessment::Results', function (h
     this.set('campaignAssessmentParticipationResult', campaignAssessmentParticipationResult);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Participant::Assessment::Results @results={{this.campaignAssessmentParticipationResult}} @displayResults={{true}} />`,
     );
 
     // then
-    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.row-title')}"]`).exists({ count: 1 });
+    assert.dom(screen.getByLabelText(this.intl.t('pages.assessment-individual-results.table.row-title'))).exists();
+
     assert
-      .dom(`[aria-label="${t('pages.assessment-individual-results.table.row-title')}"]`)
+      .dom(screen.getByLabelText(this.intl.t('pages.assessment-individual-results.table.row-title')))
       .containsText('Compétence 1');
-    assert.dom(`[aria-label="${t('pages.assessment-individual-results.table.row-title')}"]`).containsText('50%');
+
+    assert
+      .dom(screen.getByLabelText(this.intl.t('pages.assessment-individual-results.table.row-title')))
+      .containsText('50%');
   });
 });

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -2,11 +2,9 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Unit | Component | Campaign::CreateForm', (hooks) => {
   setupTest(hooks);
-  setupIntl(hooks);
 
   module('#onChangeCampaignOwner', function () {
     test('should set new owner id', async function (assert) {

--- a/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import setupIntl from '../../../../helpers/setup-intl';
 import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/organization-participants', function (hooks) {

--- a/orga/tests/unit/services/error-messages_test.js
+++ b/orga/tests/unit/services/error-messages_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { setupIntl, t } from 'ember-intl/test-support';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Unit | Service | Error messages', function (hooks) {
   setupTest(hooks);
@@ -30,7 +30,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
     // Then
-    assert.strictEqual(message, t('api-error-messages.campaign-creation.name-required'));
+    assert.strictEqual(message, this.intl.t('api-error-messages.campaign-creation.name-required'));
   });
 
   module('SEX_CODE_REQUIRED', function () {
@@ -41,7 +41,10 @@ module('Unit | Service | Error messages', function (hooks) {
       // When
       const message = errorMessages.getErrorMessage('SEX_CODE_REQUIRED', { nationalStudentId });
       // Then
-      assert.strictEqual(message, t('api-error-messages.student-xml-import.sex-code-required', { nationalStudentId }));
+      assert.strictEqual(
+        message,
+        this.intl.t('api-error-messages.student-xml-import.sex-code-required', { nationalStudentId }),
+      );
     });
   });
 
@@ -55,7 +58,9 @@ module('Unit | Service | Error messages', function (hooks) {
       // Then
       assert.strictEqual(
         message,
-        t('api-error-messages.student-xml-import.birth-city-code-required-for-french-student', { nationalStudentId }),
+        this.intl.t('api-error-messages.student-xml-import.birth-city-code-required-for-french-student', {
+          nationalStudentId,
+        }),
       );
     });
   });
@@ -68,7 +73,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // Then
     assert.strictEqual(
       message,
-      t('api-error-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 }),
+      this.intl.t('api-error-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 }),
     );
   });
 
@@ -80,10 +85,10 @@ module('Unit | Service | Error messages', function (hooks) {
     // Then
     assert.strictEqual(
       message,
-      t('api-error-messages.student-csv-import.field-bad-values', {
+      this.intl.t('api-error-messages.student-csv-import.field-bad-values', {
         line: 1,
         field: 'Boo',
-        valids: `A${t('api-error-messages.or-separator')}B`,
+        valids: `A${this.intl.t('api-error-messages.or-separator')}B`,
       }),
     );
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -167,7 +167,7 @@
     },
     "form": {
       "mandatory-all-fields": "All fields are required.",
-      "mandatory-fields": " indicates a required field",
+      "mandatory-fields": "indicates a required field",
       "mandatory-fields-title": "required"
     },
     "fullname": "{firstName} {lastName}",
@@ -192,7 +192,7 @@
     },
     "target-profile-details": {
       "results": {
-        "common": "Success rate in ",
+        "common": "Success rate in",
         "percent": "percentage",
         "star": "stars"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -170,7 +170,7 @@
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires.",
-      "mandatory-fields": " indique un champ obligatoire",
+      "mandatory-fields": "indique un champ obligatoire",
       "mandatory-fields-title": "obligatoire"
     },
     "fullname": "{firstName} {lastName}",
@@ -195,7 +195,7 @@
     },
     "target-profile-details": {
       "results": {
-        "common": "Résultats affichés en ",
+        "common": "Résultats affichés en",
         "percent": "pourcentage",
         "star": "étoile"
       },


### PR DESCRIPTION
## :unicorn: Problème
Nous avons un helper spécifique et adapté à Pix et il y a encore des endroits dans PixOrga où le setupIntl utilisé provient de ember-intl/test-support.
Il y a également des tests existant où les des sont appelés...
Et d'autres tests où il y a un setupIntl mais pas de traduction ni de texte utilisé dans les tests...

## :robot: Proposition
J'en ai profité pour faire du BSR et retirer toutes les utilisations de "contains" dans ces fichiers.
N'utiliser que celui provenant des helpers et faire disparaître l'autre de la surface de PixOrga

## :rainbow: Remarques
Arrêtons de mettre des espaces dans les traductions pour mettre du style...

## :100: Pour tester
- Juste vérifier que tous les tests front sont fonctionnels et qu'ils passent
- 🎉 