### PR TITLE
[FEATURE] Creation d'une migration pour passer tous les prescrits SUP désactivés à supprimés (PIX-9199)

### DIFF
--- a/api/db/migrations/20231003140113_delete-sup-organization-learners-disabled.js
+++ b/api/db/migrations/20231003140113_delete-sup-organization-learners-disabled.js
@@ -1,0 +1,64 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+
+const engineeringUserId = process.env.ENGINEERING_USER_ID;
+
+async function deleteSupOrganizationLearnersDisabled(
+  deletedById,
+  knexTransaction,
+  dependencies = {
+    _queryBuilderForDisabledSupLearners,
+    _deleteDisabledLearners,
+    _deleteCampaignParticipations,
+  },
+) {
+  const supOrganizationLearnersDisabledIds = await dependencies._queryBuilderForDisabledSupLearners(knexTransaction);
+
+  if (supOrganizationLearnersDisabledIds.length === 0) return;
+
+  await dependencies._deleteCampaignParticipations(supOrganizationLearnersDisabledIds, deletedById, knexTransaction);
+  await dependencies._deleteDisabledLearners(supOrganizationLearnersDisabledIds, deletedById, knexTransaction);
+}
+
+async function _deleteCampaignParticipations(supOrganizationLearnersDisabledIds, deletedById, knexTransaction) {
+  await knexTransaction('campaign-participations')
+    .whereIn('organizationLearnerId', supOrganizationLearnersDisabledIds)
+    .update({ deletedAt: new Date(), deletedBy: deletedById });
+}
+
+async function _deleteDisabledLearners(supOrganizationLearnersDisabledIds, deletedById, knexTransaction) {
+  await knexTransaction('organization-learners').whereIn('id', supOrganizationLearnersDisabledIds).update({
+    deletedAt: new Date(),
+    deletedBy: deletedById,
+  });
+}
+
+function _queryBuilderForDisabledSupLearners(knexTransaction) {
+  return knexTransaction('organization-learners')
+    .join('organizations', 'organizations.id', 'organization-learners.organizationId')
+    .where({
+      'organizations.type': 'SUP',
+      'organization-learners.isDisabled': true,
+    })
+    .whereNull('organization-learners.deletedBy')
+    .pluck('organization-learners.id');
+}
+
+const up = async function (knex) {
+  await knex.transaction(async (trx) => {
+    await deleteSupOrganizationLearnersDisabled(engineeringUserId, trx);
+  });
+};
+
+const down = async function () {
+  // Do nothing, because it's impossible to rollback
+};
+
+export { up, down, deleteSupOrganizationLearnersDisabled };

--- a/api/db/seeds/data/team-prescription/build-learners.js
+++ b/api/db/seeds/data/team-prescription/build-learners.js
@@ -1,0 +1,27 @@
+import { SUP_MANAGING_ORGANIZATION_ID } from '../common/constants.js';
+
+async function _createSupLearners(databasebuilder) {
+  await databasebuilder.factory.buildOrganizationLearner({
+    organizationId: SUP_MANAGING_ORGANIZATION_ID,
+    lastName: 'Kenobi',
+    preferredLastName: 'Kenobi',
+    firstName: 'Jedi',
+    middleName: 'Obi',
+    thirdName: 'Wan',
+    isDisabled: true,
+  });
+
+  await databasebuilder.factory.buildOrganizationLearner({
+    organizationId: SUP_MANAGING_ORGANIZATION_ID,
+    lastName: 'Skywalker',
+    preferredLastName: 'Vador',
+    firstName: 'Jedi',
+    middleName: 'Anakin',
+    thirdName: 'Skywalker',
+    isDisabled: true,
+  });
+}
+
+export function buildOrganizationLearners(databaseBuilder) {
+  return _createSupLearners(databaseBuilder);
+}

--- a/api/db/seeds/data/team-prescription/data-builder.js
+++ b/api/db/seeds/data/team-prescription/data-builder.js
@@ -1,9 +1,11 @@
 import { buildCampaigns } from './build-campaigns.js';
 import { buildTargetProfiles } from './build-target-profiles.js';
+import { buildOrganizationLearners } from './build-learners.js';
 
 async function teamPrescriptionDataBuilder({ databaseBuilder }) {
   await buildTargetProfiles(databaseBuilder);
   await buildCampaigns(databaseBuilder);
+  await buildOrganizationLearners(databaseBuilder);
 }
 
 export { teamPrescriptionDataBuilder };

--- a/api/tests/integration/migration/20231003140113_delete-sup-organization-learners-disabled_test.js
+++ b/api/tests/integration/migration/20231003140113_delete-sup-organization-learners-disabled_test.js
@@ -1,0 +1,156 @@
+import { expect, databaseBuilder, knex, sinon } from '../../test-helper.js';
+import { deleteSupOrganizationLearnersDisabled } from '../../../db/migrations/20231003140113_delete-sup-organization-learners-disabled.js';
+
+describe('Integration | Scripts | delete-sup-organization-learners-disabled', function () {
+  let clock;
+  let deletedById;
+
+  const now = new Date('2023-09-10');
+
+  beforeEach(function () {
+    deletedById = databaseBuilder.factory.buildUser().id;
+    clock = sinon.useFakeTimers(now);
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('should not delete SCO organization learners with isDisabled TRUE', async function () {
+    // given
+    const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+    const { id: scoOrganizationLearnerDisabledId } = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      isDisabled: true,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await deleteSupOrganizationLearnersDisabled(deletedById, knex);
+
+    // then
+    const organizationLearner = await knex('organization-learners')
+      .where('id', scoOrganizationLearnerDisabledId)
+      .first();
+
+    expect(organizationLearner.deletedBy).to.be.null;
+    expect(organizationLearner.deletedAt).to.be.null;
+  });
+
+  it('should not delete SUP organization learners with isDisabled FALSE', async function () {
+    // given
+    const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+    const { id: organizationLearnerNotDisabledId } = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      isDisabled: false,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await deleteSupOrganizationLearnersDisabled(deletedById, knex);
+
+    // then
+    const organizationLearner = await knex('organization-learners')
+      .where('id', organizationLearnerNotDisabledId)
+      .first();
+
+    expect(organizationLearner.deletedBy).to.be.null;
+    expect(organizationLearner.deletedAt).to.be.null;
+  });
+
+  context('when learners are SUP and with isDisabled TRUE', function () {
+    it('should delete campaign participations with given ids', async function () {
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+      const { id: firstOrganizationLearnerDisabledId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        isDisabled: true,
+      });
+      const { id: secondOrganizationLearnerDisabledId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        isDisabled: true,
+      });
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: firstOrganizationLearnerDisabledId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: secondOrganizationLearnerDisabledId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+
+      await deleteSupOrganizationLearnersDisabled(deletedById, knex);
+
+      // then
+
+      const result = await knex('campaign-participations').whereIn('organizationLearnerId', [
+        firstOrganizationLearnerDisabledId,
+        secondOrganizationLearnerDisabledId,
+      ]);
+
+      expect(result[0].deletedAt).to.deep.equal(new Date());
+      expect(result[0].deletedBy).to.equal(deletedById);
+
+      expect(result[1].deletedAt).to.deep.equal(new Date());
+      expect(result[1].deletedBy).to.equal(deletedById);
+    });
+
+    it('should delete all SUP organization learners with isDisabled TRUE', async function () {
+      // given
+      const { id: firstOrganizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+      const { id: secondOrganizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+      const firstOrganizationLearnerDisabledId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: firstOrganizationId,
+        isDisabled: true,
+      }).id;
+      const secondOrganizationLearnerDisabledId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: secondOrganizationId,
+        isDisabled: true,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      await deleteSupOrganizationLearnersDisabled(deletedById, knex);
+
+      // then
+      const firstDeletedLearner = await knex('organization-learners')
+        .where('id', firstOrganizationLearnerDisabledId)
+        .first();
+      const secondDeletedLearner = await knex('organization-learners')
+        .where('id', secondOrganizationLearnerDisabledId)
+        .first();
+
+      expect(firstDeletedLearner.deletedBy).to.equal(deletedById);
+      expect(firstDeletedLearner.deletedAt).to.deep.equal(new Date());
+
+      expect(secondDeletedLearner.deletedBy).to.equal(deletedById);
+      expect(secondDeletedLearner.deletedAt).to.deep.equal(new Date());
+    });
+
+    it('should not delete SUP organization learners already deleted', async function () {
+      // given
+      const otherDeletedById = databaseBuilder.factory.buildUser().id;
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+      const { id: organizationLearnerDeletedId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+        isDisabled: true,
+        deletedBy: deletedById,
+        deletedAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await deleteSupOrganizationLearnersDisabled(otherDeletedById, knex);
+
+      // then
+      const organizationLearner = await knex('organization-learners').where('id', organizationLearnerDeletedId).first();
+
+      expect(organizationLearner.deletedBy).to.equal(deletedById);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour notre épix sur la suppression des learners des orga de type SUP. Nous voulons changer le statut des prescrits ayant été désactivés à un statut supprimés. La désactivation n'existera plus, elle sera remplacée par une supression.

## :robot: Proposition
Création d'une migration pour récuperer la liste des prescrits sup ayant été désactivés, afin de supprimer leurs participations puis de les supprimer.

## :rainbow: Remarques
- Ajout d'une variable d'environnement "ENGINEERING_USER_ID" qui correspond à l'ID engineering Pix pour lancer divers actions interne
- Ajout de seeds pour avoir des Prescrits Sup desactivés

## :100: Pour tester

- Vérifier que les migrations se passent bien
- Une fois que la RA à été seed, supprimer dans la table "knex_migrations" la migration correspondante à cette PR
- lancer un `npm run db:migrate`
- Vérifier que les deux learners sup disabled ont bien été delete
- 🐱 