### PR TITLE
[FEATURE] Ajout de la limite de questions par sujet dans le simulateur (PIX-9397).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -12,6 +12,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   useObsoleteChallenges: Joi.boolean(),
   challengePickProbability: Joi.number().min(0).max(100),
   challengesBetweenSameCompetence: Joi.number().min(0),
+  limitToOneQuestionPerTube: Joi.boolean(),
 });
 
 const register = async (server) => {

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -29,6 +29,7 @@ async function simulateFlashAssessmentScenario(
     useObsoleteChallenges,
     challengePickProbability,
     challengesBetweenSameCompetence,
+    limitToOneQuestionPerTube,
   } = request.payload;
 
   const pickAnswerStatus = _getPickAnswerStatusMethod(dependencies.pickAnswerStatusService, request.payload);
@@ -53,6 +54,7 @@ async function simulateFlashAssessmentScenario(
           forcedCompetences,
           useObsoleteChallenges,
           challengesBetweenSameCompetence,
+          limitToOneQuestionPerTube,
         },
         _.isUndefined,
       );

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -11,6 +11,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   forcedCompetences,
   useObsoleteChallenges,
   challengesBetweenSameCompetence,
+  limitToOneQuestionPerTube,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -19,6 +20,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     forcedCompetences,
     maximumAssessmentLength: stopAtChallenge,
     challengesBetweenSameCompetence,
+    limitToOneQuestionPerTube,
   });
 
   const simulator = new AssessmentSimulator({

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -136,6 +136,68 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         });
       });
     });
+
+    context('when we limit the number of challenges per tube', function () {
+      it('should return an array of estimated level, challenge, reward and error rate for each answer', async function () {
+        // given
+        const limitToOneQuestionPerTube = true;
+        const initialCapacity = 7;
+
+        const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill', tubeId: '1' });
+        const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill', tubeId: '1' });
+        const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill', tubeId: '2' });
+        const firstChallenge = domainBuilder.buildChallenge({
+          id: 'one',
+          skill: firstSkill,
+          difficulty: -2,
+          discriminant: 0.16,
+        });
+        const secondChallenge = domainBuilder.buildChallenge({
+          id: 'two',
+          skill: secondSkill,
+          difficulty: 6,
+          discriminant: 3,
+        });
+        const thirdChallenge = domainBuilder.buildChallenge({
+          id: 'three',
+          skill: thirdSkill,
+          difficulty: 7.5,
+          discriminant: 1.587,
+        });
+
+        const challengeRepository = {
+          findFlashCompatible: sinon.stub(),
+        };
+        const pickChallenge = sinon.stub();
+        const pickAnswerStatus = sinon.stub();
+
+        challengeRepository.findFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
+
+        pickChallenge.callsFake(({ possibleChallenges }) => possibleChallenges.at(-1));
+
+        pickAnswerStatus.callsFake(() => AnswerStatus.OK);
+
+        // when
+        const result = await simulateFlashDeterministicAssessmentScenario({
+          challengeRepository,
+          locale,
+          pickChallenge,
+          pickAnswerStatus,
+          initialCapacity,
+          limitToOneQuestionPerTube,
+        });
+
+        // then
+        expect(result).to.have.lengthOf(2);
+        result.forEach((answer) => {
+          expect(answer.challenge).not.to.be.undefined;
+          expect(answer.errorRate).not.to.be.undefined;
+          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.reward).not.to.be.undefined;
+          expect(answer.answerStatus).not.to.be.undefined;
+        });
+      });
+    });
   });
 
   context('when there are not enough flash challenges left', function () {


### PR DESCRIPTION
## :unicorn: Problème

L'équipe Data a besoin de pouvoir activer ou désactiver cette fonctionnalité afin de pouvoir tester son impact sur la précision de l’algorithme.

## :robot: Proposition

Ajout dans les paramètres d'entrée du simulateur

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

```
TOKEN=$(curl 'https://api-pr7161.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7161.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity","assessmentId": "1234", "capacity": 1.5, "limitToOneQuestionPerTube": true }' | jq '.'
```