### PR TITLE
[TECH] Simplifier le script de lancement des tests de l'API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -151,7 +151,7 @@
     "start:job": "node worker.js",
     "start:job:watch": "nodemon worker.js",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
-    "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit -not -path tests/shared -not -path tests/certification) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
+    "test:api": "for testType in 'unit' 'integration' 'acceptance'; do npm run test:api:$testType || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
     "test:api:scripts": "npm run test:api:path -- tests/integration/scripts",
     "test:api:unit": "TEST_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests REDIS_URL= npm run test:api:path -- tests/**/unit/**/*test.js",

--- a/api/tests/unit/docs/jsonapi-serializer.test.js
+++ b/api/tests/unit/docs/jsonapi-serializer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '../test-helper.js';
+import { expect } from '../../test-helper.js';
 import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;


### PR DESCRIPTION
## :unicorn: Problème
Le script permettant de[ lancer les tests de l'API est compliqué depuis que nous avons fait en sorte que les tests unitaires n'aient pas de connexion à la BDD](https://github.com/1024pix/pix/pull/1927). De plus ce script doit être mis à jour en fonction des dossiers créés dans le dossier `tests`, ce qui est couteux avec l'ajout des dossiers pour les bounded context. 

## :robot: Proposition
Lancer les tests en itérant uniquement sur le script qui nous intéresse et en lancant les tests dans l'ordre de la pyramide des tests. Cela implique que tous les tests soient dans un dossier parent `unit` ou`integration` ou `acceptance`

## :rainbow: Remarques
Actuellement, 9575 sont lancés sur dev, et 9716 sur cette branche en tout en lancant la commande : `NODE_ENV=test npx mocha --recursive --dry-run --reporter=dot tests` nous avons 9735 tests. Il y a donc actuellement 19 tests qui ne sont pas lancés. 

## :100: Pour tester
- Regarder le nombre de tests lancés dans la CI, il doit être identique au retour de la commande : `NODE_ENV=test npx mocha --recursive --dry-run --reporter=dot tests`
- Regarder si les tests unitaires ne peuvent pas appeler la BDD