### PR TITLE
[FEATURE] Configurer les taux de réussite de la certif v3 dans les simulateurs (PIX-9396)

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -2,6 +2,22 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../security-pre-handlers.js';
 import { scenarioSimulatorController } from './scenario-simulator-controller.js';
 
+const _successRatesConfigurationValidator = Joi.alternatives(
+  Joi.object({
+    type: Joi.string().valid('fixed').required(),
+    startingChallengeIndex: Joi.number().integer().min(0).required(),
+    endingChallengeIndex: Joi.number().integer().min(Joi.ref('startingChallengeIndex')).required(),
+    value: Joi.number().min(0).max(1).required(),
+  }),
+  Joi.object({
+    type: Joi.string().valid('linear').required(),
+    startingChallengeIndex: Joi.number().integer().min(0).required(),
+    endingChallengeIndex: Joi.number().integer().min(Joi.ref('startingChallengeIndex')).required(),
+    startingValue: Joi.number().min(0).max(1).required(),
+    endingValue: Joi.number().min(0).max(1).required(),
+  }),
+);
+
 const _baseScenarioParametersValidator = Joi.object().keys({
   assessmentId: Joi.string().required(),
   initialCapacity: Joi.number().integer().min(-8).max(8),
@@ -13,6 +29,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   challengePickProbability: Joi.number().min(0).max(100),
   challengesBetweenSameCompetence: Joi.number().min(0),
   limitToOneQuestionPerTube: Joi.boolean(),
+  minimumEstimatedSuccessRateRanges: Joi.array().items(_successRatesConfigurationValidator),
 });
 
 const register = async (server) => {

--- a/api/lib/domain/models/FlashAssessmentSuccessRateHandler.js
+++ b/api/lib/domain/models/FlashAssessmentSuccessRateHandler.js
@@ -17,6 +17,15 @@ class FlashAssessmentSuccessRateHandler {
     return this._strategy.getMinimalSuccessRate(this.startingChallengeIndex, this.endingChallengeIndex, questionIndex);
   }
 
+  static create(successRateRange) {
+    if (successRateRange.type === 'linear') {
+      return FlashAssessmentSuccessRateHandler.createLinear(successRateRange);
+    }
+    if (successRateRange.type === 'fixed') {
+      return FlashAssessmentSuccessRateHandler.createFixed(successRateRange);
+    }
+  }
+
   static createFixed({ startingChallengeIndex, endingChallengeIndex, value }) {
     return new FlashAssessmentSuccessRateHandler({
       startingChallengeIndex,

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -12,6 +12,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   useObsoleteChallenges,
   challengesBetweenSameCompetence,
   limitToOneQuestionPerTube,
+  minimumEstimatedSuccessRateRanges,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -21,6 +22,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     maximumAssessmentLength: stopAtChallenge,
     challengesBetweenSameCompetence,
     limitToOneQuestionPerTube,
+    minimumEstimatedSuccessRateRanges,
   });
 
   const simulator = new AssessmentSimulator({

--- a/api/tests/tooling/domain-builder/factory/build-flash-assessment-algorithm-success-rate-handler.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-assessment-algorithm-success-rate-handler.js
@@ -1,0 +1,23 @@
+import { FlashAssessmentSuccessRateHandler } from '../../../../lib/domain/models/FlashAssessmentSuccessRateHandler.js';
+
+export const buildFlashAssessmentAlgorithmSuccessRateHandlerLinear = ({
+  startingChallengeIndex,
+  endingChallengeIndex,
+  startingValue,
+  endingValue,
+}) => {
+  return FlashAssessmentSuccessRateHandler.createLinear({
+    startingChallengeIndex,
+    endingChallengeIndex,
+    startingValue,
+    endingValue,
+  });
+};
+
+export const buildFlashAssessmentAlgorithmSuccessRateHandlerFixed = ({
+  startingChallengeIndex,
+  endingChallengeIndex,
+  value,
+}) => {
+  return FlashAssessmentSuccessRateHandler.createFixed({ startingChallengeIndex, endingChallengeIndex, value });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -79,6 +79,10 @@ import { buildCourse } from './build-course.js';
 import { buildCpfCertificationResult } from './build-cpf-certification-result.js';
 import * as buildDataProtectionOfficer from './build-data-protection-officer.js';
 import { buildFinalizedSession } from './build-finalized-session.js';
+import {
+  buildFlashAssessmentAlgorithmSuccessRateHandlerFixed,
+  buildFlashAssessmentAlgorithmSuccessRateHandlerLinear,
+} from './build-flash-assessment-algorithm-success-rate-handler.js';
 import { buildFramework } from './build-framework.js';
 import { buildHint } from './build-hint.js';
 import { buildSupOrganizationLearner } from './build-sup-organization-learner.js';
@@ -237,6 +241,8 @@ export {
   buildDataProtectionOfficer,
   buildFeedback,
   buildFinalizedSession,
+  buildFlashAssessmentAlgorithmSuccessRateHandlerLinear,
+  buildFlashAssessmentAlgorithmSuccessRateHandlerFixed,
   buildFramework,
   buildHint,
   buildSupOrganizationLearner,

--- a/api/tests/unit/domain/models/FlashAssessmentSuccessRateHandler_test.js
+++ b/api/tests/unit/domain/models/FlashAssessmentSuccessRateHandler_test.js
@@ -78,4 +78,44 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmSuccessRateHandler', 
       });
     });
   });
+
+  describe('#create', function () {
+    describe('when type is fixed', function () {
+      it('should return the fixed value', function () {
+        const configSuccessRate = 0.8;
+        const fixedConfig = {
+          type: 'fixed',
+          startingChallengeIndex: 0,
+          endingChallengeIndex: 7,
+          value: configSuccessRate,
+        };
+
+        const flashAssessmentSuccessRateHandler = FlashAssessmentSuccessRateHandler.create(fixedConfig);
+
+        const questionIndex = 5;
+        const successRate = flashAssessmentSuccessRateHandler.getMinimalSuccessRate(questionIndex);
+
+        expect(successRate).to.equal(configSuccessRate);
+      });
+    });
+
+    describe('when type is linear', function () {
+      it('should return the linear value', function () {
+        const linearConfig = {
+          type: 'linear',
+          startingChallengeIndex: 0,
+          endingChallengeIndex: 2,
+          startingValue: 0.8,
+          endingValue: 0.6,
+        };
+
+        const flashAssessmentSuccessRateHandler = FlashAssessmentSuccessRateHandler.create(linearConfig);
+
+        const questionIndex = 1;
+        const successRate = flashAssessmentSuccessRateHandler.getMinimalSuccessRate(questionIndex);
+
+        expect(successRate).to.equal(0.7);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -198,6 +198,74 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         });
       });
     });
+
+    context('when we set a minimum estimated success rate range', function () {
+      it('should return an array of estimated level, challenge, reward and error rate for each answer', async function () {
+        // given
+        const minimumEstimatedSuccessRateRanges = [
+          domainBuilder.buildFlashAssessmentAlgorithmSuccessRateHandlerFixed({
+            startingChallengeIndex: 0,
+            endingChallengeIndex: 1,
+            value: 0.8,
+          }),
+        ];
+        const initialCapacity = 7;
+
+        const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill', tubeId: '1' });
+        const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill', tubeId: '1' });
+        const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill', tubeId: '2' });
+        const firstChallenge = domainBuilder.buildChallenge({
+          id: 'one',
+          skill: firstSkill,
+          difficulty: -2,
+          discriminant: 0.16,
+        });
+        const secondChallenge = domainBuilder.buildChallenge({
+          id: 'two',
+          skill: secondSkill,
+          difficulty: 6,
+          discriminant: 3,
+        });
+        const thirdChallenge = domainBuilder.buildChallenge({
+          id: 'three',
+          skill: thirdSkill,
+          difficulty: 7.5,
+          discriminant: 1.587,
+        });
+
+        const challengeRepository = {
+          findFlashCompatible: sinon.stub(),
+        };
+        const pickChallenge = sinon.stub();
+        const pickAnswerStatus = sinon.stub();
+
+        challengeRepository.findFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
+
+        pickChallenge.callsFake(({ possibleChallenges }) => possibleChallenges.at(-1));
+
+        pickAnswerStatus.callsFake(() => AnswerStatus.OK);
+
+        // when
+        const result = await simulateFlashDeterministicAssessmentScenario({
+          challengeRepository,
+          locale,
+          pickChallenge,
+          pickAnswerStatus,
+          initialCapacity,
+          minimumEstimatedSuccessRateRanges,
+        });
+
+        // then
+        expect(result).to.have.lengthOf(2);
+        result.forEach((answer) => {
+          expect(answer.challenge).not.to.be.undefined;
+          expect(answer.errorRate).not.to.be.undefined;
+          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.reward).not.to.be.undefined;
+          expect(answer.answerStatus).not.to.be.undefined;
+        });
+      });
+    });
   });
 
   context('when there are not enough flash challenges left', function () {


### PR DESCRIPTION
## :unicorn: Problème
La modification des taux de réussite a été implémentée dans la certif v3, mais l'équipe data doit pouvoir jouer avec son paramétrage.

## :robot: Proposition
Ajouter de la configuration pour les simulateurs permettant de configurer des modification des taux de réussite minimum.

## :100: Pour tester
```
TOKEN=$(curl 'https://api-pr7163.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7163.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity","assessmentId": "1234", "capacity": 1.5, "minimumEstimatedSuccessRateRanges": [{"type": "fixed", "startingChallengeIndex": 0, "endingChallengeIndex": 7, "value": 0.8},{"type": "linear","startingChallengeIndex": 8,"endingChallengeIndex": 15,"startingValue": 0.8,"endingValue": 0.5}] }' | jq '.'
```