### PR TITLE
[BUGFIX] Nouveau changement de l'url pour la suspicion de fraude (PIX-9435).

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -68,11 +68,7 @@ export default class Url extends Service {
   }
 
   get fraudFormUrl() {
-    if (this.#isFrenchSpoken()) {
-      return 'https://form-eu.123formbuilder.com/41052/form';
-    }
-
-    return 'https://cloud.pix.fr/s/6Ltnqkf4emQEooS/download';
+    return 'https://form-eu.123formbuilder.com/41052/form';
   }
 
   #isFrenchSpoken() {


### PR DESCRIPTION
## :unicorn: Problème
IL'url changée dans PIX-7766 n'est finalement pas celle voulue, il faut revenir à l'url du formulaire qui lui va porter la version anglaise.

A faire : modifier le lien vers le formulaire de PV de fraude dans la version EN de Pix Certif, accessible lorsqu’un utilisateur clique sur l’option C6 Suspected fraud sur la page de finalisation d’une session

## :robot: Proposition
Modifier le lien de la version anglaise de suspicion de fraude, même lien pour toutes les langues.

## :rainbow: Remarques
Note: j'ai gardé le refacto de PIX-7766 par contre (ce n'est pas un simple revert)

## :100: Pour tester
* Sur Pix Certif avec certifpro@example.net, pour la session http://localhost:4203/sessions/7005/ , se mettre ne surveillant et confirmer une présence pour un des candidats
* Sur Pix App, passer une certif pour un des candidats de la session http://localhost:4203/sessions/7005/
* Ensuite sur Pix, finaliser la session sur http://localhost:4203/sessions/7005/finalisation
* Introduire une suspicion de fraude
![image](https://github.com/1024pix/pix/assets/170271/85a78bbf-53e2-4430-ba3c-80d0e46e5f12)

* Vérifier que ce même comportement en version anglaise sur http://localhost:4203/sessions/7005/finalisation?lang=en
