### PR TITLE
[TECH] Eviter de contacter la BDD dans les tests unitaires via lint

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,6 +52,6 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain/usecases', from: 'lib/infrastructure/repositories', except: [], message : "Repositories are automatically injected in use-case, you don't need to import them. Check for further details: https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md" }] }],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain/usecases', from: 'lib/infrastructure/repositories', except: [], message : "Repositories are automatically injected in use-case, you don't need to import them. Check for further details: https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md" },{ "target": "tests/unit", "from": "db" }] }],
   },
 };

--- a/api/tests/unit/.eslintrc.cjs
+++ b/api/tests/unit/.eslintrc.cjs
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+  extends: "../.eslintrc.cjs",
+  rules: {
+    "no-restricted-imports": ["error", {
+      paths: ["knex", "pg"]
+    }]
+  }
+};

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -1,4 +1,5 @@
 import { expect, sinon, hFake } from '../../../test-helper.js';
+// eslint-disable-next-line  import/no-restricted-paths
 import { knex } from '../../../../db/knex-database-connection.js';
 import { redisMonitor } from '../../../../lib/infrastructure/utils/redis-monitor.js';
 import { healthcheckController } from '../../../../lib/application/healthcheck/healthcheck-controller.js';

--- a/api/tests/unit/tooling/database-builder/database-buffer_test.js
+++ b/api/tests/unit/tooling/database-builder/database-buffer_test.js
@@ -1,4 +1,5 @@
 import { expect } from '../../../test-helper.js';
+// eslint-disable-next-line  import/no-restricted-paths
 import { databaseBuffer } from '../../../../db/database-builder/database-buffer.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-buffer', function () {

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -1,4 +1,5 @@
 import { expect, sinon, catchErr } from '../../../test-helper.js';
+// eslint-disable-next-line  import/no-restricted-paths
 import { DatabaseBuilder } from '../../../../db/database-builder/database-builder.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {


### PR DESCRIPTION
## :unicorn: Problème
On empêche l'accès des TU à BDD au runtime avec un hack : on passe une URL incorrecte dans le package.json.
```postgres://should.not.reach.db.in.unit.tests```

Ceci pourrait être vérifié à l'écriture du code avec le lint.

## :robot: Proposition
Le détecter au lint.
Le hack ne peut pas être enlevé à cause des bounded context.

## :rainbow: Remarques

Utilisation de deux règles :
 - pour détecter les librairies : [no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
  - pour détecter un composant applicatif : [eslint-plugin-import/no-restricted-paths
](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md
)

On pourrait ajouter un message si besoin.

## :100: Pour tester
Ajouter ces imports dans un test unitaire.
```js
import { knex } from '../../../../db/knex-database-connection.js';
import knex from 'knex';
import { Knex } from 'knex';
import pg from 'pg';
```

Exécuter le lint.
```
npm run lint:code
```

Vérifier qu'il renvoie des erreurs.
```
error  'knex' import is restricted from being used  no-restricted-imports
error  'pg' import is restricted from being used    no-restricted-imports
error *Unexpected path "../../../../db/knex-database-connection.js" imported in restricted zone  import/no-restricted-paths
```