### PR TITLE
[TECH] Prévenir l'appel de l'infrastructure depuis le domaine

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,5 +52,6 @@ module.exports = {
         ],
       },
     ],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure' }] }],
   },
 };

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,6 +52,6 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js","constants.js","DomainTransaction.js"] }] }],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js","constants.js","DomainTransaction.js","http-agent.js"] }] }],
   },
 };

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,6 +52,6 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js"] }] }],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js","constants.js"] }] }],
   },
 };

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,6 +52,6 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js","constants.js"] }] }],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js","constants.js","DomainTransaction.js"] }] }],
   },
 };

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,6 +52,6 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure' }] }],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain', from: 'lib/infrastructure', except: ["logger.js"] }] }],
   },
 };

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import { injectDefaults, injectDependencies } from '../../../src/shared/infrastructure/utils/dependency-injection.js';
 import { EventDispatcher } from '../../infrastructure/events/EventDispatcher.js';
 import { EventDispatcherLogger } from '../../infrastructure/events/EventDispatcherLogger.js';

--- a/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
+++ b/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
@@ -1,4 +1,3 @@
-import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import { UserNotAuthorizedToAccessEntityError, NoStagesForCampaign } from '../errors.js';
 
 const getCampaignParticipationsCountByStage = async function ({
@@ -6,6 +5,7 @@ const getCampaignParticipationsCountByStage = async function ({
   campaignId,
   campaignRepository,
   campaignParticipationRepository,
+  stageCollectionRepository,
 }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 

--- a/api/lib/domain/usecases/stages/handle-stage-acquisition.js
+++ b/api/lib/domain/usecases/stages/handle-stage-acquisition.js
@@ -1,44 +1,16 @@
-import * as defaultSkillRepository from '../../../infrastructure/repositories/skill-repository.js';
-import * as defaultStageRepository from '../../../infrastructure/repositories/stage-repository.js';
-import * as defaultCampaignRepository from '../../../infrastructure/repositories/campaign-repository.js';
-import * as defaultStageAcquisitionRepository from '../../../infrastructure/repositories/stage-acquisition-repository.js';
-import * as defaultCampaignParticipationRepository from '../../../infrastructure/repositories/campaign-participation-repository.js';
-import * as defaultKnowledgeElementRepositoryRepository from '../../../infrastructure/repositories/knowledge-element-repository.js';
-
-import * as defaultGetNewAcquiredStagesService from '../../services/stages/get-new-acquired-stages-service.js';
-import * as defaultGetMasteryPercentageService from '../../services/get-mastery-percentage-service.js';
-import * as defaultConvertLevelStagesIntoThresholdsService from '../../services/stages/convert-level-stages-into-thresholds-service.js';
-import * as defaultCampaignSkillRepository from '../../../infrastructure/repositories/campaign-skill-repository.js';
-
-/**
- * @param {Assessment} assessment
- * @param {DomainTransaction} domainTransaction
- * @param stageRepository
- * @param skillRepository
- * @param campaignRepository
- * @param campaignSkillRepository
- * @param stageAcquisitionRepository
- * @param knowledgeElementRepository
- * @param campaignParticipationRepository
- * @param getNewAcquiredStagesService
- * @param getMasteryPercentageService
- * @param convertLevelStagesIntoThresholdsService
- *
- * @returns {Promise<void>}
- */
 const handleStageAcquisition = async function ({
   assessment,
   domainTransaction,
-  stageRepository = defaultStageRepository,
-  skillRepository = defaultSkillRepository,
-  campaignRepository = defaultCampaignRepository,
-  campaignSkillRepository = defaultCampaignSkillRepository,
-  stageAcquisitionRepository = defaultStageAcquisitionRepository,
-  knowledgeElementRepository = defaultKnowledgeElementRepositoryRepository,
-  campaignParticipationRepository = defaultCampaignParticipationRepository,
-  getNewAcquiredStagesService = defaultGetNewAcquiredStagesService,
-  getMasteryPercentageService = defaultGetMasteryPercentageService,
-  convertLevelStagesIntoThresholdsService = defaultConvertLevelStagesIntoThresholdsService,
+  stageRepository,
+  skillRepository,
+  campaignRepository,
+  campaignSkillRepository,
+  stageAcquisitionRepository,
+  knowledgeElementRepository,
+  campaignParticipationRepository,
+  getNewAcquiredStagesService,
+  getMasteryPercentageService,
+  convertLevelStagesIntoThresholdsService,
 }) {
   if (!assessment.isForCampaign()) return;
 


### PR DESCRIPTION
## :unicorn: Problème
Dans la clean architecture, l'infrastructure (ex: repositories) est injecté, et pas importé directement.
https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md

Cela a été implémenté dans Pix mais on n'est pas sûr que tout le monde soit au courant.

## :robot: Proposition
Le vérifier avec une règle de lint

## :rainbow: Remarques
Ajout d'exceptions pour:
- l'injection de dépendances
- le logger

Injection de repositories injectés manuellement

## :100: Pour tester
Importer un repository dans un use-case et vérifier que le lint échoue.
