### PR TITLE
[BUGFIX] Corriger l'affichage de la date de dernier envoi d'invitation à un centre de certification (PIX-9427)

### DIFF
--- a/certif/app/models/certification-center-invitation.js
+++ b/certif/app/models/certification-center-invitation.js
@@ -4,6 +4,7 @@ import { memberAction } from 'ember-api-actions';
 export default class CertificationCenterInvitation extends Model {
   @attr('string') email;
   @attr('string') status;
+  @attr('date') updatedAt;
   @attr('string') certificationCenterName;
 
   accept = memberAction({


### PR DESCRIPTION
## :unicorn: Problème
Suite au merge de la PR #7073, nous avons constaté un problème d'affichage dans la colonne "Date de dernier envoi". 
Lors du rafraichissement de la page, la date se met à jour avec la date et l'heure actuelle.

## :robot: Proposition
Ajouter l'attribut date manquant dans le model Ember des invitations de centre de certification.

## :rainbow: Remarques
RAS

## :100: Pour tester
**Se connecter à Pix Admin**

1. Dans l'onglet `Centre de certification`, sélectionnez `Accèssorium` (id: 8000)
2. Puis dans l'onglet `Invitations` invitez plusieurs membres à ce centre avec 2min d'écart entre les invitations (pour avoir des dates d'envoie différentes)

**Se connecter à Pix Certif** avec `james-paledroits@example.net`

1. Dans l'onglet `Equipe` > `Invitations`, verifiez que les invitations que vous venez d'envoyer sont bien présentes et correspondent aux dates d'envoie dans Pix Admin.
2. Rafraichissez la page, et verifiez que les dates n'ont pas été mises à jour

