### PR TITLE
[TECH] Eviter d'importer les repositories dans les use-cases via lint

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,6 +52,6 @@ module.exports = {
         ],
       },
     ],
-    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain/usecases', from: 'lib/infrastructure/repositories', except: [] }] }],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain/usecases', from: 'lib/infrastructure/repositories', except: [], message : "Repositories are automatically injected in use-case, you don't need to import them. Check for further details: https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md" }] }],
   },
 };

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -52,5 +52,6 @@ module.exports = {
         ],
       },
     ],
+    'import/no-restricted-paths': ['error', { zones: [{ target: 'lib/domain/usecases', from: 'lib/infrastructure/repositories', except: [] }] }],
   },
 };

--- a/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
+++ b/api/lib/domain/usecases/get-campaign-participations-counts-by-stage.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 import { UserNotAuthorizedToAccessEntityError, NoStagesForCampaign } from '../errors.js';
 

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,5 +1,4 @@
 import { NotFoundError, UserNotAuthorizedToAccessEntityError } from '../../domain/errors.js';
-import * as stageCollectionRepository from '../../infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
 
 const getCampaign = async function ({
   campaignId,
@@ -7,6 +6,7 @@ const getCampaign = async function ({
   badgeRepository,
   campaignRepository,
   campaignReportRepository,
+  stageCollectionRepository,
 }) {
   const integerCampaignId = parseInt(campaignId);
   if (!Number.isFinite(integerCampaignId)) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 

--- a/api/lib/domain/usecases/stages/handle-stage-acquisition.js
+++ b/api/lib/domain/usecases/stages/handle-stage-acquisition.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import * as defaultSkillRepository from '../../../infrastructure/repositories/skill-repository.js';
 import * as defaultStageRepository from '../../../infrastructure/repositories/stage-repository.js';
 import * as defaultCampaignRepository from '../../../infrastructure/repositories/campaign-repository.js';

--- a/api/tests/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign_test.js
@@ -1,6 +1,6 @@
 import { expect, databaseBuilder, catchErr, mockLearningContent } from '../../../test-helper.js';
 import { NotFoundError, UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
-import { getCampaign } from '../../../../lib/domain/usecases/get-campaign.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
 import * as badgeRepository from '../../../../lib/infrastructure/repositories/badge-repository.js';
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as campaignReportRepository from '../../../../lib/infrastructure/repositories/campaign-report-repository.js';
@@ -8,7 +8,7 @@ import * as campaignReportRepository from '../../../../lib/infrastructure/reposi
 describe('Integration | UseCase | get-campaign', function () {
   context('Error case', function () {
     it('should throw a NotFoundError when the campaign not exist', async function () {
-      const error = await catchErr(getCampaign)({
+      const error = await catchErr(usecases.getCampaign)({
         campaignId: 'invalid Campaign Id',
         userId: 'whateverId',
         badgeRepository,
@@ -26,7 +26,7 @@ describe('Integration | UseCase | get-campaign', function () {
 
       await databaseBuilder.commit();
 
-      const error = await catchErr(getCampaign)({
+      const error = await catchErr(usecases.getCampaign)({
         campaignId,
         userId,
         badgeRepository,
@@ -103,7 +103,7 @@ describe('Integration | UseCase | get-campaign', function () {
 
     it('should get the campaign with no participation', async function () {
       // when
-      const resultCampaign = await getCampaign({
+      const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
         userId,
         badgeRepository,
@@ -126,7 +126,7 @@ describe('Integration | UseCase | get-campaign', function () {
       await databaseBuilder.commit();
 
       // when
-      const resultCampaign = await getCampaign({
+      const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
         userId,
         badgeRepository,
@@ -146,7 +146,7 @@ describe('Integration | UseCase | get-campaign', function () {
       await databaseBuilder.commit();
 
       // when
-      const resultCampaign = await getCampaign({
+      const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
         userId,
         badgeRepository,
@@ -185,7 +185,7 @@ describe('Integration | UseCase | get-campaign', function () {
       await databaseBuilder.commit();
 
       // when
-      const resultCampaign = await getCampaign({
+      const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
         userId,
         badgeRepository,
@@ -227,7 +227,7 @@ describe('Integration | UseCase | get-campaign', function () {
       await databaseBuilder.commit();
 
       // when
-      const resultCampaign = await getCampaign({
+      const resultCampaign = await usecases.getCampaign({
         campaignId,
         userId,
         badgeRepository,


### PR DESCRIPTION
## :unicorn: Problème
Les repositories sont injectés automatiquement.
https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md

Cela a été implémenté dans Pix mais on n'est pas sûr que tout le monde soit au courant.

## :robot: Proposition
Le vérifier avec une règle de lint.

## :rainbow: Remarques
Ajout d'exceptions pour l'injection de dépendances elle-même.
Injection de repositories dans les use-cases où il étaient importés, et si ce n'est pas possible, ajout d'exceptions.

Le temps de lint n'augmente pas :rocket: 

## :100: Pour tester
Importer un repository dans un use-case et vérifier que le lint échoue.
