### PR TITLE
[FEATURE] Ne pas écraser les données de certificabilité lors d'un import SIECLE (PIX-9378)

### DIFF
--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -137,7 +137,7 @@ const addOrUpdateOrganizationOfOrganizationLearners = async function (
 
   try {
     const organizationLearnersToSave = reconciledOrganizationLearnersToImport.map((organizationLearner) => ({
-      ..._.omit(organizationLearner, ['id', 'createdAt']),
+      ..._.omit(organizationLearner, ['id', 'createdAt', 'isCertifiable', 'certifiableAt']),
       updatedAt: knexConn.raw('CURRENT_TIMESTAMP'),
       isDisabled: false,
     }));

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -644,7 +644,7 @@ describe('Acceptance | API | Certification Center', function () {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(responseIds).to.deep.equal([invitation.id.toString(), invitation2.id.toString()]);
+        expect(responseIds).to.have.members([invitation.id.toString(), invitation2.id.toString()]);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'import SIECLE, nous écrasions les infos sur la certificabilitée avec celle du fichier d'import, c'est à dire qu'elles étaient remisent à null même si le prescrit avait des infos à jour sur sa certificabilitée.

## :robot: Proposition
Ne pas remplacer les colonnes isCertifiable et certifiableAt dans la table organisation-learners lorsqu'un prescrit à des infos sur celles-ci

## :rainbow: Remarques
Correction d'un test flaky sur `tests/acceptance/application/certification-centers/certification-center-controller_test.js`

## :100: Pour tester

- Se connecter à Pix Orga avec une orga SCO avec imports
- Importer une liste d'élèves avec un fichier SIECLE
- Mettre à jour en BDD le isCertifiable & certifiableAt pour un des élèves importés
- Refaire l'import avec la même liste
- Vérifier que son statut n'a pas bougé et est toujours présent
- 🐱 
