### PR TITLE
[TECH] Tracer la récupération de la release LCMS

### DIFF
--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -1,5 +1,6 @@
 import { httpAgent } from './http/http-agent.js';
 import { config } from '../config.js';
+import { logger } from './logger.js';
 
 const { lcms: lcmsConfig } = config;
 const getLatestRelease = async function () {
@@ -12,6 +13,11 @@ const getLatestRelease = async function () {
     throw new Error(`An error occurred while fetching ${lcmsConfig.url}`);
   }
 
+  const version = response.data.id;
+  const createdAt = response.data.createdAt;
+  const message = `Release ${version} created on ${createdAt} successfully received from LCMS`;
+
+  logger.info(message);
   return response.data.content;
 };
 

--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -4,9 +4,18 @@ import { logger } from './logger.js';
 
 const { lcms: lcmsConfig } = config;
 const getLatestRelease = async function () {
+  let signature;
+  // eslint-disable-next-line n/no-process-env
+  if (process.env.APP) {
+    // eslint-disable-next-line n/no-process-env
+    signature = `${process.env.APP}-${process.env.CONTAINER}@${process.env.REGION_NAME}`;
+  } else {
+    signature = 'pix-api';
+  }
+
   const response = await httpAgent.get({
     url: lcmsConfig.url + '/releases/latest',
-    headers: { Authorization: `Bearer ${lcmsConfig.apiKey}` },
+    headers: { Authorization: `Bearer ${lcmsConfig.apiKey}`, Referer: signature },
   });
 
   if (!response.isSuccessful) {


### PR DESCRIPTION
## :unicorn: Problème

On souhaite identifier:
- la release que l'on reçoit;
- l'appel API fait à cette occasion.

## :robot: Proposition
Tracer le numéro de release
Fournir un header `Referer `unique lors de l'appel LCMS

## :rainbow: Remarques
C'ets un peu tordre le but du header `Referer`, mais j'ai pas trouvé mieux.

## :100: Pour tester
Rafraichir le cache.
```
npm run cache:refresh
```
Vérifier le message
```
[15:33:48] INFO: Release 1167 created on 2023-09-28T03:13:04.013Z successfully received from LCMS
```