### PR TITLE
[TECH] Ne pas vérifier la présence du créateur dans l'organisation sur la création de campagnes en masse (PIX-9490)

### DIFF
--- a/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
+++ b/api/lib/domain/usecases/campaigns-administration/create-campaigns.js
@@ -24,6 +24,7 @@ const createCampaigns = async function ({
         userId: campaign.creatorId,
         organizationId: campaign.organizationId,
         shouldOwnerBeFromOrganization: false,
+        shouldCreatorBeFromOrganization: false,
       });
 
       return campaignCreator.createCampaign({

--- a/api/lib/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-creator-repository.js
@@ -2,8 +2,16 @@ import { knex } from '../../../db/knex-database-connection.js';
 import { CampaignCreator } from '../../../lib/domain/models/CampaignCreator.js';
 import { UserNotAuthorizedToCreateCampaignError } from '../../domain/errors.js';
 
-async function get({ userId, organizationId, ownerId, shouldOwnerBeFromOrganization = true }) {
-  await _checkUserIsAMemberOfOrganization({ organizationId, userId });
+async function get({
+  userId,
+  organizationId,
+  ownerId,
+  shouldOwnerBeFromOrganization = true,
+  shouldCreatorBeFromOrganization = true,
+}) {
+  if (shouldCreatorBeFromOrganization) {
+    await _checkUserIsAMemberOfOrganization({ organizationId, userId });
+  }
   if (shouldOwnerBeFromOrganization) {
     await _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId });
   }

--- a/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -145,6 +145,29 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
         expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
         expect(error.message).to.equal(`User does not have an access to the organization ${organizationId}`);
       });
+
+      it('return the campaign creator', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ organizationId, userId: ownerId });
+        const shouldCreatorBeFromOrganization = false;
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignCreatorRepository.get({
+          userId,
+          organizationId,
+          ownerId,
+          shouldCreatorBeFromOrganization,
+        });
+
+        // then
+        expect(result).to.be.instanceOf(CampaignCreator);
+      });
     });
 
     context('when the owner is not a member of the organization', function () {

--- a/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/campaigns-administration/create-campaigns_test.js
@@ -73,6 +73,7 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
         userId: campaignsToCreate[0].creatorId,
         organizationId: campaignsToCreate[0].organizationId,
         shouldOwnerBeFromOrganization: false,
+        shouldCreatorBeFromOrganization: false,
       })
       .resolves(campaignCreatorPOJO);
     campaignCreatorRepositoryStub.get
@@ -80,6 +81,7 @@ describe('Unit | UseCase | campaign-administration | create-campaign', function 
         userId: campaignsToCreate[1].creatorId,
         organizationId: campaignsToCreate[1].organizationId,
         shouldOwnerBeFromOrganization: false,
+        shouldCreatorBeFromOrganization: false,
       })
       .resolves(campaignCreatorPOJO);
 


### PR DESCRIPTION
## :unicorn: Problème
Vérification du createur sur la création de campagnes en masse

## :robot: Proposition
Ajouter une condition pour outrepasser la validation de la présence de creatorId dans le campagne.

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire un import avec des user en creatorId qui ne sont pas de l'organisation dans Pix Admin