### PR TITLE
[BUGFIX] Ajuster la taille du select sur les épreuves dans Pix-App (PIX-8539)

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -55,6 +55,20 @@
 
     &--selector {
       display: inline-block;
+      max-width: 100%;
+      margin-bottom: 1rem;
+
+      button {
+        max-width: 100%;
+      }
+
+      .pix-select {
+        max-width: 100%;
+      }
+    }
+
+    &--selector:last-of-type {
+      margin: 0;
     }
 
     &--input {


### PR DESCRIPTION
## :unicorn: Problème
La taille du select dépassait en mobile.
<img src="https://github.com/1024pix/pix/assets/49011144/d1cab626-ffe4-4002-9873-252d6d268a83" width="400">
De plus, les select étaient trop rapprochés.

## :robot: Proposition
- Ajouter des `max-width: 100%` pour s'adapter à la largeur de l'écran
- Ajouter du margin.

## :rainbow: Remarques


## :100: Pour tester
Aller sur les épreuves et vérifier la taille du select en mobile.
- QROC : [épreuve](https://app-pr7190.review.pix.fr/challenges/rec257B59J0bieEhg/preview)
- QROCM ind : [épreuve](https://app-pr7190.review.pix.fr/challenges/challenge1NDfWG5Kqi1ZGH/preview)
