### PR TITLE
[TECH] Optimisation de la conversion des challenges en objets du domaine

### DIFF
--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -227,7 +227,8 @@ export {
 };
 
 function _toDomainCollection({ challengeDataObjects, skills, successProbabilityThreshold }) {
-  const lookupSkill = (id) => _.find(skills, { id });
+  const skillMap = _.keyBy(skills, 'id');
+  const lookupSkill = (id) => skillMap[id];
   const challenges = challengeDataObjects.map((challengeDataObject) => {
     const skillDataObject = lookupSkill(challengeDataObject.skillId);
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'environnement de recette est plutôt lent à charger la question suivante lors d'une certification. Après profilage CPU, il semble que la méthode `lookupSkill()` dans `_toDomainCollection()` soit celle qui prend le plus de temps d'éxécution.

## :robot: Proposition
Utiliser un objet clé valeur pour accélérer la recherche des skills correspondant lors de la création de l'objet du domaine.

Après profiling, on passe d'une moyenne de temps d'éxécution de 80ms à environ 15ms pour la fonction `_toDomainCollection()`

## :100: Pour tester
Les tests passent.