### PR TITLE
[TECH] Retirer l'usage du composant PixDropdown sur PixOrga (PIX-9205)

### DIFF
--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -24,20 +24,18 @@
   </div>
 
   <div class="form__field-with-info form__field">
-    <PixDropdown
-      @id="campaign-owner"
+    <PixSelect
+      class="pix-select-owner"
       @options={{this.campaignOwnerOptions}}
-      @onSelect={{this.onChangeCampaignOwner}}
-      @selectedOption={{this.ownerIdOption}}
+      @onChange={{this.onChangeCampaignOwner}}
+      @value={{this.ownerIdOption}}
       @isSearchable={{true}}
       @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+      @searchLabel={{t "pages.campaign-creation.owner.search-placeholder"}}
       @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
-      @clearLabel={{t "pages.campaign-creation.owner.clear-label"}}
-      @expandLabel={{t "pages.campaign-creation.owner.expand-label"}}
-      @collapseLabel={{t "pages.campaign-creation.owner.collapse-label"}}
-      @pageSize={{10}}
       @label={{t "pages.campaign-creation.owner.label"}}
-      @requiredLabel={{t "common.form.mandatory-fields-title"}}
+      @requiredText={{t "common.form.mandatory-fields-title"}}
+      @hideDefaultOption={{true}}
     />
     {{#if @campaign.errors.owner}}
       <div class="form__error error-message">

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -27,7 +27,7 @@
 
   .pix-select {
     @include device-is('desktop') {
-      width: 355px;
+      width: 100%;
     }
   }
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -383,9 +383,6 @@
       "no": "No",
       "owner": {
         "title": "Campaign owner",
-        "clear-label": "Clear the selection",
-        "collapse-label": "Close the dropdown list",
-        "expand-label": "Open the dropdown list",
         "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign.",
         "label": "Campaign owner",
         "placeholder": "Owner’s first and last name",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -386,9 +386,6 @@
       "no": "Non",
       "owner": {
         "title": "Propriétaire de la campagne",
-        "clear-label": "Supprimer la sélection",
-        "collapse-label": "Réduire le menu déroulant",
-        "expand-label": "Ouvrir le menu déroulant",
         "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier ou archiver cette campagne.",
         "label": "Propriétaire de la campagne",
         "placeholder": "Nom et prénom du propriétaire",


### PR DESCRIPTION
## :unicorn: Problème
L'utilisation de PixDropdown n'est utilisé que dans le page de modification d'une campagne. (Il a été retiré il y a quelque temps de la page de création de campagne)

## :robot: Proposition
La supprimer aussi sur la page de modification d'une campagne

## :rainbow: Remarques
Un PR sur PixUI arrive pour supprimer complètement ce composant

## :100: Pour tester
Vérifier que la modification d'une campagne fonctionne