### PR TITLE
[BUGFIX] Borner les niveaux atteignables par le candidat. (PIX-9502)

### DIFF
--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,6 +1,8 @@
 import { status } from './AssessmentResult.js';
 import { FlashAssessmentAlgorithm } from './FlashAssessmentAlgorithm.js';
 
+const MINIMUM_ESTIMATED_LEVEL = -8;
+const MAXIMUM_ESTIMATED_LEVEL = 8;
 /*
 Score should not be totally linear. It should be piecewise linear, so we define
 here the different intervals. See documentation here :
@@ -8,7 +10,7 @@ https://1024pix.atlassian.net/wiki/spaces/DD/pages/3835133953/Vulgarisation+scor
  */
 const scoreIntervals = [
   {
-    start: -8,
+    start: MINIMUM_ESTIMATED_LEVEL,
     end: -6,
   },
   {
@@ -37,7 +39,7 @@ const scoreIntervals = [
   },
   {
     start: 6,
-    end: 8,
+    end: MAXIMUM_ESTIMATED_LEVEL,
   },
 ];
 
@@ -78,16 +80,25 @@ class CertificationAssessmentScoreV3 {
 }
 
 const _findIntervalIndex = (estimatedLevel) =>
-  scoreIntervals.findIndex(({ start, end }) => estimatedLevel < end && estimatedLevel >= start);
+  scoreIntervals.findIndex(({ start, end }) => estimatedLevel <= end && estimatedLevel >= start);
 
 const _computeScore = (estimatedLevel) => {
-  const intervalIndex = _findIntervalIndex(estimatedLevel);
+  let normalizedEstimatedLevel = estimatedLevel;
+
+  if (normalizedEstimatedLevel < MINIMUM_ESTIMATED_LEVEL) {
+    normalizedEstimatedLevel = MINIMUM_ESTIMATED_LEVEL;
+  }
+  if (normalizedEstimatedLevel > MAXIMUM_ESTIMATED_LEVEL) {
+    normalizedEstimatedLevel = MAXIMUM_ESTIMATED_LEVEL;
+  }
+
+  const intervalIndex = _findIntervalIndex(normalizedEstimatedLevel);
 
   const intervalMaxValue = scoreIntervals[intervalIndex].end;
   const intervalWidth = scoreIntervals[intervalIndex].end - scoreIntervals[intervalIndex].start;
 
   // Formula is defined here : https://1024pix.atlassian.net/wiki/spaces/DD/pages/3835133953/Vulgarisation+score+2023#Le-score
-  const score = INTERVAL_HEIGHT * (intervalIndex + 1 + (estimatedLevel - intervalMaxValue) / intervalWidth);
+  const score = INTERVAL_HEIGHT * (intervalIndex + 1 + (normalizedEstimatedLevel - intervalMaxValue) / intervalWidth);
 
   return Math.round(score);
 };


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur a trop de mauvaises réponses ou trop de bonnes réponses, son estimated level peut être en dehors des bornes [-8, 8], ce qui fait crasher le scoring

## :robot: Proposition
Normaliser les scores trop petits à -8 et ceux trop gros à 8.

## :100: Pour tester

Sur Pix-certif, se connecter avec `certifv3@example.net`
Créer une session de certification et ajouter un candidat
Sur pix-app, se connecter avec `certifiable-contenu-user@example.net`
Participer à la session de certification, passer toutes les questions
L'écran de fin de test s'affiche correctement

Répéter le process en répondant correctement à toutes les questions, et vérifier que le résultat soit identique entre les deux scénarios.