### PR TITLE
[FEATURE] Mise à jour des seuils des mailles de scoring (PIX-9514).

### DIFF
--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -11,34 +11,34 @@ https://1024pix.atlassian.net/wiki/spaces/DD/pages/3835133953/Vulgarisation+scor
 const scoreIntervals = [
   {
     start: MINIMUM_ESTIMATED_LEVEL,
-    end: -6,
+    end: -1.399264,
   },
   {
-    start: -6,
-    end: -4,
+    start: -1.399264,
+    end: -0.519812,
   },
   {
-    start: -4,
-    end: -2,
+    start: -0.519812,
+    end: 0.670847,
   },
   {
-    start: -2,
-    end: 0,
+    start: 0.670847,
+    end: 1.549962,
   },
   {
-    start: 0,
-    end: 2,
+    start: 1.549962,
+    end: 2.27406,
   },
   {
-    start: 2,
-    end: 4,
+    start: 2.27406,
+    end: 3.09502,
   },
   {
-    start: 4,
-    end: 6,
+    start: 3.09502,
+    end: 3.930395,
   },
   {
-    start: 6,
+    start: 3.930395,
     end: MAXIMUM_ESTIMATED_LEVEL,
   },
 ];

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -302,7 +302,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
       it('should build and save an assessment result with the expected arguments', async function () {
         // given
         const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
-          nbPix: 597,
+          nbPix: 479,
         });
         const assessmentResult = Symbol('AssessmentResult');
         const challenge1 = domainBuilder.buildChallenge();

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -74,7 +74,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       allAnswers: baseAnswers,
     });
 
-    expect(score.nbPix).to.equal(658);
+    expect(score.nbPix).to.equal(640);
   });
 
   describe('when a wrong answer is added', function () {


### PR DESCRIPTION
## :unicorn: Problème

Les seuils des mailles de scoring ont été mises à jour par l'équipe data.

## :robot: Proposition

Mise à jour de ces seuils

## :rainbow: Remarques

N/A

## :100: Pour tester

Sur Pix-certif, se connecter avec certifv3@example.net
Créer une session de certification et ajouter un candidat
Sur pix-app, se connecter avec certifiable-contenu-user@example.net
Participer à la session de certification, passer toutes les questions
Finaliser la session
Sur pix-admin, publier la session
Sur pix-app, vérifiez que vous obtenez bien un score à votre certification
