### PR TITLE
[TECH] Automatiser l'execution du script de reprise de données des paliers (PIX-9497)

### DIFF
--- a/api/scripts/add-existing-stage-acquisitions.js
+++ b/api/scripts/add-existing-stage-acquisitions.js
@@ -90,12 +90,15 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
   if (isLaunchedFromCommandLine) {
     try {
       await main();
+      process.exitCode = 0;
     } catch (error) {
       logger.error(error);
       process.exitCode = 1;
     } finally {
       await disconnect();
       await cache.quit();
+      // eslint-disable-next-line n/no-process-exit
+      process.exit();
     }
   }
 })();


### PR DESCRIPTION
## :unicorn: Problème
Actuellement le script n'exit pas à la fin de son execution. Cela empêche d'écrire une boucle en bash pour chaîner son execution

## :robot: Proposition
Appeler process.exit à la fin de l'execution du script

## :rainbow: Remarques

## :100: Pour tester
- Lancer le script en local : 
`node scripts/add-existing-stage-acquisitions.js --idMin 0 --idMax 1000000`
- Vérifier que le process est bien terminé
