### PR TITLE
[FIX] Pix1D - Afficher les éléments sélectionnés dans les menus déroulants des QROCM

### DIFF
--- a/1d/app/pods/components/challenge/challenge-item-qrocm/component.js
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/component.js
@@ -5,9 +5,8 @@ import proposalsAsBlocks from '../../../..//utils/proposals-as-blocks';
 import { tracked } from '@glimmer/tracking';
 
 export default class ChallengeItemQrocm extends Component {
-  ARIA_LABEL_DELIMITATOR = '#';
   @tracked answersValue;
-  @tracked selectAnswer = '';
+
   constructor() {
     super(...arguments);
     this.answersValue = this._extractProposals();
@@ -34,6 +33,7 @@ export default class ChallengeItemQrocm extends Component {
       return block;
     });
   }
+
   @action
   onInputChange(key, event) {
     this.answersValue[key] = event.target.value;
@@ -42,8 +42,10 @@ export default class ChallengeItemQrocm extends Component {
 
   @action
   onSelectChange(key, value) {
-    this.answersValue[key] = value;
-    this.selectAnswer = value;
+    // Tracked property answersValue has to be reassigned to be considered as changed
+    const newAnswersValue = this.answersValue;
+    newAnswersValue[key] = value;
+    this.answersValue = newAnswersValue;
     this.args.setAnswerValue(JSON.stringify(this.answersValue));
   }
 }

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -10,7 +10,7 @@
     {{#if (eq block.type "select")}}
       <PixSelect
         class="challenge-item-proposals__response challenge-item-proposals__response--selector"
-        @value={{this.selectAnswer}}
+        @value={{get this.answersValue block.input}}
         @label={{block.ariaLabel}}
         @screenReaderOnly={{true}}
         @placeholder={{block.placeholder}}


### PR DESCRIPTION
## :unicorn: Problème
Dans l'application Pix1d, les menus déroulants changent tous suite à un clic dans un QROCM.

## :robot: Proposition
Faire en sorte que la proposition sélectionnée reste affichée pour le menu déroulant modifié uniquement.

## :100: Pour tester
Accéder à la preview de l'épreuve "Mange oiseaux" et manipuler les champs select : challenges/challenge1NDZbXZvI88KYA/preview