### PR TITLE
[BUGFIX] Correction d'une classe manquante sur le profil utilisateur sur pix-admin (PIX-9511)

### DIFF
--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -40,6 +40,7 @@
     <LinkTo
       @route="authenticated.users.get.certification-center-memberships"
       aria-label="Centres de certification auxquels appartient l´utilisateur"
+      class="navbar-item"
     >
       {{t "pages.user-details.navbar.certification-centers-list"}}
       ({{@model.certificationCenterMembershipsCount}})


### PR DESCRIPTION
## :unicorn: Problème

Dans le bandeau des onglets, sur la page des détails d'un utilisateur, le texte **Pix Certif (x)** présente un défaut d’affichage puisqu’il est décalé par rapport aux autres onglets.

L’objectif est de réaligner l’affichage du texte **Pix Certif (x)** avec les autres onglets.


## :robot: Proposition

Ajouter la classe CSS manquante sur l'onglet en question.

## :100: Pour tester

- Se connecter à Pix Admin (https://admin-pr7201.review.pix.fr/) avec le compte `superadmin@example.net`
- Ouvrir la page de détails d'un utilisateur (ex: James Palédroits)
- Constater le bon affichage du texte **Pix Certif (x)** dans l'onglet
