### PR TITLE
[TECH] N'utiliser que le render provenant de @1024pix/ember-testing-library dans les tests (PIX-9521)

### DIFF
--- a/orga/tests/integration/components/auth/join-request-form_test.js
+++ b/orga/tests/integration/components/auth/join-request-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
-import { fillByLabel } from '@1024pix/ember-testing-library';
+import { triggerEvent } from '@ember/test-helpers';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Auth::JoinRequestForm', function (hooks) {

--- a/orga/tests/integration/components/banner/communication_test.js
+++ b/orga/tests/integration/components/banner/communication_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'pix-orga/config/environment';
 

--- a/orga/tests/integration/components/campaign/analysis/competences_test.js
+++ b/orga/tests/integration/components/campaign/analysis/competences_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Analysis::Competences', function (hooks) {

--- a/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
+++ b/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', function (hooks) {

--- a/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByDay', function (hooks) {

--- a/orga/tests/integration/components/campaign/header/tabs_test.js
+++ b/orga/tests/integration/components/campaign/header/tabs_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 

--- a/orga/tests/integration/components/campaign/header/title_test.js
+++ b/orga/tests/integration/components/campaign/header/title_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Campaign::Header::Title', function (hooks) {

--- a/orga/tests/integration/components/dropdown/icon-trigger_test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Dropdown | icon-trigger', function (hooks) {

--- a/orga/tests/integration/components/layout/organization-credit-info_test.js
+++ b/orga/tests/integration/components/layout/organization-credit-info_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import Object from '@ember/object';

--- a/orga/tests/integration/components/participant/profile/header_test.js
+++ b/orga/tests/integration/components/participant/profile/header_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Participant::Profile::Header', function (hooks) {

--- a/orga/tests/integration/components/participant/profile/table_test.js
+++ b/orga/tests/integration/components/participant/profile/table_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Participant::Profile::Table', function (hooks) {

--- a/orga/tests/integration/components/sco-organization-participant/manage-authentication-method-modal_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/manage-authentication-method-modal_test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import { resolve } from 'rsvp';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';

--- a/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -14,7 +13,7 @@ module('Integration | Component | SupOrganizationParticipant::HeaderActions', fu
       this.set('participantCount', 0);
 
       // when
-      const screen = await renderScreen(
+      const screen = await render(
         hbs`<SupOrganizationParticipant::HeaderActions @participantCount={{this.participantCount}} />`,
       );
 
@@ -27,7 +26,7 @@ module('Integration | Component | SupOrganizationParticipant::HeaderActions', fu
       this.set('participantCount', 5);
 
       // when
-      const screen = await renderScreen(
+      const screen = await render(
         hbs`<SupOrganizationParticipant::HeaderActions @participantCount={{this.participantCount}} />`,
       );
 

--- a/orga/tests/integration/components/tables/header-sort_test.js
+++ b/orga/tests/integration/components/tables/header-sort_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Tables | header-sort', function (hooks) {

--- a/orga/tests/integration/components/team/invite-form_test.js
+++ b/orga/tests/integration/components/team/invite-form_test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-import { fillByLabel } from '@1024pix/ember-testing-library';
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Team::InviteForm', function (hooks) {

--- a/orga/tests/integration/components/team/members-list_test.js
+++ b/orga/tests/integration/components/team/members-list_test.js
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';

--- a/orga/tests/integration/components/ui/chevron_test.js
+++ b/orga/tests/integration/components/ui/chevron_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::Chevron', function (hooks) {

--- a/orga/tests/integration/components/ui/empty-state_test.js
+++ b/orga/tests/integration/components/ui/empty-state_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 

--- a/orga/tests/integration/components/ui/pix-loader_test.js
+++ b/orga/tests/integration/components/ui/pix-loader_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::PixLoader', function (hooks) {

--- a/orga/tests/integration/components/ui/previous-page-button_test.js
+++ b/orga/tests/integration/components/ui/previous-page-button_test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Ui::PreviousPageButton', function (hooks) {
   setupRenderingTest(hooks);

--- a/orga/tests/integration/components/ui/search-input_test.js
+++ b/orga/tests/integration/components/ui/search-input_test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { fillByLabel } from '@1024pix/ember-testing-library';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Ui::SearchInput', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
## :unicorn: Problème
Le render utilisé dans les tests n'étaient pas le même partout. Et nous ne voulions plus utiliser celui provenant de test/helpers

## :robot: Proposition
Ne plus utiliser celui provenant de @ember/tests-helper

## :rainbow: Remarques
Non
## :100: Pour tester
- Vérifier que tous les tests passent
- :tada:
-