### PR TITLE
[TECH] Déplacer les tests de la `EntityValidationError` du `error-manager` dans `src` (API)

### DIFF
--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -4,8 +4,122 @@ import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 
 import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { handle } from '../../../../src/shared/application/error-manager.js';
+import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
 
 describe('Shared | Unit | Application | ErrorManager', function () {
+  describe('#handle', function () {
+    it('should translate EntityValidationError', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [{ attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' }],
+      });
+
+      // when
+      const response = await handle(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'The title is required',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+
+    it('should translate EntityValidationError to french', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'fr-fr',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [{ attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' }],
+      });
+
+      // when
+      const response = await handle(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'Le titre du palier est obligatoire',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+
+    it('should fallback to the message if the translation is not found', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [{ attribute: 'name', message: 'message' }],
+      });
+
+      // when
+      const response = await handle(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'message',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+
+    it('should translate EntityValidationError even if invalidAttributes is undefined', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: undefined,
+      });
+
+      // when
+      const response = await handle(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [],
+      });
+    });
+  });
+
   describe('#_mapToHttpError', function () {
     it('should instantiate NotFoundError when NotFoundError', async function () {
       // given

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -42,126 +42,12 @@ import {
   CertificationCandidateNotFoundError,
   NotEnoughDaysPassedBeforeResetCampaignParticipationError,
 } from '../../../lib/domain/errors.js';
-// import { EntityValidationError } from '../../../src/shared/domain/errors.js';
 
 import { HttpErrors } from '../../../lib/application/http-errors.js';
 import { handle } from '../../../lib/application/error-manager.js';
 import { SESSION_SUPERVISING } from '../../../lib/domain/constants/session-supervising.js';
 
 describe('Unit | Application | ErrorManager', function () {
-  // describe('#handle', function () {
-  //   it('should translate EntityValidationError', async function () {
-  //     // given
-  //     const request = {
-  //       headers: {
-  //         'accept-language': 'en',
-  //       },
-  //     };
-  //     const error = new EntityValidationError({
-  //       invalidAttributes: [{ attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' }],
-  //     });
-
-  //     // when
-  //     const response = await handle(request, hFake, error);
-
-  //     // then
-  //     expect(response.statusCode).to.equal(422);
-  //     expect(response.source).to.deep.equal({
-  //       errors: [
-  //         {
-  //           detail: 'The title is required',
-  //           source: {
-  //             pointer: '/data/attributes/name',
-  //           },
-  //           status: '422',
-  //           title: 'Invalid data attribute "name"',
-  //         },
-  //       ],
-  //     });
-  //   });
-
-  //   it('should translate EntityValidationError to french', async function () {
-  //     // given
-  //     const request = {
-  //       headers: {
-  //         'accept-language': 'fr-fr',
-  //       },
-  //     };
-  //     const error = new EntityValidationError({
-  //       invalidAttributes: [{ attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' }],
-  //     });
-
-  //     // when
-  //     const response = await handle(request, hFake, error);
-
-  //     // then
-  //     expect(response.statusCode).to.equal(422);
-  //     expect(response.source).to.deep.equal({
-  //       errors: [
-  //         {
-  //           detail: 'Le titre du palier est obligatoire',
-  //           source: {
-  //             pointer: '/data/attributes/name',
-  //           },
-  //           status: '422',
-  //           title: 'Invalid data attribute "name"',
-  //         },
-  //       ],
-  //     });
-  //   });
-
-  //   it('should fallback to the message if the translation is not found', async function () {
-  //     // given
-  //     const request = {
-  //       headers: {
-  //         'accept-language': 'en',
-  //       },
-  //     };
-  //     const error = new EntityValidationError({
-  //       invalidAttributes: [{ attribute: 'name', message: 'message' }],
-  //     });
-
-  //     // when
-  //     const response = await handle(request, hFake, error);
-
-  //     // then
-  //     expect(response.statusCode).to.equal(422);
-  //     expect(response.source).to.deep.equal({
-  //       errors: [
-  //         {
-  //           detail: 'message',
-  //           source: {
-  //             pointer: '/data/attributes/name',
-  //           },
-  //           status: '422',
-  //           title: 'Invalid data attribute "name"',
-  //         },
-  //       ],
-  //     });
-  //   });
-
-  //   it('should translate EntityValidationError even if invalidAttributes is undefined', async function () {
-  //     // given
-  //     const request = {
-  //       headers: {
-  //         'accept-language': 'en',
-  //       },
-  //     };
-  //     const error = new EntityValidationError({
-  //       invalidAttributes: undefined,
-  //     });
-
-  //     // when
-  //     const response = await handle(request, hFake, error);
-
-  //     // then
-  //     expect(response.statusCode).to.equal(422);
-  //     expect(response.source).to.deep.equal({
-  //       errors: [],
-  //     });
-  //   });
-  // });
-
   describe('#_mapToHttpError', function () {
     it('should instantiate UnauthorizedError when MissingOrInvalidCredentialsError', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Dans #7204 nous avions ignoré des tests en erreur. Ignorer des tests n'est pas souhaitable.

## :robot: Proposition
Corriger les tests qui cassaient et les réactiver.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que tous les tests passent dans Circle, et qu'on en a plus que dans `dev` actuellement (5905).
