### PR TITLE
[TECH] Remplacer la lib `eslint-plugin-local-rules` par `@1024pix/eslint-plugin`

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
   globals: {
     include: true,
   },
-  plugins: ['knex', 'unicorn', 'local-rules'],
+  plugins: ['knex', 'unicorn', '@1024pix'],
   rules: {
     'no-console': 'error',
     'mocha/no-hooks-for-single-case': 'off',
@@ -67,6 +67,6 @@ module.exports = {
         ],
       },
     ],
-    'local-rules/no-sinon-stub-with-args-oneliner': 'error',
+    '@1024pix/no-sinon-stub-with-args-oneliner': 'error',
   },
 };

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
   globals: {
     include: true,
   },
-  plugins: ['knex', 'unicorn', '@1024pix'],
+  plugins: ['knex', 'unicorn'],
   rules: {
     'no-console': 'error',
     'mocha/no-hooks-for-single-case': 'off',
@@ -67,6 +67,5 @@ module.exports = {
         ],
       },
     ],
-    '@1024pix/no-sinon-stub-with-args-oneliner': 'error',
   },
 };

--- a/api/eslint-local-rules.cjs
+++ b/api/eslint-local-rules.cjs
@@ -1,7 +1,0 @@
-"use strict";
-
-const noSinonStubWithArgsOneliner = require("@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner");
-
-module.exports = {
-  "no-sinon-stub-with-args-oneliner": noSinonStubWithArgsOneliner,
-};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -79,7 +79,7 @@
         "yargs": "^17.5.1"
       },
       "devDependencies": {
-        "@1024pix/eslint-config": "^1.0.3",
+        "@1024pix/eslint-config": "^1.1.0",
         "@1024pix/eslint-plugin": "^1.0.0",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
@@ -117,11 +117,12 @@
       }
     },
     "node_modules/@1024pix/eslint-config": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/eslint-config/-/eslint-config-1.0.3.tgz",
-      "integrity": "sha512-in7swJbHlAXZK/7q2/ZWBGfMWBJxdq1OU3nN1pSGRYxhpcuL3Rsxg9MrKtGQ4XsukOLOCqQALunfWc8vq3+NsQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/eslint-config/-/eslint-config-1.1.0.tgz",
+      "integrity": "sha512-FzSvSmif9kA2J7mqw7VmNd88BmrIYJDDyd5QFT7G6iCHvm46LyuMZocy02IqzZpx0kgjy2wV4NTGRF5FY1AM/w==",
       "dev": true,
       "dependencies": {
+        "@1024pix/eslint-config": "^1.0.3",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-yml": "^1.8.0"

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
       },
       "devDependencies": {
         "@1024pix/eslint-config": "^1.0.3",
-        "@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner": "^0.2.0",
+        "@1024pix/eslint-plugin": "^1.0.0",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@ls-lint/ls-lint": "^2.0.0",
@@ -94,7 +94,6 @@
         "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
-        "eslint-plugin-local-rules": "^2.0.0",
         "eslint-plugin-mocha": "^10.0.5",
         "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -131,10 +130,10 @@
         "eslint": ">=8.0.0"
       }
     },
-    "node_modules/@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner/-/eslint-plugin-no-sinon-stub-with-args-oneliner-0.2.0.tgz",
-      "integrity": "sha512-cPmR+jhMEU0g4ROrjqmT5bjcA0HAvDHFSqoOta32G+mT8j4eRG3X8bA5lVS++mjCrqfX2L2BZXIsgVwLV4OCJA==",
+    "node_modules/@1024pix/eslint-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/eslint-plugin/-/eslint-plugin-1.0.0.tgz",
+      "integrity": "sha512-jjNmwbnTQ2G9NxYxHWQTWxpxBmkG7VqBLBgwaka+i/xfXWLC6zoAzuhNJYlfzWCOZ1fw3Di+PiPZ3t8lAtu7aw==",
       "dev": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5208,12 +5207,6 @@
       "resolved": "git+ssh://git@github.com/1024pix/eslint-plugin-knex.git#48af579a29b194c7e061acc22548652dd32951ef",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/eslint-plugin-local-rules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.0.tgz",
-      "integrity": "sha512-sWueme0kUcP0JC1+6OBDQ9edBDVFJR92WJHSRbhiRExlenMEuUisdaVBPR+ItFBFXo2Pdw6FD2UfGZWkz8e93g==",
-      "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@1024pix/eslint-config": "^1.0.3",
-    "@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner": "^0.2.0",
+    "@1024pix/eslint-plugin": "^1.0.0",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@ls-lint/ls-lint": "^2.0.0",
@@ -100,7 +100,6 @@
     "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
-    "eslint-plugin-local-rules": "^2.0.0",
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@1024pix/eslint-config": "^1.0.3",
+    "@1024pix/eslint-config": "^1.1.0",
     "@1024pix/eslint-plugin": "^1.0.0",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-assertions": "^7.20.0",

--- a/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
+++ b/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
@@ -45,7 +45,7 @@ describe('Unit | Scripts | organizations-by-external-id-helper.js', function () 
       ];
 
       // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line local-rules/no-sinon-stub-with-args-oneliner
+      // eslint-disable-next-line @1024pix/no-sinon-stub-with-args-oneliner
       const findByExternalIdsFetchingIdsOnlyStub = sinon.stub().withArgs(['A100', 'B200']).resolves([]);
       const organizationRepository = { findByExternalIdsFetchingIdsOnly: findByExternalIdsFetchingIdsOnlyStub };
 


### PR DESCRIPTION
## :unicorn: Problème
Précédemment dans #6331, la nouvelle règle eslint `no-sinon-stub-with-args-oneliner` avait été intégrée **unitairement** dans un package npm `@1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner`, entraînant la nécessité d'utiliser le plugin eslint `eslint-plugin-local-rules`.

## :robot: Proposition
Cette règle `no-sinon-stub-with-args-oneliner` a plus sa place dans un ensemble des règles eslint : `@1024pix/eslint-plugin` (communément appelé un plugin eslint).
L'intégrer permet aussi de supprimer la librairie `eslint-plugin-local-rules`.

## :rainbow: Remarques
On va pouvoir dépublier et supprimer le package npm et [le repo git](https://github.com/1024pix/eslint-plugin-no-sinon-stub-with-args-oneliner).
https://github.com/1024pix/eslint-plugin

## :100: Pour tester
À tester en local, en se rendant sur le fichier api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js et en supprimant ligne 48 le `eslint-disable`. Ainsi, la ligne du dessous devra afficher l'erreur `ESLint: `sinon.stub()` should not be chained with the `withArgs` method.(@1024pix/no-sinon-stub-with-args-oneliner)`.
