### PR TITLE
[FEATURE] Possibilité de désactiver le passage par toutes les compétences dans le simulateur (PIX-9466).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -29,6 +29,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   challengesBetweenSameCompetence: Joi.number().min(0),
   limitToOneQuestionPerTube: Joi.boolean(),
   minimumEstimatedSuccessRateRanges: Joi.array().items(_successRatesConfigurationValidator),
+  enablePassageByAllCompetences: Joi.boolean(),
 });
 
 const register = async (server) => {

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -31,6 +31,7 @@ async function simulateFlashAssessmentScenario(
     challengesBetweenSameCompetence,
     limitToOneQuestionPerTube,
     minimumEstimatedSuccessRateRanges: minimumEstimatedSuccessRateRangesDto,
+    enablePassageByAllCompetences,
   } = request.payload;
 
   const pickAnswerStatus = _getPickAnswerStatusMethod(dependencies.pickAnswerStatusService, request.payload);
@@ -58,6 +59,7 @@ async function simulateFlashAssessmentScenario(
           challengesBetweenSameCompetence,
           limitToOneQuestionPerTube,
           minimumEstimatedSuccessRateRanges,
+          enablePassageByAllCompetences,
         },
         _.isUndefined,
       );

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -33,13 +33,14 @@ function getPossibleNextChallenges({
     challengesBetweenSameCompetence = 0,
     minimalSuccessRate = 0,
     limitToOneQuestionPerTube = false,
+    enablePassageByAllCompetences = true,
   } = {},
 } = {}) {
   let nonAnsweredChallenges = limitToOneQuestionPerTube
     ? getChallengesForNonAnsweredTubes({ allAnswers, challenges })
     : getChallengesForNonAnsweredSkills({ allAnswers, challenges });
 
-  if (allAnswers.length >= warmUpLength) {
+  if (allAnswers.length >= warmUpLength && enablePassageByAllCompetences) {
     const answersAfterWarmup = _getAnswersAfterWarmup({ answers: allAnswers, warmUpLength });
 
     nonAnsweredChallenges = _filterAlreadyAnsweredCompetences({

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -13,6 +13,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   challengesBetweenSameCompetence,
   limitToOneQuestionPerTube,
   minimumEstimatedSuccessRateRanges,
+  enablePassageByAllCompetences,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -23,6 +24,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     challengesBetweenSameCompetence,
     limitToOneQuestionPerTube,
     minimumEstimatedSuccessRateRanges,
+    enablePassageByAllCompetences,
   });
 
   const simulator = new AssessmentSimulator({

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -713,6 +713,48 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         });
       });
     });
+
+    describe('when we disable the passage by all competences', function () {
+      it('should return all non answered challenges', function () {
+        // given
+        const firstSkill = domainBuilder.buildSkill({
+          id: 'skill1',
+        });
+
+        const answeredChallenge = domainBuilder.buildChallenge({
+          id: 'recCHAL1',
+          skill: firstSkill.id,
+        });
+
+        const firstNonAnsweredChallenge = domainBuilder.buildChallenge({
+          id: 'recCHAL2',
+        });
+
+        const secondNonAnsweredChallenge = domainBuilder.buildChallenge({
+          id: 'recCHAL3',
+        });
+
+        const challenges = [answeredChallenge, firstNonAnsweredChallenge, secondNonAnsweredChallenge];
+
+        const answers = [
+          domainBuilder.buildAnswer({
+            challengeId: answeredChallenge.id,
+          }),
+        ];
+
+        // when
+        const nextChallenges = getPossibleNextChallenges({
+          allAnswers: answers,
+          challenges,
+          options: {
+            enablePassageByAllCompetences: true,
+          },
+        }).possibleChallenges;
+
+        // then
+        expect(nextChallenges).to.deep.equal([firstNonAnsweredChallenge, secondNonAnsweredChallenge]);
+      });
+    });
   });
 
   describe('#getEstimatedLevelAndErrorRate', function () {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, le passage par toutes les compétences de l’algorithme n’est pas désactivable dans les simulateur

## :robot: Proposition

Ajout d'un nouveau paramètre en entrée du simulateur pour permettre de désactiver le passage par toutes les compétences.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Exécuter la requête curl ci-dessous et vérifier que toutes les compétences peuvent ne pas être passées.

```
TOKEN=$(curl 'https://api-pr7216.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7216.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "capacity": 1.5, "enablePassageByAllCompetences": false }' | jq '.'