### PR TITLE
[FEATURE] Scoring d'une certif V3 terminée par le surveillant (PIX-9541).

### DIFF
--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -6,104 +6,101 @@ import { ChallengeDeneutralized } from '../../../../lib/domain/events/ChallengeD
 import { CertificationJuryDone } from '../../../../lib/domain/events/CertificationJuryDone.js';
 import { CertificationAssessment, CertificationResult, AssessmentResult } from '../../../../lib/domain/models/index.js';
 import { CertificationComputeError } from '../../../../lib/domain/errors.js';
+import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
 
 const CERTIFICATION_RESULT_EMITTER_AUTOJURY = CertificationResult.emitters.PIX_ALGO_AUTO_JURY;
 const CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION = CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION;
 
 describe('Unit | Domain | Events | handle-certification-rescoring', function () {
-  it('computes and persists the assessment result and competence marks when computation succeeds', async function () {
-    // given
-    const certificationCourseRepository = {
-      get: sinon.stub(),
-      update: sinon.stub(),
-    };
-    const assessmentResultRepository = { save: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-    const competenceMarkRepository = { save: sinon.stub() };
-    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-    const certificationCourse = domainBuilder.buildCertificationCourse({
-      isCancelled: false,
-    });
-    const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
-      ...certificationCourse.toDTO(),
-    });
+  describe('when handling a v3 certification', function () {
+    it('should save the score', async function () {
+      const assessmentResultRepository = {
+        save: sinon.stub(),
+      };
+      const certificationAssessmentRepository = {
+        getByCertificationCourseId: sinon.stub(),
+      };
+      const answerRepository = {
+        findByAssessment: sinon.stub(),
+      };
+      const challengeRepository = {
+        getMany: sinon.stub(),
+      };
 
-    const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
-    const certificationAssessment = new CertificationAssessment({
-      id: 123,
-      userId: 123,
-      certificationCourseId: certificationCourse.getId(),
-      createdAt: new Date('2020-01-01'),
-      completedAt: new Date('2020-01-01'),
-      state: CertificationAssessment.states.STARTED,
-      version: 2,
-      certificationChallenges: [
-        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-      ],
-      certificationAnswersByDate: ['answer'],
-    });
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId: certificationCourse.getId() })
-      .resolves(certificationAssessment);
-    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        version: CertificationVersion.V3,
+      });
 
-    const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 5 });
-    const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 4 });
-    const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-      nbPix: 9,
-      status: AssessmentResult.status.VALIDATED,
-      competenceMarks: [competenceMark1, competenceMark2],
-      percentageCorrectAnswers: 80,
-      hasEnoughNonNeutralizedChallengesToBeTrusted: true,
-    });
-    scoringCertificationService.calculateCertificationAssessmentScore
-      .withArgs({ certificationAssessment, continueOnError: false })
-      .resolves(certificationAssessmentScore);
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'chall1',
+        }),
+        domainBuilder.buildChallenge({
+          id: 'chall2',
+        }),
+      ];
 
-    const assessmentResultToBeSaved = new AssessmentResult({
-      id: undefined,
-      commentForJury: 'Computed',
-      emitter: 'PIX-ALGO-NEUTRALIZATION',
-      pixScore: 9,
-      reproducibilityRate: 80,
-      status: AssessmentResult.status.VALIDATED,
-      assessmentId: 123,
-      juryId: 7,
-    });
-    const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-    assessmentResultRepository.save
-      .withArgs({ certificationCourseId: 123, assessmentResult: assessmentResultToBeSaved })
-      .resolves(savedAssessmentResult);
+      const challengeIds = ['chall1', 'chall2'];
 
-    const dependendencies = {
-      assessmentResultRepository,
-      certificationAssessmentRepository,
-      competenceMarkRepository,
-      scoringCertificationService,
-      certificationCourseRepository,
-    };
+      const answers = challenges.map(({ id: challengeId }) =>
+        domainBuilder.buildAnswer({
+          challengeId,
+        }),
+      );
 
-    // when
-    await handleCertificationRescoring({
-      ...dependendencies,
-      event,
-    });
+      const { certificationCourseId } = certificationAssessment;
 
-    // then
-    expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
-      certificationCourseId: 123,
-      assessmentResult: assessmentResultToBeSaved,
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId })
+        .resolves(certificationAssessment);
+
+      answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
+
+      challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+
+      const event = new CertificationJuryDone({
+        certificationCourseId,
+      });
+
+      const dependencies = {
+        certificationAssessmentRepository,
+        answerRepository,
+        challengeRepository,
+        assessmentResultRepository,
+      };
+
+      const result = await handleCertificationRescoring({
+        ...dependencies,
+        event,
+      });
+
+      const expectedResult = {
+        certificationCourseId,
+        assessmentResult: new AssessmentResult({
+          commentForJury: 'Computed',
+          emitter: 'PIX-ALGO',
+          pixScore: 479,
+          reproducibilityRate: 100,
+          status: 'validated',
+          competenceMarks: [],
+          assessmentId: 123,
+        }),
+      };
+
+      expect(assessmentResultRepository.save).to.have.been.calledWith(expectedResult);
+
+      const expectedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
+        certificationCourseId,
+        userId: certificationAssessment.certificationCourseId,
+        reproducibilityRate: 100,
+      });
+
+      expect(result).to.deep.equal(expectedEvent);
     });
-    competenceMark1.assessmentResultId = savedAssessmentResult.id;
-    competenceMark2.assessmentResultId = savedAssessmentResult.id;
-    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMark1);
-    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMark2);
-    expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
   });
 
-  context('when the certification has not enough non neutralized challenges to be trusted', function () {
-    it('cancels the certification and save a not trustable assessment result', async function () {
+  describe('when handling a v2 certification', function () {
+    it('computes and persists the assessment result and competence marks when computation succeeds', async function () {
       // given
       const certificationCourseRepository = {
         get: sinon.stub(),
@@ -113,14 +110,18 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
       const competenceMarkRepository = { save: sinon.stub() };
       const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
-      sinon.spy(certificationCourse, 'cancel');
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        isCancelled: false,
+      });
+      const expectedSaveCertificationCourse = domainBuilder.buildCertificationCourse({
+        ...certificationCourse.toDTO(),
+      });
 
-      const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
+      const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
       const certificationAssessment = new CertificationAssessment({
         id: 123,
         userId: 123,
-        certificationCourseId: 789,
+        certificationCourseId: certificationCourse.getId(),
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
         state: CertificationAssessment.states.STARTED,
@@ -132,24 +133,28 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         certificationAnswersByDate: ['answer'],
       });
       certificationAssessmentRepository.getByCertificationCourseId
-        .withArgs({ certificationCourseId: 789 })
+        .withArgs({ certificationCourseId: certificationCourse.getId() })
         .resolves(certificationAssessment);
-      certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
-      const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
-      const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
+      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 5 });
+      const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 4 });
       const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+        nbPix: 9,
         status: AssessmentResult.status.VALIDATED,
         competenceMarks: [competenceMark1, competenceMark2],
         percentageCorrectAnswers: 80,
-        hasEnoughNonNeutralizedChallengesToBeTrusted: false,
+        hasEnoughNonNeutralizedChallengesToBeTrusted: true,
       });
       scoringCertificationService.calculateCertificationAssessmentScore
         .withArgs({ certificationAssessment, continueOnError: false })
         .resolves(certificationAssessmentScore);
 
-      const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.notTrustable({
+      const assessmentResultToBeSaved = new AssessmentResult({
+        id: undefined,
+        commentForJury: 'Computed',
         emitter: 'PIX-ALGO-NEUTRALIZATION',
-        pixScore: 30,
+        pixScore: 9,
         reproducibilityRate: 80,
         status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
@@ -157,7 +162,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       });
       const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
       assessmentResultRepository.save
-        .withArgs({ certificationCourseId: 789, assessmentResult: assessmentResultToBeSaved })
+        .withArgs({ certificationCourseId: 123, assessmentResult: assessmentResultToBeSaved })
         .resolves(savedAssessmentResult);
 
       const dependendencies = {
@@ -175,237 +180,19 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       });
 
       // then
-
       expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
-        certificationCourseId: 789,
-        assessmentResult: assessmentResultToBeSaved,
-      });
-      expect(certificationCourse.cancel).to.have.been.calledOnce;
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
-    });
-  });
-
-  context('when the certification has enough non neutralized challenges to be trusted', function () {
-    it('uncancels the certification and save a standard assessment result', async function () {
-      // given
-      const certificationCourseRepository = {
-        get: sinon.stub(),
-        update: sinon.stub(),
-      };
-      const assessmentResultRepository = { save: sinon.stub() };
-      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-      const competenceMarkRepository = { save: sinon.stub() };
-      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
-      sinon.spy(certificationCourse, 'uncancel');
-
-      const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
-      const certificationAssessment = new CertificationAssessment({
-        id: 123,
-        userId: 123,
-        certificationCourseId: 789,
-        createdAt: new Date('2020-01-01'),
-        completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
-        version: 2,
-        certificationChallenges: [
-          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-        ],
-        certificationAnswersByDate: ['answer'],
-      });
-      certificationAssessmentRepository.getByCertificationCourseId
-        .withArgs({ certificationCourseId: 789 })
-        .resolves(certificationAssessment);
-      certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
-      const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
-      const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
-      const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-        status: AssessmentResult.status.VALIDATED,
-        competenceMarks: [competenceMark1, competenceMark2],
-        percentageCorrectAnswers: 80,
-        hasEnoughNonNeutralizedChallengesToBeTrusted: true,
-      });
-      scoringCertificationService.calculateCertificationAssessmentScore
-        .withArgs({ certificationAssessment, continueOnError: false })
-        .resolves(certificationAssessmentScore);
-
-      const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.standard({
-        emitter: 'PIX-ALGO-NEUTRALIZATION',
-        pixScore: 30,
-        reproducibilityRate: 80,
-        status: AssessmentResult.status.VALIDATED,
-        assessmentId: 123,
-        juryId: 7,
-      });
-      const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-      assessmentResultRepository.save.resolves({
-        certificationCourseId: 789,
-        assessmentResult: savedAssessmentResult,
-      });
-
-      const dependendencies = {
-        assessmentResultRepository,
-        certificationAssessmentRepository,
-        competenceMarkRepository,
-        scoringCertificationService,
-        certificationCourseRepository,
-      };
-
-      // when
-      await handleCertificationRescoring({
-        ...dependendencies,
-        event,
-      });
-
-      // then
-      expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
-        certificationCourseId: 789,
-        assessmentResult: assessmentResultToBeSaved,
-      });
-      expect(certificationCourse.uncancel).to.have.been.calledOnce;
-      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
-    });
-  });
-
-  it('returns a CertificationRescoringCompleted event', async function () {
-    // given
-    const certificationCourseRepository = {
-      get: sinon.stub(),
-      update: sinon.stub(),
-    };
-    const assessmentResultRepository = { save: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-    const competenceMarkRepository = { save: sinon.stub() };
-    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-    const certificationCourse = domainBuilder.buildCertificationCourse();
-
-    const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
-    const certificationAssessment = domainBuilder.buildCertificationAssessment({
-      userId: 123,
-      certificationCourseId: certificationCourse.getId(),
-    });
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId: certificationCourse.getId() })
-      .resolves(certificationAssessment);
-    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
-
-    const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-      competenceMarks: [],
-      percentageCorrectAnswers: 80,
-      hasEnoughNonNeutralizedChallengesToBeTrusted: true,
-    });
-    scoringCertificationService.calculateCertificationAssessmentScore
-      .withArgs({ certificationAssessment, continueOnError: false })
-      .resolves(certificationAssessmentScore);
-    assessmentResultRepository.save.resolves(domainBuilder.buildAssessmentResult());
-
-    const dependendencies = {
-      assessmentResultRepository,
-      certificationAssessmentRepository,
-      competenceMarkRepository,
-      scoringCertificationService,
-      certificationCourseRepository,
-    };
-
-    // when
-    const returnedEvent = await handleCertificationRescoring({
-      ...dependendencies,
-      event,
-    });
-
-    // then
-    const expectedReturnedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-      certificationCourseId: certificationCourse.getId(),
-      userId: 123,
-      reproducibilityRate: 80,
-    });
-    expect(returnedEvent).to.deep.equal(expectedReturnedEvent);
-  });
-
-  it('computes and persists the assessment result in error when computation fails', async function () {
-    // given
-    const assessmentResultRepository = { save: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-    const competenceMarkRepository = { save: sinon.stub() };
-    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-
-    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
-    const certificationAssessment = new CertificationAssessment({
-      id: 123,
-      userId: 123,
-      certificationCourseId: 789,
-      createdAt: new Date('2020-01-01'),
-      completedAt: new Date('2020-01-01'),
-      state: CertificationAssessment.states.STARTED,
-      version: 2,
-      certificationChallenges: [
-        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-        domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-      ],
-      certificationAnswersByDate: ['answer'],
-    });
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId: 1 })
-      .resolves(certificationAssessment);
-
-    scoringCertificationService.calculateCertificationAssessmentScore
-      .withArgs({ certificationAssessment, continueOnError: false })
-      .rejects(new CertificationComputeError('Oopsie'));
-
-    const assessmentResultToBeSaved = new AssessmentResult({
-      id: undefined,
-      emitter: 'PIX-ALGO-NEUTRALIZATION',
-      commentForJury: 'Oopsie',
-      pixScore: 0,
-      reproducibilityRate: 0,
-      status: 'error',
-      assessmentId: 123,
-      juryId: 7,
-    });
-    const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-    assessmentResultRepository.save
-      .withArgs({
         certificationCourseId: 123,
         assessmentResult: assessmentResultToBeSaved,
-      })
-      .resolves(savedAssessmentResult);
-
-    const dependendencies = {
-      assessmentResultRepository,
-      certificationAssessmentRepository,
-      competenceMarkRepository,
-      scoringCertificationService,
-    };
-
-    // when
-    await handleCertificationRescoring({
-      ...dependendencies,
-      event,
+      });
+      competenceMark1.assessmentResultId = savedAssessmentResult.id;
+      competenceMark2.assessmentResultId = savedAssessmentResult.id;
+      expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMark1);
+      expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMark2);
+      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
     });
 
-    // then
-    expect(assessmentResultRepository.save).to.have.been.calledOnce;
-  });
-
-  // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  [
-    {
-      eventType: CertificationJuryDone,
-      emitter: CERTIFICATION_RESULT_EMITTER_AUTOJURY,
-    },
-    {
-      eventType: ChallengeNeutralized,
-      emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
-    },
-    {
-      eventType: ChallengeDeneutralized,
-      emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
-    },
-  ].forEach(({ eventType, emitter }) => {
-    context(`when event is of type ${eventType}`, function () {
-      it(`should save an assessment result with a ${emitter} emitter`, async function () {
+    context('when the certification has not enough non neutralized challenges to be trusted', function () {
+      it('cancels the certification and save a not trustable assessment result', async function () {
         // given
         const certificationCourseRepository = {
           get: sinon.stub(),
@@ -415,16 +202,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
         const competenceMarkRepository = { save: sinon.stub() };
         const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-        const certificationCourse = domainBuilder.buildCertificationCourse({
-          id: 789,
-          isCancelled: false,
-        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
+        sinon.spy(certificationCourse, 'cancel');
 
-        const event = new eventType({ certificationCourseId: certificationCourse.getId() });
+        const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
         const certificationAssessment = new CertificationAssessment({
           id: 123,
           userId: 123,
-          certificationCourseId: certificationCourse.getId(),
+          certificationCourseId: 789,
           createdAt: new Date('2020-01-01'),
           completedAt: new Date('2020-01-01'),
           state: CertificationAssessment.states.STARTED,
@@ -436,14 +221,95 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           certificationAnswersByDate: ['answer'],
         });
         certificationAssessmentRepository.getByCertificationCourseId
-          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .withArgs({ certificationCourseId: 789 })
           .resolves(certificationAssessment);
-        certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
-
-        const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 5 });
-        const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 4 });
+        certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
+        const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
+        const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
         const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-          nbPix: 9,
+          status: AssessmentResult.status.VALIDATED,
+          competenceMarks: [competenceMark1, competenceMark2],
+          percentageCorrectAnswers: 80,
+          hasEnoughNonNeutralizedChallengesToBeTrusted: false,
+        });
+        scoringCertificationService.calculateCertificationAssessmentScore
+          .withArgs({ certificationAssessment, continueOnError: false })
+          .resolves(certificationAssessmentScore);
+
+        const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.notTrustable({
+          emitter: 'PIX-ALGO-NEUTRALIZATION',
+          pixScore: 30,
+          reproducibilityRate: 80,
+          status: AssessmentResult.status.VALIDATED,
+          assessmentId: 123,
+          juryId: 7,
+        });
+        const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+        assessmentResultRepository.save
+          .withArgs({ certificationCourseId: 789, assessmentResult: assessmentResultToBeSaved })
+          .resolves(savedAssessmentResult);
+
+        const dependendencies = {
+          assessmentResultRepository,
+          certificationAssessmentRepository,
+          competenceMarkRepository,
+          scoringCertificationService,
+          certificationCourseRepository,
+        };
+
+        // when
+        await handleCertificationRescoring({
+          ...dependendencies,
+          event,
+        });
+
+        // then
+
+        expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
+          certificationCourseId: 789,
+          assessmentResult: assessmentResultToBeSaved,
+        });
+        expect(certificationCourse.cancel).to.have.been.calledOnce;
+        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+      });
+    });
+
+    context('when the certification has enough non neutralized challenges to be trusted', function () {
+      it('uncancels the certification and save a standard assessment result', async function () {
+        // given
+        const certificationCourseRepository = {
+          get: sinon.stub(),
+          update: sinon.stub(),
+        };
+        const assessmentResultRepository = { save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+        const competenceMarkRepository = { save: sinon.stub() };
+        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
+        sinon.spy(certificationCourse, 'uncancel');
+
+        const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
+        const certificationAssessment = new CertificationAssessment({
+          id: 123,
+          userId: 123,
+          certificationCourseId: 789,
+          createdAt: new Date('2020-01-01'),
+          completedAt: new Date('2020-01-01'),
+          state: CertificationAssessment.states.STARTED,
+          version: 2,
+          certificationChallenges: [
+            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          ],
+          certificationAnswersByDate: ['answer'],
+        });
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: 789 })
+          .resolves(certificationAssessment);
+        certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
+        const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
+        const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
+        const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
           status: AssessmentResult.status.VALIDATED,
           competenceMarks: [competenceMark1, competenceMark2],
           percentageCorrectAnswers: 80,
@@ -453,18 +319,19 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           .withArgs({ certificationAssessment, continueOnError: false })
           .resolves(certificationAssessmentScore);
 
-        const assessmentResultToBeSaved = new AssessmentResult({
-          id: undefined,
-          commentForJury: 'Computed',
-          emitter,
-          pixScore: 9,
+        const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.standard({
+          emitter: 'PIX-ALGO-NEUTRALIZATION',
+          pixScore: 30,
           reproducibilityRate: 80,
           status: AssessmentResult.status.VALIDATED,
           assessmentId: 123,
-          juryId: undefined,
+          juryId: 7,
         });
         const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-        assessmentResultRepository.save.resolves(savedAssessmentResult);
+        assessmentResultRepository.save.resolves({
+          certificationCourseId: 789,
+          assessmentResult: savedAssessmentResult,
+        });
 
         const dependendencies = {
           assessmentResultRepository,
@@ -484,6 +351,229 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
           certificationCourseId: 789,
           assessmentResult: assessmentResultToBeSaved,
+        });
+        expect(certificationCourse.uncancel).to.have.been.calledOnce;
+        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+      });
+    });
+
+    it('returns a CertificationRescoringCompleted event', async function () {
+      // given
+      const certificationCourseRepository = {
+        get: sinon.stub(),
+        update: sinon.stub(),
+      };
+      const assessmentResultRepository = { save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+      const competenceMarkRepository = { save: sinon.stub() };
+      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+      const certificationCourse = domainBuilder.buildCertificationCourse();
+
+      const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        userId: 123,
+        certificationCourseId: certificationCourse.getId(),
+      });
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId: certificationCourse.getId() })
+        .resolves(certificationAssessment);
+      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+      const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+        competenceMarks: [],
+        percentageCorrectAnswers: 80,
+        hasEnoughNonNeutralizedChallengesToBeTrusted: true,
+      });
+      scoringCertificationService.calculateCertificationAssessmentScore
+        .withArgs({ certificationAssessment, continueOnError: false })
+        .resolves(certificationAssessmentScore);
+      assessmentResultRepository.save.resolves(domainBuilder.buildAssessmentResult());
+
+      const dependendencies = {
+        assessmentResultRepository,
+        certificationAssessmentRepository,
+        competenceMarkRepository,
+        scoringCertificationService,
+        certificationCourseRepository,
+      };
+
+      // when
+      const returnedEvent = await handleCertificationRescoring({
+        ...dependendencies,
+        event,
+      });
+
+      // then
+      const expectedReturnedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
+        certificationCourseId: certificationCourse.getId(),
+        userId: 123,
+        reproducibilityRate: 80,
+      });
+      expect(returnedEvent).to.deep.equal(expectedReturnedEvent);
+    });
+
+    it('computes and persists the assessment result in error when computation fails', async function () {
+      // given
+      const assessmentResultRepository = { save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+      const competenceMarkRepository = { save: sinon.stub() };
+      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+
+      const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
+      const certificationAssessment = new CertificationAssessment({
+        id: 123,
+        userId: 123,
+        certificationCourseId: 789,
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-01-01'),
+        state: CertificationAssessment.states.STARTED,
+        version: 2,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+        certificationAnswersByDate: ['answer'],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId: 1 })
+        .resolves(certificationAssessment);
+
+      scoringCertificationService.calculateCertificationAssessmentScore
+        .withArgs({ certificationAssessment, continueOnError: false })
+        .rejects(new CertificationComputeError('Oopsie'));
+
+      const assessmentResultToBeSaved = new AssessmentResult({
+        id: undefined,
+        emitter: 'PIX-ALGO-NEUTRALIZATION',
+        commentForJury: 'Oopsie',
+        pixScore: 0,
+        reproducibilityRate: 0,
+        status: 'error',
+        assessmentId: 123,
+        juryId: 7,
+      });
+      const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+      assessmentResultRepository.save
+        .withArgs({
+          certificationCourseId: 123,
+          assessmentResult: assessmentResultToBeSaved,
+        })
+        .resolves(savedAssessmentResult);
+
+      const dependendencies = {
+        assessmentResultRepository,
+        certificationAssessmentRepository,
+        competenceMarkRepository,
+        scoringCertificationService,
+      };
+
+      // when
+      await handleCertificationRescoring({
+        ...dependendencies,
+        event,
+      });
+
+      // then
+      expect(assessmentResultRepository.save).to.have.been.calledOnce;
+    });
+
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        eventType: CertificationJuryDone,
+        emitter: CERTIFICATION_RESULT_EMITTER_AUTOJURY,
+      },
+      {
+        eventType: ChallengeNeutralized,
+        emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
+      },
+      {
+        eventType: ChallengeDeneutralized,
+        emitter: CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION,
+      },
+    ].forEach(({ eventType, emitter }) => {
+      context(`when event is of type ${eventType}`, function () {
+        it(`should save an assessment result with a ${emitter} emitter`, async function () {
+          // given
+          const certificationCourseRepository = {
+            get: sinon.stub(),
+            update: sinon.stub(),
+          };
+          const assessmentResultRepository = { save: sinon.stub() };
+          const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+          const competenceMarkRepository = { save: sinon.stub() };
+          const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+          const certificationCourse = domainBuilder.buildCertificationCourse({
+            id: 789,
+            isCancelled: false,
+          });
+
+          const event = new eventType({ certificationCourseId: certificationCourse.getId() });
+          const certificationAssessment = new CertificationAssessment({
+            id: 123,
+            userId: 123,
+            certificationCourseId: certificationCourse.getId(),
+            createdAt: new Date('2020-01-01'),
+            completedAt: new Date('2020-01-01'),
+            state: CertificationAssessment.states.STARTED,
+            version: 2,
+            certificationChallenges: [
+              domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+              domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+            ],
+            certificationAnswersByDate: ['answer'],
+          });
+          certificationAssessmentRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId: certificationCourse.getId() })
+            .resolves(certificationAssessment);
+          certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+
+          const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 5 });
+          const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 4 });
+          const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+            nbPix: 9,
+            status: AssessmentResult.status.VALIDATED,
+            competenceMarks: [competenceMark1, competenceMark2],
+            percentageCorrectAnswers: 80,
+            hasEnoughNonNeutralizedChallengesToBeTrusted: true,
+          });
+          scoringCertificationService.calculateCertificationAssessmentScore
+            .withArgs({ certificationAssessment, continueOnError: false })
+            .resolves(certificationAssessmentScore);
+
+          const assessmentResultToBeSaved = new AssessmentResult({
+            id: undefined,
+            commentForJury: 'Computed',
+            emitter,
+            pixScore: 9,
+            reproducibilityRate: 80,
+            status: AssessmentResult.status.VALIDATED,
+            assessmentId: 123,
+            juryId: undefined,
+          });
+          const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+          assessmentResultRepository.save.resolves(savedAssessmentResult);
+
+          const dependendencies = {
+            assessmentResultRepository,
+            certificationAssessmentRepository,
+            competenceMarkRepository,
+            scoringCertificationService,
+            certificationCourseRepository,
+          };
+
+          // when
+          await handleCertificationRescoring({
+            ...dependendencies,
+            event,
+          });
+
+          // then
+          expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
+            certificationCourseId: 789,
+            assessmentResult: assessmentResultToBeSaved,
+          });
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le candidat ne finit pas sa certification v3, le scoring v2 est utilisé, ce qui fait planter le scoring.

## :robot: Proposition
Gérer le cas de la certification v3 lors du "rescoring"

## :100: Pour tester

Sur Pix-certif, se connecter avec [certifv3@example.net](mailto:certifv3@example.net)
Créer une session de certification et ajouter un candidat
Sur pix-app, se connecter avec [certifiable-contenu-user@example.net](mailto:certifiable-contenu-user@example.net)
Participer à la session de certification, ne pas terminer la session.
Terminer la session par le surveillant
Finaliser la session en précisant l'abandon pour manque de temps
Sur pix-admin, publier la session et vérifier qu'un score est visible dans pix-admin
