### PR TITLE
[FEATURE] Rajouter des logs dans les logs des caches

### DIFF
--- a/api/lib/infrastructure/caches/DistributedCache.js
+++ b/api/lib/infrastructure/caches/DistributedCache.js
@@ -1,5 +1,6 @@
 import { Cache } from './Cache.js';
 import { RedisClient } from '../utils/RedisClient.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 class DistributedCache extends Cache {
   constructor(underlyingCache, redisUrl, channel) {
@@ -15,6 +16,7 @@ class DistributedCache extends Cache {
       this._redisClientSubscriber.subscribe(this._channel);
     });
     this._redisClientSubscriber.on('message', () => {
+      logger.info({ event: 'cache-event' }, 'Flushing the local cache');
       return this._underlyingCache.flushAll();
     });
   }

--- a/api/lib/infrastructure/caches/LayeredCache.js
+++ b/api/lib/infrastructure/caches/LayeredCache.js
@@ -1,4 +1,5 @@
 import { Cache } from './Cache.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 class LayeredCache extends Cache {
   constructor(firstLevelCache, secondLevelCache) {
@@ -9,6 +10,10 @@ class LayeredCache extends Cache {
 
   get(key, generator) {
     return this._firstLevelCache.get(key, () => {
+      logger.info(
+        { event: 'cache-event', key },
+        'Cannot found the key from the firstLevelCache. Fetching on the second one.',
+      );
       return this._secondLevelCache.get(key, generator);
     });
   }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de débugger des problèmes de désynchronisation de cache entre les instances de l'API. Les logs actuels ne le permettent pas.

## :robot: Proposition
Rajouter des logs lorsque: 
- l'instance recoit un événement de flush
- lorsque l'instance ne trouve pas le cache local et le demande à redis

## :100: Pour tester

Se connecter sur Pix App.
Vérifier la présence des logs suivants sur Pix Api :
```
{"level":30,"time":1696933443228,"pid":77,"hostname":"pix-api-review-pr7228-postdeploy-1401","msg":"Cannot found the key from the firstLevelCache. Fetching on the second one."} 
```
```
{"level":30,"time":1696933443235,"pid":77,"hostname":"pix-api-review-pr7228-postdeploy-1401","key":"LearningContent","msg":"Executing generator for Redis key"}
```
```
{"level":30,"time":1696933445208,"pid":77,"hostname":"pix-api-review-pr7228-postdeploy-1401","metrics":{"responseTime":1972.3153839111328},"msg":"End GET request to https://lcms.pix.fr/api/releases/latest success: 200"}
```
```
{"level":30,"time":1696933445209,"pid":77,"hostname":"pix-api-review-pr7228-postdeploy-1401","msg":"Release 1359 created on 2023-10-10T02:20:08.035Z successfully received from LCMS"}
```
```
{"level":30,"time":1696933445433,"pid":77,"hostname":"pix-api-review-pr7228-postdeploy-1401","key":"LearningContent","length":24110731,"msg":"Setting Redis key"} 
```