### PR TITLE
[BUGFIX] Corrige mirage en developement sur 1d

### DIFF
--- a/1d/config/environment.js
+++ b/1d/config/environment.js
@@ -20,6 +20,10 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+
+    'ember-cli-mirage': {
+      usingProxy: true,
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
## :unicorn: Problème
Depuis #7222, en developpement sur 1d, toutes les requêtes passent par mirage plutot que par le proxy.

## :robot: Proposition
Configurer ember-cli-mirage pour lui dire d'utiliser le proxy.

## :100: Pour tester
1. Lancer 1d
2. Naviguer avec un navigateur web et constater que les requetes vont bien a l'API
