### PR TITLE
[TECH] Refactoring de l'algo de choix des épreuves next-gen (PIX-9560).

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -23,6 +23,7 @@ async function handleCertificationRescoring({
   certificationCourseRepository,
   challengeRepository,
   answerRepository,
+  flashAlgorithmService,
 }) {
   checkEventTypes(event, eventTypes);
 
@@ -37,6 +38,7 @@ async function handleCertificationRescoring({
         answerRepository,
         certificationAssessment,
         assessmentResultRepository,
+        flashAlgorithmService,
       });
     }
 
@@ -68,6 +70,7 @@ async function _handleV3Certification({
   answerRepository,
   certificationAssessment,
   assessmentResultRepository,
+  flashAlgorithmService,
 }) {
   const allAnswers = await answerRepository.findByAssessment(certificationAssessment.id);
   const challengeIds = allAnswers.map(({ challengeId }) => challengeId);
@@ -76,6 +79,7 @@ async function _handleV3Certification({
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     challenges,
     allAnswers,
+    flashAlgorithmService,
   });
 
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult({

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -21,6 +21,7 @@ async function handleCertificationScoring({
   scoringCertificationService,
   answerRepository,
   challengeRepository,
+  flashAlgorithmService,
 }) {
   checkEventTypes(event, eventTypes);
 
@@ -36,6 +37,7 @@ async function handleCertificationScoring({
         assessmentResultRepository,
         certificationCourseRepository,
         competenceMarkRepository,
+        flashAlgorithmService,
       });
     }
 
@@ -97,6 +99,7 @@ async function _handleV3CertificationScoring({
   assessmentResultRepository,
   certificationCourseRepository,
   competenceMarkRepository,
+  flashAlgorithmService,
 }) {
   const allAnswers = await answerRepository.findByAssessment(assessmentId);
   const challengeIds = allAnswers.map(({ challengeId }) => challengeId);
@@ -105,6 +108,7 @@ async function _handleV3CertificationScoring({
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     challenges,
     allAnswers,
+    flashAlgorithmService,
   });
 
   await _saveResult({

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -46,6 +46,7 @@ import { handleComplementaryCertificationsScoring } from './handle-complementary
 import { handlePoleEmploiParticipationFinished } from './handle-pole-emploi-participation-finished.js';
 import { handlePoleEmploiParticipationStarted } from './handle-pole-emploi-participation-started.js';
 import { handleSessionFinalized } from './handle-session-finalized.js';
+import * as flashAlgorithmService from '../services/algorithm-methods/flash.js';
 
 const { performance } = perf_hooks;
 
@@ -76,6 +77,7 @@ const dependencies = {
   competenceRepository,
   complementaryCertificationScoringCriteriaRepository,
   finalizedSessionRepository,
+  flashAlgorithmService,
   juryCertificationSummaryRepository,
   knowledgeElementRepository,
   logger,

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -52,8 +52,10 @@ class CertificationAssessmentScoreV3 {
     this.percentageCorrectAnswers = percentageCorrectAnswers;
   }
 
-  static fromChallengesAndAnswers({ challenges, allAnswers }) {
-    const algorithm = new FlashAssessmentAlgorithm();
+  static fromChallengesAndAnswers({ challenges, allAnswers, flashAlgorithmService }) {
+    const algorithm = new FlashAssessmentAlgorithm({
+      flashAlgorithmImplementation: flashAlgorithmService,
+    });
     const { estimatedLevel } = algorithm.getEstimatedLevelAndErrorRate({
       challenges,
       allAnswers,

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -1,5 +1,6 @@
 import { AssessmentEndedError } from '../errors.js';
 import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js';
+import { config } from '../../../src/shared/config.js';
 
 const getNextChallengeForCampaignAssessment = async function ({
   challengeRepository,
@@ -10,6 +11,7 @@ const getNextChallengeForCampaignAssessment = async function ({
   locale,
   algorithmDataFetcherService,
   smartRandom,
+  flashAlgorithmService,
 }) {
   let algoResult;
 
@@ -22,7 +24,10 @@ const getNextChallengeForCampaignAssessment = async function ({
       locale,
     });
 
-    const assessmentAlgorithm = new FlashAssessmentAlgorithm();
+    const assessmentAlgorithm = new FlashAssessmentAlgorithm({
+      flashAlgorithmImplementation: flashAlgorithmService,
+      maximumAssessmentLength: config.features.numberOfChallengesForFlashMethod,
+    });
 
     const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({
       allAnswers,

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -12,6 +12,7 @@ const getNextChallengeForCertification = async function ({
   flashAssessmentResultRepository,
   locale,
   pickChallengeService,
+  flashAlgorithmService,
 }) {
   const certificationCourse = await certificationCourseRepository.get(assessment.certificationCourseId);
 
@@ -36,6 +37,7 @@ const getNextChallengeForCertification = async function ({
 
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       maximumAssessmentLength: config.v3Certification.numberOfChallengesPerCourse,
+      flashAlgorithmImplementation: flashAlgorithmService,
     });
 
     const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -13,6 +13,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   challengesBetweenSameCompetence,
   limitToOneQuestionPerTube,
   minimumEstimatedSuccessRateRanges,
+  flashAlgorithmService,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -23,6 +24,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     challengesBetweenSameCompetence,
     limitToOneQuestionPerTube,
     minimumEstimatedSuccessRateRanges,
+    flashAlgorithmImplementation: flashAlgorithmService,
   });
 
   const simulator = new AssessmentSimulator({

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -1,10 +1,9 @@
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
-import { NotFoundError } from '../../../../src/shared/domain/errors.js';
+import { NotFoundError, EntityValidationError } from '../../../../src/shared/domain/errors.js';
 
 import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { handle } from '../../../../src/shared/application/error-manager.js';
-import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
 
 describe('Shared | Unit | Application | ErrorManager', function () {
   describe('#handle', function () {


### PR DESCRIPTION
## :unicorn: Problème

Le fichier flash.js contient du code métier non lié au choix des questions (ex: paramètres du simulateur), ne facilitant pas la maintenabilité ainsi que la testabilité.

## :robot: Proposition

Nous extrayons ce code afin d’améliorer la testabilité de l’algo de choix des épreuves de certif V3 et de ne laisser dans flash.js que ce qui concerne le choix des questions.

Plus particulièrement, et afin de ne pas avoir une trop grosse PR, nous nous occupons uniquement dans cette PR d'injecter l'implémentation de l'algorithme flash.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Les tests restent au vert.
Créer et passer une certification V3 et vérifier qu'il n'y ait pas de régression.
Pix-certif: `certifv3@example.net`
Pix-app: `certifiable-contenu-user@example.net`
