### PR TITLE
[FEATURE] Modifier le design du bouton de signalement dans les épreuves (PIX-9583).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
@@ -8,7 +8,7 @@ When(`je lance la preview du challenge {string}`, (challengeId) => {
   cy.visitMonPix(`/challenges/${challengeId}/preview`);
 });
 
-When(`je clique sur Signaler un problème`, () => {
+When(`je clique sur Signaler un problème avec la question`, () => {
   cy.get(".feedback-panel__open-button").click();
 });
 

--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -10,7 +10,7 @@
       aria-controls={{this.feedbackPanelId}}
       type="button"
     >
-      <FaIcon @icon="circle-question" />
+      <FaIcon @icon="flag" />
       {{t "pages.challenge.feedback-panel.actions.open-close"}}
     </button>
   </div>

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -3,7 +3,6 @@
   padding: 0 $pix-spacing-s;
   color: $pix-neutral-60;
   font-size: 0.938rem;
-  background-color: white;
   border-radius: 10px;
 }
 
@@ -11,14 +10,16 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .feedback-panel__open-button {
+  gap: $pix-spacing-xxs;
   width: 100%;
   padding: 0.75rem 0;
-  color: $pix-neutral-50;
-  font-weight: $font-medium;
+  color: $pix-neutral-70;
+  font-weight: $font-normal;
   font-size: 0.875rem;
   font-family: $font-roboto;
   line-height: 20px;
   text-align: left;
+  text-decoration: underline;
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -3,7 +3,6 @@
   padding: 0 $pix-spacing-s;
   color: $pix-neutral-60;
   font-size: 0.938rem;
-  border-radius: 10px;
 }
 
 /* "Link" view

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -529,7 +529,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           await fillCertificationStarter({ accessCode: 'ABCD12', intl: this.intl });
 
           // when
-          await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+          await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
           // then
           assert

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -27,7 +27,7 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
     test('should be able to directly send a feedback', async function (assert) {
       const screen = await visit(`/assessments/${assessment.id}/challenges/0`);
       // then
-      assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' })).exists();
     });
 
     module('when the feedback-panel button is clicked', function (hooks) {
@@ -35,12 +35,14 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
 
       hooks.beforeEach(async function () {
         screen = await visit(`/assessments/${assessment.id}/challenges/0`);
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
       });
 
       test('should open the feedback form', function (assert) {
         // then
-        assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).hasAttribute('aria-expanded', 'true');
+        assert
+          .dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' }))
+          .hasAttribute('aria-expanded', 'true');
         assert.dom(screen.getByRole('button', { name: "J'ai un problème avec" })).exists();
       });
 
@@ -73,13 +75,13 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
           test('should not display the feedback form', async function (assert) {
             // then
             assert
-              .dom(screen.getByRole('button', { name: 'Signaler un problème' }))
+              .dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' }))
               .hasAttribute('aria-expanded', 'false');
             assert.dom(screen.queryByRole('button', { name: "J'ai un problème avec" })).doesNotExist();
           });
 
           test('should always reset the feedback form between two consecutive challenges', async function (assert) {
-            await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+            await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
             await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
             await screen.findByRole('listbox');
             await click(
@@ -117,7 +119,9 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
       await screen.findByRole('dialog');
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).hasAttribute('aria-expanded', 'false');
+      assert
+        .dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' }))
+        .hasAttribute('aria-expanded', 'false');
       assert
         .dom(screen.queryByRole('button', { name: 'Sélectionner la catégorie du problème rencontré' }))
         .doesNotExist();
@@ -128,10 +132,12 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
       await click(screen.getByRole('button', { name: 'Réponses et tutos' }));
       await screen.findByRole('dialog');
 
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).hasAttribute('aria-expanded', 'true');
+      assert
+        .dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' }))
+        .hasAttribute('aria-expanded', 'true');
       assert.dom(screen.getByRole('button', { name: "J'ai un problème avec" })).exists();
     });
   });

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -172,7 +172,7 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
       assert.ok(tutorialToLearnMore.textContent.includes(learningMoreTutorial.title));
 
       await screen.findByRole('dialog');
-      assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -47,7 +47,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       hooks.beforeEach(async function () {
         screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
 
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
@@ -133,7 +133,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         );
 
         // when
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
@@ -160,7 +160,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         );
 
         // when
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
@@ -189,7 +189,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         );
 
         // when
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
         await screen.findByRole('listbox');
@@ -214,7 +214,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         const screen = await render(
           hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`,
         );
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         // when
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
@@ -249,7 +249,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         const screen = await render(
           hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`,
         );
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         // when
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
@@ -284,7 +284,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         const screen = await render(
           hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`,
         );
-        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+        await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
         // when
         await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
@@ -331,7 +331,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Signaler un problème avec la question' })).exists();
     });
 
     test('should toggle the form view when clicking on the toggle link', async function (assert) {
@@ -339,7 +339,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel />`);
 
       // when
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
       assert
@@ -347,7 +347,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         .exists();
 
       // when
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
       assert
@@ -367,7 +367,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @context={{this.context}} />`);
 
       // when
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
       assert
@@ -417,7 +417,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
       );
 
       // then
-      assert.true(screen.getByRole('button', { name: 'Signaler un problème' }).disabled);
+      assert.true(screen.getByRole('button', { name: 'Signaler un problème avec la question' }).disabled);
       assert
         .dom(screen.getByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
         .exists();
@@ -436,7 +436,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
     test('should display the "form" view', async function (assert) {
       // given
       const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
       assert
@@ -447,10 +447,10 @@ module('Integration | Component | feedback-panel', function (hooks) {
     test('should be able to hide the form view', async function (assert) {
       // given
       const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // when
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
       assert
@@ -463,7 +463,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
     test('should not display error if "form" view (with error) was closed and re-opened', async function (assert) {
       // given
       const screen = await render(hbs`<FeedbackPanel />`);
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       await click(screen.getByRole('button', { name: "J'ai un problème avec" }));
       await screen.findByRole('listbox');
@@ -483,8 +483,8 @@ module('Integration | Component | feedback-panel', function (hooks) {
       await click(screen.getByRole('button', { name: 'Envoyer mon message de signalement' }));
 
       // when
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
-      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème avec la question' }));
 
       // then
       assert.dom(screen.queryByText('Vous devez saisir un message.')).doesNotExist();

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -568,7 +568,7 @@
       },
       "feedback-panel": {
         "actions": {
-          "open-close": "Report a problem"
+          "open-close": "Report a problem regarding the challenge"
         },
         "description": "Pix wants to hear from you so we can improve our tests!*",
         "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -568,7 +568,7 @@
       },
       "feedback-panel": {
         "actions": {
-          "open-close": "Signaler un problème"
+          "open-close": "Signaler un problème avec la question"
         },
         "description": "Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*",
         "form": {


### PR DESCRIPTION
## :unicorn: Problème
On souhaite aligner le design du bouton de signalement sur les épreuves avec celui présent sur les [maquettes](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?node-id=5858%3A107217&mode=dev). Ce design est déjà présent sur les épreuves Certif Next Gen. 

## :robot: Proposition
Aligner le design.

## :100: Pour tester
- Se connecter à Pix App
- Lancer une épreuve
- Constater que le design a changé (Drapeau, encadré blanc, graisse de la police)