### PR TITLE
[FEATURE] Ajouter le SSO "Pays de la Loire" dans la liste des SSO autorisés dans le schéma de la base de données (PIX-9581)

### DIFF
--- a/api/db/migrations/20231011092325_update-constraint-in-authentication-methods-by-adding-paysdelaloire.js
+++ b/api/db/migrations/20231011092325_update-constraint-in-authentication-methods-by-adding-paysdelaloire.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'authentication-methods';
+const CONSTRAINT_NAME = 'authentication_methods_identityProvider_check';
+
+const up = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  return knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "identityProvider" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB', 'PAYSDELALOIRE') )`,
+  );
+};
+
+const down = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  return knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "identityProvider" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB') )`,
+  );
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
La procédure de connexion n'avait pas été testée jusqu'au bout pour les utilisateurs dépendant du SSO Pays de la Loire. 
Lors du rattachement du compte SSO au compte Pix il y avait une erreur SQL : 
```sql
ERROR:  new row for relation "authentication-methods" violates check constraint "authentication_methods_identityProvider_check"
```

## :robot: Proposition
Mettre à jour la contrainte de la table `authentication-methods` en ajoutant le code du nouveau SSO `PAYSDELALOIRE`.

## :rainbow: Remarques
R.A.S

## :100: Pour tester
 
Test à faire sur votre machine :

- **Exécuter la commande `npm run db:reset` avant de continuer**
- Constater en base de données que le schema de la table `authentication-methods` a bien été modifié (présence du SSO `PAYSDELALOIRE` dans la contrainte `authentication_methods_identityProvider_check`)
- Exécuter la commande de rollback `npm run db:rollback:latest`
- Constater en base de données que le schema de la table `authentication-methods` a bien été modifié (SSO `PAYSDELALOIRE` ne figure plus dans la contrainte `authentication_methods_identityProvider_check`)

Le SSO ne sera testable de bout en bout qu'en intégration et en recette.
