### PR TITLE
[FEATURE] Ne pas indiquer de tenter le niveau supérieur lorsque l'utilisateur a atteint le niveau max (PIX-9595).

### DIFF
--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -14,7 +14,7 @@ export default class ScorecardDetails extends Component {
   @tracked showResetModal = false;
 
   get displayImprovingWaitSentence() {
-    return !this.args.scorecard.isImprovable;
+    return !this.args.scorecard.isImprovable && !this.args.scorecard.isFinishedWithMaxLevel;
   }
 
   get displayImprovingButton() {

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -201,6 +201,36 @@ function _addDefaultScorecards(user, server) {
         remainingDaysBeforeImproving: 0,
       }),
     );
+
+    scorecards.push(
+      server.create('scorecard', {
+        id: `${user.id}_competence_4_3_id`,
+        name: 'Area_4_Competence_3_name',
+        description: 'Area_4_Competence_3_description',
+        earnedPix: 50,
+        level: 5,
+        pixScoreAheadOfNextLevel: 0,
+        percentageAheadOfNextLevel: 0,
+        isFinishedWithMaxLevel: true,
+        isFinished: true,
+        isNotStarted: false,
+        isStarted: false,
+        isMaxLevel: true,
+        isProgressable: false,
+        isImprovable: false,
+        shouldWaitBeforeImproving: false,
+        isResettable: true,
+        hasNotEarnedAnything: false,
+        hasNotReachedLevelOne: false,
+        hasReachedAtLeastLevelOne: true,
+        remainingPixToNextLevel: 0,
+        area: areas[3],
+        competenceId: 'competence_4_3_id',
+        index: `${areas[3].code}.3`,
+        remainingDaysBeforeReset: 3,
+        remainingDaysBeforeImproving: 0,
+      }),
+    );
     user.update({ scorecards });
   }
 }

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -201,7 +201,6 @@ function _addDefaultScorecards(user, server) {
         remainingDaysBeforeImproving: 0,
       }),
     );
-
     scorecards.push(
       server.create('scorecard', {
         id: `${user.id}_competence_4_3_id`,

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -26,6 +26,7 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
     let scorecardWithMaxLevel;
     let scorecardWithRemainingDaysBeforeImproving;
     let scorecardWithoutRemainingDaysBeforeImproving;
+    let scorecardWithMaxLevelAndNotImprovable;
 
     hooks.beforeEach(async function () {
       await authenticate(user);
@@ -35,6 +36,7 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
       scorecardWithMaxLevel = user.scorecards.models[3];
       scorecardWithRemainingDaysBeforeImproving = user.scorecards.models[4];
       scorecardWithoutRemainingDaysBeforeImproving = user.scorecards.models[5];
+      scorecardWithMaxLevelAndNotImprovable = user.scorecards.models[6];
     });
 
     test('should be able to visit URL of competence details page', async function (assert) {
@@ -216,6 +218,20 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
             ),
           );
           assert.dom('.scorecard-details__improve-button').doesNotExist();
+        });
+      });
+
+      module('when the user has reached max level and the competence is not improvable', function () {
+        test('should not display remaining days before improving nor retry button', async function (assert) {
+          // when
+          const screen = await visit(`/competences/${scorecardWithMaxLevelAndNotImprovable.competenceId}/details`);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: 'Retenter la compétence Area_4_Competence_3_name' }))
+            .doesNotExist();
+          assert.dom('.competence-card__congrats').exists();
+          assert.notOk(screen.queryByText('0 jour.'));
         });
       });
 

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -85,7 +85,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Profiles Collection'
         const screen = await visit(`/campagnes/${campaign.code}`);
 
         // then
-        assert.ok(screen.getByText('156'));
+        assert.ok(screen.getByText('206'));
         const area1Titles = screen.getAllByText('Area_1_title').length;
 
         assert.strictEqual(area1Titles, 2);


### PR DESCRIPTION
## :unicorn: Problème
Le message "Tenter le niveau supérieur dans X jours" s'affiche même quand le niveau maximal est atteint mais ce n'est pas souhaité.

## :robot: Proposition
Ne pas indiquer de tenter le niveau supérieur lorsque l'utilisateur a atteint le niveau max (en page fin de parcours autonome et page Compétences).

## :100: Pour tester
- Se connecter à Pix App avec certif-success pour avoir les compétences au niveau max. 
- Ouvrir une compétence au niveau max 
- Constater que le message "Tenter le niveau supérieur dans 0 jour." n'apparait pas.