### PR TITLE
[FEATURE] Ajout au SSO OIDC de la nouvelle fonctionnalité générique RP-Initiated Logout (PIX-9291)

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -42,7 +42,11 @@ const register = async function (server) {
           query: Joi.object({
             identity_provider: Joi.string()
               .required()
-              .valid(OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.FWB.code),
+              .valid(
+                OidcIdentityProviders.POLE_EMPLOI.code,
+                OidcIdentityProviders.FWB.code,
+                OidcIdentityProviders.PAYSDELALOIRE.code,
+              ),
             logout_url_uuid: Joi.string()
               .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
               .required(),

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -27,7 +27,7 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
     });
 
     this.logoutUrl = config.fwb.logoutUrl;
-    this.temporaryStorage = config.fwb.temporaryStorage;
+    this.temporaryStorageConfig = config.fwb.temporaryStorage;
   }
 
   async getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
@@ -47,7 +47,7 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
     // The session ID must be unpredictable, thus we disable the entropy cache
     // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
     const uuid = randomUUID({ disableEntropyCache: true });
-    const { idTokenLifespanMs } = this.temporaryStorage;
+    const { idTokenLifespanMs } = this.temporaryStorageConfig;
 
     await logoutUrlTemporaryStorage.save({
       key: `${userId}:${uuid}`,

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -12,7 +12,7 @@ import {
 } from '../../errors.js';
 import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
 import { AuthenticationSessionContent } from '../../models/AuthenticationSessionContent.js';
-import { config } from '../../../config.js';
+import { config } from '../../../../src/shared/config.js';
 import { httpAgent } from '../../../infrastructure/http/http-agent.js';
 import * as httpErrorsHelper from '../../../infrastructure/http/errors-helper.js';
 import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';

--- a/api/lib/domain/services/authentication/paysdelaloire-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/paysdelaloire-oidc-authentication-service.js
@@ -21,6 +21,8 @@ class PaysdelaloireOidcAuthenticationService extends OidcAuthenticationService {
       authenticationUrl: config.paysdelaloire.authenticationUrl,
       authenticationUrlParameters: [{ key: 'scope', value: 'openid profile' }],
       userInfoUrl: config.paysdelaloire.userInfoUrl,
+      endSessionUrl: config.paysdelaloire.endSessionUrl,
+      postLogoutRedirectUri: config.paysdelaloire.postLogoutRedirectUri,
     });
   }
 }

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -41,7 +41,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
 
     this.logoutUrl = config[configKey].logoutUrl;
     this.afterLogoutUrl = config[configKey].afterLogoutUrl;
-    this.temporaryStorage = config[configKey].temporaryStorage;
+    this.temporaryStorageConfig = config[configKey].temporaryStorage;
   }
 
   // Override because we need idToken to send results after a campaign
@@ -90,7 +90,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
     // The session ID must be unpredictable, thus we disable the entropy cache
     // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
     const uuid = randomUUID({ disableEntropyCache: true });
-    const { idTokenLifespanMs } = this.temporaryStorage;
+    const { idTokenLifespanMs } = this.temporaryStorageConfig;
 
     await logoutUrlTemporaryStorage.save({
       key: `${userId}:${uuid}`,

--- a/api/lib/infrastructure/serializers/jsonapi/oidc-identity-providers-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/oidc-identity-providers-serializer.js
@@ -10,10 +10,11 @@ const serialize = function (oidcIdentityProviders) {
         code: oidcIdentityProvider.code,
         organizationName: oidcIdentityProvider.organizationName,
         hasLogoutUrl: oidcIdentityProvider.hasLogoutUrl,
+        useEndSession: Boolean(oidcIdentityProvider.endSessionUrl),
         source: oidcIdentityProvider.source,
       };
     },
-    attributes: ['code', 'organizationName', 'hasLogoutUrl', 'source'],
+    attributes: ['code', 'organizationName', 'hasLogoutUrl', 'useEndSession', 'source'],
   }).serialize(oidcIdentityProviders);
 };
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -548,7 +548,14 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_OIDC_USER_INFO_URL=
 
-# Temporary storage idToken expiration delay in milliseconds
+# Access Token lifespan
+#
+# presence: optional
+# type: String
+# default: 7d
+# sample: POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN=7d
+
+# Temporary storage ID Token lifespan
 #
 # presence: optional
 # type: Integer
@@ -567,6 +574,7 @@ AUTH_SECRET=Change me!
 # type: boolean
 # default: true
 # sample: PUSH_DATA_TO_POLE_EMPLOI_ENABLED=true
+
 
 # ===================
 # CNAV CONFIGURATION
@@ -608,6 +616,13 @@ AUTH_SECRET=Change me!
 # presence: required for CNAV authentication, optional otherwise
 # type: URL
 # sample: CNAV_OIDC_USER_INFO_URL=
+
+# Access Token lifespan
+#
+# presence: optional
+# type: string
+# default: 7d
+# sample: CNAV_ACCESS_TOKEN_LIFESPAN=7d
 
 
 # ===================
@@ -651,25 +666,25 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: FWB_USER_INFO_URL=
 
-# Temporary storage idToken expiration delay in milliseconds
-#
-# presence: optional
-# type: Integer
-# default: 7d
-# sample: FWB_ACCESS_TOKEN_LIFESPAN=
-
 # Logout URL
 #
 # presence: required
 # type: URL
 # sample: FWB_OIDC_LOGOUT_URL=
 
-# Temporary storage idToken expiration delay in milliseconds
+# Access Token lifespan
 #
 # presence: optional
-# type: Integer
+# type: string
 # default: 7d
-# sample: FWB_ID_TOKEN_LIFESPAN=
+# sample: FWB_ACCESS_TOKEN_LIFESPAN=7d
+
+# Temporary storage ID Token lifespan
+#
+# presence: optional
+# type: string
+# default: 7d
+# sample: FWB_ID_TOKEN_LIFESPAN=7d
 
 # ==============================
 # PAYS DE LA LOIRE CONFIGURATION
@@ -863,18 +878,6 @@ REFRESH_TOKEN_LIFESPAN=7d
 # type: String
 # default: '7d'
 SAML_ACCESS_TOKEN_LIFESPAN=7d
-
-# Pole emploi access token lifespan
-# presence: optional
-# type: String
-# default: '7d'
-POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN=7d
-
-# CNAV access token lifespan
-# presence: optional
-# type: string
-# default: 7d
-CNAV_ACCESS_TOKEN_LIFESPAN=7d
 
 # Campaign result access token lifespan
 # presence: optional

--- a/api/sample.env
+++ b/api/sample.env
@@ -696,7 +696,7 @@ AUTH_SECRET=Change me!
 # type: string
 # sample: PAYSDELALOIRE_CLIENT_ID=
 
-# Client secret
+# Client Secret
 #
 # presence: required for PAYS DE LA LOIRE authentication, optional otherwise
 # type: string
@@ -714,18 +714,36 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: PAYSDELALOIRE_AUTHENTICATION_URL=
 
-# User info URL
+# UserInfo URL
 #
 # presence: required for PAYS DE LA LOIRE authentication, optional otherwise
 # type: URL
 # sample: PAYSDELALOIRE_USER_INFO_URL=
 
-# Temporary storage idToken expiration delay in milliseconds
+# End session URL
+#
+# presence: required for PAYS DE LA LOIRE logout, optional otherwise
+# type: URL
+# sample: PAYSDELALOIRE_END_SESSION_URL=
+
+# Post logout redirect URI
+#
+# sample: PAYSDELALOIRE_POST_LOGOUT_REDIRECT_URI=https://app.pix.fr/connexion
+
+# Access token lifespan
 #
 # presence: optional
-# type: Integer
+# type: string
 # default: 7d
-# sample: PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN=
+# sample: PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN=7d
+
+# Temporary storage ID Token lifespan
+#
+# presence: optional
+# type: string
+# default: 7d
+# sample: POLE_EMPLOI_ID_TOKEN_LIFESPAN=7d
+
 
 # ===================
 # AUTHENTICATION SESSION CONFIGURATION

--- a/api/sample.env
+++ b/api/sample.env
@@ -548,20 +548,12 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_OIDC_USER_INFO_URL=
 
-# Temporary storage expiration delay
-#
-# presence: optional
-# type: Integer
-# default: 1140
-# sample: POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
-
 # Temporary storage idToken expiration delay in milliseconds
 #
 # presence: optional
 # type: Integer
 # default: 7d
 # sample: POLE_EMPLOI_ID_TOKEN_LIFESPAN=
-
 
 # Test result URL
 # Refer to https://pole-emploi.io/data/api/pole-emploi-connect

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -263,7 +263,12 @@ const configuration = (function () {
       tokenUrl: process.env.PAYSDELALOIRE_TOKEN_URL,
       userInfoUrl: process.env.PAYSDELALOIRE_USER_INFO_URL,
       authenticationUrl: process.env.PAYSDELALOIRE_AUTHENTICATION_URL,
+      endSessionUrl: process.env.PAYSDELALOIRE_END_SESSION_URL,
+      postLogoutRedirectUri: process.env.PAYSDELALOIRE_POST_LOGOUT_REDIRECT_URI,
       accessTokenLifespanMs: ms(process.env.PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN || '7d'),
+      temporaryStorage: {
+        idTokenLifespanMs: ms(process.env.PAYSDELALOIRE_ID_TOKEN_LIFESPAN || '7d'),
+      },
     },
     pgBoss: {
       connexionPoolMaxSize: _getNumber(process.env.PGBOSS_CONNECTION_POOL_MAX_SIZE, 2),

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -40,6 +40,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           attributes: {
             code: 'LIMONADE_OIDC_PROVIDER',
             'organization-name': 'Limonade OIDC Provider',
+            'use-end-session': false,
             'has-logout-url': false,
             source: 'limonade_oidc_provider',
           },
@@ -50,6 +51,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           attributes: {
             code: 'KOMBUCHA_OIDC_PROVIDER',
             'organization-name': 'Kombucha OIDC Provider',
+            'use-end-session': false,
             'has-logout-url': true,
             source: 'kombucha_oidc_provider',
           },
@@ -85,6 +87,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           code: 'SOME_OIDC_PROVIDER',
           source: 'some_oidc_provider',
           'organization-name': 'Some OIDC Provider',
+          'use-end-session': false,
           'has-logout-url': false,
         },
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/oidc-identity-providers-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/oidc-identity-providers-serializer_test.js
@@ -20,6 +20,7 @@ describe('Unit | Serializer | JSONAPI | oidc-identity-providers-serializer', fun
           attributes: {
             code: 'OIDC_PARTNER',
             'organization-name': 'Partenaire OIDC',
+            'use-end-session': false,
             'has-logout-url': true,
             source: 'oidc-external',
           },

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -450,13 +450,6 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_OIDC_AUTHENTICATION_URL=
 
-# Temporary storage expiration delay
-#
-# presence: optional
-# type: Integer
-# default: 1140
-# sample: POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
-
 # Test result URL
 # Refer to https://pole-emploi.io/data/api/pole-emploi-connect
 #

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -60,6 +60,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       logoutUrlUuid: data.logout_url_uuid,
       user_id: decodedAccessToken.user_id,
       source: identityProvider.source,
+      useEndSession: identityProvider.useEndSession,
       hasLogoutUrl: identityProvider.hasLogoutUrl,
       identityProviderCode: identityProvider.code,
     };
@@ -74,9 +75,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
     });
   }
 
+  /**
+   * @param {Object} data - The current authenticated session data
+   */
   async invalidate(data) {
-    const { access_token, hasLogoutUrl, identityProviderCode, logoutUrlUuid } = data || {};
-    if (!hasLogoutUrl) return;
+    const { access_token, useEndSession, hasLogoutUrl, identityProviderCode, logoutUrlUuid } = data || {};
+    if (!(useEndSession || hasLogoutUrl)) {
+      return;
+    }
 
     const response = await fetch(
       `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,

--- a/mon-pix/app/models/oidc-identity-provider.js
+++ b/mon-pix/app/models/oidc-identity-provider.js
@@ -3,6 +3,7 @@ import Model, { attr } from '@ember-data/model';
 export default class OidcIdentityProvider extends Model {
   @attr() code;
   @attr() organizationName;
+  @attr() useEndSession;
   @attr() hasLogoutUrl;
   @attr() source;
 }

--- a/mon-pix/tests/unit/authenticators/oidc_test.js
+++ b/mon-pix/tests/unit/authenticators/oidc_test.js
@@ -10,6 +10,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
   module('#authenticate', function (hooks) {
     const userId = 1;
     const source = 'oidc-externe';
+    const useEndSession = false;
     const hasLogoutUrl = true;
     const logoutUrlUuid = 'uuid';
     const identityProviderCode = 'OIDC_PARTNER';
@@ -55,6 +56,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
         id: identityProviderSlug,
         code: identityProviderCode,
         organizationName: 'Partenaire OIDC',
+        useEndSession,
         hasLogoutUrl,
         source,
       };
@@ -95,6 +97,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
         logoutUrlUuid,
         source,
         hasLogoutUrl,
+        useEndSession,
         user_id: userId,
         identityProviderCode,
       });
@@ -121,6 +124,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
         access_token: accessToken,
         logoutUrlUuid,
         source,
+        useEndSession,
         hasLogoutUrl,
         user_id: userId,
         identityProviderCode,

--- a/mon-pix/tests/unit/authenticators/oidc_test.js
+++ b/mon-pix/tests/unit/authenticators/oidc_test.js
@@ -101,7 +101,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
         user_id: userId,
         identityProviderCode,
       });
-      assert.ok(true);
     });
 
     test('should fetch token with code, redirectUri, and state in body', async function (assert) {
@@ -129,7 +128,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
         user_id: userId,
         identityProviderCode,
       });
-      assert.ok(true);
     });
 
     module('when user is authenticated', function () {


### PR DESCRIPTION
## :unicorn: Problème

La brique SSO générique ne dispose pas encore de la fonctionnalité standard additionnelle optionnelle _RP-Initiated Logout_ : https://openid.net/specs/openid-connect-rpinitiated-1_0-final.html

## :robot: Proposition

Implémenter dans la brique SSO générique la fonctionnalité standard additionnelle optionnelle _RP-Initiated Logout_ : https://openid.net/specs/openid-connect-rpinitiated-1_0-final.html

## :rainbow: Remarques

Le fichier `sample.env` a également été un peu retravaillé au niveau des variables d'environnement des SSO : 
* les docs de certaines variables ont été corrigées
* certaines variables qui n'étaient plus utilisées ont été supprimées
* certaines variables ont été rapatriées dans la bonne section

## :100: Pour tester

Le SSO, et donc le _RP-Initiated Logout_, est testable en local (en HTTPS sur https://app.dev.pix.fr/ avec un certificat autosigné), mais pas en RA.

1. Se connecter avec le SSO PAYSDELALOIRE par https://app.dev.pix.fr/connexion/pays-de-la-loire
2. Se déconnecter
3. Constater que la déconnexion renvoie sur une page web _« Se déconnecter »_ appartenant à l'infrastructure du partenaire PAYSDELALOIRE
4. Constater sur cette page web _« Se déconnecter_ » qu'il est proposé de choisir un compte du SSO du partenaire PAYSDELALOIRE duquel on souhaite être déconnecté
5. Sélectionner un compte du SSO du partenaire PAYSDELALOIRE duquel on souhaite effectivement être déconnecté
6. Constater la redirection vers le `post_logout_redirect_uri` `https://app.dev.pix.fr/connexion`
8. Vérifier qu'on peut bien se connecter (login) et se déconnecter (logout) avec tous les SSO actuellement disponibles de manière à s'assurer qu'il n'y a pas de régression 

