### PR TITLE
[TECH] Déclarer `eslint-plugin-118n-json` dans chaque application qui l'utilise.

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -68,6 +68,7 @@
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-ember": "^11.2.0",
+        "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-qunit": "^8.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -99,6 +99,7 @@
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.2.0",
+    "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^8.0.0",

--- a/api/.depcheckrc
+++ b/api/.depcheckrc
@@ -5,6 +5,7 @@ ignores:
     'hapi-swagger',
     'hapi-sentry',
     'mocha-junit-reporter',
+    'eslint-plugin-i18n-json',
   ]
 #  @babel/plugin-syntax-import-assertions is used by eslint
 # see https://github.com/babel/babel/blob/main/packages/babel-plugin-syntax-import-assertions/README.md
@@ -22,3 +23,5 @@ ignores:
 # "mocha-junit-reporter" is used in ../.circleci/config.yml
 # code =>  MOCHA_REPORTER: mocha-junit-reporter
 # see https://github.com/michaelleeallen/mocha-junit-reporter#usage
+
+# eslint-plugin-i18n-json is used by npm run lint:translations

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -90,6 +90,7 @@
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-chai-expect": "^3.0.0",
+        "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
         "eslint-plugin-local-rules": "^2.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -96,6 +96,7 @@
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-chai-expect": "^3.0.0",
+    "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
     "eslint-plugin-local-rules": "^2.0.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -70,6 +70,7 @@
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-ember": "^11.11.1",
+        "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-qunit": "^8.0.0",
         "loader.js": "^4.7.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -98,6 +98,7 @@
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.11.1",
+    "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^8.0.0",
     "loader.js": "^4.7.0",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -73,6 +73,7 @@
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-ember": "^11.2.0",
+        "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-qunit": "^8.0.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -104,6 +104,7 @@
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.2.0",
+    "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^8.0.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -66,6 +66,7 @@
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-ember": "^11.4.5",
+        "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-qunit": "^8.0.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -97,6 +97,7 @@
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.4.5",
+    "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^8.0.0",


### PR DESCRIPTION
## :unicorn: Problème

Lors du lint des traductions, on utilise le formateur du plugin `eslint-plugin-i18n-json`.
Cela fonctionne correctement mais n'est pas compatible à une migration éventuelle vers les workspaces, les dépendances étant installées à la racine du repo.

## :robot: Proposition

On déclare la dépendance `eslint-plugin-i18n-json` dans chaque application qui utilise le formateur.

## :rainbow: Remarques

Cela va nous faciliter la tâche pour la migration vers `pnpm` notamment.

## :100: Pour tester

Vérifier que la CI est verte, et que les lint de traductions fonctionnent toujours.
