### PR TITLE
[FEATURE] Améliorer l'affichage des options de l'épreuve validation (Pix-9610)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-actions/challenge-actions.scss
+++ b/1d/app/pods/components/challenge/challenge-actions/challenge-actions.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   justify-content: space-between;
   max-width: 850px;
-  margin: 0 auto 32px auto;
+  margin: 32px auto;
   padding: 0 30px;
 
   button:only-child {

--- a/1d/app/pods/components/challenge/item/challenge-item.scss
+++ b/1d/app/pods/components/challenge/item/challenge-item.scss
@@ -9,7 +9,7 @@
 .challenge-item {
   display: flex;
   flex-direction: column;
-  max-width: 850px;
+  max-width: 860px;
   margin: 0 auto;
 
   &__playground {


### PR DESCRIPTION
## :unicorn: Problème
L'affichage ne correspondait pas à la maquette

## :robot: Proposition
Changer pour faire du joli

## :rainbow: Remarques
Ajout aussi d'une margin-top pour les boutons

## :100: Pour tester
- aller voir la première épreuve de la mission `Recherche sur internet`
