### PR TITLE
[BUGFIX] Éviter les erreurs 400 en récupérant un module (PIX-9597)

### DIFF
--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -10,7 +10,7 @@ const register = async function (server) {
         auth: false,
         handler: modulesController.getBySlug,
         validate: {
-          params: Joi.object({ slug: Joi.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/) }).required(),
+          params: Joi.object({ slug: Joi.string().required() }),
         },
         notes: ['- Permet de récupérer un module grâce à son titre slugifié'],
         tags: ['api', 'modules'],


### PR DESCRIPTION
## :unicorn: Problème
L'API valide le format du "slug" d'un module avant de transmettre la récupération. Cela peut causer des erreurs 400 de Joi qui ne sont pas nécessaires.

## :robot: Proposition
Ne plus valider le format du slug.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que l'API renvoie une 404 quelque soit le format de slug envoyé dans l'URL (`/api/modules/${slug}`).
