### PR TITLE
[TECH] Ajouter une variable d'env pour gérer les sources possibles pour les embeds (Pix-9615)

### DIFF
--- a/1d/app/utils/embed-allowed-origins.js
+++ b/1d/app/utils/embed-allowed-origins.js
@@ -1,0 +1,9 @@
+import ENV from '1d/config/environment';
+
+export function isEmbedAllowedOrigin(origin) {
+  return getEmbedAllowedOriginsRegexps().some((allowedOrigin) => origin.match(allowedOrigin));
+}
+
+function getEmbedAllowedOriginsRegexps() {
+  return ENV.APP.EMBED_ALLOWED_ORIGINS.map((allowedOrigin) => new RegExp(allowedOrigin.replace('*', '[\\w-]+')));
+}

--- a/1d/config/environment.js
+++ b/1d/config/environment.js
@@ -20,8 +20,10 @@ module.exports = function (environment) {
       API_HOST: process.env.API_HOST || '',
       // Here you can pass flags/options to your application instance
       // when it is created
+      EMBED_ALLOWED_ORIGINS: (
+        process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io'
+      ).split(','),
     },
-
     'ember-cli-mirage': {
       usingProxy: true,
     },


### PR DESCRIPTION
## :unicorn: Problème
Une modification a été faite sur une épreuve sur pix épreuve. Pour voir la modification dans un cas réel, c'est l'url de la RA de cette épreuve qui a été utilisée dans Pix Editor.
Mais quand on affiche cette épreuve sur pix1D et qu'on sélectionne une réponse c'est comme si on avait rien sélectionné.
C'est dû au fait qu'on autorisait pas les embeds des RA. 
De plus, les sources qu'on autorisait, étaient écrites en dures et non portées par des variable d'env.

## :robot: Proposition
Ajouter une variable pour gérer les sources.
Ajouter les RA comme sources acceptées.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de faire la première épreuve du niveau validation