### PR TITLE
[BUGFIX] Admin ne se lance plus (PIX-9624)

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -109,6 +109,9 @@ module.exports = function (environment) {
         minValue: 0,
       }),
     },
+    'ember-cli-mirage': {
+      usingProxy: true,
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l’on souhaite lancer Pix Admin une erreur apparait dans la console : 
`Error while processing route: authenticated.organizations.list Mirage: Your app tried to GET '/api/feature-toggles?id=0', but there was no route defined to handle this request.`

Il semblerait que les requêtes passent par mirage plutôt que par le proxy. Cela serait dû à la montée de version de ember-cli-mirage.

## :robot: Proposition
Une correction comme pour cette [PR](https://github.com/1024pix/pix/pull/7231) corrige le soucis.

## :100: Pour tester
- Lancer Pix Admin
- Naviguer avec un navigateur web et constater que les requêtes vont bien à l'API