### PR TITLE
[BUGFIX] Ajouter une contrainte manquante pour le SSO "Pays de la Loire" dans le schéma de la base de données (PIX-9611)

### DIFF
--- a/api/db/migrations/20231012141330_update-constraint-in-organizations-by-adding-paysdelaloire.js
+++ b/api/db/migrations/20231012141330_update-constraint-in-organizations-by-adding-paysdelaloire.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'organizations';
+const CONSTRAINT_NAME = 'organizations_identityProviderForCampaigns_check';
+const COLUMN_NAME = 'identityProviderForCampaigns';
+
+const up = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  return knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB', 'PAYSDELALOIRE') )`,
+  );
+};
+
+const down = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
+  return knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB') )`,
+  );
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
Suite de #7237 

## :robot: Proposition
Mettre à jour la contrainte de la table `organizations` en ajoutant le code du nouveau SSO `PAYSDELALOIRE`.

## :rainbow: Remarques
R.A.S

## :100: Pour tester
 
Test à faire sur votre machine :

- **Exécuter la commande `npm run db:reset` avant de continuer**
- Constater en base de données que le schema de la table `organizations` a bien été modifié (présence du SSO `PAYSDELALOIRE` dans la contrainte `organizations_identityProviderForCampaigns_check`)
- Exécuter la commande de rollback `npm run db:rollback:latest`
- Constater en base de données que le schema de la table `organizations` a bien été modifié (SSO `PAYSDELALOIRE` ne figure plus dans la contrainte `organizations_identityProviderForCampaigns_check`)

Le SSO ne sera testable de bout en bout qu'en intégration et en recette.
