### PR TITLE
[BUGFIX] Utiliser la domainTransaction pour l'insertion des jobs du CRON (PIX-9623)

### DIFF
--- a/api/lib/infrastructure/jobs/JobQueue.js
+++ b/api/lib/infrastructure/jobs/JobQueue.js
@@ -11,7 +11,7 @@ class JobQueue {
 
   performJob(name, handlerClass, dependencies) {
     this.pgBoss.work(name, { teamSize, teamConcurrency }, async (job) => {
-      const jobHandler = new handlerClass(dependencies);
+      const jobHandler = new handlerClass({ ...dependencies, logger });
       const monitoredJobHandler = new MonitoredJobHandler(jobHandler, logger);
       return monitoredJobHandler.handle(job.data);
     });

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
@@ -30,18 +30,16 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
             onlyNotComputed,
             domainTransaction,
           });
-        await this.pgBossRepository.insert(
-          organizationLearnerIds.map(
-            (organizationLearnerId) => ({
-              name: ComputeCertificabilityJob.name,
-              data: { organizationLearnerId },
-              retrylimit: 0,
-              retrydelay: 30,
-              on_complete: true,
-            }),
-            domainTransaction,
-          ),
-        );
+
+        const jobsToInsert = organizationLearnerIds.map((organizationLearnerId) => ({
+          name: ComputeCertificabilityJob.name,
+          data: { organizationLearnerId },
+          retrylimit: 0,
+          retrydelay: 30,
+          on_complete: true,
+        }));
+
+        await this.pgBossRepository.insert(jobsToInsert, domainTransaction);
       }
     });
   }

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -5,10 +5,29 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCertificabilityJobHandler', function () {
   context('#handle', function () {
     let domainTransaction;
+    let pgBossRepository;
+    let organizationLearnerRepository;
+    let logger;
+
     beforeEach(function () {
       domainTransaction = Symbol('domainTransaction');
       DomainTransaction.execute = (lambda) => {
         return lambda(domainTransaction);
+      };
+
+      pgBossRepository = {
+        insert: sinon.stub(),
+      };
+
+      pgBossRepository.insert.resolves([]);
+
+      organizationLearnerRepository = {
+        findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
+        countByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
+      };
+
+      logger = {
+        info: sinon.stub(),
       };
     });
 
@@ -16,13 +35,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
       // given
       const skipLoggedLastDayCheck = undefined;
       const onlyNotComputed = undefined;
-      const pgBossRepository = {
-        insert: sinon.stub(),
-      };
-      const organizationLearnerRepository = {
-        findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
-        countByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
-      };
+
       const config = {
         features: {
           scheduleComputeOrganizationLearnersCertificability: {
@@ -30,6 +43,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           },
         },
       };
+
       organizationLearnerRepository.countByOrganizationsWhichNeedToComputeCertificability
         .withArgs({ skipLoggedLastDayCheck, onlyNotComputed, domainTransaction })
         .resolves(3);
@@ -44,6 +58,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           pgBossRepository,
           organizationLearnerRepository,
           config,
+          logger,
         });
 
       // when
@@ -81,13 +96,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
       // given
       const skipLoggedLastDayCheck = true;
       const onlyNotComputed = true;
-      const pgBossRepository = {
-        insert: sinon.stub(),
-      };
-      const organizationLearnerRepository = {
-        findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
-        countByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
-      };
+
       const config = {
         features: {
           scheduleComputeOrganizationLearnersCertificability: {
@@ -109,6 +118,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           pgBossRepository,
           organizationLearnerRepository,
           config,
+          logger,
         });
 
       // when
@@ -149,13 +159,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
       // given
       const skipLoggedLastDayCheck = undefined;
       const onlyNotComputed = undefined;
-      const pgBossRepository = {
-        insert: sinon.stub(),
-      };
-      const organizationLearnerRepository = {
-        findByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
-        countByOrganizationsWhichNeedToComputeCertificability: sinon.stub(),
-      };
+
       const chunkCount = 10;
       const limit = 3;
       const config = {
@@ -180,6 +184,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
           pgBossRepository,
           organizationLearnerRepository,
           config,
+          logger,
         });
 
       // when

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -210,6 +210,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
             on_complete: true,
           },
         ]);
+        expect(pgBossRepository.insert.getCall(index).args[1]).to.be.deep.equal(domainTransaction);
       }
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On ne passait pas la domainTransaction lors de l'insert du pgBossRepository

## :robot: Proposition
Ajouter la domainTransaction au bon endroit afin que tout soit fait lors d'une même transaction. Ajouter une assertion dans le test associé pour vérifier qu'effectivement on passe bien la transaction au repository

## :rainbow: Remarques
On ajoute également des logs dans le handler du CRON de certificabilitée, afin de nous aider à comprendre ce qui possiblement ne fonctionne pas, ou pas exactement comme on le souhaiterais.
Les logs pourront être supprimés après la fin des investigations

## :100: Pour tester

- **Pour le bugfix** : Vérifier que les tests passent
- **Pour les logs** : Inserer en BDD le job (mettre l'option skipLoggedLastDayCheck afin dêtre sur d'avoir des learners éligibles), et vérifier que les logs apparaissent bien

```sql 
INSERT INTO "pgboss"."job" (name, data) VALUES('ScheduleComputeOrganizationLearnersCertificabilityJob', '{"skipLoggedLastDayCheck":"true"');
```

- 🐱 
