### PR TITLE
[FEATURE] Remettre les boutons d'actions dans une sticky barre en bas de l'écran (Pix-9536)

### DIFF
--- a/1d/app/pods/application/template.hbs
+++ b/1d/app/pods/application/template.hbs
@@ -2,5 +2,4 @@
   <main>
     {{outlet}}
   </main>
-  <Layout::Footer />
 </div>

--- a/1d/app/pods/components/challenge/challenge-actions/challenge-actions.scss
+++ b/1d/app/pods/components/challenge/challenge-actions/challenge-actions.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   justify-content: space-between;
   max-width: 850px;
-  margin: 32px auto;
+  margin: 16px auto;
   padding: 0 30px;
 
   button:only-child {

--- a/1d/app/pods/components/challenge/challenge.scss
+++ b/1d/app/pods/components/challenge/challenge.scss
@@ -1,0 +1,8 @@
+.container__actions {
+  background-color: white;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  box-shadow: 0 0 2px 0 rgba(70, 77, 98, 0.32), 2px 4px 6px 0 rgba(70, 77, 98, 0.20);
+}

--- a/1d/app/pods/components/challenge/template.hbs
+++ b/1d/app/pods/components/challenge/template.hbs
@@ -3,11 +3,13 @@
   <RobotDialog @instruction={{@challenge.instruction}} />
   <Challenge::Item @challenge={{@challenge}} @setAnswerValue={{this.setAnswerValue}} @assessment={{@assessment}} />
 
-  <Challenge::ChallengeActions
-    @validateAnswer={{this.validateAnswer}}
-    @skipChallenge={{this.skipChallenge}}
-    @level={{@activity.level}}
-  />
+  <div class="container__actions">
+    <Challenge::ChallengeActions
+      @validateAnswer={{this.validateAnswer}}
+      @skipChallenge={{this.skipChallenge}}
+      @level={{@activity.level}}
+    />
+  </div>
 
   <AnswerFeedback
     @answer={{this.answer}}

--- a/1d/app/pods/components/layout/footer/template.hbs
+++ b/1d/app/pods/components/layout/footer/template.hbs
@@ -1,3 +1,0 @@
-<footer>
-  <img alt="pix1d" src="/images/logo.svg" />
-</footer>

--- a/1d/app/pods/components/mission-card-success/template.hbs
+++ b/1d/app/pods/components/mission-card-success/template.hbs
@@ -1,9 +1,0 @@
-<div class="card">
-  <div>
-    <img alt="Mission terminée" src="/images/green-card-header.svg" />
-  </div>
-  <div class="card__body">
-    <p>{{@title}}</p>
-    <p class="card__comment">Mission terminée</p>
-  </div>
-</div>


### PR DESCRIPTION
## :unicorn: Problème
On avait des boutons qui se baladaient dans la page en fonction du type d'épreuves, ce qui n'étaient pas correct.

## :robot: Proposition
Changement de design, on homogénéise tout en remettant les boutons d'actions dans une sticky barre en bas de l'écran.

## :rainbow: Remarques
 BSR: suppression du composant MissionCardSuccess qui n'était plus utilisé

## :100: Pour tester
- Faire un tour sur l'appli pour voir si pas de régressions / pétouilles de design
