### PR TITLE
[FEATURE] Suppression du feature toggle MASSIVE_SESSION_MANAGEMENT (PIX-9630).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -918,13 +918,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # FEATURE TOGGLES
 # ===================
 
-# Allow massive management for sessions creations and modifications
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_MASSIVE_SESSION_MANAGEMENT=true
-
 # Enable the /api/admin/assessments/{id}/always-ok-validate-next-challenge' endpoint
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -170,7 +170,6 @@ const configuration = (function () {
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },
     featureToggles: {
-      isMassiveSessionManagementEnabled: isFeatureEnabled(process.env.FT_MASSIVE_SESSION_MANAGEMENT),
       isAlwaysOkValidateNextChallengeEndpointEnabled: isFeatureEnabled(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
@@ -357,7 +356,6 @@ const configuration = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
-    config.featureToggles.isMassiveSessionManagementEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
     config.featureToggles.isTargetProfileVersioningEnabled = true;
 

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,7 +22,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           type: 'feature-toggles',
           attributes: {
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
-            'is-massive-session-management-enabled': false,
             'is-pix1d-enabled': true,
             'is-target-profile-versioning-enabled': true,
           },

--- a/certif/app/components/no-session-panel.js
+++ b/certif/app/components/no-session-panel.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
 export default class PanelHeader extends Component {
-  @service featureToggles;
   @service currentUser;
   @service currentDomain;
   @service intl;
@@ -16,10 +15,6 @@ export default class PanelHeader extends Component {
     const currentLanguage = this.intl.t('current-lang');
     const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
 
-    return (
-      this.featureToggles.featureToggles.isMassiveSessionManagementEnabled &&
-      !this.isScoManagingStudents &&
-      !isOrgTldAndEnglishCurrentLanguage
-    );
+    return !this.isScoManagingStudents && !isOrgTldAndEnglishCurrentLanguage;
   }
 }

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
 export default class PanelHeader extends Component {
-  @service featureToggles;
   @service currentUser;
   @service currentDomain;
   @service intl;
@@ -13,7 +12,6 @@ export default class PanelHeader extends Component {
     const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
 
     return (
-      this.featureToggles.featureToggles.isMassiveSessionManagementEnabled &&
       !this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents &&
       !isOrgTldAndEnglishCurrentLanguage
     );

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,5 +1,3 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
-export default class FeatureToggle extends Model {
-  @attr('boolean') isMassiveSessionManagementEnabled;
-}
+export default class FeatureToggle extends Model {}

--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -2,21 +2,17 @@ import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class ImportRoute extends Route {
-  @service featureToggles;
   @service router;
   @service currentUser;
   @service currentDomain;
   @service intl;
 
   beforeModel() {
-    const { isMassiveSessionManagementEnabled } = this.featureToggles.featureToggles;
-
     const topLevelDomain = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
     const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
 
     if (
-      !isMassiveSessionManagementEnabled ||
       this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents ||
       isOrgTldAndEnglishCurrentLanguage
     ) {

--- a/certif/mirage/factories/feature-toggle.js
+++ b/certif/mirage/factories/feature-toggle.js
@@ -2,5 +2,4 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,
-  isMassiveSessionManagementEnabled: true,
 });

--- a/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
@@ -15,83 +15,52 @@ module('Acceptance | Routes | Authenticated | Sessions | import', function (hook
 
   module('When a user tries to go on the multiple sessions import page', function () {
     module('when the user belongs to a SCO isManagingStudent center', function () {
-      module('with feature toggle authorization', function () {
-        test('it should redirect the user to the sessions list page', async function (assert) {
-          // given
-          const certificationCenter = createAllowedCertificationCenterAccess({
-            certificationCenterName: 'Centre SCO isManagingStudent',
-            certificationCenterType: 'SCO',
-            isRelatedOrganizationManagingStudents: true,
-          });
-          const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
-            pixCertifTermsOfServiceAccepted: true,
-            allowedCertificationCenterAccesses: [certificationCenter],
-          });
-          await authenticateSession(certificationPointOfContact.id);
-
-          server.create('session-summary', { certificationCenterId: certificationCenter.id });
-          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
-
-          // when
-          const screen = await visit(`/sessions/import`);
-
-          // then
-          assert.strictEqual(currentURL(), '/sessions/liste');
-          assert.dom(screen.getByText('Sessions de certification')).exists();
+      test('it should redirect the user to the sessions list page', async function (assert) {
+        // given
+        const certificationCenter = createAllowedCertificationCenterAccess({
+          certificationCenterName: 'Centre SCO isManagingStudent',
+          certificationCenterType: 'SCO',
+          isRelatedOrganizationManagingStudents: true,
         });
+        const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [certificationCenter],
+        });
+        await authenticateSession(certificationPointOfContact.id);
+
+        server.create('session-summary', { certificationCenterId: certificationCenter.id });
+
+        // when
+        const screen = await visit(`/sessions/import`);
+
+        // then
+        assert.strictEqual(currentURL(), '/sessions/liste');
+        assert.dom(screen.getByText('Sessions de certification')).exists();
       });
     });
+  });
 
-    module('when the user belongs to a center that is not SCO isManagingStudent', function () {
-      module('without feature toggle authorization', function () {
-        test('it should redirect the user to the sessions list page', async function (assert) {
-          // given
-          const certificationCenter = createAllowedCertificationCenterAccess({
-            certificationCenterName: 'Centre SUP',
-            certificationCenterType: 'SUP',
-            isRelatedOrganizationManagingStudents: false,
-          });
-          const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
-            pixCertifTermsOfServiceAccepted: true,
-            allowedCertificationCenterAccesses: [certificationCenter],
-          });
-          await authenticateSession(certificationPointOfContact.id);
-          server.create('session-summary', { certificationCenterId: certificationCenter.id });
-          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: false });
-
-          // when
-          const screen = await visit(`/sessions/import`);
-
-          // then
-          assert.strictEqual(currentURL(), '/sessions/liste');
-          assert.dom(screen.getByText('Sessions de certification')).exists();
-        });
+  module('when the user belongs to a center that is not SCO isManagingStudent', function () {
+    test('it should transition to sessions import page', async function (assert) {
+      // given
+      const certificationCenter = createAllowedCertificationCenterAccess({
+        certificationCenterName: 'Centre SUP',
+        certificationCenterType: 'SUP',
+        isRelatedOrganizationManagingStudents: false,
       });
-
-      module('with feature toggle authorization', function () {
-        test('it should transition to sessions import page', async function (assert) {
-          // given
-          const certificationCenter = createAllowedCertificationCenterAccess({
-            certificationCenterName: 'Centre SUP',
-            certificationCenterType: 'SUP',
-            isRelatedOrganizationManagingStudents: false,
-          });
-          const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
-            pixCertifTermsOfServiceAccepted: true,
-            allowedCertificationCenterAccesses: [certificationCenter],
-          });
-          await authenticateSession(certificationPointOfContact.id);
-          server.create('session-summary', { certificationCenterId: certificationCenter.id });
-          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
-
-          // when
-          const screen = await visit(`/sessions/import`);
-
-          // then
-          assert.strictEqual(currentURL(), '/sessions/import');
-          assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
-        });
+      const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+        pixCertifTermsOfServiceAccepted: true,
+        allowedCertificationCenterAccesses: [certificationCenter],
       });
+      await authenticateSession(certificationPointOfContact.id);
+      server.create('session-summary', { certificationCenterId: certificationCenter.id });
+
+      // when
+      const screen = await visit(`/sessions/import`);
+
+      // then
+      assert.strictEqual(currentURL(), '/sessions/import');
+      assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
     });
   });
 });

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -72,7 +72,6 @@ module('Acceptance | Session Import', function (hooks) {
           });
           await authenticateSession(certificationPointOfContact.id);
           server.create('session-summary', { certificationCenterId: certificationCenter.id });
-          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
         });
 
         test('it should display an error', async function (assert) {
@@ -107,7 +106,6 @@ module('Acceptance | Session Import', function (hooks) {
           });
           await authenticateSession(certificationPointOfContact.id);
           server.create('session-summary', { certificationCenterId: certificationCenter.id });
-          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
         });
 
         test('it should disable the import button before and after import', async function (assert) {

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -87,18 +87,15 @@ module('Acceptance | Session List', function (hooks) {
       assert.strictEqual(currentURL(), '/sessions/creation');
     });
 
-    module('isMassiveSessionManagementEnabled feature toggle is true', function () {
-      test('it should redirect to the import session page when clicked on create/edit sessions button', async function (assert) {
-        // given
-        server.create('feature-toggle', { isMassiveSessionManagementEnabled: true });
-        const screen = await visit('/sessions/liste');
+    test('it should redirect to the import session page when clicked on create/edit sessions button', async function (assert) {
+      // given
+      const screen = await visit('/sessions/liste');
 
-        // when
-        await click(screen.getByRole('link', { name: 'Créer plusieurs sessions' }));
+      // when
+      await click(screen.getByRole('link', { name: 'Créer plusieurs sessions' }));
 
-        // then
-        assert.strictEqual(currentURL(), '/sessions/import');
-      });
+      // then
+      assert.strictEqual(currentURL(), '/sessions/import');
     });
 
     module('when some sessions exist', function () {

--- a/certif/tests/integration/components/no-session-panel_test.js
+++ b/certif/tests/integration/components/no-session-panel_test.js
@@ -9,10 +9,17 @@ module('Integration | Component | no-session-panel', function (hooks) {
 
   test('it renders a button link to the new session creation page', async function (assert) {
     // given
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isMassiveSessionManagementEnabled: false };
+    const store = this.owner.lookup('service:store');
+    const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+      type: 'SUP',
+      isRelatedToManagingStudentsOrganization: false,
+    });
+
+    class CurrentUserStub extends Service {
+      currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
     }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+    this.owner.register('service:current-user', CurrentUserStub);
 
     // when
     const { getByRole } = await render(hbs`<NoSessionPanel />`);
@@ -21,87 +28,49 @@ module('Integration | Component | no-session-panel', function (hooks) {
     assert.dom(getByRole('link', { name: 'Créer une session' })).exists();
   });
 
-  module('isMassiveSessionManagementEnabled feature toggle', function () {
-    module('isMassiveSessionManagementEnabled feature toggle is true', function () {
-      module('when certification center is not a type SCO which manages students', function () {
-        test('it renders a button link to the sessions import page', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-            type: 'SUP',
-            isRelatedToManagingStudentsOrganization: false,
-          });
-
-          class CurrentUserStub extends Service {
-            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-          }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: true };
-          }
-
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          const { getByRole } = await render(hbs`<NoSessionPanel />`);
-
-          // then
-          assert.dom(getByRole('link', { name: 'Créer plusieurs sessions' })).exists();
-        });
+  module('when certification center is not a type SCO which manages students', function () {
+    test('it renders a button link to the sessions import page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        type: 'SUP',
+        isRelatedToManagingStudentsOrganization: false,
       });
 
-      module('when certification center is a type SCO which manages students', function () {
-        test('it does not render a button link to the sessions import page', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-            type: 'SCO',
-            isRelatedToManagingStudentsOrganization: true,
-          });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
 
-          class CurrentUserStub extends Service {
-            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-          }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: true };
-          }
+      this.owner.register('service:current-user', CurrentUserStub);
 
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
-          this.owner.register('service:current-user', CurrentUserStub);
+      // when
+      const { getByRole } = await render(hbs`<NoSessionPanel />`);
 
-          // when
-          const { queryByRole } = await render(hbs`<NoSessionPanel />`);
-
-          // then
-          assert.dom(queryByRole('link', { name: 'Créer plusieurs sessions' })).doesNotExist();
-        });
-      });
+      // then
+      assert.dom(getByRole('link', { name: 'Créer plusieurs sessions' })).exists();
     });
+  });
 
-    module('isMassiveSessionManagementEnabled feature toggle is false', function () {
-      test('it does not render a link to the session import page', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-          isRelatedToManagingStudentsOrganization: false,
-        });
-
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: false };
-        }
-
-        this.owner.register('service:feature-toggles', FeatureTogglesStub);
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        // when
-        const { queryByRole } = await render(hbs`<NoSessionPanel />`);
-
-        // then
-        assert.dom(queryByRole('link', { name: 'Créer plusieurs sessions' })).doesNotExist();
+  module('when certification center is a type SCO which manages students', function () {
+    test('it does not render a button link to the sessions import page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        type: 'SCO',
+        isRelatedToManagingStudentsOrganization: true,
       });
+
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      const { queryByRole } = await render(hbs`<NoSessionPanel />`);
+
+      // then
+      assert.dom(queryByRole('link', { name: 'Créer plusieurs sessions' })).doesNotExist();
     });
   });
 });

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -9,10 +9,17 @@ module('Integration | Component | panel-header', function (hooks) {
 
   test('it renders a link to the new session creation page', async function (assert) {
     // given
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isMassiveSessionManagementEnabled: false };
+    const store = this.owner.lookup('service:store');
+    const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+      type: 'SCO',
+      isRelatedToManagingStudentsOrganization: true,
+    });
+
+    class CurrentUserStub extends Service {
+      currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
     }
-    this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+    this.owner.register('service:current-user', CurrentUserStub);
 
     // when
     const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
@@ -21,86 +28,49 @@ module('Integration | Component | panel-header', function (hooks) {
     assert.dom(getByRole('link', { name: 'Créer une session' })).exists();
   });
 
-  module('isMassiveSessionManagementEnabled feature toggle', function () {
-    module('isMassiveSessionManagementEnabled feature toggle is true', function () {
-      module('when certification center is a type SCO which manages students', function () {
-        test('it does not render a link to the session import page', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-            type: 'SCO',
-            isRelatedToManagingStudentsOrganization: true,
-          });
-
-          class CurrentUserStub extends Service {
-            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-          }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: true };
-          }
-
-          this.owner.register('service:feature-toggles', FeatureTogglesStub);
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          const { queryByRole } = await render(hbs`<Sessions::PanelHeader />`);
-
-          // then
-          assert.dom(queryByRole('link', { name: 'Créer/éditer plusieurs sessions' })).doesNotExist();
-        });
+  module('when certification center is a type SCO which manages students', function () {
+    test('it does not render a link to the session import page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        type: 'SCO',
+        isRelatedToManagingStudentsOrganization: true,
       });
 
-      module('when certification center is not a type SCO which manages students', function () {
-        test('it renders a link to the session import page', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-            type: 'SUP',
-            isRelatedToManagingStudentsOrganization: false,
-          });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
 
-          class CurrentUserStub extends Service {
-            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-          }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: true };
-          }
+      this.owner.register('service:current-user', CurrentUserStub);
 
-          this.owner.register('service:feature-toggles', FeatureTogglesStub);
-          this.owner.register('service:current-user', CurrentUserStub);
+      // when
+      const { queryByRole } = await render(hbs`<Sessions::PanelHeader />`);
 
-          // when
-          const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
-
-          // then
-          assert.dom(getByRole('link', { name: 'Créer/éditer plusieurs sessions' })).exists();
-        });
-      });
+      // then
+      assert.dom(queryByRole('link', { name: 'Créer/éditer plusieurs sessions' })).doesNotExist();
     });
+  });
 
-    module('isMassiveSessionManagementEnabled feature toggle is false', function () {
-      test('it does not render a link to the session import page', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-          type: 'PRO',
-        });
-
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: false };
-        }
-        this.owner.register('service:feature-toggles', FeatureTogglesStub);
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        // when
-        const { queryByRole } = await render(hbs`<Sessions::PanelHeader />`);
-
-        // then
-        assert.dom(queryByRole('link', { name: 'Créer/éditer plusieurs sessions' })).doesNotExist();
+  module('when certification center is not a type SCO which manages students', function () {
+    test('it renders a link to the session import page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        type: 'SUP',
+        isRelatedToManagingStudentsOrganization: false,
       });
+
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
+
+      // then
+      assert.dom(getByRole('link', { name: 'Créer/éditer plusieurs sessions' })).exists();
     });
   });
 });

--- a/certif/tests/unit/components/no-session-panel_test.js
+++ b/certif/tests/unit/components/no-session-panel_test.js
@@ -27,9 +27,6 @@ module('Unit | Component | no-session-panel', function (hooks) {
           class CurrentUserStub extends Service {
             currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
           }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: true };
-          }
           class CurrentDomainStub extends Service {
             getExtension = sinon.stub().returns('org');
           }
@@ -38,7 +35,6 @@ module('Unit | Component | no-session-panel', function (hooks) {
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
           this.owner.register('service:current-user', CurrentUserStub);
           this.owner.register('service:intl', IntlStub);
 
@@ -61,9 +57,6 @@ module('Unit | Component | no-session-panel', function (hooks) {
           class CurrentUserStub extends Service {
             currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
           }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: true };
-          }
           class CurrentDomainStub extends Service {
             getExtension = sinon.stub().returns('org');
           }
@@ -72,7 +65,6 @@ module('Unit | Component | no-session-panel', function (hooks) {
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
           this.owner.register('service:current-user', CurrentUserStub);
           this.owner.register('service:intl', IntlStub);
 
@@ -97,9 +89,6 @@ module('Unit | Component | no-session-panel', function (hooks) {
         class CurrentUserStub extends Service {
           currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
         }
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: true };
-        }
         class CurrentDomainStub extends Service {
           getExtension = sinon.stub().returns('fr');
         }
@@ -108,7 +97,6 @@ module('Unit | Component | no-session-panel', function (hooks) {
         }
 
         this.owner.register('service:current-domain', CurrentDomainStub);
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
         this.owner.register('service:current-user', CurrentUserStub);
         this.owner.register('service:intl', IntlStub);
 

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -27,9 +27,6 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
           class CurrentUserStub extends Service {
             currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
           }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
-          }
           class CurrentDomainStub extends Service {
             getExtension = sinon.stub().returns('org');
           }
@@ -38,7 +35,6 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
           this.owner.register('service:current-user', CurrentUserStub);
           this.owner.register('service:intl', IntlStub);
 
@@ -61,9 +57,6 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
           class CurrentUserStub extends Service {
             currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
           }
-          class FeatureTogglesStub extends Service {
-            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
-          }
           class CurrentDomainStub extends Service {
             getExtension = sinon.stub().returns('org');
           }
@@ -72,7 +65,6 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
-          this.owner.register('service:featureToggles', FeatureTogglesStub);
           this.owner.register('service:current-user', CurrentUserStub);
           this.owner.register('service:intl', IntlStub);
 
@@ -97,9 +89,6 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
         class CurrentUserStub extends Service {
           currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
         }
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
-        }
         class CurrentDomainStub extends Service {
           getExtension = sinon.stub().returns('fr');
         }
@@ -108,7 +97,6 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
         }
 
         this.owner.register('service:current-domain', CurrentDomainStub);
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
         this.owner.register('service:current-user', CurrentUserStub);
         this.owner.register('service:intl', IntlStub);
 

--- a/certif/tests/unit/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/import_test.js
@@ -19,9 +19,6 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
         class CurrentUserStub extends Service {
           currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
         }
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
-        }
         class CurrentDomainStub extends Service {
           getExtension = sinon.stub().returns('org');
         }
@@ -33,7 +30,6 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
         }
 
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:feature-toggles', FeatureTogglesStub);
         this.owner.register('service:current-domain', CurrentDomainStub);
         this.owner.register('service:intl', IntlStub);
         this.owner.register('service:current-user', CurrentUserStub);
@@ -59,9 +55,6 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
         class CurrentUserStub extends Service {
           currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
         }
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
-        }
         class CurrentDomainStub extends Service {
           getExtension = sinon.stub().returns('org');
         }
@@ -73,7 +66,6 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
         }
 
         this.owner.register('service:router', RouterStub);
-        this.owner.register('service:feature-toggles', FeatureTogglesStub);
         this.owner.register('service:current-domain', CurrentDomainStub);
         this.owner.register('service:intl', IntlStub);
         this.owner.register('service:current-user', CurrentUserStub);
@@ -100,9 +92,6 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
-      }
       class CurrentDomainStub extends Service {
         getExtension = sinon.stub().returns('fr');
       }
@@ -114,7 +103,6 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
       }
 
       this.owner.register('service:router', RouterStub);
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
       this.owner.register('service:current-domain', CurrentDomainStub);
       this.owner.register('service:intl', IntlStub);
       this.owner.register('service:current-user', CurrentUserStub);

--- a/certif/tests/unit/services/feature-toggles_test.js
+++ b/certif/tests/unit/services/feature-toggles_test.js
@@ -10,9 +10,7 @@ module('Unit | Service | feature toggles', function (hooks) {
   module('feature toggles are loaded', function () {
     test('should load the feature toggles', async function (assert) {
       // Given
-      const featureToggles = Object.create({
-        isMassiveSessionManagementEnabled: false,
-      });
+      const featureToggles = Object.create({});
       const storeStub = Service.create({
         queryRecord: () => resolve(featureToggles),
       });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la gestion massive des sessions sur Pix Certif est active en production. Il n'est donc plus nécessaire de garder le feature toggle associé.

## :robot: Proposition
Supprimer le FT.

## :100: Pour tester
Se connecter sur Pix Certif et tester la gestion massive des sessions
