### PR TITLE
[TECH] Utilisation de stream pour renvoyer la réponse des simulateurs (PIX-9669).

### DIFF
--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 import { createServer } from '../../../../server.js';
-import { databaseBuilder, generateValidRequestAuthorizationHeader, mockLearningContent } from '../../../test-helper.js';
+import {
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+  parseJsonStream,
+} from '../../../test-helper.js';
 import { PIX_ADMIN } from '../../../../lib/domain/constants.js';
 
 const {
@@ -169,7 +174,8 @@ ko,aband,ok`;
 
         // then
         expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
+        const parsedResponse = parseJsonStream(response);
+        expect(parsedResponse[0].simulationReport).to.have.lengthOf(2);
       });
     });
 
@@ -183,7 +189,8 @@ ko,aband,ok`;
         const response = await server.inject(options);
         // then
         expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
+        const parsedResponse = parseJsonStream(response);
+        expect(parsedResponse[0].simulationReport).to.have.lengthOf(2);
       });
     });
 
@@ -197,8 +204,8 @@ ko,aband,ok`;
         const response = await server.inject(options);
 
         // then
-        expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
+        const parsedResponse = parseJsonStream(response);
+        expect(parsedResponse[0].simulationReport).to.have.lengthOf(2);
       });
     });
 
@@ -212,8 +219,8 @@ ko,aband,ok`;
         const response = await server.inject(options);
 
         // then
-        expect(response).to.have.property('statusCode', 200);
-        expect(response.result.data[0].attributes['simulation-report']).to.have.lengthOf(2);
+        const parsedResponse = parseJsonStream(response);
+        expect(parsedResponse[0].simulationReport).to.have.lengthOf(2);
       });
     });
 

--- a/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/integration/application/scenarios-simulator/scenario-simulator-controller_test.js
@@ -1,4 +1,4 @@
-import { expect, sinon, HttpTestServer, domainBuilder } from '../../../test-helper.js';
+import { expect, sinon, HttpTestServer, domainBuilder, parseJsonStream } from '../../../test-helper.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import * as moduleUnderTest from '../../../../lib/application/scenarios-simulator/index.js';
 import { random } from '../../../../lib/infrastructure/utils/random.js';
@@ -99,9 +99,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
             // then
             expect(response.statusCode).to.equal(200);
-            expect(response.result).to.deep.equal(
-              _generateScenarioSimulatorBatch([
-                [
+            const parsedResult = parseJsonStream(response);
+            expect(parsedResult).to.deep.equal([
+              {
+                index: 0,
+                simulationReport: [
                   {
                     challengeId: challenge1.id,
                     errorRate: errorRate1,
@@ -113,8 +115,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     discriminant: challenge1.discriminant,
                   },
                 ],
-              ]),
-            );
+              },
+            ]);
           });
         });
       });
@@ -159,9 +161,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.deep.equal(
-            _generateScenarioSimulatorBatch([
-              [
+          const parsedResult = parseJsonStream(response);
+          expect(parsedResult).to.deep.equal([
+            {
+              index: 0,
+              simulationReport: [
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
@@ -173,8 +177,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   discriminant: challenge1.discriminant,
                 },
               ],
-            ]),
-          );
+            },
+          ]);
         });
       });
 
@@ -219,9 +223,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.deep.equal(
-            _generateScenarioSimulatorBatch([
-              [
+          const parsedResult = parseJsonStream(response);
+          expect(parsedResult).to.deep.equal([
+            {
+              index: 0,
+              simulationReport: [
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
@@ -233,8 +239,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   discriminant: challenge1.discriminant,
                 },
               ],
-            ]),
-          );
+            },
+          ]);
         });
       });
 
@@ -278,9 +284,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.deep.equal(
-            _generateScenarioSimulatorBatch([
-              [
+          const parsedResult = parseJsonStream(response);
+          expect(parsedResult).to.deep.equal([
+            {
+              index: 0,
+              simulationReport: [
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
@@ -292,8 +300,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   discriminant: challenge1.discriminant,
                 },
               ],
-            ]),
-          );
+            },
+          ]);
         });
       });
 
@@ -367,9 +375,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
             // then
             expect(response.statusCode).to.equal(200);
-            expect(response.result).to.deep.equal(
-              _generateScenarioSimulatorBatch([
-                [
+            const parsedResult = parseJsonStream(response);
+            expect(parsedResult).to.deep.equal([
+              {
+                index: 0,
+                simulationReport: [
                   {
                     challengeId: challenge1.id,
                     errorRate: errorRate1,
@@ -381,8 +391,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     discriminant: challenge1.discriminant,
                   },
                 ],
-              ]),
-            );
+              },
+            ]);
           });
         });
 
@@ -546,9 +556,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.deep.equal(
-            _generateScenarioSimulatorBatch([
-              [
+          const parsedResult = parseJsonStream(response);
+          expect(parsedResult).to.deep.equal([
+            {
+              index: 0,
+              simulationReport: [
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
@@ -560,8 +572,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   discriminant: challenge1.discriminant,
                 },
               ],
-            ]),
-          );
+            },
+          ]);
         });
       });
 
@@ -604,9 +616,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(
-                _generateScenarioSimulatorBatch([
-                  [
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
@@ -618,8 +632,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       discriminant: challenge1.discriminant,
                     },
                   ],
-                ]),
-              );
+                },
+              ]);
             });
           });
 
@@ -658,9 +672,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(
-                _generateScenarioSimulatorBatch([
-                  [
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
@@ -672,8 +688,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       discriminant: challenge1.discriminant,
                     },
                   ],
-                ]),
-              );
+                },
+              ]);
             });
           });
 
@@ -727,7 +743,18 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(_generateScenarioSimulatorBatch([[result], [result]]));
+
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [result],
+                },
+                {
+                  index: 1,
+                  simulationReport: [result],
+                },
+              ]);
             });
           });
         });
@@ -773,9 +800,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(
-                _generateScenarioSimulatorBatch([
-                  [
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
@@ -787,8 +816,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       discriminant: challenge1.discriminant,
                     },
                   ],
-                ]),
-              );
+                },
+              ]);
             });
           });
 
@@ -832,9 +861,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(
-                _generateScenarioSimulatorBatch([
-                  [
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
@@ -846,8 +877,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       discriminant: challenge1.discriminant,
                     },
                   ],
-                ]),
-              );
+                },
+              ]);
             });
           });
         });
@@ -890,9 +921,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(
-                _generateScenarioSimulatorBatch([
-                  [
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
@@ -904,8 +937,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       discriminant: challenge1.discriminant,
                     },
                   ],
-                ]),
-              );
+                },
+              ]);
             });
           });
 
@@ -946,9 +979,11 @@ describe('Integration | Application | scenario-simulator-controller', function (
 
               // then
               expect(response.statusCode).to.equal(200);
-              expect(response.result).to.deep.equal(
-                _generateScenarioSimulatorBatch([
-                  [
+              const parsedResult = parseJsonStream(response);
+              expect(parsedResult).to.deep.equal([
+                {
+                  index: 0,
+                  simulationReport: [
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
@@ -960,8 +995,8 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       discriminant: challenge1.discriminant,
                     },
                   ],
-                ]),
-              );
+                },
+              ]);
             });
           });
         });
@@ -1146,24 +1181,3 @@ describe('Integration | Application | scenario-simulator-controller', function (
     });
   });
 });
-
-function _generateScenarioSimulatorBatch(data) {
-  return {
-    data: data.map((scenario, index) => ({
-      type: 'scenario-simulator-batches',
-      id: `${index}`,
-      attributes: {
-        'simulation-report': scenario.map((scenarioSimulatorChallenge) => ({
-          'challenge-id': scenarioSimulatorChallenge.challengeId,
-          'error-rate': scenarioSimulatorChallenge.errorRate,
-          'estimated-level': scenarioSimulatorChallenge.estimatedLevel,
-          'minimum-capability': scenarioSimulatorChallenge.minimumCapability,
-          'answer-status': scenarioSimulatorChallenge.answerStatus,
-          reward: scenarioSimulatorChallenge.reward,
-          difficulty: scenarioSimulatorChallenge.difficulty,
-          discriminant: scenarioSimulatorChallenge.discriminant,
-        })),
-      },
-    })),
-  };
-}

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -195,6 +195,13 @@ function streamToPromise(stream) {
   });
 }
 
+function parseJsonStream(response) {
+  return response.result
+    .split('\n')
+    .filter((row) => row !== '')
+    .map((r) => JSON.parse(r));
+}
+
 function catchErr(promiseFn, ctx) {
   return async (...args) => {
     try {
@@ -290,6 +297,7 @@ export {
   sinon,
   MockDate,
   streamToPromise,
+  parseJsonStream,
   catchErr,
   catchErrSync,
   testErr,

--- a/api/tests/test-helper_test.js
+++ b/api/tests/test-helper_test.js
@@ -1,4 +1,4 @@
-import { expect, catchErr } from './test-helper.js';
+import { expect, catchErr, parseJsonStream } from './test-helper.js';
 
 describe('Test helpers', function () {
   describe('#catchErr', function () {
@@ -27,6 +27,20 @@ describe('Test helpers', function () {
 
       // then
       await expect(promise).to.be.rejectedWith('Expected an error, but none was thrown.');
+    });
+  });
+
+  describe('#parseJsonStream', function () {
+    it('should parse JSONStream data', function () {
+      const obj1 = { a: 1 };
+      const obj2 = { b: 2 };
+      const data = [JSON.stringify(obj1), JSON.stringify(obj2), ''].join('\n');
+
+      expect(
+        parseJsonStream({
+          result: data,
+        }),
+      ).to.deep.equal([obj1, obj2]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'éxécution des simulateurs de la certif v3, le calcul des résultats peut être assez long, ce qui peut provoquer des timeout.

## :robot: Proposition
Afin d'éviter ces timeouts, nous retournons les réponses au fur et à mesure de leur calcul.

## :100: Pour tester
```
TOKEN=$(curl 'https://api-pr7261.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7261.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "capacity": 1.5, "stopAtChallenge": 2, "numberOfIterations": 10 }' | jq '.'
```

Vérifier qu'il y a bien 10 objects JSON successifs séparés par des nouvelles lignes.

