### PR TITLE
[BUGFIX] Ne pas afficher les RT qui n'ont pas de badge certifié (PIx-9596)

### DIFF
--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
@@ -66,7 +66,7 @@ async function _getBadgesForCurrentTargetProfiles({ targetProfile }) {
       level: 'complementary-certification-badges.level',
       imageUrl: 'complementary-certification-badges.imageUrl',
     })
-    .leftJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
+    .innerJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
     .where('targetProfileId', targetProfile.id)
     .whereNull('complementary-certification-badges.detachedAt')
     .orderBy('level', 'asc');


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, en prod, on peut observer coté cléA que des lignes vides apparaissent dans la table des badge certifié.

La raison est que ce sont des RT (badges) liés au profil cible actuels mais qui n’ont pas de badge certifié (ccbadges).


## :robot: Proposition
 si pas de badge certifié, alors on affiche pas les RT

## :100: Pour tester
- Ajouter en base un badge lié à un target profile
- Ne pas créer de ccbadge correspondant
- Constater que ce badge n'apparait pas dans la liste des badges certifiés du profil coble actuel


Avant correctif: 

![image](https://github.com/1024pix/pix/assets/37305474/441fc8c2-4934-432f-b5c6-4d9569ffc84a)


Après correctif:

![image](https://github.com/1024pix/pix/assets/37305474/a0d411de-a98d-43e2-83f4-873b7141f7d7)
