### PR TITLE
[FEATURE] Modification de la redirection une fois le rattachement du nouveau PC réussi (PIX-9568)

### DIFF
--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -94,7 +94,7 @@ export default class AttachTargetProfileController extends Controller {
         },
       });
 
-      this.router.transitionTo('authenticated.complementary-certifications.list');
+      this.router.transitionTo('authenticated.complementary-certifications.complementary-certification.details');
 
       this.notifications.success(
         `Profil cible rattaché à la certification ${complementaryCertification.label} mis à jour avec succès !`,

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
@@ -9,7 +9,11 @@ export default class DetailsRoute extends Route {
   }
 
   async model() {
-    return this.modelFor('authenticated.complementary-certifications.complementary-certification');
+    const complementaryCertification = await this.modelFor(
+      'authenticated.complementary-certifications.complementary-certification',
+    );
+    await complementaryCertification.reload();
+    return complementaryCertification;
   }
 
   resetController(controller, isExiting) {

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -150,7 +150,7 @@ module(
       });
 
       module('when user submits the form', function () {
-        test('it should save the new attached target profile and redirect to complementary certification list', async function (assert) {
+        test('it should save the new attached target profile and redirect to complementary certification details', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           server.create('complementary-certification', {
@@ -212,7 +212,7 @@ module(
               ),
             )
             .exists();
-          assert.strictEqual(currentURL(), '/complementary-certifications/list');
+          assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Le versioning des profils cibles et des résultats thématiques certifiants doit permettre d’assurer la pérennité des certifications complémentaires Pix en conservant un historique des différentes versions de profil cible et de RT certifiants sur lesquels elles sont basées.

Les utilisateurs Pix Admin habilités (ADMIN, METIER, SUPPORT) à créer de nouveaux profils cibles ont besoin de pouvoir détacher l'ancien PC et de rattacher le nouveau aux certifications complémentaires correspondantes (ainsi que les RT certifiants liés) afin de faire évoluer celles-ci selon les besoins de nos commanditaires.

Une fois que l’utilisateur a validé le rattachement d'un nouveau profil cible, il a la confirmation que sa modification a bien été prise en compte en étant redirigé sur la page de liste des certifications avec un toaster de succès.

la redirection vers la liste des certifications complémentaires ne permet pas à l’utilisateur de vérifier rapidement que sa modification est bien prise en compte.


## :robot: Proposition
Redirection vers la page de détail de la certification complémentaire concernée par la modification


## :100: Pour tester
Depuis pix-admin

- rattacher un nouveau profil cible à une certification complémentaire
- constater vers la redirection de la page de détail de cette même certification complémentaire