### PR TITLE
[BUGFIX] Restaurer la dépendance buffer nécessaire pour js-yaml

### DIFF
--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -35,6 +35,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@glimmer/component": "^1.1.2",
         "@sentry/ember": "^7.17.4",
+        "buffer": "^6.0.3",
         "dayjs": "^1.11.6",
         "dotenv": "^16.0.3",
         "ember-api-actions": "^0.2.9",
@@ -20656,6 +20657,30 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -66,6 +66,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@glimmer/component": "^1.1.2",
     "@sentry/ember": "^7.17.4",
+    "buffer": "^6.0.3",
     "dayjs": "^1.11.6",
     "dotenv": "^16.0.3",
     "ember-api-actions": "^0.2.9",


### PR DESCRIPTION
## :unicorn: Problème
La mise à jour de ember-cli-mirage a supprimer la dépendance buffer qui est nécessaire a js-yaml pour la compatibilité avec 
https://github.com/1024pix/pix/pull/7220/files?short_path=c802c0c#diff-c802c0cfd5b3065457eb77fcc793467acaf995c261fa7cdab2e297faa9ed7093

## :robot: Proposition
Rajouter buffer en dépendance de premier niveau de mon-pix.

## :100: Pour tester
En local et sur la CI vérifier que le build n'affiche pas de message en rapport avec buffer.
