### PR TITLE
[BUGFIX] Utiliser la bonne configuration pour la knex transaction du CRON de certificabilitée (PIX-9676)

### DIFF
--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -1,6 +1,5 @@
-import { expect, sinon } from '../../../../test-helper.js';
+import { expect, sinon, knex } from '../../../../test-helper.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from '../../../../../lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 
 describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCertificabilityJobHandler', function () {
   context('#handle', function () {
@@ -10,9 +9,16 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
     let logger;
 
     beforeEach(function () {
-      domainTransaction = Symbol('domainTransaction');
-      DomainTransaction.execute = (lambda) => {
-        return lambda(domainTransaction);
+      const transaction = Symbol('domainTransaction');
+      sinon
+        .stub(knex, 'transaction')
+        .withArgs(sinon.match.func, { isolationLevel: 'repeatable read' })
+        .callsFake((lambda) => {
+          return lambda(transaction);
+        });
+
+      domainTransaction = {
+        knexTransaction: transaction,
       };
 
       pgBossRepository = {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons identifier un problème au niveau de la transaction quand plusieurs lecture sont faites. Avec la configuration des transactions par défaut, si un commit est fait entre deux lectures, les données de la 2nde lecture peuvent avoir des données différentes

## :robot: Proposition
Ajout d'une config spécifique à la transaction utilisée dans le CRON de certificabilité.

## :rainbow: Remarques
Voir documentation PG : https://www.postgresql.org/docs/current/transaction-iso.html
Documentation knex : https://knexjs.org/guide/transactions.html#transaction-modes

## :100: Pour tester
- Vérifier que les tests passent
- 🐱 
