### PR TITLE
[TECH] Déclencher des événèments Matomo depuis le code (PIX-9456).

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -10,12 +10,14 @@ export default class ApplicationRoute extends Route {
   @service oidcIdentityProviders;
   @service session;
   @service splash;
+  @service metrics;
 
   activate() {
     this.splash.hide();
   }
 
   async beforeModel(transition) {
+    this.metrics.initialize();
     await this.session.setup();
     /*
     Ce code permet de définir une locale par défaut différente de celle d'ember-intl.

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -111,7 +111,10 @@ module.exports = function (environment) {
       strikethrough: true,
     },
 
-    matomo: {},
+    metrics: {
+      enabled: analyticsEnabled,
+      matomoUrl: process.env.WEB_ANALYTICS_URL,
+    },
 
     '@sentry/ember': {
       disablePerformance: true,
@@ -164,6 +167,7 @@ module.exports = function (environment) {
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
+    ENV.metrics.enabled = false;
   }
 
   if (environment === 'production') {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -147,12 +147,6 @@ module.exports = function (environment) {
     ENV.APP.LOG_TRANSITIONS = false;
     ENV.APP.LOG_TRANSITIONS_INTERNAL = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
-
-    // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-      ENV.matomo.debug = true;
-    }
   }
 
   if (environment === 'test') {
@@ -174,9 +168,6 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
-    if (analyticsEnabled) {
-      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
-    }
   }
 
   return ENV;

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
+        "@1024pix/ember-matomo-tag-manager": "^2.4.2",
         "@1024pix/ember-testing-library": "^0.8.1",
         "@1024pix/eslint-config": "^1.0.3",
         "@1024pix/pix-ui": "^40.0.0",
@@ -99,6 +100,15 @@
       },
       "engines": {
         "node": "^v16.20.2"
+      }
+    },
+    "node_modules/@1024pix/ember-matomo-tag-manager": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-matomo-tag-manager/-/ember-matomo-tag-manager-2.4.2.tgz",
+      "integrity": "sha512-WK4IyqympT6HZGcAjlxZ7kGdm1UO9gzLgjxM9NkNRTenYcxiYOw7gGErQqWP7x98jWnjcZ+V5o9DLsS7U/qAjg==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -41,6 +41,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
+    "@1024pix/ember-matomo-tag-manager": "^2.4.2",
     "@1024pix/ember-testing-library": "^0.8.1",
     "@1024pix/eslint-config": "^1.0.3",
     "@1024pix/pix-ui": "^40.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le seul moyen de déclencher des évènements Matomo c'est de les configurer depuis l'interface. C'est rébarbatif et couteux : création d'un déclencheur en cherchant un sélecteur css etc,  d'une balise, et la publication de la nouvelle version. 

## :robot: Proposition
Nous avons mis à jour notre addon `ember-cli-matomo-tag-manager`, qui au passage s'est fait une beauté en passant au format addon v2 (cf: https://github.com/1024pix/ember-matomo-tag-manager/pull/24) et qui a été renommé `@1024pix/ember-matomo-tag-manager`

L'addon expose désormais un service `metrics` qui nous permet d'interagir avec le DataLayer de Matomo via une fonction `add`

## :rainbow: Remarques
Nous faisons un appel à `this.metrics.initialize()`, cette méthode ne fait rien mais permet à Ember d'enclencher son mécanisme d'instanciation du service, le constructeur du service lui se charge de faire l'injection du script. 

### Côté Matomo 

- Plusieurs variables ont été créé en suivant les recommandations de Matomo, c-a-d en prefixant avec quelques choses pour éviter de potentiel conflit : 
	- `DL - Pix - EventCategory` : `pix-event-category`
	- `DL - Pix - EventAction` : `pix-event-action`
	- `DL - Pix - EventName` : `pix-event-name`
	- `DL - Pix - EventValue` : `pix-event-value`
- Un event a été créé `CustomEvent`, qui se déclenche lorsqu'on ajoute au DataLayer : `{ event: `custom-event` }`
- Un décléncheur `CustomTag` : qui est déclenché par le  `custom-event`  et qui remplie les champs EventCategory, EventAction, EventName, EventValue avec les varibales du DL. 

Voici un exemple d'usage : 
```
this.metrics.add({ 
	event: 'custom-event', 
	'pix-event-category': 'Ma Catégorie',
	'pix-event-action': 'Mon action', 
	'pix-event-name': '',
	'pix-event-value': 0
})
```

## :100: Pour tester
- Aller sur Pix App
- Vérifier que le script est bien chargé et est présent dans le html