### PR TITLE
[FEATURE] Bloquer la réutilisation d'un PC qui a déjà été lié à une complémentaire (PIX-9561).

### DIFF
--- a/api/src/certification/complementary-certification/domain/usecases/attach-badges.js
+++ b/api/src/certification/complementary-certification/domain/usecases/attach-badges.js
@@ -11,7 +11,6 @@ const attachBadges = async function ({
   userId,
   targetProfileIdToDetach,
   complementaryCertificationBadgesToAttachDTO,
-  badgeRepository,
   complementaryCertificationBadgesRepository,
 }) {
   _verifyThatLevelsAreConsistent({
@@ -20,7 +19,7 @@ const attachBadges = async function ({
 
   await _verifyThatBadgesToAttachExist({
     complementaryCertificationBadgesToAttachDTO,
-    badgeRepository,
+    complementaryCertificationBadgesRepository,
   });
 
   if (complementaryCertification.hasExternalJury) {
@@ -127,15 +126,18 @@ function _verifyThatLevelsAreConsistent({ complementaryCertificationBadgesToAtta
   }
 }
 
-async function _verifyThatBadgesToAttachExist({ complementaryCertificationBadgesToAttachDTO, badgeRepository }) {
+async function _verifyThatBadgesToAttachExist({
+  complementaryCertificationBadgesToAttachDTO,
+  complementaryCertificationBadgesRepository,
+}) {
   if (complementaryCertificationBadgesToAttachDTO?.length <= 0) {
-    throw new NotFoundError("One or several badges don't exist.");
+    throw new NotFoundError('One or several badges are not attachable.');
   }
 
   const ids = complementaryCertificationBadgesToAttachDTO.map((ccBadgeToAttach) => ccBadgeToAttach.badgeId);
-  const badges = await badgeRepository.findAllByIds({ ids });
+  const badges = await complementaryCertificationBadgesRepository.findAttachableBadgesByIds({ ids });
 
   if (badges?.length !== ids.length) {
-    throw new NotFoundError("One or several badges don't exist.");
+    throw new NotFoundError('One or several badges are not attachable.');
   }
 }

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -37,9 +37,13 @@ const attach = async function ({ domainTransaction, complementaryCertificationBa
 const findAttachableBadgesByIds = async function ({ ids }) {
   const badges = await knex
     .from('badges')
-    .leftJoin('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
-    .whereNull('complementary-certification-badges.id')
-    .whereIn('badges.id', ids);
+    .whereIn('badges.id', ids)
+    .whereNotExists(
+      knex
+        .select(1)
+        .from('complementary-certification-badges')
+        .whereRaw('"complementary-certification-badges"."badgeId" = "badges"."id"'),
+    );
 
   return badges.map((badge) => {
     return new Badge(badge);

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { Badge } from '../../../../../lib/domain/models/Badge.js';
 
 const getAllIdsByTargetProfileId = async function ({ targetProfileId }) {
   const complementaryCertificationBadgesIds = await knex('badges')
@@ -33,4 +34,16 @@ const attach = async function ({ domainTransaction, complementaryCertificationBa
   }
 };
 
-export { getAllIdsByTargetProfileId, detachByIds, attach };
+const findAttachableBadgesByIds = async function ({ ids }) {
+  const badges = await knex
+    .from('badges')
+    .leftJoin('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
+    .whereNull('complementary-certification-badges.id')
+    .whereIn('badges.id', ids);
+
+  return badges.map((badge) => {
+    return new Badge(badge);
+  });
+};
+
+export { getAllIdsByTargetProfileId, detachByIds, attach, findAttachableBadgesByIds };

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -29,6 +29,20 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         label: 'Pix+ label',
       });
 
+      const alreadyAttachedTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        id: 11,
+      });
+      const alreadyAttachedBadge = databaseBuilder.factory.buildBadge({
+        id: 999,
+        targetProfileId: alreadyAttachedTargetProfile.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 888,
+        complementaryCertificationId: complementaryCertification.id,
+        badgeId: alreadyAttachedBadge.id,
+        detachedAt: null,
+      });
+
       const targetProfile = databaseBuilder.factory.buildTargetProfile({
         id: 12,
       });
@@ -41,13 +55,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         organizationId: organization.id,
         targetProfileId: targetProfile.id,
       });
-      const badge = databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id });
-      databaseBuilder.factory.buildComplementaryCertificationBadge({
-        id: 3,
-        complementaryCertificationId: complementaryCertification.id,
-        badgeId: badge.id,
-        detachedAt: null,
-      });
+      databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id });
 
       const options = {
         method: 'PUT',
@@ -55,7 +63,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         payload: {
           data: {
             attributes: {
-              'target-profile-id': 12,
+              'target-profile-id': 11,
               'notify-organizations': true,
               'complementary-certification-badges': [
                 {
@@ -114,7 +122,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         temporaryCertificateMessage: null,
         detachedAt: null,
       });
-      expect(complementaryCertificationBadgesDetached[0].id).to.equal(3);
+      expect(complementaryCertificationBadgesDetached[0].id).to.equal(888);
     });
 
     describe('Resource access management', function () {

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -218,10 +218,12 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
       const nonExistingBadgeId = 123456789;
       const nonExistingBadge = await knex('complementary-certification-badges').whereIn('id', [nonExistingBadgeId]);
       expect(nonExistingBadge).to.be.empty;
+
       // when
       const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({
         ids: [nonExistingBadgeId],
       });
+
       // then
       expect(results).to.be.empty;
     });

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -5,7 +5,7 @@ import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTr
 import { InvalidBadgeLevelError } from '../../../../../../src/certification/complementary-certification/domain/errors.js';
 
 describe('Unit | UseCase | attach-badges', function () {
-  let complementaryCertificationForTargetProfileAttachmentRepository, badgeRepository;
+  let complementaryCertificationForTargetProfileAttachmentRepository, complementaryCertificationBadgesRepository;
   let clock;
   const now = new Date('2023-02-02');
 
@@ -13,8 +13,8 @@ describe('Unit | UseCase | attach-badges', function () {
     complementaryCertificationForTargetProfileAttachmentRepository = {
       getById: sinon.stub(),
     };
-    badgeRepository = {
-      findAllByIds: sinon.stub(),
+    complementaryCertificationBadgesRepository = {
+      findAttachableBadgesByIds: sinon.stub(),
     };
     clock = sinon.useFakeTimers(now);
   });
@@ -122,7 +122,7 @@ describe('Unit | UseCase | attach-badges', function () {
         id: 123,
         hasExternalJury: true,
       });
-      badgeRepository.findAllByIds.resolves([{ badgeId: 1 }, { badgeId: 2 }]);
+      complementaryCertificationBadgesRepository.findAttachableBadgesByIds.resolves([{ badgeId: 1 }, { badgeId: 2 }]);
 
       // when
       const error = await catchErr(attachBadges)({
@@ -131,8 +131,8 @@ describe('Unit | UseCase | attach-badges', function () {
           { badgeId: 2, level: 2, certificateMessage: null, temporaryCertificateMessage: 'temporary message' },
         ],
         complementaryCertification,
-        badgeRepository,
         complementaryCertificationForTargetProfileAttachmentRepository,
+        complementaryCertificationBadgesRepository,
       });
 
       // then
@@ -154,7 +154,7 @@ describe('Unit | UseCase | attach-badges', function () {
       context(`when  ${assessment.label}`, function () {
         it('should throw a not found error', async function () {
           // given
-          badgeRepository.findAllByIds.resolves(assessment.resolve);
+          complementaryCertificationBadgesRepository.findAttachableBadgesByIds.resolves(assessment.resolve);
 
           // when
           const error = await catchErr(attachBadges)({
@@ -163,12 +163,12 @@ describe('Unit | UseCase | attach-badges', function () {
               { badgeId: 1, level: 1 },
               { badgeId: 2, level: 2 },
             ],
-            badgeRepository,
+            complementaryCertificationBadgesRepository,
           });
 
           // then
           expect(error).to.be.instanceOf(NotFoundError);
-          expect(error.message).to.equal("One or several badges don't exist.");
+          expect(error.message).to.equal('One or several badges are not attachable.');
         });
       });
     });
@@ -191,11 +191,11 @@ describe('Unit | UseCase | attach-badges', function () {
           id: 123,
           hasExternalJury: false,
         });
-        badgeRepository.findAllByIds.resolves([badge1, badge2]);
         const complementaryCertificationBadgesRepository = {
           attach: sinon.stub().resolves(),
           detachByIds: sinon.stub(),
           getAllIdsByTargetProfileId: sinon.stub(),
+          findAttachableBadgesByIds: sinon.stub().resolves([badge1, badge2]),
         };
 
         complementaryCertificationBadgesRepository.getAllIdsByTargetProfileId
@@ -211,7 +211,6 @@ describe('Unit | UseCase | attach-badges', function () {
           ],
           targetProfileIdToDetach: 789,
           complementaryCertification,
-          badgeRepository,
           complementaryCertificationForTargetProfileAttachmentRepository,
           complementaryCertificationBadgesRepository,
         });
@@ -247,7 +246,6 @@ describe('Unit | UseCase | attach-badges', function () {
           id: 123,
           hasExternalJury: false,
         });
-        badgeRepository.findAllByIds.resolves([badge1]);
         const complementaryCertificationBadgesRepository = {
           attach: sinon.stub(),
           detachByIds: sinon.stub().resolves(),
@@ -259,6 +257,7 @@ describe('Unit | UseCase | attach-badges', function () {
               level: 1,
             }).badgeId,
           ]),
+          findAttachableBadgesByIds: sinon.stub().resolves([badge1]),
         };
 
         // when
@@ -267,7 +266,6 @@ describe('Unit | UseCase | attach-badges', function () {
           complementaryCertificationBadgesToAttachDTO: [complementaryCertificationBadge],
           targetProfileIdToDetach: 456,
           complementaryCertification,
-          badgeRepository,
           complementaryCertificationForTargetProfileAttachmentRepository,
           complementaryCertificationBadgesRepository,
         });
@@ -302,11 +300,11 @@ describe('Unit | UseCase | attach-badges', function () {
         id: 123,
         hasExternalJury: false,
       });
-      badgeRepository.findAllByIds.resolves([badge1, badge2]);
       const complementaryCertificationBadgesRepository = {
         attach: sinon.stub().resolves(),
         detachByIds: sinon.stub(),
         getAllIdsByTargetProfileId: sinon.stub(),
+        findAttachableBadgesByIds: sinon.stub().resolves([badge1, badge2]),
       };
       const BadgeToAttachValidator = {
         validate: sinon.stub().resolves(),
@@ -325,7 +323,6 @@ describe('Unit | UseCase | attach-badges', function () {
         targetProfileIdToDetach: 789,
         complementaryCertification,
         BadgeToAttachValidator,
-        badgeRepository,
         complementaryCertificationForTargetProfileAttachmentRepository,
         complementaryCertificationBadgesRepository,
       });

--- a/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachable-target-profiles-repository_test.js
@@ -63,7 +63,7 @@ describe('Integration | Repository | attachable-target-profiles', function () {
     });
 
     context('when the target profile has been linked to a complementary certification', function () {
-      it('should not return target profiles currently attached to a complementary', async function () {
+      it('should not return currently attached target profiles', async function () {
         // given
         new TargetProfileFactory({ id: 100, name: 'currentlyAttachedToATargetProfile' })
           .withBadge()
@@ -74,10 +74,10 @@ describe('Integration | Repository | attachable-target-profiles', function () {
         const results = await attachableTargetProfileRepository.find();
 
         // then
-        expect(results).to.deep.equal([]);
+        expect(results).to.be.empty;
       });
 
-      it('should return attached target profiles detached from a complementary', async function () {
+      it('should not return target profiles even if detached', async function () {
         // given
         new TargetProfileFactory({ id: 100, name: 'currentlyDetached' })
           .withBadge()
@@ -88,52 +88,7 @@ describe('Integration | Repository | attachable-target-profiles', function () {
         const results = await attachableTargetProfileRepository.find();
 
         // then
-        expect(results).to.deep.equal([{ id: 100, name: 'currentlyDetached' }]);
-      });
-
-      context('when the target profile has been multiple times detached', function () {
-        it('should appear only once in the results', async function () {
-          // given
-          new TargetProfileFactory({ id: 100, name: 'currentlyDetached' })
-            .withBadge({ id: 875, title: 'this_badge_has_been_detached_twice' })
-            .withComplementaryCertificationBadge({ detachedAt: new Date() });
-
-          databaseBuilder.factory.buildComplementaryCertificationBadge({
-            badgeId: 875,
-            complementaryCertificationId: null,
-            detachedAt: new Date(),
-          });
-
-          await databaseBuilder.commit();
-
-          // when
-          const results = await attachableTargetProfileRepository.find();
-
-          // then
-          expect(results).to.deep.equal([{ id: 100, name: 'currentlyDetached' }]);
-        });
-      });
-
-      context('when the target profile has an history where it has been detached', function () {
-        it('should not be returned', async function () {
-          // given
-          new TargetProfileFactory({ id: 100, name: 'a_PC_attached_now_but_who_got_detached_also_in_the_past' })
-            .withBadge({ id: 876, title: 'this_badge_will_be_both_linked_to_an_attached_and_detached_ccbadge' })
-            .withComplementaryCertificationBadge({ detachedAt: null });
-
-          databaseBuilder.factory.buildComplementaryCertificationBadge({
-            badgeId: 876,
-            complementaryCertificationId: null,
-            detachedAt: new Date('2021-01-01'),
-          });
-          await databaseBuilder.commit();
-
-          // when
-          const results = await attachableTargetProfileRepository.find();
-
-          // then
-          expect(results).to.be.empty;
-        });
+        expect(results).to.deep.be.empty;
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cas où un utilisateur tente de réutiliser un ancien profil cible ayant déjà été attaché à une certification complémentaire puis détaché, il y a un risque de confusion et d’erreur technique.
Il faut bloquer la réutilisation d’un profil cible et de son ou ses RT certifiants associés s’ils ont déjà été détachés d’une certification complémentaire.

## :robot: Proposition

* Empêcher la remontée de ces PC dans la recherche
* Bloquer la possibilité de rattacher un badge qui a déjà un rattachement à une complémentaire

## :rainbow: Remarques

## :100: Pour tester

### Sur l'interface

* Se connecter sur [Pix Admin](https://admin-pr7275.review.pix.fr/login) avec `superadmin@example.net`
* Aller sur la liste des certif complémentaires : https://admin-pr7275.review.pix.fr/complementary-certifications/list
* Prendre une complémentaire, notez les noms dans l'historique "Nom du profil cible"
  * Exemple pour Clé Numérique : "Parcours complet CléA numérique V1" 
* Faire "rattacher" , et dans la barre de recherche constatez que "Parcours complet CléA numérique V1" n'est pas proposé comme résultat

### Test de sécu

* Récupérer la requête cURL ou Postman pour rattacher un profil cible
* Essayer de modifier le payload du PUT en mettant un badgeId qui est un badge rattaché déjà
* Vérifier que le PUT détecte et refuse l'attachement avec l'erreur `NotFoundError('One or several badges are not attachable.')` en retour