### PR TITLE
[FEATURE] Ne pas afficher la date de certificabilitée des prescrits d'une organization avec la feature de remontée auto (PIX-9494)

### DIFF
--- a/api/lib/domain/read-models/Prescriber.js
+++ b/api/lib/domain/read-models/Prescriber.js
@@ -10,6 +10,7 @@ class Prescriber {
     memberships = [],
     userOrgaSettings,
     enableMultipleSendingAssessment,
+    computeOrganizationLearnerCertificability,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -21,6 +22,7 @@ class Prescriber {
     this.memberships = memberships;
     this.userOrgaSettings = userOrgaSettings;
     this.enableMultipleSendingAssessment = enableMultipleSendingAssessment;
+    this.computeOrganizationLearnerCertificability = computeOrganizationLearnerCertificability;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -31,6 +31,7 @@ const serialize = function (prescriber) {
       'memberships',
       'userOrgaSettings',
       'enableMultipleSendingAssessment',
+      'computeOrganizationLearnerCertificability',
     ],
     memberships: {
       ref: 'id',

--- a/api/tests/acceptance/application/prescribers/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescribers/prescriber-controller_test.js
@@ -27,6 +27,7 @@ describe('Acceptance | Controller | Prescriber-controller', function () {
           'participant-count': 0,
           lang: user.lang,
           'enable-multiple-sending-assessment': false,
+          'compute-organization-learner-certificability': false,
         },
         relationships: {
           memberships: {

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -327,32 +327,71 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
         });
       });
 
-      describe('#enableMultipleSendingAssessment', function () {
-        it('should return activated feature for current organization', async function () {
-          // given
-          expectedPrescriber.userOrgaSettings = userOrgaSettings;
-          const feature = databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
-          databaseBuilder.factory.buildOrganizationFeature({ featureId: feature.id, organizationId: organization.id });
-          await databaseBuilder.commit();
+      context('features', function () {
+        describe('#enableMultipleSendingAssessment', function () {
+          it('should return activated feature for current organization', async function () {
+            // given
+            const feature = databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
+            databaseBuilder.factory.buildOrganizationFeature({
+              featureId: feature.id,
+              organizationId: organization.id,
+            });
+            await databaseBuilder.commit();
 
-          // when
-          const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+            // when
+            const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
 
-          // then
-          expect(foundPrescriber.enableMultipleSendingAssessment).to.be.true;
+            // then
+            expect(foundPrescriber.enableMultipleSendingAssessment).to.be.true;
+          });
+
+          it('should return deactivated feature for current organization', async function () {
+            // given
+            expectedPrescriber.userOrgaSettings = userOrgaSettings;
+            databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
+            await databaseBuilder.commit();
+
+            // when
+            const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+            // then
+            expect(foundPrescriber.enableMultipleSendingAssessment).to.be.false;
+          });
         });
+        describe('#isComputeOrganizationLearnerCertificabilityEnabled', function () {
+          it('should return activated feature for current organization', async function () {
+            // given
+            const feature = databaseBuilder.factory.buildFeature(
+              apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY,
+            );
+            databaseBuilder.factory.buildOrganizationFeature({
+              featureId: feature.id,
+              organizationId: organization.id,
+            });
+            await databaseBuilder.commit();
 
-        it('should return deactivated feature for current organization', async function () {
-          // given
-          expectedPrescriber.userOrgaSettings = userOrgaSettings;
-          databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT);
-          await databaseBuilder.commit();
+            // when
+            const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
 
-          // when
-          const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+            // then
+            expect(foundPrescriber.computeOrganizationLearnerCertificability).to.be.true;
+          });
 
-          // then
-          expect(foundPrescriber.enableMultipleSendingAssessment).to.be.false;
+          it('should return deactivated feature for current organization', async function () {
+            // given
+            expectedPrescriber.userOrgaSettings = userOrgaSettings;
+            databaseBuilder.factory.buildFeature(
+              apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY,
+            );
+
+            await databaseBuilder.commit();
+
+            // when
+            const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+            // then
+            expect(foundPrescriber.computeOrganizationLearnerCertificability).to.be.false;
+          });
         });
       });
     });

--- a/api/tests/tooling/domain-builder/factory/build-prescriber.js
+++ b/api/tests/tooling/domain-builder/factory/build-prescriber.js
@@ -54,6 +54,7 @@ const buildPrescriber = function ({
   memberships = _buildMemberships(),
   userOrgaSettings = _buildUserOrgaSettings(),
   enableMultipleSendingAssessment = false,
+  computeOrganizationLearnerCertificability = false,
 } = {}) {
   return new Prescriber({
     id,
@@ -65,6 +66,7 @@ const buildPrescriber = function ({
     memberships,
     userOrgaSettings,
     enableMultipleSendingAssessment,
+    computeOrganizationLearnerCertificability,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -166,6 +166,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
           memberships: [membership],
           userOrgaSettings,
           enableMultipleSendingAssessment: true,
+          computeOrganizationLearnerCertificability: true,
         });
 
         const expectedPrescriberSerialized = createExpectedPrescriberSerialized({
@@ -204,7 +205,8 @@ function createExpectedPrescriberSerializedWithOneMoreField({
         'are-new-year-organization-learners-imported': prescriber.areNewYearOrganizationLearnersImported,
         'participant-count': prescriber.participantCount,
         lang: prescriber.lang,
-        'enable-multiple-sending-assessment': false,
+        'enable-multiple-sending-assessment': prescriber.enableMultipleSendingAssessment,
+        'compute-organization-learner-certificability': prescriber.computeOrganizationLearnerCertificability,
       },
       relationships: {
         memberships: {
@@ -309,7 +311,8 @@ function createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSe
         'are-new-year-organization-learners-imported': prescriber.areNewYearOrganizationLearnersImported,
         'participant-count': prescriber.participantCount,
         lang: prescriber.lang,
-        'enable-multiple-sending-assessment': true,
+        'enable-multiple-sending-assessment': prescriber.enableMultipleSendingAssessment,
+        'compute-organization-learner-certificability': prescriber.computeOrganizationLearnerCertificability,
       },
       relationships: {
         memberships: {

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -62,6 +62,7 @@
             @openAuthenticationMethodModal={{this.openAuthenticationMethodModal}}
             @onToggleStudent={{(fn this.addStopPropagationOnFunction toggleStudent)}}
             @onClickLearner={{(fn @onClickLearner student.id)}}
+            @hideCertifiableDate={{this.hasComputeOrganizationLearnerCertificabilityEnabled}}
           />
         </:item>
       </SelectableList>

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -33,6 +33,10 @@ export default class ScoList extends Component {
     });
   }
 
+  get hasComputeOrganizationLearnerCertificabilityEnabled() {
+    return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
+  }
+
   get divisions() {
     return this.currentUser.organization.divisions.map(({ name }) => ({
       label: name,

--- a/orga/app/components/sco-organization-participant/table-row.hbs
+++ b/orga/app/components/sco-organization-participant/table-row.hbs
@@ -44,11 +44,13 @@
   <td class="table__column--center">
     <Ui::IsCertifiable @isCertifiable={{@student.isCertifiable}} />
     {{#if @student.certifiableAt}}
-      <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
-          @student.certifiableAt
-          "DD/MM/YYYY"
-          allow-empty=true
-        }}</span>
+      {{#unless @hideCertifiableDate}}
+        <span class="organization-participant-list-page__certifiable-at">{{dayjs-format
+            @student.certifiableAt
+            "DD/MM/YYYY"
+            allow-empty=true
+          }}</span>
+      {{/unless}}
     {{/if}}
   </td>
   <td class="organization-participant-list-page__actions hide-on-mobile">

--- a/orga/app/components/ui/learner-header-info.hbs
+++ b/orga/app/components/ui/learner-header-info.hbs
@@ -5,9 +5,11 @@
         <Ui::IsCertifiable @isCertifiable={{@isCertifiable}} />
       </:title>
       <:content>
-        <span class="information__content--date">
-          <Ui::Date @date={{@certifiableAt}} />
-        </span>
+        {{#unless @hideCertifiableAt}}
+          <span class="information__content--date">
+            <Ui::Date @date={{@certifiableAt}} />
+          </span>
+        {{/unless}}
       </:content>
     </Ui::Information>
   {{/if}}

--- a/orga/app/controllers/authenticated/sco-organization-participants/sco-organization-participant.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/sco-organization-participant.js
@@ -3,6 +3,11 @@ import Controller from '@ember/controller';
 
 export default class ScoOrganizationParticipant extends Controller {
   @service intl;
+  @service currentUser;
+
+  get hasComputeOrganizationLearnerCertificabilityEnabled() {
+    return this.currentUser.prescriber.computeOrganizationLearnerCertificability;
+  }
 
   get breadcrumbLinks() {
     return [

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -8,6 +8,7 @@ export default class Prescriber extends Model {
   @attr('number') participantCount;
   @attr('string') lang;
   @attr('boolean') enableMultipleSendingAssessment;
+  @attr('boolean') computeOrganizationLearnerCertificability;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
 

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
@@ -19,6 +19,7 @@
         @authenticationMethods={{@model.organizationLearner.authenticationMethodsList}}
         @isCertifiable={{@model.organizationLearner.isCertifiable}}
         @certifiableAt={{@model.organizationLearner.certifiableAt}}
+        @hideCertifiableAt={{this.hasComputeOrganizationLearnerCertificabilityEnabled}}
       />
     </:info>
   </Learner::Header>

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -20,6 +20,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     const division = store.createRecord('division', { id: '3A', name: '3A' });
 
     class CurrentUserStub extends Service {
+      prescriber = {};
       isSCOManagingStudents = true;
       organization = store.createRecord('organization', {
         id: 1,
@@ -1091,6 +1092,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
       const division = store.createRecord('division', { id: '3BF', name: '3BF' });
       class CurrentUserStub extends Service {
+        prescriber = {};
         organization = store.createRecord('organization', {
           id: 1,
           divisions: [division],
@@ -1143,6 +1145,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
   module('action bar', function (hooks) {
     hooks.beforeEach(function () {
       class CurrentUserStub extends Service {
+        prescriber = {};
         organization = store.createRecord('organization', {
           id: 1,
           divisions: [store.createRecord('division', { id: '3Z', name: '3Z' })],

--- a/orga/tests/integration/components/sco-organization-participant/table-row_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/table-row_test.js
@@ -1,0 +1,81 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ScoOrganizationParticipant::TableRow', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when hideCertifiableDate is true', function () {
+    test('it should not display certifiableAt date', async function (assert) {
+      // given
+      const certifiableDate = '10/10/2023';
+      this.set('noop', sinon.stub());
+      const student = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        birthdate: '2020/01/01',
+        division: '3A',
+        authenticationMethods: [],
+        participationCount: 1,
+        isCertifiable: true,
+        certifiableAt: new Date(certifiableDate),
+      };
+      this.set('student', student);
+      this.set('hideCertifiableDate', true);
+
+      // when
+      const screen = await render(
+        hbs`<ScoOrganizationParticipant::TableRow
+  @showCheckbox={{this.noop}}
+  @student={{this.student}}
+  @isStudentSelected={{this.noop}}
+  @openAuthenticationMethodModal={{this.noop}}
+  @onToggleStudent={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @hideCertifiableDate={{this.hideCertifiableDate}}
+/>`,
+      );
+
+      // then
+      assert.dom(screen.queryByText(certifiableDate)).doesNotExist();
+    });
+  });
+
+  module('when hideCertifiableDate is false', function () {
+    test('it display certifiableAt date', async function (assert) {
+      // given
+      const certifiableDate = '10/10/2023';
+      this.set('noop', sinon.stub());
+      const student = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        birthdate: '2020/01/01',
+        division: '3A',
+        authenticationMethods: [],
+        participationCount: 1,
+        isCertifiable: true,
+        certifiableAt: new Date(certifiableDate),
+      };
+      this.set('student', student);
+      this.set('hideCertifiableDate', false);
+
+      // when
+      const screen = await render(
+        hbs`<ScoOrganizationParticipant::TableRow
+  @showCheckbox={{this.noop}}
+  @student={{this.student}}
+  @isStudentSelected={{this.noop}}
+  @openAuthenticationMethodModal={{this.noop}}
+  @onToggleStudent={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @hideCertifiableDate={{this.hideCertifiableDate}}
+/>`,
+      );
+
+      // then
+      assert.dom(screen.getByText(certifiableDate)).exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/ui/learner-header-info_test.js
+++ b/orga/tests/integration/components/ui/learner-header-info_test.js
@@ -123,5 +123,43 @@ module('Integration | Component | Ui::LearnerHeaderInfo', function (hooks) {
       );
       assert.strictEqual(screen.queryByText('01/01/2023'), null);
     });
+
+    test('it do not display certifiableAt when hideCertifiableAt is true', async function (assert) {
+      const isCertifiable = true;
+      const certifiableAt = '01/01/2023';
+      const hideCertifiableAt = true;
+
+      this.set('isCertifiable', isCertifiable);
+      this.set('certifiableAt', certifiableAt);
+      this.set('hideCertifiableAt', hideCertifiableAt);
+
+      const screen = await render(
+        hbs`<Ui::LearnerHeaderInfo
+  @isCertifiable={{this.isCertifiable}}
+  @certifiableAt={{this.certifiableAt}}
+  @hideCertifiableAt={{this.hideCertifiableAt}}
+/>`,
+      );
+      assert.strictEqual(screen.queryByText(certifiableAt), null);
+    });
+
+    test('it display certifiableAt when hideCertifiableAt is false', async function (assert) {
+      const isCertifiable = true;
+      const certifiableAt = '01/01/2023';
+      const hideCertifiableAt = false;
+
+      this.set('isCertifiable', isCertifiable);
+      this.set('certifiableAt', certifiableAt);
+      this.set('hideCertifiableAt', hideCertifiableAt);
+
+      const screen = await render(
+        hbs`<Ui::LearnerHeaderInfo
+  @isCertifiable={{this.isCertifiable}}
+  @certifiableAt={{this.certifiableAt}}
+  @hideCertifiableAt={{this.hideCertifiableAt}}
+/>`,
+      );
+      assert.strictEqual(screen.getByRole('definition').textContent.trim(), certifiableAt);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Même si l’epix n’est pas terminée, nous avons déjà des questions concernant la date mentionnée sous le statut de certificabilité de l'élève. 
L’utilisateur ne comprend pas à quoi correspond cette date et nous avons peur que même avec l’info-bulle prévue, les questions persistent.

## :robot: Proposition
Cacher la date affichée sous le statut de certificabilité des organizations ayant la feature de remontée auto de la certif

## :rainbow: Remarques
Cette date à été masquée dans la liste des prescrits et dans le détail d'un prescrit

## :100: Pour tester

- Se connecter à Pix Orga avec une orga ayant la feature de remontée auto activée
- Vérifier que les dates de certificabilitées dans la liste des prescrits et dans le détail d'un prescrit ne sont pas affichées
- Vérifier au contraire que sur les organisations n'ayant pas la feature d'activée la date apparaît toujours
- 🐱 
