### PR TITLE
[FEATURE] Amélioration du système de patch du cache LCMS (PIX-9687)

### DIFF
--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -10,13 +10,14 @@ const refreshCacheEntries = function (_, h, dependencies = { learningContentData
   return h.response({}).code(202);
 };
 
-const refreshCacheEntry = function (request) {
+const refreshCacheEntry = async function (request, h) {
   const updatedRecord = request.payload;
   const recordId = request.params.id;
   const datasource =
     // eslint-disable-next-line import/namespace
     LearningContentDatasources[_.findKey(LearningContentDatasources, { modelName: request.params.model })];
-  return datasource.refreshLearningContentCacheRecord(recordId, updatedRecord).then(() => null);
+  await datasource.refreshLearningContentCacheRecord(recordId, updatedRecord);
+  return h.response().code(204);
 };
 
 const cacheController = { refreshCacheEntries, refreshCacheEntry };

--- a/api/lib/domain/usecases/create-lcms-release.js
+++ b/api/lib/domain/usecases/create-lcms-release.js
@@ -1,9 +1,9 @@
 import { lcms } from '../../infrastructure/lcms.js';
-import { learningContentCache } from '../../infrastructure/caches/learning-content-cache.js';
+import { LearningContentCache } from '../../infrastructure/caches/learning-content-cache.js';
 
 const createLcmsRelease = async function () {
   const learningContent = await lcms.createRelease();
-  learningContentCache.set(learningContent);
+  LearningContentCache.instance.set(learningContent);
 };
 
 export { createLcmsRelease };

--- a/api/lib/infrastructure/caches/Cache.js
+++ b/api/lib/infrastructure/caches/Cache.js
@@ -7,6 +7,10 @@ class Cache {
     throw new Error('Method #set(key, object) must be overridden');
   }
 
+  async patch(/* key, patch */) {
+    throw new Error('Method #patch(key, patch) must be overridden');
+  }
+
   async flushAll() {
     throw new Error('Method #flushAll() must be overridden');
   }

--- a/api/lib/infrastructure/caches/DistributedCache.js
+++ b/api/lib/infrastructure/caches/DistributedCache.js
@@ -15,10 +15,21 @@ class DistributedCache extends Cache {
     this._redisClientSubscriber.on('ready', () => {
       this._redisClientSubscriber.subscribe(this._channel);
     });
-    this._redisClientSubscriber.on('message', () => {
+    this._redisClientSubscriber.on('message', this.clientSubscriberCallback.bind(this));
+  }
+
+  clientSubscriberCallback(message) {
+    // TODO: utiliser un message au format JSON pour le flushall également
+    if (message === 'Flush all') {
       logger.info({ event: 'cache-event' }, 'Flushing the local cache');
       return this._underlyingCache.flushAll();
-    });
+    } else {
+      logger.info({ event: 'cache-event' }, 'Patching the local cache');
+      const parsedMessage = JSON.parse(message);
+      if (parsedMessage.type === 'patch') {
+        this._underlyingCache.patch(parsedMessage.cacheKey, parsedMessage.patch);
+      }
+    }
   }
 
   get(key, generator) {
@@ -27,6 +38,16 @@ class DistributedCache extends Cache {
 
   set(key, object) {
     return this._underlyingCache.set(key, object);
+  }
+
+  patch(key, object) {
+    const message = {
+      patch: object,
+      cacheKey: key,
+      type: 'patch',
+    };
+    const messageAsString = JSON.stringify(message);
+    this._redisClientPublisher.publish(this._channel, messageAsString);
   }
 
   flushAll() {

--- a/api/lib/infrastructure/caches/InMemoryCache.js
+++ b/api/lib/infrastructure/caches/InMemoryCache.js
@@ -1,6 +1,6 @@
 import NodeCache from 'node-cache';
 import { Cache } from './Cache.js';
-import _ from 'lodash';
+import { applyPatch } from './apply-patch.js';
 
 class InMemoryCache extends Cache {
   constructor() {
@@ -31,12 +31,7 @@ class InMemoryCache extends Cache {
   patch(key, patch) {
     const value = this._cache.get(key);
     if (value === undefined) return;
-    if (patch.operation === 'assign') {
-      _.set(value, patch.path, patch.value);
-    } else if (patch.operation === 'push') {
-      const arr = _.get(value, patch.path);
-      arr.push(patch.value);
-    }
+    applyPatch(value, patch);
   }
 
   async flushAll() {

--- a/api/lib/infrastructure/caches/InMemoryCache.js
+++ b/api/lib/infrastructure/caches/InMemoryCache.js
@@ -1,5 +1,6 @@
 import NodeCache from 'node-cache';
 import { Cache } from './Cache.js';
+import _ from 'lodash';
 
 class InMemoryCache extends Cache {
   constructor() {
@@ -25,6 +26,17 @@ class InMemoryCache extends Cache {
       this._cache.set(key, value);
       return value;
     });
+  }
+
+  patch(key, patch) {
+    const value = this._cache.get(key);
+    if (value === undefined) return;
+    if (patch.operation === 'assign') {
+      _.set(value, patch.path, patch.value);
+    } else if (patch.operation === 'push') {
+      const arr = _.get(value, patch.path);
+      arr.push(patch.value);
+    }
   }
 
   async flushAll() {

--- a/api/lib/infrastructure/caches/LayeredCache.js
+++ b/api/lib/infrastructure/caches/LayeredCache.js
@@ -24,6 +24,11 @@ class LayeredCache extends Cache {
     return cachedObject;
   }
 
+  async patch(key, patch) {
+    await this._firstLevelCache.patch(key, patch);
+    return this._secondLevelCache.patch(key, patch);
+  }
+
   async flushAll() {
     await this._firstLevelCache.flushAll();
     return this._secondLevelCache.flushAll();

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -65,6 +65,7 @@ class RedisCache extends Cache {
     logger.info({ key, length: objectAsString.length }, 'Setting Redis key');
 
     await this._client.set(key, objectAsString);
+    await this._client.del(`${key}:${PATCHES_KEY}`);
 
     return object;
   }

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -3,11 +3,11 @@ import bluebird from 'bluebird';
 const { using } = bluebird;
 
 import Redlock from 'redlock';
-import _ from 'lodash';
 import { Cache } from './Cache.js';
 import { RedisClient } from '../utils/RedisClient.js';
 import { logger } from '../logger.js';
 import { config } from '../../config.js';
+import { applyPatch } from './apply-patch.js';
 
 const REDIS_LOCK_PREFIX = 'locks:';
 export const PATCHES_KEY = 'patches';
@@ -28,15 +28,7 @@ class RedisCache extends Cache {
     if (value) {
       const parsed = JSON.parse(value);
       const patches = await this._client.lrange(`${key}:${PATCHES_KEY}`, 0, -1);
-      patches.forEach((patchInJson) => {
-        const patch = JSON.parse(patchInJson);
-        if (patch.operation === 'assign') {
-          _.set(parsed, patch.path, patch.value);
-        } else if (patch.operation === 'push') {
-          const arr = _.get(parsed, patch.path);
-          arr.push(patch.value);
-        }
-      })
+      patches.map((patchJSON) => JSON.parse(patchJSON)).forEach((patch) => applyPatch(parsed, patch));
       return parsed;
     }
 

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -9,6 +9,7 @@ import { logger } from '../logger.js';
 import { config } from '../../config.js';
 
 const REDIS_LOCK_PREFIX = 'locks:';
+const PATCHES_KEY = 'patches';
 
 class RedisCache extends Cache {
   constructor(redis_url) {
@@ -60,6 +61,12 @@ class RedisCache extends Cache {
     await this._client.set(key, objectAsString);
 
     return object;
+  }
+
+  async patch(key, patch) {
+    const patchesKey = `${key}:${PATCHES_KEY}`;
+
+    return this._client.rpush(patchesKey, JSON.stringify(patch));
   }
 
   flushAll() {

--- a/api/lib/infrastructure/caches/apply-patch.js
+++ b/api/lib/infrastructure/caches/apply-patch.js
@@ -1,0 +1,10 @@
+import _ from 'lodash';
+
+export function applyPatch(value, patch) {
+  if (patch.operation === 'assign') {
+    _.set(value, patch.path, patch.value);
+  } else if (patch.operation === 'push') {
+    const arr = _.get(value, patch.path);
+    arr.push(patch.value);
+  }
+}

--- a/api/lib/infrastructure/caches/learning-content-cache.js
+++ b/api/lib/infrastructure/caches/learning-content-cache.js
@@ -1,4 +1,3 @@
-import { Cache } from './Cache.js';
 import { DistributedCache } from './DistributedCache.js';
 import { InMemoryCache } from './InMemoryCache.js';
 import { LayeredCache } from './LayeredCache.js';
@@ -8,18 +7,17 @@ import { config } from '../../config.js';
 const LEARNING_CONTENT_CHANNEL = 'Learning content';
 const LEARNING_CONTENT_CACHE_KEY = 'LearningContent';
 
-class LearningContentCache extends Cache {
+class LearningContentCache {
   constructor() {
-    super();
     if (config.caching.redisUrl) {
-      this.distributedCache = new DistributedCache(
+      const distributedCache = new DistributedCache(
         new InMemoryCache(),
         config.caching.redisUrl,
         LEARNING_CONTENT_CHANNEL,
       );
-      this.redisCache = new RedisCache(config.caching.redisUrl);
+      const redisCache = new RedisCache(config.caching.redisUrl);
 
-      this._underlyingCache = new LayeredCache(this.distributedCache, this.redisCache);
+      this._underlyingCache = new LayeredCache(distributedCache, redisCache);
     } else {
       this._underlyingCache = new InMemoryCache();
     }
@@ -42,6 +40,4 @@ class LearningContentCache extends Cache {
   }
 }
 
-const learningContentCache = new LearningContentCache();
-
-export { learningContentCache };
+export const learningContentCache = new LearningContentCache();

--- a/api/lib/infrastructure/caches/learning-content-cache.js
+++ b/api/lib/infrastructure/caches/learning-content-cache.js
@@ -31,6 +31,10 @@ class LearningContentCache {
     return this._underlyingCache.set(LEARNING_CONTENT_CACHE_KEY, object);
   }
 
+  patch(patch) {
+    return this._underlyingCache.patch(LEARNING_CONTENT_CACHE_KEY, patch);
+  }
+
   flushAll() {
     return this._underlyingCache.flushAll();
   }

--- a/api/lib/infrastructure/caches/learning-content-cache.js
+++ b/api/lib/infrastructure/caches/learning-content-cache.js
@@ -7,15 +7,11 @@ import { config } from '../../config.js';
 const LEARNING_CONTENT_CHANNEL = 'Learning content';
 const LEARNING_CONTENT_CACHE_KEY = 'LearningContent';
 
-class LearningContentCache {
-  constructor() {
-    if (config.caching.redisUrl) {
-      const distributedCache = new DistributedCache(
-        new InMemoryCache(),
-        config.caching.redisUrl,
-        LEARNING_CONTENT_CHANNEL,
-      );
-      const redisCache = new RedisCache(config.caching.redisUrl);
+export class LearningContentCache {
+  constructor(redisUrl) {
+    if (redisUrl) {
+      const distributedCache = new DistributedCache(new InMemoryCache(), redisUrl, LEARNING_CONTENT_CHANNEL);
+      const redisCache = new RedisCache(redisUrl);
 
       this._underlyingCache = new LayeredCache(distributedCache, redisCache);
     } else {
@@ -42,6 +38,23 @@ class LearningContentCache {
   quit() {
     return this._underlyingCache.quit();
   }
+
+  static _instance = null;
+
+  static defaultInstance() {
+    return new LearningContentCache(config.caching.redisUrl);
+  }
+
+  static get instance() {
+    if (!this._instance) {
+      this._instance = this.defaultInstance();
+    }
+    return this._instance;
+  }
+
+  static set instance(_instance) {
+    this._instance = _instance;
+  }
 }
 
-export const learningContentCache = new LearningContentCache();
+export const learningContentCache = LearningContentCache.instance;

--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { lcms } from '../../lcms.js';
 import { LearningContentResourceNotFound } from './LearningContentResourceNotFound.js';
-import { learningContentCache } from '../../caches/learning-content-cache.js';
+import { LearningContentCache } from '../../caches/learning-content-cache.js';
 
 const _DatasourcePrototype = {
   async get(id) {
@@ -36,7 +36,7 @@ const _DatasourcePrototype = {
 
   async _getLearningContent() {
     const generator = () => lcms.getLatestRelease();
-    const learningContent = await learningContentCache.get(generator);
+    const learningContent = await LearningContentCache.instance.get(generator);
     return learningContent;
   },
 
@@ -44,7 +44,7 @@ const _DatasourcePrototype = {
     const currentLearningContent = await this._getLearningContent();
 
     const patch = this._generatePatch(currentLearningContent, id, newEntry);
-    await learningContentCache.patch(patch);
+    await LearningContentCache.instance.patch(patch);
     return newEntry;
   },
 
@@ -73,7 +73,7 @@ const extend = function (props) {
 
 const refreshLearningContentCacheRecords = async function () {
   const learningContent = await lcms.getLatestRelease();
-  await learningContentCache.set(learningContent);
+  await LearningContentCache.instance.set(learningContent);
   return learningContent;
 };
 

--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -42,14 +42,26 @@ const _DatasourcePrototype = {
 
   async refreshLearningContentCacheRecord(id, newEntry) {
     const currentLearningContent = await this._getLearningContent();
+
+    const patch = this._generatePatch(currentLearningContent, id, newEntry);
+    await learningContentCache.patch(patch);
+    return newEntry;
+  },
+
+  _generatePatch(currentLearningContent, id, newEntry) {
     const index = currentLearningContent[this.modelName].findIndex((element) => element?.id === id);
     if (index === -1) {
-      currentLearningContent[this.modelName].push(newEntry);
-    } else {
-      currentLearningContent[this.modelName][index] = newEntry;
+      return {
+        operation: 'push',
+        path: this.modelName,
+        value: newEntry,
+      };
     }
-    await learningContentCache.set(currentLearningContent);
-    return newEntry;
+    return {
+      operation: 'assign',
+      path: `${this.modelName}[${index}]`,
+      value: newEntry,
+    };
   },
 };
 

--- a/api/lib/infrastructure/datasources/learning-content/index.js
+++ b/api/lib/infrastructure/datasources/learning-content/index.js
@@ -2,6 +2,7 @@ import { areaDatasource } from './area-datasource.js';
 import { challengeDatasource } from './challenge-datasource.js';
 import { competenceDatasource } from './competence-datasource.js';
 import { courseDatasource } from './course-datasource.js';
+import { frameworkDatasource } from './framework-datasource.js';
 import { skillDatasource } from './skill-datasource.js';
 import { tubeDatasource } from './tube-datasource.js';
 import { tutorialDatasource } from './tutorial-datasource.js';
@@ -11,6 +12,7 @@ export {
   challengeDatasource,
   competenceDatasource,
   courseDatasource,
+  frameworkDatasource,
   skillDatasource,
   tubeDatasource,
   tutorialDatasource,

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -28,6 +28,7 @@ class RedisClient {
     this.del = this._wrapWithPrefix(this._client.del).bind(this._client);
     this.expire = this._wrapWithPrefix(this._client.expire).bind(this._client);
     this.lpush = this._wrapWithPrefix(this._client.lpush).bind(this._client);
+    this.rpush = this._wrapWithPrefix(this._client.rpush).bind(this._client);
     this.lrem = this._wrapWithPrefix(this._client.lrem).bind(this._client);
     this.lrange = this._wrapWithPrefix(this._client.lrange).bind(this._client);
     this.ping = this._client.ping.bind(this._client);

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -447,8 +447,8 @@ const configuration = (function () {
     config.logging.enableLogEndingEventDispatch = false;
 
     config.caching.redisUrl = null;
-    config.caching.redisCacheKeyLockTTL = 0;
-    config.caching.redisCacheLockedWaitBeforeRetry = 0;
+    config.caching.redisCacheKeyLockTTL = 100;
+    config.caching.redisCacheLockedWaitBeforeRetry = 1;
 
     config.sentry.enabled = false;
 

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -8,58 +8,58 @@ import {
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
-import { learningContentCache } from '../../../../lib/infrastructure/caches/learning-content-cache.js';
 import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
-import nock from 'nock';
 
 describe('Acceptance | Controller | user-tutorial-controller', function () {
+  const userId = 4444;
   let server;
-
-  const learningContent = {
-    skills: [
-      {
-        id: 'skillId',
-        challenges: [{ id: 'k_challenge_id' }],
-      },
-    ],
-    tutorials: [
-      {
-        id: 'tutorialId',
-        locale: 'en-us',
-        duration: '00:03:31',
-        format: 'vidéo',
-        link: 'http://www.example.com/this-is-an-example.html',
-        source: 'Source Example, Example',
-        title: 'Communiquer',
-      },
-    ],
-  };
 
   beforeEach(async function () {
     server = await createServer();
-    await databaseBuilder.factory.buildUser({
-      id: 4444,
+
+    databaseBuilder.factory.buildUser({
+      id: userId,
       firstName: 'Classic',
       lastName: 'Papa',
       email: 'classic.papa@example.net',
       password: 'abcd1234',
     });
-    await databaseBuilder.commit();
 
-    mockLearningContent(learningContent);
+    await databaseBuilder.commit();
   });
 
   describe('PUT /api/users/tutorials/{tutorialId}', function () {
     let options;
+    const learningContent = {
+      skills: [
+        {
+          id: 'skillId',
+          challenges: [{ id: 'k_challenge_id' }],
+        },
+      ],
+      tutorials: [
+        {
+          id: 'tutorialId',
+          locale: 'en-us',
+          duration: '00:03:31',
+          format: 'vidéo',
+          link: 'http://www.example.com/this-is-an-example.html',
+          source: 'Source Example, Example',
+          title: 'Communiquer',
+        },
+      ],
+    };
 
-    beforeEach(async function () {
+    beforeEach(function () {
       options = {
         method: 'PUT',
         url: '/api/users/tutorials/tutorialId',
         headers: {
-          authorization: generateValidRequestAuthorizationHeader(4444),
+          authorization: generateValidRequestAuthorizationHeader(userId),
         },
       };
+
+      mockLearningContent(learningContent);
     });
 
     afterEach(async function () {
@@ -75,7 +75,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
             id: '1',
             attributes: {
               'tutorial-id': 'tutorialId',
-              'user-id': 4444,
+              'user-id': userId,
             },
           },
         };
@@ -106,7 +106,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               attributes: {
                 'skill-id': 'skillId',
                 'tutorial-id': 'tutorialId',
-                'user-id': 4444,
+                'user-id': userId,
               },
             },
           };
@@ -148,11 +148,8 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
   describe('GET /api/users/{userId}/tutorials', function () {
     let options;
     let learningContentObjects;
-    const userId = 4444;
 
     beforeEach(async function () {
-      nock.cleanAll();
-      learningContentCache.flushAll();
       options = {
         method: 'GET',
         url: `/api/users/${userId}/tutorials?filter[competences]=recCompetence1&filter[type]=saved`,
@@ -291,14 +288,14 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
 
         databaseBuilder.factory.buildUserSavedTutorial({
           id: 101,
-          userId: 4444,
+          userId,
           tutorialId: 'tuto1',
           skillId: 'skill123',
         });
 
         databaseBuilder.factory.buildUserSavedTutorial({
           id: 102,
-          userId: 4444,
+          userId,
           tutorialId: 'tuto6',
           skillId: 'recSkill4',
         });
@@ -457,21 +454,42 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
 
   describe('DELETE /api/users/tutorials/{tutorialId}', function () {
     let options;
+    const learningContent = {
+      skills: [
+        {
+          id: 'skillId',
+          challenges: [{ id: 'k_challenge_id' }],
+        },
+      ],
+      tutorials: [
+        {
+          id: 'tutorialId',
+          locale: 'en-us',
+          duration: '00:03:31',
+          format: 'vidéo',
+          link: 'http://www.example.com/this-is-an-example.html',
+          source: 'Source Example, Example',
+          title: 'Communiquer',
+        },
+      ],
+    };
 
-    beforeEach(async function () {
+    beforeEach(function () {
       options = {
         method: 'DELETE',
         url: '/api/users/tutorials/tutorialId',
         headers: {
-          authorization: generateValidRequestAuthorizationHeader(4444),
+          authorization: generateValidRequestAuthorizationHeader(userId),
         },
       };
+
+      mockLearningContent(learningContent);
     });
 
     describe('nominal case', function () {
       it('should respond with a 204', async function () {
         // given
-        databaseBuilder.factory.buildUserSavedTutorial({ userId: 4444, tutorialId: 'tutorialId' });
+        databaseBuilder.factory.buildUserSavedTutorial({ userId, tutorialId: 'tutorialId' });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -56,19 +56,23 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
     const keyToRemove = randomUUID();
     const redisClient = new RedisClient(config.redis.url);
 
+    await redisClient.lpush(keyToAdd, 'value2');
+
     await redisClient.lpush(keyToRemove, 'value1');
     await redisClient.lpush(keyToRemove, 'value2');
 
     // when
-    const keyToAddLength = await redisClient.lpush(keyToAdd, 'value1');
+    const keyToAddLength1 = await redisClient.lpush(keyToAdd, 'value1');
+    const keyToAddLength2 = await redisClient.rpush(keyToAdd, 'value3');
     const keyToAddList = await redisClient.lrange(keyToAdd, 0, -1);
 
     const valuesRemovedLength = await redisClient.lrem(keyToRemove, 0, 'value1');
     const keyToRemoveList = await redisClient.lrange(keyToRemove, 0, -1);
 
     // then
-    expect(keyToAddLength).to.equal(1);
-    expect(keyToAddList).to.deep.equal(['value1']);
+    expect(keyToAddLength1).to.equal(2);
+    expect(keyToAddLength2).to.equal(3);
+    expect(keyToAddList).to.deep.equal(['value1', 'value2', 'value3']);
 
     expect(valuesRemovedLength).to.equal(1);
     expect(keyToRemoveList).to.deep.equal(['value2']);

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -24,7 +24,7 @@ chai.use(sinonChai);
 import * as customChaiHelpers from './tooling/chai-custom-helpers/index.js';
 
 _.each(customChaiHelpers, chai.use);
-import { learningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
+import { LearningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
 
 import { config } from '../lib/config.js';
 
@@ -61,7 +61,7 @@ import { increaseCurrentTestTimeout } from './tooling/mocha-tools.js';
 /* eslint-disable mocha/no-top-level-hooks */
 afterEach(function () {
   restore();
-  learningContentCache.flushAll();
+  LearningContentCache.instance.flushAll();
   nock.cleanAll();
   return databaseBuilder.clean();
 });

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -30,7 +30,7 @@ describe('Unit | Controller | cache-controller', function () {
       expect(
         learningContentDatasources.challengeDatasource.refreshLearningContentCacheRecord,
       ).to.have.been.calledWithExactly('recId', { property: 'updatedValue' });
-      expect(response).to.be.null;
+      expect(response.statusCode).to.equal(204);
     });
 
     it('should reply with null when the cache key does not exist', async function () {
@@ -44,7 +44,7 @@ describe('Unit | Controller | cache-controller', function () {
       expect(
         learningContentDatasources.challengeDatasource.refreshLearningContentCacheRecord,
       ).to.have.been.calledWithExactly('recId', { property: 'updatedValue' });
-      expect(response).to.be.null;
+      expect(response.statusCode).to.equal(204);
     });
   });
 

--- a/api/tests/unit/infrastructure/caches/Cache_test.js
+++ b/api/tests/unit/infrastructure/caches/Cache_test.js
@@ -26,6 +26,16 @@ describe('Unit | Infrastructure | Caches | Cache', function () {
     });
   });
 
+  describe('#patch', function () {
+    it('should reject an error (because this class actually mocks an interface)', function () {
+      // when
+      const result = cacheInstance.patch('some-key', {});
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
   describe('#flushAll', function () {
     it('should reject an error (because this class actually mocks an interface)', function () {
       // when

--- a/api/tests/unit/infrastructure/caches/DistributedCache_test.js
+++ b/api/tests/unit/infrastructure/caches/DistributedCache_test.js
@@ -10,6 +10,7 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
     underlyingCache = {
       get: sinon.stub(),
       set: sinon.stub(),
+      patch: sinon.stub(),
       flushAll: sinon.stub(),
     };
     const redisUrl = 'redis://url.example.net';
@@ -33,7 +34,7 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
   });
 
   describe('#set', function () {
-    it('should resovle the underlying cache result for set() method', async function () {
+    it('should resolve the underlying cache result for set() method', async function () {
       // given
       const cacheKey = 'cache-key';
       const objectToCache = { foo: 'bar' };
@@ -44,6 +45,38 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
 
       // then
       expect(result).to.deep.equal(objectToCache);
+    });
+  });
+
+  describe('#patch', function () {
+    it('should publish the patch on the redis channel', async function () {
+      // given
+      distributedCacheInstance._redisClientPublisher = {
+        publish: sinon.stub(),
+      };
+      const cacheKey = 'cache-key';
+      const patch = {
+        operation: 'assign',
+        path: 'challenges[0]',
+        value: { id: 'recChallenge1', instruction: 'Nouvelle consigne' },
+      };
+
+      const message = {
+        patch,
+        cacheKey,
+        type: 'patch',
+      };
+      const messageAsString = JSON.stringify(message);
+      distributedCacheInstance._redisClientPublisher.publish.withArgs(channel, messageAsString).resolves(true);
+
+      // when
+      await distributedCacheInstance.patch(cacheKey, patch);
+
+      // then
+      expect(distributedCacheInstance._redisClientPublisher.publish).to.have.been.calledOnceWith(
+        channel,
+        messageAsString,
+      );
     });
   });
 
@@ -60,6 +93,40 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
 
       // then
       expect(result).to.be.true;
+    });
+  });
+
+  describe('receive message', function () {
+    it('should flushAll when flush message is received', async function () {
+      // when
+      await distributedCacheInstance.clientSubscriberCallback('Flush all');
+
+      // then
+      expect(distributedCacheInstance._underlyingCache.flushAll).to.have.been.calledOnce;
+    });
+
+    it('should patch when patch message is received', async function () {
+      // given
+      const cacheKey = 'cache-key';
+      const patch = {
+        operation: 'assign',
+        path: 'challenges[0]',
+        value: { id: 'recChallenge1', instruction: 'Nouvelle consigne' },
+      };
+
+      const message = {
+        patch,
+        cacheKey,
+        type: 'patch',
+      };
+      const messageAsString = JSON.stringify(message);
+
+      // when
+      await distributedCacheInstance.clientSubscriberCallback(messageAsString);
+
+      // then
+      expect(distributedCacheInstance._underlyingCache.flushAll).not.to.have.been.called;
+      expect(distributedCacheInstance._underlyingCache.patch).to.have.been.called;
     });
   });
 });

--- a/api/tests/unit/infrastructure/caches/DistributedCache_test.js
+++ b/api/tests/unit/infrastructure/caches/DistributedCache_test.js
@@ -86,7 +86,10 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
       distributedCacheInstance._redisClientPublisher = {
         publish: sinon.stub(),
       };
-      distributedCacheInstance._redisClientPublisher.publish.withArgs(channel, 'Flush all').resolves(true);
+      const message = {
+        type: 'flushAll',
+      };
+      distributedCacheInstance._redisClientPublisher.publish.withArgs(channel, JSON.stringify(message)).resolves(true);
 
       // when
       const result = await distributedCacheInstance.flushAll();
@@ -98,8 +101,12 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
 
   describe('receive message', function () {
     it('should flushAll when flush message is received', async function () {
+      // given
+      const message = {
+        type: 'flushAll',
+      };
       // when
-      await distributedCacheInstance.clientSubscriberCallback('Flush all');
+      await distributedCacheInstance.clientSubscriberCallback('channel', JSON.stringify(message));
 
       // then
       expect(distributedCacheInstance._underlyingCache.flushAll).to.have.been.calledOnce;
@@ -115,18 +122,18 @@ describe('Unit | Infrastructure | Caches | DistributedCache', function () {
       };
 
       const message = {
+        type: 'patch',
         patch,
         cacheKey,
-        type: 'patch',
       };
       const messageAsString = JSON.stringify(message);
 
       // when
-      await distributedCacheInstance.clientSubscriberCallback(messageAsString);
+      await distributedCacheInstance.clientSubscriberCallback('channel', messageAsString);
 
       // then
       expect(distributedCacheInstance._underlyingCache.flushAll).not.to.have.been.called;
-      expect(distributedCacheInstance._underlyingCache.patch).to.have.been.called;
+      expect(distributedCacheInstance._underlyingCache.patch).to.have.been.calledWith(cacheKey, patch);
     });
   });
 });

--- a/api/tests/unit/infrastructure/caches/InMemoryCache_test.js
+++ b/api/tests/unit/infrastructure/caches/InMemoryCache_test.js
@@ -118,6 +118,53 @@ describe('Unit | Infrastructure | Cache | in-memory-cache', function () {
     });
   });
 
+  describe('#patch', function () {
+    let getStub;
+
+    beforeEach(function () {
+      getStub = sinon.stub(inMemoryCache._cache, 'get');
+    });
+
+    it('should patch the value assigning to a path', async function () {
+      // given
+      const objectToCache = {
+        challenges: [{ id: 'recChallenge1', instruction: 'Ancienne consigne' }],
+      };
+      getStub.withArgs(CACHE_KEY).returns(objectToCache);
+      const patch = {
+        operation: 'assign',
+        path: 'challenges[0]',
+        value: { id: 'recChallenge1', instruction: 'Nouvelle consigne' },
+      };
+
+      // when
+      await inMemoryCache.patch(CACHE_KEY, patch);
+
+      // then
+      expect(objectToCache).to.deep.equal({
+        challenges: [{ id: 'recChallenge1', instruction: 'Nouvelle consigne' }],
+      });
+    });
+
+    describe('when value is not in the cache', function () {
+      it('should do nothing', async function () {
+        // given
+        getStub.withArgs(CACHE_KEY).returns(undefined);
+        const patch = {
+          operation: 'push',
+          path: 'challenges',
+          value: { id: 'recChallenge1', instruction: 'Nouvelle consigne' },
+        };
+
+        // when
+        await inMemoryCache.patch(CACHE_KEY, patch);
+
+        // then
+        expect(getStub).to.have.been.calledOnceWithExactly(CACHE_KEY);
+      });
+    });
+  });
+
   describe('#flushAll', function () {
     it('should resolve', async function () {
       // given

--- a/api/tests/unit/infrastructure/caches/LayeredCache_test.js
+++ b/api/tests/unit/infrastructure/caches/LayeredCache_test.js
@@ -8,11 +8,13 @@ describe('Unit | Infrastructure | Caches | LayeredCache', function () {
     layeredCacheInstance._firstLevelCache = {
       get: sinon.stub(),
       set: sinon.stub(),
+      patch: sinon.stub(),
       flushAll: sinon.stub(),
     };
     layeredCacheInstance._secondLevelCache = {
       get: sinon.stub(),
       set: sinon.stub(),
+      patch: sinon.stub(),
       flushAll: sinon.stub(),
     };
   });
@@ -67,6 +69,26 @@ describe('Unit | Infrastructure | Caches | LayeredCache', function () {
       // then
       expect(layeredCacheInstance._firstLevelCache.flushAll).to.have.been.calledOnce;
       expect(layeredCacheInstance._secondLevelCache.flushAll).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#patch', function () {
+    const cacheKey = 'learning-content';
+
+    it('should apply patch in first and second level cache', async function () {
+      // given
+      const patch = {
+        operation: 'assign',
+        path: 'challenges[0]',
+        value: { id: 'recChallenge1', instruction: 'Nouvelle consigne' },
+      };
+
+      // when
+      await layeredCacheInstance.patch(cacheKey, patch);
+
+      // then
+      expect(layeredCacheInstance._firstLevelCache.patch).to.have.been.calledWith(cacheKey, patch);
+      expect(layeredCacheInstance._secondLevelCache.patch).to.have.been.calledWith(cacheKey, patch);
     });
   });
 });

--- a/api/tests/unit/infrastructure/caches/RedisCache_test.js
+++ b/api/tests/unit/infrastructure/caches/RedisCache_test.js
@@ -190,6 +190,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
 
     beforeEach(function () {
       stubbedClient.set = sinon.stub();
+      stubbedClient.del = sinon.stub();
     });
 
     it('should resolve with the object to cache', function () {
@@ -215,6 +216,20 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
 
       // then
       return expect(promise).to.have.been.rejectedWith(REDIS_CLIENT_ERROR);
+    });
+
+    it('should empty patches key', async function () {
+      // given
+      stubbedClient.set.resolves();
+      stubbedClient.del.resolves();
+
+      // when
+      const promise = redisCache.set(CACHE_KEY, objectToCache);
+
+      // then
+      return expect(promise).to.have.been.fulfilled.then(() => {
+        expect(stubbedClient.del).to.have.been.calledWithExactly(`${CACHE_KEY}:patches`);
+      });
     });
   });
 

--- a/api/tests/unit/infrastructure/caches/RedisCache_test.js
+++ b/api/tests/unit/infrastructure/caches/RedisCache_test.js
@@ -205,4 +205,26 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
       return expect(promise).to.have.been.rejectedWith(REDIS_CLIENT_ERROR);
     });
   });
+
+  describe('#patch', function () {
+    beforeEach(function () {
+      stubbedClient.rpush = sinon.stub();
+    });
+
+    it('should push patch in a separate patches key', async function () {
+      // given
+      const patch = {
+        operation: 'assign',
+        path: 'challenges[0]',
+        value: { id: 'recChallenge1', instruction: 'Consigne' },
+      };
+      const expectedPatchAsString = JSON.stringify(patch);
+
+      // when
+      await redisCache.patch(CACHE_KEY, patch);
+
+      // then
+      expect(stubbedClient.rpush).to.have.been.calledOnceWith(CACHE_KEY + ':patches', expectedPatchAsString);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/caches/RedisCache_test.js
+++ b/api/tests/unit/infrastructure/caches/RedisCache_test.js
@@ -24,7 +24,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
   describe('#get', function () {
     beforeEach(function () {
       stubbedClient.get = sinon.stub();
-      stubbedClient.lrange = sinon.stub();
+      stubbedClient.lrange = sinon.stub().resolves([]);
       redisCache.set = sinon.stub();
     });
 

--- a/api/tests/unit/infrastructure/caches/learning-content-cache_test.js
+++ b/api/tests/unit/infrastructure/caches/learning-content-cache_test.js
@@ -1,0 +1,76 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { learningContentCache } from '../../../../lib/infrastructure/caches/learning-content-cache.js';
+
+describe('Unit | Infrastructure | Caches | LearningContentCache', function () {
+  let originalUnderlyingCache;
+
+  beforeEach(function () {
+    originalUnderlyingCache = learningContentCache._underlyingCache;
+
+    learningContentCache._underlyingCache = {
+      get: sinon.stub(),
+      set: sinon.stub(),
+      flushAll: sinon.stub(),
+      quit: sinon.stub(),
+    };
+  });
+
+  afterEach(function () {
+    learningContentCache._underlyingCache = originalUnderlyingCache;
+  });
+
+  describe('#get', function () {
+    it('should get learning content from underlying cache', async function () {
+      // given
+      const generator = Symbol('generator');
+      const learningContent = Symbol('LearningContent');
+      learningContentCache._underlyingCache.get.withArgs('LearningContent', generator).resolves(learningContent);
+
+      // when
+      const result = await learningContentCache.get(generator);
+
+      // then
+      expect(result).to.equal(learningContent);
+    });
+  });
+
+  describe('#set', function () {
+    it('should set learning content in underlying cache', async function () {
+      // given
+      const learningContent = Symbol('LearningContent');
+      learningContentCache._underlyingCache.set.resolves();
+
+      // when
+      await learningContentCache.set(learningContent);
+
+      // then
+      expect(learningContentCache._underlyingCache.set).to.have.been.calledWith('LearningContent', learningContent);
+    });
+  });
+
+  describe('#flushAll', function () {
+    it('should flush all the underlying cache', async function () {
+      // given
+      learningContentCache._underlyingCache.flushAll.resolves();
+
+      // when
+      await learningContentCache.flushAll();
+
+      // then
+      expect(learningContentCache._underlyingCache.flushAll).to.have.been.calledWith();
+    });
+  });
+
+  describe('#quit', function () {
+    it('should quit the underlying cache', async function () {
+      // given
+      learningContentCache._underlyingCache.quit.resolves();
+
+      // when
+      await learningContentCache.quit();
+
+      // then
+      expect(learningContentCache._underlyingCache.quit).to.have.been.calledWith();
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/caches/learning-content-cache_test.js
+++ b/api/tests/unit/infrastructure/caches/learning-content-cache_test.js
@@ -10,6 +10,7 @@ describe('Unit | Infrastructure | Caches | LearningContentCache', function () {
     learningContentCache._underlyingCache = {
       get: sinon.stub(),
       set: sinon.stub(),
+      patch: sinon.stub(),
       flushAll: sinon.stub(),
       quit: sinon.stub(),
     };
@@ -45,6 +46,20 @@ describe('Unit | Infrastructure | Caches | LearningContentCache', function () {
 
       // then
       expect(learningContentCache._underlyingCache.set).to.have.been.calledWith('LearningContent', learningContent);
+    });
+  });
+
+  describe('#patch', function () {
+    it('should patch the learning content in underlying cache', async function () {
+      // given
+      learningContentCache._underlyingCache.patch.resolves();
+      const patch = { operation: 'assign', path: 'a', value: {} };
+
+      // when
+      await learningContentCache.patch(patch);
+
+      // then
+      expect(learningContentCache._underlyingCache.patch).to.have.been.calledWith('LearningContent', patch);
     });
   });
 

--- a/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -217,7 +217,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
           learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
         };
         learningContentCache.get.resolves(learningContent);
-        sinon.stub(learningContentCache, 'set').callsFake((value) => value);
+        sinon.stub(learningContentCache, 'patch').resolves();
 
         // when
         const entry = await someDatasource.refreshLearningContentCacheRecord('rec1', record);
@@ -227,11 +227,10 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
           id: 'rec1',
           property: 'updatedValue',
         });
-        expect(learningContentCache.set).to.have.been.calledOnce;
-        const argument = learningContentCache.set.firstCall.args[0];
-        expect(argument).to.deep.equal({
-          learningContentModel: [null, { id: 'rec1', property: 'updatedValue' }, { id: 'rec2', property: 'value2' }],
-          learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
+        expect(learningContentCache.patch).to.have.been.calledWith({
+          operation: 'assign',
+          path: 'learningContentModel[1]',
+          value: record,
         });
       });
     });
@@ -245,7 +244,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
           learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
         };
         learningContentCache.get.resolves(learningContent);
-        sinon.stub(learningContentCache, 'set').callsFake((value) => value);
+        sinon.stub(learningContentCache, 'patch').resolves();
 
         // when
         const entry = await someDatasource.refreshLearningContentCacheRecord('rec4', record);
@@ -255,16 +254,10 @@ describe('Unit | Infrastructure | Datasource | Learning Content | datasource', f
           id: 'rec4',
           property: 'newValue',
         });
-        expect(learningContentCache.set).to.have.been.calledOnce;
-        const argument = learningContentCache.set.firstCall.args[0];
-        expect(argument).to.deep.equal({
-          learningContentModel: [
-            null,
-            { id: 'rec1', property: 'value1' },
-            { id: 'rec2', property: 'value2' },
-            { id: 'rec4', property: 'newValue' },
-          ],
-          learningContentOtherModel: [{ id: 'rec3', property: 'value3' }],
+        expect(learningContentCache.patch).to.have.been.calledWith({
+          operation: 'push',
+          path: 'learningContentModel',
+          value: record,
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

La taille de la release LCMS augmente constamment et a subi une brusque augmentation dernièrement en raison de la présence en double des champs traduisibles des épreuves.

Actuellement le système de patch du cache LCMS fonctionne comme suit :

1. Lecture de l’intégralité du contenu depuis le cache
  a. Lecture dans le 1er niveau ou à défaut
  b. Lecture dans le 2ème niveau ou à défaut
  c. Appel de l’API LCMS
2. Remplacement de l’entité à patcher dans le contenu
3. Écriture de l’intégralité du contenu dans le cache
  a. Écriture dans le 2ème niveau
  b. Flush distribué du 1er niveau
4. Le 1er niveau est rafraichi avec le 2ème niveau sur les différentes instances

L’ensemble de ce processus est couteux en consommation de mémoire et, suite à l’augmentation de la taille de la release fait planter l’environnement de recette.

## :robot: Proposition

Modifier le fonctionnement du système de patch du cache comme suit :

1. Lecture de l’intégralité du contenu depuis le cache
2. Écriture du patch à appliquer dans le 2ème niveau dans une clé à part
3. Distribution du patch à appliquer sur le pub/sub
4. Application du patch sur le 1er niveau (qui est mutable) sur les différentes instances

Modifier le fonctionnement de lecture dans le cache de 2ème niveau :

1. Lire la release non patchée et les patchs à appliquer dans le 2ème niveau
2. Appliquer tous les patchs sur la release non patchée
3. Écrire la release patchée dans le 1er niveau, puis la renvoyer

Modifier le fonctionnement du rafraichissement global du cache :

 - Il faut maintenant supprimer tous les patchs présents dans le 2ème niveau avant de faire un flush all distribué

## :rainbow: Remarques

N/A

## :100: Pour tester

En recette, faire à plusieurs des modifs de challenge, ou des nouveaux challenges et demander le refresh et vérifier que rien ne pète et que les modifs sont bien pris en compte.
