### PR TITLE
[FEATURE] Ajout de la fréquence de mise à jour du statut de la certificabilité (PIX-9512)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1038,7 +1038,7 @@
             "not-available": "Unavailable",
             "tooltip": {
               "aria-label": "How to know if a student is eligible for certification and what does it mean?",
-              "content": "To be eligible for certification, the student must have achieved level 1 in at least 5 different competences. This status is updated both automatically and during profile collection campaigns."
+              "content": "To be eligible for certification, the student must have achieved level 1 in at least 5 different competences. This status is updated both automatically (every 24 hours) and during profile collection campaigns."
             }
           },
           "last-name": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1041,7 +1041,7 @@
             "not-available": "Non communiqué",
             "tooltip": {
               "aria-label": "Explication sur la certificabilité",
-              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. Ce statut est mis à jour automatiquement et lors des campagnes de collectes de profils."
+              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. Ce statut est mis à jour automatiquement (toutes les 24h) et lors des campagnes de collectes de profils."
             }
           },
           "last-name": {


### PR DESCRIPTION
## :unicorn: Problème
On a supprimé la date affichée dans la colonne statut de certificabilité. 
Nous souhaitons que le prescripteur puisse connaitre la fréquence de MAJ du statut de certificabilité pour qu’il soit conscient que l’info n’est pas mise à jour en temps réel.

## :robot: Proposition
Ajout de la fréquence dans la tooltip existante.

## :rainbow: Remarques
Wording : 

- FR : “La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. Ce statut est mis à jour automatiquement (toutes les 24h) et lors des campagnes de collectes de profils.”
- EN : “To be eligible for certification, the student must have achieved level 1 in at least 5 different competences. This status is updated both automatically (every 24 hours) and during profile collection campaigns.”
 
⚠️ WARNING ⚠️ : Ce ticket peut être mergé des maintenant car il va aller dans la branche parente, qui elle, est en attente du fix CRON 

## :100: Pour tester

- Se connecter à Pix Orga avec une organisation ayant la feature de remontée auto de la certif activée
- Vérifier que le texte de la tooltip est conforme au nouveau wording
- Vérifier que pour les orga n'ayant pas cette feature activée le texte n'est pas modifié

