### PR TITLE
[FEATURE][CERTIF] Permettre l'envoi d'invitation par un admin (PIX-8562)

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -13,6 +13,7 @@ import lodash from 'lodash';
 import * as csvHelpers from './csvHelpers.js';
 import * as csvSerializer from '../../infrastructure/serializers/csv/csv-serializer.js';
 import { getHeaders } from '../../infrastructure/files/sessions-import.js';
+import { extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
 
 const { map } = lodash;
 
@@ -229,23 +230,34 @@ const createSessionsForMassImport = async function (request, h) {
   return h.response().code(201);
 };
 
+const sendInvitations = async function (request, h) {
+  const certificationCenterId = request.params.certificationCenterId;
+  const emails = request.payload.data.attributes.emails;
+  const locale = extractLocaleFromRequest(request);
+
+  await usecases.createOrUpdateCertificationCenterInvitation({ certificationCenterId, emails, locale });
+
+  return h.response().code(204);
+};
+
 const certificationCenterController = {
   create,
-  update,
-  getCertificationCenterDetails,
+  createCertificationCenterMembershipByEmail,
+  createSessionsForMassImport,
+  findCertificationCenterMemberships,
+  findCertificationCenterMembershipsByCertificationCenter,
   findPaginatedFilteredCertificationCenters,
   findPaginatedSessionSummaries,
-  getStudents,
-  getDivisions,
-  findCertificationCenterMembershipsByCertificationCenter,
-  findCertificationCenterMemberships,
-  createCertificationCenterMembershipByEmail,
   findPendingInvitations,
-  updateReferer,
-  sendInvitationForAdmin,
+  getCertificationCenterDetails,
+  getDivisions,
   getSessionsImportTemplate,
+  getStudents,
+  sendInvitationForAdmin,
+  sendInvitations,
+  update,
+  updateReferer,
   validateSessionsForMassImport,
-  createSessionsForMassImport,
 };
 
 export { certificationCenterController };

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -333,6 +333,36 @@ const register = async function (server) {
         tags: ['api', 'certification-center', 'invitations'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/certification-centers/{certificationCenterId}/invitations',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenter,
+            assign: 'isAdminOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                emails: Joi.array().items(Joi.string().email()).required(),
+              },
+            },
+          }),
+        },
+        handler: certificationCenterController.sendInvitations,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant que responsables à un centre de certification**\n' +
+            "- Elle permet d'inviter des personnes, déjà utilisateurs de Pix ou non, à être membre d'un centre de certification via leur **email**",
+        ],
+        tags: ['api', 'certification-center', 'invitations'],
+      },
+    },
 
     {
       method: 'GET',

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -416,18 +416,21 @@ class DeprecatedCertificationIssueReportSubcategoryError extends DomainError {
 class SendingEmailError extends DomainError {
   constructor() {
     super("Échec lors de l'envoi de l'email.");
+    this.code = 'SENDING_EMAIL_FAILED';
   }
 }
 
 class SendingEmailToInvalidDomainError extends DomainError {
   constructor(emailAddress) {
     super(`Failed to send email to ${emailAddress} because domain seems to be invalid.`);
+    this.code = 'INVALID_EMAIL_DOMAIN';
   }
 }
 
 class SendingEmailToInvalidEmailAddressError extends DomainError {
   constructor(emailAddress, errorMessage) {
     super(`Failed to send email to ${emailAddress} because email address seems to be invalid.`);
+    this.code = 'INVALID_EMAIL_ADDRESS_FORMAT';
     this.meta = {
       emailAddress,
       errorMessage,

--- a/api/lib/domain/services/certification-center-invitation-service.js
+++ b/api/lib/domain/services/certification-center-invitation-service.js
@@ -1,0 +1,55 @@
+import * as maillingService from './mail-service.js';
+import { CertificationCenterInvitation } from '../models/index.js';
+import {
+  SendingEmailError,
+  SendingEmailToInvalidDomainError,
+  SendingEmailToInvalidEmailAddressError,
+} from '../errors.js';
+
+const createOrUpdateCertificationCenterInvitation = function ({
+  certificationCenterInvitationRepository,
+  mailService = maillingService,
+}) {
+  return async function ({ certificationCenter, email, locale }) {
+    let certificationCenterInvitation =
+      await certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId({
+        certificationCenterId: certificationCenter.id,
+        email,
+      });
+
+    if (!certificationCenterInvitation) {
+      const certificationCenterInvitationToCreate = CertificationCenterInvitation.create({
+        certificationCenterId: certificationCenter.id,
+        email,
+      });
+
+      certificationCenterInvitation = await certificationCenterInvitationRepository.create(
+        certificationCenterInvitationToCreate,
+      );
+    }
+
+    const mailerResponse = await mailService.sendCertificationCenterInvitationEmail({
+      certificationCenterInvitationId: certificationCenterInvitation.id,
+      certificationCenterName: certificationCenter.name,
+      code: certificationCenterInvitation.code,
+      email,
+      locale,
+    });
+
+    if (mailerResponse.status !== 'SUCCESS') {
+      if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+        throw new SendingEmailToInvalidDomainError(email);
+      }
+
+      if (mailerResponse.hasFailedBecauseEmailWasInvalid()) {
+        throw new SendingEmailToInvalidEmailAddressError(email, mailerResponse.errorMessage);
+      }
+
+      throw new SendingEmailError();
+    }
+
+    await certificationCenterInvitationRepository.updateModificationDate(certificationCenterInvitation.id);
+  };
+};
+
+export { createOrUpdateCertificationCenterInvitation };

--- a/api/lib/domain/usecases/create-or-update-certification-center-invitation.js
+++ b/api/lib/domain/usecases/create-or-update-certification-center-invitation.js
@@ -1,0 +1,27 @@
+import bluebird from 'bluebird';
+
+const createOrUpdateCertificationCenterInvitation = async function ({
+  certificationCenterId,
+  emails,
+  locale,
+  certificationCenterRepository,
+  certificationCenterInvitationRepository,
+  certificationCenterInvitationService,
+}) {
+  const certificationCenter = await certificationCenterRepository.get(certificationCenterId);
+
+  const uniqueEmails = [...new Set(emails)];
+  const trimmedUniqueEmails = uniqueEmails.map((email) => email.replace(/ /g, ''));
+
+  return bluebird.mapSeries(trimmedUniqueEmails, (email) =>
+    certificationCenterInvitationService.createOrUpdateCertificationCenterInvitation({
+      certificationCenterInvitationRepository,
+    })({
+      certificationCenter,
+      email,
+      locale,
+    }),
+  );
+};
+
+export { createOrUpdateCertificationCenterInvitation };

--- a/api/lib/domain/usecases/create-or-update-certification-center-invitation.js
+++ b/api/lib/domain/usecases/create-or-update-certification-center-invitation.js
@@ -11,7 +11,7 @@ const createOrUpdateCertificationCenterInvitation = async function ({
   const certificationCenter = await certificationCenterRepository.get(certificationCenterId);
 
   const uniqueEmails = [...new Set(emails)];
-  const trimmedUniqueEmails = uniqueEmails.map((email) => email.replace(/ /g, ''));
+  const trimmedUniqueEmails = uniqueEmails.map((email) => email.replace(/[\s\r\n]/g, ''));
 
   return bluebird.mapSeries(trimmedUniqueEmails, (email) =>
     certificationCenterInvitationService.createOrUpdateCertificationCenterInvitation({

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -55,6 +55,7 @@ import * as certificationCandidateRepository from '../../infrastructure/reposito
 import * as certificationCandidatesOdsService from '../../domain/services/certification-candidates-ods-service.js';
 import * as certificationCenterForAdminRepository from '../../infrastructure/repositories/certification-center-for-admin-repository.js';
 import * as certificationCenterInvitationRepository from '../../infrastructure/repositories/certification-center-invitation-repository.js';
+import * as certificationCenterInvitationService from '../../domain/services/certification-center-invitation-service.js';
 import * as certificationCenterInvitedUserRepository from '../../infrastructure/repositories/certification-center-invited-user-repository.js';
 import * as certificationCenterMembershipRepository from '../../infrastructure/repositories/certification-center-membership-repository.js';
 import * as certificationCenterRepository from '../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
@@ -266,6 +267,7 @@ const dependencies = {
   certificationCandidatesOdsService,
   certificationCenterForAdminRepository,
   certificationCenterInvitationRepository,
+  certificationCenterInvitationService,
   certificationCenterInvitedUserRepository,
   certificationCenterMembershipRepository,
   certificationCenterRepository,

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -108,12 +108,19 @@ const markAsCancelled = async function ({ id }) {
   return _toDomain(certificationCenterInvitation);
 };
 
+const updateModificationDate = async function (certificationCenterInvitationId) {
+  await knex(CERTIFICATION_CENTER_INVITATIONS)
+    .where({ id: certificationCenterInvitationId })
+    .update({ updatedAt: new Date() });
+};
+
 export {
-  findPendingByCertificationCenterId,
-  getByIdAndCode,
-  get,
-  findOnePendingByEmailAndCertificationCenterId,
   create,
-  update,
+  findOnePendingByEmailAndCertificationCenterId,
+  findPendingByCertificationCenterId,
+  get,
+  getByIdAndCode,
   markAsCancelled,
+  update,
+  updateModificationDate,
 };

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -672,6 +672,79 @@ describe('Acceptance | API | Certification Center', function () {
     });
   });
 
+  describe('POST /api/certification-centers/{id}/invitations', function () {
+    let certificationCenterId, userId;
+    const CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME = 'certification-center-invitations';
+
+    beforeEach(async function () {
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      userId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex(CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME).delete();
+    });
+
+    context('When user is not admin of the certification center', function () {
+      it('returns an 403 HTTP error code', async function () {
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'MEMBER' });
+
+        await databaseBuilder.commit();
+
+        request = {
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          method: 'POST',
+          url: `/api/certification-centers/${certificationCenterId}/invitations`,
+          payload: {},
+        };
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('When user is admin of the certification center', function () {
+      it('returns 204 HTTP status code', async function () {
+        const emails = ['dev@example.net', 'com@example.net'];
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'ADMIN' });
+
+        await databaseBuilder.commit();
+
+        request = {
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          method: 'POST',
+          url: `/api/certification-centers/${certificationCenterId}/invitations`,
+          payload: {
+            data: {
+              attributes: {
+                emails,
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        const certificationCenterInvitations = await knex(CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME)
+          .where({ certificationCenterId })
+          .whereIn('email', emails);
+        expect(response.statusCode).to.equal(204);
+        expect(certificationCenterInvitations.length).to.equal(2);
+      });
+    });
+  });
+
   describe('POST /api/admin/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
     let certificationCenterId;
     let email;

--- a/api/tests/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
@@ -1,0 +1,31 @@
+import { databaseBuilder, knex, expect, sinon } from '../../../test-helper.js';
+import * as certificationCenterInvitationRepository from '../../../../lib/infrastructure/repositories/certification-center-invitation-repository.js';
+
+describe('Integration | Infrastructure | Repositories | CertificationCenterInvitationRepository', function () {
+  describe('#updateModificationDate', function () {
+    it('updates the certification center invitation modification date', async function () {
+      // given
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: certificationCenter.id,
+        createdAt: new Date('2023-10-10'),
+        updatedAt: new Date('2023-10-10'),
+      });
+
+      await databaseBuilder.commit();
+
+      const now = new Date('2023-10-13');
+      const clock = sinon.useFakeTimers(now);
+
+      // when
+      await certificationCenterInvitationRepository.updateModificationDate(certificationCenterInvitation.id);
+
+      // then
+      const updatedCertificationCenterInvitation = await knex('certification-center-invitations')
+        .where({ id: certificationCenterInvitation.id })
+        .first();
+      expect(updatedCertificationCenterInvitation.updatedAt).to.deep.equal(now);
+      clock.restore();
+    });
+  });
+});

--- a/api/tests/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/unit/domain/services/certification-center-invitation-service_test.js
@@ -1,0 +1,174 @@
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { createOrUpdateCertificationCenterInvitation } from '../../../../lib/domain/services/certification-center-invitation-service.js';
+import { CertificationCenterInvitation, EmailingAttempt } from '../../../../lib/domain/models/index.js';
+import { SendingEmailError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | Domain | Services | CertificationCenterInvitationService', function () {
+  describe('#createOrUpdateCertificationCenterInvitation', function () {
+    let certificationCenterInvitationRepository;
+    let mailService;
+
+    beforeEach(function () {
+      certificationCenterInvitationRepository = {
+        create: sinon.stub(),
+        findOnePendingByEmailAndCertificationCenterId: sinon.stub(),
+        updateModificationDate: sinon.stub(),
+      };
+      mailService = {
+        sendCertificationCenterInvitationEmail: sinon.stub(),
+      };
+    });
+
+    context('success', function () {
+      context('when invitation does not exist for an email', function () {
+        it('creates an invitation, sends an email and updates invitation modification date', async function () {
+          // given
+          const certificationCenter = domainBuilder.buildCertificationCenter({
+            id: 202310130,
+            name: 'Best Certification Center',
+          });
+          const code = 'AZERTY007';
+          const email = 'dick.cionère@example.net';
+          const locale = 'fr-fr';
+
+          const certificationCenterInvitationToCreate = CertificationCenterInvitation.create({
+            certificationCenterId: certificationCenter.id,
+            code,
+            email,
+          });
+          const createdCertificationCenterInvitation = new CertificationCenterInvitation({
+            ...certificationCenterInvitationToCreate,
+            id: 202310131,
+          });
+
+          certificationCenterInvitationRepository.create.resolves(createdCertificationCenterInvitation);
+          certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(null);
+          sinon.stub(CertificationCenterInvitation, 'create').returns(certificationCenterInvitationToCreate);
+          mailService.sendCertificationCenterInvitationEmail.resolves(EmailingAttempt.success(email));
+
+          // when
+          await createOrUpdateCertificationCenterInvitation({
+            certificationCenterInvitationRepository,
+            mailService,
+          })({
+            certificationCenter,
+            email,
+            locale,
+          });
+
+          // then
+          expect(
+            certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId,
+          ).to.have.been.calledWithExactly({
+            certificationCenterId: certificationCenter.id,
+            email,
+          });
+          expect(certificationCenterInvitationRepository.create).to.have.been.calledWithExactly(
+            certificationCenterInvitationToCreate,
+          );
+          expect(mailService.sendCertificationCenterInvitationEmail).to.have.been.calledWithExactly({
+            certificationCenterInvitationId: createdCertificationCenterInvitation.id,
+            certificationCenterName: certificationCenter.name,
+            code,
+            email,
+            locale,
+          });
+          expect(certificationCenterInvitationRepository.updateModificationDate).to.have.been.calledWith(
+            createdCertificationCenterInvitation.id,
+          );
+        });
+      });
+
+      context('when an invitation exist for an email', function () {
+        it('sends an email and updates invitation modification date', async function () {
+          // given
+          const certificationCenter = domainBuilder.buildCertificationCenter({
+            id: 202310130,
+            name: 'Best Certification Center',
+          });
+          const code = 'AZERTY007';
+          const email = 'dick.cionère@example.net';
+          const locale = 'fr-fr';
+          const certificationCenterInvitation = new CertificationCenterInvitation({
+            certificationCenterId: certificationCenter.id,
+            code,
+            createdAt: new Date('2023-10-10'),
+            email,
+            id: 202310131,
+            updatedAt: new Date('2023-10-11'),
+          });
+
+          certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
+            certificationCenterInvitation,
+          );
+          mailService.sendCertificationCenterInvitationEmail.resolves(EmailingAttempt.success(email));
+
+          // when
+          await createOrUpdateCertificationCenterInvitation({
+            certificationCenterInvitationRepository,
+            mailService,
+          })({
+            certificationCenter,
+            email,
+            locale,
+          });
+
+          // then
+          expect(mailService.sendCertificationCenterInvitationEmail).to.have.been.calledWithExactly({
+            certificationCenterInvitationId: certificationCenterInvitation.id,
+            certificationCenterName: certificationCenter.name,
+            code,
+            email,
+            locale,
+          });
+          expect(certificationCenterInvitationRepository.updateModificationDate).to.have.been.calledWith(
+            certificationCenterInvitation.id,
+          );
+        });
+      });
+    });
+
+    context('failure', function () {
+      context('when an error occurs', function () {
+        it('throws an error', async function () {
+          // given
+          const certificationCenter = domainBuilder.buildCertificationCenter({
+            id: 202310130,
+            name: 'Best Certification Center',
+          });
+          const code = 'AZERTY007';
+          const email = 'dick.cionère@example.net';
+          const locale = 'fr-fr';
+          const certificationCenterInvitation = new CertificationCenterInvitation({
+            certificationCenterId: certificationCenter.id,
+            code,
+            createdAt: new Date('2023-10-10'),
+            email,
+            id: 202310131,
+            updatedAt: new Date('2023-10-11'),
+          });
+
+          certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
+            certificationCenterInvitation,
+          );
+          mailService.sendCertificationCenterInvitationEmail.resolves(EmailingAttempt.failure(email));
+
+          // when
+          const error = await catchErr(
+            createOrUpdateCertificationCenterInvitation({
+              certificationCenterInvitationRepository,
+              mailService,
+            }),
+          )({
+            certificationCenter,
+            email,
+            locale,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(SendingEmailError);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/create-or-update-certification-center-invitation_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-certification-center-invitation_test.js
@@ -1,0 +1,90 @@
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import * as usecases from '../../../../lib/domain/usecases/create-or-update-certification-center-invitation.js';
+
+describe('Unit | Domain | UseCases | CreateOrUpdateCertificationCenterInvitation', function () {
+  context('when creating or updating one certification center invitation', function () {
+    it('creates or updates an invitation', async function () {
+      // given
+      const certificationCenterInvitationRepository = {};
+      const certificationCenterId = 1;
+      const emails = ['   naruto@e    xample.net   '];
+      const locale = 'fr-fr';
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        id: 1,
+        name: 'Konoha Certification Center',
+      });
+      const certificationCenterRepository = {
+        get: sinon.stub().resolves(certificationCenter),
+      };
+
+      const createOrUpdateCertificationCenterInvitationInjectorStub = sinon.stub();
+      const createOrUpdateCertificationCenterInvitationStub = sinon.stub();
+      const certificationCenterInvitationService = {
+        createOrUpdateCertificationCenterInvitation: createOrUpdateCertificationCenterInvitationInjectorStub.returns(
+          createOrUpdateCertificationCenterInvitationStub,
+        ),
+      };
+
+      // when
+      await usecases.createOrUpdateCertificationCenterInvitation({
+        certificationCenterInvitationService,
+        certificationCenterRepository,
+        certificationCenterInvitationRepository,
+        certificationCenterId,
+        emails,
+        locale,
+      });
+
+      // then
+      expect(certificationCenterRepository.get).to.have.been.calledWith(certificationCenterId);
+      expect(createOrUpdateCertificationCenterInvitationInjectorStub).to.have.been.calledOnceWithExactly({
+        certificationCenterInvitationRepository,
+      });
+      expect(createOrUpdateCertificationCenterInvitationStub).to.have.been.calledOnceWithExactly({
+        certificationCenter,
+        email: emails[0].replace(/ /g, ''),
+        locale,
+      });
+    });
+  });
+
+  context('when creating or updating multiple certification center invitations', function () {
+    it('creates or updates multiple invitations', async function () {
+      // given
+      const certificationCenterInvitationRepository = {};
+      const certificationCenterId = 1;
+      const emails = ['naruto@example.net', 'jiraya@example.net'];
+      const locale = 'fr-fr';
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        id: 1,
+        name: 'Konoha Certification Center',
+      });
+      const certificationCenterRepository = {
+        get: sinon.stub().resolves(certificationCenter),
+      };
+
+      const createOrUpdateCertificationCenterInvitationInjectorStub = sinon.stub();
+      const createOrUpdateCertificationCenterInvitationStub = sinon.stub();
+      const certificationCenterInvitationService = {
+        createOrUpdateCertificationCenterInvitation: createOrUpdateCertificationCenterInvitationInjectorStub.returns(
+          createOrUpdateCertificationCenterInvitationStub,
+        ),
+      };
+
+      // when
+      await usecases.createOrUpdateCertificationCenterInvitation({
+        certificationCenterInvitationService,
+        certificationCenterRepository,
+        certificationCenterInvitationRepository,
+        certificationCenterId,
+        emails,
+        locale,
+      });
+
+      // then
+      expect(certificationCenterRepository.get).to.have.been.calledWith(certificationCenterId);
+      expect(createOrUpdateCertificationCenterInvitationInjectorStub).to.have.been.callCount(2);
+      expect(createOrUpdateCertificationCenterInvitationStub).to.have.been.callCount(2);
+    });
+  });
+});

--- a/certif/app/adapters/certification-center-invitation.js
+++ b/certif/app/adapters/certification-center-invitation.js
@@ -16,4 +16,18 @@ export default class CertificationCenterInvitationAdapter extends ApplicationAda
     }
     return super.urlForQueryRecord(...arguments);
   }
+
+  sendInvitations({ certificationCenterId, emails }) {
+    const data = {
+      data: {
+        attributes: {
+          emails,
+        },
+      },
+    };
+
+    const url = `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/invitations`;
+
+    return this.ajax(url, 'POST', { data });
+  }
 }

--- a/certif/app/controllers/authenticated/team/invite.js
+++ b/certif/app/controllers/authenticated/team/invite.js
@@ -3,18 +3,40 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class AuthenticatedTeamInviteController extends Controller {
+  @service currentUser;
+  @service intl;
+  @service notifications;
   @service router;
+  @service store;
 
   emails = null;
 
   @action
   async createCertificationCenterInvitation(event) {
     event.preventDefault();
+
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    const emails = this.emails?.replace(/ /g, '').split(',');
+
+    try {
+      await this.store.adapterFor('certification-center-invitation').sendInvitations({ certificationCenterId, emails });
+
+      const message = this.intl.t('pages.team-invite.notifications.success.invitations', {
+        emailsCount: emails.length,
+        email: emails[0],
+      });
+
+      this.notifications.success(message);
+
+      this.router.transitionTo('authenticated.team.list.invitations');
+    } catch (error) {
+      this.notifications.error();
+    }
   }
 
   @action
   updateEmail(event) {
-    this.emails = event.target?.value?.trim();
+    this.emails = event.target?.value;
   }
 
   @action

--- a/certif/app/controllers/authenticated/team/invite.js
+++ b/certif/app/controllers/authenticated/team/invite.js
@@ -5,13 +5,17 @@ import { action } from '@ember/object';
 export default class AuthenticatedTeamInviteController extends Controller {
   @service router;
 
+  emails = null;
+
   @action
   async createCertificationCenterInvitation(event) {
     event.preventDefault();
   }
 
   @action
-  updateEmail() {}
+  updateEmail(event) {
+    this.emails = event.target?.value?.trim();
+  }
 
   @action
   cancel() {

--- a/certif/app/controllers/authenticated/team/invite.js
+++ b/certif/app/controllers/authenticated/team/invite.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import get from 'lodash/get';
 
 import ENV from 'pix-certif/config/environment';
-import get from 'lodash/get';
 
 export default class AuthenticatedTeamInviteController extends Controller {
   @service currentUser;
@@ -12,11 +13,14 @@ export default class AuthenticatedTeamInviteController extends Controller {
   @service router;
   @service store;
 
+  @tracked isLoading = false;
+
   emails = null;
 
   @action
   async createCertificationCenterInvitation(event) {
     event.preventDefault();
+    this.isLoading = true;
 
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
     const emails = this.emails?.replace(/[\s\r\n]/g, '').split(',');
@@ -40,6 +44,8 @@ export default class AuthenticatedTeamInviteController extends Controller {
         console.error(responseError);
         this.notifications.error(this.intl.t('common.form-errors.default'));
       }
+    } finally {
+      this.isLoading = false;
     }
   }
 

--- a/certif/app/controllers/authenticated/team/invite.js
+++ b/certif/app/controllers/authenticated/team/invite.js
@@ -19,7 +19,7 @@ export default class AuthenticatedTeamInviteController extends Controller {
     event.preventDefault();
 
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
-    const emails = this.emails?.replace(/ /g, '').split(',');
+    const emails = this.emails?.replace(/[\s\r\n]/g, '').split(',');
 
     try {
       await this.store.adapterFor('certification-center-invitation').sendInvitations({ certificationCenterId, emails });

--- a/certif/app/controllers/authenticated/team/invite.js
+++ b/certif/app/controllers/authenticated/team/invite.js
@@ -15,6 +15,6 @@ export default class AuthenticatedTeamInviteController extends Controller {
 
   @action
   cancel() {
-    this.router.transitionTo('authenticated.team');
+    this.router.transitionTo('authenticated.team.list.invitations');
   }
 }

--- a/certif/app/controllers/authenticated/team/invite.js
+++ b/certif/app/controllers/authenticated/team/invite.js
@@ -2,6 +2,9 @@ import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 
+import ENV from 'pix-certif/config/environment';
+import get from 'lodash/get';
+
 export default class AuthenticatedTeamInviteController extends Controller {
   @service currentUser;
   @service intl;
@@ -27,10 +30,16 @@ export default class AuthenticatedTeamInviteController extends Controller {
       });
 
       this.notifications.success(message);
-
       this.router.transitionTo('authenticated.team.list.invitations');
-    } catch (error) {
-      this.notifications.error();
+    } catch (responseError) {
+      if (responseError.errors) {
+        const errorMessage = this._handleApiError(responseError);
+        this.notifications.error(errorMessage);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(responseError);
+        this.notifications.error(this.intl.t('common.form-errors.default'));
+      }
     }
   }
 
@@ -42,5 +51,38 @@ export default class AuthenticatedTeamInviteController extends Controller {
   @action
   cancel() {
     this.router.transitionTo('authenticated.team.list.invitations');
+  }
+
+  _handleApiError(responseError) {
+    let errorMessage;
+
+    const errors = get(responseError, 'errors');
+    const error = Array.isArray(errors) && errors.length > 0 && errors[0];
+
+    switch (error.code) {
+      case 'INVALID_EMAIL_DOMAIN':
+        errorMessage = this.intl.t('pages.team-invite.notifications.error.invitations.invalid-email-domain');
+        break;
+      case 'INVALID_EMAIL_ADDRESS_FORMAT':
+        errorMessage = this.intl.t('pages.team-invite.notifications.error.invitations.invalid-email-format');
+        break;
+      case 'SENDING_EMAIL_FAILED': {
+        errorMessage = this.intl.t('pages.team-invite.notifications.error.invitations.mailer-provider-unavailable');
+        break;
+      }
+      default:
+        errorMessage = this.intl.t(this._getI18nKeyByStatus(error.status));
+    }
+
+    return errorMessage;
+  }
+
+  _getI18nKeyByStatus(status) {
+    switch (status) {
+      case '400':
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      default:
+        return ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY;
+    }
   }
 }

--- a/certif/app/templates/authenticated/team/list.hbs
+++ b/certif/app/templates/authenticated/team/list.hbs
@@ -12,7 +12,7 @@
       >{{t "pages.team.update-referer-button"}}</PixButton>
     {{/if}}
     {{#if this.shouldDisplayInviteMemberButton}}
-      <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @route="authenticated.team.invite">{{t
+      <PixButton @isBorderVisible={{true}} @route="authenticated.team.invite">{{t
           "pages.team.invite-button"
         }}</PixButton>
     {{/if}}

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -284,6 +284,23 @@ function routes() {
     return schema.certificationCenterInvitations.where({ certificationCenterId });
   });
 
+  this.post('/certification-centers/:id/invitations', (schema, request) => {
+    const certificationCenterId = request.params.id;
+    const requestBody = JSON.parse(request.requestBody);
+    const emails = requestBody.data.attributes.emails;
+
+    emails.forEach((email) => {
+      schema.certificationCenterInvitations.create({
+        certificationCenterId,
+        email,
+        status: 'PENDING',
+        createdAt: new Date(),
+      });
+    });
+
+    return new Response(204);
+  });
+
   this.get('/certification-center-invitations/:id', (schema, request) => {
     const certificationCenterInvitationId = request.params.id;
     const code = request.queryParams?.code;

--- a/certif/tests/acceptance/routes/authenticated/team/invite_test.js
+++ b/certif/tests/acceptance/routes/authenticated/team/invite_test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { currentURL, visit } from '@ember/test-helpers';
+import { clickByName, fillByLabel } from '@1024pix/ember-testing-library';
+
+import setupIntl from '../../../../helpers/setup-intl';
+import {
+  authenticateSession,
+  createCertificationPointOfContactWithTermsOfServiceAccepted,
+} from '../../../../helpers/test-init';
+
+module('Acceptance | Routes | Team | Invite', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('when user is an admin', function (hooks) {
+    let userWithAdminRole;
+
+    hooks.beforeEach(async function () {
+      userWithAdminRole = createCertificationPointOfContactWithTermsOfServiceAccepted(
+        undefined,
+        'PIX Certification Center',
+        false,
+        'ADMIN',
+      );
+      await authenticateSession(userWithAdminRole.id);
+    });
+
+    test('sends one invitation', async function (assert) {
+      // given
+      const inputLabel = this.intl.t('pages.team-invite.input-label');
+      const inviteButtonLabel = this.intl.t('pages.team-invite.invite-button');
+      const email = 'flavie.eichouette@example.net';
+
+      // when
+      await visit('/equipe/inviter');
+      await fillByLabel(inputLabel, email);
+      await clickByName(inviteButtonLabel);
+
+      // then
+      const expectedEmail = email.replace(/ /g, '');
+      assert.strictEqual(currentURL(), '/equipe/invitations');
+      assert.contains(expectedEmail);
+      assert.contains(
+        this.intl.t('pages.team-invite.notifications.success.invitations', { emailsCount: 1, email: expectedEmail }),
+      );
+    });
+
+    test('sends multiple invitations', async function (assert) {
+      // given
+      const inputLabel = this.intl.t('pages.team-invite.input-label');
+      const inviteButtonLabel = this.intl.t('pages.team-invite.invite-button');
+      const emails = 'flavie.eichouette@example.net,dick.tektiv@example.net';
+
+      // when
+      await visit('/equipe/inviter');
+      await fillByLabel(inputLabel, emails);
+      await clickByName(inviteButtonLabel);
+
+      // then
+      const expectedEmails = emails.replace(/ /g, '').split(',');
+      assert.strictEqual(currentURL(), '/equipe/invitations');
+      assert.contains(expectedEmails[0]);
+      assert.contains(expectedEmails[1]);
+      assert.contains(
+        this.intl.t('pages.team-invite.notifications.success.invitations', { emailsCount: expectedEmails.length }),
+      );
+    });
+  });
+});

--- a/certif/tests/integration/components/team/invite-form_test.js
+++ b/certif/tests/integration/components/team/invite-form_test.js
@@ -1,24 +1,23 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-import { fillByLabel } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Team::InviteForm', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.set('inviteSpy', () => {});
-    this.set('cancelSpy', () => {});
-    this.set('updateEmail', sinon.spy());
+    this.set('inviteStub', sinon.stub());
+    this.set('cancelStub', sinon.stub());
+    this.set('updateEmailStub', sinon.stub());
   });
 
   test('it contains email input and validation button', async function (assert) {
     // when
     await render(
-      hbs`<Team::InviteForm @onSubmit={{this.inviteSpy}} @onCancel={{this.cancelSpy}} @onUpdateEmail={{this.updateEmail}} />`,
+      hbs`<Team::InviteForm @onSubmit={{this.inviteStub}} @onCancel={{this.cancelStub}} @onUpdateEmail={{this.updateEmailStub}} />`,
     );
 
     // then
@@ -33,9 +32,9 @@ module('Integration | Component | Team::InviteForm', function (hooks) {
     await render(
       hbs`<Team::InviteForm
   @email={{this.email}}
-  @onSubmit={{this.inviteSpy}}
-  @onCancel={{this.cancelSpy}}
-  @onUpdateEmail={{this.updateEmail}}
+  @onSubmit={{this.inviteStub}}
+  @onCancel={{this.cancelStub}}
+  @onUpdateEmail={{this.updateEmailStub}}
 />`,
     );
 
@@ -44,6 +43,39 @@ module('Integration | Component | Team::InviteForm', function (hooks) {
     await fillByLabel(inputLabel, 'dev@example.net');
 
     // then
-    assert.ok(this.updateEmail.called);
+    assert.ok(this.updateEmailStub.called);
+  });
+
+  module('when clicking on the "submit" button', function () {
+    test('calls the submit function', async function (assert) {
+      // Given
+      this.set(
+        'inviteStub',
+        sinon.stub().callsFake((event) => event.preventDefault()),
+      );
+      this.set('email', 'dev@example.fr');
+
+      // When
+      await render(
+        hbs`<Team::InviteForm @email={{this.email}} @onSubmit={{this.inviteStub}} @onCancel={{this.cancelStub}} @onUpdateEmail={{this.updateEmailStub}} />`,
+      );
+      await clickByName(this.intl.t('pages.team-invite.invite-button'));
+
+      // Then
+      assert.ok(this.inviteStub.called);
+    });
+  });
+
+  module('when clicking on the "cancel" button', function () {
+    test('calls the cancel function', async function (assert) {
+      // When
+      await render(
+        hbs`<Team::InviteForm @onSubmit={{this.inviteStub}} @onCancel={{this.cancelStub}} @onUpdateEmail={{this.updateEmailStub}} />`,
+      );
+      await clickByName(this.intl.t('common.actions.cancel'));
+
+      // Then
+      assert.ok(this.cancelStub.called);
+    });
   });
 });

--- a/certif/tests/unit/adapters/certification-center-invitation_test.js
+++ b/certif/tests/unit/adapters/certification-center-invitation_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Adapter | certification-center-invitation', function (hooks) {
   setupTest(hooks);
@@ -47,6 +48,39 @@ module('Unit | Adapter | certification-center-invitation', function (hooks) {
         // then
         assert.true(url.endsWith('api'));
       });
+    });
+  });
+
+  module('#sendInvitations', function (hooks) {
+    let adapter;
+
+    hooks.beforeEach(function () {
+      adapter = this.owner.lookup('adapter:certification-center-invitation');
+      sinon.stub(adapter, 'ajax');
+    });
+
+    hooks.afterEach(function () {
+      adapter.ajax.restore();
+    });
+
+    test('sends certification center invitation', async function (assert) {
+      // given
+      const certificationCenterId = 1;
+      const emails = ['naruto@konoha.net, sasuke@konoha.net'];
+      const payload = {
+        data: {
+          attributes: {
+            emails,
+          },
+        },
+      };
+
+      // when
+      await adapter.sendInvitations({ certificationCenterId, emails });
+
+      // then
+      const expectedUrl = 'http://localhost:3000/api/certification-centers/1/invitations';
+      assert.ok(adapter.ajax.calledWith(expectedUrl, 'POST', { data: payload }));
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/invite_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/invite_test.js
@@ -2,8 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+import setupIntl from '../../../helpers/setup-intl';
+
 module('Unit | Controller | authenticated/team/invite', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   let controller;
 
@@ -31,6 +34,71 @@ module('Unit | Controller | authenticated/team/invite', function (hooks) {
 
       // then
       assert.strictEqual(controller.emails, '        dev@example.net   ');
+    });
+  });
+
+  module('#createCertificationCenterInvitation', function () {
+    module('success', function () {
+      test('sends an invitation and displays a success notification', async function (assert) {
+        // given
+        const router = this.owner.lookup('service:router');
+        sinon.stub(router, 'transitionTo');
+        const currentUser = this.owner.lookup('service:current-user');
+        sinon.stub(currentUser, 'currentAllowedCertificationCenterAccess').value({ id: 1 });
+        const certificationCenterId = currentUser.currentAllowedCertificationCenterAccess.id;
+        const event = { preventDefault: sinon.stub() };
+        const store = this.owner.lookup('service:store');
+        const adapter = { sendInvitations: sinon.stub().resolves() };
+        sinon.stub(store, 'adapterFor').returns(adapter);
+
+        controller.notifications = { success: sinon.stub() };
+        controller.emails = 'toto@example.net,sakura@example.net';
+
+        // when
+        await controller.createCertificationCenterInvitation(event);
+
+        // then
+        assert.ok(event.preventDefault.called, 'prevent form default behaviour');
+        assert.ok(
+          store.adapterFor.calledWith('certification-center-invitation'),
+          'get adapter: certification-center-invitation',
+        );
+        const expectedEmailsArray = ['toto@example.net', 'sakura@example.net'];
+        assert.ok(
+          adapter.sendInvitations.calledWith({ certificationCenterId, emails: expectedEmailsArray }),
+          'send invitations',
+        );
+        assert.ok(controller.notifications.success.called, 'display success notification');
+        assert.ok(
+          router.transitionTo.calledWith('authenticated.team.list.invitations'),
+          'redirect user to /equipe/invitations page',
+        );
+      });
+    });
+
+    module('failure', function () {
+      test('display an error notification', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:current-user');
+        sinon.stub(currentUser, 'currentAllowedCertificationCenterAccess').value({ id: 1 });
+
+        const event = {
+          preventDefault: sinon.stub(),
+          target: [{ type: 'textarea', value: 'toto@example.net, sakura@example.net' }],
+        };
+
+        const store = this.owner.lookup('service:store');
+        const adapter = { sendInvitations: sinon.stub().rejects() };
+        sinon.stub(store, 'adapterFor').returns(adapter);
+
+        controller.notifications = { error: sinon.stub() };
+
+        // when
+        await controller.createCertificationCenterInvitation(event);
+
+        // then
+        assert.ok(controller.notifications.error.called, 'display error notification');
+      });
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/invite_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/invite_test.js
@@ -23,4 +23,14 @@ module('Unit | Controller | authenticated/team/invite', function (hooks) {
       assert.ok(controller.router.transitionTo.calledWith('authenticated.team.list.invitations'));
     });
   });
+
+  module('#updateEmail', function () {
+    test('updates controller emails attribute', function (assert) {
+      // when
+      controller.updateEmail({ target: { value: '        dev@example.net   ' } });
+
+      // then
+      assert.strictEqual(controller.emails, '        dev@example.net   ');
+    });
+  });
 });

--- a/certif/tests/unit/controllers/authenticated/team/invite_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/invite_test.js
@@ -12,11 +12,11 @@ module('Unit | Controller | authenticated/team/invite', function (hooks) {
     sinon.stub(controller.router, 'transitionTo');
   });
 
-  test('cancel action transitions to authenticated.team route', async function (assert) {
+  test('cancel action transitions to authenticated.team.list.invitations route', async function (assert) {
     // when
     await controller.send('cancel');
 
     // then
-    assert.ok(controller.router.transitionTo.calledWith('authenticated.team'));
+    assert.ok(controller.router.transitionTo.calledWith('authenticated.team.list.invitations'));
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/invite_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/invite_test.js
@@ -9,14 +9,18 @@ module('Unit | Controller | authenticated/team/invite', function (hooks) {
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:authenticated/team/invite');
-    sinon.stub(controller.router, 'transitionTo');
   });
 
-  test('cancel action transitions to authenticated.team.list.invitations route', async function (assert) {
-    // when
-    await controller.send('cancel');
+  module('#cancel', function () {
+    test('cancel action transitions to authenticated.team.list.invitations route', async function (assert) {
+      // given
+      sinon.stub(controller.router, 'transitionTo');
 
-    // then
-    assert.ok(controller.router.transitionTo.calledWith('authenticated.team.list.invitations'));
+      // when
+      await controller.send('cancel');
+
+      // then
+      assert.ok(controller.router.transitionTo.calledWith('authenticated.team.list.invitations'));
+    });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -894,6 +894,13 @@
       "invite-button": "Invite",
       "invited-members": "By clicking on the link provided in the invitation, the invited members will be able to create an account or log in with an existing Pix account.",
       "notifications": {
+        "error": {
+          "invitations": {
+            "invalid-email-domain": "The domain of one or more e-mail addresses is incorrect.",
+            "invalid-email-format": "The format of one or more e-mail addresses is incorrect.",
+            "mailer-provider-unavailable": "The e-mail service is currently unavailable. Please try again later."
+          }
+        },
         "success": {
           "invitations": "An invitation has been sent to the {emailsCount, plural, one {e-mail address {email}.} other {e-mail addresses listed.}}"
         }

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -893,6 +893,11 @@
       "input-label": "Email address(es)",
       "invite-button": "Invite",
       "invited-members": "By clicking on the link provided in the invitation, the invited members will be able to create an account or log in with an existing Pix account.",
+      "notifications": {
+        "success": {
+          "invitations": "An invitation has been sent to the {emailsCount, plural, one {e-mail address {email}.} other {e-mail addresses listed.}}"
+        }
+      },
       "several-email-requirement": "Invite several members by separating the email addresses with commas."
     },
     "terms-of-service": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -893,6 +893,11 @@
       "input-label": "Adresse(s) e-mail",
       "invite-button": "Inviter",
       "invited-members": "À la réception de l'e-mail, les invités pourront choisir de se créer un compte Pix ou de se connecter avec un compte Pix existant.",
+      "notifications": {
+        "success": {
+          "invitations": "Une invitation a bien été envoyée {emailsCount, plural, one {à l’adresse e-mail {email}.} other {aux adresses e-mails listées.}}"
+        }
+      },
       "several-email-requirement": "Vous pouvez inviter plusieurs membres en séparant les adresses e-mails par des virgules."
     },
     "terms-of-service": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -894,6 +894,13 @@
       "invite-button": "Inviter",
       "invited-members": "À la réception de l'e-mail, les invités pourront choisir de se créer un compte Pix ou de se connecter avec un compte Pix existant.",
       "notifications": {
+        "error": {
+          "invitations": {
+            "invalid-email-domain": "Le domaine d'une ou plusieurs adresses e-mail est incorrect.",
+            "invalid-email-format": "Le format d'une ou plusieurs adresses e-mail est incorrect.",
+            "mailer-provider-unavailable": "Le service d'envoie d'e-mail est actuellement indisponible. Veuillez réessayer ultérieurement."
+          }
+        },
         "success": {
           "invitations": "Une invitation a bien été envoyée {emailsCount, plural, one {à l’adresse e-mail {email}.} other {aux adresses e-mails listées.}}"
         }


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, la page pour inviter une ou plusieurs personnes à rejoindre un centre de certification depuis Pix Certif, n'est pas fonctionnelle. Un admin peut voir cette page mais l'action pour inviter une ou plusieurs personnes n'est pas encore implémentée.

## :robot: Proposition

Permettre à un admin d'un centre de certification de pouvoir inviter une ou plusieurs personnes à accéder à l'application Pix Certif en tant que membre de ce centre.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter à Pix Certif (https://certif-pr7281.review.pix.fr/) avec le compte `james-paledroits@example.net`
- Ouvrir la page `Équipe`
- Cliquer sur le bouton `Inviter un membre`
- Fournir un ou plusieurs adresses e-mail séparées par une virgule
- Cliquer sur le bouton `Inviter`
- Constater
  - l'affichage d'une notification de succès (différente si un ou plusieurs invitations envoyées)
  - la redirection de l'utilisateur sur la page listant les invitations en attentes

### Pour les tests en local, faire ces actions supplémentaires

- S'assurer d'avoir la variable d'environnement `DEBUG=pix:mailer:email` pour l'api
- Récupérer le lien de l'invitation dans le terminal qui affiche les logs de l'api (ex: `pix:mailer:email     redirectionUrl: 'https://certif.pix.org/rejoindre?invitationId=101606&code=XOUZDDOPJ9',`)
- Modifier l'URL en `http://certif.dev.pix.fr/rejoindre?invitationId=101606&code=XOUZDDOPJ9` ou `http://localhost:4203/rejoindre?invitationId=101606&code=XOUZDDOPJ9`
- Constater l'affichage de la double mire (inscription ou connexion à un compte existant)
- S'inscrire ou se connecter avec un compte existant
- Valider les CGUs
- Constater l'affichage du dashboard
- Vérifier en base de données
  - le status de l'invitation est en `accepted`
  - l'ajout d'une entrée en tant que membre du centre de certification

### Erreurs possibles entrainant l'affichage d'une notification d'erreur

- Le domaine de l'adresse e-mail est invalide
- L'adresse e-mail est invalide
- Le service d'envoi d'invitation est indisponible
- Problème dans le code 👨🏾‍💻