### PR TITLE
[FEATURE] Ajoute une nouvelle migration pour rejouer celle de suppression des prescrits sup désactivés (PIX-9651)

### DIFF
--- a/api/db/migrations/20231019125047_rerun-delete-sup-organization-learners-disabled-migration.js
+++ b/api/db/migrations/20231019125047_rerun-delete-sup-organization-learners-disabled-migration.js
@@ -1,0 +1,21 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+
+import { up as deleteSupOrganizationLearnersDisabledMigration } from './20231003140113_delete-sup-organization-learners-disabled.js';
+
+const up = async function (knex) {
+  await deleteSupOrganizationLearnersDisabledMigration(knex);
+};
+
+const down = async function () {
+  // Do nothing, because it's impossible to rollback
+};
+
+export { up, down };

--- a/api/tests/integration/migration/20231003140113_delete-sup-organization-learners-disabled_test.js
+++ b/api/tests/integration/migration/20231003140113_delete-sup-organization-learners-disabled_test.js
@@ -1,7 +1,7 @@
 import { expect, databaseBuilder, knex, sinon } from '../../test-helper.js';
 import { deleteSupOrganizationLearnersDisabled } from '../../../db/migrations/20231003140113_delete-sup-organization-learners-disabled.js';
 
-describe('Integration | Scripts | delete-sup-organization-learners-disabled', function () {
+describe('Integration | Migration | delete-sup-organization-learners-disabled', function () {
   let clock;
   let deletedById;
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons passé en prod trop tôt la migration de cette PR : 

- https://github.com/1024pix/pix/pull/7160

D’ici à ce que l’epix de **suppression etudiants - SUP avec import** soit terminée, on risque d’avoir de nouveaux élèves du SUP disabled au lieu de deleted. 

## :robot: Proposition
Rappeler la migration crée précedemment, afin d'être sur de ne plus avoir d'étudiants désactivés non supprimés 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Supprimer dans la table 'knex_migration' la migration crée dans cette PR
- Ajouter en BDD un learner SUP désactivé
- Lancer un npm run db:migrate
- Vérifier que le learner précedemment crée à bien été supprimé