### PR TITLE
[FEATURE] Indiquer le niveau 1 par défaut pour les badges lors du rattachement d'un profil cible sur Pix Admin (PIX-9701).

### DIFF
--- a/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
@@ -14,6 +14,7 @@
       min="1"
       max="{{@badgeMaxLevel}}"
       {{on "input" (fn @onFieldUpdate @badgeId)}}
+      value="1"
     />
   </td>
   <td>

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -68,8 +68,10 @@ export default class AttachTargetProfileController extends Controller {
     try {
       const complementaryCertification = this.model.complementaryCertification;
 
-      this.store.peekAll('complementary-certification-badge').forEach(function (model) {
-        model.deleteRecord();
+      const complementaryCertificationBadges = this.store.peekAll('complementary-certification-badge').toArray();
+
+      complementaryCertificationBadges.forEach((complementaryCertificationBadge) => {
+        complementaryCertification.complementaryCertificationBadges.removeObject(complementaryCertificationBadge);
       });
 
       this.#targetProfileBadges.forEach((badge, badgeId) => {

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -3,6 +3,8 @@ import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
+const DEFAULT_BADGE_LEVEL = '1';
+
 export default class AttachTargetProfileController extends Controller {
   @service notifications;
   @service router;
@@ -62,9 +64,7 @@ export default class AttachTargetProfileController extends Controller {
   @action
   async onSubmit(event) {
     event.preventDefault();
-
     this.isSubmitting = true;
-
     try {
       const complementaryCertification = this.model.complementaryCertification;
 
@@ -76,7 +76,7 @@ export default class AttachTargetProfileController extends Controller {
         const aBadge = this.store.createRecord('complementary-certification-badge', {
           complementaryCertification,
           badgeId,
-          level: badge.level,
+          level: badge.level ?? DEFAULT_BADGE_LEVEL,
           imageUrl: badge['certificate-image'],
           label: badge['certificate-label'],
           certificateMessage: badge['certificate-message'],

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -448,7 +448,33 @@ function routes() {
     };
   });
 
-  this.put('admin/complementary-certifications/:id/badges', () => {
+  this.put('admin/complementary-certifications/:id/badges', (schema, request) => {
+    const params = JSON.parse(request.requestBody);
+    const {
+      ['badge-id']: badgeId,
+      level,
+      ['image-url']: imageUrl,
+      label,
+    } = params.data.attributes['complementary-certification-badges'][0].data.attributes;
+
+    const complementaryCertification = schema.complementaryCertifications.find(request.params.id);
+    complementaryCertification.update({
+      targetProfilesHistory: [
+        {
+          id: 3,
+          name: 'ALEX TARGET',
+          badges: [
+            {
+              id: badgeId,
+              label,
+              level,
+              imageUrl,
+            },
+          ],
+        },
+      ],
+    });
+
     return new Response(204);
   });
 

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -215,6 +215,62 @@ module(
           assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
         });
       });
+
+      module('when user does not edit the badge level', function () {
+        test('it should save the level to 1 by default', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('complementary-certification', {
+            id: 1,
+            key: 'KEY',
+            hasExternalJury: true,
+            label: 'MARIANNE CERTIF',
+            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+          });
+          server.create('attachable-target-profile', {
+            id: 5,
+            name: 'ALEX TARGET',
+          });
+          const badge = server.create('badge', {
+            id: 200,
+            title: 'Badge Arène Feu',
+          });
+          server.create('target-profile', {
+            id: 5,
+            name: 'ALEX TARGET',
+            badges: [badge],
+          });
+          const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+          const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+          await fillIn(input, '5');
+          await screen.findByRole('listbox');
+          const targetProfileSelectable = screen.getByRole('option', { name: '5 - ALEX TARGET' });
+          await targetProfileSelectable.click();
+          await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' });
+
+          const ariaLabel = '200 Badge Arène Feu';
+          await fillIn(
+            screen.getByRole('textbox', { name: `${ariaLabel} Image svg certificat Pix App` }),
+            'IMAGE1.svg',
+          );
+          await fillIn(screen.getByRole('textbox', { name: `${ariaLabel} Label du certificat` }), 'LABEL');
+          await fillIn(
+            screen.getByRole('textbox', { name: `${ariaLabel} Macaron de l'attestation PDF` }),
+            'MACARON.pdf',
+          );
+          await fillIn(screen.getByRole('textbox', { name: `${ariaLabel} Message du certificat` }), 'MESSAGE');
+          await fillIn(
+            screen.getByRole('textbox', { name: `${ariaLabel} Message temporaire certificat` }),
+            'TEMP MESSAGE',
+          );
+
+          // when
+          await clickByName('Rattacher le profil cible');
+
+          // then
+          assert.dom(screen.getByRole('row', { name: 'LABEL LABEL 1 200' })).exists();
+        });
+      });
     });
 
     module('when admin member has role "CERTIF"', function () {


### PR DESCRIPTION
## :unicorn: Problème
Lors du rattachement du nouveau PC, on rattache également ses RT liés. Pour se faire, l’utilisateur doit compléter un certain nombre d’informations dont le niveau du badge certifié compris entre 1 et le nombre total de RT liés au PC en question.

L'idéal serait de s'éviter de remplir ce champ pour ne pas avoir à l’indiquer pour les certifications complémentaires qui n’ont qu’un seul RT lié.

## :robot: Proposition
Pour simplifier le process, indiquer directement le niveau en 1 pour tous les badges à rattacher

## :rainbow: Remarques
La gestion des erreurs pour cette fonctionnalité n'est pas faite car dépriorisée.
Si vous tentez lors du test de rattacher un profil cible avec deux badges de niveau 1, un message d'erreur global apparaîtra mais l'API retourne bien une erreur lié aux niveaux qui ne peuvent être identiques.

## :100: Pour tester

- Se connecter à Pix Admin
- Aller sur l'onglet Certification complémentaire
- Cliquer sur CléANumérique (ou un autre, comme vous voulez :) )
- Rattacher un profil cible 
- Constater dans le champ du ou des niveaux que le 1 est présent par défaut.
- S'il n'y a qu'un seul badge, complétez les autres champs et validez le rattachement puis constatez que le niveau 1 s'affiche bien sur le tableau.
- S'il y a plusieurs badges, changez un des badges avec un niveau 2 puis validez et constatez que tout est good :)))


