### PR TITLE
[TECH] Ajout d'un "await" manquant lors d'une connexion de type OIDC (PIX-9700)

### DIFF
--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -46,7 +46,8 @@ const authenticateOidcUser = async function ({
     idToken: sessionContent.idToken,
     userId: user.id,
   });
-  userLoginRepository.updateLastLoggedAt({ userId: user.id });
+
+  await userLoginRepository.updateLastLoggedAt({ userId: user.id });
 
   return { pixAccessToken, logoutUrlUUID, isAuthenticationComplete: true };
 };

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -34,7 +34,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
     userRepository = { findByExternalIdentifier: sinon.stub() };
     userLoginRepository = {
-      updateLastLoggedAt: sinon.stub(),
+      updateLastLoggedAt: sinon.stub().resolves(),
     };
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement la mise à jour de la date de dernière connexion de type OIDC se fait de manière asynchrone. Ce processus est différent des autres moyen de connexions. Nous devons harmoniser le processus de mise à jour pour toutes les méthodes de connexion.

## :robot: Proposition

Ajouter le mot clé "await" manquant pour la méthode de connexion OIDC.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter à Pix App avec un SSO (Pole Emploi, CNAV, FWB, ...)
- Finaliser le processus d'inscription ou de réconciliation
- Vérifier en base de données que la date de dernière connexion pour cet utilisateur a été mise à jour
- Retenter la connexion plusieurs fois pour s'assurer que cette date est bien mise à jour
