### PR TITLE
[TECH] Mettre la release dans le cache de premier niveau avant de démarrer le serveur.

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,10 +11,12 @@ import { disconnect } from './db/knex-database-connection.js';
 import { learningContentCache } from './lib/infrastructure/caches/learning-content-cache.js';
 import { temporaryStorage } from './lib/infrastructure/temporary-storage/index.js';
 import { redisMonitor } from './lib/infrastructure/utils/redis-monitor.js';
+import { initLearningContent } from './lib/infrastructure/datasources/learning-content/datasource.js';
 
 let server;
 
 const start = async function () {
+  await initLearningContent();
   server = await createServer();
   await server.start();
 };

--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -65,4 +65,6 @@ const refreshLearningContentCacheRecords = async function () {
   return learningContent;
 };
 
-export { extend, refreshLearningContentCacheRecords };
+const initLearningContent = _DatasourcePrototype._getLearningContent;
+
+export { extend, refreshLearningContentCacheRecords, initLearningContent };


### PR DESCRIPTION
## :unicorn: Problème
Nous rencontrons actuellement des soucis lorsqu'un container démarre, car au premier appel qui nécessite la release, nous devons attendre de la récupérer dans le Redis pour la stocker en mémoire. Cela engendre le fait que des requêtes s'accumulent et le nombre de requêtes en attente augmente. 

## :robot: Proposition
Mettre la release dans le cache de premier niveau avant même de démarrer le serveur et donc que Scalingo envoie des requêtes dessus.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Récupérer la branche en local 
- Vider votre cache lcms `docker exec -it pix-api-redis redis-cli` puis `DEL cache:LearningContent` 
- En parallèle : lancer le serveur : `npm start` 
- Constater les logs comme quoi nous allons chercher la release : 
```
[14:52:48] INFO: Cannot found the key from the firstLevelCache. Fetching on the second one.
    event: "cache-event"
    key: "LearningContent"
[14:52:48] INFO: Executing generator for Redis key
    key: "LearningContent"
[14:52:51] INFO: End GET request to https://lcms.pix.fr/api/releases/latest success: 200
    user_id: "-"
    request_id: "-"
    metrics: {
      "responseTime": 2925.770833015442
    }
[14:52:51] INFO: Release 1368 created on 2023-10-19T02:16:10.195Z successfully received from LCMS
[14:52:51] INFO: Setting Redis key
    key: "LearningContent"
    length: 37280585
```

- Constater dans le redis que le cache est présent : `KEYS *` et `"cache:LearningContent"` doit être présent
- Couper le serveur et le relancer 
- Constater qu'on va chercher le cache de Redis uniquement : 
```
[14:53:03] INFO: Cannot found the key from the firstLevelCache. Fetching on the second one.
    event: "cache-event"
    key: "LearningContent"
[14:53:04] INFO: server started
    created: 1697727184666
    started: 1697727184827
    host: "Vincents-MacBook-Pro.local"
    port: 3000
    protocol: "http"
    id: "Vincents-MacBook-Pro.local:28562:lnxaxjiy"
    uri: "http://Vincents-MacBook-Pro.local:3000"
    address: "::"
```