### PR TITLE
[FEATURE] Modulix : Accéder à une leçon textuelle (PIX-9674)

### DIFF
--- a/api/src/devcomp/domain/models/Module.js
+++ b/api/src/devcomp/domain/models/Module.js
@@ -2,22 +2,29 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class Module {
   #id;
+  #slug;
   #title;
   #list;
 
-  constructor({ id, title, list }) {
+  constructor({ id, slug, title, list }) {
     assertNotNullOrUndefined(id, "L'id est obligatoire pour un module");
     assertNotNullOrUndefined(title, 'Le titre est obligatoire pour un module');
+    assertNotNullOrUndefined(slug, 'Le slug est obligatoire pour un module');
     assertNotNullOrUndefined(list, 'Une liste est obligatoire pour un module');
     this.#assertListIsAnArray(list);
 
     this.#id = id;
+    this.#slug = slug;
     this.#title = title;
     this.#list = list;
   }
 
   get id() {
     return this.#id;
+  }
+
+  get slug() {
+    return this.#slug;
   }
 
   get title() {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -5,6 +5,7 @@ const moduleDatasource = {
     const availableModules = await Promise.resolve({
       'les-adresses-mail': {
         id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: 'les-adresses-mail',
         title: 'Les adresses mail',
         list: [
           {

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -15,6 +15,7 @@ async function getBySlug({ slug, moduleDatasource }) {
 function _toDomain(moduleData) {
   return new Module({
     id: moduleData.id,
+    slug: moduleData.slug,
     title: moduleData.title,
     list: moduleData.list.map(
       (lesson) =>

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -6,13 +6,13 @@ function serialize(module) {
   return new Serializer('module', {
     transform(module) {
       return {
-        id: module.id,
+        id: module.slug,
         title: module.title,
-        element: module.list.map((element) => ({ id: element.id, content: element.content })),
+        elements: module.list.map((element) => ({ id: element.id, content: element.content })),
       };
     },
-    attributes: ['title', 'element'],
-    element: {
+    attributes: ['title', 'elements'],
+    elements: {
       ref: 'id',
       includes: true,
       attributes: ['content'],

--- a/api/tests/devcomp/unit/domain/models/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/Module_test.js
@@ -6,14 +6,16 @@ describe('Unit | Devcomp | Models | Module', function () {
     it('should create a module and keep attributes', function () {
       // given
       const id = 1;
+      const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const list = [Symbol('lesson')];
 
       // when
-      const module = new Module({ id, title, list });
+      const module = new Module({ id, slug, title, list });
 
       // then
       expect(module.id).to.equal(id);
+      expect(module.slug).to.equal(slug);
       expect(module.title).to.equal(title);
       expect(module.list).to.have.length(list.length);
     });
@@ -30,20 +32,27 @@ describe('Unit | Devcomp | Models | Module', function () {
       });
     });
 
+    describe('if a module does not have a slug', function () {
+      it('should throw an error', function () {
+        expect(() => new Module({ id: 1, title: '' })).to.throw('Le slug est obligatoire pour un module');
+      });
+    });
+
     describe('if a module does not have an element', function () {
       describe('given no list param', function () {
         it('should throw an error', function () {
-          expect(() => new Module({ id: 'id_module_1', title: 'Les adresses mail' })).to.throw(
-            'Une liste est obligatoire pour un module',
-          );
+          expect(
+            () => new Module({ id: 'id_module_1', slug: 'les-adresses-mail', title: 'Les adresses mail' }),
+          ).to.throw('Une liste est obligatoire pour un module');
         });
       });
 
       describe('given a wrong typed list param', function () {
         it('should throw an error', function () {
-          expect(() => new Module({ id: 'id_module_1', title: 'Les adresses mail', list: 'liste' })).to.throw(
-            'Un Module doit forcément posséder une liste',
-          );
+          expect(
+            () =>
+              new Module({ id: 'id_module_1', slug: 'les-adresses-mail', title: 'Les adresses mail', list: 'liste' }),
+          ).to.throw('Un Module doit forcément posséder une liste');
         });
       });
     });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -15,6 +15,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
         // then
         const expectedModuleData = {
           id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          slug: 'les-adresses-mail',
           title: 'Les adresses mail',
           list: [
             {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -8,17 +8,18 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
     it('should serialize with empty list', function () {
       // given
       const id = 'id';
+      const slug = 'les-adresses-mail';
       const title = 'Les adresses mail';
-      const moduleFromDomain = new Module({ id, title, list: [] });
+      const moduleFromDomain = new Module({ id, slug, title, list: [] });
       const expectedJson = {
         data: {
           type: 'modules',
-          id,
+          id: slug,
           attributes: {
             title,
           },
           relationships: {
-            element: {
+            elements: {
               data: [],
             },
           },
@@ -35,17 +36,18 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
     it('should serialize with list', function () {
       // given
       const id = 'id';
+      const slug = 'les-adresses-mail';
       const title = 'Les adresses mail';
-      const moduleFromDomain = new Module({ id, title, list: [new Lesson({ id: '1', content: '' })] });
+      const moduleFromDomain = new Module({ id, slug, title, list: [new Lesson({ id: '1', content: '' })] });
       const expectedJson = {
         data: {
           type: 'modules',
-          id,
+          id: slug,
           attributes: {
             title,
           },
           relationships: {
-            element: {
+            elements: {
               data: [
                 {
                   type: 'elements',

--- a/mon-pix/app/helpers/html-safe.js
+++ b/mon-pix/app/helpers/html-safe.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe as emberHtmlSafe } from '@ember/template';
+
+export function htmlSafe(text) {
+  return emberHtmlSafe(text);
+}
+export default helper(htmlSafe);

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -1,3 +1,10 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default class ModuleDetails extends Component {}
+export default class ModuleDetails extends Component {
+  @action
+  continueToNextGrain() {
+    // eslint-disable-next-line no-console
+    console.info('Continue to next grain');
+  }
+}

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class ModuleDetails extends Component {}

--- a/mon-pix/app/pods/components/module/details/styles.scss
+++ b/mon-pix/app/pods/components/module/details/styles.scss
@@ -16,4 +16,46 @@
     justify-content: center;
     margin: 1rem;
   }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $pix-spacing-s;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .grain {
+    display: flex;
+    flex-direction: column;
+    gap: $pix-spacing-s;
+    width: 100%;
+    margin: 0;
+    padding: $pix-spacing-s;
+    background: $pix-neutral-0;
+    border: 1px solid $pix-neutral-22;
+    border-radius: $pix-spacing-s;
+
+    &__element {
+      &--text {
+        @extend %pix-body-l;
+
+        color: $pix-neutral-90;
+
+        // revert the reset
+        ul, ol {
+          margin: revert;
+          padding: revert;
+          list-style: revert;
+        }
+      }
+    }
+
+    &__footer {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: $pix-spacing-xs;
+    }
+  }
 }

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -4,4 +4,10 @@
   <div class="module__title">
     <h1>{{@module.title}}</h1>
   </div>
+
+  {{#each @module.elements as |element|}}
+    <p>Test</p>
+    <p>{{element.id}}</p>
+    {{element.content}}
+  {{/each}}
 </main>

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -5,9 +5,18 @@
     <h1>{{@module.title}}</h1>
   </div>
 
-  {{#each @module.elements as |element|}}
-    <p>Test</p>
-    <p>{{element.id}}</p>
-    {{element.content}}
-  {{/each}}
+  <div class="module__content" aria-live="assertive">
+    <article class="grain">
+      {{#each @module.elements as |element|}}
+        <div class="grain__element grain__element--text">
+          {{html-safe element.content}}
+        </div>
+      {{/each}}
+      <footer class="grain__footer">
+        <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{this.continueToNextGrain}}>
+          {{t "pages.modulix.buttons.continue"}}
+        </PixButton>
+      </footer>
+    </article>
+  </div>
 </main>

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -1,0 +1,7 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class Element extends Model {
+  @attr('string') content;
+
+  @belongsTo('module') module;
+}

--- a/mon-pix/app/pods/module/model.js
+++ b/mon-pix/app/pods/module/model.js
@@ -1,5 +1,7 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Module extends Model {
   @attr('string') title;
+
+  @hasMany('element') elements;
 }

--- a/mon-pix/tests/acceptance/module/visit-module-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-page_test.js
@@ -22,24 +22,6 @@ module('Acceptance | Module | Routes | get', function (hooks) {
     assert.strictEqual(currentURL(), '/modules/les-adresses-mail');
   });
 
-  test('should display the module title as heading', async function (assert) {
-    // given
-    const module = {
-      title: 'Les adresses mail',
-    };
-
-    server.create('module', {
-      id: 'les-adresses-mail',
-      title: module.title,
-    });
-
-    // when
-    const screen = await visit('/modules/les-adresses-mail');
-
-    // then
-    assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
-  });
-
   test('should include the module title inside the page title', async function (assert) {
     // given
     const module = {

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -1,15 +1,20 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import { findAll } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | Details', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display given module title', async function (assert) {
+  test('should display given module', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
-    const module = store.createRecord('module', { title: 'Module title' });
+    const elementContent = 'toto';
+    const element = store.createRecord('element', { content: elementContent });
+    const moduleElements = [element];
+
+    const module = store.createRecord('module', { title: 'Module title', elements: moduleElements });
     this.set('module', module);
 
     // when
@@ -17,5 +22,8 @@ module('Integration | Component | Module | Details', function (hooks) {
 
     // then
     assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+    assert.dom(screen.getByText(elementContent)).exists();
+    assert.strictEqual(findAll('.grain__element').length, moduleElements.length);
+    assert.ok(screen.getByRole('button', { name: 'Continuer' }));
   });
 });

--- a/mon-pix/tests/unit/models/module_test.js
+++ b/mon-pix/tests/unit/models/module_test.js
@@ -5,10 +5,17 @@ module('Unit | Model | Module', function (hooks) {
   setupTest(hooks);
 
   test('Module model should exist with the right properties', function (assert) {
+    // given
     const title = 'Les adresses mail';
     const store = this.owner.lookup('service:store');
-    const model = store.createRecord('module', { title });
-    assert.ok(model);
-    assert.strictEqual(model.title, title);
+    const element = store.createRecord('element', { content: '' });
+
+    // when
+    const module = store.createRecord('module', { title, elements: [element] });
+
+    // then
+    assert.ok(module);
+    assert.strictEqual(module.title, title);
+    assert.strictEqual(module.elements.length, 1);
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1169,6 +1169,11 @@
         }
       }
     },
+    "modulix": {
+      "buttons": {
+        "continue": "Continue"
+      }
+    },
     "not-connected": {
       "title": "Logged out",
       "message": "You've been logged out.'<br>'Thanks! See you soon"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1169,6 +1169,11 @@
         }
       }
     },
+    "modulix": {
+      "buttons": {
+        "continue": "Continuer"
+      }
+    },
     "not-connected": {
       "title": "Déconnecté",
       "message": "Vous êtes bien déconnecté(e).'<br>'Merci, à bientôt."


### PR DESCRIPTION
## :unicorn: Problème
En tant qu’apprenant.e je souhaite accéder à un grain pédagogique de type `Leçon` composé d'éléments textuels dans un module afin de commencer à apprendre des choses.

## :robot: Proposition
Pour notre première itération, nous affichons directement les `Elements` dans le module.

## :rainbow: Remarques
Nous n'avons pas encore implémenté le niveau de granularité `Grain` dans le modèle métier. Il y a directement une relation `Module` **<==>** `Elements`. Une refacto est à prévoir.

## :100: Pour tester
En se rendant sur ce lien [_**modules/les-adresses-mail**_](https://app-pr7290.review.pix.fr/modules/les-adresses-mail), vous devriez voir le titre du module ainsi que les 3 éléments textuels.
