### PR TITLE
[BUGFIX] Corriger la gestion d'erreurs front sur Pix Certif

### DIFF
--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import get from 'lodash/get';
 
 export default class SessionsUpdateController extends Controller {
   @alias('model') session;
@@ -37,7 +38,7 @@ export default class SessionsUpdateController extends Controller {
       if (error?.code) {
         return this.notifications.error(this.intl.t(`common.api-error-messages.${error.code}`));
       }
-      if (error?.status === '400') {
+      if (_isEntityUnprocessable(responseError)) {
         return this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
       }
       return this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
@@ -95,4 +96,9 @@ export default class SessionsUpdateController extends Controller {
       this.isSessionExaminerMissing
     );
   }
+}
+
+function _isEntityUnprocessable(err) {
+  const status = get(err, 'errors[0].status');
+  return status === '422' || status === '400';
 }

--- a/certif/app/serializers/application.js
+++ b/certif/app/serializers/application.js
@@ -1,1 +1,7 @@
-export { default } from '@ember-data/serializer/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+export default class ApplicationSerializer extends JSONAPISerializer {
+  // This bypasses extractErrors emberData behavior which relies on the property being a function.
+  // This should not be needed after upgrading to ember-data v5
+  extractErrors = false;
+}

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -440,7 +440,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
                     },
                   ],
                 }),
-                400,
+                422,
               );
 
               // when


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque l'utilisateur Pix Certif commet une erreur lors de son remplissage alors il obtient un message d’erreur imprécis : "Une erreur s'est produite lors de l'ajout du candidat."

## :robot: Proposition
Corriger la gestion d'erreurs lors de l'ajout d'un candidat sur Pix Certif en surchargeant la méthode `extractErrors` pour éviter la condition qui formate nos erreurs API.

## :rainbow: Remarques
Le bug est lié à la mise à jour de ember-data à partir de la 4.7.0. 
En v4.6.4 c'est OK, et KO en 4.7.0. Donc quelque part là-dedans : [Comparing v4.6.4...v4.7.0 · emberjs/data](https://github.com/emberjs/data/compare/v4.6.4...v4.7.0)  

Si avant on s'en sortait bien c'est que le fichier `fetch-manager.ts` faisait un throw d'un objet contenant `errors` et `parsedErrors` (et notre erreur était retournée via `errors`) désormais il ne retourne que les `parsedErrors`.

Ces `parsedErrors` proviennent de la méthode `ExtractErrors` qui se veut compliant avec la specification jsonapi et s'attend à retrouver des source dans le retour API. (ce qui n'est pas notre cas)

https://github.com/emberjs/data/blob/7dc0e0fbf9206bfbb5369ba353a575604e7f4c77/packages/serializer/src/json.js#L1474
``` js
This serializer expects this `errors` object to be an Array similar
    to the following, compliant with the https://jsonapi.org/format/#errors specification:

    {
      "errors": [
        {
          "detail": "This username is already taken!",
          "source": {
            "pointer": "data/attributes/username"
          }
        },
      ]
    }

``` 

``` js
// AVANT (quand ça fonctionnait grâce au error qui est throw)

if (serializer && typeof serializer.extractErrors === 'function') {
            parsedErrors = serializer.extractErrors(store, modelClass, error, snapshot.id);
          } else {
            parsedErrors = errorsArrayToHash(error.errors);
          }

          throw { error, parsedErrors };

// APRES

if (serializer && typeof serializer.extractErrors === 'function') {
      let errorsHash = serializer.extractErrors(store, store.modelFor(identifier.type), error, identifier.id);
      error.errors = errorsHashToArray(errorsHash);
    }
```

https://github.com/emberjs/data/blob/c558543cba1ba7eeaee5130ba2ef3fe2aeef732f/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts#L219

On fait le choix de contourner le if qui va formater nos erreurs. Pour se faire, on fait en sorte qu'extractErrors ne soit plus une fonction.


## :100: Pour tester

- Se connecter sur Pix Certif avec certif-pro
- Cliquer sur une session qui n'a pas encore commencé
- Ajouter un candidat
- Remplir les données avec différentes erreurs : 

- Date de naissance : 10/10/1000 => recevoir un message d'erreur spécifique
- Code postal avec commune : 75010 / Rennes => recevoir un message d'erreur spécifique
- Renseigner les données d'un candidat déjà inscrit dans la session => recevoir un message d'erreur spécifique

Remplir correctement les infos et s'assurer que le candidat est bien inscrit.


Parcourir l'application pour voir s'il n'y a pas de régression avec cette surchage