### PR TITLE
[FEATURE] Ne pas afficher le message de perte de certificabilité pour un prescrit déjà certifié sur Pix App. (PIX-9529)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-course-result.js
+++ b/api/db/database-builder/factory/build-complementary-certification-course-result.js
@@ -6,17 +6,19 @@ import _ from 'lodash';
 import { ComplementaryCertificationCourseResult } from '../../../lib/domain/models/ComplementaryCertificationCourseResult.js';
 
 const buildComplementaryCertificationCourseResult = function ({
+  id,
   complementaryCertificationCourseId,
   partnerKey,
   source = ComplementaryCertificationCourseResult.sources.PIX,
   acquired = true,
 }) {
+  id = id ?? databaseBuffer.getNextId();
   complementaryCertificationCourseId = _.isUndefined(complementaryCertificationCourseId)
     ? _buildComplementaryCertificationCourse().id
     : complementaryCertificationCourseId;
-  return databaseBuffer.objectsToInsert.push({
+  return databaseBuffer.pushInsertable({
     tableName: 'complementary-certification-course-results',
-    values: { complementaryCertificationCourseId, partnerKey, source, acquired },
+    values: { id, complementaryCertificationCourseId, partnerKey, source, acquired },
   });
 };
 

--- a/api/lib/domain/models/ComplementaryCertificationCourseWithResults.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseWithResults.js
@@ -1,0 +1,30 @@
+class ComplementaryCertificationCourseWithResults {
+  constructor({ id, hasExternalJury = false, results, complementaryCertificationBadgeId }) {
+    this.id = id;
+    this.hasExternalJury = hasExternalJury;
+    this.results = results;
+    this.complementaryCertificationBadgeId = complementaryCertificationBadgeId;
+  }
+
+  isAcquired() {
+    if (this.#isUncompleted()) {
+      return false;
+    }
+    return this.results.every(({ acquired }) => acquired);
+  }
+
+  static from({ id, hasExternalJury, results, complementaryCertificationBadgeId }) {
+    return new ComplementaryCertificationCourseWithResults({
+      id,
+      hasExternalJury,
+      results,
+      complementaryCertificationBadgeId,
+    });
+  }
+
+  #isUncompleted() {
+    return this.results.length === 0 || (this.hasExternalJury && this.results.length < 2);
+  }
+}
+
+export { ComplementaryCertificationCourseWithResults };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -81,6 +81,7 @@ import * as competenceMarkRepository from '../../infrastructure/repositories/com
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as competenceTreeRepository from '../../infrastructure/repositories/competence-tree-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
+import * as complementaryCertificationCourseRepository from '../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-course-repository.js';
 import * as complementaryCertificationHabilitationRepository from '../../infrastructure/repositories/complementary-certification-habilitation-repository.js';
 import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
 import * as countryRepository from '../../infrastructure/repositories/country-repository.js';
@@ -291,6 +292,7 @@ const dependencies = {
   competenceRepository,
   competenceTreeRepository,
   complementaryCertificationCourseResultRepository,
+  complementaryCertificationCourseRepository,
   complementaryCertificationHabilitationRepository,
   complementaryCertificationRepository,
   config,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-eligibility-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-eligibility-serializer.js
@@ -10,6 +10,7 @@ const serialize = function (certificationEligibility) {
       return clone;
     },
     attributes: ['isCertifiable', 'complementaryCertifications'],
+    complementaryCertifications: ['label', 'imageUrl', 'isOutdated', 'isAcquired'],
   }).serialize(certificationEligibility);
 };
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-course-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-course-repository.js
@@ -1,0 +1,47 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { ComplementaryCertificationCourseWithResults } from '../../../../../lib/domain/models/ComplementaryCertificationCourseWithResults.js';
+
+const findByUserId = async function ({ userId }) {
+  const results = await knex
+    .select({
+      id: 'complementary-certification-courses.id',
+      hasExternalJury: 'complementary-certifications.hasExternalJury',
+      complementaryCertificationBadgeId: 'complementaryCertificationBadgeId',
+      results: knex.raw(
+        `array_agg(json_build_object(
+        'id', "complementary-certification-course-results".id,
+        'acquired', "complementary-certification-course-results".acquired,
+        'partnerKey', "complementary-certification-course-results"."partnerKey",
+        'source', "complementary-certification-course-results".source))`,
+      ),
+    })
+    .from('complementary-certification-courses')
+    .leftJoin(
+      'complementary-certification-course-results',
+      'complementary-certification-courses.id',
+      'complementary-certification-course-results.complementaryCertificationCourseId',
+    )
+    .innerJoin(
+      'complementary-certifications',
+      'complementary-certifications.id',
+      'complementary-certification-courses.complementaryCertificationId',
+    )
+    .innerJoin(
+      'complementary-certification-badges',
+      'complementary-certification-badges.id',
+      'complementary-certification-courses.complementaryCertificationBadgeId',
+    )
+    .innerJoin(
+      'certification-courses',
+      'certification-courses.id',
+      'complementary-certification-courses.certificationCourseId',
+    )
+    .where({ userId })
+    .groupBy('hasExternalJury', 'complementaryCertificationBadgeId', 'complementary-certification-courses.id');
+
+  if (!results.length) return [];
+
+  return results.map(ComplementaryCertificationCourseWithResults.from);
+};
+
+export { findByUserId };

--- a/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
+++ b/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
@@ -1,9 +1,9 @@
 import {
+  databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-  databaseBuilder,
-  mockLearningContent,
   learningContentBuilder,
+  mockLearningContent,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
@@ -273,6 +273,7 @@ describe('Acceptance | users-controller-is-certifiable', function () {
                   imageUrl: 'http://badge-image-url.fr',
                   label: 'PARTNER_LABEL',
                   isOutdated: false,
+                  isAcquired: false,
                 },
               ],
             },

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-course-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-course-repository_test.js
@@ -1,0 +1,144 @@
+import { knex } from '../../../../../../db/knex-database-connection.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+import * as complementaryCertificationCourseRepository from '../../../../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-course-repository.js';
+import { ComplementaryCertificationCourseResult } from '../../../../../../lib/domain/models/index.js';
+
+describe('Integration | Repository | complementary-certification-course-repository', function () {
+  describe('#findByUserId', function () {
+    afterEach(function () {
+      return knex('complementary-certification-course-results').delete();
+    });
+
+    describe('when the user has no complementary certification course taken', function () {
+      it('should return an empty array', async function () {
+        // given a user
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildComplementaryCertificationCourse({ certificationCourseId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const complementaryCertificationCoursesWithResults =
+          await complementaryCertificationCourseRepository.findByUserId({ userId });
+
+        // then
+        expect(complementaryCertificationCoursesWithResults).to.be.empty;
+      });
+    });
+
+    describe('when the user has taken and passed certification courses', function () {
+      it('should return the ComplementaryCertificationCourses', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+
+        databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_1', id: 1 });
+        databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_2', id: 2 });
+
+        databaseBuilder.factory.buildComplementaryCertification({ id: 1 });
+        databaseBuilder.factory.buildComplementaryCertification.pixEdu1erDegre({ id: 2 });
+
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 123,
+          complementaryCertificationId: 1,
+          badgeId: 1,
+          label: 'Certif Complementaire 1',
+        });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          id: 456,
+          complementaryCertificationId: 2,
+          badgeId: 2,
+          label: 'Certif Complementaire 2',
+        });
+
+        databaseBuilder.factory.buildCertificationCourse({ id: 99, userId });
+        databaseBuilder.factory.buildCertificationCourse({ id: 100, userId });
+
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          complementaryCertificationBadgeId: 123,
+          id: 999,
+          certificationCourseId: 99,
+          complementaryCertificationId: 1,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          complementaryCertificationBadgeId: 456,
+          id: 1000,
+          certificationCourseId: 100,
+          complementaryCertificationId: 2,
+        });
+
+        const complementaryCertificationCourseResultId1 =
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            acquired: true,
+            complementaryCertificationCourseId: 999,
+            partnerKey: 'PIX_TEST_1',
+            source: ComplementaryCertificationCourseResult.sources.PIX,
+          }).id;
+        const complementaryCertificationCourseResultId2 =
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            acquired: true,
+            complementaryCertificationCourseId: 1000,
+            partnerKey: 'PIX_TEST_2',
+            source: ComplementaryCertificationCourseResult.sources.PIX,
+          }).id;
+        const complementaryCertificationCourseResultId3 =
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            acquired: true,
+            complementaryCertificationCourseId: 1000,
+            partnerKey: 'PIX_TEST_2',
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+          }).id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const complementaryCertificationCoursesWithResults =
+          await complementaryCertificationCourseRepository.findByUserId({ userId });
+
+        // then
+        const complementaryCertificationCourseWithResult1 =
+          domainBuilder.buildComplementaryCertificationCourseWithResults({
+            hasExternalJury: false,
+            id: 999,
+            complementaryCertificationBadgeId: 123,
+            results: [
+              {
+                id: complementaryCertificationCourseResultId1,
+                acquired: true,
+                partnerKey: 'PIX_TEST_1',
+                source: ComplementaryCertificationCourseResult.sources.PIX,
+              },
+            ],
+          });
+        const complementaryCertificationCourseWithResult2 =
+          domainBuilder.buildComplementaryCertificationCourseWithResults({
+            id: 1000,
+            hasExternalJury: true,
+            complementaryCertificationBadgeId: 456,
+            results: [
+              {
+                id: complementaryCertificationCourseResultId3,
+                acquired: true,
+                partnerKey: 'PIX_TEST_2',
+                source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+              },
+              {
+                id: complementaryCertificationCourseResultId2,
+                acquired: true,
+                partnerKey: 'PIX_TEST_2',
+                source: ComplementaryCertificationCourseResult.sources.PIX,
+              },
+            ],
+          });
+
+        expect(complementaryCertificationCoursesWithResults).to.have.lengthOf(2);
+        expect(complementaryCertificationCoursesWithResults[0]).to.deepEqualInstance(
+          complementaryCertificationCourseWithResult1,
+        );
+        expect(complementaryCertificationCoursesWithResults[1]).to.deepEqualInstance(
+          complementaryCertificationCourseWithResult2,
+        );
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-with-results.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-with-results.js
@@ -1,0 +1,17 @@
+import { ComplementaryCertificationCourseWithResults } from '../../../../lib/domain/models/ComplementaryCertificationCourseWithResults.js';
+
+const buildComplementaryCertificationCourseWithResults = function ({
+  id = 789,
+  hasExternalJury = false,
+  results = [],
+  complementaryCertificationBadgeId = 100,
+} = {}) {
+  return new ComplementaryCertificationCourseWithResults({
+    id,
+    hasExternalJury,
+    results,
+    complementaryCertificationBadgeId,
+  });
+};
+
+export { buildComplementaryCertificationCourseWithResults };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -107,6 +107,7 @@ import { buildParticipationForCampaignManagement } from './build-participation-f
 import { buildComplementaryCertificationCourseResult } from './build-complementary-certification-course-result.js';
 import { buildComplementaryCertificationCourseResultForJuryCertification } from './build-complementary-certification-course-result-for-certification.js';
 import { buildComplementaryCertificationCourseResultForJuryCertificationWithExternal } from './build-complementary-certification-course-result-for-certification-with-external.js';
+import { buildComplementaryCertificationCourseWithResults } from './build-complementary-certification-course-with-results.js';
 import { buildComplementaryCertificationScoringWithoutComplementaryReferential } from './build-complementary-certification-scoring-without-complementary-referential.js';
 import { buildComplementaryCertificationScoringWithComplementaryReferential } from './build-pix-plus-certification-scoring.js';
 import { buildPlacementProfile } from './build-placement-profile.js';
@@ -269,6 +270,7 @@ export {
   buildComplementaryCertificationCourseResult,
   buildComplementaryCertificationCourseResultForJuryCertification,
   buildComplementaryCertificationCourseResultForJuryCertificationWithExternal,
+  buildComplementaryCertificationCourseWithResults,
   buildComplementaryCertificationScoringWithoutComplementaryReferential,
   buildComplementaryCertificationScoringWithComplementaryReferential,
   buildPlacementProfile,

--- a/api/tests/unit/domain/models/ComplementaryCertificationCourseWithResults_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationCourseWithResults_test.js
@@ -1,0 +1,147 @@
+import { ComplementaryCertificationCourseWithResults } from '../../../../lib/domain/models/ComplementaryCertificationCourseWithResults.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | Domain | Models | ComplementaryCertificationCourseWithResults', function () {
+  describe('#isAcquired', function () {
+    describe('when no external jury', function () {
+      describe('when result is acquired', function () {
+        it('should be acquired', function () {
+          // given
+          const complementaryCertificationCourseWithResults = new ComplementaryCertificationCourseWithResults({
+            id: 11,
+            hasExternalJury: false,
+            results: [
+              {
+                id: 1,
+                acquired: true,
+                partnerKey: 'key',
+                source: 'source',
+              },
+            ],
+            complementaryCertificationBadgeId: 2,
+          });
+
+          // when
+          const result = complementaryCertificationCourseWithResults.isAcquired();
+
+          // then
+          expect(result).to.be.true;
+        });
+      });
+
+      describe('when result is not acquired', function () {
+        it('should not be acquired', function () {
+          // given
+          const complementaryCertificationCourseWithResults = new ComplementaryCertificationCourseWithResults({
+            id: 11,
+            hasExternalJury: false,
+            results: [
+              {
+                id: 1,
+                acquired: false,
+                partnerKey: 'key',
+                source: 'source',
+              },
+            ],
+            complementaryCertificationBadgeId: 2,
+          });
+
+          // when
+          const result = complementaryCertificationCourseWithResults.isAcquired();
+
+          // then
+          expect(result).to.be.false;
+        });
+      });
+    });
+
+    describe('when external jury', function () {
+      describe('when external result is not acquired', function () {
+        it('should not be acquired', function () {
+          // given
+          const complementaryCertificationCourseWithResults = new ComplementaryCertificationCourseWithResults({
+            id: 11,
+            hasExternalJury: true,
+            results: [
+              {
+                id: 1,
+                acquired: true,
+                partnerKey: 'key',
+                source: 'PIX',
+              },
+              {
+                id: 2,
+                acquired: false,
+                partnerKey: 'key',
+                source: 'EXTERNAL',
+              },
+            ],
+            complementaryCertificationBadgeId: 2,
+          });
+
+          // when
+          const result = complementaryCertificationCourseWithResults.isAcquired();
+
+          // then
+          expect(result).to.be.false;
+        });
+      });
+
+      describe('when external jury result has not yet been registered', function () {
+        it('should not be acquired', function () {
+          // given
+          const complementaryCertificationCourseWithResults = new ComplementaryCertificationCourseWithResults({
+            id: 11,
+            hasExternalJury: true,
+            results: [
+              {
+                id: 1,
+                acquired: true,
+                partnerKey: 'key',
+                source: 'PIX',
+              },
+            ],
+            complementaryCertificationBadgeId: 2,
+          });
+
+          // when
+          const result = complementaryCertificationCourseWithResults.isAcquired();
+
+          // then
+          expect(result).to.be.false;
+        });
+      });
+
+      describe('when external jury is acquired and pix certification is not acquired', function () {
+        it('should not be acquired', function () {
+          // given
+          const complementaryCertificationCourseWithResults = new ComplementaryCertificationCourseWithResults({
+            id: 11,
+            hasExternalJury: true,
+            results: [
+              {
+                id: 1,
+                acquired: true,
+                partnerKey: 'key',
+                source: 'EXTERNAL',
+              },
+              {
+                id: 2,
+                acquired: false,
+                partnerKey: 'key',
+                source: 'PIX',
+              },
+            ],
+            complementaryCertificationBadgeId: 2,
+          });
+
+          // when
+          const result = complementaryCertificationCourseWithResults.isAcquired();
+
+          // then
+          expect(result).to.be.false;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -1,21 +1,21 @@
-import { sinon, expect, domainBuilder } from '../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { getUserCertificationEligibility } from '../../../../lib/domain/usecases/get-user-certification-eligibility.js';
 
 describe('Unit | UseCase | get-user-certification-eligibility', function () {
-  let clock;
+  let clock, placementProfileService, certificationBadgesService, complementaryCertificationCourseRepository;
   const now = new Date(2020, 1, 1);
-
-  const placementProfileService = {
-    getPlacementProfile: () => undefined,
-  };
-  const certificationBadgesService = {
-    findLatestBadgeAcquisitions: () => undefined,
-  };
 
   beforeEach(function () {
     clock = sinon.useFakeTimers(now);
-    placementProfileService.getPlacementProfile = sinon.stub();
-    certificationBadgesService.findLatestBadgeAcquisitions = sinon.stub();
+    complementaryCertificationCourseRepository = {
+      findByUserId: sinon.stub(),
+    };
+    certificationBadgesService = {
+      findLatestBadgeAcquisitions: sinon.stub(),
+    };
+    placementProfileService = {
+      getPlacementProfile: sinon.stub(),
+    };
   });
 
   afterEach(function () {
@@ -25,9 +25,7 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   context('when pix certification is not eligible', function () {
     it('should return the user certification eligibility without eligible complementary certifications', async function () {
       // given
-      const placementProfile = {
-        isCertifiable: () => false,
-      };
+      const placementProfile = { isCertifiable: () => false };
       placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
       certificationBadgesService.findLatestBadgeAcquisitions.throws(new Error('I should not be called'));
 
@@ -50,17 +48,17 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   context(`when badge is not acquired`, function () {
     it('should return the user certification eligibility without eligible badge', async function () {
       // given
-      const placementProfile = {
-        isCertifiable: () => true,
-      };
+      const placementProfile = { isCertifiable: () => true };
       placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
       certificationBadgesService.findLatestBadgeAcquisitions.resolves([]);
+      complementaryCertificationCourseRepository.findByUserId.resolves([]);
 
       // when
       const certificationEligibility = await getUserCertificationEligibility({
         userId: 2,
         placementProfileService,
         certificationBadgesService,
+        complementaryCertificationCourseRepository,
       });
 
       // then
@@ -69,35 +67,281 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   });
 
   context('when badge is acquired', function () {
-    it('should return the user certification eligibility with the acquired badge informations', async function () {
-      // given
-      const placementProfile = {
-        isCertifiable: () => true,
-      };
-      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-      const badgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-        badgeKey: 'BADGE_KEY',
-        complementaryCertificationBadgeLabel: 'BADGE_LABEL',
-        complementaryCertificationBadgeImageUrl: 'http://www.image-url.com',
-        isOutdated: true,
-      });
-      certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+    context('when the certification is not acquired', function () {
+      it('should return the user certification eligibility with the acquired badge information', async function () {
+        // given
+        const placementProfile = { isCertifiable: () => true };
+        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+        const badgeAcquisition = getOutdatedBadgeAcquisition();
+        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
 
-      // when
-      const certificationEligibility = await getUserCertificationEligibility({
-        userId: 2,
-        placementProfileService,
-        certificationBadgesService,
-      });
+        complementaryCertificationCourseRepository.findByUserId.resolves([
+          domainBuilder.buildComplementaryCertificationCourseWithResults({
+            id: 1,
+            hasExternalJury: false,
+            complementaryCertificationBadgeId: 2,
+            results: [
+              {
+                id: 3,
+                acquired: false,
+                partnerKey: 'BADGE_KEY',
+                source: 'PIX',
+              },
+            ],
+          }),
+        ]);
 
-      // then
-      expect(certificationEligibility.complementaryCertifications).to.deep.equal([
-        {
-          label: 'BADGE_LABEL',
-          imageUrl: 'http://www.image-url.com',
-          isOutdated: true,
-        },
-      ]);
+        // when
+        const certificationEligibility = await getUserCertificationEligibility({
+          userId: 2,
+          placementProfileService,
+          certificationBadgesService,
+          complementaryCertificationCourseRepository,
+        });
+
+        // then
+        expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+          {
+            label: 'BADGE_LABEL',
+            imageUrl: 'http://www.image-url.com',
+            isOutdated: true,
+            isAcquired: false,
+          },
+        ]);
+      });
+    });
+    context('when the certification is acquired', function () {
+      it('should return the user certification eligibility with a badge not acquired', async function () {
+        // given
+        const placementProfile = { isCertifiable: () => true };
+        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+        const badgeAcquisition = getOutdatedBadgeAcquisition();
+        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+        complementaryCertificationCourseRepository.findByUserId.resolves([
+          domainBuilder.buildComplementaryCertificationCourseWithResults({
+            id: 1,
+            hasExternalJury: false,
+            complementaryCertificationBadgeId: 2,
+            results: [
+              {
+                id: 3,
+                acquired: true,
+                partnerKey: 'BADGE_KEY',
+                source: 'PIX',
+              },
+            ],
+          }),
+        ]);
+
+        // when
+        const certificationEligibility = await getUserCertificationEligibility({
+          userId: 2,
+          placementProfileService,
+          certificationBadgesService,
+          complementaryCertificationCourseRepository,
+        });
+
+        // then
+        expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+          {
+            label: 'BADGE_LABEL',
+            imageUrl: 'http://www.image-url.com',
+            isOutdated: true,
+            isAcquired: true,
+          },
+        ]);
+      });
+    });
+    context('when the certification has no result', function () {
+      it('should return the user certification eligibility with the acquired badge information', async function () {
+        // given
+        const placementProfile = { isCertifiable: () => true };
+        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+        const badgeAcquisition = getOutdatedBadgeAcquisition();
+        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+        complementaryCertificationCourseRepository.findByUserId.resolves([
+          domainBuilder.buildComplementaryCertificationCourseWithResults({
+            id: 1,
+            hasExternalJury: false,
+            complementaryCertificationBadgeId: 2,
+            results: [],
+          }),
+        ]);
+
+        // when
+        const certificationEligibility = await getUserCertificationEligibility({
+          userId: 2,
+          placementProfileService,
+          certificationBadgesService,
+          complementaryCertificationCourseRepository,
+        });
+
+        // then
+        expect(certificationEligibility.complementaryCertifications).to.deep.equal([
+          {
+            label: 'BADGE_LABEL',
+            imageUrl: 'http://www.image-url.com',
+            isOutdated: true,
+            isAcquired: false,
+          },
+        ]);
+      });
+    });
+    context('when the certification with external jury is acquired', function () {
+      it('should return the user certification eligibility with acquired badge', async function () {
+        // given
+        const placementProfile = { isCertifiable: () => true };
+        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+        const badgeAcquisition = getOutdatedBadgeAcquisition();
+        certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+        complementaryCertificationCourseRepository.findByUserId.resolves([
+          domainBuilder.buildComplementaryCertificationCourseWithResults({
+            id: 1,
+            hasExternalJury: true,
+            complementaryCertificationBadgeId: 2,
+            results: [
+              {
+                id: 3,
+                acquired: true,
+                partnerKey: 'BADGE_KEY',
+                source: 'PIX',
+              },
+              {
+                id: 4,
+                acquired: true,
+                partnerKey: 'BADGE_KEY',
+                source: 'EXTERNAL',
+              },
+            ],
+          }),
+        ]);
+
+        // when
+        const certificationEligibility = await getUserCertificationEligibility({
+          userId: 2,
+          placementProfileService,
+          certificationBadgesService,
+          complementaryCertificationCourseRepository,
+        });
+
+        // then
+        expect(certificationEligibility.complementaryCertifications).to.deep.equals([
+          {
+            label: 'BADGE_LABEL',
+            imageUrl: 'http://www.image-url.com',
+            isOutdated: true,
+            isAcquired: true,
+          },
+        ]);
+      });
+    });
+    context('when the certification with external jury is not acquired', function () {
+      context('when the user failed the external examination', function () {
+        it('should return the user certification eligibility with the acquired badge', async function () {
+          // given
+          const placementProfile = {
+            isCertifiable: () => true,
+          };
+          placementProfileService.getPlacementProfile
+            .withArgs({ userId: 2, limitDate: now })
+            .resolves(placementProfile);
+          const badgeAcquisition = getOutdatedBadgeAcquisition();
+          certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+          complementaryCertificationCourseRepository.findByUserId.resolves([
+            domainBuilder.buildComplementaryCertificationCourseWithResults({
+              id: 1,
+              hasExternalJury: true,
+              complementaryCertificationBadgeId: 2,
+              results: [
+                {
+                  id: 3,
+                  acquired: true,
+                  partnerKey: 'BADGE_KEY',
+                  source: 'PIX',
+                },
+                {
+                  id: 4,
+                  acquired: false,
+                  partnerKey: 'BADGE_KEY',
+                  source: 'EXTERNAL',
+                },
+              ],
+            }),
+          ]);
+
+          // when
+          const certificationEligibility = await getUserCertificationEligibility({
+            userId: 2,
+            placementProfileService,
+            certificationBadgesService,
+            complementaryCertificationCourseRepository,
+          });
+
+          // then
+          expect(certificationEligibility.complementaryCertifications).to.exactlyContain([
+            {
+              label: 'BADGE_LABEL',
+              imageUrl: 'http://www.image-url.com',
+              isOutdated: true,
+              isAcquired: false,
+            },
+          ]);
+        });
+      });
+      context('when the user has not yet the external jury result', function () {
+        it('should return the user certification eligibility with the acquired badge', async function () {
+          // given
+          const placementProfile = { isCertifiable: () => true };
+          placementProfileService.getPlacementProfile
+            .withArgs({ userId: 2, limitDate: now })
+            .resolves(placementProfile);
+          const badgeAcquisition = getOutdatedBadgeAcquisition();
+          certificationBadgesService.findLatestBadgeAcquisitions.resolves([badgeAcquisition]);
+          complementaryCertificationCourseRepository.findByUserId.resolves([
+            domainBuilder.buildComplementaryCertificationCourseWithResults({
+              id: 1,
+              hasExternalJury: true,
+              complementaryCertificationBadgeId: 2,
+              results: [
+                {
+                  id: 3,
+                  acquired: true,
+                  partnerKey: 'BADGE_KEY',
+                  source: 'PIX',
+                },
+              ],
+            }),
+          ]);
+
+          // when
+          const certificationEligibility = await getUserCertificationEligibility({
+            userId: 2,
+            placementProfileService,
+            certificationBadgesService,
+            complementaryCertificationCourseRepository,
+          });
+
+          // then
+          expect(certificationEligibility.complementaryCertifications).to.exactlyContain([
+            {
+              label: 'BADGE_LABEL',
+              imageUrl: 'http://www.image-url.com',
+              isOutdated: true,
+              isAcquired: false,
+            },
+          ]);
+        });
+      });
     });
   });
+
+  function getOutdatedBadgeAcquisition() {
+    return domainBuilder.buildCertifiableBadgeAcquisition({
+      badgeKey: 'BADGE_KEY',
+      complementaryCertificationBadgeId: 2,
+      complementaryCertificationBadgeLabel: 'BADGE_LABEL',
+      complementaryCertificationBadgeImageUrl: 'http://www.image-url.com',
+      isOutdated: true,
+    });
+  }
 });

--- a/mon-pix/app/components/certification-banners/index.hbs
+++ b/mon-pix/app/components/certification-banners/index.hbs
@@ -10,8 +10,8 @@
   </CertificationBanners::CongratulationsCertificationBanner>
 {{/if}}
 
-{{#if (gt this.outdatedComplementaryCertifications.length 0)}}
+{{#if (gt this.outdatedAndNotAcquiredComplementaryCertifications.length 0)}}
   <CertificationBanners::OutdatedComplementaryCertificationBanner
-    @complementaryCertifications={{this.outdatedComplementaryCertifications}}
+    @complementaryCertifications={{this.outdatedAndNotAcquiredComplementaryCertifications}}
   />
 {{/if}}

--- a/mon-pix/app/components/certification-banners/index.js
+++ b/mon-pix/app/components/certification-banners/index.js
@@ -10,11 +10,19 @@ export default class Index extends Component {
   }
 
   get eligibleComplementaryCertifications() {
-    return this.args.certificationEligibility.complementaryCertifications?.filter((c) => !c.isOutdated) ?? [];
+    return (
+      this.args.certificationEligibility.complementaryCertifications?.filter(
+        (complementaryCertification) => !complementaryCertification.isOutdated,
+      ) ?? []
+    );
   }
 
-  get outdatedComplementaryCertifications() {
-    return this.args.certificationEligibility.complementaryCertifications?.filter((c) => c.isOutdated) ?? [];
+  get outdatedAndNotAcquiredComplementaryCertifications() {
+    return (
+      this.args.certificationEligibility.complementaryCertifications?.filter(
+        (complementaryCertification) => complementaryCertification.isOutdated && !complementaryCertification.isAcquired,
+      ) ?? []
+    );
   }
 
   @action

--- a/mon-pix/tests/integration/components/certification-banners/eligible-complementary-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/certification-banners/eligible-complementary-certification-banner_test.js
@@ -17,6 +17,7 @@ module(
               label: 'CléA Numérique',
               imageUrl: 'http://www.image-clea.com',
               isOutdated: false,
+              isAcquired: false,
             },
           ];
           this.set('eligibleComplementaryCertifications', eligibleComplementaryCertifications);
@@ -41,8 +42,14 @@ module(
               label: 'CléA Numérique',
               imageUrl: 'http://www.image-clea.com',
               isOutdated: false,
+              isAcquired: false,
             },
-            { label: 'Pix+ Édu 1er degré Confirmé', imageUrl: 'http://www.image-clea.com', isOutdated: false },
+            {
+              label: 'Pix+ Édu 1er degré Confirmé',
+              imageUrl: 'http://www.image-clea.com',
+              isOutdated: false,
+              isAcquired: false,
+            },
           ];
           this.set('eligibleComplementaryCertifications', eligibleComplementaryCertifications);
 

--- a/mon-pix/tests/integration/components/certification-banners/index_test.js
+++ b/mon-pix/tests/integration/components/certification-banners/index_test.js
@@ -3,11 +3,11 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | Certification Banners | Congratulations Certification Banner', function (hooks) {
+module('Integration | Component | Certification Banners | index.js', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('When there are eligible complementary certifications', function () {
-    test(`renders the complementary certification eligibility special message and picture`, async function (assert) {
+  module('when there are eligible complementary certifications', function () {
+    test(`should render the complementary certification eligibility special message and picture`, async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const certificationEligibility = store.createRecord('is-certifiable', {
@@ -16,6 +16,13 @@ module('Integration | Component | Certification Banners | Congratulations Certif
             label: 'CléA Numérique',
             imageUrl: 'http://www.image-clea.com',
             isOutdated: false,
+            isAcquired: false,
+          },
+          {
+            label: 'Pix+ Droit',
+            imageUrl: 'http://www.image-droit.com',
+            isOutdated: false,
+            isAcquired: true,
           },
         ],
       });
@@ -29,46 +36,88 @@ module('Integration | Component | Certification Banners | Congratulations Certif
       );
 
       // then
-      assert.ok(screen.getByText('Vous êtes également éligible à la certification complémentaire :'));
+      assert.ok(screen.getByText('Vous êtes également éligible aux certifications complémentaires :'));
       assert.ok(screen.getByText('CléA Numérique'));
       assert.ok(screen.getByRole('img', { name: 'CléA Numérique' }));
+      assert.ok(screen.getByText('Pix+ Droit'));
+      assert.ok(screen.getByRole('img', { name: 'Pix+ Droit' }));
     });
   });
 
-  module('When there are outdated complementary certifications', function () {
-    test(`renders the outdated complementary certification eligibility special message and picture`, async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certificationEligibility = store.createRecord('is-certifiable', {
-        complementaryCertifications: [
-          {
-            label: 'CléA Numérique',
-            imageUrl: 'http://www.image-clea.com',
-            isOutdated: true,
-          },
-        ],
+  module('when there is an outdated complementary certification', function () {
+    module('when the outdated complementary certification is acquired', function () {
+      test(`should not render the outdated complementary certification eligibility special message and picture`, async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationEligibility = store.createRecord('is-certifiable', {
+          complementaryCertifications: [
+            {
+              label: 'CléA Numérique',
+              imageUrl: 'http://www.image-clea.com',
+              isOutdated: true,
+              isAcquired: true,
+            },
+          ],
+        });
+        this.set('certificationEligibility', certificationEligibility);
+        this.set('fullName', 'Fifi Brindacier');
+        this.set('closeBanner', () => {});
+
+        // when
+        const screen = await render(
+          hbs`<CertificationBanners @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`,
+        );
+
+        // then
+        assert.dom(screen.queryByRole('img', { name: 'CléA Numérique' })).doesNotExist();
+        assert
+          .dom(screen.queryByText("Vous n'êtes plus éligible à la certification CléA Numérique suite à son évolution."))
+          .doesNotExist();
+        assert
+          .dom(
+            screen.queryByText(
+              "Recontactez votre établissement ou l’organisation vous ayant proposé le parcours afin de repasser une campagne et ainsi redevenir éligible. Votre progression a été conservée et vous n'aurez qu'à jouer les nouvelles épreuves, cela devrait être rapide.",
+            ),
+          )
+          .doesNotExist();
       });
-      this.set('certificationEligibility', certificationEligibility);
-      this.set('fullName', 'Fifi Brindacier');
-      this.set('closeBanner', () => {});
+    });
+    module('when the outdated complementary certification is not acquired', function () {
+      test(`should render the outdated complementary certification eligibility special message and picture`, async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationEligibility = store.createRecord('is-certifiable', {
+          complementaryCertifications: [
+            {
+              label: 'CléA Numérique',
+              imageUrl: 'http://www.image-clea.com',
+              isOutdated: true,
+              isAcquired: false,
+            },
+          ],
+        });
+        this.set('certificationEligibility', certificationEligibility);
+        this.set('fullName', 'Fifi Brindacier');
+        this.set('closeBanner', () => {});
 
-      // when
-      const screen = await render(
-        hbs`<CertificationBanners @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`,
-      );
+        // when
+        const screen = await render(
+          hbs`<CertificationBanners @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`,
+        );
 
-      // then
-      assert.dom(screen.getByRole('img', { name: 'CléA Numérique' })).exists();
-      assert
-        .dom(screen.getByText("Vous n'êtes plus éligible à la certification CléA Numérique suite à son évolution."))
-        .exists();
-      assert
-        .dom(
-          screen.getAllByText(
-            "Recontactez votre établissement ou l’organisation vous ayant proposé le parcours afin de repasser une campagne et ainsi redevenir éligible. Votre progression a été conservée et vous n'aurez qu'à jouer les nouvelles épreuves, cela devrait être rapide.",
-          )[0],
-        )
-        .exists();
+        // then
+        assert.dom(screen.getByRole('img', { name: 'CléA Numérique' })).exists();
+        assert
+          .dom(screen.getByText("Vous n'êtes plus éligible à la certification CléA Numérique suite à son évolution."))
+          .exists();
+        assert
+          .dom(
+            screen.getByText(
+              "Recontactez votre établissement ou l’organisation vous ayant proposé le parcours afin de repasser une campagne et ainsi redevenir éligible. Votre progression a été conservée et vous n'aurez qu'à jouer les nouvelles épreuves, cela devrait être rapide.",
+            ),
+          )
+          .exists();
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/certification-banners/outdated-complementary-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/certification-banners/outdated-complementary-certification-banner_test.js
@@ -4,30 +4,33 @@ import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module(
-  'Integration | Component | Certification Banners | Ourdated Complementary Certification Banner',
+  'Integration | Component | Certification Banners | Outdated Complementary Certification Banner',
   function (hooks) {
     setupIntlRenderingTest(hooks);
 
     module('When there are outdated complementary certifications', function () {
       test(`renders the outdated complementary certification`, async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
-        const certificationEligibility = store.createRecord('is-certifiable', {
-          complementaryCertifications: [
-            { label: 'CléA Numérique', imageUrl: 'http://www.image-clea.com', isOutdated: true },
-            { label: 'Pix+ Édu 1er degré Confirmé', imageUrl: 'http://www.image-clea.com', isOutdated: true },
-          ],
-        });
-        const eligibleComplementaryCertifications = [];
+        const outdatedAndNotAcquiredComplementaryCertifications = [
+          { label: 'CléA Numérique', imageUrl: 'http://www.image-clea.com', isOutdated: true, isAcquired: false },
+          {
+            label: 'Pix+ Édu 1er degré Confirmé',
+            imageUrl: 'http://www.image-clea.com',
+            isOutdated: true,
+            isAcquired: false,
+          },
+        ];
 
-        this.set('eligibleComplementaryCertifications', eligibleComplementaryCertifications);
-        this.set('certificationEligibility', certificationEligibility);
+        this.set(
+          'outdatedAndNotAcquiredComplementaryCertifications',
+          outdatedAndNotAcquiredComplementaryCertifications,
+        );
         this.set('closeBanner', () => {});
 
         // when
         const screen = await render(
           hbs`<CertificationBanners::OutdatedComplementaryCertificationBanner
-          @complementaryCertifications={{this.certificationEligibility.complementaryCertifications}} />`,
+          @complementaryCertifications={{this.outdatedAndNotAcquiredComplementaryCertifications}} />`,
         );
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Le candidat qui a obtenu son RT certifiable dans la version précédente du profil cible qui n’est plus certifiable est avertit par message d’alerte dans son onglet Certifications sur Pix App.
Si cet utilisateur est déjà certifié le message d’alerte n’est pas pertinent.

## :robot: Proposition
Ne pas afficher le message d’alerte de perte d'éligibilité (disparition simple du message d'éligibilité dans l'onglet Certifications sur Pix App) si l'utilisateur a déjà obtenu cette certification.

## :100: Pour tester
Liste d'utilisateurs certifiables et certifiés à une certification complémentaire :
1. "email": pro1000003@example.net ; "complementaryCertification":"Pix+ Édu 1er degré"
2. "email":"pro1000004@example.net" ; "complementaryCertification":"Pix+ Droit"
3. "email":"pro1000005@example.net" ; "complementaryCertification":"CléA Numérique"
4. "email":"pro1000006@example.net" ; "complementaryCertification":"Pix+ Édu 2nd degré"

- Se connecter avec un des utilisateur de la liste sur l'**app Pix**
- Aller sur la page **Certification** voir le message disant que vous etes éligible à la certif complémentaire concernée s'affiche bien
<img width="400" alt="Capture d’écran 2023-11-02 à 14 39 20" src="https://github.com/1024pix/pix/assets/103997660/bc8a22c3-37da-42ae-93ec-bea63f6ad503">

- Changer le profil cible de cette certif complémentaire dans **Pix Admin**
- Retourner sur la page **Certification** de l'app Pix et voir qu'il n'y a pas de message comme quoi la certification n'est plus valide
<img width="400" alt="Capture d’écran 2023-11-02 à 14 41 41" src="https://github.com/1024pix/pix/assets/103997660/dd2052c3-3b4c-4a77-b3c5-ebf5a48d8764">


**Ce que vous ne devez pas voir :**

<img width="400" alt="Capture d’écran 2023-11-02 à 14 41 00" src="https://github.com/1024pix/pix/assets/103997660/a0262810-0336-4694-b1db-6c27452c95b5">
