### PR TITLE
[FEATURE] Ajouter des metriques sur retenter/remise à zéro d'une campagne (PIX-9730).

### DIFF
--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -7,6 +7,7 @@ export default class EntryPoint extends Route {
   @service session;
   @service router;
   @service store;
+  @service metrics;
 
   async beforeModel() {
     if (this.session.isAuthenticated && this.currentUser.user.isAnonymous) {
@@ -26,9 +27,21 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'participantExternalId', transition.to.queryParams.participantExternalId);
     }
     if (queryParams.retry) {
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Campagnes',
+        'pix-event-action': 'Retenter la campagne',
+        'pix-event-name': 'Clic sur Retenter la campagne',
+      });
       this.campaignStorage.set(campaign.code, 'retry', transition.to.queryParams.retry);
     }
     if (queryParams.reset) {
+      this.metrics.add({
+        event: 'custom-event',
+        'pix-event-category': 'Campagnes',
+        'pix-event-action': 'Remise à zéro de la campagne',
+        'pix-event-name': 'Clic sur Remise à zéro de la campagne',
+      });
       this.campaignStorage.set(campaign.code, 'reset', transition.to.queryParams.reset);
     }
 


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons suivre l'usage de ces features, mais nous n'avons rien pour le faire . 

## :robot: Proposition
Ajouter des évènements pour ces actions

## :rainbow: Remarques
Pour rappel, nous ajoutons les évènements via le code grâce au service `metrics` : 

Le nom de l'événement ne doit pas être changé et sera toujours `custom-event`
```
this.metrics.add({
        event: 'custom-event',
        'pix-event-category': 'Campagnes',
        'pix-event-action': 'Retenter la campagne',
        'pix-event-name': 'Clic sur Retenter la campagne',
      });
```


## :100: Pour tester
- Vérifier que la RA a la variable d'environnement setté : `WEB_ANALYTICS_URL`
- Lancer l'app 
- Se connecter à Matomo 
- Aller sur la RA et ajouter la preview  Matomo `?mtmPreviewMode=fNoTNeFZ`
- Vérifier que l'événement est envoyé 
