### PR TITLE
[TECH] Ajout de seeds pour les issue-report-categories (PIX-9738).

### DIFF
--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -473,10 +473,111 @@ async function _createIssueReportCategories({ databaseBuilder }) {
     isImpactful: true,
     issueReportCategoryId: candidateInformationChangeId,
   });
+
   databaseBuilder.factory.buildIssueReportCategory({
     name: 'EXTRA_TIME_PERCENTAGE',
     isDeprecated: false,
     isImpactful: false,
     issueReportCategoryId: candidateInformationChangeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'SIGNATURE_ISSUE',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'FRAUD',
+    isDeprecated: false,
+    isImpactful: true,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'NON_BLOCKING_CANDIDATE_ISSUE',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'NON_BLOCKING_TECHNICAL_ISSUE',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+
+  const inChallengeId = databaseBuilder.factory.buildIssueReportCategory({
+    name: 'IN_CHALLENGE',
+    isDeprecated: false,
+    isImpactful: false,
+  }).id;
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'IMAGE_NOT_DISPLAYING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'EMBED_NOT_WORKING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'FILE_NOT_OPENING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'WEBSITE_UNAVAILABLE',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'WEBSITE_BLOCKED',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'EXTRA_TIME_EXCEEDED',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'SOFTWARE_NOT_WORKING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'UNINTENTIONAL_FOCUS_OUT',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'SKIP_ON_OOPS',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'ACCESSIBILITY_ISSUE',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
   });
 }


### PR DESCRIPTION
## :unicorn: Problème

Nous ne disposons pas des seeds nécessaires au bon fonctionnement en local de la validation d'une alerte émise par un candidat en certification.

## :robot: Proposition

Ajout des seeds nécessaires.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

En local, lancer un `npm run db:reset`
Le process ne plante pas.
