### PR TITLE
[TECH] Ajouter des logs lors de l'échange des tokens Pole Emploi (PIX-9742)

### DIFF
--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -152,7 +152,12 @@ class OidcAuthenticationService {
 
     if (!httpResponse.isSuccessful) {
       const message = 'Erreur lors de la récupération des tokens du partenaire.';
-      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(httpResponse, message);
+      const dataToLog = {
+        ...httpErrorsHelper.serializeHttpErrorResponse(httpResponse, message),
+        code: 'EXCHANGE_CODE_FOR_TOKEN',
+        requestPayload: data,
+        identityProvider: this.identityProvider,
+      };
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
       throw new OidcInvokingTokenEndpointError(message);
     }


### PR DESCRIPTION
## :unicorn: Problème
Il y a actuellement des erreurs 422 sur la récupération des tokens Pôle Emploi. Le code actuel ne nous permet pas de continuer l'investigation

## :robot: Proposition
Ajouter un log pour faire apparaître, dans datadog, le payload de la requête vers Pôle Emploi.

## :rainbow: Remarques
RAS

## :100: Pour tester
En local: 
- Stubber l'appel vers Pôle Emploi (L.119 du fichier oidc-authentication-service.js) en remplaçant, l'appel par : 
```
const httpResponse = sinon.stub().returns({
      data: {
        error: 'INVALID_GRANT',
      },
    });
```
- Modifier la ligne 134 (monitoringTools.logErrorWithCorrelationIds...) par `console.log({message: dataToLog});`
- Se connecter, sur Pix App, avec un compte Pôle Emploi
- Vérifier qu'une page Oups, une erreur est survenue apparaît après la connexion.
- Aller dans la console de l'API et vérifier que le payload de la requête est bien affiché.
