### PR TITLE
[BUGFIX] Rectifier le style des citations dans la modale de correction (PIX-9272).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.challenge-statement__instruction-section blockquote {
+.challenge-statement-instruction__text blockquote {
   position: relative;
   margin-left: 20px;
   font-size: inherit;


### PR DESCRIPTION
## :unicorn: Problème

Les barres verticales des blocs de citation des consignes d'épreuves ne s'affichent pas sur les écrans de correction.

## :robot: Proposition

Utiliser le même style que dans les instructions d'épreuve.

## :100: Pour tester

- Faire [cette épreuve](https://app-pr7321.review.pix.fr/challenges/challenge1HU8emnUAGzamX/preview)
- ✅ La bordure de la citation doit toujours être présente dans l'intitulé de l'épreuve
- ✅ Dans la modale "Réponse et tutos", attester que la citation a bien une bordure grise
