### PR TITLE
[CLEANUP] Corriger les avertissements de dépréciations d'ember data sur Pix certif#2

### DIFF
--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -30,19 +30,22 @@ export default class SessionAdapter extends ApplicationAdapter {
               'has-incident': model.hasIncident,
               'has-joining-issue': model.hasJoiningIssue,
             },
-            included: model.certificationReports.map((certificationReport) => {
-              return {
-                type: 'certification-reports',
-                id: certificationReport.get('id'),
-                attributes: certificationReport.toJSON(),
-              };
-            }),
+            included: model
+              .hasMany('certificationReports')
+              .value()
+              .map((certificationReport) => {
+                return {
+                  type: 'certification-reports',
+                  id: certificationReport.get('id'),
+                  attributes: certificationReport.toJSON(),
+                };
+              }),
           },
         };
         return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PUT', { data });
       }
 
-      if (snapshot.adapterOptions.studentListToAdd) {
+      if (snapshot.adapterOptions.studentListToAdd.length) {
         const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/enrol-students-to-session';
         const organizationLearnerIds = snapshot.adapterOptions.studentListToAdd.map((student) => student.id);
         const data = {

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -75,7 +75,7 @@
           >{{report.certificationCourseId}}</td>
           <td data-test-id="finalization-report-certification-issue-reports_{{report.certificationCourseId}}">
             <div class="finalization-report-examiner-comment">
-              {{#if report.certificationIssueReports}}
+              {{#if report.certificationIssueReports.length}}
                 <button
                   type="button"
                   class="button--showed-as-link add-button"

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -29,9 +29,7 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   get uncheckedHasSeenEndTestScreenCount() {
-    return sumBy(this.session.completedCertificationReports.toArray(), (reports) =>
-      Number(!reports.hasSeenEndTestScreen),
-    );
+    return sumBy(this.session.completedCertificationReports, (reports) => Number(!reports.hasSeenEndTestScreen));
   }
 
   get hasUncheckedHasSeenEndTestScreen() {
@@ -107,7 +105,9 @@ export default class SessionsFinalizeController extends Controller {
   toggleAllCertificationReportsHasSeenEndTestScreen(allChecked, parentCheckbox) {
     const newState = !allChecked;
 
-    this.session.certificationReports
+    this.session
+      .hasMany('certificationReports')
+      .value()
       .filter((certificationReport) => certificationReport.isCompleted)
       .forEach((certificationReport) => {
         certificationReport.hasSeenEndTestScreen = newState;

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -142,9 +142,10 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   isValid() {
-    const invalidCertificationReports = this.session.certificationReports.filter(
-      (certificationReport) => certificationReport.isInvalid,
-    );
+    const invalidCertificationReports = this.session
+      .hasMany('certificationReports')
+      .value()
+      .filter((certificationReport) => certificationReport.isInvalid);
 
     if (invalidCertificationReports.length) {
       const select = document.getElementById(

--- a/certif/app/models/session-for-supervising.js
+++ b/certif/app/models/session-for-supervising.js
@@ -7,5 +7,5 @@ export default class SessionForSupervising extends Model {
   @attr('string') room;
   @attr('string') certificationCenterName;
   @attr('string') accessCode;
-  @hasMany('certification-candidate-for-supervising') certificationCandidates;
+  @hasMany('certification-candidate-for-supervising', { async: false, inverse: null }) certificationCandidates;
 }

--- a/certif/tests/acceptance/session-supervising-error_test.js
+++ b/certif/tests/acceptance/session-supervising-error_test.js
@@ -29,6 +29,7 @@ module('Acceptance | Session supervising error', function (hooks) {
       this.secondSession = server.create('session', {
         id: 2001,
       });
+      this.server.get('/sessions/2001/supervising', { errors: [{ code: 403 }] }, 403);
 
       const screen = await visitScreen('/connexion-espace-surveillant');
       await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '2000');
@@ -37,7 +38,6 @@ module('Acceptance | Session supervising error', function (hooks) {
 
       // when
       const secondScreen = await visitScreen('/sessions/2001/surveiller');
-
       // then
       assert.dom(secondScreen.getByRole('heading', { name: 'Une erreur est survenue' })).exists();
       assert

--- a/certif/tests/unit/adapters/session_test.js
+++ b/certif/tests/unit/adapters/session_test.js
@@ -104,10 +104,7 @@ module('Unit | Adapter | session', function (hooks) {
           isCompleted: true,
           abortReason: null,
         };
-        const certificationReport1 = store.createRecord('certification-report', {
-          get: sinon.stub().returns(1),
-          ...certifReportAttributes1,
-        });
+
         const certifReportAttributes2 = {
           certificationCourseId: 2,
           firstName: 'Tom',
@@ -117,16 +114,12 @@ module('Unit | Adapter | session', function (hooks) {
           isCompleted: true,
           abortReason: null,
         };
-        const certificationReport2 = store.createRecord('certification-report', {
-          get: sinon.stub().returns(2),
-          ...certifReportAttributes2,
+
+        const session = await _createSessionWithCertificationReports({
+          store,
+          sessionData: { examinerGlobalComment, hasIncident, hasJoiningIssue },
+          certificationReportsData: [certifReportAttributes1, certifReportAttributes2],
         });
-        const session = {
-          examinerGlobalComment,
-          hasIncident,
-          hasJoiningIssue,
-          certificationReports: [certificationReport1, certificationReport2],
-        };
         const snapshot = {
           id: 123,
           adapterOptions: { finalization: true },
@@ -149,14 +142,14 @@ module('Unit | Adapter | session', function (hooks) {
               included: [
                 {
                   type: 'certification-reports',
-                  id: 1,
+                  id: '1',
                   attributes: {
                     ...certifReportAttributes1,
                   },
                 },
                 {
                   type: 'certification-reports',
-                  id: 2,
+                  id: '2',
                   attributes: {
                     ...certifReportAttributes2,
                   },
@@ -217,3 +210,14 @@ module('Unit | Adapter | session', function (hooks) {
     });
   });
 });
+
+async function _createSessionWithCertificationReports({ store, sessionData = {}, certificationReportsData = [] }) {
+  const session = store.createRecord('session', sessionData);
+
+  if (certificationReportsData.length) {
+    const certificationReports = await session.get('certificationReports');
+    certificationReportsData.forEach(certificationReports.createRecord);
+  }
+
+  return session;
+}


### PR DESCRIPTION
## :unicorn: Problème
Il y a pleins d'avertissements de dépréciations sur certif du a la monté d'ember data. C'est très pénible de naviguer et debugger.


## :robot: Proposition
Corriger les warnings

## :rainbow: Remarques
Le package Ember-api-actions "ember-api-actions": "^0.2.9" remonte des warnings (peut-être reproduit via session.abort lors de la finalisation). Une [PR](https://github.com/mike-north/ember-api-actions/pull/617) est cree pour corriger ce probleme mais il possible que le module ne soit pas maintenu

Il semble aussi y avoir un warning venir des tests:

> ember-testing.js:503 DEPRECATION: Accessing schema information on Models without looking up the model via the store is deprecated. Use store.modelFor (or better Snapshots or the store.getSchemaDefinitionService() apis) instead. [deprecation id: ember-data:deprecate-early-static] This will be removed in ember-data 5.0.
>         at logDeprecationStackTrace (http://localhost:4203/assets/test-support.js:487:21)

## :100: Pour tester
Tests 🟢
Naviguer dans les pages en local et vérifier qu'il n'y a plus moins d'avertissements

