### PR TITLE
[BUGFIX][ADMIN] Afficher la date de création d'un compte seulement quand elle est disponible (PIX-9570)

### DIFF
--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -124,8 +124,12 @@
             <li class="user-detail-personal-information-section__user-informations">Nom : {{@user.lastName}}</li>
             <li class="user-detail-personal-information-section__user-informations">Langue : {{@user.lang}}</li>
             <li class="user-detail-personal-information-section__user-informations">Locale : {{@user.locale}}</li>
-            <li class="user-detail-personal-information-section__user-informations">Date de création :
-              {{dayjs-format @user.createdAt "DD/MM/YYYY"}}</li>
+            <li class="user-detail-personal-information-section__user-informations">
+              Date de création :
+              {{#if @user.createdAt}}
+                {{dayjs-format @user.createdAt "DD/MM/YYYY"}}
+              {{/if}}
+            </li>
           </ul>
           <ul class="user-detail-personal-information-section__infogroup">
             <li class="user-detail-personal-information-section__user-informations">Adresse e-mail :

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -62,6 +62,32 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByText('Date de création : 10/12/2021')).exists();
       });
 
+      test("displays user's information without creation date", async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const user = store.createRecord('user', {
+          firstName: 'John',
+          lastName: 'Snow',
+          email: 'john.snow@winterfell.got',
+          username: 'kingofthenorth',
+          lang: 'fr',
+          locale: 'fr-FR',
+        });
+        this.set('user', user);
+
+        // when
+        const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+        // then
+        assert.dom(screen.getByText(`Prénom : ${this.user.firstName}`)).exists();
+        assert.dom(screen.getByText(`Nom : ${this.user.lastName}`)).exists();
+        assert.dom(screen.getByText(`Adresse e-mail : ${this.user.email}`)).exists();
+        assert.dom(screen.getByText(`Identifiant : ${this.user.username}`)).exists();
+        assert.dom(screen.getByText('Langue : fr')).exists();
+        assert.dom(screen.getByText('Locale : fr-FR')).exists();
+        assert.dom(screen.getByText('Date de création :')).exists();
+      });
+
       module('terms of service', function () {
         module('should display yes by application', function () {
           test('should display "OUI" with date when user accepted Pix App terms of service', async function (assert) {

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -51,6 +51,15 @@ function _buildUsers(databaseBuilder) {
     email: 'gaal.dornick@foundation.verse',
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+
+  // User with a specific createdAt
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Chrono',
+    lastName: 'Post',
+    username: 'chrono.post',
+    email: 'chrono.post@example.net',
+    createdAt: new Date('2000-12-31'),
+  });
 }
 
 export function buildUsers(databaseBuilder) {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -210,6 +210,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
       "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -218,6 +219,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -360,6 +362,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz",
       "integrity": "sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -584,6 +587,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
       "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
         "@babel/traverse": "^7.23.2",
@@ -672,6 +676,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.2.tgz",
       "integrity": "sha512-eR0gJQc830fJVGz37oKLvt9W9uUIQSAovUl0e9sJ3YeO09dlcoBVYD3CLrjCj4qHdXmfiyTyFt8yeQYSN5fxLg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -999,6 +1004,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.2.tgz",
       "integrity": "sha512-BBYVGxbDVHfoeXbOwcagAkOQAm9NxoTdMGfTqghu1GrvadSaw6iW3Je6IcL5PNOw8VwjxqBECXy50/iCQSY/lQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1616,6 +1622,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.2.tgz",
       "integrity": "sha512-XOntj6icgzMS58jPVtQpiuF6ZFWxQiJavISGx5KGjRj+3gqZr8+N6Kx+N9BApWzgS+DOjIZfXXj0ZesenOWDyA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1809,6 +1816,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.2.tgz",
       "integrity": "sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.23.2",
         "@babel/helper-compilation-targets": "^7.22.15",
@@ -1922,6 +1930,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
       "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1947,6 +1956,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
       "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
@@ -14346,6 +14356,7 @@
       "version": "0.3.20",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
       "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -14948,6 +14959,7 @@
       "version": "20.8.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
       "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.25.1"
       }
@@ -15016,7 +15028,8 @@
     "node_modules/@types/symlink-or-copy": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/symlink-or-copy/-/symlink-or-copy-1.2.1.tgz",
-      "integrity": "sha512-8LQKxlJ8zXQ5U0wFXTSBXLHg8+oBbLMJXEC6vOqhL+iz8EfVvSxfdwtvq8ufkT9pumab0ntnvYXQBF/+cxzl9w=="
+      "integrity": "sha512-8LQKxlJ8zXQ5U0wFXTSBXLHg8+oBbLMJXEC6vOqhL+iz8EfVvSxfdwtvq8ufkT9pumab0ntnvYXQBF/+cxzl9w==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.29",
@@ -16730,6 +16743,7 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
       "integrity": "sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
         "@babel/helper-define-polyfill-provider": "^0.4.3",
@@ -16743,6 +16757,7 @@
       "version": "0.8.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.6.tgz",
       "integrity": "sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.3",
         "core-js-compat": "^3.33.1"
@@ -16755,6 +16770,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz",
       "integrity": "sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.3"
       },
@@ -19444,6 +19460,7 @@
       "version": "1.0.30001553",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
       "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20450,6 +20467,7 @@
       "version": "3.33.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.1.tgz",
       "integrity": "sha512-6pYKNOgD/j/bkC5xS5IIg6bncid3rfrI42oBH1SQJbsmYPKF7rhzcFzYCcxYMmNQQ0rCEB8WqpW7QHndOggaeQ==",
+      "dev": true,
       "dependencies": {
         "browserslist": "^4.22.1"
       },
@@ -21544,7 +21562,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.563",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.563.tgz",
-      "integrity": "sha512-dg5gj5qOgfZNkPNeyKBZQAQitIQ/xwfIDmEQJHCbXaD9ebTZxwJXUsDYcBlAvZGZLi+/354l35J1wkmP6CqYaw=="
+      "integrity": "sha512-dg5gj5qOgfZNkPNeyKBZQAQitIQ/xwfIDmEQJHCbXaD9ebTZxwJXUsDYcBlAvZGZLi+/354l35J1wkmP6CqYaw==",
+      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -46059,6 +46078,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -46722,6 +46742,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -47390,6 +47411,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -53265,6 +53287,7 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -56746,7 +56769,8 @@
     "node_modules/undici-types": {
       "version": "5.25.3",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",


### PR DESCRIPTION
## :unicorn: Problème

Actuellement lorsque l'on affiche les informations d'un compte, il arrive lorsque le réseau n'est pas stable, qu'une date soit affichée avant la date de création du compte, donc avant que la réponse de la requête HTTP soit reçue.

L'outil de gestion des dates utilise la date d'aujourd'hui si aucune date n'est fournie. D'où l'affichage de la date d'aujourd'hui avant celle du compte.

## :robot: Proposition

Afficher uniquement l'information de la date de création uniquement lorsque cette dernière existe.

## :rainbow: Remarques

Nous nous sommes rendus compte après le merge de la PR que fichier `certif/package-lock.json` avait été malencontreusement modifié dans le deuxième commit. Etant donné que seules des propriétés `"dev": true` ont été ajoutées, nous avons choisi de ne pas faire de fix. Ces modifications disparaîtront lors de la prochaine montée de versions sur _Pix Certif_.

## :100: Pour tester

- Se connecter à Pix Admin avec le compte `superadmin@example.net`
- Ouvrir la page `Utilisateurs`
- Faire une recherche sur le prénom `James`
- Ouvrir votre console développeur
- Dans l'onglet `Network|Réseau` choisir une condition détériorée du réseau (ex: Slow 3G)
![Screenshot 2023-10-25 at 10 51 48](https://github.com/1024pix/pix/assets/6919604/433ae2c2-2348-44e0-95fe-b58f6ddb66b5)
- Ouvrir la page de détails de cette utilisateur
- Constater que la date de création n'est affichée que lorsque toutes les données du compte ont été récupéré
