### PR TITLE
[TECH] Améliorer le css des modules (PIX-9751).

### DIFF
--- a/mon-pix/app/pods/components/module/details/styles.scss
+++ b/mon-pix/app/pods/components/module/details/styles.scss
@@ -1,20 +1,12 @@
 .module {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   max-width: 960px;
   margin: 0 auto;
 
   &__title {
     @extend %pix-title-m;
 
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
     margin: 1rem;
+    text-align: center;
   }
 
   &__content {
@@ -24,38 +16,32 @@
     align-items: center;
     justify-content: center;
   }
+}
 
-  .grain {
-    display: flex;
-    flex-direction: column;
-    gap: $pix-spacing-s;
-    width: 100%;
-    margin: 0;
-    padding: $pix-spacing-s;
-    background: $pix-neutral-0;
-    border: 1px solid $pix-neutral-22;
-    border-radius: $pix-spacing-s;
+.grain {
+  background: $pix-neutral-0;
+  border: 1px solid $pix-neutral-22;
+  border-radius: $pix-spacing-s;
 
-    &__element {
-      &--text {
-        @extend %pix-body-l;
+  &__element {
+    margin: $pix-spacing-s;
 
-        color: $pix-neutral-90;
+    &--text {
+      @extend %pix-body-l;
 
-        // revert the reset
-        ul, ol {
-          margin: revert;
-          padding: revert;
-          list-style: revert;
-        }
+      color: $pix-neutral-90;
+
+      // revert the reset
+      ul,
+      ol {
+        margin: revert;
+        padding: revert;
+        list-style: revert;
       }
     }
+  }
 
-    &__footer {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      gap: $pix-spacing-xs;
-    }
+  &__footer {
+    margin: $pix-spacing-s;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Nous utilisons beaucoup de flex dans la page des modules alors que ce n'est pas utile

## :robot: Proposition
Faire sans


Avant / Après 
![output-mobile](https://github.com/1024pix/pix/assets/26384707/17a0567d-ca9d-4914-bb1c-1b57bc74726e)

![output](https://github.com/1024pix/pix/assets/26384707/65cc0795-f012-43dd-ae58-295f0e0f96d9)




## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Comparer la page `/module/les-adresses-mail` entre [la RA](https://app-pr7325.review.pix.fr/modules/les-adresses-mail) et [la recette](https://app.recette.pix.fr/modules/les-adresses-mail) 
- Constater que ça se ressemble 