### PR TITLE
[FEATURE] Ajout du tag marquant une alerte en cours dans l'espace surveillant (PIX-8816).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -64,33 +64,26 @@
     <div class="session-supervising-candidate-in-list__status-container">
       {{#if @candidate.hasStarted}}
         {{#if @candidate.isAuthorizedToResume}}
-          <span
-            class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--authorized-to-resume"
-          >
-            {{t "common.forms.certification-labels.candidate-status.authorized-to-resume"}}
-          </span>
+          <PixTag
+            @compact={{true}}
+            class="session-supervising-candidate-in-list__status-container--authorized-to-resume"
+          >{{t "common.forms.certification-labels.candidate-status.authorized-to-resume"}}</PixTag>
         {{else}}
           {{#if @candidate.liveAlertStatus}}
-            <span
-              class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--ongoing-alert"
-            >
-              {{t "common.forms.certification-labels.candidate-status.ongoing-live-alert"}}
-            </span>
+            <PixTag @compact={{true}} class="session-supervising-candidate-in-list__status-container--ongoing-alert">{{t
+                "common.forms.certification-labels.candidate-status.ongoing-live-alert"
+              }}</PixTag>
           {{else}}
-            <span
-              class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
-            >
-              {{t "common.forms.certification-labels.candidate-status.ongoing"}}
-            </span>
+            <PixTag @compact={{true}} class="session-supervising-candidate-in-list__status-container--started">{{t
+                "common.forms.certification-labels.candidate-status.ongoing"
+              }}</PixTag>
           {{/if}}
         {{/if}}
       {{/if}}
       {{#if @candidate.hasCompleted}}
-        <span
-          class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--completed"
-        >
-          {{t "common.forms.certification-labels.candidate-status.finished"}}
-        </span>
+        <PixTag @compact={{true}} class="session-supervising-candidate-in-list__status-container--completed">{{t
+            "common.forms.certification-labels.candidate-status.finished"
+          }}</PixTag>
       {{/if}}
     </div>
   </div>

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -70,11 +70,19 @@
             {{t "common.forms.certification-labels.candidate-status.authorized-to-resume"}}
           </span>
         {{else}}
-          <span
-            class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
-          >
-            {{t "common.forms.certification-labels.candidate-status.ongoing"}}
-          </span>
+          {{#if @candidate.liveAlertStatus}}
+            <span
+              class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--ongoing-alert"
+            >
+              {{t "common.forms.certification-labels.candidate-status.ongoing-live-alert"}}
+            </span>
+          {{else}}
+            <span
+              class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
+            >
+              {{t "common.forms.certification-labels.candidate-status.ongoing"}}
+            </span>
+          {{/if}}
         {{/if}}
       {{/if}}
       {{#if @candidate.hasCompleted}}

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -56,6 +56,11 @@
       background-color: $pix-primary-10;
       color: $pix-primary-70;
     }
+
+    &--ongoing-alert {
+      background-color: $pix-error-10;
+      color: $pix-error-70;
+    }
   }
 
   &__status-container {

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -34,22 +34,29 @@
     margin: 16px;
   }
 
-  &__status {
+  &__status-container {
     border-radius: 12px;
     display: inline-block;
     font-size: 0.75rem;
-    font-weight: 400;
-    margin-top: 8px;
-    padding: 4px 16px;
+    font-weight: $font-normal;
+    margin-top: $pix-spacing-xs;
+    padding: $pix-spacing-xxs 0;
+
+    @include device-is('tablet') {
+      margin-top: 0;
+      position: absolute;
+      right: $pix-spacing-s;
+      top: $pix-spacing-xxs;
+    }
+
+    &--ongoing-alert {
+      background-color: $pix-error-10;
+      color: $pix-error-70;
+    }
 
     &--started {
       background-color: $pix-success-5;
       color: $pix-success-80;
-    }
-
-    &--authorized-to-resume {
-      background-color: $pix-tertiary-5;
-      color: $pix-tertiary-80;
     }
 
     &--completed {
@@ -57,17 +64,15 @@
       color: $pix-primary-70;
     }
 
-    &--ongoing-alert {
-      background-color: $pix-error-10;
-      color: $pix-error-70;
+    &--authorized-to-resume {
+      background-color: $pix-tertiary-5;
+      color: $pix-tertiary-80;
     }
-  }
 
-  &__status-container {
-    @include device-is('tablet') {
-      position: absolute;
-      right: $pix-spacing-s;
-      top: $pix-spacing-xxs;
+    > .pix-tag--compact {
+      font-family: $font-roboto;
+      font-weight: $font-normal;
+      text-transform: none;
     }
   }
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -313,6 +313,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.getByText('Début :')).exists();
       assert.dom(screen.getByText('Fin théorique :')).exists();
       assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
+      assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
+      assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
+      assert.dom(screen.queryByText('Terminé')).doesNotExist();
     });
 
     module('when there is no current live alert', () => {
@@ -389,6 +392,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.getByText('Début :')).exists();
       assert.dom(screen.getByText('Fin théorique :')).exists();
       assert.dom(screen.getByText('+ temps majoré 12 %')).exists();
+      assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
+      assert.dom(screen.queryByText('En cours')).doesNotExist();
+      assert.dom(screen.queryByText('Terminé')).doesNotExist();
     });
   });
 
@@ -414,10 +420,37 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.queryByText('Début :')).doesNotExist();
       assert.dom(screen.queryByText('Fin théorique :')).doesNotExist();
       assert.dom(screen.queryByText('+ temps majoré 12 %')).doesNotExist();
+      assert.dom(screen.queryByText('Signalement en cours')).doesNotExist();
+      assert.dom(screen.queryByText('En cours')).doesNotExist();
+      assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
     });
   });
 
   module('when the candidate has alerted the invigilator', function () {
+    test('it displays the live alert tag', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        startDateTime: new Date('2022-10-19T14:30:15Z'),
+        theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+        extraTimePercentage: 0.12,
+        authorizedToStart: false,
+        assessmentStatus: 'started',
+        liveAlertStatus: 'ongoing',
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+              <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+            `);
+
+      // then
+      assert.dom(screen.getByText('Signalement en cours')).exists();
+      assert.dom(screen.queryByText('En cours')).doesNotExist();
+      assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
+      assert.dom(screen.queryByText('Terminé')).doesNotExist();
+    });
+
     test('it displays the alert', async function (assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -94,6 +94,7 @@
           "authorized-to-resume": "Allowed to resume",
           "finished": "Finished",
           "ongoing": "In progress",
+          "ongoing-live-alert": "Signalement en cours",
           "start": "Start"
         },
         "email-convocation": "Email for the convocation",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -94,6 +94,7 @@
           "authorized-to-resume": "Autorisé à reprendre",
           "finished": "Terminé",
           "ongoing": "En cours",
+          "ongoing-live-alert": "Signalement en cours",
           "start": "Début"
         },
         "email-convocation": "E-mail de convocation",


### PR DESCRIPTION
## :unicorn: Problème

Quand un candidat lève une alerte dans une session de certification V3, le surveillant ne peut pas identifier simplement les candidats avec un signalement en attente.

## :robot: Proposition

Ajout d'un tag remplaçant celui précisant que la session du candidat est en cours

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Créer une session de certif dans un CDC taggué “isV3Pilot” (`certifv3@example.net`)
- Inscrire un candidat à cette session
- Rejoindre la session avec ce candidat et commencer le test
- Ouvrir l’espace surveillant
- Cliquer sur le menu pour ce candidat (les trois petits points sur le côté)
- L’option “Gérer un signalement” n’est pas affichée car le candidat n’a pas de signalement en attente
- Retourner sur le test du candidat, cliquer sur “Signaler un problème avec la question”, puis “Oui, je suis sûr”
- Vérifier que le tag spécifie que le candidat a un signalement en attente
- De retour sur l’espace surveillant, cliquer le menu pour ce candidat (les trois points)
- L’option “Gérer un signalement” est affichée car le candidat a un signalement en attente

Vérifier qu’il n’y a pas eu de régression pour les sessions v2
