### PR TITLE
[FEATURE] Ajouter la configuration pour phrase

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -1,0 +1,41 @@
+phrase:
+  file_format: nested_json
+  push:
+    sources:
+    - file: ./mon-pix/translations/<locale_name>.json
+      project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+
+    - file: ./orga/translations/<locale_name>.json
+      project_id: "93a23f4b74a86dbb53244134fb21ef43"
+
+    - file: ./certif/translations/<locale_name>.json
+      project_id: "3371843f0a06e47d0fba1374b19b439c"
+
+    - file: ./admin/translations/<locale_name>.json
+      project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+
+    - file: ./1d/translations/<locale_name>.json
+      project_id: "dd99bbfc9e880398e292a808e7013896"
+
+    - file: ./api/translations/<locale_name>.json
+      project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+
+  pull:
+    targets:
+     - file: ./mon-pix/translations/<locale_name>.json
+       project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+
+     - file: ./orga/translations/<locale_name>.json
+       project_id: "93a23f4b74a86dbb53244134fb21ef43"
+
+     - file: ./certif/translations/<locale_name>.json
+       project_id: "3371843f0a06e47d0fba1374b19b439c"
+
+     - file: ./admin/translations/<locale_name>.json
+       project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+
+     - file: ./1d/translations/<locale_name>.json
+       project_id: "dd99bbfc9e880398e292a808e7013896"
+
+     - file: ./api/translations/<locale_name>.json
+       project_id: "88f30f82bdab4e25ac5e57b6663a941a"


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons centraliser la gestion des traductions dans un outils pour avoir une vue d'ensemble. Nous avons décider d'utiliser phrase.

## :robot: Proposition
Ajouter la configuration de phrase en suivant la documentation:
- https://support.phrase.com/hc/en-us/articles/5784093898908-Create-a-CLI-Configuration-File-Strings-


## :100: Pour tester
En testant avec le CLI (avant la synchro github) et avec un access token valide

> docker run --rm --tty --interactive --volume $(pwd):/code --workdir /code ghcr.io/francois2metz/phrase --access_token XXX push

Et vérifier ques les fichiers ont bien été envoyé dans Phrase.
