### PR TITLE
[FEATURE] Trier les candidats par statut d'alerte dans l'espace surveillant (PIX-8817).

### DIFF
--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -41,7 +41,7 @@ const get = async function (idSession) {
             'label', "complementary-certifications"."label",
             'certificationExtraTime', "complementary-certifications"."certificationExtraTime"
           )
-        ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
+        ) order by "ongoing-live-alerts".status, lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
     `),
     })
     .from('sessions')

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -263,7 +263,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
         );
       });
 
-      it('should return associated certifications candidates ordered by lastname and firstname', async function () {
+      it('should return associated certifications candidates ordered by live alert status, lastname and firstname', async function () {
         // given
         databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
         const session = databaseBuilder.factory.buildSession({
@@ -344,6 +344,15 @@ describe('Integration | Repository | SessionForSupervising', function () {
         );
         expect(actualCandidates).to.have.deep.ordered.members([
           {
+            userId: 12345,
+            lastName: 'Joplin',
+            firstName: 'Janis',
+            authorizedToStart: true,
+            assessmentStatus: Assessment.states.STARTED,
+            startDateTime: '2022-10-19T13:37:00+00:00',
+            liveAlertStatus: CertificationChallengeLiveAlertStatus.ONGOING,
+          },
+          {
             userId: 33333,
             lastName: 'Jackson',
             firstName: 'Janet',
@@ -360,15 +369,6 @@ describe('Integration | Repository | SessionForSupervising', function () {
             assessmentStatus: null,
             startDateTime: null,
             liveAlertStatus: null,
-          },
-          {
-            userId: 12345,
-            lastName: 'Joplin',
-            firstName: 'Janis',
-            authorizedToStart: true,
-            assessmentStatus: Assessment.states.STARTED,
-            startDateTime: '2022-10-19T13:37:00+00:00',
-            liveAlertStatus: CertificationChallengeLiveAlertStatus.ONGOING,
           },
           {
             userId: 22222,


### PR DESCRIPTION
## :unicorn: Problème

Un statut “Signalement en attente” a été ajouté dans l’espace surveillant afin de permettre au surveillant de visualiser plus simplement les candidats dans cette situation, et ne proposer l’option “Gérer un signalement” quand pour les candidats dont la certification est en attente.

Pour une session avec beaucoup de candidats, retrouver un candidat dont la certification est dans ce statut peut être fastidieux.

## :robot: Proposition

Afficher en haut de la liste des candidats ceux qui ont fait remonter une alerte.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Créer une session de certif dans un CDC taggué “isV3Pilot”
- Inscrire des candidats à cette session
- Rejoindre la session avec le dernier candidat de la liste et commencer son test
- Cliquer sur “Signaler un problème avec la question”, puis “Oui, je suis sur”
- Attendre le rafraichissement de la liste des candidats dans l’espace surveillant 

Le candidat qui a signalé un problème (donc dont le statut est “Signalement en attente”) est affiché en haut de la liste des candidats
