### PR TITLE
[TECH] Script pour générer des élèves et une orga type SCO-1D (PIX-9675)

### DIFF
--- a/api/db/database-builder/factory/build-school.js
+++ b/api/db/database-builder/factory/build-school.js
@@ -3,7 +3,7 @@ import { databaseBuffer } from '../database-buffer.js';
 import _ from 'lodash';
 
 const buildSchool = function ({ id = databaseBuffer.getNextId(), code, organizationId } = {}) {
-  organizationId = _.isNil(organizationId) ? buildOrganization().id : organizationId;
+  organizationId = _.isNil(organizationId) ? buildOrganization({ type: 'SCO-1D' }).id : organizationId;
   // Because of unicity constraint if no code is given we set the unique id as campaign code.
   code = _.isUndefined(code) ? id.toString() : code;
 

--- a/api/src/school/scripts/create-school-learners.js
+++ b/api/src/school/scripts/create-school-learners.js
@@ -1,0 +1,121 @@
+import { disconnect, knex } from '../../../db/knex-database-connection.js';
+
+import { Organization } from '../../../lib/domain/models/Organization.js';
+import * as codeGenerator from '../../../lib/domain/services/code-generator.js';
+import * as organizationRepository from '../../../lib/infrastructure/repositories/organization-repository.js';
+import * as schoolRepository from '../../../src/school/infrastructure/repositories/school-repository.js';
+import { logger } from '../../shared/infrastructure/utils/logger.js';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import bluebird from 'bluebird';
+
+const STUDENT_NAMES = [
+  { firstName: 'Ichigo', lastName: 'Hara-Masuda' },
+  { firstName: 'Zoro', lastName: 'Miura' },
+  { firstName: 'Kamina', lastName: 'Ota' },
+  { firstName: 'Goku-Yoshida', lastName: 'Fukuda' },
+  { firstName: 'Nagisa', lastName: 'Nishimura' },
+  { firstName: 'Sakura', lastName: 'Fujii' },
+  { firstName: 'Lelouch', lastName: 'Endo' },
+  { firstName: 'Shizuka', lastName: 'Sakamoto' },
+  { firstName: 'Zenitsu', lastName: 'Saito' },
+  { firstName: 'Katsuki', lastName: 'Ishii' },
+  { firstName: 'Usagi-Yoshida', lastName: 'Kondo' },
+  { firstName: 'Shinya', lastName: 'Murakami Fujimoto' },
+  { firstName: 'Hana-Belle', lastName: 'Hasegawa' },
+  { firstName: 'Ayame', lastName: 'Okada' },
+  { firstName: 'Yato-Hidaka', lastName: 'Ogawa' },
+  { firstName: 'Lucy', lastName: 'Fujita' },
+  { firstName: 'Yuki', lastName: 'Maeda' },
+  { firstName: 'Spike', lastName: 'Nakajima' },
+  { firstName: 'Hikari', lastName: 'Ishikawa Nakamura' },
+  { firstName: 'Haruka', lastName: 'Yamashita' },
+  { firstName: 'Faye', lastName: 'Hashimoto' },
+  { firstName: 'Kirito', lastName: 'Ikeda' },
+  { firstName: 'Gon', lastName: 'Abe' },
+  { firstName: 'Mikasa', lastName: 'Mori' },
+  { firstName: 'Roy-Tanaka', lastName: 'Yamazaki Yamamoto' },
+  { firstName: 'Esdras-Onishi', lastName: 'Shimizu' },
+  { firstName: 'Rin', lastName: 'Hayashi' },
+  { firstName: 'Kushina', lastName: 'Kimura' },
+  { firstName: 'Yusuke', lastName: 'Inoue' },
+  { firstName: 'Ayako-Oshiro', lastName: 'Matsumoto' },
+  { firstName: 'Kaori', lastName: 'Yamaguchi' },
+  { firstName: 'Touka', lastName: 'Yamada' },
+  { firstName: 'Chiharu', lastName: 'Sasaki' },
+  { firstName: 'Levi-Takashi', lastName: 'Yoshida' },
+  { firstName: 'Kirishima', lastName: 'Kato' },
+];
+
+async function buildSchoolOrganization({ name }) {
+  const savedOrganization = await organizationRepository.create(
+    new Organization({ name, type: Organization.types.SCO1D, isManagingStudents: true }),
+  );
+  const code = await codeGenerator.generate(schoolRepository);
+  await schoolRepository.save({ organizationId: savedOrganization.id, code });
+  logger.info(`le code de l'organisation est: ${code}`);
+  return savedOrganization;
+}
+
+async function buildLearners({ organizationId }) {
+  await bluebird.map(STUDENT_NAMES, async (studentName) => {
+    await knex('organization-learners').insert({
+      organizationId,
+      firstName: studentName.firstName,
+      lastName: studentName.lastName,
+      division: 'CM2',
+    });
+  });
+}
+
+async function showSchools() {
+  const schools = await knex('schools')
+    .select('code', 'organizationId', 'name')
+    .innerJoin('organizations', 'organizations.id', 'organizationId')
+    .where({ type: Organization.types.SCO1D })
+    .returning('*');
+
+  logger.info('code | organizationId | name');
+  schools.forEach((school) => logger.info(`${school.code} | ${school.organizationId} | ${school.name}`));
+
+  return schools;
+}
+
+function _validateArgs({ generate, name }) {
+  if (generate && !name) {
+    throw new Error('Name argument should be given to generate school.');
+  }
+  return { generate, name };
+}
+
+async function main() {
+  const commandLineArgs = yargs(hideBin(process.argv))
+    .option('generate', {
+      description: 'Creates a school with 35 learners in the database.',
+    })
+    .option('name', {
+      description: 'Name of the school to create.',
+      type: 'string',
+    })
+    .help().argv;
+  const { generate, name } = _validateArgs(commandLineArgs);
+  if (generate) {
+    const organization = await buildSchoolOrganization({ name });
+    return await buildLearners({ organizationId: organization.id });
+  } else {
+    await showSchools();
+  }
+}
+
+(async () => {
+  try {
+    await main();
+  } catch (error) {
+    logger.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+})();
+
+export { buildSchoolOrganization, buildLearners, showSchools };

--- a/api/src/school/scripts/create-school-learners.js
+++ b/api/src/school/scripts/create-school-learners.js
@@ -48,16 +48,19 @@ const STUDENT_NAMES = [
 ];
 
 async function buildSchoolOrganization({ name }) {
+  logger.info(`Create organization with name: ${name}`);
   const savedOrganization = await organizationRepository.create(
     new Organization({ name, type: Organization.types.SCO1D, isManagingStudents: true }),
   );
+  logger.info(`Create school related to organization with id: ${savedOrganization.id}`);
   const code = await codeGenerator.generate(schoolRepository);
   await schoolRepository.save({ organizationId: savedOrganization.id, code });
-  logger.info(`le code de l'organisation est: ${code}`);
+  logger.info(`School created with code: ${code}`);
   return savedOrganization;
 }
 
 async function buildLearners({ organizationId }) {
+  logger.info('Create learners for organization.');
   await bluebird.map(STUDENT_NAMES, async (studentName) => {
     await knex('organization-learners').insert({
       organizationId,
@@ -66,6 +69,7 @@ async function buildLearners({ organizationId }) {
       division: 'CM2',
     });
   });
+  logger.info('Learners created.');
 }
 
 async function showSchools() {
@@ -101,7 +105,7 @@ async function main() {
   const { generate, name } = _validateArgs(commandLineArgs);
   if (generate) {
     const organization = await buildSchoolOrganization({ name });
-    return await buildLearners({ organizationId: organization.id });
+    await buildLearners({ organizationId: organization.id });
   } else {
     await showSchools();
   }

--- a/api/src/school/scripts/create-school-learners.js
+++ b/api/src/school/scripts/create-school-learners.js
@@ -81,8 +81,6 @@ async function showSchools() {
 
   logger.info('code | organizationId | name');
   schools.forEach((school) => logger.info(`${school.code} | ${school.organizationId} | ${school.name}`));
-
-  return schools;
 }
 
 function _validateArgs({ generate, name }) {

--- a/api/tests/school/integration/scripts/create-school-learners_tests.js
+++ b/api/tests/school/integration/scripts/create-school-learners_tests.js
@@ -1,0 +1,57 @@
+import {
+  buildLearners,
+  buildSchoolOrganization,
+  showSchools,
+} from '../../../../src/school/scripts/create-school-learners.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+import { Organization } from '../../../../lib/domain/models/Organization.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+
+describe('Integration | Script | create school learners', function () {
+  afterEach(async function () {
+    await knex('organization-learners').delete();
+    await knex('schools').delete();
+    await knex('organizations').delete();
+  });
+  describe('#buildSchool', function () {
+    it('should create a school with a code', async function () {
+      const organization = await buildSchoolOrganization({ name: 'Bambino' });
+      const school = await knex('schools').where({ organizationId: organization.id }).first();
+
+      expect(organization).to.be.instanceOf(Organization);
+      expect(organization.type).to.equal('SCO-1D');
+      expect(school).to.exist;
+    });
+  });
+
+  describe('#buildLearners', function () {
+    it('should create 35 leaners', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      await buildLearners({ organizationId });
+
+      const learners = await knex('organization-learners').where({ organizationId });
+      expect(learners.length).to.equal(35);
+    });
+  });
+
+  describe('#showSchools', function () {
+    it('should display all SCO-1D schools information', async function () {
+      sinon.stub(logger, 'info');
+
+      const organization1 = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
+      const organization2 = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
+      databaseBuilder.factory.buildSchool({ code: 'TESTONS', organizationId: organization1.id });
+      databaseBuilder.factory.buildSchool({ code: 'LAVIES789', organizationId: organization2.id });
+      await databaseBuilder.commit();
+
+      await showSchools();
+
+      expect(logger.info).to.have.callCount(3);
+      expect(logger.info).to.have.been.calledWith('code | organizationId | name');
+      expect(logger.info).to.have.been.calledWith(`TESTONS | ${organization1.id} | ${organization1.name}`);
+      expect(logger.info).to.have.been.calledWith(`LAVIES789 | ${organization2.id} | ${organization2.name}`);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On souhaite faire des panels pour présenter et avoir l'avis des élèves et des professeurs sur nos travaux.
N'ayant pas d'environnement de prod, nous devons faire ces panels en recette.
Mais nous n'avons pas d'élèves rattachés à une orga de type SCO-1D, donc on ne peut pas identifier d'élève sur la recette.

## :robot: Proposition
Créer un script qui générera des élèves.
 ce script prend 2 paramêtres:
- `--generate` : qui précise qu'on souhaite crée des élèves
- `--name='École exemple'`:  qui permet de donner un nom à l 'organisation qui sera créée.
Si aucun des params ou si seulement `name` est présent, alors le script loggera les organisations de type SCO-1D existantes.
Si seulement le params `--generate` est fourni alors il y aura une erreur car le params `name` est requis pour générer une orga.

## :rainbow: Remarques


## :100: Pour tester
- se connecter à scalingo et lancer le script. Exemple : 
scalingo -a pix-api-review-pr7329 run "node src/school/scripts/create-school-learners.js --generate --name='Ecole du Jura'"
⚠️ Bien mettre la commande node complète entre double quote si le nom de l'école comporte des espaces.
- récupérer le code de l'organisation créé et le remplir sur PIX1D.
