### PR TITLE
[FEATURE] MAJ du lien de téléchargement de PV d'incident pour les session V3 (PIX-8814).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -27,6 +27,7 @@ const serialize = function ({ session, hasSupervisorAccess, hasSomeCleaAcquired 
     'supervisorPassword',
     'hasSupervisorAccess',
     'hasSomeCleaAcquired',
+    'version',
   ];
   return new Serializer('session', {
     transform(record) {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -22,6 +22,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
             date: '2017-01-20',
             time: '14:30',
             status: statuses.PROCESSED,
+            version: 2,
             description: '',
             'examiner-global-comment': 'It was a fine session my dear',
             'has-incident': true,
@@ -62,6 +63,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
         finalizedAt: new Date('2020-02-17T14:23:56Z'),
         resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
         publishedAt: new Date('2020-02-21T14:23:56Z'),
+        version: 2,
       });
     });
 

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -39,6 +39,9 @@ export default class SessionsDetailsController extends Controller {
   }
 
   get urlToDownloadSessionIssueReportSheet() {
+    if (this.session.version === 3) {
+      return this.url.urlToDownloadSessionV3IssueReportSheet;
+    }
     return this.url.urlToDownloadSessionIssueReportSheet;
   }
 }

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -29,6 +29,7 @@ export default class Session extends Model {
   @attr('boolean') hasIncident;
   @attr('boolean') hasJoiningIssue;
   @attr() certificationCenterId;
+  @attr('number') version;
   @hasMany('certificationReport', { async: true, inverse: null }) certificationReports;
 
   @computed('status')

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -67,6 +67,10 @@ export default class Url extends Service {
     return 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download';
   }
 
+  get urlToDownloadSessionV3IssueReportSheet() {
+    return 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download';
+  }
+
   get fraudFormUrl() {
     return 'https://form-eu.123formbuilder.com/41052/form';
   }

--- a/certif/tests/unit/controllers/authenticated/sessions/details_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details_test.js
@@ -108,4 +108,18 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
       assert.notOk(shouldDisplayDownloadButton);
     });
   });
+
+  module('#urlToDownloadSessionIssueReportSheet', function () {
+    test('should return a url to download the V3 issue report PDF if session is V3', function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      controller.model = { session: { version: 3 } };
+
+      // when
+      const url = controller.urlToDownloadSessionIssueReportSheet;
+
+      // then
+      assert.strictEqual(url, 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Contexte : 

Dans le cadre du nouveau process de signalement pour la certif v3, les signalements de type “E - Problème technique sur une question” seront remontés directement pendant le test de certification via l’espace surveillant, et non a posteriori comme c’est le cas pour la certif v2.

Il ne sera donc plus nécessaire de reporter les signalements de catégorie “E - Problème technique sur une question” ni sur le PV d’incident, ni sur la page de finalisation de session.

Le PV d’incident actuellement téléchargeable depuis la page de détails d’une session dans Pix certif, contient les catégories de signalement de type E, alors que ça ne doit pas être possible pour une certif v3.

## :robot: Proposition

Modifier le lien de téléchargement du PV d’incident :

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Créer une session de certif dans un CDC taggué “isV3Pilot” (`certifv3@example.net`)
- Cliquer sur le lien de téléchargement “PV d’incident”
- Le modèle de PV d’incident téléchargé ne contient pas les catégories de type E - Problème technique sur une question
- Créer une session de certif dans un CDC qui n’est PAS taggué “isV3Pilot” (`certif-pro@example.net`)
- Cliquer sur le lien de téléchargement “PV d’incident”
- Le modèle de PV d’incident téléchargé contient les catégories de type E - Problème technique sur une question
