### PR TITLE
[TECH] - Api arborescence migration - amélioration du graph time series

### DIFF
--- a/api/scripts/arborescence-monitoring/add-metrics-to-gist.js
+++ b/api/scripts/arborescence-monitoring/add-metrics-to-gist.js
@@ -1,49 +1,27 @@
 import { readFile, writeFile } from 'fs/promises';
 import { countFilesInPath } from './stats.js';
+import { TimeSeries } from './time-series.js';
 
 async function parseTimeSeriesMetrics({ metricsFilepath }) {
   const currentRawMetrics = await readFile(metricsFilepath, { encoding: 'utf-8' });
   return JSON.parse(currentRawMetrics);
 }
 
-function sortTimeSeriesMetrics(existingTimeSeriesMetrics) {
-  return existingTimeSeriesMetrics.sort((a, b) => new Date(a.x).getTime() - new Date(b.x).getTime());
-}
-
 async function main() {
   const metricsFilepath = process.argv[2];
   const existingTimeSeriesMetrics = await parseTimeSeriesMetrics({ metricsFilepath });
 
-  const updatedTimeSeriesMetrics = await _addOrUpdateTodayValue(existingTimeSeriesMetrics);
-  const sortedTimeSeriesMetrics = sortTimeSeriesMetrics(updatedTimeSeriesMetrics);
-
-  const stringifiedMetrics = JSON.stringify(sortedTimeSeriesMetrics);
-  await writeFile(metricsFilepath, stringifiedMetrics);
+  let timeSeries = new TimeSeries(existingTimeSeriesMetrics);
+  timeSeries = await _addOrUpdateTodayValue(timeSeries);
+  await writeFile(metricsFilepath, timeSeries.toString());
 }
 
-async function _addOrUpdateTodayValue(existingTimeSeriesMetrics) {
+async function _addOrUpdateTodayValue(timeSeries) {
   const usecasesCount = await countFilesInPath('./lib/domain/usecases');
-
-  const todayIndex = _todayIndex(existingTimeSeriesMetrics);
-  existingTimeSeriesMetrics.splice(todayIndex, _addOrUpdate(todayIndex), {
+  return timeSeries.add({
     x: new Date().toJSON(),
     y: usecasesCount,
   });
-  return existingTimeSeriesMetrics;
-}
-
-function _todayIndex(existingTimeSeriesMetrics) {
-  return existingTimeSeriesMetrics.findIndex(function (metric) {
-    return _isSameDay(new Date(metric.x), new Date());
-  });
-}
-
-function _isSameDay(d1, d2) {
-  return d1.getFullYear() === d2.getFullYear() && d1.getDate() === d2.getDate() && d1.getMonth() === d2.getMonth();
-}
-
-function _addOrUpdate(todayIndex) {
-  return todayIndex >= 0 ? 1 : 0;
 }
 
 await main();

--- a/api/scripts/arborescence-monitoring/time-series.js
+++ b/api/scripts/arborescence-monitoring/time-series.js
@@ -2,14 +2,15 @@ import { assertNotNullOrUndefined } from '../../src/shared/domain/models/asserts
 
 const MAXIMUM_NUMBER_OF_POINTS_THRESHOLD = 28;
 
-const PURGE_POINT_INDEX = 10;
+const PURGE_MIDDLE_POINT_INDEX = 10;
 
-const NB_POINTS_TO_PURGE = 1;
+const ONE_POINT_TO_PURGE = 1;
 
 const NULL_OR_UNDEFINED_POINTS_ERROR_MESSAGE = 'Time series should have a non null/undefined array of points';
 
 export class TimeSeries {
   #points;
+
   constructor(points) {
     assertNotNullOrUndefined(points, NULL_OR_UNDEFINED_POINTS_ERROR_MESSAGE);
     points.sort((pointA, pointB) => new Date(pointA.x).getTime() - new Date(pointB.x).getTime());
@@ -31,17 +32,16 @@ export class TimeSeries {
   add({ x, y }) {
     if (this.#sameValueThanTheLast(y)) {
       return this.#replaceLastPointByNewPoint({ x, y });
-    } else {
-      this.#points.push({ x, y });
-      if (this.#exceedMaxNumberOfPoints()) {
-        this.#purgeOnePoint();
-      }
-      return new TimeSeries(this.#points);
     }
+    this.#points.push({ x, y });
+    if (this.#exceedsMaxNumberOfPoints()) {
+      this.#purgeOnePoint();
+    }
+    return new TimeSeries(this.#points);
   }
 
   #purgeOnePoint() {
-    this.#points.splice(PURGE_POINT_INDEX, NB_POINTS_TO_PURGE);
+    this.#points.splice(PURGE_MIDDLE_POINT_INDEX, ONE_POINT_TO_PURGE);
   }
 
   #replaceLastPointByNewPoint({ x, y }) {
@@ -54,11 +54,11 @@ export class TimeSeries {
     return this.#lastPoint()?.y === y;
   }
 
-  #exceedMaxNumberOfPoints() {
-    return this.#points.length >= MAXIMUM_NUMBER_OF_POINTS_THRESHOLD;
+  #exceedsMaxNumberOfPoints() {
+    return this.size() >= MAXIMUM_NUMBER_OF_POINTS_THRESHOLD;
   }
 
   #lastPoint() {
-    return this.#points[this.#points.length - 1];
+    return this.#points[this.size() - 1];
   }
 }

--- a/api/scripts/arborescence-monitoring/time-series.js
+++ b/api/scripts/arborescence-monitoring/time-series.js
@@ -1,0 +1,41 @@
+const MAXIMUM_NUMBER_OF_POINTS_THRESHOLD = 30;
+
+const PURGE_POINT_INDEX = 10;
+
+const NB_POINTS_TO_PURGE = 1;
+
+export class TimeSeries {
+  constructor(points) {
+    points.sort((pointA, pointB) => new Date(pointA.x).getTime() - new Date(pointB.x).getTime());
+    this.points = points;
+  }
+
+  add({ x, y }) {
+    const lastPoint = this.lastPoint();
+    if (lastPoint.y === y) {
+      return this;
+    } else {
+      this.points.push({ x, y });
+      if (this.exceedMaxNumberOfPoints()) {
+        this.points.splice(PURGE_POINT_INDEX, NB_POINTS_TO_PURGE);
+      }
+      return new TimeSeries(this.points);
+    }
+  }
+
+  exceedMaxNumberOfPoints() {
+    return this.points.length >= MAXIMUM_NUMBER_OF_POINTS_THRESHOLD;
+  }
+
+  lastPoint() {
+    return this.points[this.points.length - 1];
+  }
+
+  size() {
+    return this.points.length;
+  }
+
+  get(pointIndex) {
+    return this.points[pointIndex];
+  }
+}

--- a/api/scripts/arborescence-monitoring/time-series.js
+++ b/api/scripts/arborescence-monitoring/time-series.js
@@ -1,4 +1,4 @@
-const MAXIMUM_NUMBER_OF_POINTS_THRESHOLD = 30;
+const MAXIMUM_NUMBER_OF_POINTS_THRESHOLD = 28;
 
 const PURGE_POINT_INDEX = 10;
 
@@ -11,16 +11,30 @@ export class TimeSeries {
   }
 
   add({ x, y }) {
-    const lastPoint = this.lastPoint();
-    if (lastPoint.y === y) {
-      return this;
+    if (this.sameValueThanTheLast(y)) {
+      return this.replaceLastPointByNewPoint({ x, y });
     } else {
       this.points.push({ x, y });
       if (this.exceedMaxNumberOfPoints()) {
-        this.points.splice(PURGE_POINT_INDEX, NB_POINTS_TO_PURGE);
+        this.purgeOnePoint();
       }
       return new TimeSeries(this.points);
     }
+  }
+
+  purgeOnePoint() {
+    this.points.splice(PURGE_POINT_INDEX, NB_POINTS_TO_PURGE);
+  }
+
+  replaceLastPointByNewPoint({ x, y }) {
+    this.points.pop();
+    this.points.push({ x, y });
+    return new TimeSeries(this.points);
+  }
+
+  sameValueThanTheLast(y) {
+    const lastPoint = this.lastPoint();
+    return lastPoint?.y === y;
   }
 
   exceedMaxNumberOfPoints() {
@@ -37,5 +51,9 @@ export class TimeSeries {
 
   get(pointIndex) {
     return this.points[pointIndex];
+  }
+
+  toString() {
+    return JSON.stringify(this.points);
   }
 }

--- a/api/scripts/arborescence-monitoring/time-series.js
+++ b/api/scripts/arborescence-monitoring/time-series.js
@@ -1,59 +1,64 @@
+import { assertNotNullOrUndefined } from '../../src/shared/domain/models/asserts.js';
+
 const MAXIMUM_NUMBER_OF_POINTS_THRESHOLD = 28;
 
 const PURGE_POINT_INDEX = 10;
 
 const NB_POINTS_TO_PURGE = 1;
 
+const NULL_OR_UNDEFINED_POINTS_ERROR_MESSAGE = 'Time series should have a non null/undefined array of points';
+
 export class TimeSeries {
+  #points;
   constructor(points) {
+    assertNotNullOrUndefined(points, NULL_OR_UNDEFINED_POINTS_ERROR_MESSAGE);
     points.sort((pointA, pointB) => new Date(pointA.x).getTime() - new Date(pointB.x).getTime());
-    this.points = points;
-  }
-
-  add({ x, y }) {
-    if (this.sameValueThanTheLast(y)) {
-      return this.replaceLastPointByNewPoint({ x, y });
-    } else {
-      this.points.push({ x, y });
-      if (this.exceedMaxNumberOfPoints()) {
-        this.purgeOnePoint();
-      }
-      return new TimeSeries(this.points);
-    }
-  }
-
-  purgeOnePoint() {
-    this.points.splice(PURGE_POINT_INDEX, NB_POINTS_TO_PURGE);
-  }
-
-  replaceLastPointByNewPoint({ x, y }) {
-    this.points.pop();
-    this.points.push({ x, y });
-    return new TimeSeries(this.points);
-  }
-
-  sameValueThanTheLast(y) {
-    const lastPoint = this.lastPoint();
-    return lastPoint?.y === y;
-  }
-
-  exceedMaxNumberOfPoints() {
-    return this.points.length >= MAXIMUM_NUMBER_OF_POINTS_THRESHOLD;
-  }
-
-  lastPoint() {
-    return this.points[this.points.length - 1];
+    this.#points = points;
   }
 
   size() {
-    return this.points.length;
+    return this.#points.length;
   }
 
   get(pointIndex) {
-    return this.points[pointIndex];
+    return this.#points[pointIndex];
   }
 
   toString() {
-    return JSON.stringify(this.points);
+    return JSON.stringify(this.#points);
+  }
+
+  add({ x, y }) {
+    if (this.#sameValueThanTheLast(y)) {
+      return this.#replaceLastPointByNewPoint({ x, y });
+    } else {
+      this.#points.push({ x, y });
+      if (this.#exceedMaxNumberOfPoints()) {
+        this.#purgeOnePoint();
+      }
+      return new TimeSeries(this.#points);
+    }
+  }
+
+  #purgeOnePoint() {
+    this.#points.splice(PURGE_POINT_INDEX, NB_POINTS_TO_PURGE);
+  }
+
+  #replaceLastPointByNewPoint({ x, y }) {
+    this.#points.pop();
+    this.#points.push({ x, y });
+    return new TimeSeries(this.#points);
+  }
+
+  #sameValueThanTheLast(y) {
+    return this.#lastPoint()?.y === y;
+  }
+
+  #exceedMaxNumberOfPoints() {
+    return this.#points.length >= MAXIMUM_NUMBER_OF_POINTS_THRESHOLD;
+  }
+
+  #lastPoint() {
+    return this.#points[this.#points.length - 1];
   }
 }

--- a/api/tests/acceptance/scripts/time-series_test.js
+++ b/api/tests/acceptance/scripts/time-series_test.js
@@ -3,6 +3,11 @@ import { TimeSeries } from '../../../scripts/arborescence-monitoring/time-series
 
 describe('Unit | Scripts | time-series.js', function () {
   describe('#add', function () {
+    describe('Given undefined time series', function () {
+      it('should throw an error', async function () {
+        expect(() => new TimeSeries()).to.throw('Time series should have a non null/undefined array of points');
+      });
+    });
     describe('Given empty time series', function () {
       describe('New value to add', function () {
         it('should add the point sorted to the time series', async function () {

--- a/api/tests/acceptance/scripts/time-series_test.js
+++ b/api/tests/acceptance/scripts/time-series_test.js
@@ -3,7 +3,19 @@ import { TimeSeries } from '../../../scripts/arborescence-monitoring/time-series
 
 describe('Unit | Scripts | time-series.js', function () {
   describe('#add', function () {
-    describe('Given less than 30 points', function () {
+    describe('Given empty time series', function () {
+      describe('New value to add', function () {
+        it('should add the point sorted to the time series', async function () {
+          const timeSeries = new TimeSeries([]);
+
+          const updatedTimeSeries = timeSeries.add({ x: '2021-07-19T07:00:00.000Z', y: 298 });
+
+          const expectedNumberOfPoints = 1;
+          expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
+        });
+      });
+    });
+    describe('Given less than 28 points', function () {
       describe('New value to add', function () {
         it('should add the point sorted to the time series', async function () {
           const timeSeries = new TimeSeries([
@@ -20,22 +32,22 @@ describe('Unit | Scripts | time-series.js', function () {
         });
       });
       describe('Same value than the last to add', function () {
-        it('should not add the point', async function () {
+        it('should replace the last point', async function () {
           const timeSeries = new TimeSeries([{ x: '2023-07-19T07:00:00.000Z', y: 298 }]);
 
           const updatedTimeSeries = timeSeries.add({ x: '2023-08-19T07:00:00.000Z', y: 298 });
 
           const expectedNumberOfPoints = 1;
           expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
-          expect(updatedTimeSeries.get(0).x).to.equal('2023-07-19T07:00:00.000Z');
+          expect(updatedTimeSeries.get(0).x).to.equal('2023-08-19T07:00:00.000Z');
         });
       });
     });
-    describe('Given more or equal than 30 points', function () {
+    describe('Given more or equal than 28 points', function () {
       let timeSeries;
-      const expectedNumberOfPoints = 30;
+      const expectedNumberOfPoints = 28;
       beforeEach(function () {
-        timeSeries = new TimeSeries(Array(30).fill({ x: '2023-10-25T07:03:47.926Z', y: 306 }));
+        timeSeries = new TimeSeries(Array(expectedNumberOfPoints).fill({ x: '2023-10-25T07:03:47.926Z', y: 306 }));
       });
 
       describe('New value to add', function () {
@@ -47,13 +59,22 @@ describe('Unit | Scripts | time-series.js', function () {
         });
       });
       describe('Same value than the last to add', function () {
-        it('should not add the point', async function () {
-          const updatedTimeSeries = timeSeries.add({ x: '2023-08-19T07:00:00.000Z', y: 306 });
+        it('should replace the last point', async function () {
+          const updatedTimeSeries = timeSeries.add({ x: '2023-11-19T07:00:00.000Z', y: 306 });
 
           expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
-          expect(updatedTimeSeries.get(expectedNumberOfPoints - 1).x).to.equal('2023-10-25T07:03:47.926Z');
+          expect(updatedTimeSeries.get(expectedNumberOfPoints - 1).x).to.equal('2023-11-19T07:00:00.000Z');
         });
       });
+    });
+  });
+  describe('#toString', function () {
+    it('should stringify points', function () {
+      const timeSeries = new TimeSeries([{ x: '2023-07-19T07:00:00.000Z', y: 298 }]);
+
+      const stringifyValue = timeSeries.toString();
+
+      expect(stringifyValue).to.equal('[{"x":"2023-07-19T07:00:00.000Z","y":298}]');
     });
   });
 });

--- a/api/tests/acceptance/scripts/time-series_test.js
+++ b/api/tests/acceptance/scripts/time-series_test.js
@@ -1,0 +1,59 @@
+import { expect } from '../../test-helper.js';
+import { TimeSeries } from '../../../scripts/arborescence-monitoring/time-series.js';
+
+describe('Unit | Scripts | time-series.js', function () {
+  describe('#add', function () {
+    describe('Given less than 30 points', function () {
+      describe('New value to add', function () {
+        it('should add the point sorted to the time series', async function () {
+          const timeSeries = new TimeSeries([
+            { x: '2023-07-19T07:00:00.000Z', y: 298 },
+            { x: '2023-10-20T07:04:01.550Z', y: 305 },
+            { x: '2023-10-25T07:03:47.926Z', y: 306 },
+          ]);
+
+          const updatedTimeSeries = timeSeries.add({ x: '2021-07-19T07:00:00.000Z', y: 298 });
+
+          const expectedNumberOfPoints = 4;
+          expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
+          expect(updatedTimeSeries.get(expectedNumberOfPoints - 1).x).to.equal('2023-10-25T07:03:47.926Z');
+        });
+      });
+      describe('Same value than the last to add', function () {
+        it('should not add the point', async function () {
+          const timeSeries = new TimeSeries([{ x: '2023-07-19T07:00:00.000Z', y: 298 }]);
+
+          const updatedTimeSeries = timeSeries.add({ x: '2023-08-19T07:00:00.000Z', y: 298 });
+
+          const expectedNumberOfPoints = 1;
+          expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
+          expect(updatedTimeSeries.get(0).x).to.equal('2023-07-19T07:00:00.000Z');
+        });
+      });
+    });
+    describe('Given more or equal than 30 points', function () {
+      let timeSeries;
+      const expectedNumberOfPoints = 30;
+      beforeEach(function () {
+        timeSeries = new TimeSeries(Array(30).fill({ x: '2023-10-25T07:03:47.926Z', y: 306 }));
+      });
+
+      describe('New value to add', function () {
+        it('should add the new point and remove one by keeping the first one of the time series', async function () {
+          const updatedTimeSeries = timeSeries.add({ x: '2023-17-19T07:00:00.000Z', y: 298 });
+
+          expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
+          expect(updatedTimeSeries.get(expectedNumberOfPoints - 1).y).to.equal(298);
+        });
+      });
+      describe('Same value than the last to add', function () {
+        it('should not add the point', async function () {
+          const updatedTimeSeries = timeSeries.add({ x: '2023-08-19T07:00:00.000Z', y: 306 });
+
+          expect(updatedTimeSeries.size()).to.equal(expectedNumberOfPoints);
+          expect(updatedTimeSeries.get(expectedNumberOfPoints - 1).x).to.equal('2023-10-25T07:03:47.926Z');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le graph time series utilisé pour les métriques de suivi de la migration de l'API est en échec quand celui-ci contient plus de 30 points.
Limite dû au fait que la solution utilise une URL quickchart depuis slack qui ne peut contenir plus de 3001 caractères. 
L'échec de ce chart brise l'ensemble des métriques de la migration.

## :robot: Proposition
Il n'est pas nécessaire de garder l'ensemble des points.
On se propose de retirer un point à la position X (X >1) pour garder le premier lorsqu'on dépasse 30 points.


## :100: Pour tester
TUs passent
Métriques générées dans le channel api-arbo
