### PR TITLE
[BUGFIX] Le bas de l'épreuve est masqué par les boutons d'action

### DIFF
--- a/1d/app/pods/components/challenge/item/challenge-item.scss
+++ b/1d/app/pods/components/challenge/item/challenge-item.scss
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: column;
   max-width: 860px;
-  margin: 0 auto;
+  margin: 0 auto 80px;
 
   &__playground {
     display: flex;
@@ -22,7 +22,7 @@
 
   &__image, &__qroc, &__qrocm {
     display: flex;
-    width : 49%;
+    width: 49%;
   }
 
   &__qroc, &__qrocm {
@@ -33,7 +33,7 @@
   &__qcm, &__qcu {
     display: flex;
     justify-content: center;
-    width : 100%;
+    width: 100%;
     padding-right: 50px;
     padding-left: 50px;
   }


### PR DESCRIPTION
## :unicorn: Problème
Sur les épreuves dépassant de peu la taille visible, aucun scroll n'était présent sur la page de challenge. Sur une taille supérieure, le scroll ne permettait pas de descendre tout en bas de l'épreuve.

## :robot: Proposition
Rendre scollable le contenu de l'épreuve jusqu'en bas.

## :100: Pour tester
Passer la mission "Recherche sur internet" : 
* Il n'y a pas de scroll si toute l'épreuve s'affiche sans.
* Il y a un scroll et toute l'épreuve peut être visible sinon.
