### PR TITLE
[BUGFIX] Gérer le cas de la suppression de la méthode de connexion SSO PAYSDELALOIRE (PIX-9612)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information.js
+++ b/admin/app/components/users/user-detail-personal-information.js
@@ -13,6 +13,7 @@ const typesLabel = {
   GAR: 'Médiacentre',
   CNAV: 'CNAV',
   FWB: 'Fédération Wallonie-Bruxelles',
+  PAYSDELALOIRE: 'Pays de la Loire',
 };
 
 export default class UserDetailPersonalInformationComponent extends Component {

--- a/admin/app/controllers/authenticated/users/get/information.js
+++ b/admin/app/controllers/authenticated/users/get/information.js
@@ -13,6 +13,7 @@ export default class UserInformationController extends Controller {
       GAR: "L'utilisateur a déjà une méthode de connexion Médiacentre.",
       CNAV: "L'utilisateur a déjà une méthode de connexion CNAV.",
       FWB: "L'utilisateur a déjà une méthode de connexion Fédération Wallonie-Bruxelles.",
+      PAYSDELALOIRE: "L'utilisateur a déjà une méthode de connexion Pays de la Loire.",
     },
     STATUS_400: 'Cette requête est impossible',
     STATUS_404: "Cet utilisateur n'existe pas.",

--- a/admin/tests/unit/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information_test.js
@@ -110,5 +110,15 @@ module('Unit | Component | users | user-detail-personal-information', function (
         assert.strictEqual(component.translatedType, 'Fédération Wallonie-Bruxelles');
       });
     });
+
+    module('when authentication method is PAYSDELALOIRE', function () {
+      test('it displays "Pays de la Loire"', function (assert) {
+        // given
+        component.authenticationMethodType = 'PAYSDELALOIRE';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'Pays de la Loire');
+      });
+    });
   });
 });

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -21,6 +21,7 @@ const reassignAuthenticationMethodJoiSchema = Joi.object({
           OidcIdentityProviders.POLE_EMPLOI.code,
           OidcIdentityProviders.CNAV.code,
           OidcIdentityProviders.FWB.code,
+          OidcIdentityProviders.PAYSDELALOIRE.code,
         )
         .required(),
     },
@@ -388,6 +389,7 @@ const register = async function (server) {
                     OidcIdentityProviders.POLE_EMPLOI.code,
                     OidcIdentityProviders.CNAV.code,
                     OidcIdentityProviders.FWB.code,
+                    OidcIdentityProviders.PAYSDELALOIRE.code,
                   )
                   .required(),
               },

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -30,6 +30,13 @@ const removeAuthenticationMethod = async function ({ userId, type, userRepositor
     case OidcIdentityProviders.FWB.code:
       await _removeAuthenticationMethod(userId, OidcIdentityProviders.FWB.code, authenticationMethodRepository);
       break;
+    case OidcIdentityProviders.PAYSDELALOIRE.code:
+      await _removeAuthenticationMethod(
+        userId,
+        OidcIdentityProviders.PAYSDELALOIRE.code,
+        authenticationMethodRepository,
+      );
+      break;
   }
 };
 

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1227,7 +1227,7 @@ describe('Unit | Router | user-router', function () {
         // then
         expect(statusCode).to.equal(400);
         expect(result.errors[0].detail).to.equal(
-          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV, FWB]',
+          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE]',
         );
       });
       it('returns 400 when the payload contains an invalid user id', async function () {

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -233,6 +233,26 @@ describe('Unit | UseCase | remove-authentication-method', function () {
     });
   });
 
+  context('When type is PAYSDELALOIRE', function () {
+    it('removes PAYSDELALOIRE authentication method', async function () {
+      // given
+      const type = OidcIdentityProviders.PAYSDELALOIRE.code;
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildAllAuthenticationMethodsForUser(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWithExactly({
+        userId: user.id,
+        identityProvider: OidcIdentityProviders.PAYSDELALOIRE.code,
+      });
+    });
+  });
+
   context('When there is only one remaining authentication method', function () {
     it('should throw a UserNotAuthorizedToRemoveAuthenticationMethod', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
 
Dans Pix Admin, il y a une erreur `400` lorsqu'on actionne le bouton « Supprimer » sur une méthode de connexion `Pays de la Loire`.


## :robot: Proposition

Dans le code de l'API, ajouter la prise en compte du cas de la suppression de la méthode de connexion SSO PAYSDELALOIRE.

De plus ajouter encore d'autres bouts de code manquants en se servant comme modèle de tout le travail fait dans #6886.

## :rainbow: Remarques

Cette PR ajoute d'autres bouts de code manquants pour gérer tous les cas correspondants au SSO PAYSDELALOIRE.
Avec cette nouvelle PR pour ajouter encore des bouts de code manquant, on voit bien que le travail de généricisation nécessite d'être poursuivi.

## :100: Pour tester

La procédure de test suivante ne peut pas être réalisée dans une RA. Mais elle peut-être réalisée en local (avec mise en place de HTTPS), ainsi qu'en intégration et recette.

1. Se connecter avec le SSO _PAYSDELALOIRE_ par https://app.dev.pix.fr/connexion/pays-de-la-loire avec un utilisateur dont on notera l'adresse email
2. Se connecter à Pix Admin avec un admin (par exemple `superadmin@example.net`)
3. Dans Pix Admin chercher parmi les comptes celui correspondant à l'adresse email précédemment notée
4. Se rendre sur la fiche de ce compte et constater qu'une méthode de connexion `Pays de la Loire` est présente
5. Dans les méthodes de connexion, actionner le bouton « Ajouter une adresse e-mail » et ajouter n'importe quelle adresse email
6. Dans les méthodes de connexion, actionner le bouton « Supprimer » sur la méthode de connexion `Pays de la Loire` et constater qu'il n'y a pas d'erreur