### PR TITLE
[FEATURE] Suppression des signalements de catégorie E pour la certif V3 (PIX-8773).

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -44,11 +44,13 @@
           @updateNonBlockingCandidateIssueCategoryDescription={{this.updateNonBlockingCandidateIssueCategory}}
         />
 
-        <IssueReportModal::InChallengeCertificationIssueReportFields
-          @inChallengeCategory={{this.inChallengeCategory}}
-          @toggleOnCategory={{this.toggleOnCategory}}
-          @maxlength={{@maxlength}}
-        />
+        {{#if (eq @version 2)}}
+          <IssueReportModal::InChallengeCertificationIssueReportFields
+            @inChallengeCategory={{this.inChallengeCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
+        {{/if}}
       </div>
 
       {{#if this.showCategoryMissingError}}

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -98,6 +98,7 @@
       @closeModal={{this.closeAddIssueReportModal}}
       @report={{this.reportToEdit}}
       @maxlength={{@issueReportDescriptionMaxLength}}
+      @version={{@session.version}}
     />
   {{/if}}
 

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -126,6 +126,7 @@
       @closeModal={{this.closeAddIssueReportModal}}
       @report={{this.reportToEdit}}
       @maxlength={{@issueReportDescriptionMaxLength}}
+      @version={{@session.version}}
     />
   {{/if}}
 

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -1,12 +1,16 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
-export const certificationIssueReportCategories = {
+export const v3CertificationIssueReportCategories = {
   CANDIDATE_INFORMATIONS_CHANGES: 'CANDIDATE_INFORMATIONS_CHANGES',
   SIGNATURE_ISSUE: 'SIGNATURE_ISSUE',
-  IN_CHALLENGE: 'IN_CHALLENGE',
   FRAUD: 'FRAUD',
   NON_BLOCKING_CANDIDATE_ISSUE: 'NON_BLOCKING_CANDIDATE_ISSUE',
   NON_BLOCKING_TECHNICAL_ISSUE: 'NON_BLOCKING_TECHNICAL_ISSUE',
+};
+
+export const certificationIssueReportCategories = {
+  ...v3CertificationIssueReportCategories,
+  IN_CHALLENGE: 'IN_CHALLENGE',
 };
 
 export const certificationIssueReportSubcategories = {

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -18,6 +18,7 @@
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
         @onChangeAbortReason={{this.abort}}
+        @session={{this.session}}
       />
     {{/if}}
     {{#if (gt this.session.completedCertificationReports.length 0)}}

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
@@ -6,6 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import {
+  v3CertificationIssueReportCategories,
   certificationIssueReportCategories,
   categoryToLabel,
   categoryToCode,
@@ -42,38 +43,85 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
     assert.dom(screen.getByText('Signalement du candidat : Lisa Monpud', { exact: false })).exists();
   });
 
-  test('it should show all categories code & label', async function (assert) {
-    // given
-    const report = EmberObject.create({
-      certificationCourseId: 1,
-      firstName: 'Lisa',
-      lastName: 'Monpud',
-      hasSeenEndTestScreen: false,
+  module('when session is V2', function () {
+    test('it should show all categories code & label', async function (assert) {
+      // given
+      const report = EmberObject.create({
+        certificationCourseId: 1,
+        firstName: 'Lisa',
+        lastName: 'Monpud',
+        hasSeenEndTestScreen: false,
+      });
+      const closeAddIssueReportModalStub = sinon.stub();
+      this.set('closeAddIssueReportModal', closeAddIssueReportModalStub);
+      this.set('reportToEdit', report);
+      this.set('maxlength', 500);
+
+      // when
+      const screen = await renderScreen(hbs`
+            <IssueReportModal::AddIssueReportModal
+              @closeModal={{this.closeAddIssueReportModal}}
+              @report={{this.reportToEdit}}
+              @maxlength={{@issueReportDescriptionMaxLength}}
+              @version={{2}}
+            />
+          `);
+
+      // then
+      for (const category of Object.values(certificationIssueReportCategories)) {
+        assert
+          .dom(
+            screen.getByLabelText(`${categoryToCode[category]} ${this.intl.t(categoryToLabel[category])}`, {
+              exact: false,
+            }),
+          )
+          .exists();
+      }
     });
-    const closeAddIssueReportModalStub = sinon.stub();
-    this.set('closeAddIssueReportModal', closeAddIssueReportModalStub);
-    this.set('reportToEdit', report);
-    this.set('maxlength', 500);
+  });
 
-    // when
-    const screen = await renderScreen(hbs`
-          <IssueReportModal::AddIssueReportModal
-            @closeModal={{this.closeAddIssueReportModal}}
-            @report={{this.reportToEdit}}
-            @maxlength={{@issueReportDescriptionMaxLength}}
-          />
-        `);
+  module('when session is V3', function () {
+    test('it should show all V3 categories code & label', async function (assert) {
+      // given
+      const report = EmberObject.create({
+        certificationCourseId: 1,
+        firstName: 'Lisa',
+        lastName: 'Monpud',
+        hasSeenEndTestScreen: false,
+      });
+      const closeAddIssueReportModalStub = sinon.stub();
+      this.set('closeAddIssueReportModal', closeAddIssueReportModalStub);
+      this.set('reportToEdit', report);
+      this.set('maxlength', 500);
 
-    // then
-    for (const category of Object.values(certificationIssueReportCategories)) {
+      // when
+      const screen = await renderScreen(hbs`
+            <IssueReportModal::AddIssueReportModal
+              @closeModal={{this.closeAddIssueReportModal}}
+              @report={{this.reportToEdit}}
+              @maxlength={{@issueReportDescriptionMaxLength}}
+              @version={{3}}
+            />
+          `);
+
+      // then
+      for (const category of Object.values(v3CertificationIssueReportCategories)) {
+        assert
+          .dom(
+            screen.getByLabelText(`${categoryToCode[category]} ${this.intl.t(categoryToLabel[category])}`, {
+              exact: false,
+            }),
+          )
+          .exists();
+      }
       assert
         .dom(
-          screen.getByLabelText(`${categoryToCode[category]} ${this.intl.t(categoryToLabel[category])}`, {
+          screen.queryByLabelText('E1-E12 Problème technique sur une question', {
             exact: false,
           }),
         )
-        .exists();
-    }
+        .doesNotExist();
+    });
   });
 
   test('it should show an error when trying to submit without selecting a category', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre du nouveau process de signalement pour la certif v3, les signalements de type “E - Problème technique sur une question” seront remontés directement pendant le test de certification via l’espace surveillant, et non a posteriori comme c’est le cas pour la certif v2.

Il ne sera plus nécessaire de reporter les signalements de catégorie “E - Problème technique sur une question” sur la page de finalisation de session.

## :robot: Proposition

Suppression de la catégorie “E1-E12 Problème technique sur une question” pour les certifs V3 uniquement.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Certification V3 :
Créer une session de certification dans un CDC tagué “isPilotV3” (`certifv3@example.net`) 
Inscrire un candidat dans cette session
Rejoindre la session avec ce candidat
Dans pix certif > page de détails de la session : ouvrir la page de finalisation de session
Cliquer sur le bouton “Ajouter un signalement” 
Résultat : la catégorie E **n’est pas** affichée

Créer une session de certification dans un CDC PAS TAGUE “isPilotV3” (`certif-pro@example.net`)
Inscrire un candidat dans cette session
Rejoindre la session avec ce candidat
Dans pix certif > page de détails de la session : ouvrir la page de finalisation de session
Cliquer sur le bouton “Ajouter un signalement” 
résultat : la catégorie E **est** affichée
