### PR TITLE
[TECH] Revert "Mettre la release dans le cache de premier niveau avant de démarrer le serveur."

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,12 +11,10 @@ import { disconnect } from './db/knex-database-connection.js';
 import { learningContentCache } from './lib/infrastructure/caches/learning-content-cache.js';
 import { temporaryStorage } from './lib/infrastructure/temporary-storage/index.js';
 import { redisMonitor } from './lib/infrastructure/utils/redis-monitor.js';
-import { initLearningContent } from './lib/infrastructure/datasources/learning-content/datasource.js';
 
 let server;
 
 const start = async function () {
-  await initLearningContent();
   server = await createServer();
   await server.start();
 };

--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -77,6 +77,4 @@ const refreshLearningContentCacheRecords = async function () {
   return learningContent;
 };
 
-const initLearningContent = _DatasourcePrototype._getLearningContent;
-
-export { extend, refreshLearningContentCacheRecords, initLearningContent };
+export { extend, refreshLearningContentCacheRecords };


### PR DESCRIPTION
Reverts 1024pix/pix#7287

On avait fait cette modification pour tester l'hypothèse d'un pb de lock entre redis, knex and co.
Il s'avère que ce n'est pas le cas, donc on revert cette PR qui met une pression inutile au démarrage des conteneurs sur Redis.