### PR TITLE
[TECH] Empêcher un candidat d'alerter deux fois si une alerte est en cours (PIX-9027).

### DIFF
--- a/api/lib/domain/usecases/create-certification-challenge-live-alert.js
+++ b/api/lib/domain/usecases/create-certification-challenge-live-alert.js
@@ -16,6 +16,16 @@ const createCertificationChallengeLiveAlert = async function ({
     questionNumber,
   });
 
+  const unhandledCertificationChallengeLiveAlert =
+    await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
+      challengeId,
+      assessmentId,
+    });
+
+  if (unhandledCertificationChallengeLiveAlert) {
+    return;
+  }
+
   return certificationChallengeLiveAlertRepository.save({ certificationChallengeLiveAlert });
 };
 

--- a/api/src/certification/session/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -37,6 +37,18 @@ const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {
   return _toDomain(certificationChallengeLiveAlertDto);
 };
 
+const getOngoingByChallengeIdAndAssessmentId = async ({ challengeId, assessmentId }) => {
+  const certificationChallengeLiveAlertDto = await knex('certification-challenge-live-alerts')
+    .where({
+      'certification-challenge-live-alerts.challengeId': challengeId,
+      'certification-challenge-live-alerts.assessmentId': assessmentId,
+      'certification-challenge-live-alerts.status': CertificationChallengeLiveAlertStatus.ONGOING,
+    })
+    .first();
+
+  return _toDomain(certificationChallengeLiveAlertDto);
+};
+
 const _toDomain = (certificationChallengeLiveAlertDto) => {
   if (!certificationChallengeLiveAlertDto) {
     return null;
@@ -45,4 +57,4 @@ const _toDomain = (certificationChallengeLiveAlertDto) => {
 };
 
 const _toDTO = (certificationChallengeLiveAlertDto) => certificationChallengeLiveAlertDto;
-export { save, getByAssessmentId, getOngoingBySessionIdAndUserId };
+export { save, getByAssessmentId, getOngoingBySessionIdAndUserId, getOngoingByChallengeIdAndAssessmentId };

--- a/api/tests/certification/session/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
@@ -162,4 +162,55 @@ describe('Integration | Repository | Certification Challenge Live Alert', functi
       });
     });
   });
+
+  describe('getOngoingByChallengeIdAndAssessmentId', function () {
+    const challengeId = 'rec123';
+    const assessmentId = 456;
+
+    describe('when there is no ongoing live alert', function () {
+      it('should return null', async function () {
+        // given / when
+        const liveAlert = await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
+          challengeId,
+          assessmentId,
+        });
+
+        // then
+        expect(liveAlert).to.be.null;
+      });
+    });
+
+    describe('when there is an ongoing live alert', function () {
+      it('should return the live alert', async function () {
+        // given
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+
+        const assessment = databaseBuilder.factory.buildAssessment({
+          certificationCourseId: certificationCourse.id,
+          userId: certificationCourse.userId,
+        });
+
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          status: CertificationChallengeLiveAlertStatus.DISMISSED,
+        });
+
+        const certificationChallengeLiveAlert = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessment.id,
+          status: CertificationChallengeLiveAlertStatus.ONGOING,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const liveAlert = await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
+          challengeId: certificationChallengeLiveAlert.challengeId,
+          assessmentId: assessment.id,
+        });
+
+        // then
+        expect(liveAlert).to.deep.equal(certificationChallengeLiveAlert);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

A l'heure actuelle rien n'empêche un candidat de créer plusieurs alertes sur un challenge.

## :robot: Proposition

Vérifier si une alerte est en cours pour le challenge sur lequel se situe le candidat au moment de l'alerte.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Créer une session de certification V3  avec `certifv3@example.net`
- Inscrire un candidat à cette session
- Démarrer la session de certification avec `certifiable-contenu-user@example.net`
- Dans les outils de développement, utiliser un débit réseau plus faible
- Lancer une alerte en cliquant plusieurs fois sur la confirmation
- Vérifier qu'une seule alerte est enregistrée en BDD avec le status `ongoing`
