### PR TITLE
[FEATURE] Modulix : Gérer la réponse de l'apprenant pour un QCU (PIX-9743)

### DIFF
--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -11,8 +11,8 @@ const getBySlug = async function (request, h, dependencies = { moduleSerializer,
 
 const validateAnswer = async function (request, h, dependencies = { correctionResponseSerializer, usecases }) {
   const { moduleSlug, elementId } = request.params;
-  const { proposalSelectedId } = request.payload.data.attributes;
-  const module = await dependencies.usecases.validateAnswer({ moduleSlug, proposalSelectedId, elementId });
+  const { answerId } = request.payload.data.attributes;
+  const module = await dependencies.usecases.validateAnswer({ moduleSlug, answerId, elementId });
 
   return dependencies.correctionResponseSerializer.serialize(module);
 };

--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -10,7 +10,8 @@ const getBySlug = async function (request, h, dependencies = { moduleSerializer,
 };
 
 const validateAnswer = async function (request, h, dependencies = { correctionResponseSerializer, usecases }) {
-  const { moduleSlug, proposalSelectedId, elementId } = request.payload;
+  const { moduleSlug, elementId } = request.params;
+  const { proposalSelectedId } = request.payload.data.attributes;
   const module = await dependencies.usecases.validateAnswer({ moduleSlug, proposalSelectedId, elementId });
 
   return dependencies.correctionResponseSerializer.serialize(module);

--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -1,4 +1,5 @@
 import * as moduleSerializer from '../../infrastructure/serializers/jsonapi/module-serializer.js';
+import * as correctionResponseSerializer from '../../infrastructure/serializers/jsonapi/correction-response-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const getBySlug = async function (request, h, dependencies = { moduleSerializer, usecases }) {
@@ -8,6 +9,13 @@ const getBySlug = async function (request, h, dependencies = { moduleSerializer,
   return dependencies.moduleSerializer.serialize(module);
 };
 
-const modulesController = { getBySlug };
+const validateAnswer = async function (request, h, dependencies = { correctionResponseSerializer, usecases }) {
+  const { moduleSlug, proposalSelectedId, elementId } = request.payload;
+  const module = await dependencies.usecases.validateAnswer({ moduleSlug, proposalSelectedId, elementId });
+
+  return dependencies.correctionResponseSerializer.serialize(module);
+};
+
+const modulesController = { getBySlug, validateAnswer };
 
 export { modulesController };

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -18,16 +18,22 @@ const register = async function (server) {
     },
     {
       method: 'POST',
-      path: '/api/modules/answers',
+      path: '/api/modules/{moduleSlug}/elements/{elementId}/answers',
       config: {
         auth: false,
         handler: modulesController.validateAnswer,
         validate: {
-          payload: Joi.object({
+          params: Joi.object({
             moduleSlug: Joi.string().required(),
             elementId: Joi.string().required(),
-            proposalSelectedId: Joi.string().required(),
-          }),
+          }).required(),
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                proposalSelectedId: Joi.string().required(),
+              }).required(),
+            }).required(),
+          }).required(),
         },
         notes: ['- Permet de valider la réponse à une activité soumise par un apprenant'],
         tags: ['api', 'modules', 'answers'],

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -30,7 +30,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                proposalSelectedId: Joi.string().required(),
+                answerId: Joi.string().required(),
               }).required(),
             }).required(),
           }).required(),

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -16,6 +16,23 @@ const register = async function (server) {
         tags: ['api', 'modules'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/modules/answers',
+      config: {
+        auth: false,
+        handler: modulesController.validateAnswer,
+        validate: {
+          payload: Joi.object({
+            moduleSlug: Joi.string().required(),
+            elementId: Joi.string().required(),
+            proposalSelectedId: Joi.string().required(),
+          }),
+        },
+        notes: ['- Permet de valider la réponse à une activité soumise par un apprenant'],
+        tags: ['api', 'modules', 'answers'],
+      },
+    },
   ]);
 };
 

--- a/api/src/devcomp/domain/models/Feedbacks.js
+++ b/api/src/devcomp/domain/models/Feedbacks.js
@@ -1,0 +1,13 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class Feedbacks {
+  constructor({ valid, invalid }) {
+    assertNotNullOrUndefined(valid, 'Le message de feedback valide est obligatoire');
+    assertNotNullOrUndefined(invalid, 'Le message de feedback invalide est obligatoire');
+
+    this.valid = valid;
+    this.invalid = invalid;
+  }
+}
+
+export { Feedbacks };

--- a/api/src/devcomp/domain/models/Module.js
+++ b/api/src/devcomp/domain/models/Module.js
@@ -1,4 +1,5 @@
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 
 class Module {
   #id;
@@ -39,6 +40,16 @@ class Module {
     if (!Array.isArray(list)) {
       throw new Error('Un Module doit forcément posséder une liste');
     }
+  }
+
+  getElementById(elementId) {
+    const foundElement = this.list.find(({ id }) => id === elementId);
+
+    if (foundElement === undefined) {
+      throw new NotFoundError();
+    }
+
+    return foundElement;
   }
 }
 

--- a/api/src/devcomp/domain/models/QcuCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/QcuCorrectionResponse.js
@@ -1,0 +1,15 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class QcuCorrectionResponse {
+  constructor({ globalResult, feedback, solutionId }) {
+    assertNotNullOrUndefined(globalResult, 'Le résultat global est obligatoire pour une réponse de QCU');
+    assertNotNullOrUndefined(feedback, 'Le feedback est obligatoire pour une réponse de QCU');
+    assertNotNullOrUndefined(solutionId, "L'id de la proposition correcte est obligatoire pour une réponse de QCU");
+
+    this.globalResult = globalResult;
+    this.feedback = feedback;
+    this.solutionId = solutionId;
+  }
+}
+
+export { QcuCorrectionResponse };

--- a/api/src/devcomp/domain/models/QcuProposal.js
+++ b/api/src/devcomp/domain/models/QcuProposal.js
@@ -1,0 +1,15 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class QcuProposal {
+  constructor({ id, content, isValid }) {
+    assertNotNullOrUndefined(id, "L'id est obligatoire pour une proposition de QCU");
+    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour une proposition de QCU');
+    assertNotNullOrUndefined(isValid, 'La validité est obligatoire pour une proposition de QCU');
+
+    this.id = id;
+    this.content = content;
+    this.isValid = isValid;
+  }
+}
+
+export { QcuProposal };

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -1,17 +1,42 @@
 import { Element } from './Element.js';
+import { Feedbacks } from '../Feedbacks.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ValidatorQCU } from '../validator/ValidatorQCU.js';
+import { QcuCorrectionResponse } from '../QcuCorrectionResponse.js';
 
 class QCU extends Element {
-  constructor({ id, instruction, locales, proposals }) {
+  constructor({ id, instruction, locales, proposals, solution, feedbacks, validator }) {
     super({ id });
 
     assertNotNullOrUndefined(instruction, "L'instruction est obligatoire pour un QCU");
     this.#assertProposalsIsAnArray(proposals);
     this.#assertProposalsAreNotEmpty(proposals);
+    assertNotNullOrUndefined(solution, 'La solution est obligatoire pour un QCU');
 
     this.instruction = instruction;
     this.locales = locales;
     this.proposals = proposals;
+    this.solution = solution;
+
+    if (feedbacks) {
+      this.feedbacks = new Feedbacks(feedbacks);
+    }
+
+    if (validator) {
+      this.validator = validator;
+    } else {
+      this.validator = new ValidatorQCU({ solution: { value: this.solution } });
+    }
+  }
+
+  assess(answer) {
+    const validation = this.validator.assess({ answer: { value: answer } });
+
+    return new QcuCorrectionResponse({
+      globalResult: validation.result,
+      feedback: validation.result.OK ? this.feedbacks.valid : this.feedbacks.invalid,
+      solutionId: this.solution,
+    });
   }
 
   #assertProposalsAreNotEmpty(proposals) {

--- a/api/src/devcomp/domain/models/validator/AnswerStatus.js
+++ b/api/src/devcomp/domain/models/validator/AnswerStatus.js
@@ -1,0 +1,58 @@
+const OK = 'ok';
+const KO = 'ko';
+const UNIMPLEMENTED = 'unimplemented';
+
+class AnswerStatus {
+  constructor({ status } = {}) {
+    // TODO: throw a BadAnswerStatus error if the status is bad + adapt the tests
+    this.status = status;
+  }
+
+  /* PUBLIC INTERFACE */
+  isFailed() {
+    return this.status !== OK;
+  }
+
+  isOK() {
+    return this.status === OK;
+  }
+  isKO() {
+    return this.status === KO;
+  }
+  isUNIMPLEMENTED() {
+    return this.status === UNIMPLEMENTED;
+  }
+
+  /* PUBLIC CONSTRUCTORS */
+  static get OK() {
+    return new AnswerStatus({ status: OK });
+  }
+  static get KO() {
+    return new AnswerStatus({ status: KO });
+  }
+  static get UNIMPLEMENTED() {
+    return new AnswerStatus({ status: UNIMPLEMENTED });
+  }
+
+  /* METHODES DE TRANSITION */
+  static isFailed(otherResult) {
+    return AnswerStatus.from(otherResult).isFailed();
+  }
+  static isOK(otherResult) {
+    return AnswerStatus.from(otherResult).isOK();
+  }
+  static isKO(otherResult) {
+    return AnswerStatus.from(otherResult).isKO();
+  }
+
+  /* PRIVATE */
+  static from(other) {
+    if (other instanceof AnswerStatus) {
+      return other;
+    } else {
+      return new AnswerStatus({ status: other });
+    }
+  }
+}
+
+export { AnswerStatus };

--- a/api/src/devcomp/domain/models/validator/Validation.js
+++ b/api/src/devcomp/domain/models/validator/Validation.js
@@ -1,0 +1,13 @@
+/**
+ * Traduction: Élément de correction portant sur la conformité d'une réponse
+ * Context:    Objet existant dans le cadre de la correction d'une réponse pendant le fonctionnement
+ *             interne de l'algorithme.
+ */
+class Validation {
+  constructor({ result, resultDetails } = {}) {
+    this.result = result;
+    this.resultDetails = resultDetails;
+  }
+}
+
+export { Validation };

--- a/api/src/devcomp/domain/models/validator/Validator.js
+++ b/api/src/devcomp/domain/models/validator/Validator.js
@@ -1,0 +1,20 @@
+import { AnswerStatus } from './AnswerStatus.js';
+import { Validation } from './Validation.js';
+
+/**
+ * Traduction: Vérificateur de réponse par défaut
+ */
+class Validator {
+  constructor({ solution } = {}) {
+    this.solution = solution;
+  }
+
+  assess() {
+    return new Validation({
+      result: AnswerStatus.UNIMPLEMENTED,
+      resultDetails: null,
+    });
+  }
+}
+
+export { Validator };

--- a/api/src/devcomp/domain/models/validator/ValidatorQCU.js
+++ b/api/src/devcomp/domain/models/validator/ValidatorQCU.js
@@ -1,0 +1,24 @@
+import * as solutionServiceQCU from '../../services/solution-service-qcu.js';
+import { Validation } from './Validation.js';
+import { Validator } from './Validator.js';
+
+/**
+ * Traduction: Vérificateur de réponse pour un QCU
+ */
+class ValidatorQCU extends Validator {
+  constructor({ solution, dependencies = { solutionServiceQCU } } = {}) {
+    super({ solution });
+    this.dependencies = dependencies;
+  }
+
+  assess({ answer }) {
+    const result = this.dependencies.solutionServiceQCU.match(answer.value, this.solution.value);
+
+    return new Validation({
+      result,
+      resultDetails: null,
+    });
+  }
+}
+
+export { ValidatorQCU };

--- a/api/src/devcomp/domain/services/solution-service-qcu.js
+++ b/api/src/devcomp/domain/services/solution-service-qcu.js
@@ -1,0 +1,10 @@
+import { AnswerStatus } from '../models/validator/AnswerStatus.js';
+
+const match = function (answer, solution) {
+  if (answer === solution) {
+    return AnswerStatus.OK;
+  }
+  return AnswerStatus.KO;
+};
+
+export { match };

--- a/api/src/devcomp/domain/usecases/validate-answer.js
+++ b/api/src/devcomp/domain/usecases/validate-answer.js
@@ -1,0 +1,7 @@
+async function validateAnswer({ moduleSlug, proposalSelectedId, elementId, moduleRepository }) {
+  const foundModule = await moduleRepository.getBySlug({ slug: moduleSlug });
+  const element = foundModule.getElementById(elementId);
+  return element.assess(proposalSelectedId);
+}
+
+export { validateAnswer };

--- a/api/src/devcomp/domain/usecases/validate-answer.js
+++ b/api/src/devcomp/domain/usecases/validate-answer.js
@@ -1,7 +1,7 @@
-async function validateAnswer({ moduleSlug, proposalSelectedId, elementId, moduleRepository }) {
+async function validateAnswer({ moduleSlug, answerId, elementId, moduleRepository }) {
   const foundModule = await moduleRepository.getBySlug({ slug: moduleSlug });
   const element = foundModule.getElementById(elementId);
-  return element.assess(proposalSelectedId);
+  return element.assess(answerId);
 }
 
 export { validateAnswer };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -25,8 +25,11 @@
           "type": "qcu",
           "instruction": "<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>",
           "proposals": [
-            { "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "vrai" },
-            { "id": "b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "faux" }
+            { "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "vrai",
+              "isValid": true, "feedback": "Bravo !"
+            },
+            { "id": "b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "faux",
+              "isValid": false, "feedback": "Mince..." }
           ],
           "solution": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6"
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -25,12 +25,17 @@
           "type": "qcu",
           "instruction": "<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>",
           "proposals": [
-            { "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "vrai",
-              "isValid": true, "feedback": "Bravo !"
-            },
-            { "id": "b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "faux",
-              "isValid": false, "feedback": "Mince..." }
+            { "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6", "content": "vrai", "isValid": true },
+            {
+              "id": "b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6",
+              "content": "faux",
+              "isValid": false
+            }
           ],
+          "feedbacks": {
+            "valid": "Bravo !",
+            "invalid": "Mince..."
+          },
           "solution": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6"
         }
       ]

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -30,9 +30,10 @@ function _toDomain(moduleData) {
               id: proposal.id,
               content: proposal.content,
               isValid: proposal.isValid,
-              feedback: proposal.feedback,
             });
           }),
+          feedbacks: element.feedbacks,
+          solution: element.solution,
         });
       }
 

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -2,6 +2,7 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Module } from '../../domain/models/Module.js';
 import { Text } from '../../domain/models/element/Text.js';
 import { QCU } from '../../domain/models/element/QCU.js';
+import { QcuProposal } from '../../domain/models/QcuProposal.js';
 
 async function getBySlug({ slug, moduleDatasource }) {
   try {
@@ -24,7 +25,14 @@ function _toDomain(moduleData) {
           id: element.id,
           instruction: element.instruction,
           locales: element.locales,
-          proposals: element.proposals,
+          proposals: element.proposals.map((proposal) => {
+            return new QcuProposal({
+              id: proposal.id,
+              content: proposal.content,
+              isValid: proposal.isValid,
+              feedback: proposal.feedback,
+            });
+          }),
         });
       }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js
@@ -1,0 +1,18 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+function serialize(correctionResponse) {
+  return new Serializer('correction-response', {
+    transform(correctionResponse) {
+      return {
+        ...correctionResponse,
+        id: correctionResponse.solutionId,
+        globalResult: correctionResponse.globalResult.status,
+      };
+    },
+    attributes: ['globalResult', 'feedback', 'solutionId'],
+  }).serialize(correctionResponse);
+}
+
+export { serialize };

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
           payload: {
             data: {
               attributes: {
-                proposalSelectedId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+                answerId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
               },
             },
           },
@@ -43,7 +43,7 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
           payload: {
             data: {
               attributes: {
-                proposalSelectedId: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
+                answerId: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
               },
             },
           },

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -8,16 +8,20 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
     server = await createServer();
   });
 
-  describe('POST /api/modules/answers', function () {
+  describe('POST /api/modules/:slug/element/:id/answers', function () {
     context('when given proposal is the correct answer', function () {
       it('should return valid CorrectionResponse', async function () {
+        const moduleSlug = 'les-adresses-mail';
+        const elementId = 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7';
         const options = {
           method: 'POST',
-          url: `/api/modules/answers`,
+          url: `/api/modules/${moduleSlug}/elements/${elementId}/answers`,
           payload: {
-            moduleSlug: 'les-adresses-mail',
-            elementId: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
-            proposalSelectedId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+            data: {
+              attributes: {
+                proposalSelectedId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+              },
+            },
           },
         };
 
@@ -31,13 +35,17 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
 
     context('when given proposal is the wrong answer', function () {
       it('should return invalid CorrectionResponse', async function () {
+        const moduleSlug = 'les-adresses-mail';
+        const elementId = 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7';
         const options = {
           method: 'POST',
-          url: `/api/modules/answers`,
+          url: `/api/modules/${moduleSlug}/elements/${elementId}/answers`,
           payload: {
-            moduleSlug: 'les-adresses-mail',
-            elementId: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
-            proposalSelectedId: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
+            data: {
+              attributes: {
+                proposalSelectedId: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
+              },
+            },
           },
         };
 

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -1,0 +1,52 @@
+import { expect } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+
+describe('Acceptance | Controller | modules-controller-validateAnswer', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/modules/answers', function () {
+    context('when given proposal is the correct answer', function () {
+      it('should return valid CorrectionResponse', async function () {
+        const options = {
+          method: 'POST',
+          url: `/api/modules/answers`,
+          payload: {
+            moduleSlug: 'les-adresses-mail',
+            elementId: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
+            proposalSelectedId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+          },
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.type).to.equal('correction-responses');
+        expect(response.result.data.attributes['global-result']).to.equal('ok');
+      });
+    });
+
+    context('when given proposal is the wrong answer', function () {
+      it('should return invalid CorrectionResponse', async function () {
+        const options = {
+          method: 'POST',
+          url: `/api/modules/answers`,
+          payload: {
+            moduleSlug: 'les-adresses-mail',
+            elementId: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
+            proposalSelectedId: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
+          },
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.type).to.equal('correction-responses');
+        expect(response.result.data.attributes['global-result']).to.equal('ko');
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -27,14 +27,14 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       // Given
       const moduleSlug = 'slug';
       const serializedCorrection = Symbol('serialized correction');
-      const proposalSelectedId = Symbol('proposalSelectedID');
+      const answerId = Symbol('answerId');
       const elementId = Symbol('elementId');
       const correctionResponse = Symbol('correction');
 
       const usecases = {
         validateAnswer: sinon.stub(),
       };
-      usecases.validateAnswer.withArgs({ moduleSlug, proposalSelectedId, elementId }).returns(correctionResponse);
+      usecases.validateAnswer.withArgs({ moduleSlug, answerId, elementId }).returns(correctionResponse);
 
       const correctionResponseSerializer = {
         serialize: sinon.stub(),
@@ -43,7 +43,7 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
 
       // When
       const result = await modulesController.validateAnswer(
-        { payload: { proposalSelectedId }, params: { moduleSlug, elementId } },
+        { payload: { data: { attributes: { answerId } } }, params: { moduleSlug, elementId } },
         null,
         { correctionResponseSerializer, usecases },
       );

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -24,6 +24,7 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
 
   describe('#validate-answer', function () {
     it('should call validateAnswer use-case and return the serialized CorrectionResponse', async function () {
+      // Given
       const moduleSlug = 'slug';
       const serializedCorrection = Symbol('serialized correction');
       const proposalSelectedId = Symbol('proposalSelectedID');
@@ -40,12 +41,14 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       };
       correctionResponseSerializer.serialize.withArgs(correctionResponse).returns(serializedCorrection);
 
+      // When
       const result = await modulesController.validateAnswer(
-        { payload: { moduleSlug, proposalSelectedId, elementId } },
+        { payload: { proposalSelectedId }, params: { moduleSlug, elementId } },
         null,
         { correctionResponseSerializer, usecases },
       );
 
+      // Then
       expect(result).to.equal(serializedCorrection);
     });
   });

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -21,4 +21,32 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       expect(result).to.equal(serializedModule);
     });
   });
+
+  describe('#validate-answer', function () {
+    it('should call validateAnswer use-case and return the serialized CorrectionResponse', async function () {
+      const moduleSlug = 'slug';
+      const serializedCorrection = Symbol('serialized correction');
+      const proposalSelectedId = Symbol('proposalSelectedID');
+      const elementId = Symbol('elementId');
+      const correctionResponse = Symbol('correction');
+
+      const usecases = {
+        validateAnswer: sinon.stub(),
+      };
+      usecases.validateAnswer.withArgs({ moduleSlug, proposalSelectedId, elementId }).returns(correctionResponse);
+
+      const correctionResponseSerializer = {
+        serialize: sinon.stub(),
+      };
+      correctionResponseSerializer.serialize.withArgs(correctionResponse).returns(serializedCorrection);
+
+      const result = await modulesController.validateAnswer(
+        { payload: { moduleSlug, proposalSelectedId, elementId } },
+        null,
+        { correctionResponseSerializer, usecases },
+      );
+
+      expect(result).to.equal(serializedCorrection);
+    });
+  });
 });

--- a/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
+++ b/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
@@ -1,0 +1,34 @@
+import { expect } from '../../../../test-helper.js';
+import { Feedbacks } from '../../../../../src/devcomp/domain/models/Feedbacks.js';
+
+describe('Unit | Devcomp | Domain | Models | Feedbacks', function () {
+  describe('#constructor', function () {
+    it('should instanciate a Feedbacks with right properties', function () {
+      // Given
+      const valid = 'valid';
+      const invalid = 'invalid';
+
+      // When
+      const feedbacks = new Feedbacks({
+        valid,
+        invalid,
+      });
+
+      // Then
+      expect(feedbacks.valid).equal(valid);
+      expect(feedbacks.invalid).equal(invalid);
+    });
+  });
+
+  describe('An empty Feedbacks', function () {
+    it('should throw an error', function () {
+      expect(() => new Feedbacks({})).to.throw('Le message de feedback valide est obligatoire');
+    });
+  });
+
+  describe('A Feedbacks without invalid key', function () {
+    it('should throw an error', function () {
+      expect(() => new Feedbacks({ valid: 'valid' })).to.throw('Le message de feedback invalide est obligatoire');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/Module_test.js
@@ -1,5 +1,6 @@
 import { Module } from '../../../../../src/devcomp/domain/models/Module.js';
-import { expect } from '../../../../test-helper.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 
 describe('Unit | Devcomp | Models | Module', function () {
   describe('#constructor', function () {
@@ -54,6 +55,41 @@ describe('Unit | Devcomp | Models | Module', function () {
               new Module({ id: 'id_module_1', slug: 'les-adresses-mail', title: 'Les adresses mail', list: 'liste' }),
           ).to.throw('Un Module doit forcément posséder une liste');
         });
+      });
+    });
+
+    describe('#getElementById', function () {
+      it('should return the element by Id if it exists', function () {
+        // given
+        const elementId = 'elementId';
+        const id = 1;
+        const slug = 'les-adresses-email';
+        const title = 'Les adresses email';
+        const expectedElement = { id: elementId };
+        const list = [expectedElement];
+
+        // when
+        const foundElement = new Module({ id, slug, title, list }).getElementById(elementId);
+
+        // then
+        expect(foundElement).to.deep.equal(expectedElement);
+      });
+
+      it('should throw an error if element does not exist', function () {
+        // given
+        const id = 1;
+        const slug = 'les-adresses-email';
+        const title = 'Les adresses email';
+        const expectedElement = { id: 'elementId' };
+        const list = [expectedElement];
+
+        const module = new Module({ id, slug, title, list });
+
+        // when
+        const error = catchErrSync(module.getElementById, module)('another-element-id');
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
@@ -1,0 +1,47 @@
+import { expect } from '../../../../test-helper.js';
+import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
+import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+
+describe('Unit | Devcomp | Models | QcuCorrectionResponse', function () {
+  describe('#constructor', function () {
+    it('should create a QCU correction response and keep attributes', function () {
+      // given
+      const globalResult = AnswerStatus.OK;
+      const feedback = 'Bien joué !';
+      const proposalId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
+
+      // when
+      const qcuCorrectionResponse = new QcuCorrectionResponse({ globalResult, feedback, solutionId: proposalId });
+
+      // then
+      expect(qcuCorrectionResponse).not.to.be.undefined;
+      expect(qcuCorrectionResponse.globalResult).to.deep.equal(globalResult);
+      expect(qcuCorrectionResponse.feedback).to.equal(feedback);
+      expect(qcuCorrectionResponse.solutionId).to.equal(proposalId);
+    });
+  });
+
+  describe('A QCU correction response without global result', function () {
+    it('should throw an error', function () {
+      expect(() => new QcuCorrectionResponse({})).to.throw(
+        'Le résultat global est obligatoire pour une réponse de QCU',
+      );
+    });
+  });
+
+  describe('A QCU correction response without feedback', function () {
+    it('should throw an error', function () {
+      expect(() => new QcuCorrectionResponse({ globalResult: AnswerStatus.OK })).to.throw(
+        'Le feedback est obligatoire pour une réponse de QCU',
+      );
+    });
+  });
+
+  describe('A QCU correction response without proposal id', function () {
+    it('should throw an error', function () {
+      expect(() => new QcuCorrectionResponse({ globalResult: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
+        "L'id de la proposition correcte est obligatoire pour une réponse de QCU",
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
@@ -1,0 +1,85 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
+import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
+
+describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
+  describe('#assess', function () {
+    it('should return a QcuCorrectionResponse for a valid answer', function () {
+      // given
+      const assessResult = { result: { OK: 'ok' } };
+      const givenAnswer = Symbol('givenAnswer');
+      const qcuSolution = givenAnswer;
+
+      const validator = {
+        assess: sinon.stub(),
+      };
+      validator.assess
+        .withArgs({
+          answer: {
+            value: givenAnswer,
+          },
+        })
+        .returns(assessResult);
+      const qcu = new QCU({
+        id: '',
+        instruction: '',
+        proposals: [{ id: givenAnswer }],
+        feedbacks: { valid: 'OK', invalid: 'KO' },
+        solution: qcuSolution,
+        validator,
+      });
+
+      const expectedResult = {
+        globalResult: assessResult.result,
+        feedback: qcu.feedbacks.valid,
+        solutionId: qcuSolution,
+      };
+
+      // when
+      const result = qcu.assess(givenAnswer);
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+      expect(result).to.be.instanceOf(QcuCorrectionResponse);
+    });
+
+    it('should return a QcuCorrectionResponse for a invalid answer', function () {
+      // given
+      const assessResult = { result: { KO: 'ko' } };
+      const givenAnswer = Symbol('givenAnswer');
+      const qcuSolutionId = Symbol('qcuSolution');
+
+      const validator = {
+        assess: sinon.stub(),
+      };
+      validator.assess
+        .withArgs({
+          answer: {
+            value: givenAnswer,
+          },
+        })
+        .returns(assessResult);
+      const qcu = new QCU({
+        id: '',
+        instruction: '',
+        proposals: [{ id: givenAnswer }, { id: qcuSolutionId }],
+        feedbacks: { valid: 'OK', invalid: 'KO' },
+        solution: qcuSolutionId,
+        validator,
+      });
+
+      const expectedResult = {
+        globalResult: assessResult.result,
+        feedback: qcu.feedbacks.invalid,
+        solutionId: qcuSolutionId,
+      };
+
+      // when
+      const result = qcu.assess(givenAnswer);
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+      expect(result).to.be.instanceOf(QcuCorrectionResponse);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -1,0 +1,42 @@
+import { expect } from '../../../../test-helper.js';
+import { QcuProposal } from '../../../../../src/devcomp/domain/models/QcuProposal.js';
+
+describe('Unit | Devcomp | Models | QcuProposal', function () {
+  describe('#constructor', function () {
+    it('should create a QCU proposal with correct attributes', function () {
+      // given
+      const id = '1';
+      const content = 'vrai';
+      const isValid = true;
+
+      // when
+      const proposal = new QcuProposal({ id, content, isValid });
+
+      // then
+      expect(proposal).not.to.be.undefined;
+      expect(proposal.id).to.equal(id);
+      expect(proposal.content).to.equal(content);
+      expect(proposal.isValid).to.equal(isValid);
+    });
+  });
+
+  describe('A QCU proposal without id', function () {
+    it('should throw an error', function () {
+      expect(() => new QcuProposal({})).to.throw("L'id est obligatoire pour une proposition de QCU");
+    });
+  });
+
+  describe('A QCU proposal without content', function () {
+    it('should throw an error', function () {
+      expect(() => new QcuProposal({ id: '1' })).to.throw('Le contenu est obligatoire pour une proposition de QCU');
+    });
+  });
+
+  describe('A QCU proposal without isValid', function () {
+    it('should throw an error', function () {
+      expect(() => new QcuProposal({ id: '1', content: '' })).to.throw(
+        'La validité est obligatoire pour une proposition de QCU',
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,26 +1,57 @@
 import { expect } from '../../../../../test-helper.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
+import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 
 describe('Unit | Devcomp | Domain | Models | QCU', function () {
   describe('#constructor', function () {
     it('should instanciate a QCU with right properties', function () {
+      // Given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+      const solution = Symbol('solution');
+
+      // When
       const qcu = new QCU({
         id: '123',
         instruction: 'instruction',
         locales: ['fr-FR'],
-        proposals: [
-          { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
-          { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
-        ],
+        proposals: [proposal1, proposal2],
+        solution,
       });
 
+      // Then
       expect(qcu.id).equal('123');
       expect(qcu.instruction).equal('instruction');
       expect(qcu.locales).deep.equal(['fr-FR']);
-      expect(qcu.proposals).deep.equal([
-        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
-        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
-      ]);
+      expect(qcu.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcu.solution).deep.equal(solution);
+      expect(qcu.feedbacks).to.be.undefined;
+    });
+
+    it('should instanciate a QCU with feedbacks if given', function () {
+      // Given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+      const feedbacks = { valid: 'valid', invalid: 'invalid' };
+      const solution = Symbol('solution');
+
+      // When
+      const qcu = new QCU({
+        id: '123',
+        instruction: 'instruction',
+        locales: ['fr-FR'],
+        proposals: [proposal1, proposal2],
+        feedbacks,
+        solution,
+      });
+
+      // Then
+      expect(qcu.id).equal('123');
+      expect(qcu.instruction).equal('instruction');
+      expect(qcu.locales).deep.equal(['fr-FR']);
+      expect(qcu.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcu.solution).deep.equal(solution);
+      expect(qcu.feedbacks).to.be.instanceof(Feedbacks);
     });
   });
 
@@ -48,6 +79,14 @@ describe('Unit | Devcomp | Domain | Models | QCU', function () {
     it('should throw an error', function () {
       expect(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
         'Les propositions doivent apparaître dans une liste',
+      );
+    });
+  });
+
+  describe('A QCU without a solution', function () {
+    it('should throw an error', function () {
+      expect(() => new QCU({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')] })).to.throw(
+        'La solution est obligatoire pour un QCU',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,5 +1,5 @@
-import { expect } from '../../../../test-helper.js';
-import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
+import { expect } from '../../../../../test-helper.js';
+import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 
 describe('Unit | Devcomp | Domain | Models | QCU', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/validator/AnswerStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/AnswerStatus_test.js
@@ -1,0 +1,49 @@
+import chai from 'chai';
+import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+
+const { expect } = chai;
+
+describe('Unit | Devcomp | Domain | Models | AnswerStatus', function () {
+  context('AnswerStatus#isOK', function () {
+    it('should be true with AnswerStatus.OK', function () {
+      expect(AnswerStatus.OK.isOK()).to.be.true;
+    });
+
+    it('should be false with AnswerStatuses KO', function () {
+      expect(AnswerStatus.KO.isOK()).to.be.false;
+    });
+  });
+
+  context('AnswerStatus#isKO', function () {
+    it('should be true with AnswerStatus.KO', function () {
+      expect(AnswerStatus.KO.isKO()).to.be.true;
+    });
+
+    it('should be false with AnswerStatuses OK', function () {
+      expect(AnswerStatus.OK.isKO()).to.be.false;
+      expect(AnswerStatus.UNIMPLEMENTED.isKO()).to.be.false;
+    });
+  });
+
+  context('AnswerStatus#isUNIMPLEMENTED', function () {
+    it('should be true with AnswerStatus.UNIMPLEMENTED', function () {
+      expect(AnswerStatus.UNIMPLEMENTED.isUNIMPLEMENTED()).to.be.true;
+    });
+
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, FOCUSEDOUT and TIMEDOUT', function () {
+      expect(AnswerStatus.OK.isUNIMPLEMENTED()).to.be.false;
+      expect(AnswerStatus.KO.isUNIMPLEMENTED()).to.be.false;
+    });
+  });
+
+  context('AnswerStatus#isFailed', function () {
+    it('should be false with AnswerStatus.OK', function () {
+      expect(AnswerStatus.OK.isFailed()).to.be.false;
+    });
+
+    it('should be true with AnswerStatuses KO', function () {
+      expect(AnswerStatus.KO.isFailed()).to.be.true;
+      expect(AnswerStatus.UNIMPLEMENTED.isFailed()).to.be.true;
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/validator/ValidatorQCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/ValidatorQCU_test.js
@@ -1,0 +1,51 @@
+import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
+import { ValidatorQCU } from '../../../../../../src/devcomp/domain/models/validator/ValidatorQCU.js';
+import { expect, domainBuilder, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | ValidatorQCU', function () {
+  let solutionServiceQCUStub;
+
+  beforeEach(function () {
+    solutionServiceQCUStub = {
+      match: sinon.stub(),
+    };
+  });
+
+  describe('#assess', function () {
+    let uncorrectedAnswer;
+    let validation;
+    let validator;
+    let solution;
+
+    beforeEach(function () {
+      // given
+      solutionServiceQCUStub.match.returns(AnswerStatus.OK);
+      solution = domainBuilder.buildSolution({ type: 'QCU' });
+
+      uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
+      validator = new ValidatorQCU({
+        solution: solution,
+        dependencies: { solutionServiceQCU: solutionServiceQCUStub },
+      });
+
+      // when
+      validation = validator.assess({ answer: uncorrectedAnswer });
+    });
+
+    it('should call solutionServiceQCU', function () {
+      // then
+      expect(solutionServiceQCUStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
+    });
+    it('should return a validation object with the returned status', function () {
+      const expectedValidation = domainBuilder.buildValidation({
+        result: AnswerStatus.OK,
+        resultDetails: null,
+      });
+
+      // then
+      expect(validation).to.be.an.instanceOf(Validation);
+      expect(validation).to.deep.equal(expectedValidation);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/validator/Validator_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/Validator_test.js
@@ -1,0 +1,32 @@
+import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import { Validator } from '../../../../../../src/devcomp/domain/models/validator/Validator.js';
+import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
+import { expect, domainBuilder } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Validator', function () {
+  describe('#assess', function () {
+    let uncorrectedAnswer;
+    let validation;
+    let validator;
+
+    beforeEach(function () {
+      // given
+      uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
+      validator = new Validator();
+
+      // when
+      validation = validator.assess(uncorrectedAnswer);
+    });
+
+    it('should return a validation object with Unimplemented status', function () {
+      const expectedValidation = domainBuilder.buildValidation({
+        result: AnswerStatus.UNIMPLEMENTED,
+        resultDetails: null,
+      });
+
+      // then
+      expect(validation).to.be.an.instanceOf(Validation);
+      expect(validation).to.deep.equal(expectedValidation);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/services/solution-service-qcu_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qcu_test.js
@@ -1,0 +1,15 @@
+import { expect } from '../../../../test-helper.js';
+import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import * as service from '../../../../../src/devcomp/domain/services/solution-service-qcu.js';
+
+describe('Unit | Devcomp | Domain | Service | SolutionServiceQCU ', function () {
+  describe('if solution type is QCU', function () {
+    it('should return `AnswerStatus.OK` when answer and solution are equal', function () {
+      expect(service.match('same value', 'same value')).to.deep.equal(AnswerStatus.OK);
+    });
+
+    it('should return `AnswerStatus.KO` when answer and solution are different', function () {
+      expect(service.match('answer value', 'different solution value')).to.deep.equal(AnswerStatus.KO);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/validate-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/validate-answer_test.js
@@ -8,7 +8,7 @@ describe('Unit | Devcomp | Usecases | validate-answer', function () {
         // given
         const moduleSlug = 'moduleSlug';
         const elementId = 'elementId';
-        const proposalSelectedId = 'totoId';
+        const answerId = 'totoId';
 
         const mockedModuleRepo = {
           getBySlug: sinon.stub(),
@@ -26,13 +26,13 @@ describe('Unit | Devcomp | Usecases | validate-answer', function () {
         expectedModule.getElementById.withArgs(elementId).returns(stubElement);
 
         const expectedQcuResponse = Symbol('answer');
-        stubElement.assess.withArgs(proposalSelectedId).returns(expectedQcuResponse);
+        stubElement.assess.withArgs(answerId).returns(expectedQcuResponse);
 
         // when
         const validateQcu = await validateAnswer({
           moduleSlug: moduleSlug,
           elementId: elementId,
-          proposalSelectedId: proposalSelectedId,
+          answerId: answerId,
           moduleRepository: mockedModuleRepo,
         });
 

--- a/api/tests/devcomp/unit/domain/usecases/validate-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/validate-answer_test.js
@@ -1,0 +1,44 @@
+import { validateAnswer } from '../../../../../src/devcomp/domain/usecases/validate-answer.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Usecases | validate-answer', function () {
+  describe('#validateAnswer', function () {
+    describe('When the selected proposal is valid', function () {
+      it('should return a valid Correction Response', async function () {
+        // given
+        const moduleSlug = 'moduleSlug';
+        const elementId = 'elementId';
+        const proposalSelectedId = 'totoId';
+
+        const mockedModuleRepo = {
+          getBySlug: sinon.stub(),
+        };
+
+        const expectedModule = {
+          getElementById: sinon.stub(),
+        };
+
+        mockedModuleRepo.getBySlug.withArgs({ slug: moduleSlug }).resolves(expectedModule);
+
+        const stubElement = {
+          assess: sinon.stub(),
+        };
+        expectedModule.getElementById.withArgs(elementId).returns(stubElement);
+
+        const expectedQcuResponse = Symbol('answer');
+        stubElement.assess.withArgs(proposalSelectedId).returns(expectedQcuResponse);
+
+        // when
+        const validateQcu = await validateAnswer({
+          moduleSlug: moduleSlug,
+          elementId: elementId,
+          proposalSelectedId: proposalSelectedId,
+          moduleRepository: mockedModuleRepo,
+        });
+
+        // then
+        expect(validateQcu).to.deep.equal(expectedQcuResponse);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -52,8 +52,8 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
               type: 'qcu',
               instruction: '<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>',
               proposals: [
-                { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'vrai' },
-                { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'faux' },
+                { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'vrai', isValid: true, feedback: 'Bravo !' },
+                { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'faux', isValid: false, feedback: 'Mince...' },
               ],
               solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
             },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -52,9 +52,13 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
               type: 'qcu',
               instruction: '<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>',
               proposals: [
-                { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'vrai', isValid: true, feedback: 'Bravo !' },
-                { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'faux', isValid: false, feedback: 'Mince...' },
+                { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'vrai', isValid: true },
+                { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'faux', isValid: false },
               ],
+              feedbacks: {
+                valid: 'Bravo !',
+                invalid: 'Mince...',
+              },
               solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
             },
           ],

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
@@ -1,0 +1,34 @@
+import { expect } from '../../../../../test-helper.js';
+import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
+import { AnswerStatus } from '../../../../../../lib/domain/models/index.js';
+import * as correctionResponseSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js';
+
+describe('Unit | DevComp | Serializers | CorrectionResponseSerializer', function () {
+  describe('#serialize', function () {
+    it('should return a serialized CorrectionReponse', function () {
+      // given
+      const givenCorrectionResponse = new QcuCorrectionResponse({
+        globalResult: AnswerStatus.OK,
+        feedback: 'Good job!',
+        solutionId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+      });
+      const expectedResult = {
+        data: {
+          attributes: {
+            feedback: 'Good job!',
+            'global-result': 'ok',
+            'solution-id': 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+          },
+          id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+          type: 'correction-responses',
+        },
+      };
+
+      // when
+      const result = correctionResponseSerializer.serialize(givenCorrectionResponse);
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -49,6 +49,7 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
             id: '2',
             proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: '' }],
             instruction: 'hello',
+            solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
           }),
         ],
       });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l’apprenant a sélectionné une réponse puis cliqué sur _Vérifier_, il doit recevoir le _feedback global_ ainsi que la validité de sa réponse.

## :robot: Proposition
Implémenter une nouvelle route API **[POST]** `/api/modules/{moduleSlug}/elements/{elementId}/answers` qui prend en payload l'id de la proposition sélectionnée par l'apprenant.

Désormais, le model `QCU` instancie son propre `validator` et possède une méthode `assess` qui permet de valider la réponse de l'apprenant.

## :rainbow: Remarques
Nous avons copié-collé la mécanique de validation dans le _bounded context_ `devcomp`.
Nous avons ajouté de la dette technique car actuellement notre modèle `QCU` est à la fois un _read-model_ et un modèle de correction. Il faudra implémenter un modèle `QcuForCorrection` qui possédera le `Validator` et la méthode `assess`.

## :100: Pour tester
Pour recevoir un feedback OK, il faudra se rendre sur la review app [sur la page du module](https://app-pr7344.review.pix.fr/modules/les-adresses-mail), sélectionner une bonne réponse et cliquer sur _Vérifier_.
Pour un feedback KO, se rendre [à la même adresse](https://app-pr7344.review.pix.fr/modules/les-adresses-mail) et sélectionner une mauvaise réponse, puis cliquer sur _Vérifier_.
