### PR TITLE
[FEATURE] Revue des accès pour le versioning des profils cibles sur Pix Admin (PIX-9753).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/information.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/information.hbs
@@ -14,12 +14,14 @@
         @screenReaderOnly={{true}}
       />
     {{/if}}
-    <div class="complementary-certification-details-target-profile__attach-button">
-      <PixButtonLink
-        @route="authenticated.complementary-certifications.complementary-certification.attach-target-profile"
-        @model={{@currentTargetProfile.id}}
-      >Rattacher un nouveau profil cible
-      </PixButtonLink>
-    </div>
+    {{#if this.hasAccessToAttachNewTargetProfile}}
+      <div class="complementary-certification-details-target-profile__attach-button">
+        <PixButtonLink
+          @route="authenticated.complementary-certifications.complementary-certification.attach-target-profile"
+          @model={{@currentTargetProfile.id}}
+        >Rattacher un nouveau profil cible
+        </PixButtonLink>
+      </div>
+    {{/if}}
   </div>
 </section>

--- a/admin/app/components/complementary-certifications/target-profiles/information.js
+++ b/admin/app/components/complementary-certifications/target-profiles/information.js
@@ -1,7 +1,14 @@
 import Component from '@glimmer/component';
+import { service } from '@ember/service';
 
 export default class Information extends Component {
+  @service currentUser;
+
   get isMultipleCurrentTargetProfiles() {
     return this.args.complementaryCertification.currentTargetProfiles?.length > 1;
+  }
+
+  get hasAccessToAttachNewTargetProfile() {
+    return this.currentUser.adminMember.isSuperAdmin;
   }
 }

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -5,7 +5,10 @@ export default class AttachTargetProfileRoute extends Route {
   @service accessControl;
 
   beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier', 'isSupport'], 'authenticated');
+    this.accessControl.restrictAccessTo(
+      ['isSuperAdmin'],
+      'authenticated.complementary-certifications.complementary-certification',
+    );
   }
 
   model(params) {

--- a/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
+++ b/admin/app/routes/authenticated/complementary-certifications/complementary-certification/details.js
@@ -1,13 +1,6 @@
 import Route from '@ember/routing/route';
-import { service } from '@ember/service';
 
 export default class DetailsRoute extends Route {
-  @service accessControl;
-
-  beforeModel() {
-    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier', 'isSupport'], 'authenticated');
-  }
-
   async model() {
     const complementaryCertification = await this.modelFor(
       'authenticated.complementary-certifications.complementary-certification',

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -57,13 +57,6 @@ export default class AccessControlService extends Service {
   }
 
   get hasAccessToComplementaryCertificationsScope() {
-    return (
-      this.featureToggles.featureToggles.isTargetProfileVersioningEnabled &&
-      !!(
-        this.currentUser.adminMember.isSuperAdmin ||
-        this.currentUser.adminMember.isSupport ||
-        this.currentUser.adminMember.isMetier
-      )
-    );
+    return this.featureToggles.featureToggles.isTargetProfileVersioningEnabled;
   }
 }

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -12,16 +12,32 @@ module(
     setupApplicationTest(hooks);
     setupMirage(hooks);
 
-    module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
+    module('when admin member has role "SUPER ADMIN"', function () {
       module('on information section', function () {
-        [
-          { role: 'isSuperAdmin', hasAccess: true },
-          { role: 'isSupport', hasAccess: true },
-          { role: 'isMetier', hasAccess: true },
-        ].forEach(function ({ role, hasAccess }) {
-          test('should display complementary certification and current target profile name', async function (assert) {
+        test('should display complementary certification and current target profile name', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('complementary-certification', {
+            id: 1,
+            key: 'KEY',
+            label: 'MARIANNE CERTIF',
+            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+          });
+          server.create('target-profile', {
+            id: 3,
+            name: 'ALEX TARGET',
+          });
+          const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+
+          // then
+          assert.dom(screen.getByRole('heading', { name: 'MARIANNE CERTIF' })).exists();
+          assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
+        });
+
+        module('when user click on target profile link', function () {
+          test('it should redirect to target profile detail page', async function (assert) {
             // given
-            await authenticateAdminMemberWithRole({ [role]: hasAccess })(server);
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             server.create('complementary-certification', {
               id: 1,
               key: 'KEY',
@@ -34,263 +50,241 @@ module(
             });
             const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
 
+            const currentTargetProfileLinks = screen.getAllByRole('link', { name: 'ALEX TARGET' });
+
+            // when
+            await click(currentTargetProfileLinks[0]);
+
             // then
-            assert.dom(screen.getByRole('heading', { name: 'MARIANNE CERTIF' })).exists();
-            assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
+            assert.strictEqual(currentURL(), '/target-profiles/3/details');
           });
         });
 
-        module('when user click on target profile link', function () {
-          [
-            { role: 'isSuperAdmin', hasAccess: true },
-            { role: 'isSupport', hasAccess: true },
-            { role: 'isMetier', hasAccess: true },
-          ].forEach(function ({ role, hasAccess }) {
-            test('it should redirect to target profile detail page', async function (assert) {
-              // given
-              await authenticateAdminMemberWithRole({ [role]: hasAccess })(server);
-              server.create('complementary-certification', {
-                id: 1,
-                key: 'KEY',
-                label: 'MARIANNE CERTIF',
-                targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
-              });
-              server.create('target-profile', {
-                id: 3,
-                name: 'ALEX TARGET',
-              });
-              const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
-
-              const currentTargetProfileLinks = screen.getAllByRole('link', { name: 'ALEX TARGET' });
-
-              // when
-              await click(currentTargetProfileLinks[0]);
-
-              // then
-              assert.strictEqual(currentURL(), '/target-profiles/3/details');
+        module('when user selects an attachable target profile', function () {
+          test('it should display the link of the selected target profile with a change button', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('complementary-certification', {
+              id: 1,
+              key: 'KEY',
+              label: 'MARIANNE CERTIF',
+              targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
             });
+            server.create('attachable-target-profile', {
+              id: 3,
+              name: 'ALEX TARGET',
+            });
+            server.create('target-profile', {
+              id: 3,
+              name: 'ALEX TARGET',
+              badges: [],
+            });
+            const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+            const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+            await fillIn(input, '3');
+
+            await screen.findByRole('listbox');
+            const targetProfileSelectable = await screen.findByRole('option', { name: '3 - ALEX TARGET' });
+
+            // when
+            await targetProfileSelectable.click();
+
+            // then
+            assert.dom(await screen.findByRole('link', { name: 'ALEX TARGET' })).exists();
+            assert.dom(await screen.findByRole('button', { name: 'Changer' })).exists();
+          });
+
+          test('it should display badges component', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('complementary-certification', {
+              id: 1,
+              key: 'KEY',
+              label: 'MARIANNE CERTIF',
+              targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+            });
+            server.create('attachable-target-profile', {
+              id: 5,
+              name: 'ALEX TARGET',
+            });
+            const badge = server.create('badge', {
+              id: 200,
+              title: 'Badge Arène Feu',
+            });
+            server.create('target-profile', {
+              id: 5,
+              name: 'ALEX TARGET',
+              badges: [badge],
+            });
+            const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+            const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+            await fillIn(input, '5');
+            await screen.findByRole('listbox');
+            const targetProfileSelectable = await screen.findByRole('option', { name: '5 - ALEX TARGET' });
+
+            // when
+            await targetProfileSelectable.click();
+
+            // then
+            assert
+              .dom(
+                await screen.findByRole('heading', { name: '2. Complétez les informations des résultats thématiques' }),
+              )
+              .exists();
+            assert.dom(await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' })).exists();
+            assert.dom(await screen.queryByRole('img', { name: 'loader' })).doesNotExist();
           });
         });
-      });
 
-      module('when user selects an attachable target profile', function () {
-        test('it should display the link of the selected target profile with a change button', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('complementary-certification', {
-            id: 1,
-            key: 'KEY',
-            label: 'MARIANNE CERTIF',
-            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+        module('when user submits the form', function () {
+          test('it should save the new attached target profile and redirect to complementary certification details', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('complementary-certification', {
+              id: 1,
+              key: 'KEY',
+              hasExternalJury: true,
+              label: 'MARIANNE CERTIF',
+              targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+            });
+            server.create('attachable-target-profile', {
+              id: 5,
+              name: 'ALEX TARGET',
+            });
+            const badge = server.create('badge', {
+              id: 200,
+              title: 'Badge Arène Feu',
+            });
+            server.create('target-profile', {
+              id: 5,
+              name: 'ALEX TARGET',
+              badges: [badge],
+            });
+            const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+            const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+            await fillIn(input, '5');
+            await screen.findByRole('listbox');
+            const targetProfileSelectable = screen.getByRole('option', { name: '5 - ALEX TARGET' });
+            await targetProfileSelectable.click();
+            await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' });
+
+            await fillIn(screen.getByRole('spinbutton', { name: '200 Badge Arène Feu Niveau' }), '1');
+            await fillIn(
+              screen.getByRole('textbox', { name: '200 Badge Arène Feu Image svg certificat Pix App' }),
+              'IMAGE1.svg',
+            );
+            await fillIn(screen.getByRole('textbox', { name: '200 Badge Arène Feu Label du certificat' }), 'LABEL');
+            await fillIn(
+              screen.getByRole('textbox', { name: "200 Badge Arène Feu Macaron de l'attestation PDF" }),
+              'MACARON.pdf',
+            );
+            await fillIn(screen.getByRole('textbox', { name: '200 Badge Arène Feu Message du certificat' }), 'MESSAGE');
+            await fillIn(
+              screen.getByRole('textbox', { name: '200 Badge Arène Feu Message temporaire certificat' }),
+              'TEMP MESSAGE',
+            );
+            await click(
+              screen.getByRole('checkbox', {
+                name: 'Notifier les organisations avec une campagne basée sur l’ancien PC',
+              }),
+            );
+
+            // when
+            await clickByName('Rattacher le profil cible');
+            // then
+            assert
+              .dom(
+                await screen.findByText(
+                  'Profil cible rattaché à la certification MARIANNE CERTIF mis à jour avec succès !',
+                ),
+              )
+              .exists();
+            assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
           });
-          server.create('attachable-target-profile', {
-            id: 3,
-            name: 'ALEX TARGET',
-          });
-          server.create('target-profile', {
-            id: 3,
-            name: 'ALEX TARGET',
-            badges: [],
-          });
-          const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
-          const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
-          await fillIn(input, '3');
-
-          await screen.findByRole('listbox');
-          const targetProfileSelectable = await screen.findByRole('option', { name: '3 - ALEX TARGET' });
-
-          // when
-          await targetProfileSelectable.click();
-
-          // then
-          assert.dom(await screen.findByRole('link', { name: 'ALEX TARGET' })).exists();
-          assert.dom(await screen.findByRole('button', { name: 'Changer' })).exists();
         });
 
-        test('it should display badges component', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('complementary-certification', {
-            id: 1,
-            key: 'KEY',
-            label: 'MARIANNE CERTIF',
-            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
-          });
-          server.create('attachable-target-profile', {
-            id: 5,
-            name: 'ALEX TARGET',
-          });
-          const badge = server.create('badge', {
-            id: 200,
-            title: 'Badge Arène Feu',
-          });
-          server.create('target-profile', {
-            id: 5,
-            name: 'ALEX TARGET',
-            badges: [badge],
-          });
-          const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
-          const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
-          await fillIn(input, '5');
-          await screen.findByRole('listbox');
-          const targetProfileSelectable = await screen.findByRole('option', { name: '5 - ALEX TARGET' });
+        module('when user does not edit the badge level', function () {
+          test('it should save the level to 1 by default', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            server.create('complementary-certification', {
+              id: 1,
+              key: 'KEY',
+              hasExternalJury: true,
+              label: 'MARIANNE CERTIF',
+              targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+            });
+            server.create('attachable-target-profile', {
+              id: 5,
+              name: 'ALEX TARGET',
+            });
+            const badge = server.create('badge', {
+              id: 200,
+              title: 'Badge Arène Feu',
+            });
+            server.create('target-profile', {
+              id: 5,
+              name: 'ALEX TARGET',
+              badges: [badge],
+            });
+            const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
+            const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
+            await fillIn(input, '5');
+            await screen.findByRole('listbox');
+            const targetProfileSelectable = screen.getByRole('option', { name: '5 - ALEX TARGET' });
+            await targetProfileSelectable.click();
+            await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' });
 
-          // when
-          await targetProfileSelectable.click();
+            const ariaLabel = '200 Badge Arène Feu';
+            await fillIn(
+              screen.getByRole('textbox', { name: `${ariaLabel} Image svg certificat Pix App` }),
+              'IMAGE1.svg',
+            );
+            await fillIn(screen.getByRole('textbox', { name: `${ariaLabel} Label du certificat` }), 'LABEL');
+            await fillIn(
+              screen.getByRole('textbox', { name: `${ariaLabel} Macaron de l'attestation PDF` }),
+              'MACARON.pdf',
+            );
+            await fillIn(screen.getByRole('textbox', { name: `${ariaLabel} Message du certificat` }), 'MESSAGE');
+            await fillIn(
+              screen.getByRole('textbox', { name: `${ariaLabel} Message temporaire certificat` }),
+              'TEMP MESSAGE',
+            );
 
-          // then
-          assert
-            .dom(
-              await screen.findByRole('heading', { name: '2. Complétez les informations des résultats thématiques' }),
-            )
-            .exists();
-          assert.dom(await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' })).exists();
-          assert.dom(await screen.queryByRole('img', { name: 'loader' })).doesNotExist();
-        });
-      });
+            // when
+            await clickByName('Rattacher le profil cible');
 
-      module('when user submits the form', function () {
-        test('it should save the new attached target profile and redirect to complementary certification details', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('complementary-certification', {
-            id: 1,
-            key: 'KEY',
-            hasExternalJury: true,
-            label: 'MARIANNE CERTIF',
-            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+            // then
+            assert.dom(screen.getByRole('row', { name: 'LABEL LABEL 1 200' })).exists();
           });
-          server.create('attachable-target-profile', {
-            id: 5,
-            name: 'ALEX TARGET',
-          });
-          const badge = server.create('badge', {
-            id: 200,
-            title: 'Badge Arène Feu',
-          });
-          server.create('target-profile', {
-            id: 5,
-            name: 'ALEX TARGET',
-            badges: [badge],
-          });
-          const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
-          const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
-          await fillIn(input, '5');
-          await screen.findByRole('listbox');
-          const targetProfileSelectable = screen.getByRole('option', { name: '5 - ALEX TARGET' });
-          await targetProfileSelectable.click();
-          await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' });
-
-          await fillIn(screen.getByRole('spinbutton', { name: '200 Badge Arène Feu Niveau' }), '1');
-          await fillIn(
-            screen.getByRole('textbox', { name: '200 Badge Arène Feu Image svg certificat Pix App' }),
-            'IMAGE1.svg',
-          );
-          await fillIn(screen.getByRole('textbox', { name: '200 Badge Arène Feu Label du certificat' }), 'LABEL');
-          await fillIn(
-            screen.getByRole('textbox', { name: "200 Badge Arène Feu Macaron de l'attestation PDF" }),
-            'MACARON.pdf',
-          );
-          await fillIn(screen.getByRole('textbox', { name: '200 Badge Arène Feu Message du certificat' }), 'MESSAGE');
-          await fillIn(
-            screen.getByRole('textbox', { name: '200 Badge Arène Feu Message temporaire certificat' }),
-            'TEMP MESSAGE',
-          );
-          await click(
-            screen.getByRole('checkbox', {
-              name: 'Notifier les organisations avec une campagne basée sur l’ancien PC',
-            }),
-          );
-
-          // when
-          await clickByName('Rattacher le profil cible');
-          // then
-          assert
-            .dom(
-              await screen.findByText(
-                'Profil cible rattaché à la certification MARIANNE CERTIF mis à jour avec succès !',
-              ),
-            )
-            .exists();
-          assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
-        });
-      });
-
-      module('when user does not edit the badge level', function () {
-        test('it should save the level to 1 by default', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          server.create('complementary-certification', {
-            id: 1,
-            key: 'KEY',
-            hasExternalJury: true,
-            label: 'MARIANNE CERTIF',
-            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
-          });
-          server.create('attachable-target-profile', {
-            id: 5,
-            name: 'ALEX TARGET',
-          });
-          const badge = server.create('badge', {
-            id: 200,
-            title: 'Badge Arène Feu',
-          });
-          server.create('target-profile', {
-            id: 5,
-            name: 'ALEX TARGET',
-            badges: [badge],
-          });
-          const screen = await visit('/complementary-certifications/1/attach-target-profile/3');
-          const input = screen.getByRole('searchbox', { name: 'ID du profil cible' });
-          await fillIn(input, '5');
-          await screen.findByRole('listbox');
-          const targetProfileSelectable = screen.getByRole('option', { name: '5 - ALEX TARGET' });
-          await targetProfileSelectable.click();
-          await screen.findByRole('row', { name: 'Résultat thématique 200 Badge Arène Feu' });
-
-          const ariaLabel = '200 Badge Arène Feu';
-          await fillIn(
-            screen.getByRole('textbox', { name: `${ariaLabel} Image svg certificat Pix App` }),
-            'IMAGE1.svg',
-          );
-          await fillIn(screen.getByRole('textbox', { name: `${ariaLabel} Label du certificat` }), 'LABEL');
-          await fillIn(
-            screen.getByRole('textbox', { name: `${ariaLabel} Macaron de l'attestation PDF` }),
-            'MACARON.pdf',
-          );
-          await fillIn(screen.getByRole('textbox', { name: `${ariaLabel} Message du certificat` }), 'MESSAGE');
-          await fillIn(
-            screen.getByRole('textbox', { name: `${ariaLabel} Message temporaire certificat` }),
-            'TEMP MESSAGE',
-          );
-
-          // when
-          await clickByName('Rattacher le profil cible');
-
-          // then
-          assert.dom(screen.getByRole('row', { name: 'LABEL LABEL 1 200' })).exists();
         });
       });
     });
 
-    module('when admin member has role "CERTIF"', function () {
-      test('it should not allow user to access complementary certification and target profile details', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isCertif: true })(server);
-        server.create('complementary-certification', {
-          id: 1,
-          key: 'KEY',
-          label: 'MARIANNE CERTIF',
-          targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
-        });
-        server.create('target-profile', {
-          id: 3,
-          name: 'ALEX TARGET',
-        });
-        await visit('/complementary-certifications/1/attach-target-profile/3');
+    module('when admin member has role "CERTIF", "METIER" or "SUPPORT"', function () {
+      [
+        { role: 'isCertif', hasAccess: false },
+        { role: 'isSupport', hasAccess: false },
+        { role: 'isMetier', hasAccess: false },
+      ].forEach(function ({ role, hasAccess }) {
+        test('it should not allow user to access complementary certification and target profile details', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ [role]: hasAccess })(server);
+          server.create('complementary-certification', {
+            id: 1,
+            key: 'KEY',
+            label: 'MARIANNE CERTIF',
+            targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
+          });
+          server.create('target-profile', {
+            id: 3,
+            name: 'ALEX TARGET',
+          });
+          await visit('/complementary-certifications/1/attach-target-profile/3');
 
-        // then
-        assert.strictEqual(currentURL(), '/organizations/list');
+          // then
+          assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
+        });
       });
     });
   },

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -10,76 +10,28 @@ module('Acceptance | Complementary certifications | Complementary certification 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
-    module('on information section', function () {
-      test('it should display current target profile link and redirect to details page on click', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        server.create('complementary-certification', {
-          id: 1,
-          key: 'KEY',
-          label: 'MARIANNE CERTIF',
-          targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') }],
-        });
-        server.create('target-profile', {
-          id: 3,
-          name: 'ALEX TARGET',
-        });
-        const screen = await visit('/complementary-certifications/1/details');
-        const currentTargetProfileLinks = screen.getAllByRole('link', { name: 'ALEX TARGET' });
-
-        // when
-        await click(currentTargetProfileLinks[0]);
-
-        // then
-        assert.strictEqual(currentURL(), '/target-profiles/3/details');
-      });
+  test('it should display target profiles links and redirect to details page on click', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    server.create('complementary-certification', {
+      id: 1,
+      key: 'KEY',
+      label: 'MARIANNE CERTIF',
+      targetProfilesHistory: [
+        { name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') },
+        { name: 'JEREM TARGET', id: 2, attachedAt: dayjs('2020-10-10T10:50:00Z') },
+      ],
     });
-
-    module('on history section', function () {
-      test('it should display target profiles links and redirect to details page on click', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        server.create('complementary-certification', {
-          id: 1,
-          key: 'KEY',
-          label: 'MARIANNE CERTIF',
-          targetProfilesHistory: [
-            { name: 'ALEX TARGET', id: 3, attachedAt: dayjs('2023-10-10T10:50:00Z') },
-            { name: 'JEREM TARGET', id: 2, attachedAt: dayjs('2020-10-10T10:50:00Z') },
-          ],
-        });
-        server.create('target-profile', {
-          id: 2,
-          name: 'JEREM TARGET',
-        });
-        const screen = await visit('/complementary-certifications/1/details');
-
-        // when
-        await click(screen.getByRole('link', { name: 'JEREM TARGET' }));
-
-        // then
-        assert.strictEqual(currentURL(), '/target-profiles/2/details');
-      });
+    server.create('target-profile', {
+      id: 2,
+      name: 'JEREM TARGET',
     });
-  });
+    const screen = await visit('/complementary-certifications/1/details');
 
-  module('when admin member has role "CERTIF"', function () {
-    test('it should not allow user to access complementary certification details', async function (assert) {
-      // given
-      await authenticateAdminMemberWithRole({ isCertif: true })(server);
-      server.create('complementary-certification', {
-        id: 1,
-        key: 'KEY',
-        label: 'MARIANNE CERTIF',
-        currentTargetProfile: { name: 'ALEX TARGET', id: 3 },
-      });
+    // when
+    await click(screen.getByRole('link', { name: 'JEREM TARGET' }));
 
-      // when
-      await visit('/complementary-certifications/1/details');
-
-      // then
-      assert.strictEqual(currentURL(), '/organizations/list');
-    });
+    // then
+    assert.strictEqual(currentURL(), '/target-profiles/2/details');
   });
 });

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list_test.js
@@ -19,66 +19,64 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
     });
   });
 
-  module('When admin member is logged in', function () {
-    module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function (hooks) {
-      hooks.beforeEach(async () => {
-        server.create('feature-toggle', { isTargetProfileVersioningEnabled: true });
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+  module('When admin member is logged in', function (hooks) {
+    hooks.beforeEach(async () => {
+      server.create('feature-toggle', { isTargetProfileVersioningEnabled: true });
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    });
+
+    test('it should be accessible for an authenticated user', async function (assert) {
+      // when
+      await visit('/complementary-certifications/');
+
+      // then
+      assert.strictEqual(currentURL(), '/complementary-certifications/list');
+    });
+
+    test('it should set complementary certifications menubar item active', async function (assert) {
+      // when
+      const screen = await visit('/complementary-certifications/list');
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Certifications complémentaires' })).hasClass('active');
+    });
+
+    test('it should render the complementary certifications list', async function (assert) {
+      // given
+      server.create('complementary-certification', { id: 1, key: 'AN', label: 'TOINE' });
+
+      // when
+      const screen = await visit('/complementary-certifications/list');
+
+      // then
+      assert.dom(screen.getByText('ID')).exists({ count: 1 });
+      assert.dom(screen.getByText('1')).exists({ count: 1 });
+
+      assert.dom(screen.getByText('Nom')).exists({ count: 1 });
+      assert.dom(screen.getByText('TOINE')).exists({ count: 1 });
+    });
+
+    test('it should redirect to complementary certification details on click ', async function (assert) {
+      // given
+      server.create('complementary-certification', {
+        id: 1,
+        key: 'AN',
+        label: 'TOINE',
+        targetProfilesHistory: [
+          {
+            id: 52,
+            name: 'Stephen target',
+            badges: [],
+          },
+        ],
       });
+      const screen = await visit('/complementary-certifications/list');
 
-      test('it should be accessible for an authenticated user', async function (assert) {
-        // when
-        await visit('/complementary-certifications/');
+      // when
+      await click(screen.getByRole('link', { name: 'TOINE' }));
 
-        // then
-        assert.strictEqual(currentURL(), '/complementary-certifications/list');
-      });
-
-      test('it should set complementary certifications menubar item active', async function (assert) {
-        // when
-        const screen = await visit('/complementary-certifications/list');
-
-        // then
-        assert.dom(screen.getByRole('link', { name: 'Certifications complémentaires' })).hasClass('active');
-      });
-
-      test('it should render the complementary certifications list', async function (assert) {
-        // given
-        server.create('complementary-certification', { id: 1, key: 'AN', label: 'TOINE' });
-
-        // when
-        const screen = await visit('/complementary-certifications/list');
-
-        // then
-        assert.dom(screen.getByText('ID')).exists({ count: 1 });
-        assert.dom(screen.getByText('1')).exists({ count: 1 });
-
-        assert.dom(screen.getByText('Nom')).exists({ count: 1 });
-        assert.dom(screen.getByText('TOINE')).exists({ count: 1 });
-      });
-
-      test('it should redirect to complementary certification details on click ', async function (assert) {
-        // given
-        server.create('complementary-certification', {
-          id: 1,
-          key: 'AN',
-          label: 'TOINE',
-          targetProfilesHistory: [
-            {
-              id: 52,
-              name: 'Stephen target',
-              badges: [],
-            },
-          ],
-        });
-        const screen = await visit('/complementary-certifications/list');
-
-        // when
-        await click(screen.getByRole('link', { name: 'TOINE' }));
-
-        // then
-        assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
-      });
+      // then
+      assert.strictEqual(currentURL(), '/complementary-certifications/1/details');
     });
   });
 });

--- a/admin/tests/integration/components/complementary-certifications/target-profiles/information_test.js
+++ b/admin/tests/integration/components/complementary-certifications/target-profiles/information_test.js
@@ -9,6 +9,8 @@ module('Integration | Component | complementary-certifications/target-profiles/i
   test("it should display information on the current complementary certification's target profile", async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isSuperAdmin: true };
     this.complementaryCertification = store.createRecord('complementary-certification', {
       label: 'MARIANNE CERTIF',
       targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
@@ -22,7 +24,6 @@ module('Integration | Component | complementary-certifications/target-profiles/i
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Certification complémentaire' })).exists();
-    assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
     assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
     assert.dom(screen.getByText('MARIANNE CERTIF')).exists();
   });
@@ -31,6 +32,8 @@ module('Integration | Component | complementary-certifications/target-profiles/i
     test('it should display the target profile toggle', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
       this.complementaryCertification = store.createRecord('complementary-certification', {
         label: 'MARIANNE CERTIF',
         targetProfilesHistory: [
@@ -54,6 +57,8 @@ module('Integration | Component | complementary-certifications/target-profiles/i
     test('it should not display the target profile toggle', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
       this.complementaryCertification = store.createRecord('complementary-certification', {
         label: 'MARIANNE CERTIF',
         targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
@@ -69,6 +74,50 @@ module('Integration | Component | complementary-certifications/target-profiles/i
       assert
         .dom(screen.queryByRole('button', { name: 'Accéder aux détails des profils cibles courants' }))
         .doesNotExist();
+    });
+  });
+
+  module('when admin member has role "CERTIF", "METIER" and "SUPPORT"', function () {
+    test('it should not display the button to attach new target profile', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: false };
+      const store = this.owner.lookup('service:store');
+      this.complementaryCertification = store.createRecord('complementary-certification', {
+        label: 'MARIANNE CERTIF',
+        targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
+      });
+      this.currentTargetProfile = this.complementaryCertification.currentTargetProfiles[0];
+
+      // when
+      const screen = await render(
+        hbs`<ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{this.complementaryCertification}} @currentTargetProfile={{this.currentTargetProfile}}/>`,
+      );
+
+      // then
+      assert.dom(screen.queryByText('Rattacher un nouveau profil cible')).doesNotExist();
+    });
+  });
+
+  module('when admin member has role "SUPER ADMIN"', function () {
+    test('it should display the button to attach new target profile', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      this.complementaryCertification = store.createRecord('complementary-certification', {
+        label: 'MARIANNE CERTIF',
+        targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
+      });
+      this.currentTargetProfile = this.complementaryCertification.currentTargetProfiles[0];
+
+      // when
+      const screen = await render(
+        hbs`<ComplementaryCertifications::TargetProfiles::Information @complementaryCertification={{this.complementaryCertification}} @currentTargetProfile={{this.currentTargetProfile}}/>`,
+      );
+
+      // then
+      assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
     });
   });
 });

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -180,7 +180,7 @@ module('Integration | Component | menu-bar', function (hooks) {
   });
 
   module('Complementary certifications tab', function () {
-    test('should contain link to "complementary certifications" management page when admin member have access to complementary certifications actions scope', async function (assert) {
+    test('should contain link to "complementary certifications" management page', async function (assert) {
       // given
       class AccessControlStub extends Service {
         hasAccessToComplementaryCertificationsScope = true;
@@ -192,20 +192,6 @@ module('Integration | Component | menu-bar', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('link', { name: 'Certifications complémentaires' })).exists();
-    });
-
-    test('should not contain link to "complementary certifications" management page when admin member does not have access to complementary certifications actions scope', async function (assert) {
-      // given
-      class AccessControlStub extends Service {
-        hasAccessToComplementaryCertificationsScope = false;
-      }
-      this.owner.register('service:accessControl', AccessControlStub);
-
-      // when
-      const screen = await render(hbs`<MenuBar />`);
-
-      // then
-      assert.dom(screen.queryByRole('link', { name: 'Certifications complémentaires' })).doesNotExist();
     });
   });
 

--- a/admin/tests/unit/routes/authenticated/complementary-certifications/complementary-certification/details_test.js
+++ b/admin/tests/unit/routes/authenticated/complementary-certifications/complementary-certification/details_test.js
@@ -1,35 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
-import Service from '@ember/service';
 
 module(
   'Unit | Route | authenticated/complementary-certifications/complementary-certification/details',
   function (hooks) {
     setupTest(hooks);
-
-    module('#beforeModel', function () {
-      test('it should check if current user is "SUPER_ADMIN", "SUPPORT", or "METIER"', function (assert) {
-        // given
-        const route = this.owner.lookup(
-          'route:authenticated/complementary-certifications/complementary-certification/details',
-        );
-
-        const restrictAccessToStub = sinon.stub().returns();
-
-        class AccessControlStub extends Service {
-          restrictAccessTo = restrictAccessToStub;
-        }
-
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        route.beforeModel();
-
-        // then
-        assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isMetier', 'isSupport'], 'authenticated'));
-      });
-    });
 
     module('#resetController', function (hooks) {
       let controller;

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -196,9 +196,9 @@ module('Unit | Service | access-control', function (hooks) {
         { role: 'isSuperAdmin', hasAccess: true },
         { role: 'isSupport', hasAccess: true },
         { role: 'isMetier', hasAccess: true },
-        { role: 'isCertif', hasAccess: false },
+        { role: 'isCertif', hasAccess: true },
       ].forEach(function ({ role, hasAccess }) {
-        test(`should be ${hasAccess} if current admin member is ${role}`, function (assert) {
+        test(`should be accessible for all role members (${role} access)`, function (assert) {
           // given
           const currentUser = this.owner.lookup('service:currentUser');
           currentUser.adminMember = { [role]: true };

--- a/api/src/certification/complementary-certification/application/attach-target-profile-route.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-route.js
@@ -12,13 +12,8 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
           },
         ],
         plugins: {

--- a/api/src/certification/complementary-certification/application/complementary-certification-route.js
+++ b/api/src/certification/complementary-certification/application/complementary-certification-route.js
@@ -14,6 +14,7 @@ const register = async function (server) {
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/tests/certification/complementary-certification/unit/application/attach-target-profile-route_test.js
+++ b/api/tests/certification/complementary-certification/unit/application/attach-target-profile-route_test.js
@@ -1,0 +1,100 @@
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import * as moduleUnderTest from '../../../../../src/certification/complementary-certification/application/attach-target-profile-route.js';
+import { attachTargetProfileController } from '../../../../../src/certification/complementary-certification/application/attach-target-profile-controller.js';
+
+describe('Unit | Application | Certification | ComplementaryCertification | attach-target-profile-route', function () {
+  describe('/api/admin/complementary-certifications/{complementaryCertificationId}/badges', function () {
+    context('when user has role "SUPER ADMIN"', function () {
+      it('should return a response with an HTTP status code 200', async function () {
+        // given
+        sinon.stub(attachTargetProfileController, 'attachTargetProfile').returns('ok');
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = {
+          data: {
+            attributes: {
+              'target-profile-id': 1,
+              'notify-organizations': false,
+              'complementary-certification-badges': [
+                {
+                  data: {
+                    attributes: {
+                      'badge-id': 1,
+                      level: 1,
+                      'image-url': 'imageUrl',
+                      label: 'label',
+                      'sticker-url': 'stickerUrl',
+                      'certificate-message': '',
+                      'temporary-certificate-message': '',
+                    },
+                    relationships: {},
+                    type: 'complementary-certification-badges',
+                  },
+                },
+              ],
+            },
+          },
+        };
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'PUT',
+          '/api/admin/complementary-certifications/1/badges',
+          payload,
+        );
+
+        // then
+        expect(statusCode).to.equal(200);
+      });
+    });
+
+    context('when user has role "CERTIF", "METIER" or "SUPPORT"', function () {
+      it('should return a response with an HTTP status code 403', async function () {
+        // given
+        sinon.stub(attachTargetProfileController, 'attachTargetProfile').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = {
+          data: {
+            attributes: {
+              'target-profile-id': 1,
+              'notify-organizations': false,
+              'complementary-certification-badges': [
+                {
+                  data: {
+                    attributes: {
+                      'badge-id': 1,
+                      level: 1,
+                      'image-url': 'imageUrl',
+                      label: 'label',
+                      'sticker-url': 'stickerUrl',
+                      'certificate-message': '',
+                      'temporary-certificate-message': '',
+                    },
+                    relationships: {},
+                    type: 'complementary-certification-badges',
+                  },
+                },
+              ],
+            },
+          },
+        };
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'PUT',
+          '/api/admin/complementary-certifications/1/badges',
+          payload,
+        );
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
+    });
+  });
+});

--- a/api/tests/certification/complementary-certification/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/complementary-certification/unit/application/complementary-certification-route_test.js
@@ -1,0 +1,55 @@
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import * as moduleUnderTest from '../../../../../src/certification/complementary-certification/application/complementary-certification-route.js';
+import { complementaryCertificationController } from '../../../../../src/certification/complementary-certification/application/complementary-certification-controller.js';
+
+describe('Unit | Application | Certification | ComplementaryCertification | complementary-certification-route', function () {
+  describe('/api/admin/complementary-certifications/{id}/target-profiles', function () {
+    context('when user is an admin member', function () {
+      it('should return a response with an HTTP status code 200', async function () {
+        // given
+        sinon
+          .stub(complementaryCertificationController, 'getComplementaryCertificationTargetProfileHistory')
+          .returns('ok');
+        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'GET',
+          '/api/admin/complementary-certifications/1/target-profiles',
+        );
+
+        // then
+        expect(statusCode).to.equal(200);
+      });
+    });
+
+    context('when user is not an admin member', function () {
+      it('should return a response with an HTTP status code 403', async function () {
+        // given
+        sinon
+          .stub(complementaryCertificationController, 'getComplementaryCertificationTargetProfileHistory')
+          .returns('ok');
+        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+          h
+            .response({ errors: new Error('') })
+            .code(403)
+            .takeover(),
+        );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'GET',
+          '/api/admin/complementary-certifications/1/target-profiles',
+        );
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, l'accès aux fonctionnalités des certifications complémentaires présente des incohérences :

- Accès à la liste des certifications complémentaire => autorisé à tous (SuperAdmin, certif, metier, support)
- Accès  aux détails de la complémentaire en lecture => autorisé à tous sauf Certif
- Accès au rattachement => autorisé à tous sauf Certif

## :robot: Proposition
Donner en accès lecture pour toutes les pages à TOUS les rôles et donner en accès au bouton de rattachement d’un nouveau PC uniquement au rôle Super Admin.

## :rainbow: Remarques
le bouton “rattacher un nouveau PC” ne doit pas apparaître pour les rôles CERTIF, SUPPORT, METIER

## :100: Pour tester
- Se connecter sur Pix Admin avec un rôle Certif (pixcertif@example.net)
- Cliquer dans le menu sur les certifications complémentaires
- Cliquer sur une certif 
- constater que l'on à accès aux détails mais pas au bouton pour rattacher un nouveau
- Se connecter avec un role admin (superadmin@example.net)
- Faire le process et rattacher un nouveau profil cible à une certification complémentaire
