### PR TITLE
[FEATURE][CERTIF] Restreindre l'action du choix d'un référent uniquement aux administrateurs (PIX-9393)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -226,9 +226,30 @@ const register = async function (server) {
       },
     },
   ];
+  const certifRoutes = [
+    {
+      method: 'POST',
+      path: '/api/certif/certification-centers/{certificationCenterId}/update-referer',
+      config: {
+        handler: certificationCenterController.updateReferer,
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
+            assign: 'isMemberOfCertificationCenter',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            "- Mise à jour du status de référent d'un membre d'un espace pix-certif\n",
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
+  ];
 
   server.route([
     ...adminRoutes,
+    ...certifRoutes,
     {
       method: 'GET',
       path: '/api/certification-centers/{certificationCenterId}/sessions/{sessionId}/students',
@@ -433,25 +454,6 @@ const register = async function (server) {
             "- Elle permet à un administrateur d'inviter des personnes, déjà utilisateurs de Pix ou non, à être membre d'un centre de certification, via leur **email**",
         ],
         tags: ['api', 'invitations', 'certification-center'],
-      },
-    },
-
-    {
-      method: 'POST',
-      path: '/api/certif/certification-centers/{certificationCenterId}/update-referer',
-      config: {
-        handler: certificationCenterController.updateReferer,
-        pre: [
-          {
-            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
-            assign: 'isMemberOfCertificationCenter',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            "- Mise à jour du status de référent d'un membre d'un espace pix-certif\n",
-        ],
-        tags: ['api', 'certification-center-membership'],
       },
     },
 

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -234,8 +234,8 @@ const register = async function (server) {
         handler: certificationCenterController.updateReferer,
         pre: [
           {
-            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
-            assign: 'isMemberOfCertificationCenter',
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenter,
+            assign: 'isAdminOfCertificationCenter',
           },
         ],
         notes: [

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -851,6 +851,7 @@ describe('Acceptance | API | Certification Center', function () {
         userId: certificationCenterMemberId,
         certificationCenterId,
         isReferer: false,
+        role: 'ADMIN',
       });
       await databaseBuilder.commit();
 

--- a/certif/app/controllers/authenticated/team/list.js
+++ b/certif/app/controllers/authenticated/team/list.js
@@ -18,7 +18,11 @@ export default class AuthenticatedTeamListController extends Controller {
   }
 
   get shouldDisplayNoRefererSection() {
-    return this.model.hasCleaHabilitation && _hasAtLeastOneMemberAndNoReferer(this.model.members);
+    return (
+      this.model.hasCleaHabilitation &&
+      this.currentUser.isAdminOfCurrentCertificationCenter &&
+      _hasAtLeastOneMemberAndNoReferer(this.model.members)
+    );
   }
 
   get shouldDisplayUpdateRefererButton() {

--- a/certif/app/controllers/authenticated/team/list.js
+++ b/certif/app/controllers/authenticated/team/list.js
@@ -22,7 +22,11 @@ export default class AuthenticatedTeamListController extends Controller {
   }
 
   get shouldDisplayUpdateRefererButton() {
-    return this.model.hasCleaHabilitation && _hasAtLeastTwoMembersAndOneReferer(this.model.members);
+    return (
+      this.model.hasCleaHabilitation &&
+      this.currentUser.isAdminOfCurrentCertificationCenter &&
+      _hasAtLeastTwoMembersAndOneReferer(this.model.members)
+    );
   }
 
   get shouldDisplayInviteMemberButton() {

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -274,6 +274,30 @@ module('Acceptance | authenticated | team', function (hooks) {
               });
             });
           });
+
+          module('when there is a referer', function () {
+            test('does not display the button to change the referer', async function (assert) {
+              // given
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                undefined,
+                'CCNG',
+                false,
+                'MEMBER',
+              );
+              server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
+              server.create('member', { firstName: 'Jean', lastName: 'Ticipe', isReferer: false });
+              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              await authenticateSession(certificationPointOfContact.id);
+
+              // when
+              const screen = await visitScreen('/equipe');
+
+              // then
+              assert
+                .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
+                .doesNotExist();
+            });
+          });
         });
       });
 

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -11,8 +11,6 @@ import {
 } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { waitForDialogClose } from '../helpers/wait-for';
-import { Response } from 'miragejs';
 
 module('Acceptance | authenticated | team', function (hooks) {
   setupApplicationTest(hooks);
@@ -88,6 +86,142 @@ module('Acceptance | authenticated | team', function (hooks) {
         assert.strictEqual(screen.getAllByLabelText('Invitations en attente').length, 2);
       });
     });
+
+    module('when user go to members list', function () {
+      module('when certification center has "CLEA" habilitation', function () {
+        module('when there is at least one member', function () {
+          module('when there is no referer', function () {
+            test('displays the "no referer" section', async function (assert) {
+              // given
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                undefined,
+                'CCNG',
+                false,
+                'ADMIN',
+              );
+              server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              await authenticateSession(certificationPointOfContact.id);
+
+              // when
+              const screen = await visitScreen('/equipe');
+
+              // then
+              assert.dom(screen.getByText(this.intl.t('pages.team.no-referer-section.title'))).exists();
+              assert
+                .dom(
+                  screen.getByRole('button', {
+                    name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
+                  }),
+                )
+                .exists();
+            });
+          });
+
+          module('when there is a referer', function () {
+            test('does not display the button to change the referer', async function (assert) {
+              // given
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                undefined,
+                'CCNG',
+                false,
+                'ADMIN',
+              );
+              server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
+              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              await authenticateSession(certificationPointOfContact.id);
+
+              // when
+              const screen = await visitScreen('/equipe');
+
+              // then
+              assert
+                .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
+                .doesNotExist();
+            });
+          });
+        });
+
+        module('when there is at least 2 members', function () {
+          module('when there is a referer', function () {
+            test('displays the button to change the referer', async function (assert) {
+              // given
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                undefined,
+                'CCNG',
+                false,
+                'ADMIN',
+              );
+              server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
+              server.create('member', { firstName: 'Jean', lastName: 'Ticipe', isReferer: false });
+              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              await authenticateSession(certificationPointOfContact.id);
+
+              // when
+              const screen = await visitScreen('/equipe');
+
+              // then
+              assert
+                .dom(screen.getByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
+                .exists();
+            });
+          });
+        });
+      });
+
+      test('it should be possible to see members list', async function (assert) {
+        // given
+        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
+        await authenticateSession(certificationPointOfContact.id);
+
+        // when
+        const screen = await visitScreen('/equipe');
+
+        // then
+        assert.strictEqual(currentURL(), '/equipe/membres');
+        assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
+        assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
+      });
+
+      module('when user switch to see another certification center', function () {
+        test('it should be possible to see the other members list', async function (assert) {
+          // given
+          const certificationCenterName = 'Centre de certif des Anne-atole';
+          const otherCertificationCenterName = 'Centre de certif de 7 Anne-néla';
+          const certificationPointOfContact = createAllowedCertificationCenterAccess({
+            certificationCenterName,
+            certificationCenterType: 'SCO',
+            isRelatedOrganizationManagingStudents: true,
+          });
+          const certificationPointOfContact2 = createAllowedCertificationCenterAccess({
+            certificationCenterName: otherCertificationCenterName,
+            certificationCenterType: 'SCO',
+            isRelatedOrganizationManagingStudents: true,
+          });
+          createCertificationPointOfContactWithCustomCenters({
+            pixCertifTermsOfServiceAccepted: true,
+            allowedCertificationCenterAccesses: [certificationPointOfContact, certificationPointOfContact2],
+          });
+          server.create('member', { firstName: 'Lili', lastName: 'Dupont' });
+          const memberOfTheFirstCertificationCenter = server.create('member', { firstName: 'Jack', lastName: 'Adit' });
+          await authenticateSession(certificationPointOfContact.id);
+          const screen = await visitScreen('/equipe');
+
+          // when
+          await click(screen.getByText(`${certificationCenterName} (${certificationPointOfContact.externalId})`));
+          await click(screen.getByText(`${otherCertificationCenterName}`));
+          memberOfTheFirstCertificationCenter.destroy();
+          await visitScreen('/equipe');
+
+          // then
+          assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
+          assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
+          assert.dom(screen.queryByRole('cell', { name: 'Jack' })).doesNotExist();
+          assert.dom(screen.queryByRole('cell', { name: 'Adit' })).doesNotExist();
+        });
+      });
+    });
   });
 
   module('when user is member', function () {
@@ -154,9 +288,14 @@ module('Acceptance | authenticated | team', function (hooks) {
       module('when certification center has "CLEA" habilitation', function () {
         module('when there is at least one member', function () {
           module('when there is no referer', function () {
-            test('it should be possible to see the "no referer" section', async function (assert) {
+            test('does not display the "no referer" section', async function (assert) {
               // given
-              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                undefined,
+                'CCNG',
+                false,
+                'MEMBER',
+              );
               server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
               server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
               await authenticateSession(certificationPointOfContact.id);
@@ -165,113 +304,14 @@ module('Acceptance | authenticated | team', function (hooks) {
               const screen = await visitScreen('/equipe');
 
               // then
-              assert.dom(screen.getByText(this.intl.t('pages.team.no-referer-section.title'))).exists();
+              assert.dom(screen.queryByText(this.intl.t('pages.team.no-referer-section.title'))).doesNotExist();
               assert
                 .dom(
-                  screen.getByRole('button', {
+                  screen.queryByRole('button', {
                     name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
                   }),
                 )
-                .exists();
-            });
-
-            test('it should be possible to select a referer', async function (assert) {
-              // given
-              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-              server.create('member', {
-                id: 102,
-                firstName: 'Lili',
-                lastName: 'Dupont',
-                isReferer: false,
-              });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-              await authenticateSession(certificationPointOfContact.id);
-
-              // when
-              const screen = await visitScreen('/equipe');
-
-              assert.dom(screen.queryByRole('cell', { name: 'Référent Pix' })).doesNotExist();
-
-              await click(
-                screen.getByRole('button', {
-                  name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
-                }),
-              );
-              await screen.findByRole('dialog');
-              await click(screen.getByLabelText(this.intl.t('pages.team.select-referer-modal.label')));
-              await click(
-                await screen.findByRole('option', {
-                  name: 'Lili Dupont',
-                }),
-              );
-              await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
-              await waitForDialogClose();
-
-              // then
-              assert
-                .dom(screen.queryByRole('dialog', { name: this.intl.t('pages.team.select-referer-modal.title') }))
                 .doesNotExist();
-              assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).exists();
-            });
-
-            module('when no referer is selected', function () {
-              test('it should not be possible to validate', async function (assert) {
-                // given
-                const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-                server.create('member', {
-                  id: 102,
-                  firstName: 'Lili',
-                  lastName: 'Dupont',
-                  isReferer: false,
-                });
-                server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-                await authenticateSession(certificationPointOfContact.id);
-
-                // when
-                const screen = await visitScreen('/equipe');
-
-                await click(
-                  screen.getByRole('button', {
-                    name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
-                  }),
-                );
-                await screen.findByRole('dialog');
-
-                // then
-                assert.dom(screen.getByRole('button', { name: 'Valider la sélection de référent' })).isDisabled();
-              });
-
-              module('when referer registration failed', function () {
-                test('it should return error message', async function (assert) {
-                  // given
-                  await _createAndAuthenticateMember();
-                  const screen = await visitScreen('/equipe');
-                  this.server.post('certif/certification-centers/:id/update-referer', () => {
-                    return new Response(500, {}, { errors: [{ status: '500' }] });
-                  });
-
-                  await click(screen.getByRole('button', { name: 'Désigner un référent' }));
-                  await screen.findByRole('dialog');
-                  await click(screen.getByLabelText('Sélectionner le référent Pix'));
-                  await click(
-                    await screen.findByRole('option', {
-                      name: 'Lili Dupont',
-                    }),
-                  );
-
-                  // when
-                  await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
-
-                  // then
-                  assert
-                    .dom(
-                      screen.getByText(
-                        'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
-                      ),
-                    )
-                    .exists();
-                });
-              });
             });
           });
 
@@ -354,12 +394,5 @@ module('Acceptance | authenticated | team', function (hooks) {
         });
       });
     });
-
-    async function _createAndAuthenticateMember() {
-      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-      server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-      await authenticateSession(certificationPointOfContact.id);
-    }
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/list_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list_test.js
@@ -15,6 +15,10 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('#shouldDisplayNoRefererSection', function () {
     module('when certification center has CLEA habilitation', function () {
       module('when there is a referer', function () {
@@ -186,55 +190,120 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     });
   });
 
-  module('#shouldDisplayUpdateRefererButton', function () {
+  module('#shouldDisplayUpdateRefererButton', function (hooks) {
+    let currentUser;
+
+    hooks.beforeEach(function () {
+      currentUser = this.owner.lookup('service:current-user');
+    });
+
     module('when certification center has CLEA habilitation', function (hooks) {
       hooks.beforeEach(function () {
         controller.model = { hasCleaHabilitation: true };
       });
 
-      module('when there is only one member', function () {
-        test('returns false', function (assert) {
-          // given
-          const isReferer = store.createRecord('member', {
-            isReferer: true,
-          });
-          controller.model.members = [isReferer];
-
-          // when then
-          assert.false(controller.shouldDisplayUpdateRefererButton);
+      module('when current user has the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(true);
         });
-      });
 
-      module('when there is at least 2 members', function () {
-        module('with a referer', function () {
-          test('returns true', function (assert) {
+        module('when there is only one member', function () {
+          test('returns false', function (assert) {
             // given
-            const notReferer = store.createRecord('member', {
-              isReferer: false,
-            });
             const isReferer = store.createRecord('member', {
               isReferer: true,
             });
-            controller.model.members = [notReferer, isReferer];
-
-            // when then
-            assert.true(controller.shouldDisplayUpdateRefererButton);
-          });
-        });
-
-        module('without referer', function () {
-          test('returns false', function (assert) {
-            // given
-            const notReferer = store.createRecord('member', {
-              isReferer: false,
-            });
-            const notReferer2 = store.createRecord('member', {
-              isReferer: false,
-            });
-            controller.model.members = [notReferer, notReferer2];
+            controller.model.members = [isReferer];
 
             // when then
             assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+
+        module('when there is at least 2 members', function () {
+          module('with a referer', function () {
+            test('returns true', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const isReferer = store.createRecord('member', {
+                isReferer: true,
+              });
+              controller.model.members = [notReferer, isReferer];
+
+              // when then
+              assert.true(controller.shouldDisplayUpdateRefererButton);
+            });
+          });
+
+          module('without referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const notReferer2 = store.createRecord('member', {
+                isReferer: false,
+              });
+              controller.model.members = [notReferer, notReferer2];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
+          });
+        });
+      });
+
+      module('when current user does not have the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(false);
+        });
+
+        module('when there is only one member', function () {
+          test('returns false', function (assert) {
+            // given
+            const isReferer = store.createRecord('member', {
+              isReferer: true,
+            });
+            controller.model.members = [isReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+
+        module('when there is at least 2 members', function () {
+          module('with a referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const isReferer = store.createRecord('member', {
+                isReferer: true,
+              });
+              controller.model.members = [notReferer, isReferer];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
+          });
+
+          module('without referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const notReferer2 = store.createRecord('member', {
+                isReferer: false,
+              });
+              controller.model.members = [notReferer, notReferer2];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
           });
         });
       });
@@ -245,49 +314,108 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
         controller.model = { hasCleaHabilitation: false };
       });
 
-      module('when there is only one member', function () {
-        test('returns false', function (assert) {
-          // given
-          const isReferer = store.createRecord('member', {
-            isReferer: true,
-          });
-          controller.model.members = [isReferer];
-
-          // when then
-          assert.false(controller.shouldDisplayUpdateRefererButton);
+      module('when current user has the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(true);
         });
-      });
 
-      module('when there is at least 2 members', function () {
-        module('with a referer', function () {
+        module('when there is only one member', function () {
           test('returns false', function (assert) {
             // given
-            const notReferer = store.createRecord('member', {
-              isReferer: false,
-            });
             const isReferer = store.createRecord('member', {
               isReferer: true,
             });
-            controller.model.members = [notReferer, isReferer];
+            controller.model.members = [isReferer];
 
             // when then
             assert.false(controller.shouldDisplayUpdateRefererButton);
           });
         });
 
-        module('without referer', function () {
+        module('when there is at least 2 members', function () {
+          module('with a referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const isReferer = store.createRecord('member', {
+                isReferer: true,
+              });
+              controller.model.members = [notReferer, isReferer];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
+          });
+
+          module('without referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const notReferer2 = store.createRecord('member', {
+                isReferer: false,
+              });
+              controller.model.members = [notReferer, notReferer2];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
+          });
+        });
+      });
+
+      module('when current user does not have the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(false);
+        });
+
+        module('when there is only one member', function () {
           test('returns false', function (assert) {
             // given
-            const notReferer = store.createRecord('member', {
-              isReferer: false,
+            const isReferer = store.createRecord('member', {
+              isReferer: true,
             });
-            const notReferer2 = store.createRecord('member', {
-              isReferer: false,
-            });
-            controller.model.members = [notReferer, notReferer2];
+            controller.model.members = [isReferer];
 
             // when then
             assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+
+        module('when there is at least 2 members', function () {
+          module('with a referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const isReferer = store.createRecord('member', {
+                isReferer: true,
+              });
+              controller.model.members = [notReferer, isReferer];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
+          });
+
+          module('without referer', function () {
+            test('returns false', function (assert) {
+              // given
+              const notReferer = store.createRecord('member', {
+                isReferer: false,
+              });
+              const notReferer2 = store.createRecord('member', {
+                isReferer: false,
+              });
+              controller.model.members = [notReferer, notReferer2];
+
+              // when then
+              assert.false(controller.shouldDisplayUpdateRefererButton);
+            });
           });
         });
       });

--- a/certif/tests/unit/controllers/authenticated/team/list_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list_test.js
@@ -8,10 +8,11 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
   setupIntl(hooks);
 
   let controller;
-  let store;
+  let currentUser, store;
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:authenticated/team/list');
+    currentUser = this.owner.lookup('service:current-user');
     store = this.owner.lookup('service:store');
   });
 
@@ -20,43 +21,194 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
   });
 
   module('#shouldDisplayNoRefererSection', function () {
-    module('when certification center has CLEA habilitation', function () {
-      module('when there is a referer', function () {
-        test('should return false', function (assert) {
-          // given
-          const referer = store.createRecord('member', {
-            isReferer: true,
-          });
-          const notReferer = store.createRecord('member', {
-            isReferer: false,
-          });
-          controller.model = { members: [referer, notReferer], hasCleaHabilitation: true };
+    module('when certification center has CLEA habilitation', function (hooks) {
+      hooks.beforeEach(function () {
+        controller.model = { hasCleaHabilitation: true };
+      });
 
-          // when then
-          assert.false(controller.shouldDisplayNoRefererSection);
+      module('when current user has the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(true);
+        });
+
+        module('when there is a referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const referer = store.createRecord('member', {
+              isReferer: true,
+            });
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [referer, notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no member', function () {
+          test('returns false', function (assert) {
+            // given
+            controller.model.members = [];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no referer', function () {
+          test('returns true', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [notReferer];
+
+            // when then
+            assert.true(controller.shouldDisplayNoRefererSection);
+          });
         });
       });
 
-      module('when there is no member', function () {
-        test('should return false', function (assert) {
-          // given
-          controller.model = { members: [], hasCleaHabilitation: true };
+      module('when current user does not have the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(false);
+        });
 
-          // when then
-          assert.false(controller.shouldDisplayNoRefererSection);
+        module('when there is a referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const referer = store.createRecord('member', {
+              isReferer: true,
+            });
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [referer, notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no member', function () {
+          test('returns false', function (assert) {
+            // given
+            controller.model.members = [];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+      });
+    });
+
+    module('when certification center does not have CLEA habilitation', function (hooks) {
+      hooks.beforeEach(function () {
+        controller.model = { hasCleaHabilitation: false };
+      });
+
+      module('when current user has the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(true);
+        });
+
+        module('when there is a referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const referer = store.createRecord('member', {
+              isReferer: true,
+            });
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [referer, notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no member', function () {
+          test('returns false', function (assert) {
+            // given
+            controller.model.members = [];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
         });
       });
 
-      module('when there is no referer', function () {
-        test('should return true', function (assert) {
-          // given
-          const notReferer = store.createRecord('member', {
-            isReferer: false,
-          });
-          controller.model = { members: [notReferer], hasCleaHabilitation: true };
+      module('when current user does not have the role "ADMIN"', function (hooks) {
+        hooks.beforeEach(function () {
+          sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(false);
+        });
 
-          // when then
-          assert.true(controller.shouldDisplayNoRefererSection);
+        module('when there is a referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const referer = store.createRecord('member', {
+              isReferer: true,
+            });
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [referer, notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no member', function () {
+          test('returns false', function (assert) {
+            // given
+            controller.model.members = [];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
+        });
+
+        module('when there is no referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [notReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayNoRefererSection);
+          });
         });
       });
     });
@@ -190,13 +342,7 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     });
   });
 
-  module('#shouldDisplayUpdateRefererButton', function (hooks) {
-    let currentUser;
-
-    hooks.beforeEach(function () {
-      currentUser = this.owner.lookup('service:current-user');
-    });
-
+  module('#shouldDisplayUpdateRefererButton', function () {
     module('when certification center has CLEA habilitation', function (hooks) {
       hooks.beforeEach(function () {
         controller.model = { hasCleaHabilitation: true };

--- a/certif/tests/unit/controllers/authenticated/team/list_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list_test.js
@@ -7,13 +7,19 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
+  let controller;
+  let store;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/team/list');
+    store = this.owner.lookup('service:store');
+  });
+
   module('#shouldDisplayNoRefererSection', function () {
     module('when certification center has CLEA habilitation', function () {
       module('when there is a referer', function () {
         test('should return false', function (assert) {
           // given
-          const controller = this.owner.lookup('controller:authenticated/team/list');
-          const store = this.owner.lookup('service:store');
           const referer = store.createRecord('member', {
             isReferer: true,
           });
@@ -30,7 +36,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
       module('when there is no member', function () {
         test('should return false', function (assert) {
           // given
-          const controller = this.owner.lookup('controller:authenticated/team/list');
           controller.model = { members: [], hasCleaHabilitation: true };
 
           // when then
@@ -41,9 +46,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
       module('when there is no referer', function () {
         test('should return true', function (assert) {
           // given
-          const controller = this.owner.lookup('controller:authenticated/team/list');
-          const store = this.owner.lookup('service:store');
-
           const notReferer = store.createRecord('member', {
             isReferer: false,
           });
@@ -60,8 +62,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     module('when shouldShowRefererSelectionModal is true', function () {
       test('should set the value to false', function (assert) {
         // given
-        const controller = this.owner.lookup('controller:authenticated/team/list');
-
         controller.shouldShowRefererSelectionModal = true;
 
         // when
@@ -75,8 +75,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     module('when shouldShowRefererSelectionModal is false', function () {
       test('should set the value to true', function (assert) {
         // given
-        const controller = this.owner.lookup('controller:authenticated/team/list');
-
         controller.shouldShowRefererSelectionModal = false;
 
         // when
@@ -91,8 +89,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
   module('#membersSelectOptionsSortedByLastName', function () {
     test('should return an array of non referer members select options ordered by last name', function (assert) {
       // given
-      const controller = this.owner.lookup('controller:authenticated/team/list');
-      const store = this.owner.lookup('service:store');
       const member1 = store.createRecord('member', {
         id: 102,
         firstName: 'Abe',
@@ -131,7 +127,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     test('should select the id of a selected member', function (assert) {
       // given
       const optionSelected = 102;
-      const controller = this.owner.lookup('controller:authenticated/team/list');
 
       // when
       controller.onSelectReferer(optionSelected);
@@ -145,8 +140,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     module('when a referer is selected', function () {
       test('should call updateReferer model method', function (assert) {
         // given
-        const controller = this.owner.lookup('controller:authenticated/team/list');
-        const store = this.owner.lookup('service:store');
         const updateRefererStub = sinon.stub();
         const sendStub = sinon.stub();
         const member = store.createRecord('member', {
@@ -171,8 +164,6 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
     module('when there is no referer selected', function () {
       test('should not call updateReferer model method', function (assert) {
         // given
-        const controller = this.owner.lookup('controller:authenticated/team/list');
-        const store = this.owner.lookup('service:store');
         const updateRefererStub = sinon.stub();
         const sendStub = sinon.stub();
         const member = store.createRecord('member', {
@@ -196,58 +187,55 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
   });
 
   module('#shouldDisplayUpdateRefererButton', function () {
-    module('when there is only one member', function () {
-      test('should return false', function (assert) {
-        // given
-        const controller = this.owner.lookup('controller:authenticated/team/list');
-        const store = this.owner.lookup('service:store');
-        const isReferer = store.createRecord('member', {
-          isReferer: true,
-        });
-
-        controller.model = { members: [isReferer], hasCleaHabilitation: true };
-
-        // when then
-        assert.false(controller.shouldDisplayUpdateRefererButton);
+    module('when certification center has CLEA habilitation', function (hooks) {
+      hooks.beforeEach(function () {
+        controller.model = { hasCleaHabilitation: true };
       });
-    });
-    module('when there is at least 2 members', function () {
-      module('when there is a referer', function () {
-        test('should return true', function (assert) {
-          // given
-          const controller = this.owner.lookup('controller:authenticated/team/list');
-          const store = this.owner.lookup('service:store');
 
-          const notReferer = store.createRecord('member', {
-            isReferer: false,
-          });
+      module('when there is only one member', function () {
+        test('returns false', function (assert) {
+          // given
           const isReferer = store.createRecord('member', {
             isReferer: true,
           });
-
-          controller.model = { members: [notReferer, isReferer], hasCleaHabilitation: true };
-
-          // when then
-          assert.true(controller.shouldDisplayUpdateRefererButton);
-        });
-      });
-      module('when there is no referer', function () {
-        test('should return false', function (assert) {
-          // given
-          const controller = this.owner.lookup('controller:authenticated/team/list');
-          const store = this.owner.lookup('service:store');
-
-          const notReferer = store.createRecord('member', {
-            isReferer: false,
-          });
-          const notReferer2 = store.createRecord('member', {
-            isReferer: false,
-          });
-
-          controller.model = { members: [notReferer, notReferer2], hasCleaHabilitation: true };
+          controller.model.members = [isReferer];
 
           // when then
           assert.false(controller.shouldDisplayUpdateRefererButton);
+        });
+      });
+
+      module('when there is at least 2 members', function () {
+        module('with a referer', function () {
+          test('returns true', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            const isReferer = store.createRecord('member', {
+              isReferer: true,
+            });
+            controller.model.members = [notReferer, isReferer];
+
+            // when then
+            assert.true(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+
+        module('without referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            const notReferer2 = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [notReferer, notReferer2];
+
+            // when then
+            assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
         });
       });
     });

--- a/certif/tests/unit/controllers/authenticated/team/list_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list_test.js
@@ -239,5 +239,58 @@ module('Unit | Controller | authenticated/team/list', function (hooks) {
         });
       });
     });
+
+    module('when certification center does not have CLEA habilitation', function (hooks) {
+      hooks.beforeEach(function () {
+        controller.model = { hasCleaHabilitation: false };
+      });
+
+      module('when there is only one member', function () {
+        test('returns false', function (assert) {
+          // given
+          const isReferer = store.createRecord('member', {
+            isReferer: true,
+          });
+          controller.model.members = [isReferer];
+
+          // when then
+          assert.false(controller.shouldDisplayUpdateRefererButton);
+        });
+      });
+
+      module('when there is at least 2 members', function () {
+        module('with a referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            const isReferer = store.createRecord('member', {
+              isReferer: true,
+            });
+            controller.model.members = [notReferer, isReferer];
+
+            // when then
+            assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+
+        module('without referer', function () {
+          test('returns false', function (assert) {
+            // given
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            const notReferer2 = store.createRecord('member', {
+              isReferer: false,
+            });
+            controller.model.members = [notReferer, notReferer2];
+
+            // when then
+            assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, un membre d'un centre de certification ayant l'habilitation `Cléa Numérique` peut, quelque soit son rôle, modifier le référent ou en choisir un si aucun référent n'est sélectionné.

Dans le cadre de l'ajout du rôle à un membre d'un centre de certification, seul un administrateur devrait pouvoir effectuer cette action.

## :robot: Proposition

Restreindre l'accès à l'exécution des actions permettant de modifier le référent d'un centre de certification, uniquement aux membres ayant le rôle `Administrateur`.

## :rainbow: Remarques

RAS

## :100: Pour tester

### Scénario avec un administrateur Pix Certif

- Se connecter sur Pix Admin avec le compte `superadmin@example.net`
- Ouvrir la page `Centres de certification` en cliquant sur l'onglet dédié
- Filter par nom avec `Accèssorium`
- Ouvrir la page de détails du centre de certification
- Cliquer sur le bouton `Éditer les informations`
- Cocher la case `CléA Numérique`
- Cliquer sur le bouton `Enregistrer`
- Ouvrir un nouvel onglet
- Se connecter sur Pix Certif avec le compte `james-paledroits@example.net` (ayant le rôle `ADMIN` pour le centre de certification `Accèssorium`)
- Ouvrir la page `Équipe`
- Cliquer sur le bouton `Désigner un référent`
- Sélectionner `James Palédroits`
- Constater l'affichage d'un tag `référent` sur la ligne de `James Palédroits`
- Constater la disparition du bloc `Aucun référent Pix désigné` et l'affichage du bouton `Changer de référent`
- Cliquer sur le bouton `Changer de référent`
- Sélectionner `Marc-Alex Terrieur`
- Constater l'affichage d'un tag `référent` sur la ligne de `Marc-Alex Terrieur`

### Scénario avec un membre Pix Certif sans référent

- Se connecter sur Pix Admin avec le compte `superadmin@example.net`
- Ouvrir la page `Centres de certification` en cliquant sur l'onglet dédié
- Filter par nom avec `Accèssorium`
- Ouvrir la page de détails du centre de certification
- Cliquer sur le bouton `Éditer les informations`
- Cocher la case `CléA Numérique`
- Cliquer sur le bouton `Enregistrer`
- Ouvrir un nouvel onglet
- Se connecter sur Pix Certif avec le compte `marc-alex-terrieur@example.net` (ayant le rôle `MEMBER` pour le centre de certification `Accèssorium`)
- Ouvrir la page `Équipe`
- Constater que le bloc `Aucun référent Pix désigné`, incluant le bouton `Désigner un référent`, n'est pas visible

### Scénario avec un membre Pix Certif avec un référent

- Se connecter sur Pix Admin avec le compte `superadmin@example.net`
- Ouvrir la page `Centres de certification` en cliquant sur l'onglet dédié
- Filter par nom avec `Accèssorium`
- Ouvrir la page de détails du centre de certification
- Cliquer sur le bouton `Éditer les informations`
- Cocher la case `CléA Numérique`
- Cliquer sur le bouton `Enregistrer`
- Ouvrir un nouvel onglet
- Se connecter sur Pix Certif avec le compte `james-paledroits@example.net` (ayant le rôle `ADMIN` pour le centre de certification `Accèssorium`)
- Ouvrir la page `Équipe`
- Cliquer sur le bouton `Désigner un référent`
- Sélectionner `James Palédroits`
- Se déconnecter
- Se connecter avec le compte `marc-alex-terrieur@example.net` (ayant le rôle `MEMBER` pour le centre de certification `Accèssorium`)
- Ouvrir la page `Équipe`
- Constater que le bouton `Changer de référent` n'est pas visible