### PR TITLE
[FEATURE] Créer table parcours autonome (PIX-9805).

### DIFF
--- a/api/db/migrations/20231030144246_create_autonomous_courses.js
+++ b/api/db/migrations/20231030144246_create_autonomous_courses.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'autonomous-courses';
+
+const up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('organizationId').notNullable().unsigned().references('organizations.id');
+    t.integer('targetProfileId').notNullable().unsigned().references('target-profiles.id');
+    t.integer('campaignId').notNullable().unsigned().references('campaigns.id');
+    t.string('publicTitle').notNullable();
+    t.string('internalTitle').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'y a pas de table pour persister les informations des parcours autonomes.

## :robot: Proposition
Créer la table.

## :rainbow: Remarques
- Le champ `organizationId`  devrait avoir tout le temps la même valeur dans chaque environnement. Ce n'est pas une valeur administrable.
- Le statut de la campagne associée sera aussi celui du parcours autonome.

## :100: Pour tester
Vérifier que la table est bien créée par la migration knex en local.