### PR TITLE
[BUGFIX] Utiliser le bon argument pour la modal de suppression du SUP (PIX-9814)

### DIFF
--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -15,6 +15,6 @@
     @sortByParticipationCount={{this.sortByParticipationCount}}
     @sortByLastname={{this.sortByLastname}}
     @lastnameSort={{this.lastnameSort}}
-    @deleteStudents={{this.deleteParticipants}}
+    @deleteStudents={{this.deleteStudents}}
   />
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "Oui, je confirme" sur la modal du SUP ne fonctionne pas

## :robot: Proposition
Faire en sorte que le branchement soit bon

## :100: Pour tester
Se connecter sur Pix Orga en tant que sup-orga@example.net et vérifier que la suppression d'étudiant fonctionne