### PR TITLE
[FEATURE] Reprise du test avec une nouvelle question après un signalement validé (PIX-8812).

### DIFF
--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -94,11 +94,10 @@ const _getExcludedChallengeIds = async ({
   const answers = await answerRepository.findByAssessment(assessmentId);
   const alreadyAnsweredChallengeIds = answers.map(({ challengeId }) => challengeId);
 
-  const validatedLiveAlertsForAssessment =
+  const validatedLiveAlertsChallengeIdsForAssessment =
     await certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId(assessmentId);
-  const mappedAlertedChallengeIds = validatedLiveAlertsForAssessment.map(({ challengeId }) => challengeId);
 
-  return [...alreadyAnsweredChallengeIds, ...mappedAlertedChallengeIds];
+  return [...alreadyAnsweredChallengeIds, ...validatedLiveAlertsChallengeIdsForAssessment];
 };
 
 export { getNextChallengeForCertification };

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -45,13 +45,10 @@ const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, cour
   return bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationChallenge, certificationChallenge);
 };
 
-const getNextNonAnsweredChallengeByCourseIdForV3 = async function (assessmentId, courseId) {
-  const answeredChallengeIds = await knex('answers').select('challengeId').where({ assessmentId });
-  const mappedAnsweredChallengeIds = answeredChallengeIds.map(({ challengeId }) => challengeId);
-
+const getNextChallengeByCourseIdForV3 = async function (courseId, ignoredChallengeIds) {
   const certificationChallenge = await knex('certification-challenges')
     .where({ courseId })
-    .whereNotIn('challengeId', mappedAnsweredChallengeIds)
+    .whereNotIn('challengeId', ignoredChallengeIds)
     .orderBy('id', 'asc')
     .first();
 
@@ -65,4 +62,4 @@ const getNextNonAnsweredChallengeByCourseIdForV3 = async function (assessmentId,
   return new CertificationChallenge(certificationChallenge);
 };
 
-export { save, getNextNonAnsweredChallengeByCourseId, getNextNonAnsweredChallengeByCourseIdForV3 };
+export { save, getNextNonAnsweredChallengeByCourseId, getNextChallengeByCourseIdForV3 };

--- a/api/src/certification/session/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -19,6 +19,15 @@ const getByAssessmentId = async (assessmentId) => {
   return certificationChallengeLiveAlertsDto.map(_toDomain);
 };
 
+const getLiveAlertValidatedChallengeIdsByAssessmentId = async (assessmentId) => {
+  const liveAlertValidatedChallengeIds = await knex('certification-challenge-live-alerts').select('challengeId').where({
+    assessmentId,
+    status: CertificationChallengeLiveAlertStatus.VALIDATED,
+  });
+
+  return liveAlertValidatedChallengeIds;
+};
+
 const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {
   const certificationChallengeLiveAlertDto = await knex('certification-courses')
     .leftJoin('assessments', 'certification-courses.id', 'assessments.certificationCourseId')
@@ -57,4 +66,10 @@ const _toDomain = (certificationChallengeLiveAlertDto) => {
 };
 
 const _toDTO = (certificationChallengeLiveAlertDto) => certificationChallengeLiveAlertDto;
-export { save, getByAssessmentId, getOngoingBySessionIdAndUserId, getOngoingByChallengeIdAndAssessmentId };
+export {
+  save,
+  getByAssessmentId,
+  getOngoingBySessionIdAndUserId,
+  getLiveAlertValidatedChallengeIdsByAssessmentId,
+  getOngoingByChallengeIdAndAssessmentId,
+};

--- a/api/src/certification/session/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { knex } from '../../../../../db/knex-database-connection.js';
 import {
   CertificationChallengeLiveAlert,
@@ -25,7 +26,7 @@ const getLiveAlertValidatedChallengeIdsByAssessmentId = async (assessmentId) => 
     status: CertificationChallengeLiveAlertStatus.VALIDATED,
   });
 
-  return liveAlertValidatedChallengeIds;
+  return _.map(liveAlertValidatedChallengeIds, 'challengeId');
 };
 
 const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {

--- a/api/tests/certification/session/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
@@ -113,6 +113,99 @@ describe('Integration | Repository | Certification Challenge Live Alert', functi
     });
   });
 
+  describe('getLiveAlertValidatedChallengeIdsByAssessmentId', function () {
+    describe('when a validated liveAlert is linked to the assessment id', function () {
+      it('should return a challenge ids array', async function () {
+        // given
+        const questionNumber = 2;
+        databaseBuilder.factory.buildAssessment({
+          id: assessmentIdWithLiveAlert,
+        });
+        const challengeId = databaseBuilder.factory.buildCertificationChallenge({
+          assessmentIdWithLiveAlert,
+        }).challengeId;
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessmentIdWithLiveAlert,
+          questionNumber,
+          status: CertificationChallengeLiveAlertStatus.VALIDATED,
+          challengeId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const liveAlertValidatedChallengeIds =
+          await certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId(
+            assessmentIdWithLiveAlert,
+          );
+
+        // then
+        expect(liveAlertValidatedChallengeIds).to.deep.equal([challengeId]);
+      });
+    });
+
+    describe('when no validated liveAlert is linked to the assessment id', function () {
+      it('should return an empty array', async function () {
+        // given
+        const questionNumber = 2;
+        databaseBuilder.factory.buildAssessment({
+          id: assessmentIdWithLiveAlert,
+        });
+        const challengeId = databaseBuilder.factory.buildCertificationChallenge({ assessmentIdWithLiveAlert }).id;
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessmentIdWithLiveAlert,
+          questionNumber,
+          status: CertificationChallengeLiveAlertStatus.DISMISSED,
+          challengeId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const liveAlertValidatedChallengeIds =
+          await certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId(
+            assessmentIdWithLiveAlert,
+          );
+
+        // then
+        expect(liveAlertValidatedChallengeIds).to.have.length(0);
+      });
+    });
+
+    describe('when a dismissed liveAlert and a validated liveAlert is linked to the assessment id', function () {
+      it('should return a challenge ids array', async function () {
+        // given
+        const questionNumber = 2;
+        databaseBuilder.factory.buildAssessment({
+          id: assessmentIdWithLiveAlert,
+        });
+        const challengeId = databaseBuilder.factory.buildCertificationChallenge({
+          assessmentIdWithLiveAlert,
+        }).challengeId;
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessmentIdWithLiveAlert,
+          questionNumber,
+          status: CertificationChallengeLiveAlertStatus.DISMISSED,
+          challengeId,
+        });
+        databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+          assessmentId: assessmentIdWithLiveAlert,
+          questionNumber,
+          status: CertificationChallengeLiveAlertStatus.VALIDATED,
+          challengeId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const liveAlertValidatedChallengeIds =
+          await certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId(
+            assessmentIdWithLiveAlert,
+          );
+
+        // then
+        expect(liveAlertValidatedChallengeIds).to.deep.equal([challengeId]);
+      });
+    });
+  });
+
   describe('getOngoingBySessionIdAndUserId', function () {
     const sessionId = 123;
     const userId = 456;

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -91,7 +91,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
         };
         certificationChallengeRepository = {
           save: sinon.stub(),
-          getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
+          getNextChallengeByCourseIdForV3: sinon.stub(),
         };
         algorithmDataFetcherService = {
           fetchForFlashCampaigns: sinon.stub(),
@@ -114,9 +114,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           const assessment = domainBuilder.buildAssessment();
           const locale = 'fr-FR';
 
+          answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+
           certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(v3CertificationCourse);
-          certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3
-            .withArgs(assessment.id, assessment.certificationCourseId)
+          certificationChallengeRepository.getNextChallengeByCourseIdForV3
+            .withArgs(assessment.certificationCourseId, [])
             .resolves(null);
           challengeRepository.get.resolves();
           algorithmDataFetcherService.fetchForFlashCampaigns
@@ -181,10 +183,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
         context('when resuming the session', function () {
           it('should return the last seen challenge', async function () {
             // given
-            const answerRepository = Symbol('AnswerRepository');
-            const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
-            const algorithmDataFetcherService = Symbol('algorithmDataFetcherService');
-            const pickChallengeService = Symbol('pickChallengeService');
             const locale = 'fr-FR';
 
             const v3CertificationCourse = domainBuilder.buildCertificationCourse({
@@ -200,11 +198,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               id: nonAnsweredCertificationChallenge.challengeId,
             });
 
+            answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
+
             certificationCourseRepository.get
               .withArgs(assessment.certificationCourseId)
               .resolves(v3CertificationCourse);
-            certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3
-              .withArgs(assessment.id, assessment.certificationCourseId)
+            certificationChallengeRepository.getNextChallengeByCourseIdForV3
+              .withArgs(assessment.certificationCourseId, [])
               .resolves(nonAnsweredCertificationChallenge);
             challengeRepository.get.withArgs(nonAnsweredCertificationChallenge.challengeId).resolves(lastSeenChallenge);
 
@@ -231,27 +231,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
       context('when there are no challenges left', function () {
         it('should return the AssessmentEndedError', async function () {
           // given
-          const answerRepository = Symbol('AnswerRepository');
-          const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
           const answeredChallenge = domainBuilder.buildChallenge();
           const answer = domainBuilder.buildAnswer({ challengeId: answeredChallenge.id });
           const v3CertificationCourse = domainBuilder.buildCertificationCourse({
             version: CertificationVersion.V3,
           });
           const assessment = domainBuilder.buildAssessment();
-          const certificationCourseRepository = {
-            get: sinon.stub(),
-          };
-          const challengeRepository = {
-            get: sinon.stub(),
-          };
-          const certificationChallengeRepository = {
-            save: sinon.stub(),
-            getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
-          };
-          const algorithmDataFetcherService = {
-            fetchForFlashCampaigns: sinon.stub(),
-          };
           const locale = 'fr-FR';
 
           const flashAlgorithmService = {
@@ -259,9 +244,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             getEstimatedLevelAndErrorRate: sinon.stub(),
           };
 
+          answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
+
           certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(v3CertificationCourse);
-          certificationChallengeRepository.getNextNonAnsweredChallengeByCourseIdForV3
-            .withArgs(assessment.id, assessment.certificationCourseId)
+          certificationChallengeRepository.getNextChallengeByCourseIdForV3
+            .withArgs(assessment.certificationCourseId, [answeredChallenge.id])
             .resolves(null);
           challengeRepository.get.resolves();
           algorithmDataFetcherService.fetchForFlashCampaigns

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -69,36 +69,49 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
     });
 
     context('for a v3 certification', function () {
+      let answerRepository,
+        flashAssessmentResultRepository,
+        challengeRepository,
+        certificationCourseRepository,
+        certificationChallengeRepository,
+        algorithmDataFetcherService,
+        pickChallengeService,
+        flashAlgorithmService;
+
+      beforeEach(function () {
+        answerRepository = {
+          findByAssessment: sinon.stub(),
+        };
+        flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
+        challengeRepository = {
+          get: sinon.stub(),
+        };
+        certificationCourseRepository = {
+          get: sinon.stub(),
+        };
+        certificationChallengeRepository = {
+          save: sinon.stub(),
+          getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
+        };
+        algorithmDataFetcherService = {
+          fetchForFlashCampaigns: sinon.stub(),
+        };
+        pickChallengeService = {
+          chooseNextChallenge: sinon.stub(),
+        };
+        flashAlgorithmService = {
+          getPossibleNextChallenges: sinon.stub(),
+          getEstimatedLevelAndErrorRate: sinon.stub(),
+        };
+      });
       context('when there are challenges left to answer', function () {
         it('should save the returned next challenge', async function () {
           // given
-          const answerRepository = Symbol('AnswerRepository');
-          const flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
           const nextChallengeToAnswer = domainBuilder.buildChallenge();
           const v3CertificationCourse = domainBuilder.buildCertificationCourse({
             version: CertificationVersion.V3,
           });
           const assessment = domainBuilder.buildAssessment();
-          const challengeRepository = {
-            get: sinon.stub(),
-          };
-          const certificationCourseRepository = {
-            get: sinon.stub(),
-          };
-          const certificationChallengeRepository = {
-            save: sinon.stub(),
-            getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
-          };
-          const algorithmDataFetcherService = {
-            fetchForFlashCampaigns: sinon.stub(),
-          };
-          const pickChallengeService = {
-            chooseNextChallenge: sinon.stub(),
-          };
-          const flashAlgorithmService = {
-            getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
-          };
           const locale = 'fr-FR';
 
           certificationCourseRepository.get.withArgs(assessment.certificationCourseId).resolves(v3CertificationCourse);
@@ -173,17 +186,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             const algorithmDataFetcherService = Symbol('algorithmDataFetcherService');
             const pickChallengeService = Symbol('pickChallengeService');
             const locale = 'fr-FR';
-
-            const certificationCourseRepository = {
-              get: sinon.stub(),
-            };
-            const certificationChallengeRepository = {
-              save: sinon.stub(),
-              getNextNonAnsweredChallengeByCourseIdForV3: sinon.stub(),
-            };
-            const challengeRepository = {
-              get: sinon.stub(),
-            };
 
             const v3CertificationCourse = domainBuilder.buildCertificationCourse({
               version: CertificationVersion.V3,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -272,7 +272,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             })
             .resolves({
               allAnswers: [],
-              challenges: [nextChallenge],
+              challenges: [nextChallenge, lastSeenChallenge],
               estimatedLevel: 0,
             });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la certif v3, il va être possible pour un candidat de signaler un problème sur une question, et pour le surveillant d’agir sur ce signalement en le refusant ou en l’acceptant. Dans le cas où le surveillant valide le signalement, le candidat doit pouvoir reprendre son test sur une nouvelle question.

## :robot: Proposition
Lorsqu’un candidat rentre dans le tunnel pour signaler un problème technique, qu’il clique sur “Rafraichir la page” après que le surveillant ait validé le signalement :

- une nouvelle question est affichée avec le même numéro de question que la question précédemment ignorée (il s’agit d’un remplacement de question pour le candidat, même si techniquement on fait autrement)
- les boutons “Je passe” et “Je valide” sont actifs
- la section “Signaler un problème” est fermée

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Créer une session de certification V3 avec certifv3@example.net
- Inscrire un candidat à cette session
- Démarrer la session de certification avec certifiable-contenu-user@example.net
- Rejoindre la session avec ce candidat et commencer le test
- Ouvrir l’espace surveillant
- Cliquer sur le menu pour ce candidat (les trois petits points sur le côté)
- L’option “Gérer un signalement” n’est pas affichée car le candidat n’a pas de signalement en attente
- Retourner sur le test du candidat, cliquer sur “Signaler un problème avec la question”, puis “Oui, je suis sûr”
- De retour sur l’espace surveillant, cliquer le menu pour ce candidat (les trois points)
- Cliquer sur “Gérer un signalement”, choisir "E1 L'image ne s'affiche pas", "Valider le signalement"
- Retourner sur le test du candidat, cliquer sur "Rafraîchir la page"
   - une nouvelle question, que le candidat n’a pas encore vue lors de son test, est affichée avec le même numéro de question que la précédente qui a été ignorée
   - le nombre de questions total n’a pas changé
   - le candidat peut continuer son test


Vérifier qu’il n’y a pas eu de régression pour les sessions v2

