### PR TITLE
[FEATURE] Personnaliser la page de fin de parcours lors de création de campagne en masse (PIX-9686)

### DIFF
--- a/api/lib/domain/models/CampaignForCreation.js
+++ b/api/lib/domain/models/CampaignForCreation.js
@@ -12,6 +12,9 @@ class CampaignForCreation {
     organizationId,
     multipleSendings,
     code,
+    customResultPageText,
+    customResultPageButtonText,
+    customResultPageButtonUrl,
   } = {}) {
     this.name = name;
     this.title = title;
@@ -24,6 +27,9 @@ class CampaignForCreation {
     this.organizationId = organizationId;
     this.multipleSendings = multipleSendings;
     this.code = code;
+    this.customResultPageText = customResultPageText;
+    this.customResultPageButtonText = customResultPageButtonText;
+    this.customResultPageButtonUrl = customResultPageButtonUrl;
     validate(this);
   }
 }

--- a/api/lib/domain/validators/campaign-creation-validator.js
+++ b/api/lib/domain/validators/campaign-creation-validator.js
@@ -29,6 +29,39 @@ const schema = Joi.object({
     'string.max': 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG',
   }),
 
+  customResultPageText: Joi.string().empty('').allow(null).default(null).max(5000).messages({
+    'string.max': 'CUSTOM_RESULT_PAGE_TEXT_IS_TOO_LONG',
+  }),
+
+  customResultPageButtonText: Joi.when('type', {
+    is: Joi.string().required().valid(CampaignTypes.PROFILES_COLLECTION),
+    then: Joi.valid(null),
+    otherwise: Joi.when('customResultPageButtonUrl', {
+      then: Joi.string().required(),
+      otherwise: Joi.string().allow(null).default(null),
+    }),
+  }).messages({
+    'any.only': 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
+    'string.base': 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
+    'string.empty': 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
+    'any.required': 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
+  }),
+
+  customResultPageButtonUrl: Joi.when('type', {
+    is: Joi.string().required().valid(CampaignTypes.PROFILES_COLLECTION),
+    then: Joi.valid(null),
+    otherwise: Joi.when('customResultPageButtonText', {
+      then: Joi.string().uri().required(),
+      otherwise: Joi.string().allow(null).default(null),
+    }),
+  }).messages({
+    'any.only': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
+    'string.uri': 'CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL',
+    'string.base': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
+    'string.empty': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
+    'any.required': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
+  }),
+
   ownerId: Joi.number().integer().required().messages({
     'any.required': 'MISSING_OWNER',
     'number.base': 'MISSING_OWNER',

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -68,6 +68,9 @@ const save = async function (campaigns, dependencies = { skillRepository }) {
         'targetProfileId',
         'multipleSendings',
         'createdAt',
+        'customResultPageText',
+        'customResultPageButtonText',
+        'customResultPageButtonUrl',
       ]);
       const [createdCampaignDTO] = await trx(CAMPAIGNS_TABLE).insert(campaignAttributes).returning('*');
       latestCreatedCampaign = new Campaign(createdCampaignDTO);
@@ -102,6 +105,9 @@ const update = async function (campaign) {
     'archivedAt',
     'archivedBy',
     'ownerId',
+    'customResultPageText',
+    'customResultPageButtonText',
+    'customResultPageButtonUrl',
   ]);
 
   const [editedCampaign] = await knex('campaigns').update(editedAttributes).where({ id: campaign.id }).returning('*');

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -214,6 +214,9 @@ async function parseForCampaignsImport(cleanedData, { parseCsvData } = csvHelper
     customLandingPageText: data['Descriptif du parcours'],
     multipleSendings: data['Envoi multiple'].toLowerCase() === 'oui' ? true : false,
     ownerId: data['Identifiant du propriétaire'] || null,
+    customResultPageText: data['Texte de la page de fin de parcours'] || null,
+    customResultPageButtonText: data['Texte du bouton de la page de fin de parcours'] || null,
+    customResultPageButtonUrl: data['URL du bouton de la page de fin de parcours'] || null,
   }));
 }
 

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -578,6 +578,9 @@ describe('Integration | Repository | Campaign', function () {
             type: CampaignTypes.ASSESSMENT,
             targetProfileId,
             title: 'Parcours recherche internet',
+            customResultPageText: null,
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
           },
           {
             name: 'Evaluation niveau 1 recherche internet #2',
@@ -590,6 +593,9 @@ describe('Integration | Repository | Campaign', function () {
             type: CampaignTypes.ASSESSMENT,
             targetProfileId,
             title: 'Parcours recherche internet #2',
+            customResultPageText: 'Bravo !',
+            customResultPageButtonText: 'Cliquez ici',
+            customResultPageButtonUrl: 'https://hmpg.net/',
           },
         ];
 
@@ -609,6 +615,9 @@ describe('Integration | Repository | Campaign', function () {
             'targetProfileId',
             'multipleSendings',
             'ownerId',
+            'customResultPageText',
+            'customResultPageButtonText',
+            'customResultPageButtonUrl',
           )
           .orderBy('code');
 
@@ -624,6 +633,9 @@ describe('Integration | Repository | Campaign', function () {
             'targetProfile',
             'multipleSendings',
             'ownerId',
+            'customResultPageText',
+            'customResultPageButtonText',
+            'customResultPageButtonUrl',
           ]),
         );
 
@@ -639,6 +651,9 @@ describe('Integration | Repository | Campaign', function () {
             'targetProfile',
             'multipleSendings',
             'ownerId',
+            'customResultPageText',
+            'customResultPageButtonText',
+            'customResultPageButtonUrl',
           ]),
         );
       });

--- a/api/tests/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/unit/domain/models/CampaignForCreation_test.js
@@ -16,6 +16,8 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
             organizationId: 3,
             title: '',
             customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
           };
 
           expect(() => new CampaignForCreation(attributes)).to.not.throw();
@@ -98,6 +100,67 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
             expect(error.message).to.equal("Échec de validation de l'entité.");
             expect(error.invalidAttributes).to.deep.equal([
               { attribute: 'customLandingPageText', message: 'CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG' },
+            ]);
+          });
+        });
+
+        context('customResultPageText max length over 5000 character', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageText = 'Godzilla vs Kong'.repeat(335);
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'customResultPageText', message: 'CUSTOM_RESULT_PAGE_TEXT_IS_TOO_LONG' },
+            ]);
+          });
+        });
+
+        context('customResultPageButtonUrl is required if customResultPageButtonText is defined', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageButtonText = 'Godzilla vs Kong';
+            attributes.customResultPageButtonUrl = null;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              {
+                attribute: 'customResultPageButtonUrl',
+                message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
+              },
+            ]);
+          });
+        });
+
+        context('customResultPageButtonText is required if customResultPageButtonUrl is defined', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageButtonUrl = 'https://http.dog/';
+            attributes.customResultPageButtonText = null;
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              {
+                attribute: 'customResultPageButtonText',
+                message: 'CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED',
+              },
+            ]);
+          });
+        });
+
+        context('customResultPageButtonUrl must be an URL', function () {
+          it('throws an error', async function () {
+            // given
+            attributes.customResultPageButtonText = 'Godzilla vs Kong';
+            attributes.customResultPageButtonUrl = 'Godzilla vs Kong';
+
+            const error = await catchErr(() => new CampaignForCreation(attributes))();
+            expect(error.message).to.equal("Échec de validation de l'entité.");
+            expect(error.invalidAttributes).to.deep.equal([
+              { attribute: 'customResultPageButtonUrl', message: 'CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL' },
             ]);
           });
         });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1067,11 +1067,11 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
   describe('#parseForCampaignsImport', function () {
     const headerCsv =
-      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire\n";
+      "Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Identifiant du créateur*;Titre du parcours;Descriptif du parcours;Envoi multiple;Identifiant du propriétaire;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours\n";
 
     it('should return parsed campaign data', async function () {
       // given
-      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non;`;
+      const csv = `${headerCsv}1;chaussette;1234;numéro étudiant;789;titre 1;descriptif 1;Oui;45\n2;chapeau;1234;identifiant;666;titre 2;descriptif 2;Non\n3;chausson;1234;identifiant;123;titre 3;descriptif 3;Non;;Bravo !;Cliquez ici;https://hmpg.net/`;
 
       // when
       const parsedData = await csvSerializer.parseForCampaignsImport(csv);
@@ -1088,6 +1088,9 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           creatorId: 789,
           multipleSendings: true,
           ownerId: 45,
+          customResultPageText: null,
+          customResultPageButtonText: null,
+          customResultPageButtonUrl: null,
         },
         {
           organizationId: 2,
@@ -1099,6 +1102,23 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           creatorId: 666,
           multipleSendings: false,
           ownerId: null,
+          customResultPageText: null,
+          customResultPageButtonText: null,
+          customResultPageButtonUrl: null,
+        },
+        {
+          organizationId: 3,
+          name: 'chausson',
+          targetProfileId: 1234,
+          idPixLabel: 'identifiant',
+          title: 'titre 3',
+          customLandingPageText: 'descriptif 3',
+          creatorId: 123,
+          multipleSendings: false,
+          ownerId: null,
+          customResultPageText: 'Bravo !',
+          customResultPageButtonText: 'Cliquez ici',
+          customResultPageButtonUrl: 'https://hmpg.net/',
         },
       ];
       expect(parsedData).to.have.deep.members(expectedParsedData);


### PR DESCRIPTION
## :unicorn: Problème
La création de campagne en masse est bien utilisée et appréciée mais un besoin a émergé, notamment dans le cadre des campagnes lancées par Pole Emploi : pouvoir personnaliser la page de fin de parcours en même temps que la création des campagnes en masse car pour le moment cette personnalisation se fait à la main. 
Exemple : au mois de novembre, une centaine de campagnes nécessitant une personnalisation de la page de fin de parcours.devront être crées pour Pole Emploi. 

Rôle : Super_admin

## :robot: Proposition
Pouvoir gérer ces nouvelles colonnes lors de l’import pour la création en masse de campagne dans Pix Admin : 

- texte de la page de fin de parcours 
- texte du bouton de la page de fin de parcours
- URL du bouton de la page de fin de parcours

- [x] Il faudra bien ajouter les colonnes en questions dans le template d’import ☝️

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Fichier de test : 
`Identifiant de l'organisation*;Nom de la campagne*;Identifiant du profil cible*;Libellé de l'identifiant externe;Titre du parcours;Descriptif du parcours;Identifiant du propriétaire;Envoi multiple;Identifiant du créateur*;Texte de la page de fin de parcours;Texte du bouton de la page de fin de parcours;URL du bouton de la page de fin de parcours
2023;test Mache;76;;Saphira est là;Juste la balade de Saphi;;;9000;ici le texte de la page de fin de parcours;Finir le parcours;https://www.chateaudegoulaine.fr/5711-la-belle-et-la-bete.html`
- Se connecter à PixAdmin en tant que superAdmin
- Créer plusieurs campagnes en masse avec personnalisation de la page de fin de parcours et du texte mis en forme avec des balises.
- 🎉 