### PR TITLE
[TECH] Détruire le pool de connexion PgBoss à la fin de migration de BdD

### DIFF
--- a/api/scripts/database/pg-boss-migration.js
+++ b/api/scripts/database/pg-boss-migration.js
@@ -9,7 +9,7 @@ async function main() {
   const databaseUrl = process.env.NODE_ENV === 'test' ? process.env.TEST_DATABASE_URL : process.env.DATABASE_URL;
   const boss = new PgBoss(databaseUrl);
   await boss.start();
-  await boss.stop();
+  await boss.stop({ destroy: true });
 }
 
 (async () => {


### PR DESCRIPTION
## :unicorn: Problème
Dans la tâche `db:migrate`, PgBoss met du temps même quand il ne fait aucune modif du schéma.

## :robot: Proposition
Demander à PgBoss de détruire le pool de connexion quand il s'arrête.

## :rainbow: Remarques
N/A

## :100: Pour tester
Lancer un `npm run db:reset` et checker que PgBoss a bien créer son schéma.