### PR TITLE
[FEATURE] Modifier l'affichage du texte de suppression des participants/étudiants (Pix-9211)

### DIFF
--- a/orga/app/components/organization-participant/deletion-modal.hbs
+++ b/orga/app/components/organization-participant/deletion-modal.hbs
@@ -1,6 +1,22 @@
-<PixModal @title={{this.text.title}} @showModal={{@showModal}} @onCloseButtonClick={{@onCloseModal}}>
+<PixModal
+  @title={{t
+    "pages.organization-participants.deletion-modal.title"
+    count=this.count
+    firstname=this.firstName
+    lastname=this.lastName
+    htmlSafe=true
+  }}
+  @showModal={{@showModal}}
+  @onCloseButtonClick={{@onCloseModal}}
+>
   <:content>
-    {{this.text.content}}
+    <p>{{t "pages.organization-participants.deletion-modal.content.header" count=this.count}}</p>
+    <p>{{t "pages.organization-participants.deletion-modal.content.main-participation-prevent" count=this.count}}</p>
+    <p>{{t "pages.organization-participants.deletion-modal.content.main-campaign-prevent" count=this.count}}</p>
+    <p>{{t "pages.organization-participants.deletion-modal.content.main-participation-access" count=this.count}}</p>
+    <p>{{t "pages.organization-participants.deletion-modal.content.main-new-campaign-access" count=this.count}}</p>
+    <p><strong>{{t "pages.organization-participants.deletion-modal.content.footer" count=this.count}}</strong></p>
+
     {{#if this.isMultipleDeletion}}
       <PixCheckbox
         {{on "click" this.giveDeletionPermission}}
@@ -9,7 +25,7 @@
         @class="deletion-modal__permission-checkbox"
       >
         <strong>
-          {{t "pages.organization-participants.deletion-modal.confirmation-checkbox" count=@itemsToDelete.length}}
+          {{t "pages.organization-participants.deletion-modal.confirmation-checkbox" count=this.count}}
         </strong>
       </PixCheckbox>
     {{/if}}

--- a/orga/app/components/organization-participant/deletion-modal.js
+++ b/orga/app/components/organization-participant/deletion-modal.js
@@ -8,7 +8,7 @@ export default class DeletionModal extends Component {
   @tracked allowDeletion = false;
 
   get isMultipleDeletion() {
-    return this.args.itemsToDelete.length > 1;
+    return this.count > 1;
   }
 
   get canDelete() {
@@ -18,24 +18,16 @@ export default class DeletionModal extends Component {
     return this.allowDeletion;
   }
 
-  get text() {
-    if (this.isMultipleDeletion) {
-      return {
-        title: this.intl.t('pages.organization-participants.deletion-modal.many-items.title', {
-          count: this.args.itemsToDelete.length,
-          htmlSafe: true,
-        }),
-        content: this.intl.t('pages.organization-participants.deletion-modal.many-items.content', { htmlSafe: true }),
-      };
-    }
-    return {
-      title: this.intl.t('pages.organization-participants.deletion-modal.one-item.title', {
-        firstname: this.args.itemsToDelete[0].firstName,
-        lastname: this.args.itemsToDelete[0].lastName,
-        htmlSafe: true,
-      }),
-      content: this.intl.t('pages.organization-participants.deletion-modal.one-item.content', { htmlSafe: true }),
-    };
+  get count() {
+    return this.args.itemsToDelete.length;
+  }
+
+  get firstName() {
+    return this.args.itemsToDelete[0].firstName;
+  }
+
+  get lastName() {
+    return this.args.itemsToDelete[0].lastName;
   }
 
   @action

--- a/orga/app/components/sup-organization-participant/modal/deletion.hbs
+++ b/orga/app/components/sup-organization-participant/modal/deletion.hbs
@@ -1,6 +1,24 @@
-<PixModal @title={{this.text.title}} @showModal={{@showModal}} @onCloseButtonClick={{@onCloseModal}}>
+<PixModal
+  @title={{t
+    "pages.sup-organization-participants.deletion-modal.title"
+    count=this.count
+    firstname=this.firstName
+    lastname=this.lastName
+    htmlSafe=true
+  }}
+  @showModal={{@showModal}}
+  @onCloseButtonClick={{@onCloseModal}}
+>
   <:content>
-    {{this.text.content}}
+    <p>{{t "pages.sup-organization-participants.deletion-modal.content.header" count=this.count}}</p>
+    <p>{{t
+        "pages.sup-organization-participants.deletion-modal.content.main-participation-prevent"
+        count=this.count
+      }}</p>
+    <p>{{t "pages.sup-organization-participants.deletion-modal.content.main-campaign-prevent" count=this.count}}</p>
+    <p>{{t "pages.sup-organization-participants.deletion-modal.content.main-participation-access" count=this.count}}</p>
+    <p>{{t "pages.sup-organization-participants.deletion-modal.content.main-new-campaign-access" count=this.count}}</p>
+    <p><strong>{{t "pages.sup-organization-participants.deletion-modal.content.footer" count=this.count}}</strong></p>
     {{#if this.isMultipleDeletion}}
       <PixCheckbox
         {{on "click" this.giveDeletionPermission}}

--- a/orga/app/components/sup-organization-participant/modal/deletion.js
+++ b/orga/app/components/sup-organization-participant/modal/deletion.js
@@ -18,26 +18,16 @@ export default class Deletion extends Component {
     return this.allowDeletion;
   }
 
-  get text() {
-    if (this.isMultipleDeletion) {
-      return {
-        title: this.intl.t('pages.sup-organization-participants.deletion-modal.many-items.title', {
-          count: this.args.itemsToDelete.length,
-          htmlSafe: true,
-        }),
-        content: this.intl.t('pages.sup-organization-participants.deletion-modal.many-items.content', {
-          htmlSafe: true,
-        }),
-      };
-    }
-    return {
-      title: this.intl.t('pages.sup-organization-participants.deletion-modal.one-item.title', {
-        firstname: this.args.itemsToDelete[0].firstName,
-        lastname: this.args.itemsToDelete[0].lastName,
-        htmlSafe: true,
-      }),
-      content: this.intl.t('pages.sup-organization-participants.deletion-modal.one-item.content', { htmlSafe: true }),
-    };
+  get count() {
+    return this.args.itemsToDelete.length;
+  }
+
+  get firstName() {
+    return this.args.itemsToDelete[0].firstName;
+  }
+
+  get lastName() {
+    return this.args.itemsToDelete[0].lastName;
   }
 
   @action

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1081,16 +1081,17 @@
         "show-actions": "Show actions"
       },
       "deletion-modal": {
+        "title": "Delete '<strong>'{count, plural, =1 {{firstname} {lastname}} other {{count}}}'</strong>' {count, plural, =1 {of your} other {selected}} students?",
         "confirmation-checkbox": "I confirm that I have understood the impacts of the {count} deletions",
-        "delete-button": "Yes, I delete",
-        "many-items": {
-          "title": "Delete '<strong>'{count}'</strong>' selected students?",
-          "content": "These students will no longer be visible in Pix Orga.'<br/>'All their participations to campaigns will be deleted.This will have an impact on the results and analytics for these campaigns. They won’t able to participate again in campaigns in which they have already taken part in the past. However, they will still be able to take part in new campaigns.'<br/><strong>Please note that this action is irreversible.</strong>'"
+        "content": {
+          "footer": "Please note that this action is irreversible.",
+          "header": "{count, plural, =1 {This student} other {These students}} will no longer be visible in Pix Orga.",
+          "main-campaign-prevent": "This will have an impact on the results and analytics for these campaigns.",
+          "main-new-campaign-access": "However, they will still be able to take part in new campaigns.",
+          "main-participation-access": "They won't able to participate again in campaigns in which they have already taken part in the past.",
+          "main-participation-prevent": "All their participations to campaigns will be deleted."
         },
-        "one-item": {
-          "title": "Delete '<strong>'{firstname} {lastname}'</strong>' of your students?",
-          "content": "This student will no longer be visible in Pix Orga.'<br/>'All their participations to campaigns will be deleted. This will have an impact on the results and analytics for these campaigns. They won't able to participate again in campaigns in which they have already taken part in the past. However, they will still be able to take part in new campaigns.'<br/><strong>Please note that this action is irreversible.</strong>'"
-        }
+        "delete-button": "Yes, I delete"
       },
       "edit-student-number-modal": {
         "title": "Edit a student number",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -767,16 +767,17 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} has successfully been deleted from the participants list.} other {The {count} selected participants have successfully been deleted from the list.}}"
       },
       "deletion-modal": {
+        "title": "Delete '<strong>'{count, plural, =1 {{firstname} {lastname}} other {{count}}}'</strong>' {count, plural, =1 {of your} other {selected}} participants?",
         "confirmation-checkbox": "I confirm that I have understood the impacts of the {count} deletions",
-        "delete-button": "Yes, I delete",
-        "many-items": {
-          "title": "Delete '<strong>'{count}'</strong>' selected participants?",
-          "content": "These participants will no longer be visible in Pix Orga.'<br/>'All their participations to campaigns will be deleted.This will have an impact on the results and analytics for these campaigns. They won’t able to participate again in campaigns in which they have already taken part in the past. However, they will still be able to take part in new campaigns.'<br/><strong>Please note that this action is irreversible.</strong>'"
+        "content": {
+          "footer": "Please note that this action is irreversible.",
+          "header": "{count, plural, =1 {This participant} other {These participants}} will no longer be visible in Pix Orga.",
+          "main-campaign-prevent": "This will have an impact on the results and analytics for these campaigns.",
+          "main-new-campaign-access": "However, they will still be able to take part in new campaigns.",
+          "main-participation-access": "They won't able to participate again in campaigns in which they have already taken part in the past.",
+          "main-participation-prevent": "All their participations to campaigns will be deleted."
         },
-        "one-item": {
-          "title": "Delete '<strong>'{firstname} {lastname}'</strong>' of your participants?",
-          "content": "This participant will no longer be visible in Pix Orga.'<br/>'All their participations to campaigns will be deleted. This will have an impact on the results and analytics for these campaigns. They won't able to participate again in campaigns in which they have already taken part in the past. However, they will still be able to take part in new campaigns.'<br/><strong>Please note that this action is irreversible.</strong>'"
-        }
+        "delete-button": "Yes, I delete"
       },
       "empty-state": {
         "action": "See my campaigns",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -772,9 +772,9 @@
         "content": {
           "footer": "Please note that this action is irreversible.",
           "header": "{count, plural, =1 {This participant} other {These participants}} will no longer be visible in Pix Orga.",
-          "main-campaign-prevent": "This will have an impact on the results and analytics for these campaigns.",
+          "main-campaign-prevent": "This will have an impact on the results and analytics of your campaigns.",
           "main-new-campaign-access": "However, they will still be able to take part in new campaigns.",
-          "main-participation-access": "They won't able to participate again in campaigns in which they have already taken part in the past.",
+          "main-participation-access": "They  will no longer be able to take part in any previous campaigns.",
           "main-participation-prevent": "All their participations to campaigns will be deleted."
         },
         "delete-button": "Yes, I delete"
@@ -1086,9 +1086,9 @@
         "content": {
           "footer": "Please note that this action is irreversible.",
           "header": "{count, plural, =1 {This student} other {These students}} will no longer be visible in Pix Orga.",
-          "main-campaign-prevent": "This will have an impact on the results and analytics for these campaigns.",
+          "main-campaign-prevent": "This will have an impact on the results and analytics of your campaigns.",
           "main-new-campaign-access": "However, they will still be able to take part in new campaigns.",
-          "main-participation-access": "They won't able to participate again in campaigns in which they have already taken part in the past.",
+          "main-participation-access": "They  will no longer be able to take part in any previous campaigns.",
           "main-participation-prevent": "All their participations to campaigns will be deleted."
         },
         "delete-button": "Yes, I delete"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -770,16 +770,17 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} a bien été supprimé de la liste des participants.} other {Les {count} participants sélectionnés ont bien été supprimés de la liste.}}"
       },
       "deletion-modal": {
+        "title": "{count, plural, =1 {Supprimer '<strong>'{firstname} {lastname}'</strong>' de vos} other {Êtes-vous sûr(e) de vouloir supprimer '<strong>'{count}'</strong>'}} participants ?",
         "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions",
-        "delete-button": "Oui, je supprime",
-        "many-items": {
-          "title": "Êtes-vous sûr(e) de vouloir supprimer '<strong>'{count}'</strong>' participants ?",
-          "content": "Ces participants ne seront plus visibles dans Pix Orga.'<br/>'Toutes leurs participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses pour leurs campagnes. Ils ne pourront pas participer à nouveau aux campagnes auxquelles ils avaient participé par le passé. Cependant des participations à de nouvelles campagnes resteront possibles.'<br/><strong>'Attention, cette action est irréversible.'</strong>'"
+        "content": {
+          "footer": "Attention, cette action est irréversible.",
+          "header": "{count, plural, =1 {Ce participant ne sera plus visible} other {Ces participants ne seront plus visibles}} dans Pix Orga.",
+          "main-campaign-prevent": "Cela impactera donc les résultats et analyses pour {count, plural, =1 {ses} other {leurs}} campagnes.",
+          "main-new-campaign-access": "Cependant {count, plural, =1 {la participation} other {des participations}} à de nouvelles campagnes {count, plural, =1 {restera} other {resteront}} possibles.",
+          "main-participation-access": "{count, plural, =1 {Il ne pourra} other {Ils ne pourront}} pas participer à nouveau aux campagnes auxquelles {count, plural, =1 {il avait} other {ils avaient}} participé par le passé.",
+          "main-participation-prevent": "Toutes {count, plural, =1 {ses} other {leurs}} participations aux campagnes seront supprimées."
         },
-        "one-item": {
-          "title": "Supprimer '<strong>'{firstname} {lastname}'</strong>' de vos participants ?",
-          "content": "Ce participant ne sera plus visible dans Pix Orga.'<br/>'Toutes ses participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses pour ces campagnes. Il ne pourra pas participer à nouveau aux campagnes auxquelles il avait participé par le passé. Cependant la participation à de nouvelles campagne restera possible.'<br/><strong>'Attention, cette action est irréversible'</strong>'."
-        }
+        "delete-button": "Oui, je supprime"
       },
       "empty-state": {
         "action": "Voir mes campagnes",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -775,9 +775,9 @@
         "content": {
           "footer": "Attention, cette action est irréversible.",
           "header": "{count, plural, =1 {Ce participant ne sera plus visible} other {Ces participants ne seront plus visibles}} dans Pix Orga.",
-          "main-campaign-prevent": "Cela impactera donc les résultats et analyses pour {count, plural, =1 {ses} other {leurs}} campagnes.",
-          "main-new-campaign-access": "Cependant {count, plural, =1 {la participation} other {des participations}} à de nouvelles campagnes {count, plural, =1 {restera} other {resteront}} possibles.",
-          "main-participation-access": "{count, plural, =1 {Il ne pourra} other {Ils ne pourront}} pas participer à nouveau aux campagnes auxquelles {count, plural, =1 {il avait} other {ils avaient}} participé par le passé.",
+          "main-campaign-prevent": "Cela impactera donc les résultats et analyses des campagnes qu' {count, plural, =1 {il a réalisée} other {ils ont réalisées}}.",
+          "main-new-campaign-access": "Cependant {count, plural, =1 {il pourra} other {ils pourront}} participer à de nouvelles campagnes.",
+          "main-participation-access": "{count, plural, =1 {Il ne pourra} other {Ils ne pourront}} plus participer à nouveau aux campagnes auxquelles {count, plural, =1 {il avait} other {ils avaient}} participé par le passé.",
           "main-participation-prevent": "Toutes {count, plural, =1 {ses} other {leurs}} participations aux campagnes seront supprimées."
         },
         "delete-button": "Oui, je supprime"
@@ -1089,9 +1089,9 @@
         "content": {
           "footer": "Attention, cette action est irréversible.",
           "header": "{count, plural, =1 {Cet étudiant ne sera plus visible} other {Ces étudiants ne seront plus visibles}} dans Pix Orga.",
-          "main-campaign-prevent": "Cela impactera donc les résultats et analyses pour {count, plural, =1 {ses} other {leurs}} campagnes.",
-          "main-new-campaign-access": "Cependant {count, plural, =1 {la participation} other {des participations}} à de nouvelles campagnes {count, plural, =1 {restera} other {resteront}} possibles.",
-          "main-participation-access": "{count, plural, =1 {Il ne pourra} other {Ils ne pourront}} pas participer à nouveau aux campagnes auxquelles {count, plural, =1 {il avait} other {ils avaient}} participé par le passé.",
+          "main-campaign-prevent": "Cela impactera donc les résultats et analyses des campagnes qu' {count, plural, =1 {il a réalisée} other {ils ont réalisées}}.",
+          "main-new-campaign-access": "Cependant {count, plural, =1 {il pourra} other {ils pourront}} participer à de nouvelles campagnes.",
+          "main-participation-access": "{count, plural, =1 {Il ne pourra} other {Ils ne pourront}} plus participer à nouveau aux campagnes auxquelles {count, plural, =1 {il avait} other {ils avaient}} participé par le passé.",
           "main-participation-prevent": "Toutes {count, plural, =1 {ses} other {leurs}} participations aux campagnes seront supprimées."
         },
         "delete-button": "Oui, je supprime"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1084,16 +1084,17 @@
         "show-actions": "Afficher les actions"
       },
       "deletion-modal": {
+        "title": "{count, plural, =1 {Supprimer '<strong>'{firstname} {lastname}'</strong>' de vos} other {Êtes-vous sûr(e) de vouloir supprimer '<strong>'{count}'</strong>'}} étudiants ?",
         "confirmation-checkbox": "Je confirme avoir bien compris les impacts des {count} suppressions",
-        "delete-button": "Oui, je supprime",
-        "many-items": {
-          "title": "Êtes-vous sûr(e) de vouloir supprimer '<strong>'{count}'</strong>' étudiants ?",
-          "content": "Ces étudiants ne seront plus visibles dans Pix Orga.'<br/>'Toutes leurs participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses pour leurs campagnes. Ils ne pourront pas participer à nouveau aux campagnes auxquelles ils avaient participé par le passé. Cependant des participations à de nouvelles campagnes resteront possibles.'<br/><strong>'Attention, cette action est irréversible.'</strong>'"
+        "content": {
+          "footer": "Attention, cette action est irréversible.",
+          "header": "{count, plural, =1 {Cet étudiant ne sera plus visible} other {Ces étudiants ne seront plus visibles}} dans Pix Orga.",
+          "main-campaign-prevent": "Cela impactera donc les résultats et analyses pour {count, plural, =1 {ses} other {leurs}} campagnes.",
+          "main-new-campaign-access": "Cependant {count, plural, =1 {la participation} other {des participations}} à de nouvelles campagnes {count, plural, =1 {restera} other {resteront}} possibles.",
+          "main-participation-access": "{count, plural, =1 {Il ne pourra} other {Ils ne pourront}} pas participer à nouveau aux campagnes auxquelles {count, plural, =1 {il avait} other {ils avaient}} participé par le passé.",
+          "main-participation-prevent": "Toutes {count, plural, =1 {ses} other {leurs}} participations aux campagnes seront supprimées."
         },
-        "one-item": {
-          "title": "Supprimer '<strong>'{firstname} {lastname}'</strong>' de vos étudiants ?",
-          "content": "Cet étudiant ne sera plus visible dans Pix Orga.'<br/>'Toutes ses participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses pour ces campagnes. Il ne pourra pas participer à nouveau aux campagnes auxquelles il avait participé par le passé. Cependant la participation à de nouvelles campagne restera possible.'<br/><strong>'Attention, cette action est irréversible'</strong>'."
-        }
+        "delete-button": "Oui, je supprime"
       },
       "edit-student-number-modal": {
         "title": "Édition du numéro étudiant",


### PR DESCRIPTION
## :unicorn: Problème
Le texte fait un peu pâté croûte

## :robot: Proposition
Aérer le texte, afin qu'il soit plus "croissant" 🥐 

## :rainbow: Remarques
Pourquoi le tri ordre alpha met les title en haut dans le json, c'est pas très très logique tout ça.

## :100: Pour tester
Vérifier que le texte est bien aérer sur les modal de suppression SUP et PRO