### PR TITLE
[FEATURE] Supprimer le feature toggle FT_TARGET_PROFILE_VERSIONING (PIX-9024).

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -52,18 +52,16 @@
         </PixTooltip>
       </li>
     {{/if}}
-    {{#if this.accessControl.hasAccessToComplementaryCertificationsScope}}
-      <li class="menu-bar__entry">
-        <PixTooltip @position="right" @inline={{true}}>
-          <:triggerElement>
-            <LinkTo @route="authenticated.complementary-certifications" class="menu-bar__link">
-              <FaIcon @icon="stamp" @title="Certifications complémentaires" />
-            </LinkTo>
-          </:triggerElement>
-          <:tooltip>Certifications complémentaires</:tooltip>
-        </PixTooltip>
-      </li>
-    {{/if}}
+    <li class="menu-bar__entry">
+      <PixTooltip @position="right" @inline={{true}}>
+        <:triggerElement>
+          <LinkTo @route="authenticated.complementary-certifications" class="menu-bar__link">
+            <FaIcon @icon="stamp" @title="Certifications complémentaires" />
+          </LinkTo>
+        </:triggerElement>
+        <:tooltip>Certifications complémentaires</:tooltip>
+      </PixTooltip>
+    </li>
     {{#if this.accessControl.hasAccessToTargetProfilesActionsScope}}
       <li class="menu-bar__entry">
         <PixTooltip @position="right" @inline={{true}}>

--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,5 +1,3 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
-export default class FeatureToggle extends Model {
-  @attr('boolean') isTargetProfileVersioningEnabled;
-}
+export default class FeatureToggle extends Model {}

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -55,8 +55,4 @@ export default class AccessControlService extends Service {
   get hasAccessToOrganizationPlacesActionsScope() {
     return !!(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier);
   }
-
-  get hasAccessToComplementaryCertificationsScope() {
-    return this.featureToggles.featureToggles.isTargetProfileVersioningEnabled;
-  }
 }

--- a/admin/mirage/factories/feature-toggle.js
+++ b/admin/mirage/factories/feature-toggle.js
@@ -2,5 +2,4 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,
-  isTargetProfileVersioningEnabled: true,
 });

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list_test.js
@@ -21,7 +21,6 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
 
   module('When admin member is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      server.create('feature-toggle', { isTargetProfileVersioningEnabled: true });
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -7,14 +7,6 @@ import Service from '@ember/service';
 module('Integration | Component | menu-bar', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(async function () {
-    this.owner.lookup('service:store');
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isTargetProfileVersioningEnabled: true };
-    }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
-  });
-
   test('should display principal navigation', async function (assert) {
     // given
     const currentUser = this.owner.lookup('service:currentUser');

--- a/admin/tests/unit/services/access-control_test.js
+++ b/admin/tests/unit/services/access-control_test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
@@ -162,52 +161,6 @@ module('Unit | Service | access-control', function (hooks) {
 
         // when / then
         assert.deepEqual(service.hasAccessToCertificationActionsScope, hasAccess);
-      });
-    });
-  });
-
-  module('#hasAccessToComplementaryCertificationsScope', function () {
-    test('should be false if FT_TARGET_PROFILE_VERSIONING is false', function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true };
-      this.owner.lookup('service:store');
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isTargetProfileVersioningEnabled: false };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-
-      const service = this.owner.lookup('service:access-control');
-
-      // when / then
-      assert.false(service.hasAccessToComplementaryCertificationsScope);
-    });
-
-    module('when FT_TARGET_PROFILE_VERSIONING is true ', function (hooks) {
-      hooks.beforeEach(async function () {
-        this.owner.lookup('service:store');
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isTargetProfileVersioningEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-      });
-
-      [
-        { role: 'isSuperAdmin', hasAccess: true },
-        { role: 'isSupport', hasAccess: true },
-        { role: 'isMetier', hasAccess: true },
-        { role: 'isCertif', hasAccess: true },
-      ].forEach(function ({ role, hasAccess }) {
-        test(`should be accessible for all role members (${role} access)`, function (assert) {
-          // given
-          const currentUser = this.owner.lookup('service:currentUser');
-          currentUser.adminMember = { [role]: true };
-
-          const service = this.owner.lookup('service:access-control');
-
-          // when / then
-          assert.deepEqual(service.hasAccessToComplementaryCertificationsScope, hasAccess);
-        });
       });
     });
   });

--- a/admin/tests/unit/services/feature-toggles_test.js
+++ b/admin/tests/unit/services/feature-toggles_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
+import Object from '@ember/object';
 import Service from '@ember/service';
 
 module('Unit | Service | feature toggles', function (hooks) {
@@ -9,9 +10,8 @@ module('Unit | Service | feature toggles', function (hooks) {
   module('feature toggles are loaded', function () {
     test('should load the feature toggles', async function (assert) {
       // Given
-      const store = this.owner.lookup('service:store');
-      const featureToggles = store.createRecord('feature-toggle', {
-        isTargetProfileVersioningEnabled: false,
+      const featureToggles = Object.create({
+        aFakeFeatureToggle: false,
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(featureToggles),
@@ -23,7 +23,7 @@ module('Unit | Service | feature toggles', function (hooks) {
       await featureToggleService.load();
 
       // Then
-      assert.deepEqual(featureToggleService.featureToggles, featureToggles);
+      assert.false(featureToggleService.featureToggles.aFakeFeatureToggle);
     });
   });
 });

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -29,7 +29,6 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
-  FT_TARGET_PROFILE_VERSIONING: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -952,13 +952,6 @@ FT_TRAINING_RECOMMENDATION=false
 # default: false
 # FT_PIX_1D_ENABLED=false
 
-# Enable the new versioning of target profile
-#
-# presence: optional
-# type: boolean
-# default: false
-# FT_TARGET_PROFILE_VERSIONING=true
-
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -174,7 +174,6 @@ const configuration = (function () {
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
       isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
-      isTargetProfileVersioningEnabled: isFeatureEnabled(process.env.FT_TARGET_PROFILE_VERSIONING),
     },
     fwb: {
       isEnabled: isFeatureEnabled(process.env.FWB_ENABLED),
@@ -362,7 +361,6 @@ const configuration = (function () {
 
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
-    config.featureToggles.isTargetProfileVersioningEnabled = true;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'brevo';

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -23,7 +23,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-pix1d-enabled': true,
-            'is-target-profile-versioning-enabled': true,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème
Le développement d’une nouvelle page dans Pix Admin pour permettre d’assurer le versioning des profils cibles et des résultats thématiques certifiants est terminé. Seul les agents Pix ayant le rôle super admin peuvent faire le rattachement d'un nouveau profil cible.

## :robot: Proposition
Supprimer le feature toggle protégeant la fonctionnalité

## :100: Pour tester
- Se connecter sur Pix Admin avec superadmin@example (le FT a été supprimé sur la RA, veillez à le retirer si test en local)
- Voir que le menu certification complémentaire apparaît bien ! 
