### PR TITLE
[BUGFIX] Mettre à jour individuellement un palier dans un profil cible (PIX-9837).

### DIFF
--- a/admin/app/adapters/stage.js
+++ b/admin/app/adapters/stage.js
@@ -9,4 +9,23 @@ export default class StageAdapter extends ApplicationAdapter {
     serializer.serializeIntoHash(data, type, snapshot, { includeId: true, onlyInformation: true });
     return this.ajax(this.buildURL(type.modelName, snapshot.id, snapshot, 'deleteRecord'), 'DELETE', { data: data });
   }
+
+  updateRecord(store, type, snapshot) {
+    const { adapterOptions } = snapshot;
+
+    const payload = this.serialize(snapshot);
+    payload.data.attributes = {
+      message: adapterOptions.stage.message,
+      prescriberDescription: adapterOptions.stage.prescriberDescription,
+      prescriberTitle: adapterOptions.stage.prescriberTitle,
+      title: adapterOptions.stage.title,
+      level: adapterOptions.stage.level,
+      threshold: adapterOptions.stage.threshold,
+      targetProfileId: adapterOptions.targetProfileId,
+    };
+
+    const url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
+
+    return this.ajax(url, 'PATCH', { data: payload });
+  }
 }

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/stages/stage.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/stages/stage.js
@@ -2,9 +2,11 @@ import difference from 'lodash/difference';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 export default class StageController extends Controller {
   @tracked isEditMode = false;
+  @service store;
 
   get availableLevels() {
     const unavailableLevels = this.model.stageCollection.stages.map((stage) =>
@@ -31,6 +33,8 @@ export default class StageController extends Controller {
 
   @action
   async update() {
-    await this.model.stageCollection.save({ adapterOptions: { stages: this.model.stageCollection.stages } });
+    await this.store
+      .createRecord('stage', this.model.stage)
+      .save({ adapterOptions: { stage: this.model.stage, targetProfileId: Number(this.model.targetProfile.id) } });
   }
 }

--- a/admin/tests/integration/components/stages/stage_test.js
+++ b/admin/tests/integration/components/stages/stage_test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { render } from '@1024pix/ember-testing-library';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Stages::Stage', function (hooks) {
   let stage;
@@ -204,6 +204,57 @@ module('Integration | Component | Stages::Stage', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('spinbutton', { name: 'Seuil du palier' })).hasAttribute('readonly');
+    });
+  });
+
+  module('when edit mode is true', function () {
+    test('it should be possible to update message, title, prescriber description and prescriber title', async function (assert) {
+      // given
+      stage = {
+        id: 34,
+        isTypeLevel: false,
+        threshold: 40,
+        title: 'dummy',
+        message: 'dummy',
+        prescriberTitle: 'dummy',
+        prescriberDescription: 'dummy',
+      };
+
+      this.set('isEditMode', true);
+      this.set('stage', stage);
+      this.set('hasLinkedCampaign', true);
+
+      this.toggleEditMode = sinon.stub().callsFake(() => {
+        this.set('isEditMode', false);
+      });
+      this.update = sinon.stub().callsFake(() => {
+        return new Promise((resolve) => resolve());
+      });
+
+      // when
+      const screen = await render(
+        hbs`<Stages::Stage
+          @stage={{this.stage}}
+          @toggleEditMode={{this.toggleEditMode}}
+          @isEditMode={{this.isEditMode}}
+          @hasLinkedCampaign={{this.hasLinkedCampaign}}
+          @onUpdate={{this.update}} />`,
+      );
+
+      await fillByLabel('Titre', 'New title');
+      await fillByLabel('Message', 'New message');
+      await fillByLabel('Titre pour le prescripteur', 'New prescriber title');
+      await fillByLabel('Description pour le prescripteur', 'New prescriber description');
+
+      await click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+      // then
+      assert.dom(screen.getByText('Titre : New title', { exact: false })).exists();
+      assert.dom(screen.getByText('Message : New message', { exact: false })).exists();
+      assert.dom(screen.getByText('Titre pour le prescripteur : New prescriber title', { exact: false })).exists();
+      assert
+        .dom(screen.getByText('Description pour le prescripteur : New prescriber description', { exact: false }))
+        .exists();
     });
   });
 });

--- a/admin/tests/unit/adapters/stage_test.js
+++ b/admin/tests/unit/adapters/stage_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | stage', function (hooks) {
+  setupTest(hooks);
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:stage');
+  });
+
+  module('#updateRecord', function () {
+    test('should trigger an ajax call with the right method and payload', function (assert) {
+      // given
+      const updatedStageData = {
+        message: 'message',
+        prescriberDescription: 'description',
+        prescriberTitle: 'prescriber title',
+        title: 'title',
+        level: 3,
+        threshold: undefined,
+      };
+
+      const targetProfileId = 20;
+
+      const expectedPayload = {
+        data: {
+          data: {
+            attributes: { ...updatedStageData, targetProfileId },
+          },
+        },
+      };
+
+      const snapshot = {
+        id: 123,
+        adapterOptions: {
+          stage: { ...updatedStageData, id: 123 },
+          targetProfileId,
+        },
+        serialize: sinon.stub().returns({
+          data: {
+            attributes: {},
+          },
+        }),
+      };
+
+      adapter.ajax = sinon.stub();
+
+      // when
+      adapter.updateRecord(null, { modelName: 'stage' }, snapshot);
+
+      // then
+      sinon.assert.calledWithExactly(
+        adapter.ajax,
+        'http://localhost:3000/api/admin/stages/123',
+        'PATCH',
+        expectedPayload,
+      );
+      assert.ok(adapter);
+    });
+  });
+});

--- a/api/src/evaluation/application/stages/index.js
+++ b/api/src/evaluation/application/stages/index.js
@@ -1,0 +1,55 @@
+import Joi from 'joi';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { stageController } from './stage-controller.js';
+import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'PATCH',
+      path: '/api/admin/stages/{id}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.stageId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                targetProfileId: Joi.number().integer().positive().required(),
+                title: Joi.string().required(),
+                message: Joi.string().allow('').allow(null),
+                prescriberDescription: Joi.string().allow('').allow(null),
+                prescriberTitle: Joi.string().allow('').allow(null),
+                level: Joi.number().allow(null),
+                threshold: Joi.number().allow(null),
+              },
+              relationships: Joi.object(),
+              type: Joi.any(),
+            },
+          }),
+        },
+        handler: stageController.update,
+        tags: ['api', 'admin', 'stage'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet de modifier un palier d'un profil cible",
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'stage-api';
+export { register, name };

--- a/api/src/evaluation/application/stages/stage-controller.js
+++ b/api/src/evaluation/application/stages/stage-controller.js
@@ -1,0 +1,18 @@
+import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
+
+const update = async function (request, h) {
+  const stageId = request.params.id;
+  const { targetProfileId, ...stageDataFromPayload } = request.payload.data.attributes;
+  await usecases.updateStage({
+    payloadStage: {
+      id: stageId,
+      targetProfileId: targetProfileId,
+      attributesToUpdate: stageDataFromPayload,
+    },
+  });
+  return h.response().code(204);
+};
+
+const stageController = { update };
+
+export { stageController };

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -1,0 +1,14 @@
+class DomainError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+class StageWithLinkedCampaignError extends DomainError {
+  constructor() {
+    super('The stage is part of a target profile linked to a campaign');
+  }
+}
+
+export { DomainError, StageWithLinkedCampaignError };

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -7,6 +7,8 @@ import * as answerRepository from '../../infrastructure/repositories/answer-repo
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as competenceEvaluationRepository from '../../infrastructure/repositories/competence-evaluation-repository.js';
+import * as stageRepository from '../../../../lib/infrastructure/repositories/stage-repository.js';
+import * as targetProfileForAdminRepository from '../../../../lib/infrastructure/repositories/target-profile-for-admin-repository.js';
 import { getCompetenceLevel } from '../services/get-competence-level.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
@@ -20,6 +22,8 @@ const dependencies = {
   assessmentRepository,
   competenceEvaluationRepository,
   competenceRepository,
+  stageRepository,
+  targetProfileForAdminRepository,
   getCompetenceLevel,
 };
 

--- a/api/src/evaluation/domain/usecases/update-stage.js
+++ b/api/src/evaluation/domain/usecases/update-stage.js
@@ -1,0 +1,45 @@
+import { StageWithLinkedCampaignError } from '../errors.js';
+
+/**
+ * @typedef attributesToUpdate
+ * @type {object}
+ * @property {string} title
+ * @property {number} level
+ * @property {number} threshold
+ * @property {string} title
+ * @property {string} message
+ * @property {string} prescriberTitle
+ * @property {string} prescriberDescription
+ */
+
+/**
+ * Update stage with payload
+ *
+ * @param {object} payloadStage
+ * @param {number} payloadStage.id
+ * @param {number} payloadStage.targetProfileId
+ * @param {attributesToUpdate} payloadStage.attributesToUpdate
+ * @param knexConnection
+ *
+ * @returns Promise<Stage[]>
+ */
+const updateStage = async function ({ payloadStage, stageRepository, targetProfileForAdminRepository }) {
+  const stage = await stageRepository.get(payloadStage.id);
+
+  const targetProfile = await targetProfileForAdminRepository.get({ id: payloadStage.targetProfileId });
+
+  const isLevelUpdated = payloadStage.attributesToUpdate.level && payloadStage.attributesToUpdate.level !== stage.level;
+
+  const isThresholdUpdated =
+    payloadStage.attributesToUpdate.threshold && payloadStage.attributesToUpdate.threshold !== stage.threshold;
+
+  const payloadWithLevelOrThreshold = isLevelUpdated || isThresholdUpdated;
+
+  if (targetProfile.hasLinkedCampaign && payloadWithLevelOrThreshold) {
+    throw new StageWithLinkedCampaignError();
+  }
+
+  return stageRepository.update(payloadStage);
+};
+
+export { updateStage };

--- a/api/src/evaluation/routes.js
+++ b/api/src/evaluation/routes.js
@@ -1,5 +1,6 @@
 import * as competenceEvaluationsRoutes from './application/competence-evaluations/index.js';
+import * as stagesRoutes from './application/stages/index.js';
 
-const evaluationRoutes = [competenceEvaluationsRoutes];
+const evaluationRoutes = [competenceEvaluationsRoutes, stagesRoutes];
 
 export { evaluationRoutes };

--- a/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
@@ -1,0 +1,88 @@
+import { createServer } from '../../../../../server.js';
+
+import {
+  expect,
+  generateValidRequestAuthorizationHeader,
+  databaseBuilder,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | API | Stages', function () {
+  let server;
+  let userId;
+
+  beforeEach(async function () {
+    userId = databaseBuilder.factory.buildUser.withRole().id;
+    server = await createServer();
+
+    const learningContent = [
+      {
+        id: 'recArea0',
+        competences: [
+          {
+            id: 'recNv8qhaY887jQb2',
+            index: '1.3',
+            name: 'Traiter des données',
+          },
+        ],
+      },
+    ];
+    const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+    mockLearningContent(learningContentObjects);
+  });
+
+  describe('PATCH /api/admin/stages/{id}', function () {
+    context('When user is authenticated', function () {
+      afterEach(async function () {
+        await knex('stages').delete();
+      });
+
+      context('the stage exists', function () {
+        it('should return 204', async function () {
+          // given
+          const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+          const stageId = databaseBuilder.factory.buildStage({
+            targetProfileId,
+          }).id;
+
+          await databaseBuilder.commit();
+
+          const stageToUpdateAttributes = {
+            message: 'new message',
+            title: 'new title',
+            prescriberTitle: 'new prescriber title',
+            prescriberDescription: 'new prescriber description',
+          };
+
+          // when
+          const options = {
+            method: 'PATCH',
+            url: `/api/admin/stages/${stageId}`,
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            payload: {
+              data: {
+                attributes: {
+                  targetProfileId: targetProfileId,
+                  ...stageToUpdateAttributes,
+                },
+              },
+            },
+          };
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+          const [updatedStage] = await knex('stages').where({ id: stageId });
+          expect(updatedStage.message).to.equal(stageToUpdateAttributes.message);
+          expect(updatedStage.title).to.equal(stageToUpdateAttributes.title);
+          expect(updatedStage.prescriberTitle).to.equal(stageToUpdateAttributes.prescriberTitle);
+          expect(updatedStage.prescriberDescription).to.equal(stageToUpdateAttributes.prescriberDescription);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/integration/domain/usecases/update-stage_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/update-stage_test.js
@@ -1,0 +1,227 @@
+import {
+  catchErr,
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../test-helper.js';
+import { Stage } from '../../../../../lib/domain/models/Stage.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { StageWithLinkedCampaignError } from '../../../../../src/evaluation/domain/errors.js';
+
+function _buildLearningContent() {
+  const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
+  const learningContentObjects = learningContentBuilder([learningContent]);
+  mockLearningContent(learningContentObjects);
+}
+
+describe('Integration | Domain | UseCases | update-stage', function () {
+  context('when the stage exists', function () {
+    context('when there is no linked campaign', function () {
+      it('should return the updated domain object including level or threshold', async function () {
+        // given
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        const stage = databaseBuilder.factory.buildStage({
+          id: 100,
+          targetProfileId,
+          title: 'initial title',
+          level: 1,
+        });
+
+        await databaseBuilder.commit();
+        _buildLearningContent();
+
+        const payload = {
+          id: stage.id,
+          targetProfileId,
+          attributesToUpdate: {
+            title: 'new title',
+            level: 2,
+          },
+        };
+
+        // when
+        const updatedStage = await evaluationUsecases.updateStage({
+          payloadStage: payload,
+        });
+
+        // then
+        expect(updatedStage).to.be.instanceOf(Stage);
+        expect(updatedStage.id).to.equal(payload.id);
+        expect(updatedStage.title).to.equal(payload.attributesToUpdate.title);
+        expect(updatedStage.level).to.equal(payload.attributesToUpdate.level);
+      });
+    });
+
+    context('when a campaign is linked', function () {
+      context('when it is a level stage', function () {
+        context('when level stage is updated', function () {
+          it('should throw an error', async function () {
+            // given
+            const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+            databaseBuilder.factory.buildCampaign({
+              targetProfileId,
+            });
+            const stage = databaseBuilder.factory.buildStage({
+              id: 100,
+              targetProfileId,
+              title: 'initial title',
+              level: 1,
+              threshold: null,
+            });
+
+            await databaseBuilder.commit();
+
+            _buildLearningContent();
+
+            const payload = {
+              id: stage.id,
+              targetProfileId: stage.targetProfileId,
+              attributesToUpdate: {
+                level: 2,
+              },
+            };
+
+            // when
+            const error = await catchErr(evaluationUsecases.updateStage)({
+              payloadStage: payload,
+            });
+
+            // then
+            expect(error).to.be.instanceof(StageWithLinkedCampaignError);
+            expect(error.message).to.equal('The stage is part of a target profile linked to a campaign');
+          });
+        });
+        context('when level stage is the same', function () {
+          it('should update the stage', async function () {
+            // given
+            const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+            databaseBuilder.factory.buildCampaign({
+              targetProfileId,
+            });
+            const stage = databaseBuilder.factory.buildStage({
+              id: 100,
+              targetProfileId,
+              title: 'initial title',
+              level: 1,
+              threshold: null,
+            });
+
+            await databaseBuilder.commit();
+            _buildLearningContent();
+
+            const payload = {
+              id: stage.id,
+              targetProfileId,
+              attributesToUpdate: {
+                title: 'new title',
+                message: 'new message',
+                prescriberTitle: 'new prescriber title',
+                prescriberDescription: 'new prescriber description',
+                level: 1,
+              },
+            };
+
+            // when
+            const updatedStage = await evaluationUsecases.updateStage({
+              payloadStage: payload,
+            });
+
+            // then
+            expect(updatedStage).to.be.instanceOf(Stage);
+            expect(updatedStage.id).to.equal(payload.id);
+            expect(updatedStage.level).to.equal(1);
+            expect(updatedStage.title).to.equal(payload.attributesToUpdate.title);
+            expect(updatedStage.message).to.equal(payload.attributesToUpdate.message);
+            expect(updatedStage.prescriberTitle).to.equal(payload.attributesToUpdate.prescriberTitle);
+            expect(updatedStage.prescriberDescription).to.equal(payload.attributesToUpdate.prescriberDescription);
+          });
+        });
+      });
+
+      context('when it is a threshold stage', function () {
+        context('when threshold is updated', function () {
+          it('should throw an error', async function () {
+            // given
+            const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+            databaseBuilder.factory.buildCampaign({
+              targetProfileId,
+            });
+            const stage = databaseBuilder.factory.buildStage({
+              id: 100,
+              targetProfileId,
+              title: 'initial title',
+              threshold: 10,
+            });
+
+            await databaseBuilder.commit();
+
+            _buildLearningContent();
+
+            const payload = {
+              id: stage.id,
+              targetProfileId: stage.targetProfileId,
+              attributesToUpdate: {
+                threshold: 20,
+              },
+            };
+
+            // when
+            const error = await catchErr(evaluationUsecases.updateStage)({
+              payloadStage: payload,
+            });
+
+            // then
+            expect(error).to.be.instanceof(StageWithLinkedCampaignError);
+            expect(error.message).to.equal('The stage is part of a target profile linked to a campaign');
+          });
+        });
+        context('when threshold is the same', function () {
+          it('should update the stage', async function () {
+            // given
+            const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+            databaseBuilder.factory.buildCampaign({
+              targetProfileId,
+            });
+            const stage = databaseBuilder.factory.buildStage({
+              id: 100,
+              targetProfileId,
+              title: 'initial title',
+              threshold: 10,
+            });
+
+            await databaseBuilder.commit();
+            _buildLearningContent();
+
+            const payload = {
+              id: stage.id,
+              targetProfileId,
+              attributesToUpdate: {
+                title: 'new title',
+                message: 'new message',
+                prescriberTitle: 'new prescriber title',
+                prescriberDescription: 'new prescriber description',
+                threshold: 10,
+              },
+            };
+
+            // when
+            const updatedStage = await evaluationUsecases.updateStage({
+              payloadStage: payload,
+            });
+
+            // then
+            expect(updatedStage).to.be.instanceOf(Stage);
+            expect(updatedStage.id).to.equal(payload.id);
+            expect(updatedStage.threshold).to.equal(10);
+            expect(updatedStage.title).to.equal(payload.attributesToUpdate.title);
+            expect(updatedStage.message).to.equal(payload.attributesToUpdate.message);
+            expect(updatedStage.prescriberTitle).to.equal(payload.attributesToUpdate.prescriberTitle);
+            expect(updatedStage.prescriberDescription).to.equal(payload.attributesToUpdate.prescriberDescription);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, la modification des informations d'un palier n'est plus possible depuis la sauvegarde des acquisitions de palier. Cette impossibilité est un effet de bord qui n'a pas été traité. Cette PR propose de modifier un palier de manière individuelle afin de contourner le blocage technique lié aux violations de contraintes de clé étrangère que rencontrait la fonctionnalité.

## :robot: Proposition
Créer une route de modification d'un palier, afin de permettre la modification du titre, du message, du titre pour le prescripteur et de la description pour le prescripteur. 

## :100: Pour tester
- Lancer Pix Admin avec le compte `superadmin`
- Se connecter sur un profil cible ayant des paliers, que celui-ci soit lié ou non à une campagne
- Modifier un palier