### PR TITLE
[FEATURE] Limiter la variation du niveau estimé en certif V3 (PIX-9832).

### DIFF
--- a/api/lib/application/scenarios-simulator/index.js
+++ b/api/lib/application/scenarios-simulator/index.js
@@ -30,6 +30,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   limitToOneQuestionPerTube: Joi.boolean(),
   minimumEstimatedSuccessRateRanges: Joi.array().items(_successRatesConfigurationValidator),
   enablePassageByAllCompetences: Joi.boolean(),
+  variationPercent: Joi.number().min(0).max(1),
 });
 
 const register = async (server) => {

--- a/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
+++ b/api/lib/application/scenarios-simulator/scenario-simulator-controller.js
@@ -33,6 +33,7 @@ async function simulateFlashAssessmentScenario(
     limitToOneQuestionPerTube,
     minimumEstimatedSuccessRateRanges: minimumEstimatedSuccessRateRangesDto,
     enablePassageByAllCompetences,
+    variationPercent,
   } = request.payload;
 
   const pickAnswerStatus = _getPickAnswerStatusMethod(dependencies.pickAnswerStatusService, request.payload);
@@ -63,6 +64,7 @@ async function simulateFlashAssessmentScenario(
           limitToOneQuestionPerTube,
           minimumEstimatedSuccessRateRanges,
           enablePassageByAllCompetences,
+          variationPercent,
         },
         _.isUndefined,
       );

--- a/api/lib/domain/models/flash-assessment-algorithm/FlashAssessmentAlgorithm.js
+++ b/api/lib/domain/models/flash-assessment-algorithm/FlashAssessmentAlgorithm.js
@@ -55,12 +55,14 @@ class FlashAssessmentAlgorithm {
     limitToOneQuestionPerTube,
     flashAlgorithmImplementation,
     enablePassageByAllCompetences,
+    variationPercent,
   } = {}) {
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
     this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
     this.minimumEstimatedSuccessRateRanges = minimumEstimatedSuccessRateRanges;
     this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
     this.flashAlgorithmImplementation = flashAlgorithmImplementation;
+    this.variationPercent = variationPercent;
 
     this.ruleEngine = new FlashAssessmentAlgorithmRuleEngine(availableRules, {
       limitToOneQuestionPerTube,
@@ -84,6 +86,7 @@ class FlashAssessmentAlgorithm {
       allAnswers,
       challenges,
       initialCapacity,
+      variationPercent: this.variationPercent,
     });
 
     const minimalSuccessRate = this._computeMinimalSuccessRate(allAnswers.length);
@@ -135,6 +138,7 @@ class FlashAssessmentAlgorithm {
       allAnswers,
       challenges,
       estimatedLevel: initialCapacity,
+      variationPercent: this.variationPercent,
     });
   }
 

--- a/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/lib/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -15,6 +15,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   limitToOneQuestionPerTube = true,
   minimumEstimatedSuccessRateRanges = [],
   enablePassageByAllCompetences = false,
+  variationPercent,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -27,6 +28,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     minimumEstimatedSuccessRateRanges,
     flashAlgorithmImplementation: flashAlgorithmService,
     enablePassageByAllCompetences,
+    variationPercent,
   });
 
   const simulator = new AssessmentSimulator({
@@ -35,6 +37,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     pickChallenge,
     initialCapacity,
     pickAnswerStatus,
+    variationPercent,
   });
 
   return simulator.run();

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -355,6 +355,60 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         }
       });
     });
+
+    context('when limiting the estimated level variation', function () {
+      context('when giving a right answer', function () {
+        it('should return the limited estimatedLevel', function () {
+          // given
+          const challenges = [
+            domainBuilder.buildChallenge({
+              discriminant: 1.86350005965093,
+              difficulty: 0.194712138508747,
+            }),
+          ];
+
+          const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+          const variationPercent = 0.5;
+
+          // when
+          const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+            allAnswers,
+            challenges,
+            variationPercent,
+          });
+
+          // then
+          expect(estimatedLevel).to.be.closeTo(0.5, 0.00000000001);
+        });
+      });
+
+      context('when giving a wrong answer', function () {
+        it('should return the limited estimatedLevel', function () {
+          // given
+          const challenges = [
+            domainBuilder.buildChallenge({
+              discriminant: 1.86350005965093,
+              difficulty: 0.194712138508747,
+            }),
+          ];
+
+          const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[0].id })];
+
+          const variationPercent = 0.5;
+
+          // when
+          const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+            allAnswers,
+            challenges,
+            variationPercent,
+          });
+
+          // then
+          expect(estimatedLevel).to.be.closeTo(-0.5, 0.00000000001);
+        });
+      });
+    });
   });
 
   describe('#getChallengesForNonAnsweredSkills', function () {

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -69,6 +69,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           challenges,
           allAnswers: answers,
           estimatedLevel: sinon.match.number,
+          variationPercent: undefined,
         })
         .returns({
           estimatedLevel: expectedEstimatedLevel,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -328,6 +328,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             challenges,
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
+            variationPercent: undefined,
           })
           .returns({
             estimatedLevel: expectedEstimatedLevel,
@@ -382,6 +383,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             challenges,
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
+            variationPercent: undefined,
           })
           .returns({
             estimatedLevel: 2,

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -75,11 +75,13 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
     challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
     flashAlgorithmService.getEstimatedLevelAndErrorRate
-      .withArgs({
-        challenges: baseChallenges,
-        allAnswers: baseAnswers,
-        estimatedLevel: sinon.match.number,
-      })
+      .withArgs(
+        _getEstimatedLevelAndErrorRateParams({
+          challenges: baseChallenges,
+          allAnswers: baseAnswers,
+          estimatedLevel: sinon.match.number,
+        }),
+      )
       .returns({
         estimatedLevel: expectedEstimatedLevel,
       });
@@ -103,11 +105,13 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.KO);
 
       flashAlgorithmService.getEstimatedLevelAndErrorRate
-        .withArgs({
-          challenges,
-          allAnswers,
-          estimatedLevel: sinon.match.number,
-        })
+        .withArgs(
+          _getEstimatedLevelAndErrorRateParams({
+            challenges,
+            allAnswers,
+            estimatedLevel: sinon.match.number,
+          }),
+        )
         .returns({
           estimatedLevel: veryLowEstimatedLevel,
         });
@@ -134,11 +138,13 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
       flashAlgorithmService.getEstimatedLevelAndErrorRate
-        .withArgs({
-          challenges,
-          allAnswers,
-          estimatedLevel: sinon.match.number,
-        })
+        .withArgs(
+          _getEstimatedLevelAndErrorRateParams({
+            challenges,
+            allAnswers,
+            estimatedLevel: sinon.match.number,
+          }),
+        )
         .returns({
           estimatedLevel: veryHighEstimatedLevel,
         });
@@ -167,6 +173,11 @@ const _buildChallenges = (difficulty, numberOfChallenges) => {
     }),
   );
 };
+
+const _getEstimatedLevelAndErrorRateParams = (params) => ({
+  ...params,
+  variationPercent: undefined,
+});
 
 const _buildAnswersForChallenges = (challenges, answerResult) => {
   return challenges.map(({ id: challengeId }) =>

--- a/api/tests/unit/domain/models/flash-assessment-algorithm/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/unit/domain/models/flash-assessment-algorithm/FlashAssessmentAlgorithm_test.js
@@ -103,11 +103,13 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           const challenges = [answeredChallengeTube1, unansweredChallengeTube1, unansweredChallengeTube2];
 
           flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
-            .withArgs({
-              allAnswers,
-              challenges,
-              estimatedLevel: initialCapacity,
-            })
+            .withArgs(
+              _getEstimatedLevelAndErrorRateParams({
+                allAnswers,
+                challenges,
+                estimatedLevel: initialCapacity,
+              }),
+            )
             .returns({
               estimatedLevel: computedEstimatedLevel,
             });
@@ -175,11 +177,13 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           const challenges = [answeredChallengeTube1, unansweredChallengeTube1, unansweredChallengeTube2];
 
           flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
-            .withArgs({
-              allAnswers,
-              challenges,
-              estimatedLevel: initialCapacity,
-            })
+            .withArgs(
+              _getEstimatedLevelAndErrorRateParams({
+                allAnswers,
+                challenges,
+                estimatedLevel: initialCapacity,
+              }),
+            )
             .returns({
               estimatedLevel: computedEstimatedLevel,
             });
@@ -355,4 +359,9 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
       });
     });
   });
+});
+
+const _getEstimatedLevelAndErrorRateParams = (params) => ({
+  variationPercent: undefined,
+  ...params,
 });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -143,6 +143,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               challenges,
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              variationPercent: undefined,
             })
             .returns({
               estimatedLevel: 0,
@@ -203,6 +204,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               challenges,
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              variationPercent: undefined,
             })
             .returns({
               estimatedLevel: 0,
@@ -276,6 +278,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               challenges,
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              variationPercent: undefined,
             })
             .returns({
               estimatedLevel: 0,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -125,6 +125,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               allAnswers: [],
               challenges: [nextChallengeToAnswer],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              variationPercent: undefined,
             })
             .returns({ estimatedLevel: 0 });
 
@@ -280,6 +281,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               allAnswers: [answer],
               challenges: [answeredChallenge],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              variationPercent: undefined,
             })
             .returns({
               estimatedLevel: 2,

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -315,24 +315,28 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       allAnswers: [],
       challenges: sinon.match.any,
       estimatedLevel: initialCapacity,
+      variationPercent: undefined,
     })
     .returns({ estimatedLevel: 0, errorRate: 0.1 })
     .withArgs({
       allAnswers: [successAnswerMatcher],
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
+      variationPercent: undefined,
     })
     .returns({ estimatedLevel: 1, errorRate: 1.1 })
     .withArgs({
       allAnswers: [successAnswerMatcher, successAnswerMatcher],
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
+      variationPercent: undefined,
     })
     .returns({ estimatedLevel: 2, errorRate: 2.1 })
     .withArgs({
       allAnswers: [successAnswerMatcher, successAnswerMatcher, successAnswerMatcher],
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
+      variationPercent: undefined,
     })
     .returns({ estimatedLevel: 3, errorRate: 3.1 });
 


### PR DESCRIPTION
## :unicorn: Problème

Le fait que l’algo de déroulé des épreuves “brut” propose les épreuves suivantes suivant une probabilité de 50% de bonne réponse est vécu avec un ressenti de mise en difficulté inconfortable.

L’objectif est d’attenuer ce ressenti de difficulté sans altérer les calculs de capacité.

## :robot: Proposition

Le choix de l'épreuve suivante dépend de : 
    la capacité préalablement calculée (suite à la réponse à l'épreuve précédente ou initiale s’il s’agit de la première)
    la difficulté des épreuves non jouées
    le discriminant des épreuves non jouées

Afin d’éviter de biaiser les calculs, l’idée est de borner la capacité calculée afin d’atténuer la pente.

## :rainbow: Remarques

Pour plus de détails, se référer à la documentation disponible [ICI](https://1024pix.atlassian.net/wiki/spaces/DD/pages/3915153412/Caper+l+volution+de+la+capacit)

## :100: Pour tester

```
TOKEN=$(curl 'https://api-pr7377.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7377.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "capacity": 1.5, "variationPercent": 0.2 }' | jq '.'