### PR TITLE
[FEATURE] Sauvegarde du discriminant et de la difficulté en BDD (PIX-9831).

### DIFF
--- a/api/db/migrations/20231103103002_create-difficulty-and-discriminant-columns-in-certification-challenges.js
+++ b/api/db/migrations/20231103103002_create-difficulty-and-discriminant-columns-in-certification-challenges.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'certification-challenges';
+const DIFFICULTY_COLUMN_NAME = 'difficulty';
+const DISCRIMINANT_COLUMN_NAME = 'discriminant';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.float(DIFFICULTY_COLUMN_NAME).defaultTo(null);
+    table.float(DISCRIMINANT_COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(DIFFICULTY_COLUMN_NAME);
+    table.dropColumn(DISCRIMINANT_COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -8,6 +8,8 @@ class CertificationChallenge {
     competenceId,
     isNeutralized,
     certifiableBadgeKey,
+    difficulty,
+    discriminant,
   } = {}) {
     this.id = id;
     this.associatedSkillName = associatedSkillName;
@@ -17,6 +19,8 @@ class CertificationChallenge {
     this.courseId = courseId;
     this.isNeutralized = isNeutralized;
     this.certifiableBadgeKey = certifiableBadgeKey;
+    this.difficulty = difficulty;
+    this.discriminant = discriminant;
   }
 
   static createForPixCertification({ associatedSkillName, associatedSkillId, challengeId, competenceId }) {

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -80,6 +80,8 @@ const getNextChallengeForCertification = async function ({
       courseId: certificationCourse.getId(),
       isNeutralized: false,
       certifiableBadgeKey: null,
+      discriminant: challenge.discriminant,
+      difficulty: challenge.difficulty,
     });
 
     await certificationChallengeRepository.save({ certificationChallenge });

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -20,6 +20,8 @@ const save = async function ({ certificationChallenge, domainTransaction = Domai
     associatedSkillId: certificationChallenge.associatedSkillId,
     courseId: certificationChallenge.courseId,
     certifiableBadgeKey: certificationChallenge.certifiableBadgeKey,
+    difficulty: certificationChallenge.difficulty,
+    discriminant: certificationChallenge.discriminant,
   });
   const savedCertificationChallenge = await certificationChallengeToSave.save(null, {
     transacting: domainTransaction.knexTransaction,

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
@@ -10,6 +10,8 @@ const buildCertificationChallenge = function ({
   associatedSkillName = buildSkill().name,
   isNeutralized = false,
   certifiableBadgeKey = null,
+  discriminant = null,
+  difficulty = null,
 } = {}) {
   return new CertificationChallenge({
     id,
@@ -20,6 +22,8 @@ const buildCertificationChallenge = function ({
     associatedSkillName,
     isNeutralized,
     certifiableBadgeKey,
+    discriminant,
+    difficulty,
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème

Pour garder un historique des versions de la calibration des épreuves, notamment en cas de besoin de recalcul d’un score, il est souhaitable de garder en mémoire pour chaque certif v3 passé les données de calibration du moment, à savoir la difficulté et le discriminant.

## :robot: Proposition

Ajout de ces 2 colonnes en BDD dans la table `certification-challenges`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Créer une session de certification V3 avec `certifv3@example.net`
Inscrire un candidat à cette session
Démarrer la session de certification avec `certifiable-contenu-user@example.net`
Rejoindre la session avec ce candidat et commencer le test
Réaliser plusieurs challenges
Vérifier en BDD que les données de difficulté et de discriminant ont bien été enregistrées.

Refaire la même chose en certif V2 et vérifier que ces mêmes données soient `null`
