### PR TITLE
[TECH] Supprimer la méthode `findOperative` du `challengeRepository` qui n'est plus utilisé (PIX-9842).

### DIFF
--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -33,7 +33,7 @@ const pickCertificationChallenges = async function (
     placementProfile.profileDate,
   );
 
-  const allOperativeChallengesForLocale = await injectedChallengeRepository.findOperativeHavingLocale(locale);
+  const allOperativeChallengesForLocale = await injectedChallengeRepository.findOperative(locale);
 
   return _pickCertificationChallengesForCertifiableCompetences(
     certifiableUserCompetences,
@@ -64,7 +64,7 @@ const pickCertificationChallengesForPixPlus = async function (
 
   const alreadyAnsweredChallengeIds = certifiableProfile.getAlreadyAnsweredChallengeIds();
 
-  const allOperativeChallengesForLocale = await injectedChallengeRepository.findOperativeHavingLocale(locale);
+  const allOperativeChallengesForLocale = await injectedChallengeRepository.findOperative(locale);
   return _pickCertificationChallengesForAllAreas(
     skillIdsByDecreasingDifficultyGroupedByArea,
     alreadyAnsweredChallengeIds,

--- a/api/lib/domain/usecases/simulate-old-scoring.js
+++ b/api/lib/domain/usecases/simulate-old-scoring.js
@@ -5,7 +5,7 @@ const { sortBy } = lodash;
 import fp from 'lodash/fp.js';
 
 const simulateOldScoring = async function ({ challengeRepository, simulations, locale }) {
-  const challenges = await challengeRepository.findOperativeHavingLocale(locale);
+  const challenges = await challengeRepository.findOperative(locale);
   const challengesById = new Map(challenges.map((challenge) => [challenge.id, challenge]));
 
   // prettier-ignore

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -154,7 +154,7 @@ const findValidated = async function () {
   return _toDomainCollection({ challengeDataObjects, skills: activeSkills });
 };
 
-const findOperativeHavingLocale = async function (locale) {
+const findOperative = async function (locale) {
   const challengeDataObjects = await challengeDatasource.findOperativeHavingLocale(locale);
   const operativeSkills = await skillDatasource.findOperative();
   return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
@@ -210,7 +210,7 @@ export {
   getMany,
   list,
   findValidated,
-  findOperativeHavingLocale,
+  findOperative,
   findValidatedByCompetenceId,
   findOperativeBySkills,
   findFlashCompatible,

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -154,12 +154,6 @@ const findValidated = async function () {
   return _toDomainCollection({ challengeDataObjects, skills: activeSkills });
 };
 
-const findOperative = async function () {
-  const challengeDataObjects = await challengeDatasource.findOperative();
-  const operativeSkills = await skillDatasource.findOperative();
-  return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
-};
-
 const findOperativeHavingLocale = async function (locale) {
   const challengeDataObjects = await challengeDatasource.findOperativeHavingLocale(locale);
   const operativeSkills = await skillDatasource.findOperative();
@@ -216,7 +210,6 @@ export {
   getMany,
   list,
   findValidated,
-  findOperative,
   findOperativeHavingLocale,
   findValidatedByCompetenceId,
   findOperativeBySkills,

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -553,66 +553,6 @@ describe('Integration | Repository | challenge-repository', function () {
     });
   });
 
-  describe('#findOperative', function () {
-    it('should return only operative challenges with skills', async function () {
-      // given
-      const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
-      const operativeChallenge = domainBuilder.buildChallenge({ skill, status: 'archivé' });
-      const nonOperativeChallenge = domainBuilder.buildChallenge({ skill, status: 'PAS operative' });
-      const learningContent = {
-        skills: [{ ...skill, status: 'actif', level: skill.difficulty }],
-        challenges: [
-          { ...operativeChallenge, skillId: 'recSkill1' },
-          { ...nonOperativeChallenge, skillId: 'recSkill1' },
-        ],
-      };
-      mockLearningContent(learningContent);
-
-      // when
-      const actualChallenges = await challengeRepository.findOperative();
-
-      // then
-      expect(actualChallenges).to.have.lengthOf(1);
-      expect(actualChallenges[0]).to.be.instanceOf(Challenge);
-      expect(_.omit(actualChallenges[0], 'validator')).to.deep.equal(_.omit(actualChallenges[0], 'validator'));
-    });
-
-    it('should setup the expected validator and solution on found challenges', async function () {
-      // given
-      const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
-      const operativeChallenge = domainBuilder.buildChallenge({
-        type: Challenge.Type.QCM,
-        skill,
-        status: 'validé',
-      });
-      const learningContent = {
-        skills: [{ ...skill, status: 'actif', level: skill.difficulty }],
-        challenges: [
-          {
-            ...operativeChallenge,
-            skillId: 'recSkill1',
-            t1Status: 'Activé',
-            t2Status: 'Activé',
-            t3Status: 'Désactivé',
-          },
-        ],
-      };
-      mockLearningContent(learningContent);
-
-      // when
-      const [actualChallenge] = await challengeRepository.findOperative();
-
-      // then
-      expect(actualChallenge.validator).to.be.instanceOf(Validator);
-      expect(actualChallenge.validator.solution.id).to.equal(operativeChallenge.id);
-      expect(actualChallenge.validator.solution.isT1Enabled).to.equal(true);
-      expect(actualChallenge.validator.solution.isT2Enabled).to.equal(true);
-      expect(actualChallenge.validator.solution.isT3Enabled).to.equal(false);
-      expect(actualChallenge.validator.solution.type).to.equal(operativeChallenge.type);
-      expect(actualChallenge.validator.solution.value).to.equal(operativeChallenge.solution);
-    });
-  });
-
   describe('#findOperativeHavingLocale', function () {
     it('should return only french france operative challenges with skills', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -553,7 +553,7 @@ describe('Integration | Repository | challenge-repository', function () {
     });
   });
 
-  describe('#findOperativeHavingLocale', function () {
+  describe('#findOperative', function () {
     it('should return only french france operative challenges with skills', async function () {
       // given
       const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
@@ -570,7 +570,7 @@ describe('Integration | Repository | challenge-repository', function () {
       mockLearningContent(learningContent);
 
       // when
-      const actualChallenges = await challengeRepository.findOperativeHavingLocale(locale);
+      const actualChallenges = await challengeRepository.findOperative(locale);
 
       // then
       expect(actualChallenges).to.have.lengthOf(1);

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -242,11 +242,11 @@ describe('Unit | Service | Certification Challenge Service', function () {
     let answerRepository;
 
     beforeEach(function () {
-      challengeRepository = { findOperativeHavingLocale: sinon.stub() };
+      challengeRepository = { findOperative: sinon.stub() };
       knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
       answerRepository = { findChallengeIdsFromAnswerIds: sinon.stub() };
 
-      challengeRepository.findOperativeHavingLocale
+      challengeRepository.findOperative
         .withArgs(locale)
         .resolves([
           challengeForSkillCitation4,
@@ -819,7 +819,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         }),
       ];
 
-      challengeRepository.findOperativeHavingLocale
+      challengeRepository.findOperative
         .withArgs(locale)
         .resolves([
           domainBuilder.buildChallenge({ id: 'challengeToto6', competenceId: 'competenceId', skill: toto6 }),
@@ -926,7 +926,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
         }),
       ];
 
-      challengeRepository.findOperativeHavingLocale
+      challengeRepository.findOperative
         .withArgs(locale)
         .resolves([
           domainBuilder.buildChallenge({ id: 'challengeToto6', competenceId: 'competenceId', skill: toto6 }),
@@ -1180,8 +1180,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
 
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -1365,8 +1365,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', { id: 'laverLesDents3_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 2));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -1557,8 +1557,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit5', { id: 'faireSonLit5_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -1750,8 +1750,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit5', { id: 'faireSonLit5_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -1900,8 +1900,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit5', { id: 'faireSonLit5_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -1994,8 +1994,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents2', { id: 'laverLesDents2_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', { id: 'laverLesDents3_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit', { id: 'faireSonLit6_id' }, 1));
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -2168,8 +2168,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
       challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', { id: 'laverLesDents3_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 1));
       challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
-      const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-      challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+      const challengeRepository = { findOperative: sinon.stub() };
+      challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
       // when
       const certificationChallengesForPlus = await certificationChallengesService.pickCertificationChallengesForPixPlus(
@@ -2336,8 +2336,8 @@ describe('Unit | Service | Certification Challenge Service', function () {
         challenges = challenges.concat(_createChallengeWithDecl('ch_laverLesDents3', { id: 'laverLesDents3_id' }, 1));
         challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit4', { id: 'faireSonLit4_id' }, 1));
         challenges = challenges.concat(_createChallengeWithDecl('ch_faireSonLit6', { id: 'faireSonLit6_id' }, 1));
-        const challengeRepository = { findOperativeHavingLocale: sinon.stub() };
-        challengeRepository.findOperativeHavingLocale.withArgs(locale).resolves(challenges);
+        const challengeRepository = { findOperative: sinon.stub() };
+        challengeRepository.findOperative.withArgs(locale).resolves(challenges);
 
         // when
         const certificationChallengesForPlus =


### PR DESCRIPTION
## :unicorn: Problème
Lors de cette [PR](https://github.com/1024pix/pix/pull/7368) nous avons supprimé les usages de la méthode `findOperative` du `challengeRepository`, mais nous n'avons pas supprimé la méthode.

## :robot: Proposition
Supprimer la méthode `findOperative` du `challengeRepository`.

## :rainbow: Remarques
La méthode `findOperativeBySkills` est utilisé dans  `data-fetcher.js` ne prend pas en compte la locale.

## :100: Pour tester
RAS
