### PR TITLE
[FEATURE] [API] Créer une variable d'environnement pour définir les claims OIDC supplémentaires à sauvegarder (PIX-9379)

### DIFF
--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -24,6 +24,7 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
       authenticationUrl: config.fwb.authenticationUrl,
       authenticationUrlParameters: [{ key: 'scope', value: 'openid profile' }],
       userInfoUrl: config.fwb.userInfoUrl,
+      claimsToStore: config.fwb.claimsToStore,
     });
 
     this.logoutUrl = config.fwb.logoutUrl;

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -45,6 +45,7 @@ class OidcAuthenticationService {
       endSessionUrl,
       postLogoutRedirectUri,
       additionalRequiredProperties,
+      claimsToStore,
     },
     { sessionTemporaryStorage = defaultSessionTemporaryStorage } = {},
   ) {
@@ -63,7 +64,13 @@ class OidcAuthenticationService {
     this.userInfoUrl = userInfoUrl;
     this.endSessionUrl = endSessionUrl;
     this.postLogoutRedirectUri = postLogoutRedirectUri;
+
+    if (!lodash.isEmpty(claimsToStore)) {
+      this.claimsToStore = claimsToStore;
+    }
+
     this.sessionTemporaryStorage = sessionTemporaryStorage;
+
     if (!this.configKey) {
       logger.error(`${this.constructor.name}: Missing configKey`);
       return;

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -191,7 +191,7 @@ class OidcAuthenticationService {
     return { redirectTarget: redirectTarget.toString(), state, nonce };
   }
 
-  async getUserInfoFromEndpoint({ accessToken }) {
+  async _getUserInfoFromEndpoint({ accessToken }) {
     const httpResponse = await httpAgent.get({
       url: this.userInfoUrl,
       headers: { Authorization: `Bearer ${accessToken}` },
@@ -222,7 +222,7 @@ class OidcAuthenticationService {
       throw new OidcUserInfoFormatError(message, error.code, meta);
     }
 
-    const userInfoMissingFields = this.getUserInfoMissingFields({ userInfoContent });
+    const userInfoMissingFields = this._getUserInfoMissingFields({ userInfoContent });
     const message = `Un ou des champs obligatoires (${userInfoMissingFields}) n'ont pas été renvoyés par votre fournisseur d'identité ${this.organizationName}.`;
 
     if (userInfoMissingFields) {
@@ -246,7 +246,7 @@ class OidcAuthenticationService {
     };
   }
 
-  getUserInfoMissingFields({ userInfoContent }) {
+  _getUserInfoMissingFields({ userInfoContent }) {
     const missingFields = [];
     if (!userInfoContent.family_name) {
       missingFields.push('family_name');
@@ -269,7 +269,7 @@ class OidcAuthenticationService {
     const isMandatoryUserInfoMissing = !family_name || !given_name || !sub;
 
     if (isMandatoryUserInfoMissing) {
-      userInfoContent = await this.getUserInfoFromEndpoint({ accessToken });
+      userInfoContent = await this._getUserInfoFromEndpoint({ accessToken });
     }
 
     return {

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -263,7 +263,7 @@ class OidcAuthenticationService {
   }
 
   async getUserInfo({ idToken, accessToken }) {
-    const { family_name, given_name, sub, nonce } = await jsonwebtoken.decode(idToken);
+    const { family_name, given_name, sub, nonce } = jsonwebtoken.decode(idToken);
     let userInfoContent;
 
     const isMandatoryUserInfoMissing = !family_name || !given_name || !sub;

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -191,9 +191,9 @@ class OidcAuthenticationService {
     return { redirectTarget: redirectTarget.toString(), state, nonce };
   }
 
-  async getUserInfoFromEndpoint({ accessToken, userInfoUrl }) {
+  async getUserInfoFromEndpoint({ accessToken }) {
     const httpResponse = await httpAgent.get({
-      url: userInfoUrl,
+      url: this.userInfoUrl,
       headers: { Authorization: `Bearer ${accessToken}` },
       timeout: config.partner.fetchTimeOut,
     });
@@ -269,7 +269,7 @@ class OidcAuthenticationService {
     const isMandatoryUserInfoMissing = !family_name || !given_name || !sub;
 
     if (isMandatoryUserInfoMissing) {
-      userInfoContent = await this.getUserInfoFromEndpoint({ accessToken, userInfoUrl: this.userInfoUrl });
+      userInfoContent = await this.getUserInfoFromEndpoint({ accessToken });
     }
 
     return {

--- a/api/sample.env
+++ b/api/sample.env
@@ -672,6 +672,12 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: FWB_OIDC_LOGOUT_URL=
 
+# Claims to store
+#
+# presence: optional
+# type: list of strings
+# sample: FWB_CLAIMS_TO_STORE=employeeNumber,studentGroup
+
 # Access Token lifespan
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -3,7 +3,7 @@ import path from 'path';
 import moment from 'moment';
 import ms from 'ms';
 
-import { getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
+import { getArrayOfStrings, getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
 
 import * as url from 'url';
 
@@ -182,6 +182,7 @@ const configuration = (function () {
       tokenUrl: process.env.FWB_TOKEN_URL,
       authenticationUrl: process.env.FWB_AUTHENTICATION_URL,
       userInfoUrl: process.env.FWB_USER_INFO_URL,
+      claimsToStore: getArrayOfStrings(process.env.FWB_CLAIMS_TO_STORE),
       accessTokenLifespanMs: ms(process.env.FWB_ACCESS_TOKEN_LIFESPAN || '7d'),
       logoutUrl: process.env.FWB_OIDC_LOGOUT_URL,
       temporaryStorage: {

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -3,7 +3,7 @@ import path from 'path';
 import moment from 'moment';
 import ms from 'ms';
 
-import { getArrayOfStrings } from './infrastructure/utils/string-utils.js';
+import { getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
 
 import * as url from 'url';
 
@@ -160,7 +160,7 @@ const configuration = (function () {
       newYearOrganizationLearnersImportDate: _getDate(process.env.NEW_YEAR_ORGANIZATION_LEARNERS_IMPORT_DATE),
       numberOfChallengesForFlashMethod: _getNumber(process.env.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD),
       successProbabilityThreshold: parseFloat(process.env.SUCCESS_PROBABILITY_THRESHOLD ?? '0.95'),
-      pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
+      pixCertifScoBlockedAccessWhitelist: getArrayOfUpperStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
       scheduleComputeOrganizationLearnersCertificability: {

--- a/api/src/shared/infrastructure/utils/string-utils.js
+++ b/api/src/shared/infrastructure/utils/string-utils.js
@@ -2,6 +2,11 @@ import { _ } from './lodash-utils.js';
 
 function getArrayOfStrings(commaSeparatedStrings) {
   if (!commaSeparatedStrings) return [];
+  return _(commaSeparatedStrings).split(',').map(_.trim).value();
+}
+
+function getArrayOfUpperStrings(commaSeparatedStrings) {
+  if (!commaSeparatedStrings) return [];
   return _(commaSeparatedStrings).split(',').map(_.trim).map(_.toUpper).value();
 }
 
@@ -71,6 +76,7 @@ export {
   splitIntoWordsAndRemoveBackspaces,
   cleanStringAndParseFloat,
   getArrayOfStrings,
+  getArrayOfUpperStrings,
   normalizeAndSortChars,
   normalize,
   toArrayOfFixedLengthStringsConservingWords,

--- a/api/tests/shared/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/string-utils_test.js
@@ -3,6 +3,7 @@ import {
   isNumeric,
   cleanStringAndParseFloat,
   getArrayOfStrings,
+  getArrayOfUpperStrings,
   splitIntoWordsAndRemoveBackspaces,
   normalizeAndSortChars,
   normalize,
@@ -99,9 +100,41 @@ describe('Unit | Shared | infrastructure | Utils | string-utils', function () {
     });
 
     context('given value has only one string', function () {
-      it('should return array of 1', function () {
+      it('should return array of 1 string, trimmed', function () {
         // when
-        const array = getArrayOfStrings('un');
+        const array = getArrayOfStrings('uN');
+
+        // then
+        expect(array).to.deep.equal(['uN']);
+      });
+    });
+
+    context('given value has more than one string', function () {
+      it('should return an array containing the strings, trimmed', function () {
+        // when
+        const array = getArrayOfStrings('uN, DoS');
+
+        // then
+        expect(array).to.deep.equal(['uN', 'DoS']);
+      });
+    });
+  });
+
+  describe('#getArrayOfUpperStrings', function () {
+    context('given value is undefined', function () {
+      it('should return an empty array', function () {
+        // when
+        const array = getArrayOfUpperStrings(undefined);
+
+        // then
+        expect(array).to.be.empty;
+      });
+    });
+
+    context('given value has only one string', function () {
+      it('should return array of 1 string, trimmed and uppercased', function () {
+        // when
+        const array = getArrayOfUpperStrings('un');
 
         // then
         expect(array).to.deep.equal(['UN']);
@@ -109,9 +142,9 @@ describe('Unit | Shared | infrastructure | Utils | string-utils', function () {
     });
 
     context('given value has more than one string', function () {
-      it('should return an array containing the strings, trimmed and uppercase', function () {
+      it('should return an array containing the strings, trimmed and uppercased', function () {
         // when
-        const array = getArrayOfStrings('un, dos');
+        const array = getArrayOfUpperStrings('un, dos');
 
         // then
         expect(array).to.deep.equal(['UN', 'DOS']);

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -203,13 +203,13 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
   });
 
-  describe('#getUserInfoMissingFields', function () {
+  describe('#_getUserInfoMissingFields', function () {
     it('should return a message with missing fields list', async function () {
       // given
       const oidcAuthenticationService = new OidcAuthenticationService({});
 
       // when
-      const response = oidcAuthenticationService.getUserInfoMissingFields({
+      const response = oidcAuthenticationService._getUserInfoMissingFields({
         userInfoContent: {
           given_name: 'givenName',
           family_name: undefined,
@@ -227,7 +227,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const oidcAuthenticationService = new OidcAuthenticationService({});
 
       // when
-      const response = oidcAuthenticationService.getUserInfoMissingFields({
+      const response = oidcAuthenticationService._getUserInfoMissingFields({
         userInfoContent: {
           given_name: 'givenName',
           family_name: 'familyName',
@@ -468,7 +468,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
 
         const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl });
-        sinon.stub(oidcAuthenticationService, 'getUserInfoFromEndpoint');
+        sinon.stub(oidcAuthenticationService, '_getUserInfoFromEndpoint');
 
         // when
         await oidcAuthenticationService.getUserInfo({
@@ -477,14 +477,14 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
 
         // then
-        expect(oidcAuthenticationService.getUserInfoFromEndpoint).to.have.been.calledOnceWithExactly({
+        expect(oidcAuthenticationService._getUserInfoFromEndpoint).to.have.been.calledOnceWithExactly({
           accessToken: 'accessToken',
         });
       });
     });
   });
 
-  describe('#getUserInfoFromEndpoint', function () {
+  describe('#_getUserInfoFromEndpoint', function () {
     // given
     const userInfoUrl = 'userInfoUrl';
     const accessToken = 'accessToken';
@@ -514,7 +514,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
 
       // when
-      const result = await oidcAuthenticationService.getUserInfoFromEndpoint({
+      const result = await oidcAuthenticationService._getUserInfoFromEndpoint({
         accessToken: 'accessToken',
         userInfoUrl: 'userInfoUrl',
       });
@@ -552,7 +552,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // when
         let errorResponse;
         try {
-          await oidcAuthenticationService.getUserInfoFromEndpoint({
+          await oidcAuthenticationService._getUserInfoFromEndpoint({
             accessToken: 'accessToken',
             userInfoUrl: 'userInfoUrl',
           });
@@ -597,7 +597,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
         // when
         const error = await catchErr(
-          oidcAuthenticationService.getUserInfoFromEndpoint,
+          oidcAuthenticationService._getUserInfoFromEndpoint,
           oidcAuthenticationService,
         )({
           accessToken,
@@ -646,7 +646,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
         // when
         const error = await catchErr(
-          oidcAuthenticationService.getUserInfoFromEndpoint,
+          oidcAuthenticationService._getUserInfoFromEndpoint,
           oidcAuthenticationService,
         )({
           accessToken: 'accessToken',

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -21,6 +21,60 @@ import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-to
 import { OIDC_ERRORS } from '../../../../../lib/domain/constants.js';
 
 describe('Unit | Domain | Services | oidc-authentication-service', function () {
+  describe('constructor', function () {
+    context('when claimsToStore is undefined', function () {
+      it('does not set claimsToStore', async function () {
+        // given
+        const args = {};
+
+        // when
+        const oidcAuthenticationService = new OidcAuthenticationService(args);
+
+        // then
+        expect(oidcAuthenticationService.claimsToStore).not.to.exist;
+      });
+    });
+
+    context('when claimsToStore is null', function () {
+      it('does not set claimsToStore', async function () {
+        // given
+        const args = { claimsToStore: null };
+
+        // when
+        const oidcAuthenticationService = new OidcAuthenticationService(args);
+
+        // then
+        expect(oidcAuthenticationService.claimsToStore).not.to.exist;
+      });
+    });
+
+    context('when claimsToStore is an empty array', function () {
+      it('does not set claimsToStore', async function () {
+        // given
+        const args = { claimsToStore: [] };
+
+        // when
+        const oidcAuthenticationService = new OidcAuthenticationService(args);
+
+        // then
+        expect(oidcAuthenticationService.claimsToStore).not.to.exist;
+      });
+    });
+
+    context('when claimsToStore is not empty', function () {
+      it('sets claimsToStore', async function () {
+        // given
+        const args = { claimsToStore: ['employeeNumber', 'studentGroup'] };
+
+        // when
+        const oidcAuthenticationService = new OidcAuthenticationService(args);
+
+        // then
+        expect(oidcAuthenticationService.claimsToStore).to.exist;
+      });
+    });
+  });
+
   describe('#isReady', function () {
     describe('when configKey is set', function () {
       describe('when enabled in config', function () {

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -209,7 +209,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const oidcAuthenticationService = new OidcAuthenticationService({});
 
       // when
-      const response = await oidcAuthenticationService.getUserInfoMissingFields({
+      const response = oidcAuthenticationService.getUserInfoMissingFields({
         userInfoContent: {
           given_name: 'givenName',
           family_name: undefined,
@@ -227,7 +227,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const oidcAuthenticationService = new OidcAuthenticationService({});
 
       // when
-      const response = await oidcAuthenticationService.getUserInfoMissingFields({
+      const response = oidcAuthenticationService.getUserInfoMissingFields({
         userInfoContent: {
           given_name: 'givenName',
           family_name: 'familyName',

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -461,11 +461,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           );
         }
 
+        const userInfoUrl = 'infoUrl';
         const idToken = generateIdToken({
           nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
           sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
         });
-        const userInfoUrl = 'infoUrl';
 
         const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl });
         sinon.stub(oidcAuthenticationService, 'getUserInfoFromEndpoint');
@@ -479,7 +479,6 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(oidcAuthenticationService.getUserInfoFromEndpoint).to.have.been.calledOnceWithExactly({
           accessToken: 'accessToken',
-          userInfoUrl,
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Pour certains partenaires SSO, il y a le nouveau besoin de stocker certaines informations (_claims_ OIDC) sur l'utilisateur, lors de la connexion de l'utilisateur par le SSO. Et ces informations sont différentes suivant chaque partenaire SSO.

## :robot: Proposition

Ajouter une option de configuration `claimsToStore` remplie à partir de la variable d’environnement `${IDP}_CLAIMS_TO_STORE` (à définir pour chaque SSO OIDC) pour définir les _claims_ à sauvegarder.

Les _claims_ définis par `${IDP}_CLAIMS_TO_STORE` sont des _claims_ **obligatoires**. Si un de ces _claims_ n’est pas récupéré à partir des _userInfo_, alors l’authentification échoue.

Exemple : 

```shell
FWB_CLAIMS_TO_STORE=employeeNumber,studentGroup
```

Les _claims_ spécifiés ne doivent pas obligatoirement être des _claims_ OIDC standards, même si c’est mieux. Pour info voici la liste des _claims_ OIDC standards : 
https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

On précise bien qu’un compte utilisateur ne pourra avoir qu’une seule valeur pour un _claim_ donné. Par exemple un compte utilisateur ne pourra avoir qu’un `employeeNumber`.

## :rainbow: Remarques

### Refactors de préparation

Les premiers commits de cette PR sont des petits correctifs et des petits réarrangements pour préparer la place aux changements plus importants, qui vont se charger du stockage des informations utilisateurs supplémentaires, et qui vont avoir lieu dans une PR suivante.

### Facilitation de la gestion de tous les cas pour claimsToStore

Enfin, une remarque sur le code suivant qui a été mis dans le constructeur de `OidcAuthenticationService` : 
```javascript
if (!lodash.isEmpty(claimsToStore)) {
  this.claimsToStore = claimsToStore;
}
```

Ce code permettra dans le code à venir de faire un simple test `if (this.claimsToStore)` chaque fois qu'on voudra savoir s'il faut gérer le cas où il y a des `claimsToStore`, sans avoir à tester tous les cas possibles à chaque fois. Car un tableau vide est aussi un [Truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) en JavaScript.

## :100: Pour tester

Au niveau des RA il n'est pas facile de tester les SSO, donc on ne teste pas

En local : 

1. Définir la variable d'environnement suivante : 

   ```shell
   FWB_CLAIMS_TO_STORE=employeeNumber,studentGroup
   ```
2. L'ajout de cette variable n'entraine, au stade de cette PR, aucun changement de comportement. Donc tester uniquement tous les SSO et vérifier qu'il n'y a pas de régression