### PR TITLE
[TECH] Suppression de la documentation sur la variable d'environnement `FT_TRAINING_RECOMMENDATION`

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -938,13 +938,6 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT=false
 
-# Enable the training recommendation feature
-#
-# presence: optional
-# type: boolean
-# default: false
-FT_TRAINING_RECOMMENDATION=false
-
 # Enable all Pix1D unsecured endpoints
 #
 # presence: optional


### PR DESCRIPTION
## :unicorn: Problème
On documente une variable d'environnement que nous avons supprimé via #6015.

## :robot: Proposition
Supprimer cette doc

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier qu'elle n'est plus mentionnée nul part dans le code.