### PR TITLE
[FEATURE] Ne pas envoyer d'email sans lien pour le CPF (PIX-9863).

### DIFF
--- a/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
@@ -1,5 +1,6 @@
 import { config } from '../../../../config.js';
 import cronParser from 'cron-parser';
+import { logger } from '../../../logger.js';
 
 const { cpf } = config;
 const sendEmail = async function ({ getPreSignedUrls, mailService }) {
@@ -10,7 +11,11 @@ const sendEmail = async function ({ getPreSignedUrls, mailService }) {
 
   const generatedFiles = await getPreSignedUrls({ date: lastGeneratedFilesDate });
 
-  await mailService.sendCpfEmail({ email: cpf.sendEmailJob.recipient, generatedFiles });
+  if (generatedFiles.length) {
+    await mailService.sendCpfEmail({ email: cpf.sendEmailJob.recipient, generatedFiles });
+  } else {
+    logger.info(`No new generated cpf files since ${lastGeneratedFilesDate}`);
+  }
 };
 
 export { sendEmail };

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
@@ -2,6 +2,15 @@ import { expect, sinon } from '../../../../../test-helper.js';
 import { sendEmail } from '../../../../../../lib/infrastructure/jobs/cpf-export/handlers/send-email.js';
 import cronParser from 'cron-parser';
 import { config } from '../../../../../../lib/config.js';
+import { logger } from '../../../../../../lib/infrastructure/logger.js';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
+import dayOfYear from 'dayjs/plugin/dayOfYear.js';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(dayOfYear);
 
 const { cpf } = config;
 describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
@@ -19,6 +28,11 @@ describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
     const day = '15';
     const month = '01';
     sinon.stub(cpf, 'plannerJob').value({ cron: `0 0 ${day} ${month} *` });
+    getPreSignedUrls.resolves([
+      'https://bucket.url.com/file1.xml',
+      'https://bucket.url.com/file2.xml',
+      'https://bucket.url.com/file3.xml',
+    ]);
 
     const expectedDate = new Date('2022-01-15T00:00:00Z');
     const cronExpressionParserStub = {
@@ -37,29 +51,48 @@ describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
     });
   });
 
-  it('should send an email with a list of generated files url', async function () {
-    // given
-    const day = '15';
-    const month = '01';
-    sinon.stub(cpf, 'plannerJob').value({ cron: `0 0 ${day} ${month} *` });
-    sinon.stub(cpf, 'sendEmailJob').value({ recipient: 'teamcertif@example.net' });
+  describe('when generated files are found', function () {
+    it('should send an email with a list of generated files url', async function () {
+      // given
+      const day = '15';
+      const month = '01';
+      sinon.stub(cpf, 'plannerJob').value({ cron: `0 0 ${day} ${month} *` });
+      sinon.stub(cpf, 'sendEmailJob').value({ recipient: 'teamcertif@example.net' });
 
-    getPreSignedUrls.resolves([
-      'https://bucket.url.com/file1.xml',
-      'https://bucket.url.com/file2.xml',
-      'https://bucket.url.com/file3.xml',
-    ]);
-    // when
-    await sendEmail({ getPreSignedUrls, mailService });
-
-    // then
-    expect(mailService.sendCpfEmail).to.have.been.calledWithExactly({
-      email: 'teamcertif@example.net',
-      generatedFiles: [
+      getPreSignedUrls.resolves([
         'https://bucket.url.com/file1.xml',
         'https://bucket.url.com/file2.xml',
         'https://bucket.url.com/file3.xml',
-      ],
+      ]);
+      // when
+      await sendEmail({ getPreSignedUrls, mailService });
+
+      // then
+      expect(mailService.sendCpfEmail).to.have.been.calledWithExactly({
+        email: 'teamcertif@example.net',
+        generatedFiles: [
+          'https://bucket.url.com/file1.xml',
+          'https://bucket.url.com/file2.xml',
+          'https://bucket.url.com/file3.xml',
+        ],
+      });
+    });
+  });
+
+  describe('when no generated file is found', function () {
+    it('should not send an email', async function () {
+      // given
+      const loggedDate = dayjs().tz('Europe/Paris').second(0).minute(11).hour(12).dayOfYear(15).month(0).toDate();
+      sinon.stub(cpf, 'plannerJob').value({ cron: '11 12 15 01 *' });
+      sinon.stub(logger, 'info');
+
+      getPreSignedUrls.resolves([]);
+      // when
+      await sendEmail({ getPreSignedUrls, mailService });
+
+      // then
+      expect(mailService.sendCpfEmail).to.not.have.been.called;
+      expect(logger.info).to.have.been.calledWithExactly(`No new generated cpf files since ${loggedDate.toString()}`);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Quand le job d'envoi d'email CPF ne trouve rien à envoyer, il envoie quand même un email vide.
L'email reçu est par ailleurs confusant car le template ne prévoit pas ce cas de figure.

## :robot: Proposition
Ne pas envoyer d'email quand il n'y a rien à envoyer.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

* Sur la base que MAILING_ENABLED=true & que CPF_SEND_EMAIL_JOB_RECIPIENT est set sur une adresse email où vous allez pouvoir consulgter la réception de l'email
  * + de détails dans [la procédure CPF](https://1024pix.atlassian.net/wiki/spaces/DC/pages/3549462542/Export+des+donn+es+de+certification+pour+le+CPF) 
* Mettre le cron CPF_PLANNER_JOB_CRON du planner à une date ou aucun fichier sur le bucket pix-cpf-dev ne correspond en terme de date, par exemple une minute avant votre review
  * La raison a cela est que le job d'envoi d'email consomme la date du planner pour savoir quelle période de temps scanner
* Lancer le cron via CPF_SEND_EMAIL_JOB_CRON   
* Vérifier qu'un logger WARNING s'écrit dans les logs pour dire qu'il n'y a aucun ficheir à envoyer
* Vérifier qu'aucun n'email n'a été reçu
