### PR TITLE
[FEATURE] Afficher le feedback global à l'apprenant (PIX-9861) (PIX-9707)

### DIFF
--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -34,6 +34,9 @@ const register = async function (server) {
               }).required(),
             }).required(),
           }).required(),
+          options: {
+            allowUnknown: true,
+          },
         },
         notes: ['- Permet de valider la réponse à une activité soumise par un apprenant'],
         tags: ['api', 'modules', 'answers'],

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
@@ -21,6 +21,15 @@ function serialize(elementAnswer) {
       ref: 'id',
       includes: true,
       attributes: ['feedback', 'status', 'solutionId'],
+      type: 'correction-responses',
+    },
+    typeForAttribute(attribute, { type }) {
+      if (attribute === 'elementAnswer') {
+        return type;
+      }
+      if (attribute === 'correction') {
+        return 'correction-responses';
+      }
     },
   }).serialize(elementAnswer);
 }

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
@@ -29,7 +29,7 @@ describe('Unit | DevComp | Serializers | ElementAnswerSerializer', function () {
           relationships: {
             correction: {
               data: {
-                type: 'corrections',
+                type: 'correction-responses',
               },
             },
           },
@@ -42,7 +42,7 @@ describe('Unit | DevComp | Serializers | ElementAnswerSerializer', function () {
               status: 'ok',
               'solution-id': givenCorrectionResponse.solutionId,
             },
-            type: 'corrections',
+            type: 'correction-responses',
           },
         ],
       };

--- a/mon-pix/app/adapters/element-answer.js
+++ b/mon-pix/app/adapters/element-answer.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class ElementAnswer extends ApplicationAdapter {
+  urlForCreateRecord(modelName, { adapterOptions }) {
+    return `${this.host}/${this.namespace}/modules/${adapterOptions.moduleSlug}/elements/${adapterOptions.elementId}/answers`;
+  }
+}

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -1,30 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class ModuleDetails extends Component {
-  @service store;
-
-  @tracked correctionResponse = {};
-
-  @action
-  async submitAnswer(answerData) {
-    const elementAnswer = await this.store
-      .createRecord('element-answer', {
-        userResponse: answerData.userResponse,
-      })
-      .save({
-        adapterOptions: { elementId: answerData.elementId, moduleSlug: this.args.module.id },
-      });
-
-    // Change ref to refresh the component
-    this.correctionResponse = {
-      ...this.correctionResponse,
-    };
-    this.correctionResponse[answerData.elementId] = await elementAnswer.correction;
-  }
-
   @action
   continueToNextGrain() {
     // eslint-disable-next-line no-console

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -22,7 +22,7 @@ export default class ModuleDetails extends Component {
     this.correctionResponse = {
       ...this.correctionResponse,
     };
-    this.correctionResponse[answerData.elementId] = elementAnswer.correction;
+    this.correctionResponse[answerData.elementId] = await elementAnswer.correction;
   }
 
   @action

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -1,7 +1,30 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class ModuleDetails extends Component {
+  @service store;
+
+  @tracked correctionResponse = {};
+
+  @action
+  async submitAnswer(answerData) {
+    const elementAnswer = await this.store
+      .createRecord('element-answer', {
+        userResponse: answerData.userResponse,
+      })
+      .save({
+        adapterOptions: { elementId: answerData.elementId, moduleSlug: this.args.module.id },
+      });
+
+    // Change ref to refresh the component
+    this.correctionResponse = {
+      ...this.correctionResponse,
+    };
+    this.correctionResponse[answerData.elementId] = elementAnswer.correction;
+  }
+
   @action
   continueToNextGrain() {
     // eslint-disable-next-line no-console

--- a/mon-pix/app/pods/components/module/details/styles.scss
+++ b/mon-pix/app/pods/components/module/details/styles.scss
@@ -24,6 +24,8 @@
   border-radius: $pix-spacing-s;
 
   &__footer {
-    margin: $pix-spacing-s;
+    padding: $pix-spacing-s;
+    background: $pix-tertiary-5;
+    border-radius: 0 0 $pix-spacing-s $pix-spacing-s;
   }
 }

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -15,8 +15,8 @@
           {{else if element.isQcu}}
             <Module::Qcu
               @qcu={{element}}
-              @submitAnswer={{this.submitAnswer}}
-              @correctionResponse={{get this.correctionResponse element.id}}
+              @submitAnswer={{@submitAnswer}}
+              @correctionResponse={{get @correctionResponse element.id}}
             />
           {{/if}}
         {{/each}}

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -13,13 +13,17 @@
           {{#if element.isText}}
             <Module::Text @text={{element}} />
           {{else if element.isQcu}}
-            <Module::Qcu @qcu={{element}} />
+            <Module::Qcu
+              @qcu={{element}}
+              @submitAnswer={{this.submitAnswer}}
+              @correctionResponse={{get this.correctionResponse element.id}}
+            />
           {{/if}}
         {{/each}}
       {{/each}}
       <footer class="grain__footer">
         <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{this.continueToNextGrain}}>
-          {{t "pages.modulix.buttons.continue"}}
+          {{t "pages.modulix.buttons.grain.continue"}}
         </PixButton>
       </footer>
     </article>

--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -1,10 +1,22 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class ModuleQcu extends Component {
+  @tracked selectedAnswerId = null;
+  @tracked correctionResponse = null;
+
   @action
-  radioClicked(value) {
-    // eslint-disable-next-line no-console
-    console.info(value);
+  radioClicked(proposalId) {
+    this.selectedAnswerId = proposalId;
+  }
+
+  @action
+  async submitAnswer(event) {
+    event.preventDefault();
+    const elementId = this.args.qcu.id;
+    const answerData = { elementId, userResponse: [this.selectedAnswerId] };
+    const elementAnswer = await this.args.submitAnswer(answerData);
+    this.correctionResponse = elementAnswer.correction;
   }
 }

--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -5,6 +5,14 @@ import { action } from '@ember/object';
 export default class ModuleQcu extends Component {
   @tracked selectedAnswerId = null;
 
+  get feedbackType() {
+    return this.args.correctionResponse?.isOk ? 'success' : 'error';
+  }
+
+  get disableInput() {
+    return !!this.args.correctionResponse;
+  }
+
   @action
   radioClicked(proposalId) {
     this.selectedAnswerId = proposalId;

--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 
 export default class ModuleQcu extends Component {
   @tracked selectedAnswerId = null;
-  @tracked correctionResponse = null;
 
   @action
   radioClicked(proposalId) {
@@ -16,7 +15,6 @@ export default class ModuleQcu extends Component {
     event.preventDefault();
     const elementId = this.args.qcu.id;
     const answerData = { elementId, userResponse: [this.selectedAnswerId] };
-    const elementAnswer = await this.args.submitAnswer(answerData);
-    this.correctionResponse = elementAnswer.correction;
+    await this.args.submitAnswer(answerData);
   }
 }

--- a/mon-pix/app/pods/components/module/qcu/styles.scss
+++ b/mon-pix/app/pods/components/module/qcu/styles.scss
@@ -4,6 +4,14 @@
   margin: $pix-spacing-s;
   color: $pix-neutral-90;
 
+  &__verify_button {
+    margin: $pix-spacing-s $pix-spacing-s $pix-spacing-s 0;
+  }
+
+  &__feedback {
+    margin: $pix-spacing-s 0 $pix-spacing-s 0;
+  }
+
   // revert the reset
   ul,
   ol {
@@ -16,11 +24,14 @@
 .element-qcu-header {
   &__instruction {
     @extend %pix-body-m;
+
+    margin-bottom: $pix-spacing-xs;
   }
 
   &__direction {
     @extend %pix-body-s;
 
+    margin-bottom: $pix-spacing-s;
     color: $pix-neutral-60;
   }
 }

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -1,5 +1,5 @@
-<form class="element-qcu">
-  <fieldset>
+<form class="element-qcu" {{on "submit" this.submitAnswer}}>
+  <fieldset disabled={{this.disableInput}}>
     <div class="element-qcu__header">
       <div class="element-qcu-header__instruction">
         {{html-safe @qcu.instruction}}
@@ -12,10 +12,29 @@
 
     <div class="element-qcu__proposals">
       {{#each @qcu.proposals as |proposal|}}
-        <PixRadioButton name={{@qcu.id}} @value={{proposal.id}} {{on "click" (fn this.radioClicked proposal.id)}}>
+        <PixRadioButton
+          name={{@qcu.id}}
+          @value={{proposal.id}}
+          {{on "click" (fn this.radioClicked proposal.id)}}
+          required
+        >
           {{proposal.content}}
         </PixRadioButton>
       {{/each}}
     </div>
   </fieldset>
+
+  {{#unless @correctionResponse}}
+    <PixButton @backgroundColor="green" @shape="rounded" @type="submit" class="element-qcu__verify_button">
+      {{t "pages.modulix.buttons.activity.verify"}}
+    </PixButton>
+  {{/unless}}
+
+  <div role="status" tabindex="-1">
+    {{#if @correctionResponse}}
+      <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qcu__feedback">
+        {{html-safe @correctionResponse.feedback}}
+      </PixMessage>
+    {{/if}}
+  </div>
 </form>

--- a/mon-pix/app/pods/correction-response/model.js
+++ b/mon-pix/app/pods/correction-response/model.js
@@ -1,0 +1,12 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class CorrectionResponse extends Model {
+  @attr('string') status;
+  @attr('string') feedback;
+  @attr('string') solutionId;
+  @belongsTo('element') element;
+
+  get isOk() {
+    return this.status === 'ok';
+  }
+}

--- a/mon-pix/app/pods/element-answer/model.js
+++ b/mon-pix/app/pods/element-answer/model.js
@@ -1,0 +1,6 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ElementAnswer extends Model {
+  @attr('array') userResponse;
+  @belongsTo('correction-response') correction;
+}

--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -1,0 +1,27 @@
+import Controller from '@ember/controller';
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class GetController extends Controller {
+  @service store;
+
+  @tracked correctionResponse = {};
+
+  @action
+  async submitAnswer(answerData) {
+    const elementAnswer = await this.store
+      .createRecord('element-answer', {
+        userResponse: answerData.userResponse,
+      })
+      .save({
+        adapterOptions: { elementId: answerData.elementId, moduleSlug: this.model.id },
+      });
+
+    // Change ref to refresh the component
+    this.correctionResponse = {
+      ...this.correctionResponse,
+    };
+    this.correctionResponse[answerData.elementId] = await elementAnswer.correction;
+  }
+}

--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class GetController extends Controller {
   @service store;
+  @service metrics;
 
   @tracked correctionResponse = {};
 
@@ -23,5 +24,12 @@ export default class GetController extends Controller {
       ...this.correctionResponse,
     };
     this.correctionResponse[answerData.elementId] = await elementAnswer.correction;
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.model.id}`,
+      'pix-event-name': `Click sur le bouton vérifier de l'élément : ${answerData.elementId}`,
+    });
   }
 }

--- a/mon-pix/app/pods/module/get/template.hbs
+++ b/mon-pix/app/pods/module/get/template.hbs
@@ -1,3 +1,7 @@
 <div class="modulix">
-  <Module::Details @module={{@model}} />
+  <Module::Details
+    @module={{@model}}
+    @submitAnswer={{this.submitAnswer}}
+    @correctionResponse={{this.correctionResponse}}
+  />
 </div>

--- a/mon-pix/mirage/routes/modules/index.js
+++ b/mon-pix/mirage/routes/modules/index.js
@@ -1,5 +1,7 @@
 import getModule from './get-module';
+import submitAnswer from './submit-answer';
 
 export default function index(config) {
   config.get('/modules/:slug', getModule);
+  config.post('/modules/:slug/elements/:elementId/answers', submitAnswer);
 }

--- a/mon-pix/mirage/routes/modules/submit-answer.js
+++ b/mon-pix/mirage/routes/modules/submit-answer.js
@@ -1,0 +1,5 @@
+export default function (schema, request) {
+  const elementId = request.params.elementId;
+  const correction = schema.correctionResponses.find(elementId);
+  return schema.elementAnswers.create({ correction });
+}

--- a/mon-pix/mirage/serializers/element-answer.js
+++ b/mon-pix/mirage/serializers/element-answer.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  include: ['grains'],
+});

--- a/mon-pix/mirage/serializers/grain.js
+++ b/mon-pix/mirage/serializers/grain.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  include: ['elements'],
+});

--- a/mon-pix/mirage/serializers/module.js
+++ b/mon-pix/mirage/serializers/module.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['correction'],
+  include: ['grains'],
 });

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -45,14 +45,14 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
       id: 'elementId-1',
       feedback: "Bravo ! C'est la bonne réponse.",
       status: 'ok',
-      solution: 'qcu-1-proposal-2',
+      solutionId: 'qcu-1-proposal-2',
     });
 
     server.create('correction-response', {
       id: 'elementId-2',
       feedback: 'Pas ouf',
       status: 'ko',
-      solution: 'qcu-2-proposal-1',
+      solutionId: 'qcu-2-proposal-1',
     });
 
     // when

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -1,0 +1,77 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click } from '@ember/test-helpers';
+
+module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('can validate my QCU answer', async function (assert) {
+    // given
+    const qcu1 = server.create('qcu', {
+      id: 'elementId-1',
+      type: 'qcus',
+      instruction: 'instruction',
+      proposals: [
+        { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
+        { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
+      ],
+    });
+    const qcu2 = server.create('qcu', {
+      id: 'elementId-2',
+      type: 'qcus',
+      instruction: 'instruction',
+      proposals: [
+        { id: 'qcu-2-proposal-1', content: 'Vrai' },
+        { id: 'qcu-2-proposal-2', content: 'Faux' },
+      ],
+    });
+
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      elements: [qcu1, qcu2],
+    });
+
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: 'qcu-1-proposal-2',
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-2',
+      feedback: 'Pas ouf',
+      status: 'ko',
+      solution: 'qcu-2-proposal-1',
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail');
+    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+    const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
+
+    // when
+    await click(screen.getByLabelText('I am the right answer!'));
+    await click(firstQcuVerifyButton);
+
+    // then
+    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+    // when
+    await click(screen.getByLabelText('Faux'));
+    await click(nextQcuVerifyButton);
+
+    // then
+    assert.dom(screen.getByText('Pas ouf')).exists();
+  });
+});

--- a/mon-pix/tests/helpers/create-pods-component.js
+++ b/mon-pix/tests/helpers/create-pods-component.js
@@ -1,0 +1,10 @@
+import { getContext } from '@ember/test-helpers';
+import GlimmerComponentManager from '@glimmer/component/-private/ember-component-manager';
+
+export default function createPodsComponent(lookupPath, named = {}) {
+  const { owner } = getContext();
+  const result = owner.factoryFor(`component:${lookupPath}`);
+  const componentClass = result.class;
+  const componentManager = new GlimmerComponentManager(owner);
+  return componentManager.createComponent(componentClass, { named });
+}

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -16,8 +16,8 @@ module('Integration | Component | Module | Details', function (hooks) {
       proposals: ['radio1', 'radio2'],
       type: 'qcus',
     });
-    const moduleElements = [textElement, qcuElement];
-    const grain = store.createRecord('grain', { elements: moduleElements });
+    const elements = [textElement, qcuElement];
+    const grain = store.createRecord('grain', { elements });
 
     const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
     this.set('module', module);
@@ -30,6 +30,6 @@ module('Integration | Component | Module | Details', function (hooks) {
     assert.strictEqual(findAll('.element-text').length, 1);
     assert.strictEqual(findAll('.element-qcu').length, 1);
 
-    assert.ok(screen.getByRole('button', { name: 'Continuer' }));
+    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
   });
 });

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -84,9 +84,15 @@ module('Integration | Component | Module | QCU', function (hooks) {
       solution: 'solutionId',
     });
 
+    // when
     const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
 
-    assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
+    // then
+    assert.ok(screen.getByText('Good job!'));
+    assert.ok(screen.getByRole('group').disabled);
+    assert.ok(screen.getByLabelText('radio1').required);
+    assert.ok(screen.getByLabelText('radio2').required);
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
 
   test('should display a ko feedback when exists', async function (assert) {
@@ -102,13 +108,20 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
     this.set('qcu', qcuElement);
     const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Good job!',
+      feedback: 'Too Bad!',
       status: 'ko',
       solution: 'solutionId',
     });
+
+    // when
     const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
 
-    assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
+    // then
+    assert.ok(screen.getByText('Too Bad!'));
+    assert.ok(screen.getByRole('group').disabled);
+    assert.ok(screen.getByLabelText('radio1').required);
+    assert.ok(screen.getByLabelText('radio2').required);
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
 });
 
@@ -119,12 +132,4 @@ async function renderQcuWithCorrectionResponse(correctionResponse) {
   return await render(
     hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} @correctionResponse={{this.correctionResponse}} />`,
   );
-}
-
-function assertsWhenCorrectionResponseHasBeenGiven(assert, screen) {
-  assert.ok(screen.getByText('Good job!'));
-  assert.ok(screen.getByRole('group').disabled);
-  assert.ok(screen.getByLabelText('radio1').required);
-  assert.ok(screen.getByLabelText('radio2').required);
-  assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
 }

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -37,7 +37,6 @@ module('Integration | Component | Module | QCU', function (hooks) {
 
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
     assert.dom(verifyButton).exists();
-    assert.true(verifyButton.disabled);
   });
 
   test('should call action when verify button is clicked', async function (assert) {
@@ -52,7 +51,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     });
     this.set('qcu', qcuElement);
     const elementId = qcuElement.id;
-    const answerId = answeredProposal.id;
+    const userResponse = [answeredProposal.id];
     const givenSubmitAnswerSpy = sinon.spy();
     this.set('submitAnswer', givenSubmitAnswerSpy);
     const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
@@ -63,8 +62,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(verifyButton);
 
     // then
-    assert.false(verifyButton.disabled);
-    sinon.assert.calledWith(givenSubmitAnswerSpy, { elementId, answerId });
+    sinon.assert.calledWith(givenSubmitAnswerSpy, { elementId, userResponse });
+    assert.ok(true);
   });
 
   test('should display an ok feedback when exists', async function (assert) {
@@ -81,13 +80,14 @@ module('Integration | Component | Module | QCU', function (hooks) {
     this.set('qcu', qcuElement);
     const correctionResponse = store.createRecord('correction-response', {
       feedback: 'Good job!',
-      globalResult: 'ok',
-      solutionId: 'solutionId',
+      status: 'ok',
+      solution: 'solutionId',
     });
 
     const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
 
     assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
+
     assert.strictEqual(findAll('.element-qcu__feedback--ok').length, 1);
   });
 
@@ -105,8 +105,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     this.set('qcu', qcuElement);
     const correctionResponse = store.createRecord('correction-response', {
       feedback: 'Good job!',
-      globalResult: 'ko',
-      solutionId: 'solutionId',
+      status: 'ko',
+      solution: 'solutionId',
     });
     const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
 
@@ -126,7 +126,8 @@ async function renderQcuWithCorrectionResponse(correctionResponse) {
 
 function assertsWhenCorrectionResponseHasBeenGiven(assert, screen) {
   assert.ok(screen.getByText('Good job!'));
-  assert.ok(screen.getByLabelText('radio1').disabled);
-  assert.ok(screen.getByLabelText('radio2').disabled);
+  assert.ok(screen.getByRole('group').disabled);
+  assert.ok(screen.getByLabelText('radio1').required);
+  assert.ok(screen.getByLabelText('radio2').required);
   assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
 }

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -87,8 +87,6 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
 
     assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
-
-    assert.strictEqual(findAll('.element-qcu__feedback--ok').length, 1);
   });
 
   test('should display a ko feedback when exists', async function (assert) {
@@ -111,7 +109,6 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
 
     assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
-    assert.strictEqual(findAll('.element-qcu__feedback--ko').length, 1);
   });
 });
 

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -81,7 +81,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const correctionResponse = store.createRecord('correction-response', {
       feedback: 'Good job!',
       status: 'ok',
-      solution: 'solutionId',
+      solutionId: 'solutionId',
     });
 
     // when
@@ -110,7 +110,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const correctionResponse = store.createRecord('correction-response', {
       feedback: 'Too Bad!',
       status: 'ko',
-      solution: 'solutionId',
+      solutionId: 'solutionId',
     });
 
     // when

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { findAll } from '@ember/test-helpers';
+import { click, findAll } from '@ember/test-helpers';
+import sinon from 'sinon';
 
 module('Integration | Component | Module | QCU', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -18,10 +19,10 @@ module('Integration | Component | Module | QCU', function (hooks) {
       ],
       type: 'qcus',
     });
+    const givenSubmitAnswerStub = sinon.stub();
     this.set('qcu', qcuElement);
-
-    //  when
-    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} />`);
+    this.set('submitAnswer', givenSubmitAnswerStub);
+    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
 
     // then
     assert.ok(screen);
@@ -29,8 +30,103 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.strictEqual(findAll('.element-qcu-header__direction').length, 1);
     assert.ok(screen.getByText('Instruction'));
     assert.ok(screen.getByText(this.intl.t('pages.modulix.qcu.direction')));
+
     assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
     assert.ok(screen.getByLabelText('radio1'));
     assert.ok(screen.getByLabelText('radio2'));
+
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    assert.dom(verifyButton).exists();
+    assert.true(verifyButton.disabled);
+  });
+
+  test('should call action when verify button is clicked', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const answeredProposal = { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' };
+    const qcuElement = store.createRecord('qcu', {
+      id: 'qcu-id-1',
+      instruction: 'Instruction',
+      proposals: [answeredProposal, { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' }],
+      type: 'qcus',
+    });
+    this.set('qcu', qcuElement);
+    const elementId = qcuElement.id;
+    const answerId = answeredProposal.id;
+    const givenSubmitAnswerSpy = sinon.spy();
+    this.set('submitAnswer', givenSubmitAnswerSpy);
+    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+
+    // when
+    await click(screen.getByLabelText(answeredProposal.content));
+    await click(verifyButton);
+
+    // then
+    assert.false(verifyButton.disabled);
+    sinon.assert.calledWith(givenSubmitAnswerSpy, { elementId, answerId });
+  });
+
+  test('should display an ok feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcuElement = store.createRecord('qcu', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
+        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+      ],
+      type: 'qcus',
+    });
+    this.set('qcu', qcuElement);
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Good job!',
+      globalResult: 'ok',
+      solutionId: 'solutionId',
+    });
+
+    const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
+
+    assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
+    assert.strictEqual(findAll('.element-qcu__feedback--ok').length, 1);
+  });
+
+  test('should display a ko feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcuElement = store.createRecord('qcu', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
+        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+      ],
+      type: 'qcus',
+    });
+    this.set('qcu', qcuElement);
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Good job!',
+      globalResult: 'ko',
+      solutionId: 'solutionId',
+    });
+    const screen = await renderQcuWithCorrectionResponse.call(this, correctionResponse);
+
+    assertsWhenCorrectionResponseHasBeenGiven(assert, screen);
+    assert.strictEqual(findAll('.element-qcu__feedback--ko').length, 1);
   });
 });
+
+async function renderQcuWithCorrectionResponse(correctionResponse) {
+  this.set('submitAnswer', () => {});
+  this.set('correctionResponse', correctionResponse);
+
+  return await render(
+    hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} @correctionResponse={{this.correctionResponse}} />`,
+  );
+}
+
+function assertsWhenCorrectionResponseHasBeenGiven(assert, screen) {
+  assert.ok(screen.getByText('Good job!'));
+  assert.ok(screen.getByLabelText('radio1').disabled);
+  assert.ok(screen.getByLabelText('radio2').disabled);
+  assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+}

--- a/mon-pix/tests/unit/adapters/element-answer_test.js
+++ b/mon-pix/tests/unit/adapters/element-answer_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
+  setupTest(hooks);
+
+  module('#urlForCreateRecord', function () {
+    test('should build url for create record', function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:element-answer');
+      const option = {
+        adapterOptions: {
+          moduleSlug: 'module-slug',
+          elementId: 'elementId',
+        },
+      };
+      // when
+      const url = adapter.urlForCreateRecord('element-answer', option);
+
+      // then
+      assert.true(
+        url.endsWith(
+          `api/modules/${option.adapterOptions.moduleSlug}/elements/${option.adapterOptions.elementId}/answers`,
+        ),
+      );
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/module/qcu_test.js
+++ b/mon-pix/tests/unit/components/module/qcu_test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createPodsComponent from '../../../helpers/create-pods-component';
+
+module('Unit | Component | Module | QCU', function (hooks) {
+  setupTest(hooks);
+
+  module('#feedbackType', function () {
+    module('When correction status is ko', function () {
+      test('should be error', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const correctionResponse = store.createRecord('correction-response', { status: 'ko' });
+        const component = createPodsComponent('module/qcu', { correctionResponse });
+
+        // when
+        const feedbackType = component.feedbackType;
+
+        // then
+        assert.strictEqual(feedbackType, 'error');
+      });
+    });
+
+    module('When correction status is ok', function () {
+      test('should be success', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const correctionResponse = store.createRecord('correction-response', { status: 'ok' });
+        const component = createPodsComponent('module/qcu', { correctionResponse });
+
+        // when
+        const feedbackType = component.feedbackType;
+
+        // then
+        assert.strictEqual(feedbackType, 'success');
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Module | Controller | get', function (hooks) {
+  setupTest(hooks);
+
+  module('#action submitAnswer', function () {
+    test('it should use the store and save the element answer', async function (assert) {
+      // given
+      const expectedCorrection = 'correction';
+      const userResponse = 'userResponse';
+      const elementId = 'elementId';
+      const moduleSlug = 'moduleSlug';
+
+      const answerData = {
+        userResponse,
+        elementId,
+        moduleSlug,
+      };
+
+      const controller = this.owner.lookup('controller:module/get');
+      controller.model = {
+        id: moduleSlug,
+      };
+      controller.store = {
+        createRecord: sinon.stub(),
+      };
+      const saveStub = sinon.stub();
+
+      controller.store.createRecord
+        .withArgs('element-answer', {
+          userResponse,
+        })
+        .returns({
+          save: saveStub,
+        });
+
+      saveStub
+        .withArgs({
+          adapterOptions: {
+            elementId: answerData.elementId,
+            moduleSlug: moduleSlug,
+          },
+        })
+        .resolves({ correction: expectedCorrection });
+
+      // when
+      await controller.submitAnswer(answerData);
+
+      // then
+      assert.strictEqual(controller.correctionResponse[elementId], expectedCorrection);
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Module | Controller | get', function (hooks) {
   setupTest(hooks);
@@ -18,6 +19,13 @@ module('Unit | Module | Controller | get', function (hooks) {
         elementId,
         moduleSlug,
       };
+
+      const metricAddStub = sinon.stub();
+      class MetricsStubService extends Service {
+        add = metricAddStub;
+      }
+      this.owner.register('service:metrics', MetricsStubService);
+      const metricsService = this.owner.lookup('service:metrics');
 
       const controller = this.owner.lookup('controller:module/get');
       controller.model = {
@@ -50,6 +58,12 @@ module('Unit | Module | Controller | get', function (hooks) {
 
       // then
       assert.strictEqual(controller.correctionResponse[elementId], expectedCorrection);
+      sinon.assert.calledWith(metricsService.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${moduleSlug}`,
+        'pix-event-name': `Click sur le bouton vérifier de l'élément : ${elementId}`,
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/models/modules/correction-response_test.js
+++ b/mon-pix/tests/unit/models/modules/correction-response_test.js
@@ -8,17 +8,17 @@ module('Unit | Model | Module | CorrectionResponse', function (hooks) {
     // given
     const feedback = 'Good job!';
     const status = 'ok';
-    const solution = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
+    const solutionId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
     const store = this.owner.lookup('service:store');
 
     // when
-    const correctionResponse = store.createRecord('correction-response', { feedback, status, solution });
+    const correctionResponse = store.createRecord('correction-response', { feedback, status, solutionId });
 
     // then
     assert.ok(correctionResponse);
     assert.strictEqual(correctionResponse.feedback, feedback);
     assert.strictEqual(correctionResponse.status, status);
-    assert.strictEqual(correctionResponse.solution, solution);
+    assert.strictEqual(correctionResponse.solutionId, solutionId);
     assert.true(correctionResponse.isOk);
   });
 });

--- a/mon-pix/tests/unit/models/modules/correction-response_test.js
+++ b/mon-pix/tests/unit/models/modules/correction-response_test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | Module | CorrectionResponse', function (hooks) {
+  setupTest(hooks);
+
+  test('CorrectionResponse model should exist with the right properties', function (assert) {
+    // given
+    const feedback = 'Good job!';
+    const status = 'ok';
+    const solution = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
+    const store = this.owner.lookup('service:store');
+
+    // when
+    const correctionResponse = store.createRecord('correction-response', { feedback, status, solution });
+
+    // then
+    assert.ok(correctionResponse);
+    assert.strictEqual(correctionResponse.feedback, feedback);
+    assert.strictEqual(correctionResponse.status, status);
+    assert.strictEqual(correctionResponse.solution, solution);
+    assert.true(correctionResponse.isOk);
+  });
+});

--- a/mon-pix/tests/unit/models/modules/module_test.js
+++ b/mon-pix/tests/unit/models/modules/module_test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | Module', function (hooks) {
+  setupTest(hooks);
+
+  test('Module model should exist with the right properties', function (assert) {
+    // given
+    const title = 'Bien écrire son adresse mail';
+    const store = this.owner.lookup('service:store');
+    const elementText = store.createRecord('text', { content: '' });
+    const elementQCU = store.createRecord('qcu', { instruction: '', proposals: [''] });
+    const elements = [elementText, elementQCU];
+
+    // when
+    const module = store.createRecord('module', { title, elements });
+
+    // then
+    assert.ok(module);
+    assert.strictEqual(module.title, title);
+    assert.strictEqual(module.elements.length, elements.length);
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1171,7 +1171,12 @@
     },
     "modulix": {
       "buttons": {
-        "continue": "Continue"
+        "activity": {
+          "verify": "Verify"
+        },
+        "grain": {
+          "continue": "Continue"
+        }
       },
       "qcu": {
         "direction": "Select one answer."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1171,7 +1171,12 @@
     },
     "modulix": {
       "buttons": {
-        "continue": "Continuer"
+        "activity": {
+          "verify": "Vérifier"
+        },
+        "grain": {
+          "continue": "Continuer"
+        }
       },
       "qcu": {
         "direction": "Choisissez une seule réponse."


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous affichons uniquement les QCU et l'utilisateur ne peut même pas vérifier sa réponse.

## :robot: Proposition
Nous ajoutons un bouton vérifier à chaque QCU qui appel la route POST `/modules/{moduleSlug}/elements/{elementId/answers`. Cette route nous renvoie une answer ainsi que sa correction qui contient un feedback que l'on affiche à l'utilisateur.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- [Se rendre sur Pix App `/modules/bien-ecrire-son-adresse-mail` ](https://app-pr7390.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
- Répondre à un QCU et appuyer sur Vérifier
- Constater que le feedback s'affiche bien
