### PR TITLE
[FEATURE] [API] Stocker des infos de l'utilisateur (claims de userInfo) lors d'une connexion SSO OIDC (PIX-9270)

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -116,7 +116,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   const values = {
     id,
     identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
-    authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
+    authenticationComplement: new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
       accessToken,
       refreshToken,
       expiredDate,

--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -136,9 +136,6 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   id = databaseBuffer.getNextId(),
   identityProvider,
   externalIdentifier,
-  accessToken = 'ABC789',
-  refreshToken = 'DEF753',
-  expiredDate = new Date('2022-01-01'),
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
@@ -152,11 +149,6 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   const values = {
     id,
     identityProvider,
-    authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
-      accessToken,
-      refreshToken,
-      expiredDate,
-    }),
     externalIdentifier: generatedIdentifier,
     userId,
     createdAt,

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -30,8 +30,7 @@ function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
     lastName: 'Emploi',
   });
 
-  databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+  databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
     userId: user.id,
   });
 }

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -75,9 +75,9 @@ const validationSchema = Joi.object({
     { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.object().instance(PixAuthenticationComplement).required() },
     { is: POLE_EMPLOI.code, then: Joi.object().instance(PoleEmploiOidcAuthenticationComplement).required() },
     { is: NON_OIDC_IDENTITY_PROVIDERS.GAR.code, then: Joi.any().empty() },
-    { is: CNAV.code, then: Joi.any().empty() },
-    { is: FWB.code, then: Joi.any().empty() },
-    { is: PAYSDELALOIRE.code, then: Joi.any().empty() },
+    { is: CNAV.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
+    { is: FWB.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
+    { is: PAYSDELALOIRE.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
   ]),
   externalIdentifier: Joi.when('identityProvider', [
     { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.any().forbidden() },

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -3,7 +3,13 @@ import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 import { validateEntity } from '../validators/entity-validator.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
-import { getValidOidcProviderCodes, POLE_EMPLOI, CNAV, FWB } from '../constants/oidc-identity-providers.js';
+import {
+  getValidOidcProviderCodes,
+  POLE_EMPLOI,
+  CNAV,
+  FWB,
+  PAYSDELALOIRE,
+} from '../constants/oidc-identity-providers.js';
 
 class PixAuthenticationComplement {
   constructor({ password, shouldChangePassword } = {}) {
@@ -63,6 +69,7 @@ const validationSchema = Joi.object({
     { is: NON_OIDC_IDENTITY_PROVIDERS.GAR.code, then: Joi.any().empty() },
     { is: CNAV.code, then: Joi.any().empty() },
     { is: FWB.code, then: Joi.any().empty() },
+    { is: PAYSDELALOIRE.code, then: Joi.any().empty() },
   ]),
   externalIdentifier: Joi.when('identityProvider', [
     { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.any().forbidden() },
@@ -70,6 +77,7 @@ const validationSchema = Joi.object({
     { is: POLE_EMPLOI.code, then: Joi.string().required() },
     { is: CNAV.code, then: Joi.string().required() },
     { is: FWB.code, then: Joi.string().required() },
+    { is: PAYSDELALOIRE.code, then: Joi.string().required() },
   ]),
   userId: Joi.number().integer().required(),
   createdAt: Joi.date().optional(),

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -26,11 +26,19 @@ class PixAuthenticationComplement {
   }
 }
 
-class PoleEmploiOidcAuthenticationComplement {
+class OidcAuthenticationComplement {
+  constructor(properties) {
+    validateEntity(Joi.object().required().min(1), properties);
+
+    Object.entries(properties).forEach(([key, value]) => {
+      this[key] = value;
+    });
+  }
+}
+
+class PoleEmploiOidcAuthenticationComplement extends OidcAuthenticationComplement {
   constructor({ accessToken, refreshToken, expiredDate } = {}) {
-    this.accessToken = accessToken;
-    this.refreshToken = refreshToken;
-    this.expiredDate = expiredDate;
+    super({ accessToken, refreshToken, expiredDate });
 
     validateEntity(
       Joi.object({
@@ -120,6 +128,7 @@ class AuthenticationMethod {
 }
 
 AuthenticationMethod.PixAuthenticationComplement = PixAuthenticationComplement;
+AuthenticationMethod.OidcAuthenticationComplement = OidcAuthenticationComplement;
 AuthenticationMethod.PoleEmploiOidcAuthenticationComplement = PoleEmploiOidcAuthenticationComplement;
 AuthenticationMethod.GARAuthenticationComplement = GARAuthenticationComplement;
 export { AuthenticationMethod };

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -26,7 +26,7 @@ class PixAuthenticationComplement {
   }
 }
 
-class OidcAuthenticationComplement {
+class PoleEmploiOidcAuthenticationComplement {
   constructor({ accessToken, refreshToken, expiredDate } = {}) {
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
@@ -65,7 +65,7 @@ const validationSchema = Joi.object({
     .required(),
   authenticationComplement: Joi.when('identityProvider', [
     { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.object().instance(PixAuthenticationComplement).required() },
-    { is: POLE_EMPLOI.code, then: Joi.object().instance(OidcAuthenticationComplement).required() },
+    { is: POLE_EMPLOI.code, then: Joi.object().instance(PoleEmploiOidcAuthenticationComplement).required() },
     { is: NON_OIDC_IDENTITY_PROVIDERS.GAR.code, then: Joi.any().empty() },
     { is: CNAV.code, then: Joi.any().empty() },
     { is: FWB.code, then: Joi.any().empty() },
@@ -120,6 +120,6 @@ class AuthenticationMethod {
 }
 
 AuthenticationMethod.PixAuthenticationComplement = PixAuthenticationComplement;
-AuthenticationMethod.OidcAuthenticationComplement = OidcAuthenticationComplement;
+AuthenticationMethod.PoleEmploiOidcAuthenticationComplement = PoleEmploiOidcAuthenticationComplement;
 AuthenticationMethod.GARAuthenticationComplement = GARAuthenticationComplement;
 export { AuthenticationMethod };

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -81,9 +81,9 @@ class OidcAuthenticationService {
       return;
     }
 
-    const requiredProperties = DEFAULT_REQUIRED_PROPERTIES;
+    const requiredProperties = Array.from(DEFAULT_REQUIRED_PROPERTIES);
     if (additionalRequiredProperties) {
-      requiredProperties.concat(additionalRequiredProperties);
+      requiredProperties.push(...additionalRequiredProperties);
     }
     const missingRequiredProperties = [];
     requiredProperties.forEach((requiredProperty) => {

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -22,10 +22,14 @@ import { temporaryStorage } from '../../../infrastructure/temporary-storage/inde
 
 const DEFAULT_REQUIRED_PROPERTIES = ['clientId', 'clientSecret', 'authenticationUrl', 'userInfoUrl', 'tokenUrl'];
 
+const DEFAULT_REQUIRED_CLAIMS = ['sub', 'family_name', 'given_name'];
+
 const defaultSessionTemporaryStorage = temporaryStorage.withPrefix('oidc-session:');
 
 class OidcAuthenticationService {
   #isReady = false;
+
+  #requiredClaims = Array.from(DEFAULT_REQUIRED_CLAIMS);
 
   constructor(
     {
@@ -67,8 +71,8 @@ class OidcAuthenticationService {
 
     if (!lodash.isEmpty(claimsToStore)) {
       this.claimsToStore = claimsToStore;
+      this.#requiredClaims.push(...claimsToStore);
     }
-
     this.sessionTemporaryStorage = sessionTemporaryStorage;
 
     if (!this.configKey) {
@@ -195,33 +199,46 @@ class OidcAuthenticationService {
   }
 
   async getUserInfo({ idToken, accessToken }) {
-    const { family_name, given_name, sub, nonce } = jsonwebtoken.decode(idToken);
-    let userInfo;
-
-    const isMandatoryUserInfoMissing = !family_name || !given_name || !sub;
-
-    if (isMandatoryUserInfoMissing) {
+    let userInfo = jsonwebtoken.decode(idToken);
+    const missingRequiredClaims = this.#findMissingRequiredClaims(userInfo);
+    if (missingRequiredClaims.length > 0) {
       userInfo = await this._getUserInfoFromEndpoint({ accessToken });
     }
 
-    return {
-      firstName: given_name || userInfo?.given_name,
-      lastName: family_name || userInfo?.family_name,
-      externalIdentityId: sub || userInfo?.sub,
-      nonce: nonce || userInfo?.nonce,
+    const pickedUserInfo = {
+      firstName: userInfo.given_name,
+      lastName: userInfo.family_name,
+      externalIdentityId: userInfo.sub,
+      nonce: userInfo.nonce,
     };
+
+    if (this.claimsToStore) {
+      this.claimsToStore.forEach((claim) => {
+        pickedUserInfo[claim] = userInfo[claim];
+      });
+    }
+
+    return pickedUserInfo;
   }
 
-  async createUserAccount({ user, externalIdentityId, userToCreateRepository, authenticationMethodRepository }) {
+  async createUserAccount({
+    user,
+    userInfo,
+    externalIdentityId,
+    userToCreateRepository,
+    authenticationMethodRepository,
+  }) {
     let createdUserId;
 
     await DomainTransaction.execute(async (domainTransaction) => {
       createdUserId = (await userToCreateRepository.create({ user, domainTransaction })).id;
 
+      const authenticationComplement = this.createAuthenticationComplement({ userInfo });
       const authenticationMethod = new AuthenticationMethod({
         identityProvider: this.identityProvider,
         userId: createdUserId,
         externalIdentifier: externalIdentityId,
+        authenticationComplement,
       });
       await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
     });
@@ -229,8 +246,15 @@ class OidcAuthenticationService {
     return createdUserId;
   }
 
-  createAuthenticationComplement() {
-    return null;
+  createAuthenticationComplement({ userInfo }) {
+    if (!this.claimsToStore) {
+      return undefined;
+    }
+
+    const claimsToStoreWithValues = Object.fromEntries(
+      Object.entries(userInfo).filter(([key, _value]) => this.claimsToStore.includes(key)),
+    );
+    return new AuthenticationMethod.OidcAuthenticationComplement(claimsToStoreWithValues);
   }
 
   async getRedirectLogoutUrl({ userId, logoutUrlUUID } = {}) {
@@ -273,7 +297,7 @@ class OidcAuthenticationService {
       const message = `Les informations utilisateur renvoyées par votre fournisseur d'identité ${this.organizationName} ne sont pas au format attendu.`;
       const dataToLog = {
         message,
-        typeOfuserInfo: typeof userInfo,
+        typeOfUserInfo: typeof userInfo,
         userInfo,
       };
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
@@ -284,13 +308,14 @@ class OidcAuthenticationService {
       throw new OidcUserInfoFormatError(message, error.code, meta);
     }
 
-    const userInfoMissingFields = this._getUserInfoMissingFields({ userInfo });
-    const message = `Un ou des champs obligatoires (${userInfoMissingFields}) n'ont pas été renvoyés par votre fournisseur d'identité ${this.organizationName}.`;
-
-    if (userInfoMissingFields) {
+    const missingRequiredClaims = this.#findMissingRequiredClaims(userInfo);
+    if (missingRequiredClaims.length > 0) {
+      const message = `Un ou des champs obligatoires (${missingRequiredClaims.join(
+        ',',
+      )}) n'ont pas été renvoyés par votre fournisseur d'identité ${this.organizationName}.`;
       monitoringTools.logErrorWithCorrelationIds({
         message,
-        missingFields: userInfoMissingFields,
+        missingFields: missingRequiredClaims.join(', '),
         userInfo,
       });
       const error = OIDC_ERRORS.USER_INFO.missingFields;
@@ -300,28 +325,29 @@ class OidcAuthenticationService {
       throw new OidcMissingFieldsError(message, error.code, meta);
     }
 
-    return {
-      given_name: userInfo?.given_name,
-      family_name: userInfo?.family_name,
-      sub: userInfo?.sub,
-      nonce: userInfo?.nonce,
+    const pickedUserInfo = {
+      given_name: userInfo.given_name,
+      family_name: userInfo.family_name,
+      sub: userInfo.sub,
+      nonce: userInfo.nonce,
     };
+
+    if (this.claimsToStore) {
+      this.claimsToStore.forEach((claim) => {
+        pickedUserInfo[claim] = userInfo[claim];
+      });
+    }
+
+    return pickedUserInfo;
   }
 
-  _getUserInfoMissingFields({ userInfo }) {
-    const missingFields = [];
-    if (!userInfo.family_name) {
-      missingFields.push('family_name');
-    }
-    if (!userInfo.given_name) {
-      missingFields.push('given_name');
-    }
-    if (!userInfo.sub) {
-      missingFields.push('sub');
-    }
-
-    const thereIsAtLeastOneRequiredMissingField = missingFields.length > 0;
-    return thereIsAtLeastOneRequiredMissingField ? `Champs manquants : ${missingFields.join(',')}` : false;
+  #findMissingRequiredClaims(userInfo) {
+    return this.#requiredClaims.reduce((missingRequiredClaims, requiredClaim) => {
+      if (!userInfo[requiredClaim]) {
+        missingRequiredClaims.push(requiredClaim);
+      }
+      return missingRequiredClaims;
+    }, []);
   }
 }
 

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -117,10 +117,6 @@ class OidcAuthenticationService {
     return jsonwebtoken.sign({ user_id: userId }, config.authentication.secret, this.jwtOptions);
   }
 
-  createAuthenticationComplement() {
-    return null;
-  }
-
   async saveIdToken({ idToken, userId } = {}) {
     if (!(this.endSessionUrl || this.hasLogoutUrl)) {
       return null;
@@ -231,6 +227,10 @@ class OidcAuthenticationService {
     });
 
     return createdUserId;
+  }
+
+  createAuthenticationComplement() {
+    return null;
   }
 
   async getRedirectLogoutUrl({ userId, logoutUrlUUID } = {}) {

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -102,7 +102,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   createAuthenticationComplement({ sessionContent }) {
-    return new AuthenticationMethod.OidcAuthenticationComplement({
+    return new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
       accessToken: sessionContent.accessToken,
       refreshToken: sessionContent.refreshToken,
       expiredDate: dayjs().add(sessionContent.expiresIn, 's').toDate(),

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -65,7 +65,6 @@ async function _updateAuthenticationMethodWithComplement({
     userInfo,
     sessionContent,
   });
-  if (!authenticationComplement) return;
 
   return await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
     authenticationComplement,

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -55,12 +55,16 @@ const authenticateOidcUser = async function ({
 export { authenticateOidcUser };
 
 async function _updateAuthenticationMethodWithComplement({
+  userInfo,
   userId,
   sessionContent,
   oidcAuthenticationService,
   authenticationMethodRepository,
 }) {
-  const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({ sessionContent });
+  const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({
+    userInfo,
+    sessionContent,
+  });
   if (!authenticationComplement) return;
 
   return await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({

--- a/api/lib/domain/usecases/create-oidc-user.js
+++ b/api/lib/domain/usecases/create-oidc-user.js
@@ -37,6 +37,7 @@ const createOidcUser = async function ({
 
   const userId = await oidcAuthenticationService.createUserAccount({
     user,
+    userInfo,
     sessionContent,
     externalIdentityId: userInfo.externalIdentityId,
     userToCreateRepository,

--- a/api/lib/domain/usecases/reconcile-oidc-user.js
+++ b/api/lib/domain/usecases/reconcile-oidc-user.js
@@ -20,7 +20,10 @@ const reconcileOidcUser = async function ({
 
   const { userId, externalIdentityId } = userInfo;
 
-  const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({ sessionContent });
+  const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({
+    userInfo,
+    sessionContent,
+  });
   await authenticationMethodRepository.create({
     authenticationMethod: new AuthenticationMethod({
       identityProvider: oidcAuthenticationService.identityProvider,

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -66,7 +66,7 @@ const notify = async (userId, payload, dependencies) => {
     }
 
     accessToken = tokenResponse.data['access_token'];
-    const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+    const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
       accessToken,
       refreshToken: tokenResponse.data['refresh_token'],
       expiredDate: moment().add(tokenResponse.data['expires_in'], 's').toDate(),

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -289,7 +289,7 @@ function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationCo
   }
 
   if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.code) {
-    return new AuthenticationMethod.OidcAuthenticationComplement(bookshelfAuthenticationComplement);
+    return new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement(bookshelfAuthenticationComplement);
   }
 
   if (identityProvider === NON_OIDC_IDENTITY_PROVIDERS.GAR.code) {

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -572,6 +572,10 @@ function _getAuthenticationComplementAndExternalIdentifier(authenticationMethodB
       refreshToken: authenticationComplement.refreshToken,
       expiredDate: authenticationComplement.expiredDate,
     });
+  } else if (OidcIdentityProviders.getValidOidcProviderCodes().includes(identityProvider)) {
+    if (authenticationComplement) {
+      authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement(authenticationComplement);
+    }
   }
 
   return { authenticationComplement, externalIdentifier };

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -567,7 +567,7 @@ function _getAuthenticationComplementAndExternalIdentifier(authenticationMethodB
     });
     externalIdentifier = undefined;
   } else if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.code) {
-    authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+    authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
       accessToken: authenticationComplement.accessToken,
       refreshToken: authenticationComplement.refreshToken,
       expiredDate: authenticationComplement.expiredDate,

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -109,8 +109,7 @@ describe('Acceptance | Route | oidc | token', function () {
         lastName,
       }).id;
 
-      databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
         externalIdentifier,
         accessToken: 'access_token',
         refreshToken: 'refresh_token',
@@ -163,8 +162,7 @@ describe('Acceptance | Route | oidc | token', function () {
           lastName,
         }).id;
 
-        databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           externalIdentifier,
           accessToken: 'access_token',
           refreshToken: 'refresh_token',
@@ -257,8 +255,7 @@ describe('Acceptance | Route | oidc | token', function () {
               lastName,
             }).id;
 
-            databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-              identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+            databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
               externalIdentifier,
               accessToken: 'access_token',
               refreshToken: 'refresh_token',

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -354,7 +354,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
 
         // then
         expect(pixAuthenticationMethod.authenticationComplement).to.deep.equal(
-          new AuthenticationMethod.OidcAuthenticationComplement({
+          new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
             accessToken: 'AGENCENATIONALEPOURLEMPLOI',
             refreshToken: 'FRANCETRAVAIL',
             expiredDate: '2021-01-01T00:00:00.000Z',
@@ -804,7 +804,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // given
         const userId = authenticationMethod.userId;
         const expiredDate = Date.now();
-        const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+        const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
           accessToken: 'new_access_token',
           refreshToken: 'new_refresh_token',
           expiredDate,
@@ -830,7 +830,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // given
         const userId = authenticationMethod.userId;
         const expiredDate = Date.now();
-        const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+        const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
           accessToken: 'new_access_token',
           refreshToken: 'new_refresh_token',
           expiredDate,

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -785,9 +785,8 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       beforeEach(function () {
         clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
         const userId = databaseBuilder.factory.buildUser().id;
-        authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+        authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           id: 123,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
           externalIdentifier: 'identifier',
           accessToken: 'to_be_updated',
           refreshToken: 'to_be_updated',

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -87,25 +87,51 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
   describe('find user', function () {
     describe('#findByExternalIdentifier', function () {
-      it('should return user informations for the given external identity id and identity provider', async function () {
-        // given
-        const externalIdentityId = 'external-identity-id';
-        const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
-          externalIdentifier: externalIdentityId,
-          userId,
-        });
-        await databaseBuilder.commit();
+      context('when identityProvider is generic', function () {
+        it('should return user informations for the given external identity id and identity provider', async function () {
+          // given
+          const externalIdentityId = 'external-identity-id';
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+            externalIdentifier: externalIdentityId,
+            identityProvider: OidcIdentityProviders.PAYSDELALOIRE.code,
+            userId,
+          });
+          await databaseBuilder.commit();
 
-        // when
-        const foundUser = await userRepository.findByExternalIdentifier({
-          externalIdentityId,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
-        });
+          // when
+          const foundUser = await userRepository.findByExternalIdentifier({
+            externalIdentityId,
+            identityProvider: OidcIdentityProviders.PAYSDELALOIRE.code,
+          });
 
-        // then
-        expect(foundUser).to.be.an.instanceof(User);
-        expect(foundUser.id).to.equal(userId);
+          // then
+          expect(foundUser).to.be.an.instanceof(User);
+          expect(foundUser.id).to.equal(userId);
+        });
+      });
+
+      context('when identityProvider is POLE_EMPLOI', function () {
+        it('should return user informations for the given external identity id and identity provider', async function () {
+          // given
+          const externalIdentityId = 'external-identity-id';
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+            externalIdentifier: externalIdentityId,
+            userId,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const foundUser = await userRepository.findByExternalIdentifier({
+            externalIdentityId,
+            identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          });
+
+          // then
+          expect(foundUser).to.be.an.instanceof(User);
+          expect(foundUser.id).to.equal(userId);
+        });
       });
 
       it('should return undefined when no user was found with this external identity id', async function () {

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -110,7 +110,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   return new AuthenticationMethod({
     id,
     identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
-    authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
+    authenticationComplement: new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
       accessToken,
       refreshToken,
       expiredDate,

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -126,9 +126,6 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   id,
   identityProvider,
   externalIdentifier = `externalId${id}`,
-  accessToken = 'ABC456789',
-  refreshToken = 'ZFGEADZA789',
-  expiredDate = new Date('2022-01-01'),
   userId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-02-01'),
@@ -138,11 +135,6 @@ buildAuthenticationMethod.withIdentityProvider = function ({
   return new AuthenticationMethod({
     id,
     identityProvider,
-    authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
-      accessToken,
-      refreshToken,
-      expiredDate,
-    }),
     externalIdentifier,
     userId,
     createdAt,

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -59,7 +59,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
 
     it('should successfully instantiate object when identityProvider is POLE_EMPLOI and externalIdentifier and authenticationComplements are defined', function () {
       // given
-      const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+      const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
         expiredDate: Date.now(),
@@ -213,7 +213,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       });
     });
 
-    context('OidcAuthenticationComplement', function () {
+    context('PoleEmploiOidcAuthenticationComplement', function () {
       let validArguments;
       beforeEach(function () {
         validArguments = {
@@ -225,7 +225,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
 
       it('should successfully instantiate object when passing all valid arguments', function () {
         // when
-        expect(() => new AuthenticationMethod.OidcAuthenticationComplement(validArguments)).not.to.throw(
+        expect(() => new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement(validArguments)).not.to.throw(
           ObjectValidationError,
         );
       });
@@ -233,27 +233,41 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       it('should throw an ObjectValidationError when accessToken is not valid', function () {
         // when
         expect(
-          () => new AuthenticationMethod.OidcAuthenticationComplement({ ...validArguments, accessToken: 1234 }),
+          () =>
+            new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({ ...validArguments, accessToken: 1234 }),
         ).to.throw(ObjectValidationError);
         expect(
-          () => new AuthenticationMethod.OidcAuthenticationComplement({ ...validArguments, accessToken: undefined }),
+          () =>
+            new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+              ...validArguments,
+              accessToken: undefined,
+            }),
         ).to.throw(ObjectValidationError);
       });
 
       it('should throw an ObjectValidationError when refreshToken is not valid', function () {
         // when
         expect(
-          () => new AuthenticationMethod.OidcAuthenticationComplement({ ...validArguments, refreshToken: 1234 }),
+          () =>
+            new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({ ...validArguments, refreshToken: 1234 }),
         ).to.throw(ObjectValidationError);
       });
 
       it('should throw an ObjectValidationError when expiredDate is not valid', function () {
         // when
         expect(
-          () => new AuthenticationMethod.OidcAuthenticationComplement({ ...validArguments, expiredDate: 'not_valid' }),
+          () =>
+            new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+              ...validArguments,
+              expiredDate: 'not_valid',
+            }),
         ).to.throw(ObjectValidationError);
         expect(
-          () => new AuthenticationMethod.OidcAuthenticationComplement({ ...validArguments, expiredDate: undefined }),
+          () =>
+            new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+              ...validArguments,
+              expiredDate: undefined,
+            }),
         ).to.throw(ObjectValidationError);
       });
     });

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -213,6 +213,25 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       });
     });
 
+    context('OidcAuthenticationComplement', function () {
+      it('cannot be created without properties', function () {
+        // when
+        expect(() => new AuthenticationMethod.OidcAuthenticationComplement()).to.throw(ObjectValidationError);
+        expect(() => new AuthenticationMethod.OidcAuthenticationComplement({})).to.throw(ObjectValidationError);
+      });
+
+      it('can hold any properties', function () {
+        // given
+        const properties = { family_name: 'AAAAA', given_name: 'BBBBBB' };
+
+        // when
+        const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement(properties);
+
+        // then
+        expect(authenticationComplement).to.be.instanceOf(Object);
+      });
+    });
+
     context('PoleEmploiOidcAuthenticationComplement', function () {
       let validArguments;
       beforeEach(function () {

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -272,7 +272,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
       // when
       const response = oidcAuthenticationService._getUserInfoMissingFields({
-        userInfoContent: {
+        userInfo: {
           given_name: 'givenName',
           family_name: undefined,
           nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
@@ -290,7 +290,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
       // when
       const response = oidcAuthenticationService._getUserInfoMissingFields({
-        userInfoContent: {
+        userInfo: {
           given_name: 'givenName',
           family_name: 'familyName',
           nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
@@ -675,8 +675,8 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
           message: {
             message: `Les informations utilisateur renvoyées par votre fournisseur d'identité ${organizationName} ne sont pas au format attendu.`,
-            typeOfUserInfoContent: 'string',
-            userInfoContent: '',
+            typeOfuserInfo: 'string',
+            userInfo: '',
           },
         });
       });
@@ -722,7 +722,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
           message: errorMessage,
           missingFields: 'Champs manquants : family_name',
-          userInfoContent: {
+          userInfo: {
             given_name: 'givenName',
             family_name: undefined,
             nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -17,6 +17,7 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import { UserToCreate } from '../../../../../lib/domain/models/UserToCreate.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
 import * as OidcIdentityProviders from '../../../../../lib/domain/constants/oidc-identity-providers.js';
+import { logger } from '../../../../../lib/infrastructure/logger.js';
 import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { OIDC_ERRORS } from '../../../../../lib/domain/constants.js';
 
@@ -106,17 +107,24 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         describe('when config is invalid', function () {
           it('returns false', function () {
             // given
+            sinon.stub(logger, 'error');
+
             settings.someOidcProviderService = {
               isEnabled: true,
             };
             const oidcAuthenticationService = new OidcAuthenticationService({
               configKey: 'someOidcProviderService',
+              identityProvider: 'Example OP code',
+              additionalRequiredProperties: ['exampleProperty'],
             });
 
             // when
             const result = oidcAuthenticationService.isReady;
 
             // then
+            expect(logger.error).to.have.been.calledWithExactly(
+              'Invalid config for OIDC Provider "Example OP code": the following required properties are missing: clientId, clientSecret, authenticationUrl, userInfoUrl, tokenUrl, exampleProperty',
+            );
             expect(result).to.be.false;
           });
         });

--- a/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -66,7 +66,7 @@ describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', f
       const result = poleEmploiOidcAuthenticationService.createAuthenticationComplement({ sessionContent });
 
       // then
-      expect(result).to.be.instanceOf(AuthenticationMethod.OidcAuthenticationComplement);
+      expect(result).to.be.instanceOf(AuthenticationMethod.PoleEmploiOidcAuthenticationComplement);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -182,7 +182,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
     context('when user has an account', function () {
       context('when the provider does not have an authentication complement', function () {
-        it('does not update the authentication method', async function () {
+        it('updates the authentication method', async function () {
           // given
           _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
           userRepository.findByExternalIdentifier.resolves({ id: 10 });
@@ -201,8 +201,13 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           });
 
           // then
-          expect(authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider).not.to.have
-            .been.called;
+          expect(
+            authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
+          ).to.have.been.calledWithExactly({
+            authenticationComplement,
+            userId: 10,
+            identityProvider: oidcAuthenticationService.identityProvider,
+          });
         });
       });
 

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -1,144 +1,76 @@
 import { expect, sinon, catchErr } from '../../../../test-helper.js';
-import { UnexpectedOidcStateError } from '../../../../../lib/domain/errors.js';
+
+import { PAYSDELALOIRE, POLE_EMPLOI } from '../../../../../lib/domain/constants/oidc-identity-providers.js';
+
 import { logger } from '../../../../../lib/infrastructure/logger.js';
+
+import { UnexpectedOidcStateError } from '../../../../../lib/domain/errors.js';
 import { authenticateOidcUser } from '../../../../../lib/domain/usecases/authentication/authenticate-oidc-user.js';
 import { AuthenticationSessionContent } from '../../../../../lib/domain/models/AuthenticationSessionContent.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
-import * as OidcIdentityProviders from '../../../../../lib/domain/constants/oidc-identity-providers.js';
 
 describe('Unit | UseCase | authenticate-oidc-user', function () {
-  let oidcAuthenticationService;
-  let authenticationSessionService;
-  let authenticationMethodRepository;
-  let userRepository;
-  let userLoginRepository;
-  const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
+  context('when identityProvider is generic', function () {
+    let oidcAuthenticationService;
+    let authenticationSessionService;
+    let authenticationMethodRepository;
+    let userRepository;
+    let userLoginRepository;
+    const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
 
-  beforeEach(function () {
-    oidcAuthenticationService = {
-      identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
-      createAccessToken: sinon.stub(),
-      saveIdToken: sinon.stub(),
-      createAuthenticationComplement: sinon.stub(),
-      exchangeCodeForTokens: sinon.stub(),
-      getUserInfo: sinon.stub(),
-    };
+    beforeEach(function () {
+      oidcAuthenticationService = {
+        identityProvider: PAYSDELALOIRE.code,
+        createAccessToken: sinon.stub(),
+        saveIdToken: sinon.stub(),
+        createAuthenticationComplement: sinon.stub(),
+        exchangeCodeForTokens: sinon.stub(),
+        getUserInfo: sinon.stub(),
+      };
 
-    authenticationMethodRepository = {
-      updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
-    };
+      authenticationMethodRepository = {
+        updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
+      };
 
-    authenticationSessionService = {
-      save: sinon.stub(),
-    };
+      authenticationSessionService = {
+        save: sinon.stub(),
+      };
 
-    userRepository = { findByExternalIdentifier: sinon.stub() };
-    userLoginRepository = {
-      updateLastLoggedAt: sinon.stub().resolves(),
-    };
-  });
+      userRepository = { findByExternalIdentifier: sinon.stub() };
+      userLoginRepository = {
+        updateLastLoggedAt: sinon.stub().resolves(),
+      };
+    });
 
-  context('When the request state does not match the response state', function () {
-    it('should throw an UnexpectedOidcStateError', async function () {
-      // given
-      const stateSent = 'stateSent';
-      const stateReceived = 'stateReceived';
-      sinon.stub(logger, 'error');
+    context('when the request state does not match the response state', function () {
+      it('throws an UnexpectedOidcStateError', async function () {
+        // given
+        const stateSent = 'stateSent';
+        const stateReceived = 'stateReceived';
+        sinon.stub(logger, 'error');
 
-      // when
-      const error = await catchErr(authenticateOidcUser)({
-        stateReceived,
-        stateSent,
+        // when
+        const error = await catchErr(authenticateOidcUser)({
+          stateReceived,
+          stateSent,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(UnexpectedOidcStateError);
+        expect(logger.error).to.have.been.calledWithExactly(
+          `State sent ${stateSent} did not match the state received ${stateReceived}`,
+        );
       });
-
-      // then
-      expect(error).to.be.an.instanceOf(UnexpectedOidcStateError);
-      expect(logger.error).to.have.been.calledWithExactly(
-        `State sent ${stateSent} did not match the state received ${stateReceived}`,
-      );
-    });
-  });
-
-  it('should retrieve authentication token', async function () {
-    // given
-    _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-
-    // when
-    await authenticateOidcUser({
-      code: 'code',
-      redirectUri: 'redirectUri',
-      stateReceived: 'state',
-      stateSent: 'state',
-      oidcAuthenticationService,
-      authenticationSessionService,
-      authenticationMethodRepository,
-      userRepository,
-      userLoginRepository,
     });
 
-    // then
-    expect(oidcAuthenticationService.exchangeCodeForTokens).to.have.been.calledOnceWithExactly({
-      code: 'code',
-      redirectUri: 'redirectUri',
-    });
-  });
-
-  it('should retrieve user info', async function () {
-    // given
-    const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-
-    // when
-    await authenticateOidcUser({
-      stateReceived: 'state',
-      stateSent: 'state',
-      oidcAuthenticationService,
-      authenticationSessionService,
-      authenticationMethodRepository,
-      userRepository,
-      userLoginRepository,
-    });
-
-    // then
-    expect(oidcAuthenticationService.getUserInfo).to.have.been.calledWithExactly({
-      idToken: sessionContent.idToken,
-      accessToken: sessionContent.accessToken,
-    });
-  });
-
-  it('should retrieve user with matching external id and identity provider', async function () {
-    // given
-    _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-
-    // when
-    await authenticateOidcUser({
-      stateReceived: 'state',
-      stateSent: 'state',
-      oidcAuthenticationService,
-      authenticationSessionService,
-      authenticationMethodRepository,
-      userRepository,
-      userLoginRepository,
-    });
-
-    // then
-    expect(userRepository.findByExternalIdentifier).to.have.been.calledWithExactly({
-      externalIdentityId,
-      identityProvider: oidcAuthenticationService.identityProvider,
-    });
-  });
-
-  context('When user does not have an account', function () {
-    it('should save the authentication session and return the authentication key', async function () {
+    it('retrieves authentication token', async function () {
       // given
-      const sessionContent = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-      const authenticationKey = 'aaa-bbb-ccc';
-      const givenName = 'Mélusine';
-      const familyName = 'TITEGOUTTE';
-      authenticationSessionService.save.resolves(authenticationKey);
-      userRepository.findByExternalIdentifier.resolves(null);
+      _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
 
       // when
-      const result = await authenticateOidcUser({
+      await authenticateOidcUser({
+        code: 'code',
+        redirectUri: 'redirectUri',
         stateReceived: 'state',
         stateSent: 'state',
         oidcAuthenticationService,
@@ -149,14 +81,15 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       });
 
       // then
-      expect(authenticationSessionService.save).to.have.been.calledWithExactly(sessionContent);
-      expect(result).to.deep.equal({ authenticationKey, givenName, familyName, isAuthenticationComplete: false });
+      expect(oidcAuthenticationService.exchangeCodeForTokens).to.have.been.calledOnceWithExactly({
+        code: 'code',
+        redirectUri: 'redirectUri',
+      });
     });
 
-    it('should not create an access token, save the id token in storage, or update the last logged date', async function () {
+    it('retrieves user info', async function () {
       // given
-      _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-      userRepository.findByExternalIdentifier.resolves(null);
+      const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
 
       // when
       await authenticateOidcUser({
@@ -170,19 +103,64 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       });
 
       // then
-      expect(oidcAuthenticationService.saveIdToken).to.not.have.been.called;
-      expect(oidcAuthenticationService.createAccessToken).to.not.have.been.called;
-      expect(userLoginRepository.updateLastLoggedAt).to.not.have.been.called;
+      expect(oidcAuthenticationService.getUserInfo).to.have.been.calledWithExactly({
+        idToken: sessionContent.idToken,
+        accessToken: sessionContent.accessToken,
+      });
     });
-  });
 
-  context('When user has an account', function () {
-    context('When the provider does not have an authentication complement', function () {
-      it('should not update authentication method', async function () {
+    it('retrieves user with matching external id and identity provider', async function () {
+      // given
+      _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+
+      // when
+      await authenticateOidcUser({
+        stateReceived: 'state',
+        stateSent: 'state',
+        oidcAuthenticationService,
+        authenticationSessionService,
+        authenticationMethodRepository,
+        userRepository,
+        userLoginRepository,
+      });
+
+      // then
+      expect(userRepository.findByExternalIdentifier).to.have.been.calledWithExactly({
+        externalIdentityId,
+        identityProvider: oidcAuthenticationService.identityProvider,
+      });
+    });
+
+    context('when user does not have an account', function () {
+      it('saves the authentication session and returns the authentication key', async function () {
+        // given
+        const sessionContent = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+        const authenticationKey = 'aaa-bbb-ccc';
+        const givenName = 'Mélusine';
+        const familyName = 'TITEGOUTTE';
+        authenticationSessionService.save.resolves(authenticationKey);
+        userRepository.findByExternalIdentifier.resolves(null);
+
+        // when
+        const result = await authenticateOidcUser({
+          stateReceived: 'state',
+          stateSent: 'state',
+          oidcAuthenticationService,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          userRepository,
+          userLoginRepository,
+        });
+
+        // then
+        expect(authenticationSessionService.save).to.have.been.calledWithExactly(sessionContent);
+        expect(result).to.deep.equal({ authenticationKey, givenName, familyName, isAuthenticationComplete: false });
+      });
+
+      it('does not create an access token, nor saves the id token in storage, nor updates the last logged date', async function () {
         // given
         _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-        userRepository.findByExternalIdentifier.resolves({ id: 10 });
-        oidcAuthenticationService.createAuthenticationComplement.returns(null);
+        userRepository.findByExternalIdentifier.resolves(null);
 
         // when
         await authenticateOidcUser({
@@ -196,16 +174,147 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         });
 
         // then
-        expect(authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider).not.to.have
-          .been.called;
+        expect(oidcAuthenticationService.saveIdToken).to.not.have.been.called;
+        expect(oidcAuthenticationService.createAccessToken).to.not.have.been.called;
+        expect(userLoginRepository.updateLastLoggedAt).to.not.have.been.called;
       });
     });
 
-    context('When the provider has an authentication complement', function () {
-      it('should update authentication method', async function () {
+    context('when user has an account', function () {
+      context('when the provider does not have an authentication complement', function () {
+        it('does not update the authentication method', async function () {
+          // given
+          _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+          userRepository.findByExternalIdentifier.resolves({ id: 10 });
+          oidcAuthenticationService.createAuthenticationComplement.returns(null);
+
+          // when
+          await authenticateOidcUser({
+            stateReceived: 'state',
+            stateSent: 'state',
+            oidcAuthenticationService,
+            authenticationSessionService,
+            authenticationMethodRepository,
+            userRepository,
+            userLoginRepository,
+          });
+
+          // then
+          expect(authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider).not.to.have
+            .been.called;
+        });
+      });
+    });
+  });
+
+  context('when identityProvider is POLE_EMPLOI', function () {
+    let oidcAuthenticationService;
+    let authenticationSessionService;
+    let authenticationMethodRepository;
+    let userRepository;
+    let userLoginRepository;
+    const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
+
+    beforeEach(function () {
+      oidcAuthenticationService = {
+        identityProvider: POLE_EMPLOI.code,
+        createAccessToken: sinon.stub(),
+        saveIdToken: sinon.stub(),
+        createAuthenticationComplement: sinon.stub(),
+        exchangeCodeForTokens: sinon.stub(),
+        getUserInfo: sinon.stub(),
+      };
+
+      authenticationMethodRepository = {
+        updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
+      };
+
+      authenticationSessionService = {
+        save: sinon.stub(),
+      };
+
+      userRepository = { findByExternalIdentifier: sinon.stub() };
+      userLoginRepository = {
+        updateLastLoggedAt: sinon.stub().resolves(),
+      };
+    });
+
+    context('when user has an account', function () {
+      context('when the provider has an authentication complement', function () {
+        it('updates the authentication method', async function () {
+          // given
+          const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+          userRepository.findByExternalIdentifier.resolves({ id: 1 });
+          const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+            accessToken: sessionContent.accessToken,
+            refreshToken: sessionContent.refreshToken,
+            expiredDate: new Date(),
+          });
+          oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
+
+          // when
+          await authenticateOidcUser({
+            stateReceived: 'state',
+            stateSent: 'state',
+            oidcAuthenticationService,
+            authenticationSessionService,
+            authenticationMethodRepository,
+            userRepository,
+            userLoginRepository,
+          });
+
+          // then
+          expect(
+            authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
+          ).to.have.been.calledWithExactly({
+            authenticationComplement,
+            userId: 1,
+            identityProvider: oidcAuthenticationService.identityProvider,
+          });
+        });
+      });
+
+      it('returns an access token, the logout url uuid and update the last logged date with the existing external user id', async function () {
         // given
         const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-        userRepository.findByExternalIdentifier.resolves({ id: 1 });
+        userRepository.findByExternalIdentifier
+          .withArgs({ externalIdentityId, identityProvider: oidcAuthenticationService.identityProvider })
+          .resolves({ id: 10 });
+        oidcAuthenticationService.createAuthenticationComplement.returns(null);
+        oidcAuthenticationService.createAccessToken.withArgs(10).returns('accessTokenForExistingExternalUser');
+        oidcAuthenticationService.saveIdToken
+          .withArgs({ idToken: sessionContent.idToken, userId: 10 })
+          .resolves('logoutUrlUUID');
+
+        // when
+        const accessToken = await authenticateOidcUser({
+          stateReceived: 'state',
+          stateSent: 'state',
+          oidcAuthenticationService,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          userRepository,
+          userLoginRepository,
+        });
+
+        // then
+        sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
+        sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
+        expect(accessToken).to.deep.equal({
+          pixAccessToken: 'accessTokenForExistingExternalUser',
+          logoutUrlUUID: 'logoutUrlUUID',
+          isAuthenticationComplete: true,
+        });
+      });
+    });
+
+    context('when user is logged with their pix account but also has a separate oidc account', function () {
+      it('updates the oidc authentication method', async function () {
+        // given
+        const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+        userRepository.findByExternalIdentifier
+          .withArgs({ externalIdentityId, identityProvider: oidcAuthenticationService.identityProvider })
+          .resolves({ id: 10 });
         const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
           accessToken: sessionContent.accessToken,
           refreshToken: sessionContent.refreshToken,
@@ -229,78 +338,9 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
         ).to.have.been.calledWithExactly({
           authenticationComplement,
-          userId: 1,
+          userId: 10,
           identityProvider: oidcAuthenticationService.identityProvider,
         });
-      });
-    });
-
-    it('should return an access token, the logout url uuid and update the last logged date with the existing external user id', async function () {
-      // given
-      const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-      userRepository.findByExternalIdentifier
-        .withArgs({ externalIdentityId, identityProvider: oidcAuthenticationService.identityProvider })
-        .resolves({ id: 10 });
-      oidcAuthenticationService.createAuthenticationComplement.returns(null);
-      oidcAuthenticationService.createAccessToken.withArgs(10).returns('accessTokenForExistingExternalUser');
-      oidcAuthenticationService.saveIdToken
-        .withArgs({ idToken: sessionContent.idToken, userId: 10 })
-        .resolves('logoutUrlUUID');
-
-      // when
-      const accessToken = await authenticateOidcUser({
-        stateReceived: 'state',
-        stateSent: 'state',
-        oidcAuthenticationService,
-        authenticationSessionService,
-        authenticationMethodRepository,
-        userRepository,
-        userLoginRepository,
-      });
-
-      // then
-      sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-      sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
-      expect(accessToken).to.deep.equal({
-        pixAccessToken: 'accessTokenForExistingExternalUser',
-        logoutUrlUUID: 'logoutUrlUUID',
-        isAuthenticationComplete: true,
-      });
-    });
-  });
-
-  context('When user is logged with their pix account but also has a separate oidc account', function () {
-    it('should update the oidc authentication method', async function () {
-      // given
-      const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-      userRepository.findByExternalIdentifier
-        .withArgs({ externalIdentityId, identityProvider: oidcAuthenticationService.identityProvider })
-        .resolves({ id: 10 });
-      const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
-        accessToken: sessionContent.accessToken,
-        refreshToken: sessionContent.refreshToken,
-        expiredDate: new Date(),
-      });
-      oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
-
-      // when
-      await authenticateOidcUser({
-        stateReceived: 'state',
-        stateSent: 'state',
-        oidcAuthenticationService,
-        authenticationSessionService,
-        authenticationMethodRepository,
-        userRepository,
-        userLoginRepository,
-      });
-
-      // then
-      expect(
-        authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
-      ).to.have.been.calledWithExactly({
-        authenticationComplement,
-        userId: 10,
-        identityProvider: oidcAuthenticationService.identityProvider,
       });
     });
   });

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -206,7 +206,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         // given
         const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
         userRepository.findByExternalIdentifier.resolves({ id: 1 });
-        const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+        const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
           accessToken: sessionContent.accessToken,
           refreshToken: sessionContent.refreshToken,
           expiredDate: new Date(),
@@ -276,7 +276,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       userRepository.findByExternalIdentifier
         .withArgs({ externalIdentityId, identityProvider: oidcAuthenticationService.identityProvider })
         .resolves({ id: 10 });
-      const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+      const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
         accessToken: sessionContent.accessToken,
         refreshToken: sessionContent.refreshToken,
         expiredDate: new Date(),

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
@@ -28,11 +28,12 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       sessionContent,
       userInfo: { userId: 1, externalIdentityId: 'external_id', firstName: 'Anne' },
     });
-    oidcAuthenticationService.createAuthenticationComplement
-      .withArgs({ sessionContent })
-      .returns(
-        new AuthenticationMethod.OidcAuthenticationComplement({ accessToken: 'accessToken', expiredDate: new Date() }),
-      );
+    oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
+      new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+        accessToken: 'accessToken',
+        expiredDate: new Date(),
+      }),
+    );
 
     // when
     await reconcileOidcUser({
@@ -56,11 +57,12 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       sessionContent,
       userInfo: { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' },
     });
-    oidcAuthenticationService.createAuthenticationComplement
-      .withArgs({ sessionContent })
-      .returns(
-        new AuthenticationMethod.OidcAuthenticationComplement({ accessToken: 'accessToken', expiredDate: new Date() }),
-      );
+    oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
+      new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+        accessToken: 'accessToken',
+        expiredDate: new Date(),
+      }),
+    );
 
     // when
     await reconcileOidcUser({
@@ -76,7 +78,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
     const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
     expect(authenticationMethod).to.deep.contain({ identityProvider, externalIdentifier, userId });
     expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
-      AuthenticationMethod.OidcAuthenticationComplement,
+      AuthenticationMethod.PoleEmploiOidcAuthenticationComplement,
     );
   });
 
@@ -89,11 +91,12 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       sessionContent,
       userInfo: { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' },
     });
-    oidcAuthenticationService.createAuthenticationComplement
-      .withArgs({ sessionContent })
-      .returns(
-        new AuthenticationMethod.OidcAuthenticationComplement({ accessToken: 'accessToken', expiredDate: new Date() }),
-      );
+    oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
+      new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+        accessToken: 'accessToken',
+        expiredDate: new Date(),
+      }),
+    );
     oidcAuthenticationService.createAccessToken.withArgs(userId).returns('accessToken');
     oidcAuthenticationService.saveIdToken
       .withArgs({ idToken: sessionContent.idToken, userId })

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
@@ -1,155 +1,64 @@
 import { expect, sinon, catchErr } from '../../../test-helper.js';
+
+import { PAYSDELALOIRE, POLE_EMPLOI } from '../../../../lib/domain/constants/oidc-identity-providers.js';
+
 import { reconcileOidcUser } from '../../../../lib/domain/usecases/reconcile-oidc-user.js';
 import { AuthenticationKeyExpired, MissingUserAccountError } from '../../../../lib/domain/errors.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
 
 describe('Unit | UseCase | reconcile-oidc-user', function () {
-  let authenticationMethodRepository, userLoginRepository, authenticationSessionService, oidcAuthenticationService;
-  const identityProvider = 'POLE_EMPLOI';
+  context('when identityProvider is generic', function () {
+    let identityProvider;
+    let authenticationMethodRepository;
+    let userLoginRepository;
+    let authenticationSessionService;
+    let oidcAuthenticationService;
 
-  beforeEach(function () {
-    authenticationMethodRepository = { create: sinon.stub() };
-    userLoginRepository = {
-      updateLastLoggedAt: sinon.stub(),
-    };
-    authenticationSessionService = { getByKey: sinon.stub() };
-    oidcAuthenticationService = {
-      identityProvider,
-      createAccessToken: sinon.stub(),
-      saveIdToken: sinon.stub(),
-      createAuthenticationComplement: sinon.stub(),
-    };
-  });
-
-  it('should retrieve user session content', async function () {
-    // given
-    const sessionContent = { idToken: 'idToken' };
-    authenticationSessionService.getByKey.resolves({
-      sessionContent,
-      userInfo: { userId: 1, externalIdentityId: 'external_id', firstName: 'Anne' },
-    });
-    oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
-      new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
-        accessToken: 'accessToken',
-        expiredDate: new Date(),
-      }),
-    );
-
-    // when
-    await reconcileOidcUser({
-      authenticationKey: 'authenticationKey',
-      oidcAuthenticationService,
-      authenticationSessionService,
-      authenticationMethodRepository,
-      userLoginRepository,
+    beforeEach(function () {
+      identityProvider = PAYSDELALOIRE.code;
+      authenticationMethodRepository = { create: sinon.stub() };
+      userLoginRepository = {
+        updateLastLoggedAt: sinon.stub(),
+      };
+      authenticationSessionService = { getByKey: sinon.stub() };
+      oidcAuthenticationService = {
+        identityProvider,
+        createAccessToken: sinon.stub(),
+        saveIdToken: sinon.stub(),
+        createAuthenticationComplement: sinon.stub(),
+      };
     });
 
-    // then
-    expect(authenticationSessionService.getByKey).to.be.calledOnceWith('authenticationKey');
-  });
+    context('when authentication key is expired', function () {
+      it('throws an AuthenticationKeyExpired', async function () {
+        // given
+        authenticationSessionService.getByKey.resolves(null);
 
-  it('should create authentication method with complement', async function () {
-    // given
-    const sessionContent = { idToken: 'idToken' };
-    const externalIdentifier = 'external_id';
-    const userId = 1;
-    authenticationSessionService.getByKey.resolves({
-      sessionContent,
-      userInfo: { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' },
-    });
-    oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
-      new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
-        accessToken: 'accessToken',
-        expiredDate: new Date(),
-      }),
-    );
+        // when
+        const error = await catchErr(reconcileOidcUser)({
+          authenticationKey: 'authenticationKey',
+          oidcAuthenticationService,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          userLoginRepository,
+        });
 
-    // when
-    await reconcileOidcUser({
-      authenticationKey: 'authenticationKey',
-      oidcAuthenticationService,
-      authenticationSessionService,
-      authenticationMethodRepository,
-      userLoginRepository,
-    });
-
-    // then
-    expect(authenticationMethodRepository.create).to.be.calledOnce;
-    const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
-    expect(authenticationMethod).to.deep.contain({ identityProvider, externalIdentifier, userId });
-    expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
-      AuthenticationMethod.PoleEmploiOidcAuthenticationComplement,
-    );
-  });
-
-  it('should return an access token, the logout url uuid and update the last logged date', async function () {
-    // given
-    const sessionContent = { idToken: 'idToken' };
-    const externalIdentifier = 'external_id';
-    const userId = 1;
-    authenticationSessionService.getByKey.resolves({
-      sessionContent,
-      userInfo: { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' },
-    });
-    oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
-      new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
-        accessToken: 'accessToken',
-        expiredDate: new Date(),
-      }),
-    );
-    oidcAuthenticationService.createAccessToken.withArgs(userId).returns('accessToken');
-    oidcAuthenticationService.saveIdToken
-      .withArgs({ idToken: sessionContent.idToken, userId })
-      .resolves('logoutUrlUUID');
-
-    // when
-    const result = await reconcileOidcUser({
-      authenticationKey: 'authenticationKey',
-      oidcAuthenticationService,
-      authenticationSessionService,
-      authenticationMethodRepository,
-      userLoginRepository,
-    });
-
-    // then
-    sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-    sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
-    sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId });
-    expect(result).to.deep.equal({
-      accessToken: 'accessToken',
-      logoutUrlUUID: 'logoutUrlUUID',
-    });
-  });
-
-  context('when authentication key is expired', function () {
-    it('should throw an AuthenticationKeyExpired', async function () {
-      // given
-      authenticationSessionService.getByKey.resolves(null);
-
-      // when
-      const error = await catchErr(reconcileOidcUser)({
-        authenticationKey: 'authenticationKey',
-        oidcAuthenticationService,
-        authenticationSessionService,
-        authenticationMethodRepository,
-        userLoginRepository,
+        // then
+        expect(error).to.be.instanceOf(AuthenticationKeyExpired);
+        expect(error.message).to.be.equal('This authentication key has expired.');
       });
-
-      // then
-      expect(error).to.be.instanceOf(AuthenticationKeyExpired);
-      expect(error.message).to.be.equal('This authentication key has expired.');
     });
-  });
 
-  context('when user id is not stored in session info', function () {
-    it('should throw an MissingUserAccountError', async function () {
+    it('looks for user session content', async function () {
       // given
+      const sessionContent = { idToken: 'idToken' };
       authenticationSessionService.getByKey.resolves({
-        sessionContent: { idToken: 'idToken' },
+        sessionContent,
+        userInfo: { userId: 1, externalIdentityId: 'external_id', firstName: 'Anne' },
       });
 
       // when
-      const error = await catchErr(reconcileOidcUser)({
+      await reconcileOidcUser({
         authenticationKey: 'authenticationKey',
         oidcAuthenticationService,
         authenticationSessionService,
@@ -158,8 +67,125 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
       });
 
       // then
-      expect(error).to.be.instanceOf(MissingUserAccountError);
-      expect(error.message).to.be.equal('Les informations de compte requises sont manquantes');
+      expect(authenticationSessionService.getByKey).to.be.calledOnceWith('authenticationKey');
+    });
+
+    context('when user id is not stored in session info', function () {
+      it('throws an MissingUserAccountError', async function () {
+        // given
+        authenticationSessionService.getByKey.resolves({
+          sessionContent: { idToken: 'idToken' },
+        });
+
+        // when
+        const error = await catchErr(reconcileOidcUser)({
+          authenticationKey: 'authenticationKey',
+          oidcAuthenticationService,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          userLoginRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(MissingUserAccountError);
+        expect(error.message).to.be.equal('Les informations de compte requises sont manquantes');
+      });
+    });
+  });
+
+  context('when identityProvider is POLE_EMPLOI', function () {
+    let identityProvider;
+    let authenticationMethodRepository;
+    let userLoginRepository;
+    let authenticationSessionService;
+    let oidcAuthenticationService;
+
+    beforeEach(function () {
+      identityProvider = POLE_EMPLOI.code;
+      authenticationMethodRepository = { create: sinon.stub() };
+      userLoginRepository = {
+        updateLastLoggedAt: sinon.stub(),
+      };
+      authenticationSessionService = { getByKey: sinon.stub() };
+      oidcAuthenticationService = {
+        identityProvider,
+        createAccessToken: sinon.stub(),
+        saveIdToken: sinon.stub(),
+        createAuthenticationComplement: sinon.stub(),
+      };
+    });
+
+    it('creates authentication method with complement', async function () {
+      // given
+      const sessionContent = { idToken: 'idToken' };
+      const externalIdentifier = 'external_id';
+      const userId = 1;
+      authenticationSessionService.getByKey.resolves({
+        sessionContent,
+        userInfo: { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' },
+      });
+      oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
+        new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+          accessToken: 'accessToken',
+          expiredDate: new Date(),
+        }),
+      );
+
+      // when
+      await reconcileOidcUser({
+        authenticationKey: 'authenticationKey',
+        oidcAuthenticationService,
+        authenticationSessionService,
+        authenticationMethodRepository,
+        userLoginRepository,
+      });
+
+      // then
+      expect(authenticationMethodRepository.create).to.be.calledOnce;
+      const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
+      expect(authenticationMethod).to.deep.contain({ identityProvider, externalIdentifier, userId });
+      expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
+        AuthenticationMethod.PoleEmploiOidcAuthenticationComplement,
+      );
+    });
+
+    it('returns an access token, the logout url uuid and updates the last logged date', async function () {
+      // given
+      const sessionContent = { idToken: 'idToken' };
+      const externalIdentifier = 'external_id';
+      const userId = 1;
+      authenticationSessionService.getByKey.resolves({
+        sessionContent,
+        userInfo: { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' },
+      });
+      oidcAuthenticationService.createAuthenticationComplement.withArgs({ sessionContent }).returns(
+        new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
+          accessToken: 'accessToken',
+          expiredDate: new Date(),
+        }),
+      );
+      oidcAuthenticationService.createAccessToken.withArgs(userId).returns('accessToken');
+      oidcAuthenticationService.saveIdToken
+        .withArgs({ idToken: sessionContent.idToken, userId })
+        .resolves('logoutUrlUUID');
+
+      // when
+      const result = await reconcileOidcUser({
+        authenticationKey: 'authenticationKey',
+        oidcAuthenticationService,
+        authenticationSessionService,
+        authenticationMethodRepository,
+        userLoginRepository,
+      });
+
+      // then
+      sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
+      sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
+      sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId });
+      expect(result).to.deep.equal({
+        accessToken: 'accessToken',
+        logoutUrlUUID: 'logoutUrlUUID',
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -24,9 +24,8 @@ describe('Unit | UseCase | remove-authentication-method', function () {
     return [
       domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId }),
       domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
-      domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+      domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
         userId,
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
       }),
     ];
   }
@@ -35,9 +34,8 @@ describe('Unit | UseCase | remove-authentication-method', function () {
     return [
       domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId }),
       domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
-      domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+      domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
         userId,
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
       }),
       domainBuilder.buildAuthenticationMethod.withIdentityProvider({
         userId,

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -188,7 +188,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
             .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
             .resolves(authenticationMethod);
           httpAgent.post.resolves({ isSuccessful: true, code, data });
-          const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+          const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
             accessToken: data['access_token'],
             refreshToken: data['refresh_token'],
             expiredDate: dayjs().add(data['expires_in'], 's').toDate(),
@@ -214,7 +214,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
 
         it('should send the notification to Pole Emploi', async function () {
           // given
-          const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+          const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
             accessToken: data['access_token'],
             refreshToken: data['refresh_token'],
             expiredDate: dayjs().add(data['expires_in'], 's').toDate(),


### PR DESCRIPTION
## :unicorn: Problème

Lors d'une connexion via un SSO OIDC, les _claims_ correspondant à la variable d'environnement `${IDP}_CLAIMS_TO_STORE` peuvent être définis (#7387) mais ne sont pas encore stockés.

## :robot: Proposition

Il y a 3 cas de figure pouvant se produire dans le cadre d'une authentification SSO OIDC : 

a. première connexion avec un compte SSO et création d'un nouveau compte Pix associé
b. première connexion avec un compte SSO et association avec un compte Pix préexistant
c. connexion avec un compte SSO déjà associé avec un compte Pix

La proposition est, **pour chacun de ces cas de figure**, de stocker les _claims_ correspondant à la variable d'environnement `${IDP}_CLAIMS_TO_STORE` dans le `authenticationComplement` de la table `authentication-methods` en écrasant toute potentielle valeur préexistante.

Les _claims_ définis par `${IDP}_CLAIMS_TO_STORE` sont des _claims_ **obligatoires**. Si un de ces _claims_ n’est pas récupéré à partir des _userInfo_, alors l’authentification échoue.

Les _claims_ spécifiés ne doivent pas obligatoirement être des _claims_ OIDC standards, même si c’est mieux. Pour info voici la liste des _claims_ OIDC standards : 
https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

On précise bien qu’un compte utilisateur ne peut avoir qu’une seule valeur pour un _claim_ donné. Par exemple un compte utilisateur ne peut avoir qu’un `employeeNumber`.

Le SSO Pôle emploi individu est pour l'instant exclu de ce dispositif.

## :rainbow: Remarques

### Correction d'un gros bug

Le  commit abdd328d027a43315daa8dc8d9d8d1367afde667 est un correctif d'un gros bug de copie par référence au lieu de copie par valeur (_copy by reference vs copy by value_) introduit par la PR #6229.

### Changement d'un null en undefined

Lorsqu'il n'y a pas d'`authenticationComplement` à stocker, la fonction `createAuthenticationComplement` renvoie maintenant `undefined` à la place de `null`, de manière à ce que dans ce cas la propriété `authenticationComplement` d'une `AuthenticationMethod` soit considérée comme absente et donc non à stocker, avec la règle _Joi_ associée : `Joi.object().instance(OidcAuthenticationComplement).empty()`

## :100: Pour tester

L'objectif est de tester les 3 cas de figure pouvant se produire dans le cadre d'une authentification SSO OIDC : 

a. première connexion avec un compte SSO et création d'un nouveau compte Pix associé
b. première connexion avec un compte SSO et association avec un compte Pix préexistant
c. connexion avec un compte SSO déjà associé avec un compte Pix

### Avec les RA

Au niveau des RA il n'est pas facile de tester les SSO, donc on ne teste pas dans cet environnement.

### En local 

1. Réinitialiser la BDD de manière à ce que plus aucun compte n'ait d'_authenticationMethod_ : 

   ```shell
   npm run db:reset
   ```

2. Définir la variable d'environnement suivante : 

   ```shell
   FWB_CLAIMS_TO_STORE=family_name, given_name, employeeNumber
   ```

3. Se connecter avec le SSO FWB avec n'importe quel compte du SSO

4. Au niveau de la double mire, choisir la partie _« Je n’ai pas de compte Pix »_ et cliquer sur le bouton _« Je crée mon compte »_

5. Après la création de compte réussie, vérifier en BDD que le compte créé a une `authentication-methods` : 

   ```sql
   select * from "authentication-methods" where "identityProvider"='FWB';
   ```

   avec un `authenticationComplement` qui contient une valeur JSON du type suivant : 
 
   ```json
   { "family_name": "AAAAA", "given_name": "BBBBB", "employeeNumber": "CCCCC" }
   ```

6. Se déconnecter.

7. Se connecter avec tous les autres SSO OIDC et vérifier qu'il n'y a pas de régression.

8. Vérifier que le `authenticationComplement` est absent pour toutes les `authentication-methods` des fournisseurs `CNAV`, `PAYSDELALOIRE` : 

   ```sql
   select * from "authentication-methods" where "identityProvider" in ('CNAV', 'PAYSDELALOIRE');
   ```

9. Vérifier que le `authenticationComplement` des `authentication-methods` du fournisseur `POLE_EMPLOI` n'est pas absent et contient toujours uniquement des données de connexion : 

   ```sql
   select * from "authentication-methods" where "identityProvider"='POLE_EMPLOI';
   ```
   avec un `authenticationComplement` qui contient une valeur JSON du type suivant : 

   ```json
   {"accessToken": "TTTTT", "expiredDate": "DDDDD", "refreshToken": "RRRRR"}
   ```

10. Avec chacun des SSO OIDC, se connecter avec un compte du SSO différent de la fois précédente et reprendre toutes les vérifications à partir du 4. mais au niveau de la double mire aller dans la partie _« J’ai déjà un compte Pix »_ et cliquer sur le bouton _« Je me connecte »_

11. Modifier la variable d'environnement précédemment définie comme suit : 

    ```shell
    FWB_CLAIMS_TO_STORE=family_name, given_name, employeeNumber, population
    ```

12. Avec chacun des SSO OIDC, se connecter avec le compte du SSO précédemment utilisé et reprendre toutes les vérifications à partir du 3. La seule chose qui changer dans le déroulé est que la double mire n'est plus affichée car le compte SSO est déjà associé à un compte Pix. Enfin constater que l'`authenticationComplement` pour le compte Pix associé à un compte SSO FWB a été « modifié-écrasé » avec une nouvelle valeur contenant la propriété `population` : 

    ```sql
    select * from "authentication-methods" where "identityProvider"='FWB';
    ```

    avec un `authenticationComplement` qui contient une valeur JSON du type suivant : 
 
    ```json
    { "family_name": "AAAAA", "given_name": "BBBBB", "employeeNumber": "CCCCC", "population": "DDDDD" }
    ```

