### PR TITLE
[FEATURE] Ajout de la double mesure de la capacité dans les simulateurs (pix-9833)

### DIFF
--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -33,6 +33,7 @@ async function simulateFlashAssessmentScenario(
     limitToOneQuestionPerTube,
     minimumEstimatedSuccessRateRanges: minimumEstimatedSuccessRateRangesDto,
     enablePassageByAllCompetences,
+    doubleMeasuresUntil,
     variationPercent,
   } = request.payload;
 
@@ -64,6 +65,7 @@ async function simulateFlashAssessmentScenario(
           limitToOneQuestionPerTube,
           minimumEstimatedSuccessRateRanges,
           enablePassageByAllCompetences,
+          doubleMeasuresUntil,
           variationPercent,
         },
         _.isUndefined,

--- a/api/src/certification/flash-certification/application/scenario-simulator-route.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-route.js
@@ -31,6 +31,7 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   minimumEstimatedSuccessRateRanges: Joi.array().items(_successRatesConfigurationValidator),
   enablePassageByAllCompetences: Joi.boolean(),
   variationPercent: Joi.number().min(0).max(1),
+  doubleMeasuresUntil: Joi.number().min(0),
 });
 
 const register = async (server) => {

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
@@ -15,8 +15,8 @@ export class AssessmentSimulator {
           break;
         }
 
-        challengesAnswers.push(simulatorStepResult.challengeAnswer);
-        result.push(simulatorStepResult.result);
+        challengesAnswers.push(...simulatorStepResult.challengeAnswers);
+        result.push(...simulatorStepResult.results);
       } catch (err) {
         break;
       }

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
@@ -12,8 +12,6 @@ export class AssessmentSimulator {
   run() {
     const challengesAnswers = [];
     const result = [];
-    let estimatedLevel =
-      this.initialCapacity ?? this.algorithm.getEstimatedLevelAndErrorRate({ allAnswers: [] }).estimatedLevel;
 
     for (let i = 0; i < Infinity; i++) {
       try {
@@ -36,25 +34,24 @@ export class AssessmentSimulator {
           break;
         }
 
-        challengesAnswers.push(new Answer({ result: answerStatus, challengeId: nextChallenge.id }));
-
-        const reward = this.algorithm.getReward({
-          estimatedLevel,
-          difficulty: nextChallenge.difficulty,
-          discriminant: nextChallenge.discriminant,
-        });
-
-        estimatedLevel = this.algorithm.getEstimatedLevelAndErrorRate({
+        const estimatedLevelBeforeAnswering = this.algorithm.getEstimatedLevelAndErrorRate({
           allAnswers: challengesAnswers,
           challenges: this.challenges,
           initialCapacity: this.initialCapacity,
         }).estimatedLevel;
 
-        const errorRate = this.algorithm.getEstimatedLevelAndErrorRate({
+        challengesAnswers.push(new Answer({ result: answerStatus, challengeId: nextChallenge.id }));
+        const { estimatedLevel, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
           allAnswers: challengesAnswers,
           challenges: this.challenges,
           initialCapacity: this.initialCapacity,
-        }).errorRate;
+        });
+
+        const reward = this.algorithm.getReward({
+          estimatedLevel: estimatedLevelBeforeAnswering,
+          difficulty: nextChallenge.difficulty,
+          discriminant: nextChallenge.discriminant,
+        });
 
         result.push({
           challenge: nextChallenge,

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
@@ -1,20 +1,23 @@
 export class AssessmentSimulator {
-  constructor({ strategy }) {
-    this.strategy = strategy;
+  constructor({ getStrategy }) {
+    this.getStrategy = getStrategy;
   }
 
   run() {
     const challengesAnswers = [];
     const result = [];
 
-    for (let i = 0; i < Infinity; i++) {
+    let stepIndex = 0;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
       try {
-        const simulatorStepResult = this.strategy.run({ challengesAnswers, stepIndex: i });
+        const simulatorStepResult = this.getStrategy(stepIndex).run({ challengesAnswers, stepIndex });
 
         if (!simulatorStepResult) {
           break;
         }
-
+        stepIndex = simulatorStepResult.nextStepIndex;
         challengesAnswers.push(...simulatorStepResult.challengeAnswers);
         result.push(...simulatorStepResult.results);
       } catch (err) {

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
@@ -4,7 +4,7 @@ export class AssessmentSimulator {
   }
 
   run() {
-    let challengesAnswers = [];
+    const challengesAnswers = [];
     const result = [];
 
     for (let i = 0; i < Infinity; i++) {
@@ -15,7 +15,7 @@ export class AssessmentSimulator {
           break;
         }
 
-        challengesAnswers = simulatorStepResult.challengesAnswers;
+        challengesAnswers.push(simulatorStepResult.challengeAnswer);
         result.push(simulatorStepResult.result);
       } catch (err) {
         break;

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulator.js
@@ -1,64 +1,6 @@
-import { Answer } from '../../../../evaluation/domain/models/Answer.js';
-
 export class AssessmentSimulator {
-  constructor({ algorithm, challenges, pickChallenge, pickAnswerStatus, initialCapacity }) {
-    this.algorithm = algorithm;
-    this.challenges = challenges;
-    this.pickAnswerStatus = pickAnswerStatus;
-    this.pickChallenge = pickChallenge;
-    this.initialCapacity = initialCapacity;
-  }
-
-  _runSimulatorStep({ challengesAnswers, stepIndex }) {
-    const possibleChallenges = this.algorithm.getPossibleNextChallenges({
-      allAnswers: challengesAnswers,
-      challenges: this.challenges,
-      initialCapacity: this.initialCapacity,
-    });
-
-    const nextChallenge = this.pickChallenge({ possibleChallenges });
-
-    const answerStatus = this.pickAnswerStatus({
-      answerIndex: stepIndex,
-      nextChallenge,
-    });
-
-    const noMoreAnswerRemaining = !answerStatus;
-
-    if (noMoreAnswerRemaining) {
-      return null;
-    }
-
-    const estimatedLevelBeforeAnswering = this.algorithm.getEstimatedLevelAndErrorRate({
-      allAnswers: challengesAnswers,
-      challenges: this.challenges,
-      initialCapacity: this.initialCapacity,
-    }).estimatedLevel;
-
-    const newAnswers = [...challengesAnswers, new Answer({ result: answerStatus, challengeId: nextChallenge.id })];
-
-    const { estimatedLevel, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
-      allAnswers: newAnswers,
-      challenges: this.challenges,
-      initialCapacity: this.initialCapacity,
-    });
-
-    const reward = this.algorithm.getReward({
-      estimatedLevel: estimatedLevelBeforeAnswering,
-      difficulty: nextChallenge.difficulty,
-      discriminant: nextChallenge.discriminant,
-    });
-
-    return {
-      result: {
-        challenge: nextChallenge,
-        errorRate,
-        estimatedLevel,
-        reward,
-        answerStatus,
-      },
-      challengesAnswers: newAnswers,
-    };
+  constructor({ strategy }) {
+    this.strategy = strategy;
   }
 
   run() {
@@ -67,7 +9,7 @@ export class AssessmentSimulator {
 
     for (let i = 0; i < Infinity; i++) {
       try {
-        const simulatorStepResult = this._runSimulatorStep({ challengesAnswers, stepIndex: i });
+        const simulatorStepResult = this.strategy.run({ challengesAnswers, stepIndex: i });
 
         if (!simulatorStepResult) {
           break;

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -11,7 +11,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
   }
 
   run({ challengesAnswers, stepIndex }) {
-    const result = [];
+    const results = [];
     const challengeAnswers = [];
     const possibleChallenges = this.algorithm.getPossibleNextChallenges({
       allAnswers: challengesAnswers,
@@ -32,7 +32,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
         return null;
       }
 
-      result.push({
+      results.push({
         challenge: nextChallenge,
       });
 
@@ -40,7 +40,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     }
 
     return {
-      result,
+      results,
       challengeAnswers,
     };
   }

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -1,0 +1,73 @@
+import { Answer } from '../../../../evaluation/domain/models/Answer.js';
+
+const NUMBER_OF_MEASURES = 2;
+export class AssessmentSimulatorDoubleMeasureStrategy {
+  constructor({ algorithm, challenges, pickChallenge, pickAnswerStatus, initialCapacity }) {
+    this.algorithm = algorithm;
+    this.challenges = challenges;
+    this.pickAnswerStatus = pickAnswerStatus;
+    this.pickChallenge = pickChallenge;
+    this.initialCapacity = initialCapacity;
+  }
+
+  run({ challengesAnswers, stepIndex }) {
+    const result = [];
+    const challengeAnswers = [];
+    const possibleChallenges = this.algorithm.getPossibleNextChallenges({
+      allAnswers: challengesAnswers,
+      challenges: this.challenges,
+      initialCapacity: this.initialCapacity,
+    });
+
+    for (let index = 0; index < NUMBER_OF_MEASURES; index++) {
+      const availableChallenges = possibleChallenges.filter(({ id }) => {
+        return challengeAnswers.every(({ challengeId }) => challengeId !== id);
+      });
+      const { hasAssessmentEnded, nextChallenge, answer } = this._getNextChallengeAndAnswer({
+        possibleChallenges: availableChallenges,
+        stepIndex: stepIndex + index,
+      });
+
+      if (hasAssessmentEnded) {
+        return null;
+      }
+
+      result.push({
+        challenge: nextChallenge,
+      });
+
+      challengeAnswers.push(answer);
+    }
+
+    return {
+      result,
+      challengeAnswers,
+    };
+  }
+
+  _getNextChallengeAndAnswer({ possibleChallenges, stepIndex }) {
+    const nextChallenge = this.pickChallenge({ possibleChallenges });
+
+    const answerStatus = this.pickAnswerStatus({
+      answerIndex: stepIndex,
+      nextChallenge,
+    });
+
+    const noMoreAnswerRemaining = !answerStatus;
+
+    if (noMoreAnswerRemaining) {
+      return {
+        hasAssessmentEnded: true,
+      };
+    }
+
+    return {
+      nextChallenge,
+      answer: new Answer({
+        result: answerStatus,
+        challengeId: nextChallenge.id,
+      }),
+      hasAssessmentEnded: false,
+    };
+  }
+}

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -52,7 +52,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     return {
       results: results.map((result) => ({ ...result, estimatedLevel })),
       challengeAnswers: newAnswers,
-      nextStepIndex: stepIndex + 2,
+      nextStepIndex: stepIndex + NUMBER_OF_MEASURES,
     };
   }
 

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -50,6 +50,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     return {
       results: results.map((result) => ({ ...result, estimatedLevel })),
       challengeAnswers: newAnswers,
+      nextStepIndex: stepIndex + 2,
     };
   }
 

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -14,13 +14,15 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
   run({ challengesAnswers, stepIndex }) {
     const results = [];
     const newAnswers = [];
-    const possibleChallenges = this.algorithm.getPossibleNextChallenges({
-      allAnswers: challengesAnswers,
-      challenges: this.challenges,
-      initialCapacity: this.initialCapacity,
-    });
 
     for (let index = 0; index < NUMBER_OF_MEASURES; index++) {
+      const possibleChallenges = this.algorithm.getPossibleNextChallenges({
+        allAnswers: [...challengesAnswers, ...newAnswers],
+        challenges: this.challenges,
+        initialCapacity: this.initialCapacity,
+        answersForComputingEstimatedLevel: challengesAnswers,
+      });
+
       const availableChallenges = possibleChallenges.filter(({ id }) => {
         return newAnswers.every(({ challengeId }) => challengeId !== id);
       });

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -15,6 +15,13 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     const results = [];
     const newAnswers = [];
 
+    const { estimatedLevel: estimatedLevelBefore } = this.algorithm.getEstimatedLevelAndErrorRate({
+      allAnswers: challengesAnswers,
+      challenges: this.challenges,
+      initialCapacity: this.initialCapacity,
+      doubleMeasuresUntil: this.doubleMeasuresUntil,
+    });
+
     for (let index = 0; index < NUMBER_OF_MEASURES; index++) {
       const possibleChallenges = this.algorithm.getPossibleNextChallenges({
         allAnswers: [...challengesAnswers, ...newAnswers],
@@ -35,8 +42,16 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
         return null;
       }
 
+      const reward = this.algorithm.getReward({
+        estimatedLevel: estimatedLevelBefore,
+        difficulty: nextChallenge.difficulty,
+        discriminant: nextChallenge.discriminant,
+      });
+
       results.push({
         challenge: nextChallenge,
+        answerStatus: answer.result.status,
+        reward,
       });
 
       newAnswers.push(answer);

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
@@ -50,6 +50,7 @@ export class AssessmentSimulatorSingleMeasureStrategy {
     });
 
     return {
+      nextStepIndex: stepIndex + 1,
       results: [
         {
           challenge: nextChallenge,

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
@@ -35,10 +35,10 @@ export class AssessmentSimulatorSingleMeasureStrategy {
       initialCapacity: this.initialCapacity,
     }).estimatedLevel;
 
-    const newAnswers = [...challengesAnswers, new Answer({ result: answerStatus, challengeId: nextChallenge.id })];
+    const newAnswer = new Answer({ result: answerStatus, challengeId: nextChallenge.id });
 
     const { estimatedLevel, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
-      allAnswers: newAnswers,
+      allAnswers: [...challengesAnswers, newAnswer],
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
     });
@@ -57,7 +57,7 @@ export class AssessmentSimulatorSingleMeasureStrategy {
         reward,
         answerStatus,
       },
-      challengesAnswers: newAnswers,
+      challengeAnswer: newAnswer,
     };
   }
 }

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
@@ -1,0 +1,63 @@
+import { Answer } from '../../../../evaluation/domain/models/Answer.js';
+
+export class AssessmentSimulatorSingleMeasureStrategy {
+  constructor({ algorithm, challenges, pickChallenge, pickAnswerStatus, initialCapacity }) {
+    this.algorithm = algorithm;
+    this.challenges = challenges;
+    this.pickAnswerStatus = pickAnswerStatus;
+    this.pickChallenge = pickChallenge;
+    this.initialCapacity = initialCapacity;
+  }
+
+  run({ challengesAnswers, stepIndex }) {
+    const possibleChallenges = this.algorithm.getPossibleNextChallenges({
+      allAnswers: challengesAnswers,
+      challenges: this.challenges,
+      initialCapacity: this.initialCapacity,
+    });
+
+    const nextChallenge = this.pickChallenge({ possibleChallenges });
+
+    const answerStatus = this.pickAnswerStatus({
+      answerIndex: stepIndex,
+      nextChallenge,
+    });
+
+    const noMoreAnswerRemaining = !answerStatus;
+
+    if (noMoreAnswerRemaining) {
+      return null;
+    }
+
+    const estimatedLevelBeforeAnswering = this.algorithm.getEstimatedLevelAndErrorRate({
+      allAnswers: challengesAnswers,
+      challenges: this.challenges,
+      initialCapacity: this.initialCapacity,
+    }).estimatedLevel;
+
+    const newAnswers = [...challengesAnswers, new Answer({ result: answerStatus, challengeId: nextChallenge.id })];
+
+    const { estimatedLevel, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
+      allAnswers: newAnswers,
+      challenges: this.challenges,
+      initialCapacity: this.initialCapacity,
+    });
+
+    const reward = this.algorithm.getReward({
+      estimatedLevel: estimatedLevelBeforeAnswering,
+      difficulty: nextChallenge.difficulty,
+      discriminant: nextChallenge.discriminant,
+    });
+
+    return {
+      result: {
+        challenge: nextChallenge,
+        errorRate,
+        estimatedLevel,
+        reward,
+        answerStatus,
+      },
+      challengesAnswers: newAnswers,
+    };
+  }
+}

--- a/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js
@@ -50,14 +50,16 @@ export class AssessmentSimulatorSingleMeasureStrategy {
     });
 
     return {
-      result: {
-        challenge: nextChallenge,
-        errorRate,
-        estimatedLevel,
-        reward,
-        answerStatus,
-      },
-      challengeAnswer: newAnswer,
+      results: [
+        {
+          challenge: nextChallenge,
+          errorRate,
+          estimatedLevel,
+          reward,
+          answerStatus,
+        },
+      ],
+      challengeAnswers: [newAnswer],
     };
   }
 }

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
@@ -81,13 +81,14 @@ class FlashAssessmentAlgorithm {
     allAnswers,
     challenges,
     initialCapacity = config.v3Certification.defaultCandidateCapacity,
+    answersForComputingEstimatedLevel,
   }) {
     if (allAnswers.length >= this.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }
 
     const { estimatedLevel } = this.getEstimatedLevelAndErrorRate({
-      allAnswers,
+      allAnswers: answersForComputingEstimatedLevel ?? allAnswers,
       challenges,
       initialCapacity,
       variationPercent: this.variationPercent,

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
@@ -45,6 +45,8 @@ class FlashAssessmentAlgorithm {
    * @param limitToOneQuestionPerTube - limits questions to one per tube
    * @param flashImplementation - the flash algorithm implementation
    * @param enablePassageByAllCompetences - enable or disable the passage through all competences
+   * @param variationPercent - maximum variation of estimated level between two answers
+   * @param doubleMeasuresUntil - use the double measure strategy for specified number of challenges
    */
   constructor({
     warmUpLength,
@@ -56,6 +58,7 @@ class FlashAssessmentAlgorithm {
     flashAlgorithmImplementation,
     enablePassageByAllCompetences,
     variationPercent,
+    doubleMeasuresUntil,
   } = {}) {
     this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
     this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
@@ -63,6 +66,7 @@ class FlashAssessmentAlgorithm {
     this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
     this.flashAlgorithmImplementation = flashAlgorithmImplementation;
     this.variationPercent = variationPercent;
+    this.doubleMeasuresUntil = doubleMeasuresUntil;
 
     this.ruleEngine = new FlashAssessmentAlgorithmRuleEngine(availableRules, {
       limitToOneQuestionPerTube,
@@ -139,6 +143,7 @@ class FlashAssessmentAlgorithm {
       challenges,
       estimatedLevel: initialCapacity,
       variationPercent: this.variationPercent,
+      doubleMeasuresUntil: this.doubleMeasuresUntil,
     });
   }
 

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -54,7 +54,7 @@ function getEstimatedLevelAndErrorRate({
   let answerIndex = 0;
 
   while (answerIndex < allAnswers.length) {
-    if (!_shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex })) {
+    if (!_shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex, answersLength: allAnswers.length })) {
       const answer = allAnswers[answerIndex];
       ({ latestEstimatedLevel, likelihood, normalizedPosteriori } = _singleMeasure({
         challenges,
@@ -87,8 +87,9 @@ function getEstimatedLevelAndErrorRate({
   return { estimatedLevel: latestEstimatedLevel, errorRate };
 }
 
-function _shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex }) {
-  return doubleMeasuresUntil > answerIndex;
+function _shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex, answersLength }) {
+  const isLastAnswer = answersLength === answerIndex + 1;
+  return doubleMeasuresUntil > answerIndex && !isLastAnswer;
 }
 
 function _singleMeasure({

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -18,6 +18,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   minimumEstimatedSuccessRateRanges = [],
   enablePassageByAllCompetences = false,
   variationPercent,
+  doubleMeasuresUntil,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -31,6 +32,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
     flashAlgorithmImplementation: flashAlgorithmService,
     enablePassageByAllCompetences,
     variationPercent,
+    doubleMeasuresUntil,
   });
 
   const strategy = new AssessmentSimulatorSingleMeasureStrategy({

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -1,5 +1,6 @@
 import { FlashAssessmentAlgorithm } from '../model/FlashAssessmentAlgorithm.js';
 import { AssessmentSimulator } from '../model/AssessmentSimulator.js';
+import { AssessmentSimulatorSingleMeasureStrategy } from '../model/AssessmentSimulatorSingleMeasureStrategy.js';
 
 export async function simulateFlashDeterministicAssessmentScenario({
   challengeRepository,
@@ -32,13 +33,16 @@ export async function simulateFlashDeterministicAssessmentScenario({
     variationPercent,
   });
 
-  const simulator = new AssessmentSimulator({
+  const strategy = new AssessmentSimulatorSingleMeasureStrategy({
     algorithm: flashAssessmentAlgorithm,
     challenges,
     pickChallenge,
-    initialCapacity,
     pickAnswerStatus,
-    variationPercent,
+    initialCapacity,
+  });
+
+  const simulator = new AssessmentSimulator({
+    strategy,
   });
 
   return simulator.run();

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -1,0 +1,121 @@
+import { expect, domainBuilder, sinon } from '../../../../../test-helper.js';
+import { AssessmentSimulatorDoubleMeasureStrategy } from '../../../../../../src/certification/flash-certification/domain/model/AssessmentSimulatorDoubleMeasureStrategy.js';
+import { Answer, AnswerStatus } from '../../../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', function () {
+  describe('#run', function () {
+    context('when there is no available answer', function () {
+      it('should return null', function () {
+        // given
+        const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+        const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+        const allChallenges = [challenge1, challenge2];
+        const initialCapacity = 0;
+        const algorithm = {
+          getPossibleNextChallenges: sinon.stub(),
+          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getReward: sinon.stub(),
+        };
+        const pickChallenge = sinon.stub();
+        const pickAnswerStatus = sinon.stub();
+
+        algorithm.getPossibleNextChallenges
+          .withArgs({
+            allAnswers: [],
+            challenges: allChallenges,
+            initialCapacity,
+          })
+          .returns([challenge2, challenge1]);
+
+        pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
+        pickAnswerStatus.withArgs({ nextChallenge: challenge2, answerIndex: 0 }).returns(undefined);
+
+        // when
+        const strategy = new AssessmentSimulatorDoubleMeasureStrategy({
+          algorithm,
+          challenges: allChallenges,
+          pickChallenge,
+          pickAnswerStatus,
+          initialCapacity,
+        });
+        const result = strategy.run({ challengesAnswers: [], stepIndex: 0 });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+
+    context('when there are two available answers', function () {
+      it('should return the result for both challenges', function () {
+        // given
+        const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+        const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+        const allChallenges = [challenge1, challenge2];
+        const answerForSimulator1 = AnswerStatus.OK;
+        const answerForSimulator2 = AnswerStatus.OK;
+        const initialCapacity = 0;
+        const algorithm = {
+          getPossibleNextChallenges: sinon.stub(),
+          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getReward: sinon.stub(),
+        };
+        const pickChallenge = sinon.stub();
+        const pickAnswerStatus = sinon.stub();
+
+        algorithm.getPossibleNextChallenges
+          .withArgs({
+            allAnswers: [],
+            challenges: allChallenges,
+            initialCapacity,
+          })
+          .returns([challenge2, challenge1]);
+
+        pickChallenge
+          .withArgs({ possibleChallenges: [challenge2, challenge1] })
+          .returns(challenge2)
+          .withArgs({ possibleChallenges: [challenge1] })
+          .returns(challenge1);
+
+        pickAnswerStatus
+          .withArgs({ nextChallenge: challenge2, answerIndex: 0 })
+          .returns(answerForSimulator1)
+          .withArgs({ nextChallenge: challenge1, answerIndex: 1 })
+          .returns(answerForSimulator2);
+
+        // when
+        const expectedResult = {
+          result: [
+            {
+              challenge: challenge2,
+            },
+            {
+              challenge: challenge1,
+            },
+          ],
+          challengeAnswers: [
+            new Answer({
+              result: answerForSimulator1,
+              challengeId: challenge2.id,
+            }),
+            new Answer({
+              result: answerForSimulator2,
+              challengeId: challenge1.id,
+            }),
+          ],
+        };
+
+        const strategy = new AssessmentSimulatorDoubleMeasureStrategy({
+          algorithm,
+          challenges: allChallenges,
+          pickChallenge,
+          pickAnswerStatus,
+          initialCapacity,
+        });
+        const result = strategy.run({ challengesAnswers: [], stepIndex: 0 });
+
+        // then
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+  });
+});

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -48,6 +48,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
     context('when there are two available answers', function () {
       it('should return the result for both challenges', function () {
         // given
+        const stepIndex = 0;
         const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
         const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
         const allChallenges = [challenge1, challenge2];
@@ -118,6 +119,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
               challengeId: challenge1.id,
             }),
           ],
+          nextStepIndex: stepIndex + 2,
         };
 
         const strategy = new AssessmentSimulatorDoubleMeasureStrategy({
@@ -129,7 +131,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
           doubleMeasuresUntil: 2,
         });
 
-        const result = strategy.run({ challengesAnswers: [], stepIndex: 0 });
+        const result = strategy.run({ challengesAnswers: [], stepIndex });
 
         // then
         expect(result).to.deep.equal(expectedResult);

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
 
         // when
         const expectedResult = {
-          result: [
+          results: [
             {
               challenge: challenge2,
             },

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -24,6 +24,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             allAnswers: [],
             challenges: allChallenges,
             initialCapacity,
+            answersForComputingEstimatedLevel: [],
           })
           .returns([challenge2, challenge1]);
 
@@ -71,8 +72,16 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             allAnswers: [],
             challenges: allChallenges,
             initialCapacity,
+            answersForComputingEstimatedLevel: [],
           })
-          .returns([challenge2, challenge1]);
+          .returns([challenge2, challenge1])
+          .withArgs({
+            allAnswers: [newAnswer2],
+            challenges: allChallenges,
+            initialCapacity,
+            answersForComputingEstimatedLevel: [],
+          })
+          .returns([challenge1]);
 
         algorithm.getEstimatedLevelAndErrorRate
           .withArgs({

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -103,17 +103,21 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
 
           // when
           const expectedResult = {
-            result: {
-              challenge: challenge2,
-              estimatedLevel: expectedEstimatedLevel,
-              errorRate: expectedErrorRate,
-              reward: expectedReward,
-              answerStatus: answerForSimulator,
-            },
-            challengeAnswer: new Answer({
-              result: answerForSimulator,
-              challengeId: challenge2.id,
-            }),
+            results: [
+              {
+                challenge: challenge2,
+                estimatedLevel: expectedEstimatedLevel,
+                errorRate: expectedErrorRate,
+                reward: expectedReward,
+                answerStatus: answerForSimulator,
+              },
+            ],
+            challengeAnswers: [
+              new Answer({
+                result: answerForSimulator,
+                challengeId: challenge2.id,
+              }),
+            ],
           };
 
           const strategy = new AssessmentSimulatorSingleMeasureStrategy({
@@ -234,17 +238,21 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
 
           // when
           const expectedResult = {
-            result: {
-              challenge: challenge2,
-              estimatedLevel: expectedEstimatedLevel,
-              errorRate: expectedErrorRate,
-              reward: expectedReward,
-              answerStatus: answerForSimulator,
-            },
-            challengeAnswer: new Answer({
-              result: answerForSimulator,
-              challengeId: challenge2.id,
-            }),
+            results: [
+              {
+                challenge: challenge2,
+                estimatedLevel: expectedEstimatedLevel,
+                errorRate: expectedErrorRate,
+                reward: expectedReward,
+                answerStatus: answerForSimulator,
+              },
+            ],
+            challengeAnswers: [
+              new Answer({
+                result: answerForSimulator,
+                challengeId: challenge2.id,
+              }),
+            ],
           };
 
           const strategy = new AssessmentSimulatorSingleMeasureStrategy({

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -49,6 +49,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
       context('when there is an available answer', function () {
         it('should return the result and the challengesAnswers with one element', function () {
           // given
+          const stepIndex = 0;
           const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
           const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
           const allChallenges = [challenge1, challenge2];
@@ -118,6 +119,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
                 challengeId: challenge2.id,
               }),
             ],
+            nextStepIndex: stepIndex + 1,
           };
 
           const strategy = new AssessmentSimulatorSingleMeasureStrategy({
@@ -127,7 +129,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
             pickAnswerStatus,
             initialCapacity,
           });
-          const result = strategy.run({ challengesAnswers: [], stepIndex: 0 });
+          const result = strategy.run({ challengesAnswers: [], stepIndex });
 
           // then
           expect(result).to.deep.equal(expectedResult);
@@ -182,6 +184,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
       context('when there is an available answer', function () {
         it('should return the result and the challengesAnswers with two elements', function () {
           // given
+          const stepIndex = 1;
           const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
           const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
           const allChallenges = [challenge1, challenge2];
@@ -253,6 +256,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
                 challengeId: challenge2.id,
               }),
             ],
+            nextStepIndex: stepIndex + 1,
           };
 
           const strategy = new AssessmentSimulatorSingleMeasureStrategy({
@@ -262,7 +266,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
             pickAnswerStatus,
             initialCapacity: capacityAfterFirstChallenge,
           });
-          const result = strategy.run({ challengesAnswers: [challengeAnswer], stepIndex: 1 });
+          const result = strategy.run({ challengesAnswers: [challengeAnswer], stepIndex });
 
           // then
           expect(result).to.deep.equal(expectedResult);

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -1,0 +1,270 @@
+import { expect, domainBuilder, sinon } from '../../../../../test-helper.js';
+import { Answer, AnswerStatus } from '../../../../../../lib/domain/models/index.js';
+import { AssessmentSimulatorSingleMeasureStrategy } from '../../../../../../src/certification/flash-certification/domain/model/AssessmentSimulatorSingleMeasureStrategy.js';
+
+describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', function () {
+  describe('#run', function () {
+    context('when no challenge has been answered yet', function () {
+      context('when there is no available answer', function () {
+        it('should return null', function () {
+          // given
+          const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+          const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+          const allChallenges = [challenge1, challenge2];
+          const initialCapacity = 0;
+          const algorithm = {
+            getPossibleNextChallenges: sinon.stub(),
+            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getReward: sinon.stub(),
+          };
+          const pickChallenge = sinon.stub();
+          const pickAnswerStatus = sinon.stub();
+
+          algorithm.getPossibleNextChallenges
+            .withArgs({
+              allAnswers: [],
+              challenges: allChallenges,
+              initialCapacity,
+            })
+            .returns([challenge2, challenge1]);
+
+          pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
+          pickAnswerStatus.withArgs({ nextChallenge: challenge2, answerIndex: 0 }).returns(undefined);
+
+          // when
+          const strategy = new AssessmentSimulatorSingleMeasureStrategy({
+            algorithm,
+            challenges: allChallenges,
+            pickChallenge,
+            pickAnswerStatus,
+            initialCapacity,
+          });
+          const result = strategy.run({ challengesAnswers: [], stepIndex: 0 });
+
+          // then
+          expect(result).to.be.null;
+        });
+      });
+
+      context('when there is an available answer', function () {
+        it('should return the result and the challengesAnswers with one element', function () {
+          // given
+          const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+          const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+          const allChallenges = [challenge1, challenge2];
+          const answerForSimulator = AnswerStatus.OK;
+          const answer1 = { challengeId: challenge2.id, result: answerForSimulator };
+          const initialCapacity = 0;
+          const expectedEstimatedLevel = 0.4;
+          const expectedErrorRate = 0.2;
+          const expectedReward = 5;
+          const algorithm = {
+            getPossibleNextChallenges: sinon.stub(),
+            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getReward: sinon.stub(),
+          };
+          const pickChallenge = sinon.stub();
+          const pickAnswerStatus = sinon.stub();
+
+          algorithm.getEstimatedLevelAndErrorRate
+            .withArgs({
+              allAnswers: [],
+              challenges: allChallenges,
+              initialCapacity,
+            })
+            .returns({
+              estimatedLevel: initialCapacity,
+            })
+            .withArgs({
+              allAnswers: [sinon.match(answer1)],
+              challenges: allChallenges,
+              initialCapacity,
+            })
+            .returns({ estimatedLevel: expectedEstimatedLevel, errorRate: expectedErrorRate });
+
+          algorithm.getPossibleNextChallenges
+            .withArgs({
+              allAnswers: [],
+              challenges: allChallenges,
+              initialCapacity,
+            })
+            .returns([challenge2, challenge1]);
+
+          pickChallenge.withArgs({ possibleChallenges: [challenge2, challenge1] }).returns(challenge2);
+          pickAnswerStatus.withArgs({ nextChallenge: challenge2, answerIndex: 0 }).returns(answerForSimulator);
+
+          algorithm.getReward
+            .withArgs({
+              estimatedLevel: initialCapacity,
+              difficulty: challenge1.difficulty,
+              discriminant: challenge1.discriminant,
+            })
+            .returns(expectedReward);
+
+          // when
+          const expectedResult = {
+            result: {
+              challenge: challenge2,
+              estimatedLevel: expectedEstimatedLevel,
+              errorRate: expectedErrorRate,
+              reward: expectedReward,
+              answerStatus: answerForSimulator,
+            },
+            challengesAnswers: [
+              new Answer({
+                result: answerForSimulator,
+                challengeId: challenge2.id,
+              }),
+            ],
+          };
+
+          const strategy = new AssessmentSimulatorSingleMeasureStrategy({
+            algorithm,
+            challenges: allChallenges,
+            pickChallenge,
+            pickAnswerStatus,
+            initialCapacity,
+          });
+          const result = strategy.run({ challengesAnswers: [], stepIndex: 0 });
+
+          // then
+          expect(result).to.deep.equal(expectedResult);
+        });
+      });
+    });
+
+    context('when a challenge has already been answered', function () {
+      context('when there is no available answer', function () {
+        it('should return null', function () {
+          // given
+          const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+          const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+          const allChallenges = [challenge1, challenge2];
+          const capacityAfterFirstChallenge = 1.2;
+          const algorithm = {
+            getPossibleNextChallenges: sinon.stub(),
+            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getReward: sinon.stub(),
+          };
+          const challengeAnswer = domainBuilder.buildAnswer({ challengeId: challenge1.id });
+          const pickChallenge = sinon.stub();
+          const pickAnswerStatus = sinon.stub();
+
+          algorithm.getPossibleNextChallenges
+            .withArgs({
+              allAnswers: [challengeAnswer],
+              challenges: allChallenges,
+              initialCapacity: capacityAfterFirstChallenge,
+            })
+            .returns([challenge1, challenge2]);
+
+          pickChallenge.withArgs({ possibleChallenges: [challenge1, challenge2] }).returns(challenge2);
+
+          pickAnswerStatus.withArgs({ nextChallenge: challenge2, answerIndex: 1 }).returns(undefined);
+
+          // when
+          const strategy = new AssessmentSimulatorSingleMeasureStrategy({
+            algorithm,
+            challenges: allChallenges,
+            pickChallenge,
+            pickAnswerStatus,
+            initialCapacity: capacityAfterFirstChallenge,
+          });
+          const result = strategy.run({ challengesAnswers: [domainBuilder.buildAnswer()], stepIndex: 1 });
+
+          // then
+          expect(result).to.be.null;
+        });
+      });
+
+      context('when there is an available answer', function () {
+        it('should return the result and the challengesAnswers with two elements', function () {
+          // given
+          const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
+          const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
+          const allChallenges = [challenge1, challenge2];
+          const answerForSimulator = AnswerStatus.OK;
+          const answer1 = { challengeId: challenge2.id, result: answerForSimulator };
+          const capacityAfterFirstChallenge = 1.2;
+          const expectedEstimatedLevel = 0.4;
+          const expectedErrorRate = 0.2;
+          const expectedReward = 5;
+          const algorithm = {
+            getPossibleNextChallenges: sinon.stub(),
+            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getReward: sinon.stub(),
+          };
+          const challengeAnswer = domainBuilder.buildAnswer({ challengeId: challenge1.id });
+          const pickChallenge = sinon.stub();
+          const pickAnswerStatus = sinon.stub();
+
+          algorithm.getEstimatedLevelAndErrorRate
+            .withArgs({
+              allAnswers: [challengeAnswer],
+              challenges: allChallenges,
+              initialCapacity: capacityAfterFirstChallenge,
+            })
+            .returns({
+              estimatedLevel: capacityAfterFirstChallenge,
+            })
+            .withArgs({
+              allAnswers: [challengeAnswer, sinon.match(answer1)],
+              challenges: allChallenges,
+              initialCapacity: capacityAfterFirstChallenge,
+            })
+            .returns({ estimatedLevel: expectedEstimatedLevel, errorRate: expectedErrorRate });
+
+          algorithm.getPossibleNextChallenges
+            .withArgs({
+              allAnswers: [challengeAnswer],
+              challenges: allChallenges,
+              initialCapacity: capacityAfterFirstChallenge,
+            })
+            .returns([challenge1, challenge2]);
+
+          pickChallenge.withArgs({ possibleChallenges: [challenge1, challenge2] }).returns(challenge2);
+
+          pickAnswerStatus.withArgs({ nextChallenge: challenge2, answerIndex: 1 }).returns(answerForSimulator);
+
+          algorithm.getReward
+            .withArgs({
+              estimatedLevel: capacityAfterFirstChallenge,
+              difficulty: challenge1.difficulty,
+              discriminant: challenge1.discriminant,
+            })
+            .returns(expectedReward);
+
+          // when
+          const expectedResult = {
+            result: {
+              challenge: challenge2,
+              estimatedLevel: expectedEstimatedLevel,
+              errorRate: expectedErrorRate,
+              reward: expectedReward,
+              answerStatus: answerForSimulator,
+            },
+            challengesAnswers: [
+              challengeAnswer,
+              new Answer({
+                result: answerForSimulator,
+                challengeId: challenge2.id,
+              }),
+            ],
+          };
+
+          const strategy = new AssessmentSimulatorSingleMeasureStrategy({
+            algorithm,
+            challenges: allChallenges,
+            pickChallenge,
+            pickAnswerStatus,
+            initialCapacity: capacityAfterFirstChallenge,
+          });
+          const result = strategy.run({ challengesAnswers: [challengeAnswer], stepIndex: 1 });
+
+          // then
+          expect(result).to.deep.equal(expectedResult);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -110,12 +110,10 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
               reward: expectedReward,
               answerStatus: answerForSimulator,
             },
-            challengesAnswers: [
-              new Answer({
-                result: answerForSimulator,
-                challengeId: challenge2.id,
-              }),
-            ],
+            challengeAnswer: new Answer({
+              result: answerForSimulator,
+              challengeId: challenge2.id,
+            }),
           };
 
           const strategy = new AssessmentSimulatorSingleMeasureStrategy({
@@ -243,13 +241,10 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
               reward: expectedReward,
               answerStatus: answerForSimulator,
             },
-            challengesAnswers: [
-              challengeAnswer,
-              new Answer({
-                result: answerForSimulator,
-                challengeId: challenge2.id,
-              }),
-            ],
+            challengeAnswer: new Answer({
+              result: answerForSimulator,
+              challengeId: challenge2.id,
+            }),
           };
 
           const strategy = new AssessmentSimulatorSingleMeasureStrategy({

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
@@ -3,328 +3,55 @@ import { AnswerStatus, AssessmentSimulator } from '../../../../../../lib/domain/
 
 describe('Unit | Domain | Models | AssessmentSimulator', function () {
   describe('#run', function () {
-    context('with the "pickAnswerStatus" function provided', function () {
-      context('when there are always answers available', function () {
-        it('should return the list of all the challenges', function () {
-          // given
-          const answersForSimulator = [AnswerStatus.OK, AnswerStatus.KO];
-          const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
-          const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
-          const answer1 = { challengeId: challenge2.id, result: answersForSimulator[0] };
-          const answer2 = { challengeId: challenge1.id, result: answersForSimulator[1] };
-          const allChallenges = [challenge1, challenge2];
-          const initialCapacity = 0;
-          const expectedEstimatedLevels = [0.4, 0.1];
-          const expectedErrorRates = [0.2, 0.5];
-          const expectedRewards = [5, 6];
-          const algorithm = {
-            getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
-            getReward: sinon.stub(),
-          };
-          const pickChallenge = sinon.stub();
-          const pickAnswerStatus = sinon.stub();
+    it('should return the list of all the challenges', function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({ id: 'rec2' });
+      const answerForSimulator = AnswerStatus.OK;
+      const expectedEstimatedLevel = 0.4;
+      const expectedErrorRate = 0.2;
+      const expectedReward = 5;
+      const strategy = {
+        run: sinon.stub(),
+      };
 
-          algorithm.getEstimatedLevelAndErrorRate
-            .withArgs({
-              allAnswers: [],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns({
-              estimatedLevel: initialCapacity,
-            })
-            .withArgs({
-              allAnswers: [sinon.match(answer1)],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
-            .withArgs({
-              allAnswers: [sinon.match(answer1), sinon.match(answer2)],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns({
-              estimatedLevel: expectedEstimatedLevels[1],
-              errorRate: expectedErrorRates[1],
-            });
-
-          algorithm.getPossibleNextChallenges
-            .withArgs({
-              allAnswers: [],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns([challenge2, challenge1])
-            .withArgs({
-              allAnswers: [sinon.match(answer1)],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns([challenge1]);
-
-          pickChallenge
-            .withArgs({ possibleChallenges: [challenge2, challenge1] })
-            .returns(challenge2)
-            .withArgs({ possibleChallenges: [challenge1] })
-            .returns(challenge1);
-
-          pickAnswerStatus
-            .withArgs({ nextChallenge: challenge2, answerIndex: 0 })
-            .returns(answersForSimulator[0])
-            .withArgs({ nextChallenge: challenge1, answerIndex: 1 })
-            .returns(answersForSimulator[1]);
-
-          algorithm.getReward
-            .withArgs({
-              estimatedLevel: initialCapacity,
-              difficulty: challenge1.difficulty,
-              discriminant: challenge1.discriminant,
-            })
-            .returns(expectedRewards[0])
-            .withArgs({
-              estimatedLevel: expectedEstimatedLevels[0],
-              difficulty: challenge2.difficulty,
-              discriminant: challenge2.discriminant,
-            })
-            .returns(expectedRewards[1]);
-
-          // when
-          const expectedResult = [
-            {
-              challenge: challenge2,
-              estimatedLevel: expectedEstimatedLevels[0],
-              errorRate: expectedErrorRates[0],
-              reward: expectedRewards[0],
-              answerStatus: answersForSimulator[0],
-            },
-            {
-              challenge: challenge1,
-              estimatedLevel: expectedEstimatedLevels[1],
-              errorRate: expectedErrorRates[1],
-              reward: expectedRewards[1],
-              answerStatus: answersForSimulator[1],
-            },
-          ];
-
-          const result = new AssessmentSimulator({
-            algorithm,
-            challenges: allChallenges,
-            pickChallenge,
-            pickAnswerStatus,
-            initialCapacity,
-          }).run();
-
-          // then
-          expect(result).to.deep.equal(expectedResult);
-        });
-      });
-
-      context('when there not enough answers available', function () {
-        it('should return the list of all the taken challenges', function () {
-          // given
-          const answersForSimulator = [AnswerStatus.OK, AnswerStatus.KO];
-          const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
-          const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
-          const answer = { challengeId: challenge2.id, result: answersForSimulator[0] };
-          const allChallenges = [challenge1, challenge2];
-          const initialCapacity = 0;
-          const expectedEstimatedLevels = [0.4, 0.1];
-          const expectedErrorRates = [0.2, 0.5];
-          const expectedRewards = [5, 6];
-          const algorithm = {
-            getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
-            getReward: sinon.stub(),
-          };
-          const pickChallenge = sinon.stub();
-          const pickAnswerStatus = sinon.stub();
-
-          algorithm.getEstimatedLevelAndErrorRate
-            .withArgs({
-              allAnswers: [],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns({
-              estimatedLevel: initialCapacity,
-            })
-            .withArgs({
-              allAnswers: [sinon.match(answer)],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] });
-
-          algorithm.getPossibleNextChallenges
-            .withArgs({
-              allAnswers: [],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns([challenge2, challenge1])
-            .withArgs({
-              allAnswers: [sinon.match(answer)],
-              challenges: allChallenges,
-              initialCapacity,
-            })
-            .returns([challenge1]);
-
-          pickChallenge
-            .withArgs({ possibleChallenges: [challenge2, challenge1] })
-            .returns(challenge2)
-            .withArgs({ possibleChallenges: [challenge1] })
-            .returns(challenge1);
-
-          pickAnswerStatus.withArgs({ nextChallenge: challenge2, answerIndex: 0 }).returns(answersForSimulator[0]);
-
-          algorithm.getReward
-            .withArgs({
-              estimatedLevel: initialCapacity,
-              difficulty: challenge1.difficulty,
-              discriminant: challenge1.discriminant,
-            })
-            .returns(expectedRewards[0]);
-
-          // when
-          const expectedResult = [
-            {
-              challenge: challenge2,
-              estimatedLevel: expectedEstimatedLevels[0],
-              errorRate: expectedErrorRates[0],
-              reward: expectedRewards[0],
-              answerStatus: answersForSimulator[0],
-            },
-          ];
-
-          const result = new AssessmentSimulator({
-            algorithm,
-            challenges: allChallenges,
-            pickChallenge,
-            pickAnswerStatus,
-            initialCapacity,
-          }).run();
-
-          // then
-          expect(result).to.deep.equal(expectedResult);
-        });
-      });
-    });
-
-    context('when an initial capacity is provided', function () {
-      it('should return the list of all the challenges', function () {
-        // given
-        const answersForSimulator = [AnswerStatus.OK, AnswerStatus.KO];
-        const challenge1 = domainBuilder.buildChallenge({ id: 'rec1' });
-        const challenge2 = domainBuilder.buildChallenge({ id: 'rec2' });
-        const answer1 = { challengeId: challenge2.id, result: answersForSimulator[0] };
-        const answer2 = { challengeId: challenge1.id, result: answersForSimulator[1] };
-        const allChallenges = [challenge1, challenge2];
-        const expectedEstimatedLevels = [0.4, 0.1];
-        const expectedErrorRates = [0.2, 0.5];
-        const expectedRewards = [5, 6];
-        const initialCapacity = 2;
-        const algorithm = {
-          getPossibleNextChallenges: sinon.stub(),
-          getEstimatedLevelAndErrorRate: sinon.stub(),
-          getReward: sinon.stub(),
-        };
-        const pickChallenge = sinon.stub();
-        const pickAnswerStatus = sinon.stub();
-
-        algorithm.getEstimatedLevelAndErrorRate
-          .withArgs({
-            allAnswers: [],
-            challenges: allChallenges,
-            initialCapacity,
-          })
-          .returns({ estimatedLevel: initialCapacity })
-          .withArgs({
-            allAnswers: [sinon.match(answer1)],
-            challenges: allChallenges,
-            initialCapacity,
-          })
-          .returns({ estimatedLevel: expectedEstimatedLevels[0], errorRate: expectedErrorRates[0] })
-          .withArgs({
-            allAnswers: [sinon.match(answer1), sinon.match(answer2)],
-            challenges: allChallenges,
-            initialCapacity,
-          })
-          .returns({
-            estimatedLevel: expectedEstimatedLevels[1],
-            errorRate: expectedErrorRates[1],
-          });
-
-        algorithm.getPossibleNextChallenges
-          .withArgs({
-            allAnswers: [],
-            challenges: allChallenges,
-            initialCapacity,
-          })
-          .returns([challenge2, challenge1])
-          .withArgs({
-            allAnswers: [sinon.match(answer1)],
-            challenges: allChallenges,
-            initialCapacity,
-          })
-          .returns([challenge1]);
-
-        pickChallenge
-          .withArgs({ possibleChallenges: [challenge2, challenge1] })
-          .returns(challenge2)
-          .withArgs({ possibleChallenges: [challenge1] })
-          .returns(challenge1);
-
-        pickAnswerStatus
-          .withArgs({ nextChallenge: challenge2, answerIndex: 0 })
-          .returns(answersForSimulator[0])
-          .withArgs({ nextChallenge: challenge1, answerIndex: 1 })
-          .returns(answersForSimulator[1]);
-
-        algorithm.getReward
-          .withArgs({
-            estimatedLevel: initialCapacity,
-            difficulty: challenge1.difficulty,
-            discriminant: challenge1.discriminant,
-          })
-          .returns(expectedRewards[0])
-          .withArgs({
-            estimatedLevel: expectedEstimatedLevels[0],
-            difficulty: challenge2.difficulty,
-            discriminant: challenge2.discriminant,
-          })
-          .returns(expectedRewards[1]);
-
-        // when
-        const expectedResult = [
-          {
-            challenge: challenge2,
-            estimatedLevel: expectedEstimatedLevels[0],
-            errorRate: expectedErrorRates[0],
-            reward: expectedRewards[0],
-            answerStatus: answersForSimulator[0],
+      strategy.run
+        .withArgs({
+          challengesAnswers: [],
+          stepIndex: 0,
+        })
+        .returns({
+          result: {
+            challenge: challenge,
+            estimatedLevel: expectedEstimatedLevel,
+            errorRate: expectedErrorRate,
+            reward: expectedReward,
+            answerStatus: answerForSimulator,
           },
-          {
-            challenge: challenge1,
-            estimatedLevel: expectedEstimatedLevels[1],
-            errorRate: expectedErrorRates[1],
-            reward: expectedRewards[1],
-            answerStatus: answersForSimulator[1],
-          },
-        ];
+          challengesAnswers: [
+            domainBuilder.buildAnswer({
+              result: answerForSimulator,
+              challengeId: challenge.id,
+            }),
+          ],
+        });
 
-        const result = new AssessmentSimulator({
-          algorithm,
-          challenges: allChallenges,
-          pickChallenge,
-          pickAnswerStatus,
-          initialCapacity,
-        }).run();
+      // when
+      const expectedResult = [
+        {
+          challenge,
+          estimatedLevel: expectedEstimatedLevel,
+          errorRate: expectedErrorRate,
+          reward: expectedReward,
+          answerStatus: answerForSimulator,
+        },
+      ];
 
-        // then
-        expect(result).to.deep.equal(expectedResult);
-      });
+      const result = new AssessmentSimulator({
+        strategy,
+      }).run();
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
     });
   });
 });

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
@@ -11,7 +11,11 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
       const expectedEstimatedLevels = [0.4, 0.2];
       const expectedErrorRates = [0.2, 0.1];
       const expectedRewards = [5, 3];
-      const strategy = {
+      const strategy1 = {
+        run: sinon.stub(),
+      };
+
+      const strategy2 = {
         run: sinon.stub(),
       };
 
@@ -24,7 +28,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
         challengeId: secondChallenge.id,
       });
 
-      strategy.run
+      strategy1.run
         .withArgs({
           challengesAnswers: [],
           stepIndex: 0,
@@ -40,7 +44,9 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             },
           ],
           challengeAnswers: [firstRunAnswer],
-        })
+          nextStepIndex: 1,
+        });
+      strategy2.run
         .withArgs({
           challengesAnswers: [firstRunAnswer],
           stepIndex: 1,
@@ -56,7 +62,10 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             },
           ],
           challengeAnswers: [secondRunAnswer],
+          nextStepIndex: 2,
         });
+
+      const getStrategy = (stepIndex) => (stepIndex === 0 ? strategy1 : strategy2);
 
       // when
       const expectedResult = [
@@ -77,7 +86,7 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
       ];
 
       const result = new AssessmentSimulator({
-        strategy,
+        getStrategy,
       }).run();
 
       // then

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
@@ -28,6 +28,8 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           algorithm.getEstimatedLevelAndErrorRate
             .withArgs({
               allAnswers: [],
+              challenges: allChallenges,
+              initialCapacity,
             })
             .returns({
               estimatedLevel: initialCapacity,
@@ -142,6 +144,8 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           algorithm.getEstimatedLevelAndErrorRate
             .withArgs({
               allAnswers: [],
+              challenges: allChallenges,
+              initialCapacity,
             })
             .returns({
               estimatedLevel: initialCapacity,
@@ -230,6 +234,12 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
         const pickAnswerStatus = sinon.stub();
 
         algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            allAnswers: [],
+            challenges: allChallenges,
+            initialCapacity,
+          })
+          .returns({ estimatedLevel: initialCapacity })
           .withArgs({
             allAnswers: [sinon.match(answer1)],
             challenges: allChallenges,

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
@@ -27,12 +27,10 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
             reward: expectedReward,
             answerStatus: answerForSimulator,
           },
-          challengesAnswers: [
-            domainBuilder.buildAnswer({
-              result: answerForSimulator,
-              challengeId: challenge.id,
-            }),
-          ],
+          challengeAnswer: domainBuilder.buildAnswer({
+            result: answerForSimulator,
+            challengeId: challenge.id,
+          }),
         });
 
       // when

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
@@ -1,18 +1,28 @@
 import { expect, domainBuilder, sinon } from '../../../../../test-helper.js';
-import { AnswerStatus, AssessmentSimulator } from '../../../../../../lib/domain/models/index.js';
+import { Answer, AnswerStatus, AssessmentSimulator } from '../../../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Models | AssessmentSimulator', function () {
   describe('#run', function () {
     it('should return the list of all the challenges', function () {
       // given
-      const challenge = domainBuilder.buildChallenge({ id: 'rec2' });
-      const answerForSimulator = AnswerStatus.OK;
-      const expectedEstimatedLevel = 0.4;
-      const expectedErrorRate = 0.2;
-      const expectedReward = 5;
+      const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1' });
+      const secondChallenge = domainBuilder.buildChallenge({ id: 'rec2' });
+      const answersForSimulator = [AnswerStatus.OK, AnswerStatus.KO];
+      const expectedEstimatedLevels = [0.4, 0.2];
+      const expectedErrorRates = [0.2, 0.1];
+      const expectedRewards = [5, 3];
       const strategy = {
         run: sinon.stub(),
       };
+
+      const firstRunAnswer = new Answer({
+        result: answersForSimulator[0],
+        challengeId: firstChallenge.id,
+      });
+      const secondRunAnswer = new Answer({
+        result: answersForSimulator[1],
+        challengeId: secondChallenge.id,
+      });
 
       strategy.run
         .withArgs({
@@ -21,26 +31,44 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
         })
         .returns({
           result: {
-            challenge: challenge,
-            estimatedLevel: expectedEstimatedLevel,
-            errorRate: expectedErrorRate,
-            reward: expectedReward,
-            answerStatus: answerForSimulator,
+            challenge: firstChallenge,
+            estimatedLevel: expectedEstimatedLevels[0],
+            errorRate: expectedErrorRates[0],
+            reward: expectedRewards[0],
+            answerStatus: answersForSimulator[0],
           },
-          challengeAnswer: domainBuilder.buildAnswer({
-            result: answerForSimulator,
-            challengeId: challenge.id,
-          }),
+          challengeAnswer: firstRunAnswer,
+        })
+        .withArgs({
+          challengesAnswers: [firstRunAnswer],
+          stepIndex: 1,
+        })
+        .returns({
+          result: {
+            challenge: secondChallenge,
+            estimatedLevel: expectedEstimatedLevels[1],
+            errorRate: expectedErrorRates[1],
+            reward: expectedRewards[1],
+            answerStatus: answersForSimulator[1],
+          },
+          challengeAnswer: secondRunAnswer,
         });
 
       // when
       const expectedResult = [
         {
-          challenge,
-          estimatedLevel: expectedEstimatedLevel,
-          errorRate: expectedErrorRate,
-          reward: expectedReward,
-          answerStatus: answerForSimulator,
+          challenge: firstChallenge,
+          estimatedLevel: expectedEstimatedLevels[0],
+          errorRate: expectedErrorRates[0],
+          reward: expectedRewards[0],
+          answerStatus: answersForSimulator[0],
+        },
+        {
+          challenge: secondChallenge,
+          estimatedLevel: expectedEstimatedLevels[1],
+          errorRate: expectedErrorRates[1],
+          reward: expectedRewards[1],
+          answerStatus: answersForSimulator[1],
         },
       ];
 

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulator_test.js
@@ -30,28 +30,32 @@ describe('Unit | Domain | Models | AssessmentSimulator', function () {
           stepIndex: 0,
         })
         .returns({
-          result: {
-            challenge: firstChallenge,
-            estimatedLevel: expectedEstimatedLevels[0],
-            errorRate: expectedErrorRates[0],
-            reward: expectedRewards[0],
-            answerStatus: answersForSimulator[0],
-          },
-          challengeAnswer: firstRunAnswer,
+          results: [
+            {
+              challenge: firstChallenge,
+              estimatedLevel: expectedEstimatedLevels[0],
+              errorRate: expectedErrorRates[0],
+              reward: expectedRewards[0],
+              answerStatus: answersForSimulator[0],
+            },
+          ],
+          challengeAnswers: [firstRunAnswer],
         })
         .withArgs({
           challengesAnswers: [firstRunAnswer],
           stepIndex: 1,
         })
         .returns({
-          result: {
-            challenge: secondChallenge,
-            estimatedLevel: expectedEstimatedLevels[1],
-            errorRate: expectedErrorRates[1],
-            reward: expectedRewards[1],
-            answerStatus: answersForSimulator[1],
-          },
-          challengeAnswer: secondRunAnswer,
+          results: [
+            {
+              challenge: secondChallenge,
+              estimatedLevel: expectedEstimatedLevels[1],
+              errorRate: expectedErrorRates[1],
+              reward: expectedRewards[1],
+              answerStatus: answersForSimulator[1],
+            },
+          ],
+          challengeAnswers: [secondRunAnswer],
         });
 
       // when

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -363,5 +363,6 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
 const _getEstimatedLevelAndErrorRateParams = (params) => ({
   variationPercent: undefined,
+  doubleMeasuresUntil: undefined,
   ...params,
 });

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -202,6 +202,81 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
       });
     });
 
+    context('when settings specific answers for computing estimated level', function () {
+      it('should choose a challenge that has the required success rate first', function () {
+        // Given
+        const easyDifficulty = -3;
+        const hardDifficulty = 3;
+        const discriminant = 1;
+        const initialCapacity = 3;
+
+        const easyChallenge = domainBuilder.buildChallenge({
+          id: 'easyChallenge',
+          skill: domainBuilder.buildSkill({
+            id: 'skillEasy',
+          }),
+          competenceId: 'compEasy',
+          discriminant,
+          difficulty: easyDifficulty,
+        });
+
+        const hardChallenge = domainBuilder.buildChallenge({
+          id: 'hardChallenge',
+          skill: domainBuilder.buildSkill({
+            id: 'skillHard',
+          }),
+          competenceId: 'compHard',
+          discriminant,
+          difficulty: hardDifficulty,
+        });
+
+        const answer1 = domainBuilder.buildAnswer({
+          challengeId: easyChallenge.id,
+        });
+
+        const challenges = [hardChallenge, easyChallenge];
+        const allAnswers = [answer1];
+        const answersForComputingEstimatedLevel = [];
+
+        // when
+        const algorithm = new FlashAssessmentAlgorithm({
+          flashAlgorithmImplementation,
+          ...baseFlashAssessmentAlgorithmConfig,
+        });
+
+        flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
+          .withArgs(
+            _getEstimatedLevelAndErrorRateParams({
+              allAnswers: answersForComputingEstimatedLevel,
+              challenges,
+              estimatedLevel: initialCapacity,
+            }),
+          )
+          .returns({
+            estimatedLevel: 0,
+          });
+
+        flashAlgorithmImplementation.getPossibleNextChallenges
+          .withArgs({
+            availableChallenges: [hardChallenge],
+            estimatedLevel: 0,
+            options: {
+              ...baseGetNextChallengeOptions,
+            },
+          })
+          .returns([hardChallenge]);
+
+        const nextChallenges = algorithm.getPossibleNextChallenges({
+          allAnswers,
+          challenges,
+          initialCapacity,
+          answersForComputingEstimatedLevel,
+        });
+
+        expect(nextChallenges).to.deep.equal([hardChallenge]);
+      });
+    });
+
     context('when specifying a minimal success rate', function () {
       context('when a fixed minimal success rate has been set', function () {
         it('should choose a challenge that has the required success rate first', function () {

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -91,322 +91,363 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
   });
 
   describe('#getEstimatedLevelAndErrorRate', function () {
-    it('should return 0 when there is no answers', function () {
-      // given
-      const allAnswers = [];
-
-      // when
-      const result = flash.getEstimatedLevelAndErrorRate({ allAnswers });
-
-      // then
-      expect(result).to.deep.equal({
-        estimatedLevel: 0,
-        errorRate: 5,
-      });
-    });
-
-    it('should return the correct estimatedLevel when there is one answer', function () {
-      // given
-      const challenges = [
-        domainBuilder.buildChallenge({
-          discriminant: 1.86350005965093,
-          difficulty: 0.194712138508747,
-        }),
-      ];
-
-      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
-
-      // when
-      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
-
-      // then
-      expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
-      expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
-    });
-
-    it('should return the correct estimatedLevel when there is two answers', function () {
-      // given
-      const challenges = [
-        domainBuilder.buildChallenge({
-          id: 'ChallengeFirstAnswers',
-          discriminant: 1.86350005965093,
-          difficulty: 0.194712138508747,
-        }),
-        domainBuilder.buildChallenge({
-          id: 'ChallengeSecondAnswers',
-          discriminant: 2.25422414740233,
-          difficulty: 0.823376599163319,
-        }),
-      ];
-
-      const allAnswers = [
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
-      ];
-
-      // when
-      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
-
-      // then
-      expect(estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
-      expect(errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
-    });
-
-    it('should return the correct estimatedLevel when there is three answers', function () {
-      // given
-      const challenges = [
-        domainBuilder.buildChallenge({
-          id: 'ChallengeFirstAnswers',
-          discriminant: 1.06665273005823,
-          difficulty: -0.030736508016524,
-        }),
-        domainBuilder.buildChallenge({
-          id: 'ChallengeSecondAnswers',
-          discriminant: 1.50948587856458,
-          difficulty: 1.62670103354638,
-        }),
-        domainBuilder.buildChallenge({
-          id: 'ChallengeThirdAnswers',
-          discriminant: 0.950709518595358,
-          difficulty: 1.90647729810166,
-        }),
-      ];
-
-      const allAnswers = [
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
-      ];
-
-      // when
-      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
-
-      // then
-      expect(estimatedLevel).to.be.closeTo(2.851063556136754, 0.00000000001);
-      expect(errorRate).to.be.closeTo(0.9271693210547304, 0.00000000001);
-    });
-
-    context('when the user answers a lot of challenges', function () {
-      it('should return the correct estimatedLevel and errorRate', function () {
-        const listSkills = {
-          url5: domainBuilder.buildSkill({ id: 'url5' }),
-          web3: domainBuilder.buildSkill({ id: 'web3' }),
-          sourceinfo5: domainBuilder.buildSkill({ id: 'sourceinfo5' }),
-          installogiciel2: domainBuilder.buildSkill({ id: 'installogiciel2' }),
-          fichier4: domainBuilder.buildSkill({ id: 'fichier4' }),
-          sauvegarde5: domainBuilder.buildSkill({ id: 'sauvegarde5' }),
-          langbalise6: domainBuilder.buildSkill({ id: 'langbalise6' }),
-          pratiquesinternet4: domainBuilder.buildSkill({ id: 'pratiquesinternet4' }),
-          langbalise7: domainBuilder.buildSkill({ id: 'langbalise7' }),
-        };
-
-        const listChallenges = [
-          domainBuilder.buildChallenge({
-            id: 'recA',
-            skill: listSkills.url5,
-            difficulty: -0.917927344545694,
-            discriminant: 1.02282430250024,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recB',
-            skill: listSkills.web3,
-            difficulty: 0.301604780272093,
-            discriminant: 0.815896135600247,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recC',
-            skill: listSkills.sourceinfo5,
-            difficulty: -1.69218011589622,
-            discriminant: 1.38594509996278,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recD',
-            skill: listSkills.installogiciel2,
-            difficulty: -5.4464574841729,
-            discriminant: 0.427255285029657,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recE',
-            skill: listSkills.fichier4,
-            difficulty: -1.5526216455839,
-            discriminant: 1.21015304225808,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recF',
-            skill: listSkills.fichier4,
-            difficulty: -1.36561917255237,
-            discriminant: 1.09320650236677,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recG',
-            skill: listSkills.fichier4,
-            difficulty: -4.20230915443229,
-            discriminant: 0.562929008226957,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recH',
-            skill: listSkills.fichier4,
-            difficulty: 0.262904155422314,
-            discriminant: 0.901542609459213,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recI',
-            skill: listSkills.fichier4,
-            difficulty: -0.754355900389256,
-            discriminant: 0.834990152043718,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recJ',
-            skill: listSkills.sauvegarde5,
-            difficulty: 3.174339929941,
-            discriminant: 0.827526706077148,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recK',
-            skill: listSkills.sauvegarde5,
-            difficulty: -1.16967416012961,
-            discriminant: 1.17433370794629,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recL',
-            skill: listSkills.sauvegarde5,
-            difficulty: -0.030736508016524,
-            discriminant: 1.06665273005823,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recM',
-            skill: listSkills.sauvegarde5,
-            difficulty: -2.37249657419562,
-            discriminant: 0.656224379307742,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recN',
-            skill: listSkills.langbalise6,
-            difficulty: 1.62670103354638,
-            discriminant: 1.50948587856458,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recO',
-            skill: listSkills.langbalise6,
-            difficulty: 2.811956480867,
-            discriminant: 1.04445171700575,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recP',
-            skill: listSkills.langbalise6,
-            difficulty: 0.026713944730478,
-            discriminant: 0.703441785686095,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recQ',
-            skill: listSkills.pratiquesinternet4,
-            difficulty: -1.83253533603,
-            discriminant: 0.711777117426424,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recR',
-            skill: listSkills.pratiquesinternet4,
-            difficulty: 0.251708600387063,
-            discriminant: 0.369707224301943,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recS',
-            skill: listSkills.pratiquesinternet4,
-            difficulty: 1.90647729810166,
-            discriminant: 0.950709518595358,
-          }),
-          domainBuilder.buildChallenge({
-            id: 'recT',
-            skill: listSkills.langbalise6,
-            difficulty: -1.82670103354638,
-            discriminant: 2.50948587856458,
-          }),
-        ];
-
-        const answers = [
-          domainBuilder.buildAnswer({ challengeId: 'recL', result: AnswerStatus.KO }),
-          domainBuilder.buildAnswer({ challengeId: 'recC', result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: 'recT', result: AnswerStatus.KO }),
-          domainBuilder.buildAnswer({ challengeId: 'recE', result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: 'recA', result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: 'recQ', result: AnswerStatus.OK }),
-        ];
-        const expectedEstimatedLevel = [
-          0, -0.6086049191210775, -0.6653800198379971, -1.7794873733366134, -1.8036203882448785, -1.557864373635504,
-          -1.3925555729766932,
-        ];
-
-        const expectedErrorRate = [
-          5, 1.0659524854635638, 0.9249688328247474, 0.6682031829777919, 0.6193894938423906, 0.5934694499356048,
-          0.5880298028515323,
-        ];
-
+    context('when single measure', function () {
+      it('should return 0 when there is no answers', function () {
+        // given
         const allAnswers = [];
-        let result;
 
-        for (let i = 0; i < answers.length; i++) {
-          result = flash.getEstimatedLevelAndErrorRate({ challenges: listChallenges, allAnswers });
+        // when
+        const result = flash.getEstimatedLevelAndErrorRate({ allAnswers });
 
-          // then
-          expect(result.estimatedLevel).to.be.closeTo(expectedEstimatedLevel[i], 0.000000001);
-          expect(result.errorRate).to.be.closeTo(expectedErrorRate[i], 0.000000001);
+        // then
+        expect(result).to.deep.equal({
+          estimatedLevel: 0,
+          errorRate: 5,
+        });
+      });
 
-          allAnswers.push(answers[i]);
-        }
+      it('should return the correct estimatedLevel when there is one answer', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+          }),
+        ];
+
+        const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+        // when
+        const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+
+        // then
+        expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+        expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
+      });
+
+      it('should return the correct estimatedLevel when there is two answers', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ChallengeFirstAnswers',
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeSecondAnswers',
+            discriminant: 2.25422414740233,
+            difficulty: 0.823376599163319,
+          }),
+        ];
+
+        const allAnswers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+        ];
+
+        // when
+        const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+
+        // then
+        expect(estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
+        expect(errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
+      });
+
+      it('should return the correct estimatedLevel when there is three answers', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ChallengeFirstAnswers',
+            discriminant: 1.06665273005823,
+            difficulty: -0.030736508016524,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeSecondAnswers',
+            discriminant: 1.50948587856458,
+            difficulty: 1.62670103354638,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeThirdAnswers',
+            discriminant: 0.950709518595358,
+            difficulty: 1.90647729810166,
+          }),
+        ];
+
+        const allAnswers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+        ];
+
+        // when
+        const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+
+        // then
+        expect(estimatedLevel).to.be.closeTo(2.851063556136754, 0.00000000001);
+        expect(errorRate).to.be.closeTo(0.9271693210547304, 0.00000000001);
+      });
+
+      context('when the user answers a lot of challenges', function () {
+        it('should return the correct estimatedLevel and errorRate', function () {
+          const listSkills = {
+            url5: domainBuilder.buildSkill({ id: 'url5' }),
+            web3: domainBuilder.buildSkill({ id: 'web3' }),
+            sourceinfo5: domainBuilder.buildSkill({ id: 'sourceinfo5' }),
+            installogiciel2: domainBuilder.buildSkill({ id: 'installogiciel2' }),
+            fichier4: domainBuilder.buildSkill({ id: 'fichier4' }),
+            sauvegarde5: domainBuilder.buildSkill({ id: 'sauvegarde5' }),
+            langbalise6: domainBuilder.buildSkill({ id: 'langbalise6' }),
+            pratiquesinternet4: domainBuilder.buildSkill({ id: 'pratiquesinternet4' }),
+            langbalise7: domainBuilder.buildSkill({ id: 'langbalise7' }),
+          };
+
+          const listChallenges = [
+            domainBuilder.buildChallenge({
+              id: 'recA',
+              skill: listSkills.url5,
+              difficulty: -0.917927344545694,
+              discriminant: 1.02282430250024,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recB',
+              skill: listSkills.web3,
+              difficulty: 0.301604780272093,
+              discriminant: 0.815896135600247,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recC',
+              skill: listSkills.sourceinfo5,
+              difficulty: -1.69218011589622,
+              discriminant: 1.38594509996278,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recD',
+              skill: listSkills.installogiciel2,
+              difficulty: -5.4464574841729,
+              discriminant: 0.427255285029657,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recE',
+              skill: listSkills.fichier4,
+              difficulty: -1.5526216455839,
+              discriminant: 1.21015304225808,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recF',
+              skill: listSkills.fichier4,
+              difficulty: -1.36561917255237,
+              discriminant: 1.09320650236677,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recG',
+              skill: listSkills.fichier4,
+              difficulty: -4.20230915443229,
+              discriminant: 0.562929008226957,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recH',
+              skill: listSkills.fichier4,
+              difficulty: 0.262904155422314,
+              discriminant: 0.901542609459213,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recI',
+              skill: listSkills.fichier4,
+              difficulty: -0.754355900389256,
+              discriminant: 0.834990152043718,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recJ',
+              skill: listSkills.sauvegarde5,
+              difficulty: 3.174339929941,
+              discriminant: 0.827526706077148,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recK',
+              skill: listSkills.sauvegarde5,
+              difficulty: -1.16967416012961,
+              discriminant: 1.17433370794629,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recL',
+              skill: listSkills.sauvegarde5,
+              difficulty: -0.030736508016524,
+              discriminant: 1.06665273005823,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recM',
+              skill: listSkills.sauvegarde5,
+              difficulty: -2.37249657419562,
+              discriminant: 0.656224379307742,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recN',
+              skill: listSkills.langbalise6,
+              difficulty: 1.62670103354638,
+              discriminant: 1.50948587856458,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recO',
+              skill: listSkills.langbalise6,
+              difficulty: 2.811956480867,
+              discriminant: 1.04445171700575,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recP',
+              skill: listSkills.langbalise6,
+              difficulty: 0.026713944730478,
+              discriminant: 0.703441785686095,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recQ',
+              skill: listSkills.pratiquesinternet4,
+              difficulty: -1.83253533603,
+              discriminant: 0.711777117426424,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recR',
+              skill: listSkills.pratiquesinternet4,
+              difficulty: 0.251708600387063,
+              discriminant: 0.369707224301943,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recS',
+              skill: listSkills.pratiquesinternet4,
+              difficulty: 1.90647729810166,
+              discriminant: 0.950709518595358,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'recT',
+              skill: listSkills.langbalise6,
+              difficulty: -1.82670103354638,
+              discriminant: 2.50948587856458,
+            }),
+          ];
+
+          const answers = [
+            domainBuilder.buildAnswer({ challengeId: 'recL', result: AnswerStatus.KO }),
+            domainBuilder.buildAnswer({ challengeId: 'recC', result: AnswerStatus.OK }),
+            domainBuilder.buildAnswer({ challengeId: 'recT', result: AnswerStatus.KO }),
+            domainBuilder.buildAnswer({ challengeId: 'recE', result: AnswerStatus.OK }),
+            domainBuilder.buildAnswer({ challengeId: 'recA', result: AnswerStatus.OK }),
+            domainBuilder.buildAnswer({ challengeId: 'recQ', result: AnswerStatus.OK }),
+          ];
+          const expectedEstimatedLevel = [
+            0, -0.6086049191210775, -0.6653800198379971, -1.7794873733366134, -1.8036203882448785, -1.557864373635504,
+            -1.3925555729766932,
+          ];
+
+          const expectedErrorRate = [
+            5, 1.0659524854635638, 0.9249688328247474, 0.6682031829777919, 0.6193894938423906, 0.5934694499356048,
+            0.5880298028515323,
+          ];
+
+          const allAnswers = [];
+          let result;
+
+          for (let i = 0; i < answers.length; i++) {
+            result = flash.getEstimatedLevelAndErrorRate({ challenges: listChallenges, allAnswers });
+
+            // then
+            expect(result.estimatedLevel).to.be.closeTo(expectedEstimatedLevel[i], 0.000000001);
+            expect(result.errorRate).to.be.closeTo(expectedErrorRate[i], 0.000000001);
+
+            allAnswers.push(answers[i]);
+          }
+        });
+      });
+
+      context('when limiting the estimated level variation', function () {
+        context('when giving a right answer', function () {
+          it('should return the limited estimatedLevel', function () {
+            // given
+            const challenges = [
+              domainBuilder.buildChallenge({
+                discriminant: 1.86350005965093,
+                difficulty: 0.194712138508747,
+              }),
+            ];
+
+            const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+            const variationPercent = 0.5;
+
+            // when
+            const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+              allAnswers,
+              challenges,
+              variationPercent,
+            });
+
+            // then
+            expect(estimatedLevel).to.be.closeTo(0.5, 0.00000000001);
+          });
+        });
+
+        context('when giving a wrong answer', function () {
+          it('should return the limited estimatedLevel', function () {
+            // given
+            const challenges = [
+              domainBuilder.buildChallenge({
+                discriminant: 1.86350005965093,
+                difficulty: 0.194712138508747,
+              }),
+            ];
+
+            const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[0].id })];
+
+            const variationPercent = 0.5;
+
+            // when
+            const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+              allAnswers,
+              challenges,
+              variationPercent,
+            });
+
+            // then
+            expect(estimatedLevel).to.be.closeTo(-0.5, 0.00000000001);
+          });
+        });
       });
     });
 
-    context('when limiting the estimated level variation', function () {
-      context('when giving a right answer', function () {
-        it('should return the limited estimatedLevel', function () {
-          // given
-          const challenges = [
-            domainBuilder.buildChallenge({
-              discriminant: 1.86350005965093,
-              difficulty: 0.194712138508747,
-            }),
-          ];
+    context('when double measure', function () {
+      it('should return the correct estimatedLevel when there is three answers', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ChallengeFirstAnswers',
+            discriminant: 1.06665273005823,
+            difficulty: -0.03,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeSecondAnswers',
+            discriminant: 1.06665273005823,
+            difficulty: -0.06,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeThirdAnswers',
+            discriminant: 0.950709518595358,
+            difficulty: 1.90647729810166,
+          }),
+        ];
 
-          const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+        const allAnswers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+        ];
 
-          const variationPercent = 0.5;
-
-          // when
-          const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
-            allAnswers,
-            challenges,
-            variationPercent,
-          });
-
-          // then
-          expect(estimatedLevel).to.be.closeTo(0.5, 0.00000000001);
+        // when
+        const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+          allAnswers,
+          challenges,
+          doubleMeasuresUntil: 2,
         });
-      });
 
-      context('when giving a wrong answer', function () {
-        it('should return the limited estimatedLevel', function () {
-          // given
-          const challenges = [
-            domainBuilder.buildChallenge({
-              discriminant: 1.86350005965093,
-              difficulty: 0.194712138508747,
-            }),
-          ];
-
-          const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[0].id })];
-
-          const variationPercent = 0.5;
-
-          // when
-          const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
-            allAnswers,
-            challenges,
-            variationPercent,
-          });
-
-          // then
-          expect(estimatedLevel).to.be.closeTo(-0.5, 0.00000000001);
-        });
+        // then
+        expect(estimatedLevel).to.be.closeTo(1.663469355503838, 0.00000000001);
       });
     });
   });

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -449,6 +449,45 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         // then
         expect(estimatedLevel).to.be.closeTo(1.663469355503838, 0.00000000001);
       });
+
+      context('when double measure is active with an odd number of challenges', function () {
+        it('should return the correct estimatedLevel when there is three answers', function () {
+          // given
+          const challenges = [
+            domainBuilder.buildChallenge({
+              id: 'ChallengeFirstAnswers',
+              discriminant: 1.06665273005823,
+              difficulty: -0.03,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'ChallengeSecondAnswers',
+              discriminant: 1.06665273005823,
+              difficulty: -0.06,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'ChallengeThirdAnswers',
+              discriminant: 0.950709518595358,
+              difficulty: 1.90647729810166,
+            }),
+          ];
+
+          const allAnswers = [
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+          ];
+
+          // when
+          const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+            allAnswers,
+            challenges,
+            doubleMeasuresUntil: 4,
+          });
+
+          // then
+          expect(estimatedLevel).to.be.closeTo(1.663469355503838, 0.00000000001);
+        });
+      });
     });
   });
 

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -70,6 +70,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           allAnswers: answers,
           estimatedLevel: sinon.match.number,
           variationPercent: undefined,
+          doubleMeasuresUntil: undefined,
         })
         .returns({
           estimatedLevel: expectedEstimatedLevel,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -329,6 +329,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
             variationPercent: undefined,
+            doubleMeasuresUntil: undefined,
           })
           .returns({
             estimatedLevel: expectedEstimatedLevel,
@@ -384,6 +385,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
             variationPercent: undefined,
+            doubleMeasuresUntil: undefined,
           })
           .returns({
             estimatedLevel: 2,

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -176,6 +176,7 @@ const _buildChallenges = (difficulty, numberOfChallenges) => {
 
 const _getEstimatedLevelAndErrorRateParams = (params) => ({
   ...params,
+  doubleMeasuresUntil: undefined,
   variationPercent: undefined,
 });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -144,6 +144,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              doubleMeasuresUntil: undefined,
             })
             .returns({
               estimatedLevel: 0,
@@ -205,6 +206,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              doubleMeasuresUntil: undefined,
             })
             .returns({
               estimatedLevel: 0,
@@ -279,6 +281,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              doubleMeasuresUntil: undefined,
             })
             .returns({
               estimatedLevel: 0,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -148,6 +148,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               challenges: [nextChallengeToAnswer],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              doubleMeasuresUntil: undefined,
             })
             .returns({ estimatedLevel: 0 });
 
@@ -282,6 +283,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               challenges: [nextChallenge],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              doubleMeasuresUntil: undefined,
             })
             .returns({ estimatedLevel: 0 });
 
@@ -379,6 +381,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               challenges: [answeredChallenge],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              doubleMeasuresUntil: undefined,
             })
             .returns({
               estimatedLevel: 2,

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -403,17 +403,29 @@ function prepareStubs({
     })
     .returns([firstChallenge, thirdChallenge, secondChallenge])
     .withArgs({
-      availableChallenges: [secondChallenge, thirdChallenge],
-      estimatedLevel: 1,
-      options: getNextChallengesOptionsMatcher,
-    })
-    .returns([thirdChallenge, secondChallenge])
-    .withArgs({
       availableChallenges: [thirdChallenge],
       estimatedLevel: 2,
       options: getNextChallengesOptionsMatcher,
     })
     .returns([thirdChallenge]);
+
+  if (doubleMeasuresUntil) {
+    flashAlgorithmService.getPossibleNextChallenges
+      .withArgs({
+        availableChallenges: [secondChallenge, thirdChallenge],
+        estimatedLevel: 0,
+        options: getNextChallengesOptionsMatcher,
+      })
+      .returns([thirdChallenge, secondChallenge]);
+  } else {
+    flashAlgorithmService.getPossibleNextChallenges
+      .withArgs({
+        availableChallenges: [secondChallenge, thirdChallenge],
+        estimatedLevel: 1,
+        options: getNextChallengesOptionsMatcher,
+      })
+      .returns([thirdChallenge, secondChallenge]);
+  }
 
   challengeRepository.findFlashCompatible.resolves([firstChallenge, secondChallenge, thirdChallenge]);
 

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -59,7 +59,6 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({
-          doubleMeasuresUntil: undefined,
           challengeRepository,
           locale,
           pickChallenge,
@@ -127,7 +126,6 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({
-          doubleMeasuresUntil: undefined,
           challengeRepository,
           locale,
           pickChallenge,
@@ -168,7 +166,6 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({
-          doubleMeasuresUntil: undefined,
           challengeRepository,
           locale,
           pickChallenge,
@@ -187,6 +184,33 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
           expect(answer.estimatedLevel).not.to.be.undefined;
           expect(answer.reward).not.to.be.undefined;
           expect(answer.answerStatus).not.to.be.undefined;
+        });
+      });
+    });
+
+    context('when doing a double measure', function () {
+      it('should return an array of estimated level, challenge, reward and error rate for each answer', async function () {
+        // given
+        const { challengeRepository, pickChallenge, pickAnswerStatus, flashAlgorithmService } = prepareStubs({
+          doubleMeasuresUntil: 2,
+        });
+
+        // when
+        const result = await simulateFlashDeterministicAssessmentScenario({
+          challengeRepository,
+          locale,
+          pickChallenge,
+          pickAnswerStatus,
+          flashAlgorithmService,
+          enablePassageByAllCompetences: false,
+          doubleMeasuresUntil: 2,
+        });
+
+        // then
+        expect(result).to.have.lengthOf(3);
+        result.forEach((answer) => {
+          expect(answer.challenge).not.to.be.undefined;
+          expect(answer.estimatedLevel).not.to.be.undefined;
         });
       });
     });
@@ -242,7 +266,6 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
       // when
       const result = await simulateFlashDeterministicAssessmentScenario({
-        doubleMeasuresUntil: undefined,
         challengeRepository,
         locale,
         pickChallenge,
@@ -266,7 +289,11 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
   });
 });
 
-function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidateCapacity, minimalSuccessRate } = {}) {
+function prepareStubs({
+  initialCapacity = config.v3Certification.defaultCandidateCapacity,
+  minimalSuccessRate,
+  doubleMeasuresUntil = 0,
+} = {}) {
   const firstSkill = domainBuilder.buildSkill({ id: 'firstSkill', tubeId: '1' });
   const secondSkill = domainBuilder.buildSkill({ id: 'secondSkill', tubeId: '2' });
   const thirdSkill = domainBuilder.buildSkill({ id: 'thirdSkill', tubeId: '3' });
@@ -320,7 +347,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: sinon.match.any,
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
-      doubleMeasuresUntil: undefined,
+      doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 0, errorRate: 0.1 })
     .withArgs({
@@ -328,7 +355,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
-      doubleMeasuresUntil: undefined,
+      doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 1, errorRate: 1.1 })
     .withArgs({
@@ -336,7 +363,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
-      doubleMeasuresUntil: undefined,
+      doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 2, errorRate: 2.1 })
     .withArgs({
@@ -344,7 +371,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
-      doubleMeasuresUntil: undefined,
+      doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 3, errorRate: 3.1 });
 

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -59,6 +59,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({
+          doubleMeasuresUntil: undefined,
           challengeRepository,
           locale,
           pickChallenge,
@@ -126,6 +127,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({
+          doubleMeasuresUntil: undefined,
           challengeRepository,
           locale,
           pickChallenge,
@@ -166,6 +168,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
         // when
         const result = await simulateFlashDeterministicAssessmentScenario({
+          doubleMeasuresUntil: undefined,
           challengeRepository,
           locale,
           pickChallenge,
@@ -239,6 +242,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
       // when
       const result = await simulateFlashDeterministicAssessmentScenario({
+        doubleMeasuresUntil: undefined,
         challengeRepository,
         locale,
         pickChallenge,
@@ -316,6 +320,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: sinon.match.any,
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      doubleMeasuresUntil: undefined,
     })
     .returns({ estimatedLevel: 0, errorRate: 0.1 })
     .withArgs({
@@ -323,6 +328,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      doubleMeasuresUntil: undefined,
     })
     .returns({ estimatedLevel: 1, errorRate: 1.1 })
     .withArgs({
@@ -330,6 +336,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      doubleMeasuresUntil: undefined,
     })
     .returns({ estimatedLevel: 2, errorRate: 2.1 })
     .withArgs({
@@ -337,6 +344,7 @@ function prepareStubs({ initialCapacity = config.v3Certification.defaultCandidat
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      doubleMeasuresUntil: undefined,
     })
     .returns({ estimatedLevel: 3, errorRate: 3.1 });
 


### PR DESCRIPTION
## :unicorn: Problème
La méthode actuelle de lissage de la difficulté pose des problèmes mathématiques lors de l'évaluation de la capacité de l'utilisateur. 

## :robot: Proposition
Pour remédier à ça, nous implémentons une nouvelle manière de mesurer cette capacité dans les simulateurs (double mesure) afin de permettre à l'équipe data de tester cette approche.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
```
curl https://api-pr7394.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "capacity": 1.5, "stopAtChallenge": 32, "numberOfIterations": 1, "doubleMeasuresUntil": 20 }' | jq '.'
```
