### PR TITLE
[TECH] Corrige des messages de dépréciation relatifs a ember-data sur certif

### DIFF
--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -85,7 +85,7 @@
     {{/if}}
 
     {{#if this.errorMessage}}
-      <PixMessage @type="alert">
+      <PixMessage @type="error">
         {{this.errorMessage}}
       </PixMessage>
     {{/if}}

--- a/certif/app/components/auth/toggable-login-form.hbs
+++ b/certif/app/components/auth/toggable-login-form.hbs
@@ -29,7 +29,7 @@
   />
 
   {{#if this.isErrorMessagePresent}}
-    <PixMessage @type="alert">
+    <PixMessage @type="error">
       {{this.errorMessage}}
     </PixMessage>
   {{/if}}

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -54,13 +54,13 @@
       </div>
 
       {{#if this.showCategoryMissingError}}
-        <PixMessage @type="alert">{{t
+        <PixMessage @type="error">{{t
             "pages.session-finalization.add-issue-modal.actions.select-category"
           }}</PixMessage>
       {{/if}}
 
       {{#if this.showIssueReportSubmitError}}
-        <PixMessage @type="alert">{{t "pages.session-finalization.add-issue-modal.errors.add-reporting"}}</PixMessage>
+        <PixMessage @type="error">{{t "pages.session-finalization.add-issue-modal.errors.add-reporting"}}</PixMessage>
       {{/if}}
     </form>
   </:content>

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -34,7 +34,7 @@
     </div>
 
     {{#if this.showDeletionError}}
-      <PixMessage @type="alert">{{t
+      <PixMessage @type="error">{{t
           "pages.session-finalization.issue-reports-modal.errors.delete-reporting"
         }}</PixMessage>
     {{/if}}

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import every from 'lodash/every';
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
@@ -24,7 +23,7 @@ export default class CertificationCandidatesController extends Controller {
 
   @computed('certificationCandidates', 'certificationCandidates.@each.isLinked')
   get importAllowed() {
-    return every(this.certificationCandidates.toArray(), (certificationCandidate) => {
+    return this.certificationCandidates.every((certificationCandidate) => {
       return !certificationCandidate.isLinked;
     });
   }

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -149,7 +149,7 @@ export default class SessionsFinalizeController extends Controller {
 
     if (invalidCertificationReports.length) {
       const select = document.getElementById(
-        `finalization-report-abort-reason__select${invalidCertificationReports.firstObject.id}`,
+        `finalization-report-abort-reason__select${invalidCertificationReports[0].id}`,
       );
 
       this.showErrorNotification(this.intl.t('pages.session-finalization.errors.no-abort-reason'));

--- a/certif/app/controllers/authenticated/team/list.js
+++ b/certif/app/controllers/authenticated/team/list.js
@@ -45,7 +45,7 @@ export default class AuthenticatedTeamListController extends Controller {
   async onValidateReferer() {
     if (this.selectedReferer !== '') {
       const userId = this.selectedReferer;
-      const member = this.model.members.toArray().find((member) => member.id === userId);
+      const member = this.model.members.find((member) => member.id === userId);
 
       try {
         await member.updateReferer({ userId: member.id, isReferer: true });
@@ -65,9 +65,9 @@ export default class AuthenticatedTeamListController extends Controller {
 }
 
 function _hasAtLeastOneMemberAndNoReferer(members) {
-  return members.length > 0 && !members.toArray().some((member) => member.isReferer);
+  return members.length > 0 && !members.some((member) => member.isReferer);
 }
 
 function _hasAtLeastTwoMembersAndOneReferer(members) {
-  return members.length > 1 && members.toArray().some((member) => member.isReferer);
+  return members.length > 1 && members.some((member) => member.isReferer);
 }

--- a/certif/app/models/certification-report.js
+++ b/certif/app/models/certification-report.js
@@ -15,7 +15,7 @@ export default class CertificationReport extends Model {
 
   @computed('certificationIssueReports.@each.description')
   get firstIssueReportDescription() {
-    const firstIssueReport = this.certificationIssueReports.firstObject;
+    const firstIssueReport = this.certificationIssueReports[0];
     return firstIssueReport ? firstIssueReport.description : '';
   }
 

--- a/certif/config/deprecation-workflow.js
+++ b/certif/config/deprecation-workflow.js
@@ -1,0 +1,9 @@
+// eslint-disable-next-line no-undef
+window.deprecationWorkflow = self.deprecationWorkflow || {};
+// eslint-disable-next-line no-undef
+window.deprecationWorkflow.config = {
+  workflow: [
+    { handler: 'silence', matchId: 'ember-data:deprecate-early-static' },
+    { handler: 'silence', matchId: 'ember-polyfills.deprecate-assign' },
+  ],
+};

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -40,6 +40,7 @@
         "ember-cli-babel": "^8.0.0",
         "ember-cli-clipboard": "^1.1.0",
         "ember-cli-dependency-checker": "^3.3.1",
+        "ember-cli-deprecation-workflow": "^2.2.0",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-matomo-tag-manager": "^1.3.1",
@@ -26077,6 +26078,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.2.0.tgz",
+      "integrity": "sha512-23bXZqZJBJSKBTfT0LK7qzSJX861TgafL6RVdMfn/iubpLnoZIWergYwEdgs24CNTUbuehVbHy2Q71o8jYfwfw==",
+      "dev": true,
+      "dependencies": {
+        "@ember/string": "^3.0.0",
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-plugin": "^4.0.5"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-cli-get-component-path-option": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -71,6 +71,7 @@
     "ember-cli-babel": "^8.0.0",
     "ember-cli-clipboard": "^1.1.0",
     "ember-cli-dependency-checker": "^3.3.1",
+    "ember-cli-deprecation-workflow": "^2.2.0",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-matomo-tag-manager": "^1.3.1",


### PR DESCRIPTION
## :unicorn: Problème
Il y a des avertissements de dépréciation relatifs a ember-data sur pix-certif. C'est pénible.

## :robot: Proposition
Corriger les avertissements de notre code, et rendre silencieux les autres.

## :rainbow: Remarques
Ajout de https://github.com/mixonic/ember-cli-deprecation-workflow pour `rendre silencieux les autres`

## :100: Pour tester
Lancer les tests et voir qu'il n'y a plus de messages d'avertissement.
