### PR TITLE
[TECH] le hook de pre-commit lance les commandes de lint depuis les dossiers des applis front

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npx lint-staged --cwd 1d
+npx lint-staged --cwd admin
+npx lint-staged --cwd certif
+npx lint-staged --cwd mon-pix
+npx lint-staged --cwd orga
 npx lint-staged
 
 .husky/detect-secret

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,5 @@
 {
-  "*.{js,yml, yaml}": "eslint --fix",
+  "!(admin|1d|certif|monpix|orga)/**/*.{js,yml, yaml}": "eslint --fix",
+  "./*.{js,yml, yaml}": "eslint --fix",
   "*.scss": "stylelint --fix"
 }

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -57,8 +57,8 @@ module.exports = {
       {
         zones: [
           {
-            target: 'lib/domain/usecases',
-            from: 'lib/infrastructure/repositories',
+            target: ['api/lib/domain/usecases', 'lib/domain/usecases'],
+            from: ['api/lib/infrastructure/repositories', 'lib/infrastructure/repositories'],
             except: [],
             message:
               "Repositories are automatically injected in use-case, you don't need to import them. Check for further details: https://github.com/1024pix/pix/blob/dev/docs/adr/0046-injecter-les-dependances-api.md",


### PR DESCRIPTION
## :unicorn: Problème
Le hook de pre-commit ajouté par husky ne fonctionne pas lorsqu'un fichier js du répertoire admin a été modifié

## :unicorn: :unicorn: Problème bis
Ça concerne pas que Admin 😱 

## :robot: Proposition
Faire en sorte que le hook lance `eslint --fix` depuis le dossier admin pour les fichiers modifiés dans le dossier admin  

## :robot: :robot: Proposition bis
Ajouter la dépendance `@babel/plugin-proposal-decorators` à la racine du projet.
On évite le côté error prone des expressions [micromatch](https://github.com/micromatch/micromatch) en cascade

## :rainbow: Remarques
L'erreur en question: 
<img width="1192" alt="image" src="https://github.com/1024pix/pix/assets/3033624/db24b382-a227-43ca-a1bb-11db8537d79c">


Eslint/babel semble chercher cette dépendance à partir des nodes_modules où la commande est lancée, et non à partir du fichier. J'imagine qu'il la cherche car elle est listée dans le `eslintrc` du dossier `admin`, sans certitudes 🤷  

D'autres options:
- lister la dépendance manquante `@babel/plugin-proposal-decorators` à la racine du projet |=> invasif 😕
- mettre en place un git hook qui installerait cette dépendance sans la sauver et diffuser ce hook aux personnes qui travaillent sur admin |=> ça parait bancale
- autres idées ?

## :100: Pour tester
- Mettre en place le hook de pre-commit: `npm run local:add-optional-checks`
   Voir [cette doc](https://github.com/1024pix/pix/blob/dev/INSTALLATION.md#ex%C3%A9cuter-le-lint-%C3%A0-chaque-commit)
- modifier un fichier js dans `admin` et le commit
