### PR TITLE
[FEATURE] Ajouter un script pour mettre à jour le rôle de membres de centres de certification (PIX-9826)

### DIFF
--- a/api/lib/domain/usecases/set-certification-center-membership-role-to-admin.js
+++ b/api/lib/domain/usecases/set-certification-center-membership-role-to-admin.js
@@ -1,0 +1,25 @@
+import { NotFoundError } from '../errors.js';
+
+async function setCertificationCenterMembershipRoleToAdmin({
+  certificationCenterId,
+  userId,
+  certificationCenterMembershipRepository,
+}) {
+  const certificationCenterMembership =
+    await certificationCenterMembershipRepository.findOneWithCertificationCenterIdAndUserId({
+      certificationCenterId,
+      userId,
+    });
+
+  if (!certificationCenterMembership) {
+    throw new NotFoundError(
+      `Certification center membership not found with certificationCenterId(${certificationCenterId}) and userId(${userId})`,
+    );
+  }
+
+  certificationCenterMembership.updateRole({ role: 'ADMIN' });
+
+  await certificationCenterMembershipRepository.update(certificationCenterMembership);
+}
+
+export { setCertificationCenterMembershipRoleToAdmin };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -236,9 +236,20 @@ const findById = async function (certificationCenterMembershipId) {
   return _toDomain(certificationCenterMembership);
 };
 
+const findOneWithCertificationCenterIdAndUserId = async function ({ certificationCenterId, userId }) {
+  const certificationCenterMembership = await knex('certification-center-memberships')
+    .where({ certificationCenterId, userId })
+    .first();
+
+  if (!certificationCenterMembership) return;
+
+  return _toDomain(certificationCenterMembership);
+};
+
 export {
   findByUserId,
   findActiveByCertificationCenterIdSortedById,
+  findOneWithCertificationCenterIdAndUserId,
   save,
   isAdminOfCertificationCenter,
   isMemberOfCertificationCenter,

--- a/api/scripts/team-acces/set-certification-center-memberships-role-to-admin.js
+++ b/api/scripts/team-acces/set-certification-center-memberships-role-to-admin.js
@@ -1,0 +1,77 @@
+import url from 'url';
+
+import _ from 'lodash';
+import bluebird from 'bluebird';
+
+import { disconnect } from '../../db/knex-database-connection.js';
+import { checkCsvHeader, parseCsvWithHeader } from '../helpers/csvHelpers.js';
+import { usecases } from '../../lib/domain/usecases/index.js';
+
+const MODULE_PATH = url.fileURLToPath(import.meta.url);
+const IS_LAUNCHED_FROM_CLI = process.argv[1] === MODULE_PATH;
+const TIMER_NAME = '';
+const REQUIRED_FIELD_NAMES = ['certificationCenterId', 'userId'];
+
+async function main() {
+  const filePath = process.argv[2];
+  const parsingOptions = {
+    skipEmptyLines: true,
+    header: true,
+    transform: (value) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (_.isEmpty(value)) {
+        value = null;
+      }
+
+      return value;
+    },
+  };
+
+  await checkCsvHeader({
+    filePath,
+    requiredFieldNames: REQUIRED_FIELD_NAMES,
+  });
+
+  console.log('Reading and parsing csv data file... ');
+
+  const certificationCenterMembershipsData = await parseCsvWithHeader(filePath, parsingOptions);
+  const errors = [];
+
+  await bluebird.mapSeries(certificationCenterMembershipsData, async (certificationCenterMembershipData) => {
+    const { certificationCenterId, userId } = certificationCenterMembershipData;
+
+    try {
+      await usecases.setCertificationCenterMembershipRoleToAdmin({ certificationCenterId, userId });
+    } catch (error) {
+      errors.push({ certificationCenterMembershipData, error });
+    }
+  });
+
+  if (errors.length === 0) return;
+
+  console.log(`Errors occurs on ${errors.length} element(s)!`);
+  errors.forEach((error) => {
+    console.log(JSON.stringify(error.certificationCenterMembershipData));
+    console.error(error.error?.message);
+  });
+
+  throw new Error('Process done with errors');
+}
+
+(async function () {
+  if (IS_LAUNCHED_FROM_CLI) {
+    try {
+      console.time(TIMER_NAME);
+      await main();
+      console.log('\nCertification center memberships updated with success!');
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      console.timeEnd(TIMER_NAME);
+    }
+  }
+})();

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -270,6 +270,42 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
   });
 
+  describe('#findOneWithCertificationCenterIdAndUserId', function () {
+    context('when certification center membership does not exist', function () {
+      it('returns undefined', async function () {
+        // given
+        // when
+        const response = await certificationCenterMembershipRepository.findOneWithCertificationCenterIdAndUserId({
+          certificationCenterId: 2023,
+          userId: 2021,
+        });
+
+        // then
+        expect(response).to.be.undefined;
+      });
+    });
+
+    context('when certification center membership exists', function () {
+      it('returns a certification center membership', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ certificationCenterId, userId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await certificationCenterMembershipRepository.findOneWithCertificationCenterIdAndUserId({
+          certificationCenterId,
+          userId,
+        });
+
+        // then
+        expect(response).to.be.instanceOf(CertificationCenterMembership);
+      });
+    });
+  });
+
   describe('#isAdminOfCertificationCenter', function () {
     let certificationCenterId, userId;
 

--- a/api/tests/unit/domain/usecases/set-certification-center-membership-role-to-admin_test.js
+++ b/api/tests/unit/domain/usecases/set-certification-center-membership-role-to-admin_test.js
@@ -1,0 +1,86 @@
+import { catchErr, expect, sinon } from '../../../test-helper.js';
+
+import { setCertificationCenterMembershipRoleToAdmin } from '../../../../lib/domain/usecases/set-certification-center-membership-role-to-admin.js';
+import { CertificationCenterMembership } from '../../../../lib/domain/models/CertificationCenterMembership.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | Domain | UseCases | set-certification-center-memberships-role-to-admin', function () {
+  let certificationCenterMembershipRepository, clock;
+  const now = new Date();
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(now);
+    certificationCenterMembershipRepository = {
+      findOneWithCertificationCenterIdAndUserId: sinon.stub(),
+      update: sinon.stub(),
+    };
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('when certification center membership exists', function () {
+    it('updates certification center memberships role to admin', async function () {
+      // given
+      const certificationCenterId = 1;
+      const userId = 1;
+      const certificationCenterMembership = new CertificationCenterMembership({
+        id: 1,
+        role: 'MEMBER',
+      });
+      const updatedCertificationCenterMembership = new CertificationCenterMembership({
+        ...certificationCenterMembership,
+        updatedAt: now,
+        role: 'ADMIN',
+      });
+
+      certificationCenterMembershipRepository.findOneWithCertificationCenterIdAndUserId
+        .withArgs({
+          certificationCenterId,
+          userId,
+        })
+        .resolves(certificationCenterMembership);
+      certificationCenterMembershipRepository.update.withArgs(updatedCertificationCenterMembership).resolves();
+
+      // when
+      await setCertificationCenterMembershipRoleToAdmin({
+        certificationCenterId,
+        userId,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(certificationCenterMembershipRepository.findOneWithCertificationCenterIdAndUserId).to.have.been.called;
+      expect(certificationCenterMembershipRepository.update).to.have.been.called;
+    });
+  });
+
+  context('when certification center membership does not exist', function () {
+    it('throws a NotFound error', async function () {
+      // given
+      const certificationCenterId = 1;
+      const userId = 1;
+
+      certificationCenterMembershipRepository.findOneWithCertificationCenterIdAndUserId
+        .withArgs({
+          certificationCenterId,
+          userId,
+        })
+        .resolves();
+
+      // when
+      const error = await catchErr(setCertificationCenterMembershipRoleToAdmin)({
+        certificationCenterId,
+        userId,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(
+        `Certification center membership not found with certificationCenterId(${certificationCenterId}) and userId(${userId})`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la gestion des membres d'un centre de certification, une colonne `role` a été ajoutée à la table `certification-center-memberships` avec comme valeur par défaut `MEMBER`.
Les agents Pix devront, via Pix Admin, modifier le rôle de certains membres de centres de certification et cette action risque d'être fastidieuse.

## :robot: Proposition
 Créer un script qui reçoit en entrée un fichier CSV avec 2 colonnes nommées `certificationCenterId` et `userId`, et met à jour le rôle de chaque combinaison `certificationCenterId` et `userId`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Test à faire uniquement en local

- Se connecter à la base de données
- Afficher les entrées de la table `certification-center-memberships`
- Récupérer le userId et certificationCenterId des entrées que vous souhaitez mettre à jour
- Créer un fichier CSV avec le template suivant

```
certificationCenterId;userId
```

- Exécuter le script en fournissant votre fichier CSV

```
node api/scripts/team-acces/set-certification-center-memberships-role-to-admin.js <LE_CHEMIN_VERS_VOTRE_FICHIER_CSV>
```

- Vérifier en base de données que les entrées ont bien été mise à jour