### PR TITLE
[FEATURE] Permettre la réinitialisation du résultat d'un jury externe de certification complémentaire (PIX-9705)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -86,6 +86,7 @@ export default class CertificationInformationsController extends Controller {
     return [
       ...this.certification.complementaryCertificationCourseResultWithExternal.get('allowedExternalLevels'),
       { value: 'REJECTED', label: 'Rejetée' },
+      { value: 'UNSET', label: 'En attente' },
     ];
   }
 

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -24,6 +24,7 @@ export default class CertificationInformationsController extends Controller {
   @alias('model.countries') countries;
   @tracked editingCandidateResults = false;
   @service notifications;
+  @service intl;
   @service featureToggles;
 
   @tracked displayConfirm = false;
@@ -83,10 +84,15 @@ export default class CertificationInformationsController extends Controller {
   }
 
   get juryLevelOptions() {
+    const translatedDefaultJuryOptions = this.certification.complementaryCertificationCourseResultWithExternal
+      .get('defaultJuryOptions')
+      .map((value) => ({
+        value,
+        label: this.intl.t(`components.certifications.external-jury-select-options.${value}`),
+      }));
     return [
       ...this.certification.complementaryCertificationCourseResultWithExternal.get('allowedExternalLevels'),
-      { value: 'REJECTED', label: 'Rejetée' },
-      { value: 'UNSET', label: 'En attente' },
+      ...translatedDefaultJuryOptions,
     ];
   }
 

--- a/admin/app/models/complementary-certification-course-result-with-external.js
+++ b/admin/app/models/complementary-certification-course-result-with-external.js
@@ -6,6 +6,7 @@ export default class complementaryCertificationCourseResultWithExternal extends 
   @attr('string') externalResult;
   @attr('string') finalResult;
   @attr() allowedExternalLevels;
+  @attr() defaultJuryOptions;
 
   get isExternalResultEditable() {
     return this.pixResult !== 'Rejetée';

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -52,7 +52,7 @@
 
     &--pix-edu {
       flex: 1;
-      color: $pix-neutral-40;
+      color: $pix-neutral-50;
       font-weight: 500;
       text-align: center;
       background-color: $pix-neutral-5;

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -328,6 +328,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
               pixResult: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
               externalResult: 'En attente',
               finalResult: 'En attente',
+              defaultJuryOptions: ['UNSET', 'WAITING'],
               allowedExternalLevels: [
                 {
                   value: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME',
@@ -385,6 +386,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                   label: 'Pix+ Édu Initiale 1er degré Confirmé',
                 },
               ],
+              defaultJuryOptions: ['UNSET'],
             },
           );
           certification.update({ complementaryCertificationCourseResultWithExternal });
@@ -452,6 +454,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                   label: 'Pix+ Édu Initiale 1er degré Confirmé',
                 },
               ],
+              defaultJuryOptions: ['UNSET', 'WAITING'],
             },
           );
           const certification1 = this.server.create('certification', {
@@ -475,6 +478,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                   label: 'Pix+ Édu Initiale 2nd degré Confirmé',
                 },
               ],
+              defaultJuryOptions: ['UNSET', 'WAITING'],
             },
           );
           const certification2 = this.server.create('certification', {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -4,9 +4,11 @@ import { setupTest } from 'ember-qunit';
 import { getSettledState, settled } from '@ember/test-helpers';
 
 import EmberObject from '@ember/object';
+import setupIntl from '../../../../../helpers/setup-intl';
 
 module('Unit | Controller | authenticated/certifications/certification/informations', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   const createCompetence = (code, score, level) => {
     return {
@@ -238,6 +240,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
             label: 'je veux',
           },
         ],
+        defaultJuryOptions: ['REJECTED', 'UNSET'],
       });
       controller.model = {
         certification: EmberObject.create({

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -256,6 +256,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
           label: 'je veux',
         },
         { value: 'REJECTED', label: 'Rejetée' },
+        { value: 'UNSET', label: 'En attente' },
       ]);
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -50,6 +50,12 @@
         "roleLabel": "Role"
       }
     },
+    "certifications": {
+      "external-jury-select-options": {
+        "REJECTED": "Rejected",
+        "UNSET": "Waiting"
+      }
+    },
     "complementary-certifications": {
       "target-profiles": {
         "badges-list": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -58,6 +58,12 @@
         "roleLabel": "Rôle"
       }
     },
+    "certifications": {
+      "external-jury-select-options": {
+        "REJECTED": "Rejetée",
+        "UNSET": "En attente"
+      }
+    },
     "complementary-certifications": {
       "target-profiles": {
         "badges-list": {

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -3,6 +3,11 @@ const sources = {
   PIX: 'PIX',
 };
 
+const juryOptions = {
+  REJECTED: 'REJECTED',
+  UNSET: 'UNSET',
+};
+
 class ComplementaryCertificationCourseResult {
   constructor({ complementaryCertificationCourseId, partnerKey, source, acquired, label } = {}) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
@@ -23,7 +28,7 @@ class ComplementaryCertificationCourseResult {
   }
 
   static buildFromJuryLevel({ complementaryCertificationCourseId, juryLevel, pixPartnerKey }) {
-    if (juryLevel === 'REJECTED') {
+    if (juryLevel === juryOptions.REJECTED) {
       return new ComplementaryCertificationCourseResult({
         complementaryCertificationCourseId,
         partnerKey: pixPartnerKey,
@@ -54,5 +59,6 @@ class ComplementaryCertificationCourseResult {
 }
 
 ComplementaryCertificationCourseResult.sources = sources;
+ComplementaryCertificationCourseResult.juryOptions = juryOptions;
 
-export { ComplementaryCertificationCourseResult, sources };
+export { ComplementaryCertificationCourseResult, sources, juryOptions };

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 
 const { minBy } = lodash;
 
-import { sources } from '../models/ComplementaryCertificationCourseResult.js';
+import { juryOptions, sources } from '../models/ComplementaryCertificationCourseResult.js';
 
 const { EXTERNAL, PIX } = sources;
 
@@ -33,6 +33,7 @@ class ComplementaryCertificationCourseResultForJuryCertificationWithExternal {
       level: externalLevel,
     });
     this.allowedExternalLevels = allowedExternalLevels;
+    this.defaultJuryOptions = Object.values(juryOptions);
   }
 
   static from(complementaryCertificationCourseResultWithExternal, badgeKeyAndLabelsGroupedByTargetProfile) {

--- a/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
+++ b/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
@@ -19,11 +19,18 @@ const saveJuryComplementaryCertificationCourseResult = async function ({
 
   const { partnerKey: pixPartnerKey } = pixSourceComplementaryCertificationCourseResult;
 
+  if (juryLevel === ComplementaryCertificationCourseResult.juryOptions.UNSET) {
+    await complementaryCertificationCourseResultRepository.removeExternalJuryResult({
+      complementaryCertificationCourseId,
+    });
+    return;
+  }
+
   const allowedJuryLevels = await complementaryCertificationCourseResultRepository.getAllowedJuryLevelByBadgeKey({
     key: pixPartnerKey,
   });
 
-  if (![...allowedJuryLevels, 'REJECTED'].includes(juryLevel)) {
+  if (![...allowedJuryLevels, ComplementaryCertificationCourseResult.juryOptions.REJECTED].includes(juryLevel)) {
     throw new InvalidJuryLevelError();
   }
 

--- a/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -26,4 +26,15 @@ const save = async function ({ complementaryCertificationCourseId, partnerKey, a
     .merge();
 };
 
-export { getPixSourceResultByComplementaryCertificationCourseId, getAllowedJuryLevelByBadgeKey, save };
+const removeExternalJuryResult = async function ({ complementaryCertificationCourseId }) {
+  await knex('complementary-certification-course-results')
+    .where({ complementaryCertificationCourseId, source: ComplementaryCertificationCourseResult.sources.EXTERNAL })
+    .delete();
+};
+
+export {
+  getPixSourceResultByComplementaryCertificationCourseId,
+  getAllowedJuryLevelByBadgeKey,
+  save,
+  removeExternalJuryResult,
+};

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -52,6 +52,7 @@ const serialize = function (juryCertification) {
         'externalResult',
         'finalResult',
         'allowedExternalLevels',
+        'defaultJuryOptions',
       ],
     },
     certificationIssueReports: {

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -401,6 +401,7 @@ describe('Acceptance | API | Certification Course', function () {
                 value: 'PIX_BOXE_3',
               },
             ],
+            'default-jury-options': ['REJECTED', 'UNSET'],
             'complementary-certification-course-id': 654,
             'external-result': 'Rejetée',
             'final-result': 'Rejetée',

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -197,6 +197,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
               label: 'Badge for complementary certification without external jury',
             },
           ],
+          defaultJuryOptions: ['REJECTED', 'UNSET'],
         },
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal_test.js
@@ -124,6 +124,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultForJury
             { value: 'KEY_1', label: 'Key 1' },
             { value: 'KEY_2', label: 'Key 2' },
           ],
+          defaultJuryOptions: ['REJECTED', 'UNSET'],
         }),
       );
     });

--- a/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
+++ b/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | save-jury-complementary-certification-course-results'
         save: sinon.stub(),
         getPixSourceResultByComplementaryCertificationCourseId: sinon.stub(),
         getAllowedJuryLevelByBadgeKey: sinon.stub(),
+        removeExternalJuryResult: sinon.stub(),
       };
     });
 
@@ -68,6 +69,33 @@ describe('Unit | UseCase | save-jury-complementary-certification-course-results'
       });
 
       context('when the jury level is valid', function () {
+        context('when the jury level is unset', function () {
+          it('should remove the external ComplementaryCertificationCourseResult', async function () {
+            // given
+            complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId
+              .withArgs({ complementaryCertificationCourseId: 1234 })
+              .resolves(
+                domainBuilder.buildComplementaryCertificationCourseResult({
+                  partnerKey: 'KEY_1',
+                  complementaryCertificationCourseId: 1234,
+                  source: ComplementaryCertificationCourseResult.sources.PIX,
+                }),
+              );
+
+            // when
+            await saveJuryComplementaryCertificationCourseResult({
+              complementaryCertificationCourseId: 1234,
+              juryLevel: ComplementaryCertificationCourseResult.juryOptions.UNSET,
+              complementaryCertificationCourseResultRepository,
+            });
+
+            // then
+            expect(
+              complementaryCertificationCourseResultRepository.removeExternalJuryResult,
+            ).to.have.been.calledWithExactly({ complementaryCertificationCourseId: 1234 });
+          });
+        });
+
         it('should save the result', async function () {
           // given
           complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -150,6 +150,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
                   value: 'BADGE_KEY_4',
                 },
               ],
+              'default-jury-options': ['REJECTED', 'UNSET'],
               'complementary-certification-course-id': 1234,
               'pix-result': 'Badge Key 3',
               'external-result': 'Badge Key 4',


### PR DESCRIPTION
## :unicorn: Problème
Une fois le résultat du jury externe d'une certification complémentaire saisi, il est impossible de le retirer.
En cas d'erreur de saisie, le pôle certif doit demander une modification dans la base de prod aux développeurs qui n'auront plus les droits très prochainement.

## :robot: Proposition
Rajouter une option dans le select pour remettre le résultat de la partie externe de la certification complémentaire à `En attente` 

## :rainbow: Remarques
nope

## :100: Pour tester
Se rendre sur la [certification d'un utilisateur de pix+edu](https://admin-pr7403.review.pix.fr/certifications/136067) (superadmin@example.net | pix123)
Cliquer sur modifier le volet jury externe.
Sélectionner un niveau ou le rejet et enregistrer.
Constater la MàJ de la certification
Cliquer sur le volet jury externe
Sélectionner l'option `En attente`
Cliquer sur enregistrer
Constater que la certification est de nouveau en attente du volet jury externe
