### PR TITLE
[FEATURE] Ajouter la connexion SSO Google à Pix Admin (PIX-8809)

### DIFF
--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -10,26 +10,19 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   @service session;
   @service oidcIdentityProviders;
 
-  async authenticate({ code, redirectUri, state, authenticationKey, hostSlug, email, identityProviderSlug }) {
-    const request = {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    };
-    let host = `${ENV.APP.API_HOST}/api/oidc/`;
-    let body;
+  async authenticate({ code, redirectUri, state, authenticationKey, email, identityProviderSlug }) {
     const identityProvider = this.oidcIdentityProviders.list.find((provider) => provider.id === identityProviderSlug);
 
-    if (authenticationKey) {
-      host = `${ENV.APP.API_HOST}/api/admin/oidc/`;
-      body = {
-        identity_provider: identityProvider.code,
-        authentication_key: authenticationKey,
-        email,
-      };
-    } else {
+    let url = `${ENV.APP.API_HOST}/api/admin/oidc/user/reconcile`;
+    let body = {
+      identity_provider: identityProvider.code,
+      authentication_key: authenticationKey,
+      email,
+    };
+
+    const isReconciliation = authenticationKey === undefined;
+    if (isReconciliation) {
+      url = `${ENV.APP.API_HOST}/api/oidc/token`;
       body = {
         identity_provider: identityProvider.code,
         code,
@@ -44,8 +37,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       }
     }
 
-    request.body = JSON.stringify({ data: { attributes: body } });
-    const response = await fetch(host + hostSlug, request);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ data: { attributes: body } }),
+    });
 
     const data = await response.json();
     if (!response.ok) {

--- a/admin/app/authenticators/oidc.js
+++ b/admin/app/authenticators/oidc.js
@@ -1,0 +1,73 @@
+import { service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+import fetch from 'fetch';
+import ENV from 'pix-admin/config/environment';
+import { decodeToken } from 'pix-admin/helpers/jwt';
+import RSVP from 'rsvp';
+
+export default class OidcAuthenticator extends BaseAuthenticator {
+  @service session;
+  @service oidcIdentityProviders;
+
+  async authenticate({ code, redirectUri, state, authenticationKey, hostSlug, email, identityProviderSlug }) {
+    const request = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    };
+    let host = `${ENV.APP.API_HOST}/api/oidc/`;
+    let body;
+    const identityProvider = this.oidcIdentityProviders.list.find((provider) => provider.id === identityProviderSlug);
+
+    if (authenticationKey) {
+      host = `${ENV.APP.API_HOST}/api/admin/oidc/`;
+      body = {
+        identity_provider: identityProvider.code,
+        authentication_key: authenticationKey,
+        email,
+      };
+    } else {
+      body = {
+        identity_provider: identityProvider.code,
+        code,
+        redirect_uri: redirectUri,
+        state: state,
+        audience: 'admin',
+      };
+
+      if (this.session.isAuthenticated) {
+        this.session.set('skipRedirectAfterSessionInvalidation', true);
+        await this.session.invalidate();
+      }
+    }
+
+    request.body = JSON.stringify({ data: { attributes: body } });
+    const response = await fetch(host + hostSlug, request);
+
+    const data = await response.json();
+    if (!response.ok) {
+      return RSVP.reject(data);
+    }
+
+    const decodedAccessToken = decodeToken(data.access_token);
+
+    return {
+      access_token: data.access_token,
+      user_id: decodedAccessToken.user_id,
+      source: identityProvider.source,
+      identityProviderCode: identityProvider.code,
+    };
+  }
+
+  restore(data) {
+    return new RSVP.Promise((resolve, reject) => {
+      if (!isEmpty(data['access_token'])) {
+        resolve(data);
+      }
+      reject();
+    });
+  }
+}

--- a/admin/app/components/login-form.hbs
+++ b/admin/app/components/login-form.hbs
@@ -10,6 +10,25 @@
         <img src="/google-logo.svg" alt="" class="login-form__oidc-connect-link__logo" />
         <span class="login-form__oidc-connect-link__label">{{t "pages.login.google.label"}}</span>
       </LinkTo>
+
+      {{#if @userShouldCreateAnAccount}}
+        <PixMessage @type="alert">
+          Vous n'avez pas de compte Pix.
+        </PixMessage>
+      {{/if}}
+
+      {{#if @unknownErrorHasOccured}}
+        <PixMessage @type="alert">
+          Une erreur est survenue. Veuillez recommencer ou contacter les administrateurs de la plateforme.
+        </PixMessage>
+      {{/if}}
+
+      {{#if @userShouldRequestAccess}}
+        <PixMessage @type="alert">
+          Vous n'avez pas les droits pour vous connecter. Veuillez demander un accès aux administrateurs de la
+          plateforme.
+        </PixMessage>
+      {{/if}}
     {{else}}
       <Input
         class="login-form__fields login-form__email-field"

--- a/admin/app/controllers/login.js
+++ b/admin/app/controllers/login.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class LoginController extends Controller {
+  queryParams = ['userShouldCreateAnAccount', 'unknownErrorHasOccured', 'userShouldRequestAccess'];
+}

--- a/admin/app/errors/json-api-error.js
+++ b/admin/app/errors/json-api-error.js
@@ -1,0 +1,30 @@
+export default class JSONApiError extends Error {
+  constructor(message, extras) {
+    super(message);
+    this._extras = extras;
+  }
+
+  get code() {
+    return this._extras?.code;
+  }
+
+  get meta() {
+    return this._extras?.meta;
+  }
+
+  get shortCode() {
+    return this._extras?.meta?.shortCode;
+  }
+
+  get detail() {
+    return this._extras?.detail;
+  }
+
+  get title() {
+    return this._extras?.title;
+  }
+
+  get status() {
+    return this._extras?.status;
+  }
+}

--- a/admin/app/helpers/jwt.js
+++ b/admin/app/helpers/jwt.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import { jwtDecode } from 'jwt-decode';
+
+export function decodeToken(accessToken) {
+  return jwtDecode(accessToken);
+}
+
+export default helper(decodeToken);

--- a/admin/app/routes/authentication/login-oidc.js
+++ b/admin/app/routes/authentication/login-oidc.js
@@ -41,7 +41,6 @@ export default class LoginOidcRoute extends Route {
         authenticationKey,
         identityProviderSlug,
         email,
-        hostSlug: 'user/reconcile',
       });
     } catch (response) {
       const apiError = get(response, 'errors[0]');
@@ -73,7 +72,6 @@ export default class LoginOidcRoute extends Route {
         redirectUri,
         state,
         identityProviderSlug,
-        hostSlug: 'token',
       });
     } catch (response) {
       const apiError = get(response, 'errors[0]');

--- a/admin/app/routes/authentication/login-oidc.js
+++ b/admin/app/routes/authentication/login-oidc.js
@@ -1,0 +1,112 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import fetch from 'fetch';
+import get from 'lodash/get';
+import ENV from 'pix-admin/config/environment';
+import JSONApiError from 'pix-admin/errors/json-api-error';
+
+export default class LoginOidcRoute extends Route {
+  @service session;
+  @service router;
+  @service location;
+  @service oidcIdentityProviders;
+
+  beforeModel(transition) {
+    const queryParams = transition.to.queryParams;
+    if (!queryParams.code) {
+      this._cleanSession();
+
+      const identityProviderSlug = transition.to.params.identity_provider_slug.toString();
+      const identityProvider = this.oidcIdentityProviders.list.find((provider) => provider.id === identityProviderSlug);
+      if (identityProvider !== undefined) return this._handleRedirectRequest(identityProvider);
+
+      return this.router.replaceWith('login');
+    }
+  }
+
+  async model(params, transition) {
+    await this.oidcIdentityProviders.loadReadyIdentityProviders();
+
+    const queryParams = transition.to.queryParams;
+    const identityProviderSlug = params.identity_provider_slug;
+    if (queryParams.code) {
+      return this._handleCallbackRequest(queryParams.code, queryParams.state, identityProviderSlug);
+    }
+  }
+
+  async afterModel({ shouldUserCreateAnAccount, authenticationKey, identityProviderSlug, email } = {}) {
+    if (!shouldUserCreateAnAccount && !authenticationKey) return;
+    try {
+      await this.session.authenticate('authenticator:oidc', {
+        authenticationKey,
+        identityProviderSlug,
+        email,
+        hostSlug: 'user/reconcile',
+      });
+    } catch (response) {
+      const apiError = get(response, 'errors[0]');
+      const error = new JSONApiError(apiError?.detail, apiError);
+
+      let queryParams;
+
+      if (error.status === '404' && error.code === 'USER_ACCOUNT_NOT_FOUND') {
+        queryParams = { userShouldCreateAnAccount: true };
+      } else {
+        queryParams = { unknownErrorHasOccured: true };
+      }
+
+      return this.router.replaceWith('login', {
+        queryParams,
+      });
+    }
+  }
+
+  _cleanSession() {
+    this.session.set('data.nextURL', undefined);
+  }
+
+  async _handleCallbackRequest(code, state, identityProviderSlug) {
+    try {
+      const redirectUri = this._getRedirectUri(identityProviderSlug);
+      await this.session.authenticate('authenticator:oidc', {
+        code,
+        redirectUri,
+        state,
+        identityProviderSlug,
+        hostSlug: 'token',
+      });
+    } catch (response) {
+      const apiError = get(response, 'errors[0]');
+      const error = new JSONApiError(apiError.detail, apiError);
+
+      const shouldUserCreateAnAccount = error.code === 'SHOULD_VALIDATE_CGU';
+      const { authenticationKey, email } = error.meta ?? {};
+      if (shouldUserCreateAnAccount && authenticationKey) {
+        return { shouldUserCreateAnAccount, authenticationKey, email, identityProviderSlug };
+      }
+
+      if (error.status === '403' && error.code === 'PIX_ADMIN_ACCESS_NOT_ALLOWED') {
+        return this.router.replaceWith('login', {
+          queryParams: {
+            userShouldRequestAccess: true,
+          },
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  _getRedirectUri(identityProviderId) {
+    const { protocol, host } = window.location;
+    return `${protocol}//${host}/connexion/${identityProviderId}`;
+  }
+
+  async _handleRedirectRequest(identityProvider) {
+    const response = await fetch(
+      `${ENV.APP.API_HOST}/api/oidc/authorization-url?identity_provider=${identityProvider.code}&audience=admin`,
+    );
+    const { redirectTarget } = await response.json();
+    this.location.replace(redirectTarget);
+  }
+}

--- a/admin/app/services/location.js
+++ b/admin/app/services/location.js
@@ -1,0 +1,7 @@
+import Service from '@ember/service';
+
+export default class LocationService extends Service {
+  replace(url) {
+    return location.replace(url);
+  }
+}

--- a/admin/app/templates/login.hbs
+++ b/admin/app/templates/login.hbs
@@ -1,6 +1,10 @@
 <div class="login-page">
   <main class="login-page__main">
-    <LoginForm />
+    <LoginForm
+      @unknownErrorHasOccured={{this.unknownErrorHasOccured}}
+      @userShouldCreateAnAccount={{this.userShouldCreateAnAccount}}
+      @userShouldRequestAccess={{this.userShouldRequestAccess}}
+    />
 
     <footer>
     </footer>

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -73,6 +73,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-qunit": "^8.0.0",
         "joi": "^17.12.2",
+        "jwt-decode": "^4.0.0",
         "loader.js": "^4.7.0",
         "lodash": "^4.17.21",
         "npm-run-all2": "^6.0.0",
@@ -46313,6 +46314,15 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -104,6 +104,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^8.0.0",
     "joi": "^17.12.2",
+    "jwt-decode": "^4.0.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
     "npm-run-all2": "^6.0.0",

--- a/admin/tests/unit/authenticators/oidc_test.js
+++ b/admin/tests/unit/authenticators/oidc_test.js
@@ -74,7 +74,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
       const token = await authenticator.authenticate({
         identityProviderSlug,
         authenticationKey: 'key',
-        hostSlug: 'users/reconcile',
         email: 'user@example.net',
       });
 
@@ -108,7 +107,6 @@ module('Unit | Authenticator | oidc', function (hooks) {
         redirectUri,
         state,
         identityProviderSlug,
-        hostSlug: 'token',
       });
 
       // then
@@ -140,7 +138,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
         authenticator.session = sessionStub;
 
         // when
-        await authenticator.authenticate({ code, redirectUri, state, identityProviderSlug, hostSlug: 'token' });
+        await authenticator.authenticate({ code, redirectUri, state, identityProviderSlug });
 
         // then
         request.body = body;

--- a/admin/tests/unit/authenticators/oidc_test.js
+++ b/admin/tests/unit/authenticators/oidc_test.js
@@ -1,0 +1,153 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import * as fetch from 'fetch';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Authenticator | oidc', function (hooks) {
+  setupTest(hooks);
+
+  module('#authenticate', function (hooks) {
+    const userId = 1;
+    const source = 'oidc-externe';
+    const identityProviderCode = 'OIDC_PARTNER';
+    const identityProviderSlug = 'oidc-partner';
+    const code = 'code';
+    const redirectUri = 'redirectUri';
+    const state = 'state';
+    const request = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    };
+    const body = JSON.stringify({
+      data: {
+        attributes: {
+          identity_provider: identityProviderCode,
+          code: code,
+          redirect_uri: redirectUri,
+          state,
+          audience: 'admin',
+        },
+      },
+    });
+    const accessToken =
+      'aaa.' +
+      btoa(`{
+        "user_id": ${userId},
+        "source": "${source}",
+        "identity_provider": "${identityProviderCode}",
+        "iat": 1545321469,
+        "exp": 4702193958
+      }`) +
+      '.bbb';
+
+    hooks.beforeEach(function () {
+      sinon.stub(fetch, 'default').resolves({
+        json: sinon.stub().resolves({ access_token: accessToken }),
+        ok: true,
+      });
+      const oidcPartner = {
+        id: identityProviderSlug,
+        code: identityProviderCode,
+        organizationName: 'Partenaire OIDC',
+        source,
+      };
+      class OidcIdentityProvidersStub extends Service {
+        [identityProviderSlug] = oidcPartner;
+        list = [oidcPartner];
+      }
+      this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+    });
+
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('fetches token with authentication key', async function (assert) {
+      // given
+      const authenticator = this.owner.lookup('authenticator:oidc');
+
+      // when
+      const token = await authenticator.authenticate({
+        identityProviderSlug,
+        authenticationKey: 'key',
+        hostSlug: 'users/reconcile',
+        email: 'user@example.net',
+      });
+
+      // then
+      request.body = JSON.stringify({
+        data: {
+          attributes: {
+            identity_provider: identityProviderCode,
+            authentication_key: 'key',
+            email: 'user@example.net',
+          },
+        },
+      });
+      sinon.assert.calledWith(fetch.default, `http://localhost:3000/api/admin/oidc/users/reconcile`, request);
+      assert.deepEqual(token, {
+        access_token: accessToken,
+        source,
+        user_id: userId,
+        identityProviderCode,
+      });
+      assert.ok(true);
+    });
+
+    test('fetches token with code, redirectUri, and state in body', async function (assert) {
+      // given
+      const authenticator = this.owner.lookup('authenticator:oidc');
+
+      // when
+      const token = await authenticator.authenticate({
+        code,
+        redirectUri,
+        state,
+        identityProviderSlug,
+        hostSlug: 'token',
+      });
+
+      // then
+      request.body = body;
+      sinon.assert.calledWith(fetch.default, 'http://localhost:3000/api/oidc/token', request);
+      assert.deepEqual(token, {
+        access_token: accessToken,
+        source,
+        user_id: userId,
+        identityProviderCode,
+      });
+      assert.ok(true);
+    });
+
+    module('when user is authenticated', function () {
+      test('invalidates session', async function (assert) {
+        // given
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+          invalidate: sinon.stub(),
+          data: {
+            authenticated: {
+              access_token: accessToken,
+            },
+          },
+        });
+
+        const authenticator = this.owner.lookup('authenticator:oidc');
+        authenticator.session = sessionStub;
+
+        // when
+        await authenticator.authenticate({ code, redirectUri, state, identityProviderSlug, hostSlug: 'token' });
+
+        // then
+        request.body = body;
+        sinon.assert.calledWith(fetch.default, `http://localhost:3000/api/oidc/token`, request);
+        sinon.assert.calledOnce(sessionStub.invalidate);
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/authenticators/oidc_test.js
+++ b/admin/tests/unit/authenticators/oidc_test.js
@@ -88,7 +88,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
           },
         },
       });
-      sinon.assert.calledWith(fetch.default, `http://localhost:3000/api/admin/oidc/users/reconcile`, request);
+      sinon.assert.calledWith(fetch.default, `http://localhost:3000/api/admin/oidc/user/reconcile`, request);
       assert.deepEqual(token, {
         access_token: accessToken,
         source,

--- a/admin/tests/unit/routes/authentication/login-oidc_test.js
+++ b/admin/tests/unit/routes/authentication/login-oidc_test.js
@@ -1,0 +1,301 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import * as fetch from 'fetch';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | login-oidc', function (hooks) {
+  setupTest(hooks);
+
+  module('#beforeModel', function () {
+    module('when no code exists in queryParams', function (hooks) {
+      let fetchStub;
+
+      hooks.beforeEach(function () {
+        fetchStub = sinon.stub(fetch, 'default').resolves({
+          json: sinon.stub().resolves({
+            redirectTarget: `https://oidc.example.net/connexion`,
+          }),
+        });
+        const oidcPartner = {
+          id: 'oidc-partner',
+          code: 'OIDC_PARTNER',
+        };
+
+        class OidcIdentityProvidersStub extends Service {
+          list = [oidcPartner];
+        }
+
+        this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+      });
+
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      module('when identity provider is not supported', function () {
+        test('redirects the user to main login page', async function (assert) {
+          // given
+          const route = this.owner.lookup('route:authentication/login-oidc');
+          route.router = { replaceWith: sinon.stub() };
+
+          // when
+          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'idp' } } });
+
+          // then
+          sinon.assert.calledWith(route.router.replaceWith, 'login');
+          assert.ok(true);
+        });
+      });
+
+      module('when identity provider is supported', function () {
+        test('redirects the user to authorization url', async function (assert) {
+          // given
+          const route = this.owner.lookup('route:authentication/login-oidc');
+          route.location.replace = sinon.stub();
+
+          // when
+          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc-partner' } } });
+
+          // then
+          sinon.assert.calledWith(
+            fetchStub,
+            'http://localhost:3000/api/oidc/authorization-url?identity_provider=OIDC_PARTNER&audience=admin',
+          );
+          sinon.assert.calledWith(route.location.replace, 'https://oidc.example.net/connexion');
+          assert.ok(true);
+        });
+      });
+    });
+  });
+
+  module('#afterModel', function () {
+    module('when user has a pix account', function () {
+      test('authenticates user with reconciliation', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authentication/login-oidc');
+        const authenticateStub = sinon.stub().resolves();
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+        });
+        route.set('session', sessionStub);
+
+        // when
+        await route.afterModel({
+          authenticationKey: '123',
+          identityProviderSlug: 'super-idp-name',
+          email: 'john@example.net',
+        });
+
+        // then
+        sinon.assert.calledWith(route.session.authenticate, 'authenticator:oidc', {
+          authenticationKey: '123',
+          identityProviderSlug: 'super-idp-name',
+          email: 'john@example.net',
+          hostSlug: 'user/reconcile',
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('when user has no pix account', function () {
+      test('redirects to login with userShouldCreateAnAccount queryParam', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:authentication/login-oidc');
+        const errors = {
+          errors: [{ status: '404', code: 'USER_ACCOUNT_NOT_FOUND' }],
+        };
+        route.router = { replaceWith: sinon.stub() };
+        const authenticateStub = sinon.stub().rejects(errors);
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+        });
+        route.set('session', sessionStub);
+
+        // when
+        await route.afterModel({
+          authenticationKey: '123',
+          identityProviderSlug: 'super-idp-name',
+          email: 'john@example.net',
+        });
+
+        // then
+        sinon.assert.calledWith(route.router.replaceWith, 'login', {
+          queryParams: {
+            userShouldCreateAnAccount: true,
+          },
+        });
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('#model', function () {
+    test('requests to authenticate user with identity provider', async function (assert) {
+      // given
+      const authenticateStub = sinon.stub().resolves();
+      const sessionStub = Service.create({
+        authenticate: authenticateStub,
+        data: {},
+      });
+
+      const route = this.owner.lookup('route:authentication/login-oidc');
+      route.set('session', sessionStub);
+      sinon.stub(route.oidcIdentityProviders, 'loadReadyIdentityProviders');
+      route.oidcIdentityProviders.loadReadyIdentityProviders.resolves();
+
+      // when
+      await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+
+      // then
+      sinon.assert.calledWithMatch(authenticateStub, 'authenticator:oidc', {
+        code: 'test',
+        state: undefined,
+      });
+      assert.ok(authenticateStub.getCall(0).args[1].redirectUri.includes('connexion/oidc'));
+      assert.deepEqual(sessionStub.data, {});
+    });
+
+    test('returns values to be received by after model to validate CGUs', async function (assert) {
+      // given
+      const authenticateStub = sinon.stub().rejects({
+        errors: [
+          {
+            code: 'SHOULD_VALIDATE_CGU',
+            meta: {
+              authenticationKey: 'key',
+              givenName: 'Mélusine',
+              familyName: 'TITEGOUTTE',
+              email: 'melu@example.net',
+            },
+          },
+        ],
+      });
+      const sessionStub = Service.create({
+        authenticate: authenticateStub,
+        data: {},
+      });
+      const route = this.owner.lookup('route:authentication/login-oidc');
+      route.set('session', sessionStub);
+      route.router = { replaceWith: sinon.stub() };
+      sinon.stub(route.oidcIdentityProviders, 'loadReadyIdentityProviders');
+      route.oidcIdentityProviders.loadReadyIdentityProviders.resolves();
+
+      // when
+      const response = await route.model(
+        { identity_provider_slug: 'oidc-partner' },
+        { to: { queryParams: { code: 'test' } } },
+      );
+
+      // then
+      sinon.assert.calledOnce(authenticateStub);
+      assert.deepEqual(response, {
+        shouldUserCreateAnAccount: true,
+        authenticationKey: 'key',
+        email: 'melu@example.net',
+        identityProviderSlug: 'oidc-partner',
+      });
+      assert.ok(true);
+    });
+
+    test('throws error if CGUs are already validated and authenticate fails', async function (assert) {
+      // given
+      assert.expect(2);
+      const authenticateStub = sinon.stub().rejects({ errors: [{ detail: 'there was an error' }] });
+      const sessionStub = Service.create({
+        authenticate: authenticateStub,
+        data: {},
+      });
+      const route = this.owner.lookup('route:authentication/login-oidc');
+      route.set('session', sessionStub);
+      route.router = { replaceWith: sinon.stub() };
+      sinon.stub(route.oidcIdentityProviders, 'loadReadyIdentityProviders');
+      route.oidcIdentityProviders.loadReadyIdentityProviders.resolves();
+
+      try {
+        // when
+        await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+      } catch (error) {
+        // then
+        sinon.assert.calledOnce(authenticateStub);
+        assert.strictEqual(error.message, 'there was an error');
+        assert.ok(true);
+      }
+    });
+
+    module('when the identity provider does not provide all the user required information', function () {
+      test('throws an error', async function (assert) {
+        // given
+        assert.expect(1);
+        const authenticateStub = sinon.stub().rejects({
+          errors: [
+            {
+              status: '422',
+              code: 'USER_INFO_MANDATORY_MISSING_FIELDS',
+              title: 'Unprocessable entity',
+              detail:
+                "Un ou des champs obligatoires (Champs manquants : given_name}) n'ont pas été renvoyés par votre fournisseur d'identité OIDC partner.",
+              meta: {
+                shortCode: 'OIDC01',
+              },
+            },
+          ],
+        });
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/login-oidc');
+        route.set('session', sessionStub);
+        route.router = { replaceWith: sinon.stub() };
+        sinon.stub(route.oidcIdentityProviders, 'loadReadyIdentityProviders');
+        route.oidcIdentityProviders.loadReadyIdentityProviders.resolves();
+
+        try {
+          // when
+          await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+        } catch (error) {
+          // then
+          assert.strictEqual(
+            error.message,
+            "Un ou des champs obligatoires (Champs manquants : given_name}) n'ont pas été renvoyés par votre fournisseur d'identité OIDC partner.",
+          );
+        }
+      });
+    });
+
+    module('when user does not have rights to access to pix admin', function () {
+      test('redirects to login page', async function (assert) {
+        // given
+        const authenticateStub = sinon.stub().rejects({
+          errors: [
+            {
+              status: '403',
+              code: 'PIX_ADMIN_ACCESS_NOT_ALLOWED',
+            },
+          ],
+        });
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/login-oidc');
+        route.set('session', sessionStub);
+        route.router = { replaceWith: sinon.stub() };
+        sinon.stub(route.oidcIdentityProviders, 'loadReadyIdentityProviders');
+        route.oidcIdentityProviders.loadReadyIdentityProviders.resolves();
+
+        // when
+        await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+
+        // then
+        sinon.assert.calledWith(route.router.replaceWith, 'login', {
+          queryParams: {
+            userShouldRequestAccess: true,
+          },
+        });
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/routes/authentication/login-oidc_test.js
+++ b/admin/tests/unit/routes/authentication/login-oidc_test.js
@@ -92,7 +92,6 @@ module('Unit | Route | login-oidc', function (hooks) {
           authenticationKey: '123',
           identityProviderSlug: 'super-idp-name',
           email: 'john@example.net',
-          hostSlug: 'user/reconcile',
         });
         assert.ok(true);
       });

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -89,7 +89,6 @@ const register = async function (server) {
         validate: {
           query: Joi.object({
             identity_provider: Joi.string().required(),
-            redirect_uri: Joi.string().required(),
             audience: Joi.string().valid('app', 'admin').optional(),
           }),
         },

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -3,7 +3,7 @@ import { oidcAuthenticationServiceRegistry as authenticationServiceRegistry } fr
 import { usecases } from '../../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../../infrastructure/serializers/jsonapi/oidc-identity-providers-serializer.js';
 import * as oidcSerializer from '../../../infrastructure/serializers/jsonapi/oidc-serializer.js';
-import { UnauthorizedError } from '../../http-errors.js';
+import { BadRequestError, UnauthorizedError } from '../../http-errors.js';
 
 const getAllIdentityProvidersForAdmin = async function (request, h) {
   const identityProviders = usecases.getAllIdentityProviders();
@@ -108,6 +108,10 @@ const authenticateUser = async function (
   const sessionState = request.yar.get('state', true);
   const nonce = request.yar.get('nonce', true);
   await request.yar.commit(h);
+
+  if (sessionState === null) {
+    throw new BadRequestError('Required cookie "state" is missing');
+  }
 
   const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -87,9 +87,7 @@ const getAuthorizationUrl = async function (
     identityProviderCode: identityProvider,
     audience,
   });
-  const { nonce, state, ...payload } = oidcAuthenticationService.getAuthorizationUrl({
-    redirectUri: request.query['redirect_uri'],
-  });
+  const { nonce, state, ...payload } = oidcAuthenticationService.getAuthorizationUrl();
 
   request.yar.set('state', state);
   request.yar.set('nonce', nonce);

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -117,6 +117,7 @@ const authenticateUser = async function (
   });
 
   const result = await usecases.authenticateOidcUser({
+    audience,
     code,
     redirectUri,
     state,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -222,6 +222,7 @@ const configuration = (function () {
       isEnabledForPixAdmin: isFeatureEnabled(process.env.GOOGLE_ENABLED_FOR_PIX_ADMIN),
       openidConfigurationUrl: process.env.GOOGLE_OPENID_CONFIGURATION_URL,
       redirectUri: process.env.GOOGLE_REDIRECT_URI,
+      temporaryStorage: { idTokenLifespanMs: ms(process.env.GOOGLE_ID_TOKEN_LIFESPAN || '7d') },
     },
     hapi: {
       options: {},

--- a/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
@@ -15,7 +15,7 @@ describe('Acceptance | Route | oidc authentication url', function () {
         // given
         const query = querystring.stringify({
           identity_provider: 'OIDC_EXAMPLE_NET',
-          redirect_uri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+          audience: 'app',
         });
 
         // when

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -21,7 +21,6 @@ describe('Acceptance | Route | oidc | token', function () {
 
       const query = querystring.stringify({
         identity_provider: 'OIDC_EXAMPLE_NET',
-        redirect_uri: 'https://app.dev.pix.org/connexion/oidc-example-net',
       });
       const authUrlResponse = await server.inject({
         method: 'GET',

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -176,5 +176,145 @@ describe('Acceptance | Route | oidc | token', function () {
         expect(response.result['logout_url_uuid']).to.match(uuidPattern);
       });
     });
+
+    context('when audience is admin', function () {
+      context('when user does not have an admin role', function () {
+        it('returns 403', async function () {
+          // given
+          const firstName = 'John';
+          const lastName = 'Doe';
+          const externalIdentifier = 'sub';
+
+          payload.data.attributes.audience = 'admin';
+
+          const userId = databaseBuilder.factory.buildUser({
+            firstName,
+            lastName,
+          }).id;
+
+          databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+            identityProvider: 'OIDC_EXAMPLE_NET',
+            externalIdentifier,
+            accessToken: 'access_token',
+            refreshToken: 'refresh_token',
+            expiresIn: 1000,
+            userId,
+          });
+          await databaseBuilder.commit();
+
+          const idToken = jsonwebtoken.sign(
+            {
+              given_name: firstName,
+              family_name: lastName,
+              sub: externalIdentifier,
+            },
+            'secret',
+          );
+          const getAccessTokenResponse = {
+            access_token: 'access_token',
+            id_token: idToken,
+            expires_in: 60,
+            refresh_token: 'refresh_token',
+          };
+          /*
+          Le code ci-dessous a été commenté parce qu'on utilise un fournisseur d'identité
+          non valide d'exemple et l'utilisation de nock n'est pas possible car la librairie
+          openid-client tentera de valider le token reçu avec une configuration de chiffrement
+          d'exemple.
+           */
+          // const getAccessTokenRequest = nock(settings.poleEmploi.tokenUrl).post('/').reply(200, getAccessTokenResponse);
+          oidcExampleNetProvider.client.callback.resolves(getAccessTokenResponse);
+
+          // when
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/oidc/token',
+            headers: { cookie: cookies[0] },
+            payload,
+          });
+
+          // then
+          /*
+          Le code ci-dessous a été commenté parce qu'on utilise un fournisseur d'identité
+          non valide d'exemple et l'utilisation de nock n'est pas possible car la librairie
+          openid-client tentera de valider le token reçu avec une configuration de chiffrement
+          d'exemple.
+           */
+          // expect(getAccessTokenRequest.isDone()).to.be.true;
+          expect(oidcExampleNetProvider.client.callback).to.have.been.calledOnce;
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+
+      context('when user has an admin role', function () {
+        it('returns 200', async function () {
+          // given
+          const firstName = 'John';
+          const lastName = 'Doe';
+          const externalIdentifier = 'sub';
+
+          payload.data.attributes.audience = 'admin';
+
+          const userId = databaseBuilder.factory.buildUser.withRole({
+            firstName,
+            lastName,
+            role: 'SUPER_ADMIN',
+          }).id;
+
+          databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+            identityProvider: 'OIDC_EXAMPLE_NET',
+            externalIdentifier,
+            accessToken: 'access_token',
+            refreshToken: 'refresh_token',
+            expiresIn: 1000,
+            userId,
+          });
+
+          await databaseBuilder.commit();
+
+          const idToken = jsonwebtoken.sign(
+            {
+              given_name: firstName,
+              family_name: lastName,
+              sub: externalIdentifier,
+            },
+            'secret',
+          );
+          const getAccessTokenResponse = {
+            access_token: 'access_token',
+            id_token: idToken,
+            expires_in: 60,
+            refresh_token: 'refresh_token',
+          };
+          /*
+          Le code ci-dessous a été commenté parce qu'on utilise un fournisseur d'identité
+          non valide d'exemple et l'utilisation de nock n'est pas possible car la librairie
+          openid-client tentera de valider le token reçu avec une configuration de chiffrement
+          d'exemple.
+           */
+          // const getAccessTokenRequest = nock(settings.poleEmploi.tokenUrl).post('/').reply(200, getAccessTokenResponse);
+          oidcExampleNetProvider.client.callback.resolves(getAccessTokenResponse);
+
+          // when
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/oidc/token',
+            headers: { cookie: cookies[0] },
+            payload,
+          });
+
+          // then
+          /*
+          Le code ci-dessous a été commenté parce qu'on utilise un fournisseur d'identité
+          non valide d'exemple et l'utilisation de nock n'est pas possible car la librairie
+          openid-client tentera de valider le token reçu avec une configuration de chiffrement
+          d'exemple.
+           */
+          // expect(getAccessTokenRequest.isDone()).to.be.true;
+          expect(oidcExampleNetProvider.client.callback).to.have.been.calledOnce;
+          expect(response.statusCode).to.equal(200);
+        });
+      });
+    });
   });
 });

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -159,9 +159,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       await oidcController.getAuthorizationUrl(request, hFake, dependencies);
 
       //then
-      expect(oidcAuthenticationService.getAuthorizationUrl).to.have.been.calledWithExactly({
-        redirectUri: 'http:/exemple.net/',
-      });
+      expect(oidcAuthenticationService.getAuthorizationUrl).to.have.been.called;
       expect(request.yar.set).to.have.been.calledTwice;
       expect(request.yar.commit).to.have.been.calledOnce;
     });

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -258,6 +258,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
 
       // then
       expect(usecases.authenticateOidcUser).to.have.been.calledWithExactly({
+        audience: undefined,
         code,
         redirectUri,
         state: identityProviderState,

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -1,5 +1,5 @@
 import { oidcController } from '../../../../../lib/application/authentication/oidc/oidc-controller.js';
-import { UnauthorizedError } from '../../../../../lib/application/http-errors.js';
+import { BadRequestError, UnauthorizedError } from '../../../../../lib/application/http-errors.js';
 import { usecases } from '../../../../../lib/domain/usecases/index.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
@@ -307,6 +307,21 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           identityProviderCode: identityProvider,
           audience: PIX_ADMIN.AUDIENCE,
         });
+      });
+    });
+
+    context('when state cookie is missing', function () {
+      it('returns a BadRequestError', async function () {
+        // given
+        request.yar.get.returns(null);
+        const dependencies = {};
+
+        // when
+        const error = await catchErr(oidcController.authenticateUser)(request, hFake, dependencies);
+
+        // then
+        expect(error).to.be.an.instanceOf(BadRequestError);
+        expect(error.message).to.equal('Required cookie "state" is missing');
       });
     });
 

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -111,14 +111,9 @@ export default class LoginOidcRoute extends Route {
       this.session.set('data.nextURL', url);
     }
 
-    const redirectUri = this._getRedirectUri(identityProviderSlug);
     const identityProvider = this.oidcIdentityProviders[identityProviderSlug]?.code;
     const response = await fetch(
-      `${
-        ENV.APP.API_HOST
-      }/api/oidc/authorization-url?identity_provider=${identityProvider}&redirect_uri=${encodeURIComponent(
-        redirectUri,
-      )}`,
+      `${ENV.APP.API_HOST}/api/oidc/authorization-url?identity_provider=${identityProvider}`,
     );
     const { redirectTarget } = await response.json();
     this.location.replace(redirectTarget);

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -41,10 +41,9 @@ export default function (config) {
     };
   });
 
-  config.get('/oidc/authorization-url', (schema, request) => {
-    const redirectUri = request.queryParams.redirect_uri;
+  config.get('/oidc/authorization-url', () => {
     return {
-      redirectTarget: `https://oidc/connexion/oauth2/authorize?redirect_uri=${redirectUri}`,
+      redirectTarget: `https://oidc/connexion/oauth2/authorize`,
     };
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Pix Admin propose actuellement une connexion via formulaire (email et mot de passe).
Les agents Pix disposent de comptes Google permettant la connexion SSO Google.

Lors des tech days Pix4Pix, nous avons pu tester l'implémentation de cette nouvelle connexion, en se basant sur l'existant dans Pix App. L'essai étant une réussite, nous souhaitons l'appliquer sur notre application interne Pix Admin.

## :robot: Proposition

Ajouter la connexion SSO Google sur Admin avec une gestion de réconciliation de compte (silencieuse)

## :rainbow: Remarques

Initialement nous avions implémenté une page de réconciliation permettant une confirmation d'identité par l'agent. 
Or la proposition d'une réconciliation silencieuse à été choisie. 

Google permet de récupérer l'email de l'agent lors de l'authent, nous permettant de vérifier directement si un compte Pix existe avec ce dernier.

---

Un quickwin a été fait pour permettre une connexion via google uniquement sur Pix Admin et non sur Pix App.

## :100: Pour tester

### Non-regression

- Vérifier la connexion SSO dans Pix App (uniquement génération de l'authorization url)
- Vérifier, lorsque le SSO Google est désactivé la connexion à Pix Admin avec la mire classique

### SSO Google

- Aller sur Pix Admin 
- Tenter une connexion via Google sans avoir de compte Pix
- Constater que l'on est redirigé sur la page de login avec un message d'erreur
<img width="563" alt="Capture d’écran 2024-03-26 à 16 43 37" src="https://github.com/1024pix/pix/assets/58915422/bdc15f04-b006-4909-80f7-d7f74906c078">

- Créer un compte sur Pix App et retenter la connexion sur Pix Admin
- Constater une redirection sur login avec une nouvelle erreur : il faut des droits d'accès.
<img width="525" alt="Capture d’écran 2024-03-26 à 16 43 58" src="https://github.com/1024pix/pix/assets/58915422/54272bd6-e8c5-414c-844d-2e846d76012e">

- S'ajouter un accès sur la table `pix-admin-roles`
- Se connecter à nouveau
- Accéder à Pix Admin ✨
- Constater en BDD qu'une réconciliation à été fait, table `authentication-methods` avec l'identity provider 'GOOGLE'
- Tenter une connexion via Google sur Pix App ( http://localhost:4200/connexion/google ) et constater que cela échoue