### PR TITLE
[TECH] Remplacer contains et not Contains par du testing-library dans les tests  Orga (PIX-9885)

### DIFF
--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
-import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
 import authenticateSession from '../helpers/authenticate-session';
 import { setupApplicationTest } from 'ember-qunit';
@@ -100,7 +99,7 @@ module('Acceptance | authentication', function (hooks) {
         // given
         server.create('campaign');
 
-        await visit('/connexion');
+        const screen = await visit('/connexion');
         await fillByLabel('Adresse e-mail', user.email);
         await fillByLabel('Mot de passe', 'secret');
 
@@ -109,8 +108,7 @@ module('Acceptance | authentication', function (hooks) {
 
         // then
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-
-        assert.contains('Harry Cover');
+        assert.ok(screen.getByText('Harry Cover'));
       });
     });
   });
@@ -164,10 +162,10 @@ module('Acceptance | authentication', function (hooks) {
 
       test('it should display the organization linked to the connected prescriber', async function (assert) {
         // when
-        await visit('/');
+        const screen = await visit('/');
 
         // then
-        assert.contains('BRO & Evil Associates (EXTBRO)');
+        assert.ok(screen.getByText('BRO & Evil Associates (EXTBRO)'));
       });
 
       test('it should redirect prescriber to the campaigns list on root url', async function (assert) {
@@ -181,11 +179,11 @@ module('Acceptance | authentication', function (hooks) {
       module('when a lang query param is present', function () {
         test('sets and remembers the locale to the lang query param which wins over the user’s lang', async function (assert) {
           // when
-          await visitScreen('/?lang=en');
-          const screen = await visitScreen('/');
+          await visit('/?lang=en');
+          const screen = await visit('/');
 
           // then
-          assert.dom(screen.getByRole('link', { name: 'Team' })).exists();
+          assert.ok(screen.getByRole('link', { name: 'Team' }));
         });
       });
     });
@@ -205,7 +203,7 @@ module('Acceptance | authentication', function (hooks) {
         // when
         await visit('/');
         // then
-        assert.dom('.organization-credit-info').exists();
+        assert.ok('.organization-credit-info');
       });
     });
 

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -94,8 +94,8 @@ module('Acceptance | Campaign Activity', function (hooks) {
 
       await clickByName('Oui, je supprime');
       // then
-      assert.contains('La participation a été supprimée avec succès.');
-      assert.contains('Aucun participant');
+      assert.ok(screen.getByText('La participation a été supprimée avec succès.'));
+      assert.ok(screen.getByText('Aucun participant'));
     });
 
     test('Error case: should display an error notification', async function (assert) {
@@ -116,8 +116,8 @@ module('Acceptance | Campaign Activity', function (hooks) {
       await clickByName('Oui, je supprime');
 
       // then
-      assert.contains('Bacri');
-      assert.contains('Un problème est survenu lors de la suppression de la participation.');
+      assert.ok(screen.getByText('Bacri'));
+      assert.ok(screen.getByText('Un problème est survenu lors de la suppression de la participation.'));
     });
   });
 

--- a/orga/tests/acceptance/campaign-analysis_test.js
+++ b/orga/tests/acceptance/campaign-analysis_test.js
@@ -1,14 +1,15 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
-
+import setupIntl from '../helpers/setup-intl';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | Campaign Analysis', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(async () => {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -28,9 +29,10 @@ module('Acceptance | Campaign Analysis', function (hooks) {
 
   test('it should display campaign analysis', async function (assert) {
     // when
-    await visit('/campagnes/1/analyse');
+    const screen = await visit('/campagnes/1/analyse');
 
     // then
-    assert.dom('[aria-label="Analyse par sujet"]').containsText('Sujets (2)');
+    assert.ok(screen.getByLabelText(this.intl.t('pages.campaign-review.table.analysis.title')));
+    assert.ok(screen.getByText(this.intl.t('pages.campaign-review.table.analysis.column.subjects', { count: 2 })));
   });
 });

--- a/orga/tests/acceptance/campaign-assessment-results_test.js
+++ b/orga/tests/acceptance/campaign-assessment-results_test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import { currentURL, click } from '@ember/test-helpers';
-import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { visit, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
 
 import setupIntl from '../helpers/setup-intl';
@@ -42,7 +41,7 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
 
       // then
       assert.dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`).exists({ count: pageSize });
-      assert.contains('Page 1 / 2');
+      assert.ok(screen.getByText('Page 1 / 2'));
       assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
 
@@ -60,7 +59,7 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       assert
         .dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`)
         .exists({ count: changedPageSize });
-      assert.contains('Page 2 / 2');
+      assert.ok(screen.getByText('Page 2 / 2'));
       assert
         .dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')))
         .hasText(changedPageSize.toString());
@@ -92,7 +91,7 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       assert
         .dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`)
         .exists({ count: changedPageSize });
-      assert.contains('Page 1 / 2');
+      assert.ok(screen.getByText('Page 1 / 2'));
       assert
         .dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')))
         .hasText(changedPageSize.toString());
@@ -105,13 +104,13 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       const screen = await visit('/campagnes/1/resultats-evaluation');
       await click(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')));
       await click(await screen.findByRole('option', { name: changedPageSize }));
-      const someElementFromPage1 = this.element.querySelector('[aria-label="Participant"]:nth-child(5)').textContent;
+      const someElementFromPage1 = document.querySelector('[aria-label="Participant"]:nth-child(5)').textContent;
 
       // when
       await clickByName('Aller à la page suivante');
 
       // then
-      assert.contains('Page 2 / 10');
+      assert.ok(screen.getByText('Page 2 / 10'));
       assert.dom('table tbody').doesNotContainText(someElementFromPage1);
     });
 
@@ -130,7 +129,7 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       assert
         .dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`)
         .exists({ count: changedPageSize });
-      assert.contains('Page 1 / 4');
+      assert.ok(screen.getByText('Page 1 / 4'));
       assert
         .dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')))
         .hasText(changedPageSize.toString());

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -43,11 +43,11 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should be accessible for an authenticated prescriber', async function (assert) {
       // when
-      await visit('/campagnes/creation');
+      const screen = await visit('/campagnes/creation');
 
       // then
       assert.strictEqual(currentURL(), '/campagnes/creation');
-      assert.contains("Création d'une campagne");
+      assert.ok(screen.getByText("Création d'une campagne"));
     });
 
     test('it should allow to create a campaign of type ASSESSMENT and redirect to the newly created campaign', async function (assert) {
@@ -130,7 +130,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByName('Créer la campagne');
 
       // then
-      assert.dom(screen.getByText('Harry Cover', { selector: 'dd' })).exists();
+      assert.ok(screen.getByText('Harry Cover', { selector: 'dd' }));
     });
 
     test('it should display error on global form when error 500 is returned from backend', async function (assert) {
@@ -154,7 +154,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/campagnes/creation');
-      assert.contains('Une erreur est survenue. Veuillez réessayer ultérieurement.');
+      assert.ok(screen.getByText('Une erreur est survenue. Veuillez réessayer ultérieurement.'));
     });
   });
 });

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
-import { fillByLabel, clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
@@ -8,7 +8,7 @@ import setupIntl from '../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | campaigns/all-campaigns ', function (hooks) {
+module('Acceptance | campaigns/all-campaigns', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
@@ -16,7 +16,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
   module('When prescriber is not logged in', function () {
     test('it should not be accessible', async function (assert) {
       // given / when
-      await visitScreen('/campagnes/toutes');
+      await visit('/campagnes/toutes');
 
       // then
       assert.deepEqual(currentURL(), '/connexion');
@@ -31,7 +31,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
       await authenticateSession(user.id);
 
       // when
-      await visitScreen('/campagnes/toutes');
+      await visit('/campagnes/toutes');
 
       // then
       assert.deepEqual(currentURL(), '/campagnes/toutes');
@@ -47,7 +47,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
         server.createList('campaign', 12);
 
         // when
-        const screen = await visitScreen('/campagnes/toutes');
+        const screen = await visit('/campagnes/toutes');
 
         // then
         assert.strictEqual(screen.getAllByLabelText('Campagne').length, 12, 'the number of campaigns');
@@ -60,7 +60,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
         await authenticateSession(user.id);
 
         server.create('campaign', { id: 1, name: 'CampagneEtPrairie' });
-        await visitScreen('/campagnes/toutes');
+        await visit('/campagnes/toutes');
 
         // when
         await clickByName('CampagneEtPrairie');
@@ -78,7 +78,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
 
           const owner = server.create('user', { firstName: 'Harry', lastName: 'Cojaune' });
           server.create('campaign', { ownerFirstName: owner.firstName, ownerLastName: owner.lastName });
-          await visitScreen('/campagnes/toutes');
+          await visit('/campagnes/toutes');
 
           // when
           await fillByLabel('Rechercher un propriétaire', owner.firstName);
@@ -95,7 +95,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
 
           const owner = server.create('user', { firstName: 'Harry', lastName: 'Jaune' });
           server.create('campaign', { ownerFirstName: owner.firstName, ownerLastName: owner.lastName });
-          await visitScreen(`/campagnes/toutes?ownerName=${owner.firstName}`);
+          await visit(`/campagnes/toutes?ownerName=${owner.firstName}`);
 
           // when
           await fillByLabel('Rechercher un propriétaire', '');
@@ -122,14 +122,14 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
             ownerFirstName: otherOwner.firstName,
             ownerLastName: otherOwner.lastName,
           });
-          const screen = await visitScreen('/campagnes/toutes');
+          const screen = await visit('/campagnes/toutes');
 
           // when
           await fillByLabel('Rechercher un propriétaire', owner.firstName);
 
           // then
-          assert.dom(screen.getByText('ma super campagne')).exists();
-          assert.dom(screen.queryByLabelText('la campagne de Sara')).doesNotExist();
+          assert.ok(screen.getByText('ma super campagne'));
+          assert.notOk(screen.queryByLabelText('la campagne de Sara'));
         });
       });
 
@@ -146,14 +146,14 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           server.create('campaign', {
             name: 'la campagne de Sara',
           });
-          const screen = await visitScreen('/campagnes/toutes');
+          const screen = await visit('/campagnes/toutes');
 
           // when
           await fillByLabel('Rechercher une campagne', 'Sara');
 
           // then
-          assert.dom(screen.getByText('la campagne de Sara')).exists();
-          assert.dom(screen.queryByLabelText('ma super campagne')).doesNotExist();
+          assert.ok(screen.getByText('la campagne de Sara'));
+          assert.notOk(screen.queryByLabelText('ma super campagne'));
         });
 
         test('it should update URL with campaign name filter', async function (assert) {
@@ -164,7 +164,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
 
           const campaignName = 'CampagneV2';
           server.create('campaign', { name: campaignName });
-          await visitScreen('/campagnes/toutes');
+          await visit('/campagnes/toutes');
 
           // when
           await fillByLabel('Rechercher une campagne', campaignName);
@@ -198,16 +198,16 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
             ownerFirstName: otherOwner.firstName,
             ownerLastName: otherOwner.lastName,
           });
-          await visitScreen('/campagnes/toutes');
+          const screen = await visit('/campagnes/toutes');
 
           // when
           await fillByLabel('Rechercher un propriétaire', 'Harry');
           await fillByLabel('Rechercher une campagne', 'campagne');
 
           // then
-          assert.contains('ma super campagne');
-          assert.notContains('Evaluation');
-          assert.notContains('la campagne de Sara');
+          assert.ok(screen.getByText('ma super campagne'));
+          assert.notOk(screen.queryByText('Evaluation'));
+          assert.notOk(screen.queryByText('la campagne de Sara'));
         });
       });
 
@@ -225,7 +225,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
             ownerFirstName: owner.firstName,
             ownerLastName: owner.lastName,
           });
-          const screen = await visitScreen('/campagnes/toutes');
+          const screen = await visit('/campagnes/toutes');
 
           // when
           await fillByLabel('Rechercher une campagne', campaignName1);
@@ -234,8 +234,8 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
 
           //then
-          assert.dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-owner'))).containsText('');
-          assert.dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name'))).containsText('');
+          assert.ok(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner')));
+          assert.ok(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-name')));
           assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
           assert.deepEqual(currentURL(), '/campagnes/toutes');
         });
@@ -250,10 +250,10 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
         await authenticateSession(user.id);
 
         // when
-        const screen = await visitScreen('/campagnes/toutes');
+        const screen = await visit('/campagnes/toutes');
 
         // then
-        assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign'))).exists();
+        assert.ok(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign')));
       });
     });
   });

--- a/orga/tests/acceptance/campaign-list-my-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-my-campaigns_test.js
@@ -162,9 +162,7 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
             await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
 
             //then
-            assert
-              .dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name')))
-              .containsText('');
+            assert.ok(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name')));
             assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
             assert.deepEqual(currentURL(), '/campagnes/les-miennes');
           });
@@ -183,7 +181,7 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
         const screen = await visitScreen('/campagnes/les-miennes');
 
         // then
-        assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign'))).exists();
+        assert.ok(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign')));
       });
     });
   });

--- a/orga/tests/acceptance/campaign-list_test.js
+++ b/orga/tests/acceptance/campaign-list_test.js
@@ -49,7 +49,7 @@ module('Acceptance | Campaign List', function (hooks) {
       const screen = await visitScreen('/campagnes');
 
       // then
-      assert.dom(screen.getByRole('heading', 'Créez votre première campagne')).exists();
+      assert.ok(screen.getByRole('heading', 'Créez votre première campagne'));
     });
 
     test('it should show the two tabs: my campaigns and all campaigns', async function (assert) {
@@ -64,9 +64,9 @@ module('Acceptance | Campaign List', function (hooks) {
       const screen = await visitScreen('/campagnes');
 
       // then
-      assert.dom(screen.getByRole('heading', this.intl.t('pages.campaigns-list.title'))).exists();
-      assert.contains(this.intl.t('pages.campaigns-list.tabs.my-campaigns'));
-      assert.contains(this.intl.t('pages.campaigns-list.tabs.all-campaigns'));
+      assert.ok(screen.getByRole('heading', this.intl.t('pages.campaigns-list.title')));
+      assert.ok(screen.getByText(this.intl.t('pages.campaigns-list.tabs.my-campaigns')));
+      assert.ok(screen.getByText(this.intl.t('pages.campaigns-list.tabs.all-campaigns')));
     });
   });
 });

--- a/orga/tests/acceptance/campaign-profiles_test.js
+++ b/orga/tests/acceptance/campaign-profiles_test.js
@@ -33,7 +33,7 @@ module('Acceptance | Campaign Profiles', function (hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: pageSize });
-      assert.contains('Page 1 / 2');
+      assert.ok(screen.getByText('Page 1 / 2'));
       assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
 
@@ -47,7 +47,7 @@ module('Acceptance | Campaign Profiles', function (hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });
-      assert.contains('Page 2 / 2');
+      assert.ok(screen.getByText('Page 2 / 2'));
       assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
   });
@@ -64,7 +64,7 @@ module('Acceptance | Campaign Profiles', function (hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });
-      assert.contains('Page 1 / 2');
+      assert.ok(screen.getByText('Page 1 / 2'));
       assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
 
@@ -76,13 +76,13 @@ module('Acceptance | Campaign Profiles', function (hooks) {
       await click(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')));
       await click(await screen.findByRole('option', { name: changedPageSize }));
 
-      const someElementFromPage1 = this.element.querySelector('table tbody tr:nth-child(5)').textContent;
+      const someElementFromPage1 = document.querySelector('table tbody tr:nth-child(5)').textContent;
 
       // when
       await clickByName('Aller à la page suivante');
 
       // then
-      assert.contains('Page 2 / 10');
+      assert.ok(screen.getByText('Page 2 / 10'));
       assert.dom('table tbody').doesNotContainText(someElementFromPage1);
     });
 
@@ -98,7 +98,7 @@ module('Acceptance | Campaign Profiles', function (hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });
-      assert.contains('Page 1 / 2');
+      assert.ok(screen.getByText('Page 1 / 2'));
       assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
   });

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserManagingStudents, createPrescriberByUser } from '../helpers/test-init';
@@ -31,7 +31,7 @@ module('Acceptance | Certifications page', function (hooks) {
       await visit('/certifications');
 
       // then
-      assert.dom('.pix-banner').exists();
+      assert.ok('.pix-banner');
     });
 
     test('should not show any banner outside certification period', async function (assert) {
@@ -48,14 +48,14 @@ module('Acceptance | Certifications page', function (hooks) {
     module('When organizations has no students imported yet', function () {
       test('should show warning message inviting user to import students on Certifications page', async function (assert) {
         // given / when
-        await visit('/certifications');
+        const screen = await visit('/certifications');
 
         // then
-        assert
-          .dom('.certifications-page__text')
-          .containsText(
+        assert.ok(
+          screen.getByText(
             'Dans cet onglet, vous retrouverez les résultats et les attestations de certification des élèves. Vous devez, dans un premier temps, importer la base élèves de votre établissement.',
-          );
+          ),
+        );
       });
     });
 
@@ -70,17 +70,17 @@ module('Acceptance | Certifications page', function (hooks) {
 
       test('should show Certifications page', async function (assert) {
         // given / when
-        await visit('/certifications');
+        const screen = await visit('/certifications');
 
         // then
-        assert
-          .dom('.certifications-page__text')
-          .containsText(
+        assert.ok(
+          screen.getByText(
             'Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les attestations (.pdf). Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.',
-          );
-        assert.contains('Exporter les résultats');
-        assert.contains('Certifications');
-        assert.contains('Classe');
+          ),
+        );
+        assert.ok(screen.getByText('Exporter les résultats'));
+        assert.ok(screen.getByText('Certifications'));
+        assert.ok(screen.getByText('Classe'));
       });
 
       test('should show documentation about certification results link', async function (assert) {
@@ -88,7 +88,7 @@ module('Acceptance | Certifications page', function (hooks) {
         await visit('/certifications');
 
         // then
-        assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
+        assert.ok('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]');
       });
 
       test('should display attestation download button', async function (assert) {
@@ -96,7 +96,7 @@ module('Acceptance | Certifications page', function (hooks) {
         await visit('/certifications');
 
         // then
-        assert.dom('button[id="download_attestations"]').exists();
+        assert.ok('button[id="download_attestations"]');
       });
     });
   });

--- a/orga/tests/acceptance/invitations-list_test.js
+++ b/orga/tests/acceptance/invitations-list_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 import authenticateSession from '../helpers/authenticate-session';
 import { createPrescriberForOrganization } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
@@ -30,12 +29,11 @@ module('Acceptance | Invitations list', function (hooks) {
     await authenticateSession(user.id);
 
     // when
-    await visit('/equipe/invitations');
+    const screen = await visit('/equipe/invitations');
     await clickByName(this.intl.t('pages.team-invitations.cancel-invitation'));
 
     // then
-    assert.notContains('gigi@example.net');
-    assert.contains('Invitations (-)');
-    assert.ok(true);
+    assert.notOk(screen.queryByText('gigi@example.net'));
+    assert.ok(screen.getByText('Invitations (-)'));
   });
 });

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -67,9 +67,7 @@ module('Acceptance | join', function (hooks) {
           // when
           const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`);
 
-          assert
-            .dom(screen.getByText('You have been invited to join the organisation Le collège fou fou fou'))
-            .exists();
+          assert.ok(screen.getByText('You have been invited to join the organisation Le collège fou fou fou'));
 
           await click(screen.getByRole('button', { name: 'English' }));
           await screen.findByRole('listbox');
@@ -110,7 +108,7 @@ module('Acceptance | join', function (hooks) {
         // then
         assert.strictEqual(currentURL(), '/connexion');
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-        assert.dom('.login-form__invitation-error').exists();
+        assert.ok('.login-form__invitation-error');
         assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);
       });
     });
@@ -127,12 +125,12 @@ module('Acceptance | join', function (hooks) {
         }).id;
 
         // when
-        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+        const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
         // then
         assert.strictEqual(currentURL(), '/connexion');
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-        assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
+        assert.ok(screen.getByText(this.intl.t('pages.login-form.invitation-was-cancelled')));
       });
     });
   });
@@ -199,7 +197,7 @@ module('Acceptance | join', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/cgu');
-        assert.dom(screen.getByText("CONDITIONS GÉNÉRALES D'UTILISATION DE LA PLATEFORME PIX ORGA")).exists();
+        assert.ok(screen.getByText("CONDITIONS GÉNÉRALES D'UTILISATION DE LA PLATEFORME PIX ORGA"));
       });
 
       test('does not show menu nor top bar', async function (assert) {
@@ -244,7 +242,7 @@ module('Acceptance | join', function (hooks) {
         // given
         server.create('campaign');
 
-        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+        const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await clickByName(loginFormButton);
         await fillByLabel(emailInputLabel, user.email);
         await fillByLabel(passwordInputLabel, 'secret');
@@ -253,10 +251,9 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
-
         assert.strictEqual(currentURL(), '/campagnes/les-miennes');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-        assert.contains('Harry Cover');
+        assert.ok(screen.getByText('Harry Cover'));
       });
     });
 
@@ -290,7 +287,7 @@ module('Acceptance | join', function (hooks) {
             401,
           );
 
-          await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+          const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
           await clickByName(loginFormButton);
           await fillByLabel(emailInputLabel, user.email);
           await fillByLabel(passwordInputLabel, 'fakepassword');
@@ -305,7 +302,7 @@ module('Acceptance | join', function (hooks) {
 
           assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
           assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-          assert.contains(this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY));
+          assert.ok(screen.getByText(this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY)));
         });
       });
 
@@ -334,7 +331,7 @@ module('Acceptance | join', function (hooks) {
             `/organization-invitations/${organizationInvitationId}/response`,
             () => new Response(409, {}, { errors: [{ status: '409' }] }),
           );
-          await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+          const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
           await clickByName(loginFormButton);
           await fillByLabel(emailInputLabel, user.email);
           await fillByLabel(passwordInputLabel, 'secret');
@@ -345,7 +342,7 @@ module('Acceptance | join', function (hooks) {
           // then
           assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
           assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-          assert.contains(this.intl.t('pages.login-form.errors.status.409'));
+          assert.ok(screen.getByText(this.intl.t('pages.login-form.errors.status.409')));
         });
       });
 
@@ -486,7 +483,7 @@ module('Acceptance | join', function (hooks) {
 
             // then
             assert.strictEqual(currentURL(), '/cgu');
-            assert.dom(screen.getByText('TERMS AND CONDITIONS OF USE OF THE PIX ORGA PLATFORM')).exists();
+            assert.ok(screen.getByText('TERMS AND CONDITIONS OF USE OF THE PIX ORGA PLATFORM'));
           });
         });
       });

--- a/orga/tests/acceptance/organization-participant-list_test.js
+++ b/orga/tests/acceptance/organization-participant-list_test.js
@@ -26,11 +26,13 @@ module('Acceptance | Organization Participant List', function (hooks) {
 
       test('it should be accessible and display the no-participant-panel when no participant', async function (assert) {
         // when
-        await visit('/participants');
+        const screen = await visit('/participants');
 
         // then
         assert.strictEqual(currentURL(), '/participants');
-        assert.contains(this.intl.t('pages.organization-participants.empty-state.message'));
+        assert.ok(
+          screen.getByText(this.intl.t('pages.organization-participants.empty-state.message'), { exact: false }),
+        );
       });
 
       test('it should return participant-list when having participants', async function (assert) {
@@ -41,11 +43,11 @@ module('Acceptance | Organization Participant List', function (hooks) {
         server.create('organization-participant', { organizationId, firstName: 'Xavier', lastName: 'Charles' });
 
         await authenticateSession(user.id);
-        await visit('/participants');
+        const screen = await visit('/participants');
 
         // then
-        assert.notContains(this.intl.t('pages.organization-participants.empty-state.message'));
-        assert.contains('Charles');
+        assert.notOk(screen.queryByText(this.intl.t('pages.organization-participants.empty-state.message')));
+        assert.ok(screen.getByText('Charles'));
       });
 
       test('it should filter by certificability', async function (assert) {

--- a/orga/tests/acceptance/profile_test.js
+++ b/orga/tests/acceptance/profile_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click } from '@ember/test-helpers';
-import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import { currentURL, click } from '@ember/test-helpers';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
@@ -30,7 +30,8 @@ module('Acceptance | Campaign Profile', function (hooks) {
     server.create('organization-participant', { id: 1, organizationId });
 
     // when
-    const screen = await visitScreen('/campagnes/1/profils/1');
+    const screen = await visit('/campagnes/1/profils/1');
+
     await click(screen.getByRole('link', { name: this.intl.t('common.actions.link-to-participant') }));
 
     // then
@@ -43,7 +44,7 @@ module('Acceptance | Campaign Profile', function (hooks) {
     server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
 
     // when
-    await visitScreen('/campagnes/1/profils/1');
+    await visit('/campagnes/1/profils/1');
     await click(
       within(document.querySelector('main')).getByRole('link', { name: this.intl.t('navigation.main.campaigns') }),
     );
@@ -58,7 +59,7 @@ module('Acceptance | Campaign Profile', function (hooks) {
     server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
 
     // when
-    await visitScreen('/campagnes/1/profils/1');
+    await visit('/campagnes/1/profils/1');
     await clickByName('CampagneEtPrairie');
 
     // then
@@ -75,9 +76,9 @@ module('Acceptance | Campaign Profile', function (hooks) {
     });
 
     // when
-    await visit('/campagnes/2/profils/1');
+    const screen = await visit('/campagnes/2/profils/1');
 
     // then
-    assert.contains('Jules Winnfield');
+    assert.ok(screen.getByText('Jules Winnfield'));
   });
 });

--- a/orga/tests/acceptance/remove-membership_test.js
+++ b/orga/tests/acceptance/remove-membership_test.js
@@ -6,23 +6,19 @@ import authenticateSession from '../helpers/authenticate-session';
 import { createPrescriberByUser, createUserMembershipWithRole } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-
-async function createAuthenticatedSession() {
-  const user = createUserMembershipWithRole('ADMIN');
-  createPrescriberByUser(user);
-
-  await authenticateSession(user.id);
-
-  return user;
-}
+import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Remove membership', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
   let user;
 
   hooks.beforeEach(async function () {
-    const adminUser = await createAuthenticatedSession();
+    const adminUser = createUserMembershipWithRole('ADMIN');
+    createPrescriberByUser(adminUser);
+
+    await authenticateSession(adminUser.id);
     const organizationId = adminUser.memberships.models.firstObject.organizationId;
 
     user = server.create('user', { firstName: 'John', lastName: 'Doe' });
@@ -32,15 +28,23 @@ module('Acceptance | Remove membership', function (hooks) {
   test('should remove the membership', async function (assert) {
     // given
     const screen = await visit('/equipe');
-    await clickByName('Gérer');
-    await clickByName('Supprimer');
+
+    await clickByName(this.intl.t('pages.team-members.actions.manage'));
+    await clickByName(this.intl.t('pages.team-members.actions.remove-membership'));
 
     await screen.findByRole('dialog');
 
     // when
-    await clickByName('Oui, supprimer le membre');
+    await clickByName(this.intl.t('pages.team-members.remove-membership-modal.actions.remove'));
 
     // then
-    assert.contains(`${user.firstName} ${user.lastName} a été supprimé avec succès de votre équipe Pix Orga.`);
+    assert.ok(
+      screen.findByText(
+        this.intl.t('pages.team-members.notifications.remove-membership.success', {
+          memberFirstName: user.firstName,
+          memberLastName: user.lastName,
+        }),
+      ),
+    );
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le contains et notContains a été créé en interne il y a plus de 3ans afin de répondre au besoin de vérification de textes dans les tests fronts.
Depuis ce temps nous avons la lib testing-library qui a des solutions plus précises comme getByText, queryByText, getByLabelText,... Qui répondent totalement à nos besoin et nous permette de supprimer nos contains et notContains

## :robot: Proposition
Remplacer les utilisations de contains et notContains par des solutions de testing-library afin de pouvoir, par la suite, supprimer le développement de contains et notContains

## :rainbow: Remarques
Ils sont partout partout alors je n'ai pas supprimé de tous les fichiers pour des soucis de taille de PR et de Review.

Réalisés :
- authentication test
- campaign-activity test 
- campaign-analysis test
-  campaign-assessment-results test 
- campaign-creation test
-  campaign-list test
- campaign-list all-campaigns test
- campaign-list my-campaigns test
-  campaign-profiles test
-  certifications test
- invitations-list test
-  join test
-  organization-participant-list test
- profile test
- remove-membership test

## :100: Pour tester
Vérifier que tous les tests passent