### PR TITLE
[FEATURE] Permettre la création de parcours autonomes dans l'API (PIX-9806).

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -25,6 +25,8 @@ const MAX_DIFF_BETWEEN_USER_LEVEL_AND_SKILL_LEVEL = 2;
 const ALL_TREATMENTS = ['t1', 't2', 't3'];
 const PIX_ORIGIN = 'Pix';
 
+const AUTONOMOUS_COURSES_ORGANIZATION_ID = config.autonomousCourse.autonomousCoursesOrganizationId;
+
 const PIX_CERTIF = {
   SCOPE: 'pix-certif',
   NOT_LINKED_CERTIFICATION_MSG:
@@ -120,6 +122,7 @@ const constants = {
   OIDC_ERRORS,
   CERTIFICATION_CENTER_TYPES,
   ORGANIZATION_FEATURE,
+  AUTONOMOUS_COURSES_ORGANIZATION_ID,
 };
 
 export {

--- a/api/sample.env
+++ b/api/sample.env
@@ -1108,3 +1108,12 @@ PIX_AUDIT_LOGGER_BASE_URL=http://localhost:3001
 # type: string
 # sample: PIX_AUDIT_LOGGER_CLIENT_SECRET=pixApiClientSecretTest
 PIX_AUDIT_LOGGER_CLIENT_SECRET=pixApiClientSecretTest
+
+# This organization is used as a unique organization for autonomous courses creation.
+# This is strictly for internal use and this organization should not be exposed
+# outside PIX administration.
+#
+# presence: required
+# type: number
+# sample: AUTONOMOUS_COURSES_ORGANIZATION_ID=9000000
+AUTONOMOUS_COURSES_ORGANIZATION_ID=9000000

--- a/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
+++ b/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
@@ -1,0 +1,19 @@
+import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
+import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
+import * as autonomousCourseSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
+
+const save = async (request, h, dependencies = { requestResponseUtils, usecases, autonomousCourseSerializer }) => {
+  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const autonomousCourseForCreation = {
+    ...request.payload.data.attributes,
+    ownerId: userId,
+  };
+  const autonomousCourseId = await dependencies.usecases.saveAutonomousCourse({
+    autonomousCourse: autonomousCourseForCreation,
+  });
+  return h.response(dependencies.autonomousCourseSerializer.serializeId(autonomousCourseId)).created();
+};
+
+const autonomousCourseController = { save };
+
+export { autonomousCourseController };

--- a/api/src/evaluation/application/autonomous-courses/index.js
+++ b/api/src/evaluation/application/autonomous-courses/index.js
@@ -1,0 +1,47 @@
+import Joi from 'joi';
+import { autonomousCourseController } from './autonomous-course-controller.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/autonomous-courses',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: autonomousCourseController.save,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              type: Joi.string().valid('autonomous-courses'),
+              attributes: Joi.object({
+                targetProfileId: identifiersType.targetProfileId,
+                internalTitle: Joi.string().required(),
+                publicTitle: Joi.string().required(),
+                customLandingPageText: Joi.string().allow(null).optional(),
+              }),
+            }),
+          }),
+        },
+        notes: [
+          '- **Route nécessitant une authentification**\n' + '- Cette route permet de créer un parcours autonome.',
+        ],
+        tags: ['api', 'autonomous-courses'],
+      },
+    },
+  ]);
+};
+
+const name = 'autonomous-courses-api';
+export { register, name };

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -11,4 +11,21 @@ class StageWithLinkedCampaignError extends DomainError {
   }
 }
 
-export { DomainError, StageWithLinkedCampaignError };
+class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
+  constructor() {
+    super('Autonomous course requires a target profile with simplified access.');
+  }
+}
+
+class TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization extends DomainError {
+  constructor() {
+    super('Target profile requires to be linked to autonomous course organization.');
+  }
+}
+
+export {
+  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  DomainError,
+  StageWithLinkedCampaignError,
+  TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+};

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -8,6 +8,7 @@ import * as areaRepository from '../../../../lib/infrastructure/repositories/are
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../../lib/infrastructure/repositories/campaign-participation-repository.js';
+import { repositories } from '../../infrastructure/repositories/index.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as competenceEvaluationRepository from '../../infrastructure/repositories/competence-evaluation-repository.js';
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
@@ -16,6 +17,7 @@ import * as stageCollectionForTargetProfileRepository from '../../infrastructure
 import * as stageRepository from '../../infrastructure/repositories/stage-repository.js';
 import * as feedbackRepository from '../../infrastructure/repositories/feedback-repository.js';
 import * as targetProfileForAdminRepository from '../../../../lib/infrastructure/repositories/target-profile-for-admin-repository.js';
+import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import { getCompetenceLevel } from '../services/get-competence-level.js';
 import * as scorecardService from '../services/scorecard-service.js';
 
@@ -31,6 +33,7 @@ const dependencies = {
   assessmentRepository,
   campaignRepository,
   campaignParticipationRepository,
+  autonomousCourseRepository: repositories.autonomousCourseRepository,
   competenceEvaluationRepository,
   competenceRepository,
   knowledgeElementRepository,
@@ -39,6 +42,7 @@ const dependencies = {
   feedbackRepository,
   stageRepository,
   targetProfileForAdminRepository,
+  targetProfileRepository,
   getCompetenceLevel,
   scorecardService,
 };

--- a/api/src/evaluation/domain/usecases/save-autonomous-course.js
+++ b/api/src/evaluation/domain/usecases/save-autonomous-course.js
@@ -1,0 +1,42 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import {
+  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+} from '../errors.js';
+import { constants } from '../../../../lib/domain/constants.js';
+
+/**
+ * @param {AutonomousCourse} autonomousCourse
+ * @param autonomousCourseRepository
+ * @param targetProfileRepository
+ * @param targetProfileForAdminRepository
+ * @returns {Promise<*>}
+ */
+const saveAutonomousCourse = async ({
+  autonomousCourse,
+  autonomousCourseRepository,
+  targetProfileRepository,
+  targetProfileForAdminRepository,
+}) => {
+  let targetProfile;
+
+  try {
+    targetProfile = await targetProfileForAdminRepository.get({ id: autonomousCourse.targetProfileId });
+  } catch (e) {
+    throw new NotFoundError(`No target profile found for ID ${autonomousCourse.targetProfileId}`);
+  }
+
+  const organizationIds = await targetProfileRepository.findOrganizationIds(autonomousCourse.targetProfileId);
+
+  if (![...organizationIds, targetProfile.ownerOrganizationId].includes(constants.AUTONOMOUS_COURSES_ORGANIZATION_ID)) {
+    throw new TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization();
+  }
+
+  if (!targetProfile.isSimplifiedAccess) {
+    throw new AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError();
+  }
+
+  return autonomousCourseRepository.save({ autonomousCourse });
+};
+
+export { saveAutonomousCourse };

--- a/api/src/evaluation/infrastructure/repositories/autonomous-course-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/autonomous-course-repository.js
@@ -1,0 +1,21 @@
+import { constants } from '../../../../lib/domain/constants.js';
+
+/**
+ * @param {AutonomousCourse} autonomousCourse
+ * @param {CampaignApi} campaignApi
+ * @returns {Promise<number>} returns the created campaign id
+ */
+const save = async function ({ autonomousCourse, campaignApi }) {
+  const { id } = await campaignApi.save({
+    name: autonomousCourse.internalTitle,
+    title: autonomousCourse.publicTitle,
+    targetProfileId: autonomousCourse.targetProfileId,
+    organizationId: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+    creatorId: autonomousCourse.ownerId,
+    customLandingPageText: autonomousCourse.customLandingPageText,
+  });
+
+  return id;
+};
+
+export { save };

--- a/api/src/evaluation/infrastructure/repositories/index.js
+++ b/api/src/evaluation/infrastructure/repositories/index.js
@@ -1,0 +1,15 @@
+import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import * as autonomousCourseRepository from './autonomous-course-repository.js';
+import * as campaignApi from '../../../prescription/campaigns/application/api/campaigns-api.js';
+
+const repositoriesWithoutInjectedDependencies = {
+  autonomousCourseRepository,
+};
+
+const dependencies = {
+  campaignApi,
+};
+
+const repositories = injectDependencies(repositoriesWithoutInjectedDependencies, dependencies);
+
+export { repositories };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js
@@ -1,0 +1,7 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+const { Serializer } = jsonapiSerializer;
+const serializeId = function (autonomousCourseId) {
+  return new Serializer('autonomous-course', {}).serialize({ id: autonomousCourseId });
+};
+
+export { serializeId };

--- a/api/src/evaluation/routes.js
+++ b/api/src/evaluation/routes.js
@@ -1,14 +1,16 @@
+import * as autonomousCoursesRoutes from './application/autonomous-courses/index.js';
 import * as competenceEvaluationsRoutes from './application/competence-evaluations/index.js';
 import * as feedbacksRoutes from './application/feedbacks/index.js';
-import * as scorecards from './application/scorecards/index.js';
+import * as scorecardsRoutes from './application/scorecards/index.js';
 import * as stagesRoutes from './application/stages/index.js';
 import * as stageCollectionRoutes from './application/stage-collections/index.js';
 
 const evaluationRoutes = [
+  autonomousCoursesRoutes,
   competenceEvaluationsRoutes,
   stageCollectionRoutes,
   feedbacksRoutes,
-  scorecards,
+  scorecardsRoutes,
   stagesRoutes,
 ];
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -348,6 +348,9 @@ const configuration = (function () {
       challengesBetweenSameCompetence: 2,
     },
     version: process.env.CONTAINER_VERSION || 'development',
+    autonomousCourse: {
+      autonomousCoursesOrganizationId: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
+    },
   };
 
   if (config.environment === 'development') {

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -1,0 +1,93 @@
+import { createServer } from '../../../../../server.js';
+
+import {
+  expect,
+  generateValidRequestAuthorizationHeader,
+  databaseBuilder,
+  sinon,
+  mockLearningContent,
+  learningContentBuilder,
+  knex,
+} from '../../../../test-helper.js';
+import { constants } from '../../../../../lib/domain/constants.js';
+
+describe('Acceptance | API | Autonomous Course', function () {
+  let server;
+  let userId;
+
+  beforeEach(async function () {
+    userId = databaseBuilder.factory.buildUser.withRole().id;
+    await databaseBuilder.commit();
+    server = await createServer();
+
+    const learningContent = [
+      {
+        id: 'recArea0',
+        competences: [
+          {
+            id: 'recNv8qhaY887jQb2',
+            index: '1.3',
+            name: 'Traiter des données',
+          },
+        ],
+      },
+    ];
+    const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+    mockLearningContent(learningContentObjects);
+  });
+
+  describe('POST /api/autonomous-course', function () {
+    context('When user is authenticated', function () {
+      let targetProfileId;
+      beforeEach(async function () {
+        sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          id: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+        });
+        targetProfileId = databaseBuilder.factory.buildTargetProfile({
+          isSimplifiedAccess: true,
+          ownerOrganizationId: organizationId,
+        }).id;
+        databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+        await databaseBuilder.commit();
+      });
+
+      context('when the organization owns the target profile', function () {
+        it('should return 201', async function () {
+          // when
+          const autonomousCourseAttributes = {
+            internalTitle: 'Titre pour usage interne',
+            publicTitle: 'Titre pour usage public',
+            targetProfileId,
+            customLandingPageText: 'customLandingPageText',
+          };
+          const payload = {
+            data: {
+              type: 'autonomous-courses',
+              attributes: autonomousCourseAttributes,
+            },
+          };
+
+          const options = {
+            method: 'POST',
+            url: '/api/autonomous-courses',
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            payload,
+          };
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(201);
+          expect(response.result.data.type).to.equal('autonomous-courses');
+          expect(response.result.data.id).to.be.not.null;
+
+          const campaign = await knex('campaigns').where({ id: response.result.data.id }).first();
+          expect(campaign).to.exist;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
@@ -1,0 +1,120 @@
+import {
+  catchErr,
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  mockLearningContent,
+  learningContentBuilder,
+  knex,
+  sinon,
+} from '../../../../test-helper.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization } from '../../../../../src/evaluation/domain/errors.js';
+import { constants } from '../../../../../lib/domain/constants.js';
+
+describe('Integration | Usecases | Save autonomous course', function () {
+  beforeEach(async function () {
+    sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
+    databaseBuilder.factory.buildTargetProfile({
+      id: 1,
+    });
+
+    await databaseBuilder.commit();
+
+    const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
+    const learningContentObjects = learningContentBuilder([learningContent]);
+    mockLearningContent(learningContentObjects);
+  });
+
+  afterEach(async function () {
+    await knex('autonomous-courses').delete();
+  });
+
+  context('when target-profile does not exist', function () {
+    it('should throw a not found error', async function () {
+      // when
+      const error = await catchErr(evaluationUsecases.saveAutonomousCourse)({
+        autonomousCourse: {
+          targetProfileId: 777,
+        },
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal('No target profile found for ID 777');
+    });
+  });
+
+  context('when target-profile organization is not shared with organization', function () {
+    context('and autonomous course organization is not the owner', function () {
+      it('should throw an error', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({
+          id: 34,
+        });
+        const otherOrganization = databaseBuilder.factory.buildOrganization();
+
+        const targetProfileNotOwnedByAutonomousCourse = databaseBuilder.factory.buildTargetProfile({
+          ownerOrganizationId: organization.id,
+        });
+        databaseBuilder.factory.buildTargetProfileShare({
+          organizationId: otherOrganization.id,
+          targetProfileId: targetProfileNotOwnedByAutonomousCourse.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(evaluationUsecases.saveAutonomousCourse)({
+          autonomousCourse: {
+            targetProfileId: targetProfileNotOwnedByAutonomousCourse.id,
+          },
+        });
+
+        // then
+        expect(error).to.be.instanceOf(TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization);
+        expect(error.message).to.equal('Target profile requires to be linked to autonomous course organization.');
+      });
+    });
+
+    context('and autonomous course organization is the owner', function () {
+      it('should save the autonomous course', async function () {
+        // given
+        const { id: userId } = databaseBuilder.factory.buildUser();
+
+        const organization = databaseBuilder.factory.buildOrganization({
+          id: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+        });
+
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
+
+        const targetProfileOwnedByAutonomousCourseOrganization = databaseBuilder.factory.buildTargetProfile({
+          ownerOrganizationId: organization.id,
+          isSimplifiedAccess: true,
+        });
+        databaseBuilder.factory.buildTargetProfileShare({
+          organizationId: organization.id,
+          targetProfileId: targetProfileOwnedByAutonomousCourseOrganization.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const autonomousCourseId = await evaluationUsecases.saveAutonomousCourse({
+          autonomousCourse: {
+            ownerId: userId,
+            targetProfileId: targetProfileOwnedByAutonomousCourseOrganization.id,
+            publicTitle: 'public title',
+            internalTitle: 'internal title',
+            customLandingPageText: 'custom landing text page text',
+          },
+        });
+
+        // then
+        expect(autonomousCourseId).to.be.above(0);
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
@@ -1,0 +1,37 @@
+import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { repositories } from '../../../../../src/evaluation/infrastructure/repositories/index.js';
+import { constants } from '../../../../../lib/domain/constants.js';
+
+describe('Integration | Repository | Autonomous Course', function () {
+  afterEach(function () {
+    return knex('autonomous-courses').delete();
+  });
+
+  it('#save', async function () {
+    // given
+    sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+    const { id: userId } = databaseBuilder.factory.buildUser();
+    const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+      id: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+    });
+    databaseBuilder.factory.buildMembership({ organizationId, userId });
+    const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
+
+    await databaseBuilder.commit();
+
+    // when
+    const savedAutonomousCourseId = await repositories.autonomousCourseRepository.save({
+      autonomousCourse: {
+        ownerId: userId,
+        organizationId,
+        targetProfileId,
+        publicTitle: 'public title',
+        internalTitle: 'internal title',
+        customLandingPageText: 'custom landing text page text',
+      },
+    });
+
+    // then
+    expect(savedAutonomousCourseId).to.be.above(0);
+  });
+});

--- a/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
@@ -1,0 +1,54 @@
+import { expect, sinon, hFake } from '../../../../test-helper.js';
+import { autonomousCourseController } from '../../../../../src/evaluation/application/autonomous-courses/autonomous-course-controller.js';
+
+describe('Unit | Controller | autonomous-course-controller', function () {
+  describe('#save', function () {
+    it('should return autonomous course created Id', async function () {
+      // given
+      const autonomousCourseAttributes = {
+        internalTitle: 'Titre pour usage interne',
+        publicTitle: 'Titre pour usage public',
+        targetProfileId: 'targetProfileId',
+        customLandingPageText: 'customLandingPageText',
+      };
+      const payload = {
+        data: {
+          type: 'autonomous-courses',
+          attributes: autonomousCourseAttributes,
+        },
+      };
+      const request = {
+        headers: { 'user-agent': 'Mozilla' },
+        payload: payload,
+      };
+      const h = {
+        ...hFake,
+      };
+      const userId = '123';
+      const requestResponseUtils = {
+        extractUserIdFromRequest: sinon.stub().returns(userId),
+      };
+      const expectedAutonomousCourseId = 123;
+      const usecases = {
+        saveAutonomousCourse: sinon.stub().resolves(expectedAutonomousCourseId),
+      };
+      const serializedAutonomousCourseId = Symbol('serializedAutonomousCourseId');
+      const autonomousCourseSerializer = { serializeId: sinon.stub().returns(serializedAutonomousCourseId) };
+      const dependencies = {
+        requestResponseUtils,
+        usecases,
+        autonomousCourseSerializer,
+      };
+
+      // when
+      await autonomousCourseController.save(request, h, dependencies);
+
+      // then
+      expect(requestResponseUtils.extractUserIdFromRequest).to.have.been.called;
+      expect(usecases.saveAutonomousCourse).to.have.been.calledWithExactly({
+        autonomousCourse: { ...autonomousCourseAttributes, ownerId: userId },
+      });
+      expect(autonomousCourseSerializer.serializeId).to.have.been.calledWithExactly(expectedAutonomousCourseId);
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/save-autonomous-course_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-autonomous-course_test.js
@@ -1,0 +1,97 @@
+import { expect, sinon, domainBuilder, catchErr } from '../../../../test-helper.js';
+import { saveAutonomousCourse } from '../../../../../src/evaluation/domain/usecases/save-autonomous-course.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError } from '../../../../../src/evaluation/domain/errors.js';
+import { constants } from '../../../../../lib/domain/constants.js';
+
+describe('Unit | UseCase | save-autonomous-course', function () {
+  let autonomousCourse;
+  let autonomousCourseRepository;
+  let targetProfileRepository;
+  let targetProfileForAdminRepository;
+
+  beforeEach(function () {
+    sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
+    autonomousCourse = {
+      id: 1,
+      organizationId: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+      targetProfileId: 3,
+      campaignId: 4,
+      publicTitle: 'default public title',
+      internalTitle: 'default internal title',
+    };
+
+    autonomousCourseRepository = {
+      save: sinon.stub(),
+    };
+    autonomousCourseRepository.save.resolves(autonomousCourse.id);
+
+    targetProfileRepository = {
+      findOrganizationIds: sinon.stub(),
+    };
+
+    targetProfileForAdminRepository = {
+      get: sinon.stub(),
+    };
+  });
+
+  context('when all foreign keys exist', function () {
+    it('should save an autonomous-course', async function () {
+      // given
+      targetProfileRepository.findOrganizationIds.resolves([constants.AUTONOMOUS_COURSES_ORGANIZATION_ID]);
+      targetProfileForAdminRepository.get.resolves({ isSimplifiedAccess: true });
+
+      // when
+      await saveAutonomousCourse({
+        autonomousCourse,
+        autonomousCourseRepository,
+        targetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(autonomousCourseRepository.save).to.be.calledOnceWithExactly({ autonomousCourse });
+    });
+  });
+
+  context('when target profile is not simplified access', function () {
+    it('should throw a domain error', async function () {
+      const targetProfile = domainBuilder.buildTargetProfile({ isSimplifiedAccess: false });
+      targetProfileForAdminRepository.get.withArgs({ id: autonomousCourse.targetProfileId }).resolves(targetProfile);
+      targetProfileRepository.findOrganizationIds.resolves([constants.AUTONOMOUS_COURSES_ORGANIZATION_ID]);
+
+      // when
+      const error = await catchErr(saveAutonomousCourse)({
+        autonomousCourse,
+        autonomousCourseRepository,
+        targetProfileForAdminRepository,
+        targetProfileRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError);
+      expect(autonomousCourseRepository.save).to.not.have.been.called;
+    });
+  });
+
+  context('when target profile does not exist', function () {
+    it('should throw a not found error', async function () {
+      // given
+      targetProfileForAdminRepository.get.rejects();
+
+      // when
+      const error = await catchErr(saveAutonomousCourse)({
+        autonomousCourse,
+        autonomousCourseRepository,
+        targetProfileRepository,
+        targetProfileForAdminRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`No target profile found for ID ${autonomousCourse.targetProfileId}`);
+      expect(autonomousCourseRepository.save).to.not.have.been.called;
+    });
+  });
+});

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-serializer_test.js
@@ -1,0 +1,20 @@
+import { expect } from '../../../../../test-helper.js';
+import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | autonomous-course-serializer', function () {
+  describe('#serializeId', function () {
+    it('should return a serialized autonomous course to JSONAPI with only ID filled', function () {
+      // when
+      const serializedAutonomousCourse = serializer.serializeId(1);
+
+      // then
+      const expectedSerializedAutonomousCourse = {
+        data: {
+          id: '1',
+          type: 'autonomous-courses',
+        },
+      };
+      return expect(serializedAutonomousCourse).to.deep.equal(expectedSerializedAutonomousCourse);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons créer des parcours autonomes dans pix Admin, mais il n'y a actuellement pas de route API qui permette cela.

## :robot: Proposition
Créer la route API de création dans l'API.

## :rainbow: Remarques
Dans notre bounded-context evaluation, on fait appel via une méthode de repository à une API exposée par le bounded-context prescription. C'est cette API qui a la responsabilité de créer une campagne. 

Cette campagne est reliée à un target profile (selectionné dans pix admin), lui même relié à une organisation spécifique aux parcours autonomes (dont l'Id est administré par une variable d'env). 

On a créé une variable d'env `AUTONOMOUS_COURSES_ORGANIZATION_ID` qui porte l'Id de l'organisation, car on ne peut pas assurer que l'Id de l'organisation soit le même sur tous les environnements.

## :100: Pour tester
- tests verts