### PR TITLE
[FEATURE] Empêcher un candidat de répondre en cas d'alerte en cours (PIX-9007).

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -25,6 +25,7 @@ const correctAnswerThenUpdateAssessment = async function ({
   campaignRepository,
   knowledgeElementRepository,
   flashAssessmentResultRepository,
+  certificationChallengeLiveAlertRepository,
   flashAlgorithmService,
   algorithmDataFetcherService,
   examiner,
@@ -45,6 +46,17 @@ const correctAnswerThenUpdateAssessment = async function ({
   }
 
   const challenge = await challengeRepository.get(answer.challengeId);
+
+  const onGoingCertificationChallengeLiveAlert =
+    await certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId({
+      challengeId: challenge.id,
+      assessmentId: assessment.id,
+    });
+
+  if (onGoingCertificationChallengeLiveAlert) {
+    throw new ForbiddenAccess('An alert has been set.');
+  }
+
   const correctedAnswer = _evaluateAnswer({ challenge, answer, assessment, examiner });
   const now = dateUtils.getNowDate();
   const lastQuestionDate = assessment.lastQuestionDate || now;

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -39,6 +39,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   const knowledgeElementRepository = {
     findUniqByUserIdAndAssessmentId: () => undefined,
   };
+  const certificationChallengeLiveAlertRepository = { getOngoingByChallengeIdAndAssessmentId: () => undefined };
   const flashAlgorithmService = { getEstimatedLevelAndErrorRate: () => undefined };
   const algorithmDataFetcherService = { fetchForFlashLevelEstimation: () => undefined };
   const nowDate = new Date('2021-03-11T11:00:04Z');
@@ -55,6 +56,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     sinon.stub(flashAssessmentResultRepository, 'save');
     sinon.stub(scorecardService, 'computeScorecard');
     sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndAssessmentId');
+    sinon.stub(certificationChallengeLiveAlertRepository, 'getOngoingByChallengeIdAndAssessmentId');
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
     sinon.stub(flashAlgorithmService, 'getEstimatedLevelAndErrorRate');
     sinon.stub(algorithmDataFetcherService, 'fetchForFlashLevelEstimation');
@@ -85,6 +87,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       campaignRepository,
       knowledgeElementRepository,
       flashAssessmentResultRepository,
+      certificationChallengeLiveAlertRepository,
       scorecardService,
       flashAlgorithmService,
       algorithmDataFetcherService,
@@ -951,6 +954,40 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           expect(correctedAnswer).to.deep.contain(expected);
         });
       });
+    });
+  });
+
+  context('when a live alert has been set in V3 certification', function () {
+    it('should throw an error', async function () {
+      // given
+      const challenge = domainBuilder.buildChallenge({ id: '123' });
+      const assessment = domainBuilder.buildAssessment({
+        userId,
+        lastQuestionDate: nowDate,
+        state: Assessment.states.STARTED,
+      });
+      const answer = domainBuilder.buildAnswer({ challengeId: challenge.id });
+      const certificationChallengeLiveAlert = domainBuilder.buildCertificationChallengeLiveAlert({
+        assessmentId: assessment.id,
+        challengeId: challenge.id,
+      });
+      assessmentRepository.get.resolves(assessment);
+      challengeRepository.get.withArgs(challenge.id).resolves(challenge);
+
+      certificationChallengeLiveAlertRepository.getOngoingByChallengeIdAndAssessmentId
+        .withArgs({ challengeId: challenge.id, assessmentId: assessment.id })
+        .resolves(certificationChallengeLiveAlert);
+
+      // when
+      const error = await catchErr(correctAnswerThenUpdateAssessment)({
+        answer,
+        userId,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(ForbiddenAccess);
+      expect(error.message).to.equal('An alert has been set.');
     });
   });
 });

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -26,40 +26,37 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     pix: 8,
   };
   let dateUtils;
-  const answerRepository = {
-    saveWithKnowledgeElements: () => undefined,
-  };
-  const assessmentRepository = { get: () => undefined };
-  const challengeRepository = { get: () => undefined };
+  let assessmentRepository,
+    answerRepository,
+    challengeRepository,
+    skillRepository,
+    campaignRepository,
+    flashAssessmentResultRepository,
+    scorecardService,
+    knowledgeElementRepository,
+    certificationChallengeLiveAlertRepository,
+    flashAlgorithmService,
+    algorithmDataFetcherService;
   const competenceEvaluationRepository = {};
-  const campaignRepository = { findSkillsByCampaignParticipationId: () => undefined };
-  const skillRepository = { findActiveByCompetenceId: () => undefined };
-  const flashAssessmentResultRepository = { save: () => undefined };
-  const scorecardService = { computeScorecard: () => undefined };
-  const knowledgeElementRepository = {
-    findUniqByUserIdAndAssessmentId: () => undefined,
-  };
-  const certificationChallengeLiveAlertRepository = { getOngoingByChallengeIdAndAssessmentId: () => undefined };
-  const flashAlgorithmService = { getEstimatedLevelAndErrorRate: () => undefined };
-  const algorithmDataFetcherService = { fetchForFlashLevelEstimation: () => undefined };
+
   const nowDate = new Date('2021-03-11T11:00:04Z');
 
   let dependencies;
 
   beforeEach(function () {
     nowDate.setMilliseconds(1);
-    sinon.stub(answerRepository, 'saveWithKnowledgeElements');
-    sinon.stub(assessmentRepository, 'get');
-    sinon.stub(challengeRepository, 'get');
-    sinon.stub(skillRepository, 'findActiveByCompetenceId');
-    sinon.stub(campaignRepository, 'findSkillsByCampaignParticipationId');
-    sinon.stub(flashAssessmentResultRepository, 'save');
-    sinon.stub(scorecardService, 'computeScorecard');
-    sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndAssessmentId');
-    sinon.stub(certificationChallengeLiveAlertRepository, 'getOngoingByChallengeIdAndAssessmentId');
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
-    sinon.stub(flashAlgorithmService, 'getEstimatedLevelAndErrorRate');
-    sinon.stub(algorithmDataFetcherService, 'fetchForFlashLevelEstimation');
+    answerRepository = { saveWithKnowledgeElements: sinon.stub() };
+    assessmentRepository = { get: sinon.stub() };
+    challengeRepository = { get: sinon.stub() };
+    skillRepository = { findActiveByCompetenceId: sinon.stub() };
+    campaignRepository = { findSkillsByCampaignParticipationId: sinon.stub() };
+    flashAssessmentResultRepository = { save: sinon.stub() };
+    scorecardService = { computeScorecard: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserIdAndAssessmentId: sinon.stub() };
+    certificationChallengeLiveAlertRepository = { getOngoingByChallengeIdAndAssessmentId: sinon.stub() };
+    flashAlgorithmService = { getEstimatedLevelAndErrorRate: sinon.stub() };
+    algorithmDataFetcherService = { fetchForFlashLevelEstimation: sinon.stub() };
     dateUtils = {
       getNowDate: sinon.stub(),
     };


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’un candidat fait appel au surveillant pour signaler un problème lors d’une certification, les boutons d’actions sur la page du challenge se grisent.
Toutefois, il est possible par un appel curl d’outrepasser cette protection.

## :robot: Proposition

Bloquer côté back les actions si un appel au surveillant est en cours.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Créer une certification V3 `certifv3@example.net` 
Rentrer dans la certification créée `certifiable-contenu-user@example.net`
Appeler le surveillant pour signaler un problème
Vérifier qu’il ne soit plus possible de passer ou valider la question tant que l’appel au surveillant est en cours.
