### PR TITLE
[TECH][CERTIF] Ajouter le rôle "Membre" sur les invitations en attentes (PIX-9874)

### DIFF
--- a/api/db/migrations/20231109084208_add-default-role-to-pending-certification-center-invitation.js
+++ b/api/db/migrations/20231109084208_add-default-role-to-pending-certification-center-invitation.js
@@ -1,0 +1,11 @@
+const TABLE_NAME = 'certification-center-invitations';
+
+const up = async function (knex) {
+  await knex(TABLE_NAME).whereNull('role').andWhere({ status: 'pending' }).update({ role: 'MEMBER' });
+};
+
+const down = async function () {
+  // do nothing
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème

Nous avons ajouter une nouvelle colonne `role` à la table `certification-center-invitations`, dans le cadre de l'_epix_ sur la gestion des membres d'un centre de certification, avec un contrainte et sans valeur par défaut. Nous avons maintenant des invitations qui n'ont pas de rôle associé.

Nous devons ajouter le rôle sur les invitations qui sont en attentes avec le rôle par défaut `MEMBER`.

## :robot: Proposition

Ajouter une nouvelle migration de base de données pour définir le rôle de chacune des invitations à un centre de certification qui seraient en attentes.

## :rainbow: Remarques

- ⚠️ Il n'est pas possible de le tester en local sans faire de modification au niveau de la structure du schéma de la table `certification-center-invitations`, ni sur la RA.
- Nous avons testé la clause `where` qui serait adapté sur l'environnement d'intégration.

## :100: Pour tester

- Exécuter la migration avec la commande `npm run db:migrate`
- Supprimer en base de données la contrainte `certification-center-invitations_role_check` de la table `certification-center-invitations`
- Exécuter la commande NPM suivante `npm run db:empty` pour vider la base de données
- Retirer la valeur par défaut de l'attribut `role` dans le fichier `api/db/database-builder/factory/build-certification-center-invitation.js#L10`
- Exécuter la commande NPM suivante `npm run db:seed` pour ajouter les seeds
- Exécuter la commande NPM suivante `npm run db:rollback:latest` pour retirer les modifications de la migration précédente
- Exécuter de nouveau la migration avec la commande `npm run db:migrate`
- Constater en base de données que les invitations en attente ont le rôle `MEMBRE`
