### PR TITLE
[BUGFIX] Récupérer que les acquis avec un statut actif ou en construction (Pix-9900)

### DIFF
--- a/api/lib/infrastructure/datasources/learning-content/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/skill-datasource.js
@@ -13,10 +13,10 @@ const skillDatasource = datasource.extend({
     return _.filter(skills, { status: ACTIVE_STATUS });
   },
 
-  async findAllByName(name) {
+  async findAllSkillsByNameForPix1d(name) {
     const skills = await this.list();
     const filteredSkills = _.filter(skills, function (skill) {
-      return _.isEqual(skill.name, name);
+      return _.isEqual(skill.name, name) && _.includes([ACTIVE_STATUS, IN_BUILD_STATUS], skill.status);
     });
     return filteredSkills;
   },

--- a/api/src/certification/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/challenge-repository.js
@@ -52,7 +52,7 @@ const getChallengeFor1d = async function ({ missionId, activityLevel, challengeN
     }
     const skillNamePrefix = _getPix1dActivityLevelTubeName(missionNamePrefix, activityLevel);
     const skillName = `${skillNamePrefix}${challengeNumber}`;
-    const skills = await skillDatasource.findAllByName(skillName);
+    const skills = await skillDatasource.findAllSkillsByNameForPix1d(skillName);
     if (skills.length === 0) {
       _throwNotFoundError(activityLevel, missionId, challengeNumber);
     }

--- a/api/tests/unit/infrastructure/datasources/learning-content/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/skill-datasource_test.js
@@ -49,20 +49,33 @@ describe('Unit | Infrastructure | Datasource | LearningContent | SkillDatasource
     });
   });
 
-  describe('#findAllByName', function () {
+  describe('#findAllSkillsByNameForPix1d', function () {
     it('should return the corresponding skills', async function () {
       // given
-      const rawSkill1 = { id: 'recSkill1', name: '@rechercher_didacticiel1' };
-      const rawSkill2 = { id: 'recSkill2', name: '@rechercher_didacticiel1' };
-      const rawSkill3 = { id: 'recSkill3', name: '@rechercher_entrainement1' };
-      const rawSkill4 = { id: 'recSkill4', name: '@rechercher_didacticiel2' };
-      const rawSkill5 = { id: 'recSkill5', name: '@rechercher_didacticiel12' };
+      const rawSkill1 = { id: 'recSkill1', name: '@rechercher_didacticiel1', status: 'actif' };
+      const rawSkill2 = { id: 'recSkill2', name: '@rechercher_didacticiel1', status: 'actif' };
+      const rawSkill3 = { id: 'recSkill3', name: '@rechercher_entrainement1', status: 'en construction' };
+      const rawSkill4 = { id: 'recSkill4', name: '@rechercher_didacticiel2', status: 'actif' };
+      const rawSkill5 = { id: 'recSkill5', name: '@rechercher_didacticiel12', status: 'en construction' };
       sinon
         .stub(lcms, 'getLatestRelease')
         .resolves({ skills: [rawSkill1, rawSkill2, rawSkill3, rawSkill4, rawSkill5] });
 
       // when
-      const result = await skillDatasource.findAllByName('@rechercher_didacticiel1');
+      const result = await skillDatasource.findAllSkillsByNameForPix1d('@rechercher_didacticiel1');
+
+      // then
+      expect(result).to.deep.equal([rawSkill1, rawSkill2]);
+    });
+    it('should return the skills with active or building status ', async function () {
+      // given
+      const rawSkill1 = { id: 'recSkill1', name: '@rechercher_didacticiel1', status: 'actif' };
+      const rawSkill2 = { id: 'recSkill2', name: '@rechercher_didacticiel1', status: 'en construction' };
+      const rawSkill3 = { id: 'recSkill3', name: '@rechercher_didacticiel1', status: 'archivé' };
+      sinon.stub(lcms, 'getLatestRelease').resolves({ skills: [rawSkill1, rawSkill2, rawSkill3] });
+
+      // when
+      const result = await skillDatasource.findAllSkillsByNameForPix1d('@rechercher_didacticiel1');
 
       // then
       expect(result).to.deep.equal([rawSkill1, rawSkill2]);
@@ -74,7 +87,7 @@ describe('Unit | Infrastructure | Datasource | LearningContent | SkillDatasource
         sinon.stub(lcms, 'getLatestRelease').resolves({ skills: [] });
 
         // when
-        const result = await skillDatasource.findAllByName('@rechercher_validation');
+        const result = await skillDatasource.findAllSkillsByNameForPix1d('@rechercher_validation');
 
         // then
         expect(result).to.deep.equal([]);


### PR DESCRIPTION
## :unicorn: Problème
On récupérait tous les acquis, tout statut confondu, or quand il y avait un acquis avec un statut `archivé` on ne souhaite pas jouer les épreuves qui lui sont associées.

## :robot: Proposition
Ajouter un filtre pour ne prendre que les acquis avec un statut `actif` ou `en construction`

## :rainbow: Remarques


## :100: Pour tester
- Commencer la mission `Recherche sur internet` et aller sur l'activité entraînement et voir qu'il y a 4 épreuves