### PR TITLE
[BUGFIX][API] Donner le bon rôle par défaut à un utilisateur invité à un Centre de Certification (PIX-9893)

### DIFF
--- a/api/lib/domain/usecases/accept-certification-center-invitation.js
+++ b/api/lib/domain/usecases/accept-certification-center-invitation.js
@@ -17,6 +17,13 @@ const acceptCertificationCenterInvitation = async function ({
   const userId = certificationCenterInvitedUser.userId;
   const certificationCenterId = certificationCenterInvitedUser.invitation.certificationCenterId;
 
+  const certificationCenterMembersCount =
+    await certificationCenterMembershipRepository.countActiveMembersForCertificationCenter(certificationCenterId);
+
+  if (!certificationCenterInvitedUser.role) {
+    certificationCenterInvitedUser.role = certificationCenterMembersCount > 0 ? 'MEMBER' : 'ADMIN';
+  }
+
   const isMembershipExisting = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
     userId,
     certificationCenterId,

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -17,6 +17,8 @@ import { User } from '../../domain/models/User.js';
 import { CertificationCenterMembership } from '../../domain/models/CertificationCenterMembership.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 
+const CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME = 'certification-center-memberships';
+
 function _toDomain(certificationCenterMembershipDTO) {
   let user, certificationCenter;
   if (certificationCenterMembershipDTO.lastName || certificationCenterMembershipDTO.firstName) {
@@ -48,6 +50,20 @@ function _toDomain(certificationCenterMembershipDTO) {
     role: certificationCenterMembershipDTO.role,
   });
 }
+
+/**
+ * Get the number of active members in a certification center
+ *
+ * @param certificationCenterId
+ * @returns {Promise<number>}
+ */
+const countActiveMembersForCertificationCenter = async function (certificationCenterId) {
+  const { count } = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
+    .where({ certificationCenterId, disabledAt: null })
+    .count('id')
+    .first();
+  return count;
+};
 
 const findByUserId = async function (userId) {
   const certificationCenterMemberships = await knex
@@ -247,16 +263,17 @@ const findOneWithCertificationCenterIdAndUserId = async function ({ certificatio
 };
 
 export {
+  countActiveMembersForCertificationCenter,
+  disableById,
+  disableMembershipsByUserId,
+  findById,
   findByUserId,
   findActiveByCertificationCenterIdSortedById,
   findOneWithCertificationCenterIdAndUserId,
   save,
   isAdminOfCertificationCenter,
   isMemberOfCertificationCenter,
-  disableById,
   updateRefererStatusByUserIdAndCertificationCenterId,
   getRefererByCertificationCenterId,
-  disableMembershipsByUserId,
   update,
-  findById,
 };

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -15,6 +15,38 @@ import {
 import * as certificationCenterMembershipRepository from '../../../../lib/infrastructure/repositories/certification-center-membership-repository.js';
 
 describe('Integration | Repository | Certification Center Membership', function () {
+  describe('#countActiveMembersForCertificationCenter', function () {
+    it('returns the number of members', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId,
+        userId: databaseBuilder.factory.buildUser().id,
+        role: 'ADMIN',
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId,
+        userId: databaseBuilder.factory.buildUser().id,
+        role: 'MEMBER',
+      });
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId,
+        userId: databaseBuilder.factory.buildUser().id,
+        role: 'MEMBER',
+        disabledAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const membersCount =
+        await certificationCenterMembershipRepository.countActiveMembersForCertificationCenter(certificationCenterId);
+
+      // then
+      expect(membersCount).to.equal(2);
+    });
+  });
+
   describe('#save', function () {
     let userId, certificationCenterId;
 


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, lorsqu'un utilisateur envoie une invitation en automatique et que l'utilisateur accepte l’invitation, aucun rôle n'est attribué à cet utilisateur. Et le design dans la liste des invitations est cassé.

## :robot: Proposition
S'il n'y a pas d’admin dans le centre de certification => donner le rôle administrateur à l'utilisateur invité
Si un admin est déjà présent dans le centre de certification => donner le rôle membre à l'utilisateur invité

## :rainbow: Remarques
RAS.

## :100: Pour tester

### 🧑🏼‍💼 Rôle membre par défaut

**Se connecter à `Pix Admin`**

1. Dans l'onglet `Centres de Certification`, sélectionner le centre `Accessorium (id: 8000)` qui a déjà des membres
2. Dans l'onglet `Invitation`, saisissez une adresse e-mail à laquelle vous pourrez récupérer l'invitation (par le terminal de l'API en local) et passez lui le rôle `Automatique`
3. Vous devez voir dans la `liste des invitations`, le mail a qui s'adresse l'invitation avec dans la colonne rôle `-`

**Récupérer l'invitation et allez sur `Pix Certif`**

1. Arrivez sur la **double mire, inscrivez-vous** avec l'adresse fournit pour l'invitation
2. Après avoir accepté les CGU, vous devez être connecté à Pix Certif et voir votre nom dans la liste de l'onglet Equipe

**Retourner sur `Pix Admin`**

1. Dans la **liste des membres** du Centre de certification `Accessorium`, vous devriez voir votre utilisateur avec le **rôle Membre**

### 👸🏽 Rôle administrateur par défaut
**Se connecter à `Pix Admin`**

1. Dans l'onglet `Centres de Certification`, sélectionner le centre `Centre de certification pro (id: 7002)` qui n'a aucun membre (⚠️ si il en a, désactivez les)
2. Dans l'onglet `Invitation`, saisissez une adresse e-mail à laquelle vous pourrez récupérer l'invitation (par le terminal de l'API en local) et passez lui le rôle `Automatique`
3. Vous devez voir dans la `liste des invitations`, le mail a qui s'adresse l'invitation avec dans la colonne rôle `-`

**Récupérer l'invitation et allez sur `Pix Certif`**

1. Arrivez sur la **double mire, inscrivez-vous** avec l'adresse fournit pour l'invitation
2. Après avoir accepté les CGU, vous devez être connecté à Pix Certif et voir votre nom dans la liste de l'onglet Equipe
3. Vous devez également pouvoir inviter d'autres membres via un bouton présent au dessus de la liste

**Retourner sur `Pix Admin`**

1. Dans la **liste des membres** du Centre de certification `Centre de certification pro`, vous devriez voir votre utilisateur avec le **rôle Administrateur**