### PR TITLE
[TECH] Créer l'API Campagne avec la méthode save (PIX-9906)

### DIFF
--- a/api/src/prescription/campaigns/application/api/campaigns-api.js
+++ b/api/src/prescription/campaigns/application/api/campaigns-api.js
@@ -1,0 +1,54 @@
+import { usecases } from '../../../../../lib/domain/usecases/index.js';
+
+/**
+ * @typedef CampaignApi
+ * @type {object}
+ * @function save
+ */
+
+/**
+ * @typedef CampaignPayload
+ * @type {object}
+ * @property {string} name
+ * @property {string} title
+ * @property {number} targetProfileId
+ * @property {number} organizationId
+ * @property {number} creatorId
+ * @property {string} customLandingPageText
+ */
+
+/**
+ * @typedef UserNotAuthorizedToCreateCampaignError
+ * @type {object}
+ * @property {string} message
+ */
+
+/**
+ * @typedef SavedCampaignResponse
+ * @type {object}
+ * @property {number} id
+ * @property {string} code
+ */
+
+/**
+ * @function
+ * @name save
+ *
+ * @param {CampaignPayload} campaign
+ * @returns {Promise<SavedCampaignResponse>}
+ * @throws {UserNotAuthorizedToCreateCampaignError} to be improved to handle different error types
+ */
+export const save = async (campaign) => {
+  const savedCampaign = await usecases.createCampaign({
+    campaign: {
+      ...campaign,
+      type: 'ASSESSMENT',
+      ownerId: campaign.creatorId,
+      multipleSendings: false,
+    },
+  });
+  return {
+    id: savedCampaign.id,
+    code: savedCampaign.code,
+  };
+};

--- a/api/tests/prescription/campaigns/application/api/unit/campaigns-api_test.js
+++ b/api/tests/prescription/campaigns/application/api/unit/campaigns-api_test.js
@@ -1,0 +1,80 @@
+import { usecases } from '../../../../../../lib/domain/usecases/index.js';
+import * as campaignApi from '../../../../../../src/prescription/campaigns/application/api/campaigns-api.js';
+import { expect, sinon, catchErr } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { Campaign } from '../../../../../../lib/domain/models/index.js';
+import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../lib/domain/errors.js';
+
+describe('Unit | API | Campaigns', function () {
+  describe('#save', function () {
+    it('should return code', async function () {
+      const createdCampaign = domainBuilder.buildCampaign({ code: 'SOMETHING' });
+
+      const createCampaignStub = sinon.stub(usecases, 'createCampaign');
+      createCampaignStub
+        .withArgs({
+          campaign: {
+            name: 'ABCDiag',
+            title: 'Mon diagnostic Pix',
+            customLandingPageText: 'Bienvenue',
+            type: 'ASSESSMENT',
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 1,
+            multipleSendings: false,
+          },
+        })
+        .resolves(createdCampaign);
+
+      // when
+      const result = await campaignApi.save({
+        name: 'ABCDiag',
+        title: 'Mon diagnostic Pix',
+        targetProfileId: 1,
+        organizationId: 1,
+        creatorId: 2,
+        customLandingPageText: 'Bienvenue',
+      });
+
+      // then
+      expect(result.id).to.equal(createdCampaign.id);
+      expect(result.code).to.equal(createdCampaign.code);
+      expect(result).not.to.be.instanceOf(Campaign);
+    });
+
+    describe('When creator is not in organization or has no right to use target profile', function () {
+      it('should throw an error', async function () {
+        const createCampaignStub = sinon.stub(usecases, 'createCampaign');
+        createCampaignStub
+          .withArgs({
+            campaign: {
+              name: 'ABCDiag',
+              title: 'Mon diagnostic Pix',
+              customLandingPageText: 'Bienvenue',
+              type: 'ASSESSMENT',
+              targetProfileId: 1,
+              creatorId: 2,
+              ownerId: 2,
+              organizationId: 1,
+              multipleSendings: false,
+            },
+          })
+          .rejects(new UserNotAuthorizedToCreateCampaignError());
+
+        // when
+        const error = await catchErr(campaignApi.save)({
+          name: 'ABCDiag',
+          title: 'Mon diagnostic Pix',
+          targetProfileId: 1,
+          organizationId: 1,
+          creatorId: 2,
+          customLandingPageText: 'Bienvenue',
+        });
+
+        // then
+        expect(error).is.instanceOf(UserNotAuthorizedToCreateCampaignError);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix sur les parcours autonome la team ExpEval a besoin de créer des campagnes. Les campagnes sont actuellement géré par la team Prescription. Utiliser directement les usecases de la team Prescription fait fuiter le domain hors du bounded context. Nous avons besoin d'établir une limite clair entre le code des parcours autonomes et celui des campagnes.

## :robot: Proposition
Dans cette PR, on introduit le concept d'API entre deux bounded contexts (ou sous domain). la team Prescription fournit une API à partir de la couche application du sous domain **campaigns** qui pourrait être consommé depuis la couche infrastructure du sous domain **autonomous-courses** par la team ExpEval.

Voici un schéma qui résume le fonctionnement (le code écrit sur l'image n'est pas celui de la PR et est là pour se faire une idée) :
![image](https://github.com/1024pix/pix/assets/13099512/c54db226-f272-4e96-8d0b-a55753116b1d)


## :rainbow: Remarques

Il faudra prévoir un ADR et le processus qui va avec à l'issue du développement de la première mouture des parcours autonomes.

Documentation (en cours d'écriture) : https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3929735180/Comment+faire+une+API+entre+deux+bounded+contexts+ou+des+sous+domain

Nous nous laissons la possibilité de revoir/faire évoluer ce système d'ici là en fonction des retours.

## :100: Pour tester

La CI passe 🍏 
