### PR TITLE
[TECH] Améliorer le nettoyage des tables après chaque tests d'intégration et d'acceptance

### DIFF
--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
@@ -3,10 +3,6 @@ import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Route | Account-recovery', function () {
   describe('PATCH /api/account-recovery', function () {
-    afterEach(async function () {
-      await knex('account-recovery-demands').delete();
-    });
-
     context('when user has pix authentication method', function () {
       it("should proceed to the account recover by changing user's password and email", async function () {
         // given

--- a/api/tests/acceptance/application/account-recovery/account-recovery-route_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route_test.js
@@ -10,10 +10,6 @@ describe('Acceptance | Route | Account-recovery', function () {
       server = await createServer();
     });
 
-    afterEach(async function () {
-      await databaseBuilder.knex('account-recovery-demands').delete();
-    });
-
     const studentInformation = {
       ineIna: '123456789aa',
       firstName: 'Jude',

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -38,11 +38,6 @@ describe('Acceptance | Controller | answer-controller-save', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('knowledge-elements').delete();
-      await knex('answers').delete();
-    });
-
     context('when the user is linked to the assessment', function () {
       beforeEach(async function () {
         // given

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -71,17 +71,6 @@ describe('Acceptance | Controller | assessment-results-controller', function () 
       return insertUserWithRoleSuperAdmin();
     });
 
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('competence-marks').delete();
-      await knex('certification-courses-last-assessment-results').delete();
-      await knex('assessment-results').delete();
-      await knex('assessments').delete();
-      await knex('certification-courses').delete();
-      await knex('pix-admin-roles').delete();
-      await knex('users').delete();
-    });
-
     it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
       // given
       const nonSuperAdminUserId = 9999;

--- a/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -79,10 +79,6 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('answers').delete();
-    });
-
     it('records an "ok" answer and returns 200 HTTP status code', async function () {
       // when
       const response = await server.inject({

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -187,11 +187,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
     };
   });
 
-  afterEach(async function () {
-    await knex('certification-courses-last-assessment-results').delete();
-    return knex('assessment-results').delete();
-  });
-
   describe('PATCH /assessments/{id}/complete-assessment', function () {
     context('when user is not the owner of the assessment', function () {
       it('should return a 401 HTTP status code', async function () {
@@ -231,11 +226,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           targetProfileId: targetProfile.id,
           trainingId: training.id,
         });
-      });
-
-      afterEach(async function () {
-        await knex('badge-acquisitions').delete();
-        await knex('user-recommended-trainings').delete();
       });
 
       it('should create a badge when it is acquired', async function () {
@@ -363,12 +353,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           return databaseBuilder.commit();
         });
 
-        afterEach(async function () {
-          await knex('certification-courses-last-assessment-results').delete();
-          await knex('competence-marks').delete();
-          await knex('assessment-results').delete();
-        });
-
         it('should complete the certification assessment', async function () {
           // given
           options.url = `/api/assessments/${certificationAssessmentId}/complete-assessment`;
@@ -410,12 +394,6 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
           databaseBuilder.factory.buildBadge();
 
           return databaseBuilder.commit();
-        });
-
-        afterEach(async function () {
-          await knex('certification-courses-last-assessment-results').delete();
-          await knex('competence-marks').delete();
-          await knex('assessment-results').delete();
         });
 
         it('should complete the certification assessment', async function () {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-last-challenge-id_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-last-challenge-id_test.js
@@ -1,7 +1,6 @@
 import {
   expect,
   databaseBuilder,
-  knex,
   insertUserWithRoleSuperAdmin,
   generateValidRequestAuthorizationHeader,
 } from '../../../test-helper.js';
@@ -33,10 +32,6 @@ describe('Acceptance | API | assessment-controller-get-last-challenge-id', funct
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      return knex('assessments').delete();
-    });
-
     context('Nominal cases', function () {
       beforeEach(function () {
         options = {
@@ -46,10 +41,6 @@ describe('Acceptance | API | assessment-controller-get-last-challenge-id', funct
             authorization: `Bearer ${generateValidRequestAuthorizationHeader(userId)}`,
           },
         };
-      });
-
-      afterEach(async function () {
-        return knex('assessments').delete();
       });
 
       it('should return 200 HTTP status code', async function () {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -75,10 +75,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
     mockLearningContent(learningContentObjects);
   });
 
-  afterEach(async function () {
-    await knex('certification-challenges').delete();
-  });
-
   describe('GET /api/assessments/:assessment_id/next', function () {
     const assessmentId = 1;
     const userId = 1234;

--- a/api/tests/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
@@ -33,10 +33,6 @@ describe('Acceptance | API | assessment-controller-pause-assessment', function (
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('certification-challenge-live-alerts').delete();
-    });
-
     it('should respond with a 401 if requested user is not the same as the user of the assessment', async function () {
       // given
       const otherUserId = 9999;

--- a/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
@@ -1,4 +1,4 @@
-import { expect, knex, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { BookshelfAssessment } from '../../../../lib/infrastructure/orm-models/Assessment.js';
 
@@ -10,11 +10,6 @@ describe('Acceptance | API | Assessments POST', function () {
   });
 
   describe('POST /api/assessments', function () {
-    afterEach(async function () {
-      await knex('assessments').delete();
-      return knex('users').delete();
-    });
-
     let options;
     let userId;
 

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -9,10 +9,6 @@ const { ROLES } = PIX_ADMIN;
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | authentication-controller', function () {
-  afterEach(async function () {
-    await knex('user-logins').delete();
-  });
-
   describe('POST /api/token', function () {
     const orgaRoleInDB = { id: 1, name: 'ADMIN' };
 
@@ -357,10 +353,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
 
     beforeEach(async function () {
       server = await createServer();
-    });
-
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
     });
 
     describe('when user has a reconciled Pix account, then connect to Pix from GAR', function () {

--- a/api/tests/acceptance/application/authentication/oidc/check-reconciliation-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/check-reconciliation-route-post_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, knex } from '../../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../../test-helper.js';
 import { createServer } from '../../../../../server.js';
 import jsonwebtoken from 'jsonwebtoken';
 import * as authenticationSessionService from '../../../../../lib/domain/services/authentication/authentication-session-service.js';
@@ -6,10 +6,6 @@ import * as authenticationSessionService from '../../../../../lib/domain/service
 describe('Acceptance | Application | Oidc | Routes', function () {
   describe('POST /api/oidc/user/check-reconciliation', function () {
     context('when user has no oidc authentication method', function () {
-      afterEach(async function () {
-        await knex('user-logins').delete();
-      });
-
       it('should return 200 HTTP status', async function () {
         // given
         const server = await createServer();

--- a/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
@@ -13,12 +13,6 @@ describe('Acceptance | Route | oidc users', function () {
   });
 
   describe('POST /api/oidc/users', function () {
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('user-logins').truncate();
-      await knex('users').delete();
-    });
-
     it('should return 200 HTTP status for oidc', async function () {
       // given
       const firstName = 'Brice';

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-  knex,
 } from '../../../test-helper.js';
 
 describe('Acceptance | API | Badges', function () {
@@ -30,10 +29,6 @@ describe('Acceptance | API | Badges', function () {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('badges').delete();
     });
 
     it('should update the existing badge', async function () {
@@ -79,11 +74,6 @@ describe('Acceptance | API | Badges', function () {
   });
 
   describe('DELETE /api/admin/badges/{id}', function () {
-    afterEach(async function () {
-      await knex('badge-acquisitions').delete();
-      await knex('badges').delete();
-    });
-
     it('should delete the existing badge if not associated to a badge acquisition', async function () {
       // given
       badge = databaseBuilder.factory.buildBadge({ id: 1 });

--- a/api/tests/acceptance/application/campaign-administration/create-campaigns_test.js
+++ b/api/tests/acceptance/application/campaign-administration/create-campaigns_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { PIX_ADMIN, ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
@@ -10,10 +10,6 @@ let server;
 describe('Acceptance | Application | campaign-controller-create-campaigns', function () {
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  afterEach(async function () {
-    await knex('campaigns').delete();
   });
 
   describe('POST /api/admin/campaigns', function () {

--- a/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -20,11 +20,6 @@ const { SHARED, STARTED } = CampaignParticipationStatuses;
 describe('Acceptance | API | Campaign Participations', function () {
   let server, options, user;
 
-  afterEach(async function () {
-    await knex('pgboss.job').delete();
-    await knex('knowledge-element-snapshots').delete();
-  });
-
   beforeEach(async function () {
     server = await createServer();
     user = databaseBuilder.factory.buildUser();
@@ -197,15 +192,6 @@ describe('Acceptance | API | Campaign Participations', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('knowledge-elements').delete();
-      await knex('answers').delete();
-      await knex('competence-evaluations').delete();
-      await knex('assessments').delete();
-      await knex('campaign-participations').delete();
-      await knex('organization-learners').delete();
-    });
-
     it('should return 201 and the campaign participation when it has been successfully created', async function () {
       // given
       options.payload.data.relationships.campaign.data.id = campaignId;
@@ -279,10 +265,6 @@ describe('Acceptance | API | Campaign Participations', function () {
   });
 
   describe('PATCH /api/campaign-participations/{id}/begin-improvement', function () {
-    afterEach(function () {
-      return knex('assessments').delete();
-    });
-
     it('should return 401 HTTP status code when user is not connected', async function () {
       // given
       options = {

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -5,7 +5,6 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-  knex,
   learningContentBuilder,
   mockLearningContent,
 } from '../../../test-helper.js';
@@ -656,11 +655,6 @@ describe('Acceptance | API | Campaign Controller', function () {
   });
 
   describe('POST /api/campaigns', function () {
-    afterEach(async function () {
-      await knex('campaign_skills').delete();
-      await knex('campaigns').delete();
-    });
-
     it('should return 201 status code and the campaign created with type ASSESSMENT and owner id', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -17,10 +17,6 @@ describe('Acceptance | API | Certification center invitations', function () {
   });
 
   describe('POST /api/certification-center-invitations/{id}/accept', function () {
-    afterEach(async function () {
-      await knex('certification-center-memberships').delete();
-    });
-
     it('it should return an HTTP code 204', async function () {
       // given
       databaseBuilder.factory.buildUser({ id: 293, email: 'user@example.net' });

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -18,12 +18,6 @@ describe('Acceptance | API | Certification Center', function () {
     await insertUserWithRoleSuperAdmin();
   });
 
-  afterEach(async function () {
-    await knex('data-protection-officers').delete();
-    await knex('certification-candidates').delete();
-    await knex('sessions').delete();
-  });
-
   describe('GET /api/certification-centers', function () {
     beforeEach(async function () {
       request = {
@@ -172,9 +166,6 @@ describe('Acceptance | API | Certification Center', function () {
     });
     afterEach(async function () {
       complementaryCertification = null;
-      await knex('complementary-certification-habilitations').delete();
-      await knex('data-protection-officers').delete();
-      await knex('certification-centers').delete();
     });
 
     context('when user is Super Admin', function () {
@@ -683,10 +674,6 @@ describe('Acceptance | API | Certification Center', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex(CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME).delete();
-    });
-
     context('When user is not admin of the certification center', function () {
       it('returns an 403 HTTP error code', async function () {
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'MEMBER' });
@@ -765,10 +752,6 @@ describe('Acceptance | API | Certification Center', function () {
       };
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('certification-center-memberships').delete();
     });
 
     it('should return 201 HTTP status', async function () {

--- a/api/tests/acceptance/application/certification-centers/index_test.js
+++ b/api/tests/acceptance/application/certification-centers/index_test.js
@@ -3,7 +3,6 @@ import {
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-  knex,
   sinon,
 } from '../../../test-helper.js';
 
@@ -15,12 +14,6 @@ describe('Acceptance | Route | Certification Centers', function () {
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  afterEach(async function () {
-    await knex('complementary-certification-habilitations').delete();
-    await knex('data-protection-officers').delete();
-    await knex('certification-center-invitations').delete();
   });
 
   describe('PATCH /api/admin/certification-centers/{id}', function () {

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
@@ -4,13 +4,6 @@ import * as temporarySessionsStorageForMassImportService from '../../../../../li
 
 describe('Acceptance | Controller | certification-centers-controller-post-create-sessions', function () {
   describe('POST /api/certification-centers/{certificationCenterId}/sessions/confirm-for-mass-import', function () {
-    afterEach(async function () {
-      await knex('sessions').delete();
-      await knex('certification-center-memberships').delete();
-      await knex('certification-centers').delete();
-      await knex('users').delete();
-    });
-
     context('when certification center is not V3 Pilot', function () {
       context('when user confirm sessions for import', function () {
         it('should return status 201', async function () {

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -1,10 +1,4 @@
-import {
-  expect,
-  databaseBuilder,
-  generateValidRequestAuthorizationHeader,
-  knex,
-  sinon,
-} from '../../../../test-helper.js';
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader, sinon } from '../../../../test-helper.js';
 
 import { createServer } from '../../../../../server.js';
 import lodash from 'lodash';
@@ -16,13 +10,6 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  afterEach(async function () {
-    await knex('certification-cpf-cities').delete();
-    await knex('certification-cpf-countries').delete();
-    await knex('certification-candidates').delete();
-    return knex('sessions').delete();
   });
 
   describe('POST /api/certification-centers/{certificationCenterId}/sessions/validate-for-mass-import', function () {

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -811,15 +811,6 @@ describe('Acceptance | API | Certification Course', function () {
       ];
 
       context('when locale is fr-fr', function () {
-        afterEach(async function () {
-          await knex('knowledge-elements').delete();
-          await knex('answers').delete();
-          await knex('assessments').delete();
-          await knex('certification-challenges').delete();
-          await knex('complementary-certification-courses').delete();
-          await knex('certification-courses').delete();
-        });
-
         it('should respond with 201 status code', async function () {
           // given
           const { options, userId, sessionId } = _createRequestOptions();
@@ -907,15 +898,6 @@ describe('Acceptance | API | Certification Course', function () {
       });
 
       context('when locale is en', function () {
-        afterEach(async function () {
-          await knex('knowledge-elements').delete();
-          await knex('answers').delete();
-          await knex('assessments').delete();
-          await knex('certification-challenges').delete();
-          await knex('complementary-certification-courses').delete();
-          await knex('certification-courses').delete();
-        });
-
         it('should have only en challenges associated with certification-course', async function () {
           // given
           const { options, userId, sessionId } = _createRequestOptions({ locale: 'en' });

--- a/api/tests/acceptance/application/certification-courses/index_test.js
+++ b/api/tests/acceptance/application/certification-courses/index_test.js
@@ -16,14 +16,6 @@ describe('Acceptance | Route | Certification Courses', function () {
     server = await createServer();
   });
 
-  afterEach(async function () {
-    await knex('knowledge-elements').delete();
-    await knex('answers').delete();
-    await knex('assessments').delete();
-    await knex('certification-challenges').delete();
-    await knex('certification-courses').delete();
-  });
-
   describe('POST /api/certification-courses', function () {
     context('when the certification course does not exist', function () {
       let learningContent;

--- a/api/tests/acceptance/application/certification-reports/certification-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-reports/certification-report-controller_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, knex, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | certification-report-controller', function () {
@@ -20,11 +20,6 @@ describe('Acceptance | Controller | certification-report-controller', function (
   });
 
   describe('POST /api/certification-reports/{id}/certification-issue-reports', function () {
-    afterEach(async function () {
-      await knex('certification-issue-reports').delete();
-      await knex('issue-report-categories').delete();
-    });
-
     it('should return 201 HTTP status code', async function () {
       // given
       const request = {

--- a/api/tests/acceptance/application/memberships/membership-controller_test.js
+++ b/api/tests/acceptance/application/memberships/membership-controller_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 
@@ -51,10 +51,6 @@ describe('Acceptance | Controller | membership-controller', function () {
     });
 
     context('Success cases', function () {
-      afterEach(function () {
-        return knex('memberships').delete();
-      });
-
       it('should return the created membership', async function () {
         // when
         const response = await server.inject(options);
@@ -170,10 +166,6 @@ describe('Acceptance | Controller | membership-controller', function () {
     });
 
     context('Success cases', function () {
-      afterEach(async function () {
-        await knex('certification-center-memberships').delete();
-      });
-
       it('should return the updated membership and add certification center membership', async function () {
         // given
         const expectedMembership = {

--- a/api/tests/acceptance/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitations/organization-invitation-controller_test.js
@@ -1,4 +1,4 @@
-import { expect, knex, databaseBuilder } from '../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../test-helper.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { OrganizationInvitation } from '../../../../lib/domain/models/OrganizationInvitation.js';
 import { createServer } from '../../../../server.js';
@@ -8,10 +8,6 @@ describe('Acceptance | Application | organization-invitation-controller', functi
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  afterEach(async function () {
-    await knex('user-orga-settings').delete();
   });
 
   describe('POST /api/organization-invitations/{id}/response', function () {
@@ -56,10 +52,6 @@ describe('Acceptance | Application | organization-invitation-controller', functi
         await databaseBuilder.commit();
       });
 
-      afterEach(function () {
-        return knex('memberships').delete();
-      });
-
       it('should return 204 HTTP status code', async function () {
         // when
         const response = await server.inject(options);
@@ -70,10 +62,6 @@ describe('Acceptance | Application | organization-invitation-controller', functi
     });
 
     context('Error cases', function () {
-      afterEach(async function () {
-        await knex('organization-invitations').delete();
-      });
-
       it('should respond with a 404 if organization-invitation does not exist with id and code', async function () {
         // given
         const user = databaseBuilder.factory.buildUser({ email: 'user@example.net' });

--- a/api/tests/acceptance/application/organizations-administration/organization-administration-patch_test.js
+++ b/api/tests/acceptance/application/organizations-administration/organization-administration-patch_test.js
@@ -1,6 +1,5 @@
 import {
   expect,
-  knex,
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
@@ -14,12 +13,6 @@ describe('Acceptance | Routes | organization-administration-controller', functio
   beforeEach(async function () {
     server = await createServer();
     await insertUserWithRoleSuperAdmin();
-  });
-
-  afterEach(async function () {
-    await knex('organization-features').delete();
-    await knex('organization-tags').delete();
-    await knex('data-protection-officers').delete();
   });
 
   describe('PATCH /api/admin/organizations/{id}', function () {

--- a/api/tests/acceptance/application/organizations/create-organization-places-lot_test.js
+++ b/api/tests/acceptance/application/organizations/create-organization-places-lot_test.js
@@ -3,7 +3,6 @@ import {
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-  knex,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
@@ -11,10 +10,6 @@ import * as organizationPlacesCategories from '../../../../lib/domain/constants/
 
 describe('Acceptance | Route | Organizations', function () {
   describe('POST /api/admin/organizations/{id}/places', function () {
-    afterEach(async function () {
-      await knex('organization-places').delete();
-    });
-
     it('should return 201 HTTP status code', async function () {
       // given
       const server = await createServer();

--- a/api/tests/acceptance/application/organizations/organization-controller-import-sco-organization-learners_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-sco-organization-learners_test.js
@@ -49,10 +49,6 @@ describe('Acceptance | Application | organization-controller-import-sco-organiza
       };
     });
 
-    afterEach(function () {
-      return knex('organization-learners').delete();
-    });
-
     context('When a XML SIECLE file is loaded', function () {
       context('when no organizationLearner has been imported yet, and the file is well formatted', function () {
         beforeEach(function () {

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -50,11 +50,6 @@ describe('Acceptance | Application | organization-controller', function () {
       };
     });
 
-    afterEach(async function () {
-      await knex('data-protection-officers').delete();
-      await knex('organizations').delete();
-    });
-
     describe('Success case', function () {
       it('returns 200 HTTP status code with the created organization', async function () {
         // given
@@ -151,16 +146,6 @@ describe('Acceptance | Application | organization-controller', function () {
   });
 
   describe('POST /api/admin/organizations/import-csv', function () {
-    afterEach(async function () {
-      await knex('data-protection-officers').delete();
-      await knex('target-profile-shares').delete();
-      await knex('target-profiles').delete();
-      await knex('organization-tags').delete();
-      await knex('tags').delete();
-      await knex('organization-features').delete();
-      await knex('organizations').delete();
-    });
-
     it('create organizations for the given csv file', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
@@ -821,10 +806,6 @@ describe('Acceptance | Application | organization-controller', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('organization-invitations').delete();
-    });
-
     context('Expected output', function () {
       it('should return the matching organization-invitations as JSON API', async function () {
         // given
@@ -913,7 +894,6 @@ describe('Acceptance | Application | organization-controller', function () {
 
     afterEach(async function () {
       clock.restore();
-      await knex('organization-invitations').delete();
     });
 
     it('should return the matching organization invitation as JSON API', async function () {
@@ -1008,11 +988,6 @@ describe('Acceptance | Application | organization-controller', function () {
       };
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('memberships').delete();
-      await knex('organization-invitations').delete();
     });
 
     context('Expected output', function () {
@@ -1253,10 +1228,6 @@ describe('Acceptance | Application | organization-controller', function () {
         targetProfileId: alreadyAttachedTargetProfileId,
       });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('target-profile-shares').delete();
     });
 
     context('when target profiles to attach exists', function () {

--- a/api/tests/acceptance/application/organizations/send-invitation-by-lang-and-role-route-post_test.js
+++ b/api/tests/acceptance/application/organizations/send-invitation-by-lang-and-role-route-post_test.js
@@ -1,7 +1,6 @@
 import {
   databaseBuilder,
   expect,
-  knex,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
 } from '../../../test-helper.js';
@@ -11,10 +10,6 @@ import { Membership } from '../../../../lib/domain/models/Membership.js';
 
 describe('Acceptance | Route | Organizations', function () {
   describe('POST /api/admin/organizations/{id}/invitations', function () {
-    afterEach(async function () {
-      await knex('organization-invitations').delete();
-    });
-
     it('should return 201 HTTP status code', async function () {
       // given
       const server = await createServer();

--- a/api/tests/acceptance/application/passwords/password-controller_test.js
+++ b/api/tests/acceptance/application/passwords/password-controller_test.js
@@ -1,4 +1,4 @@
-import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../test-helper.js';
 import { tokenService } from '../../../../lib/domain/services/token-service.js';
 import * as resetPasswordService from '../../../../lib/domain/services/reset-password-service.js';
 
@@ -33,10 +33,6 @@ describe('Acceptance | Controller | password-controller', function () {
       const userId = databaseBuilder.factory.buildUser({ email }).id;
       databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('reset-password-demands').delete();
     });
 
     context('when email provided is unknown', function () {
@@ -120,10 +116,6 @@ describe('Acceptance | Controller | password-controller', function () {
   });
 
   describe('POST /api/expired-password-updates', function () {
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-    });
-
     context('Success cases', function () {
       it('should return 201 HTTP status code', async function () {
         // given

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -245,10 +245,6 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-    });
-
     context('when creation is with email', function () {
       it('should return an 204 status after having successfully created user and associated user to organizationLearner', async function () {
         // when
@@ -328,11 +324,6 @@ describe('Acceptance | Controller | sco-organization-learners', function () {
       });
       campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('user-logins').truncate();
     });
 
     context('when an external user try to reconcile for the first time', function () {

--- a/api/tests/acceptance/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecards/scorecard-controller_test.js
@@ -1,7 +1,6 @@
 import {
   databaseBuilder,
   expect,
-  knex,
   generateValidRequestAuthorizationHeader,
   mockLearningContent,
 } from '../../../test-helper.js';
@@ -107,14 +106,6 @@ describe('Acceptance | Controller | scorecard-controller', function () {
     databaseBuilder.factory.buildUser({ id: userId });
     await databaseBuilder.commit();
     mockLearningContent(learningContent);
-  });
-
-  afterEach(async function () {
-    await knex('knowledge-elements').delete();
-    await knex('answers').delete();
-    await knex('competence-evaluations').delete();
-    await knex('assessments').delete();
-    return knex('campaign-participations').delete();
   });
 
   describe('GET /scorecards/{id}', function () {

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -1,4 +1,4 @@
-import { sinon, expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } from '../../../test-helper.js';
+import { sinon, expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
 
@@ -68,10 +68,6 @@ describe('Acceptance | Controller | session-controller-enrol-students-to-session
       const birthCityCode = 'Detroit313';
       const FRANCE_INSEE_CODE = '99100';
       const FRANCE_ORGANIZATION_LEARNER_INSEE_CODE = '100';
-
-      afterEach(function () {
-        return knex('certification-candidates').delete();
-      });
 
       beforeEach(async function () {
         const { id: certificationCenterId, externalId } = databaseBuilder.factory.buildCertificationCenter({

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
@@ -1,4 +1,4 @@
-import { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex, sinon } from '../../../test-helper.js';
+import { databaseBuilder, expect, generateValidRequestAuthorizationHeader, sinon } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { clearResolveMx, setResolveMx } from '../../../../src/shared/mail/infrastructure/services/mail-check.js';
 import fs from 'fs';
@@ -62,10 +62,6 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('certification-candidates').delete();
     });
 
     context('The user can access the session', function () {

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -113,11 +113,6 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('complementary-certification-subscriptions').delete();
-      return knex('certification-candidates').delete();
-    });
-
     it('should respond with a 201 created', async function () {
       // when
       const response = await server.inject(options);

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -96,14 +96,6 @@ describe('Acceptance | Controller | sessions-controller', function () {
     });
 
     describe('Success case', function () {
-      afterEach(async function () {
-        await knex('certification-courses-last-assessment-results').delete();
-        await knex('certification-issue-reports').delete();
-        await knex('finalized-sessions').delete();
-        await knex('competence-marks').delete();
-        await knex('assessment-results').delete();
-      });
-
       it('should update session', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
@@ -15,10 +15,6 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
     server = await createServer();
   });
 
-  afterEach(function () {
-    return knex('supervisor-accesses').delete();
-  });
-
   it('should return a HTTP 204 No Content', async function () {
     // given
 

--- a/api/tests/acceptance/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/acceptance/application/stage-collections/stage-collection-controller_test.js
@@ -2,7 +2,6 @@ import {
   databaseBuilder,
   domainBuilder,
   expect,
-  knex,
   generateValidRequestAuthorizationHeader,
   learningContentBuilder,
   mockLearningContent,
@@ -21,12 +20,6 @@ describe('Acceptance | Controller | stage-collection', function () {
       const learningContent = [{ id: 'recArea0', competences: [] }];
       const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
       mockLearningContent(learningContentObjects);
-    });
-
-    afterEach(async function () {
-      await knex('campaigns').delete();
-      await knex('stages').delete();
-      await knex('target-profiles').delete();
     });
 
     context('when the target-profile is not linked to a campaign', function () {

--- a/api/tests/acceptance/application/tags/tag-api_test.js
+++ b/api/tests/acceptance/application/tags/tag-api_test.js
@@ -6,17 +6,12 @@ import {
   insertUserWithRoleSuperAdmin,
   insertUserWithRoleCertif,
   databaseBuilder,
-  knex,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Route | tag-router', function () {
   describe('POST /api/admin/tags', function () {
-    afterEach(async function () {
-      await knex('tags').delete();
-    });
-
     it('should return the created tag with 201 HTTP status code', async function () {
       // given
       const tagName = 'SUPER TAG';

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -79,11 +79,6 @@ describe('Acceptance | Route | target-profiles', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('target-profile_tubes').delete();
-      await knex('target-profiles').delete();
-    });
-
     it('should return 200', async function () {
       // given
       databaseBuilder.factory.buildOrganization({ id: 1 });
@@ -235,10 +230,6 @@ describe('Acceptance | Route | target-profiles', function () {
       mockLearningContent(learningContent);
     });
 
-    afterEach(function () {
-      return knex('target-profile-shares').delete();
-    });
-
     it('should return 200', async function () {
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const user = databaseBuilder.factory.buildUser.withRole();
@@ -271,10 +262,6 @@ describe('Acceptance | Route | target-profiles', function () {
   describe('POST /api/admin/target-profiles/{id}/copy-organizations', function () {
     beforeEach(async function () {
       mockLearningContent(learningContent);
-    });
-
-    afterEach(function () {
-      return knex('target-profile-shares').delete();
     });
 
     it('should return 204', async function () {
@@ -386,10 +373,7 @@ describe('Acceptance | Route | target-profiles', function () {
         databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tubeId3', level: 4 });
         await databaseBuilder.commit();
       });
-      afterEach(async function () {
-        await knex('badge-criteria').delete();
-        await knex('badges').delete();
-      });
+
       it('should create a badge with capped tubes criterion', async function () {
         const badgeCreation = {
           key: 'badge1',

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -147,10 +147,6 @@ describe('Acceptance | Controller | training-controller', function () {
   });
 
   describe('POST /api/admin/trainings', function () {
-    afterEach(async function () {
-      await databaseBuilder.knex('account-recovery-demands').delete();
-    });
-
     it('should create a new training and response with a 201', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
@@ -377,11 +373,6 @@ describe('Acceptance | Controller | training-controller', function () {
       mockLearningContent(learningContentObjects);
     });
 
-    afterEach(async function () {
-      await knex('training-trigger-tubes').delete();
-      await knex('training-triggers').delete();
-    });
-
     it('should update training trigger', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
@@ -500,10 +491,6 @@ describe('Acceptance | Controller | training-controller', function () {
         targetProfileId: alreadyAttachedTargetProfileId,
       });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('target-profile-trainings').delete();
     });
 
     context('when target profiles to attach exists', function () {

--- a/api/tests/acceptance/application/tutorials/tutorial-evaluations-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/tutorial-evaluations-controller_test.js
@@ -2,7 +2,6 @@ import {
   mockLearningContent,
   databaseBuilder,
   expect,
-  knex,
   generateValidRequestAuthorizationHeader,
 } from '../../../test-helper.js';
 
@@ -42,10 +41,6 @@ describe('Acceptance | Controller | tutorial-evaluations-controller', function (
 
   describe('PUT /api/users/tutorials/{tutorialId}/evaluate', function () {
     let options;
-
-    afterEach(async function () {
-      return knex('tutorial-evaluations').delete();
-    });
 
     describe('nominal case', function () {
       it('should respond with a 201 when a status is provided', async function () {

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -4,7 +4,6 @@ import {
   mockLearningContent,
   learningContentBuilder,
   databaseBuilder,
-  knex,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
@@ -60,10 +59,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
       };
 
       mockLearningContent(learningContent);
-    });
-
-    afterEach(async function () {
-      return knex('user-saved-tutorials').delete();
     });
 
     describe('nominal case', function () {

--- a/api/tests/acceptance/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | user-orga-settings-controller', function () {
@@ -6,10 +6,6 @@ describe('Acceptance | Controller | user-orga-settings-controller', function () 
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  afterEach(async function () {
-    await knex('user-orga-settings').delete();
   });
 
   describe('PUT /api/user-orga-settings/{id}', function () {

--- a/api/tests/acceptance/application/users/add-pix-authentication-method-by-email-route-post_test.js
+++ b/api/tests/acceptance/application/users/add-pix-authentication-method-by-email-route-post_test.js
@@ -3,16 +3,11 @@ import {
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-  knex,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Route | Users', function () {
-  afterEach(function () {
-    return knex('authentication-methods').delete();
-  });
-
   describe('POST /api/users/{id}/add-pix-authentication-method', function () {
     it('should return 201 HTTP status code and updated user', async function () {
       // given

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -106,14 +106,6 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
     server = await createServer();
   });
 
-  afterEach(async function () {
-    await knex('knowledge-elements').delete();
-    await knex('answers').delete();
-    await knex('competence-evaluations').delete();
-    await knex('assessments').delete();
-    await knex('campaign-participations').delete();
-  });
-
   describe('POST /users/{id}/competences/{id}/reset', function () {
     describe('Resource access management', function () {
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 const { pick } = lodash;
 
-import { domainBuilder, expect, knex, nock } from '../../../test-helper.js';
+import { domainBuilder, expect, nock } from '../../../test-helper.js';
 
 import * as userRepository from '../../../../src/shared/infrastructure/repositories/user-repository.js';
 
@@ -12,13 +12,6 @@ describe('Acceptance | Controller | users-controller', function () {
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  afterEach(async function () {
-    await knex('authentication-methods').delete();
-    await knex('pix-admin-roles').delete();
-    await knex('sessions').delete();
-    await knex('users').delete();
   });
 
   describe('save', function () {

--- a/api/tests/acceptance/application/users/users-controller-update-password_test.js
+++ b/api/tests/acceptance/application/users/users-controller-update-password_test.js
@@ -20,12 +20,6 @@ describe('Acceptance | Controller | users-controller-update-password', function 
     await _insertPasswordResetDemand(temporaryKey, user.email);
   });
 
-  afterEach(async function () {
-    await knex('authentication-methods').delete();
-    await knex('reset-password-demands').delete();
-    await knex('user-logins').delete();
-  });
-
   describe('Error case', function () {
     it('should reply with an error, when temporary key is invalid', async function () {
       // given

--- a/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
+++ b/api/tests/acceptance/scripts/add-many-divisions-and-students-to-sco-organization_test.js
@@ -7,10 +7,6 @@ describe('Acceptance | Scripts | add-many-divisions-and-students-to-sco-organiza
   const organizationId = 123;
 
   describe('#addManyDivisionsAndStudentsToScoCertificationCenter', function () {
-    afterEach(function () {
-      return knex('organization-learners').delete();
-    });
-
     it('should insert many divisions and organization learners', async function () {
       // given
       const numberOfDivisionsToCreate = 4;

--- a/api/tests/acceptance/scripts/add-many-fake-members-related-to-one-organization_test.js
+++ b/api/tests/acceptance/scripts/add-many-fake-members-related-to-one-organization_test.js
@@ -20,13 +20,12 @@ describe('Acceptance | Scripts | add-many-divisions-and-students-to-sco-organiza
     const numberOfUsers = 2;
     const organizationRole = 'MEMBER';
     const userId = 45678902;
-    const userId2 = 45678903;
     const organizationId = 234567890;
 
     databaseBuilder.factory.buildOrganization({ id: organizationId });
     await databaseBuilder.commit();
 
-    const stub = sinon
+    sinon
       .stub(process, 'argv')
       .value(['One argument', 'Another argument', numberOfUsers, organizationId, organizationRole, userId]);
 
@@ -42,9 +41,5 @@ describe('Acceptance | Scripts | add-many-divisions-and-students-to-sco-organiza
     const memberShip = await knex('memberships').where('userId', userId).first();
     expect(memberShip.organizationRole).to.equal(organizationRole);
     expect(memberShip.organizationId).to.equal(organizationId);
-
-    await knex('memberships').whereIn('userId', [userId, userId2]).delete();
-    await knex('users').whereIn('id', [userId, userId2]).delete();
-    stub.restore();
   });
 });

--- a/api/tests/acceptance/scripts/add-many-students-to-sco-certification-center_test.js
+++ b/api/tests/acceptance/scripts/add-many-students-to-sco-certification-center_test.js
@@ -1,15 +1,10 @@
 import { expect, databaseBuilder } from '../../test-helper.js';
-import { knex } from '../../../lib/infrastructure/bookshelf.js';
 import { BookshelfOrganizationLearner } from '../../../lib/infrastructure/orm-models/OrganizationLearner.js';
 import { addManyStudentsToScoCertificationCenter } from '../../../scripts/data-generation/add-many-students-to-sco-certification-center.js';
 
 describe('Acceptance | Scripts | add-many-students-to-sco-certification-centers.js', function () {
   const organizationId = 123;
   describe('#addManyStudentsToScoCertificationCenter', function () {
-    afterEach(function () {
-      return knex('organization-learners').delete();
-    });
-
     it('should insert 2 sco certification centers', async function () {
       // given
       const numberOfOrganizationLearnerToCreate = 3;

--- a/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
+++ b/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
@@ -15,8 +15,6 @@ describe('Acceptance | Scripts | create-users-accounts-for-contest', function ()
 
     afterEach(async function () {
       clock.restore();
-      await knex('authentication-methods').delete();
-      await knex('users').delete();
     });
 
     it('should insert users', async function () {

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -17,10 +17,6 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
   });
 
   describe('PUT /admin/complementary-certifications/{complementaryCertificationId}/badges/', function () {
-    afterEach(function () {
-      return knex('complementary-certification-badges').delete();
-    });
-
     it('should return an OK status after saving in database', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -106,7 +106,6 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
 
     afterEach(async function () {
       clock.restore();
-      return knex('complementary-certification-badges').delete();
     });
 
     it('should attach the complementary certification badges', async function () {

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-course-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-course-repository_test.js
@@ -1,14 +1,9 @@
-import { knex } from '../../../../../../db/knex-database-connection.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 import * as complementaryCertificationCourseRepository from '../../../../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-course-repository.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../lib/domain/models/index.js';
 
 describe('Integration | Repository | complementary-certification-course-repository', function () {
   describe('#findByUserId', function () {
-    afterEach(function () {
-      return knex('complementary-certification-course-results').delete();
-    });
-
     describe('when the user has no complementary certification course taken', function () {
       it('should return an empty array', async function () {
         // given a user

--- a/api/tests/certification/session/acceptance/application/session-live-alert-controller_test.js
+++ b/api/tests/certification/session/acceptance/application/session-live-alert-controller_test.js
@@ -9,10 +9,6 @@ describe('Certification | Session | Acceptance | Controller | session-live-alert
     server = await createServer();
   });
 
-  afterEach(async function () {
-    await knex('certification-issue-reports').delete();
-  });
-
   describe('PATCH /sessions/{id}/candidates/{candidateId}/dismiss-live-alert', function () {
     describe('when user has supervisor authorization', function () {
       it('should return 204 when the alert is ongoing', async function () {

--- a/api/tests/certification/session/acceptance/create-session_test.js
+++ b/api/tests/certification/session/acceptance/create-session_test.js
@@ -37,10 +37,6 @@ describe('Acceptance | Controller | Session | create-session', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('sessions').delete();
-    });
-
     it('should return an OK status after saving in database', async function () {
       // when
       const response = await server.inject(options);

--- a/api/tests/certification/session/integration/domain/usecases/get-cpf-import-status-from-xml_test.js
+++ b/api/tests/certification/session/integration/domain/usecases/get-cpf-import-status-from-xml_test.js
@@ -5,12 +5,6 @@ import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 describe('Integration | UseCase | Certification | get-cpf-import-status-from-xml', function () {
-  afterEach(async function () {
-    await knex('certification-courses-cpf-infos').delete();
-    await knex('certification-courses').delete();
-    await knex('sessions').delete();
-    await knex('users').delete();
-  });
   describe('#getCPfImportstatusFromXml', function () {
     describe('when xml is not empty', function () {
       it('should update cpf import status', async function () {

--- a/api/tests/certification/session/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/certification-challenge-live-alert-repository_test.js
@@ -7,10 +7,6 @@ const assessmentIdWithNoAlerts = 123;
 const assessmentIdWithLiveAlert = 456;
 
 describe('Integration | Repository | Certification Challenge Live Alert', function () {
-  afterEach(async function () {
-    await knex('certification-challenge-live-alerts').delete();
-  });
-
   describe('#save', function () {
     it('should persist a non existing alert for this specific certification live challenge in db', async function () {
       // given

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -34,10 +34,6 @@ describe('Integration | Repository | Session', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('sessions').delete();
-    });
-
     it('should persist the session in db', async function () {
       // when
       await sessionRepository.save(session);

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, knex, databaseBuilder, domainBuilder, catchErr, sinon } from '../../../../../test-helper.js';
+import { expect, databaseBuilder, domainBuilder, catchErr, sinon } from '../../../../../test-helper.js';
 import * as certificationCenterRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import { CertificationCenter } from '../../../../../../lib/domain/models/CertificationCenter.js';
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';
@@ -218,10 +218,6 @@ describe('Integration | Repository | Certification Center', function () {
   });
 
   describe('#save', function () {
-    afterEach(function () {
-      return knex('certification-centers').delete();
-    });
-
     it('should save the given certification center', async function () {
       // given
       const certificationCenter = new CertificationCenter({

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -8,10 +8,6 @@ import {
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 
 describe('Integration | Repository | Certification Issue Report', function () {
-  afterEach(async function () {
-    await knex('certification-issue-reports').delete();
-  });
-
   describe('#save', function () {
     describe('when there is no corresponding issue report', function () {
       it('should persist the certif issue report in db', async function () {

--- a/api/tests/certification/shared/integration/infrastructure/repositories/issue-report-categories-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/issue-report-categories-repository_test.js
@@ -1,11 +1,7 @@
-import { expect, databaseBuilder, knex } from '../../../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../../../test-helper.js';
 import * as issueReportCategoryRepository from '../../../../../../src/certification/shared/infrastructure/repositories/issue-report-category-repository.js';
 
 describe('Integration | Repository | Issue Report Categories', function () {
-  afterEach(async function () {
-    await knex('issue-report-categories').delete();
-  });
-
   describe('#get', function () {
     it('should return a certification issue report', async function () {
       // given

--- a/api/tests/evaluation/acceptance/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -42,11 +42,6 @@ describe('Acceptance | API | Competence Evaluations', function () {
         mockLearningContent(learningContentObjects);
       });
 
-      afterEach(async function () {
-        await knex('competence-evaluations').delete();
-        await knex('assessments').delete();
-      });
-
       context('and competence exists', function () {
         it('should return 201 and the competence evaluation when it has been successfully created', async function () {
           // when
@@ -135,13 +130,6 @@ describe('Acceptance | API | Competence Evaluations', function () {
     const competenceId = 'recABCD123';
 
     context('When user is authenticated', function () {
-      afterEach(async function () {
-        await knex('competence-evaluations').delete();
-        await knex('knowledge-elements').delete();
-        await knex('answers').delete();
-        await knex('assessments').delete();
-      });
-
       context('and competence exists', function () {
         let response, assessment;
 

--- a/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
@@ -50,10 +50,6 @@ describe('Acceptance | Controller | feedback-controller', function () {
       };
     });
 
-    afterEach(function () {
-      return knex('feedbacks').delete();
-    });
-
     it('should return 201 HTTP status code', function () {
       // when
       const promise = server.inject(options);

--- a/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/stages/stage-controller_test.js
@@ -35,10 +35,6 @@ describe('Acceptance | API | Stages', function () {
 
   describe('PATCH /api/admin/stages/{id}', function () {
     context('When user is authenticated', function () {
-      afterEach(async function () {
-        await knex('stages').delete();
-      });
-
       context('the stage exists', function () {
         it('should return 204', async function () {
           // given

--- a/api/tests/evaluation/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/answer-repository_test.js
@@ -305,11 +305,6 @@ describe('Integration | Repository | answerRepository', function () {
   });
 
   describe('#saveWithKnowledgeElements', function () {
-    afterEach(async function () {
-      await knex('knowledge-elements').delete();
-      await knex('answers').delete();
-    });
-
     it('should save and return the answer', async function () {
       // given
       const answerToSave = domainBuilder.buildAnswer({

--- a/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -16,10 +16,6 @@ describe('Integration | Repository | Competence Evaluation', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('competence-evaluations').delete();
-    });
-
     it('should return the given competence evaluation', async function () {
       // given
       const competenceEvaluationToSave = new CompetenceEvaluation({

--- a/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
@@ -27,12 +27,6 @@ describe('Integration | Application | Controller | organization-administration-c
     await databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('organization-features').delete();
-    await knex('organization-tags').delete();
-    await knex('data-protection-officers').delete();
-  });
-
   describe('#updateOrganizationInformation', function () {
     it('return updated basic organization information', async function () {
       //given && when

--- a/api/tests/integration/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/integration/application/stage-collections/stage-collection-controller_test.js
@@ -1,4 +1,4 @@
-import { expect, knex, databaseBuilder, mockLearningContent, hFake } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent, hFake } from '../../../test-helper.js';
 import { stageCollectionController } from '../../../../lib/application/stage-collections/stage-collection-controller.js';
 import * as stageCollectionRepository from '../../../../lib/infrastructure/repositories/target-profile-management/stage-collection-repository.js';
 
@@ -12,10 +12,6 @@ describe('Integration | Application | stage-collection-controller', function () 
         tubes: [{ id: 'tubeId1' }],
       };
       mockLearningContent(learningContent);
-    });
-
-    afterEach(async function () {
-      await knex('stages').delete();
     });
 
     it('should modify stage collection according to the request', async function () {

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -1,4 +1,4 @@
-import { expect, sinon, HttpTestServer, knex } from '../../../test-helper.js';
+import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
 import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
 import { userController } from '../../../../lib/application/users/user-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/users/index.js';
@@ -25,11 +25,6 @@ describe('Integration | Application | Users | Routes', function () {
   });
 
   describe('POST /api/users', function () {
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('users').delete();
-    });
-
     context('when user create account before joining campaign', function () {
       it('should return HTTP 201', async function () {
         // given / when

--- a/api/tests/integration/domain/event/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/integration/domain/event/handle-pole-emploi-participation-finished_test.js
@@ -44,10 +44,6 @@ describe('Integration | Event | Handle Pole emploi participation finished', func
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('pole-emploi-sendings').delete();
-    });
-
     it('should notify pole emploi and save success of this notification', async function () {
       // when
       await handlePoleEmploiParticipationFinished({

--- a/api/tests/integration/domain/event/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/integration/domain/event/handle-pole-emploi-participation-started_test.js
@@ -44,10 +44,6 @@ describe('Integration | Event | Handle Pole emploi participation started', funct
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('pole-emploi-sendings').delete();
-    });
-
     it('should notify pole emploi and save success of this notification', async function () {
       // when
       await handlePoleEmploiParticipationStarted({

--- a/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -24,10 +24,6 @@ describe('Integration | Domain | Services | pole-emploi-oidc-authentication-serv
   });
 
   describe('#createUserAccount', function () {
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-    });
-
     it('creates a user with an authentication method and returns a user id', async function () {
       // given
       const externalIdentityId = '1HHF940';

--- a/api/tests/integration/domain/services/organization-invitation-service_test.js
+++ b/api/tests/integration/domain/services/organization-invitation-service_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, knex, sinon, catchErr } from '../../../test-helper.js';
+import { expect, databaseBuilder, sinon, catchErr } from '../../../test-helper.js';
 
 import * as organizationInvitationRepository from '../../../../lib/infrastructure/repositories/organization-invitation-repository.js';
 import * as organizationRepository from '../../../../lib/infrastructure/repositories/organization-repository.js';
@@ -21,7 +21,6 @@ describe('Integration | Service | Organization-Invitation Service', function () 
     });
 
     afterEach(async function () {
-      await knex('organization-invitations').delete();
       clock.restore();
     });
 

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -31,11 +31,6 @@ describe('Integration | Domain | Services | user-service', function () {
       });
     });
 
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('users').delete();
-    });
-
     it('should return saved user and authenticationMethod', async function () {
       // given
       const expectedUser = pick(user, userPickedAttributes);
@@ -93,11 +88,6 @@ describe('Integration | Domain | Services | user-service', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('users').delete();
-    });
-
     it('should update user username and user authenticationMethod password', async function () {
       // given
       const userId = user.id;
@@ -150,12 +140,6 @@ describe('Integration | Domain | Services | user-service', function () {
       }).id;
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('organization-learners').delete();
-      await knex('authentication-methods').delete();
-      await knex('users').delete();
     });
 
     context('when all goes well', function () {

--- a/api/tests/integration/domain/usecases/attach-organizations-from-existing-target-profile_test.js
+++ b/api/tests/integration/domain/usecases/attach-organizations-from-existing-target-profile_test.js
@@ -9,9 +9,6 @@ describe('Integration | UseCase | attach-organizations-from-existing-target-prof
   beforeEach(function () {
     sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([]);
   });
-  afterEach(function () {
-    return knex('target-profile-shares').delete();
-  });
 
   describe('#attachOrganizationsFromExistingTargetProfile', function () {
     it('attaches organizations to target profile with given existing target profile', async function () {

--- a/api/tests/integration/domain/usecases/attach-organizations-to-target-profile_test.js
+++ b/api/tests/integration/domain/usecases/attach-organizations-to-target-profile_test.js
@@ -7,9 +7,7 @@ describe('Integration | UseCase | attach-organizations-to-target-profile', funct
   beforeEach(function () {
     sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([]);
   });
-  afterEach(function () {
-    return knex('target-profile-shares').delete();
-  });
+
   describe('#attachOrganizationsToTargetProfile', function () {
     it('attaches organization to target profile', async function () {
       const targetProfile = databaseBuilder.factory.buildTargetProfile();

--- a/api/tests/integration/domain/usecases/correct-answer_test.js
+++ b/api/tests/integration/domain/usecases/correct-answer_test.js
@@ -4,10 +4,6 @@ import * as activityAnswerRepository from '../../../../lib/infrastructure/reposi
 import * as activityRepository from '../../../../lib/infrastructure/repositories/activity-repository.js';
 
 describe('Integration | UseCases | correct-answer', function () {
-  let createdAnswerRecordId;
-  afterEach(async function () {
-    await knex('activity-answers').where({ id: createdAnswerRecordId }).delete();
-  });
   context('when there is assessmentId', function () {
     it('returns newly created answer', async function () {
       // given
@@ -31,9 +27,6 @@ describe('Integration | UseCases | correct-answer', function () {
         activityAnswerRepository,
         activityRepository,
       });
-
-      // For cleanup purpose
-      createdAnswerRecordId = record.id;
 
       const savedAnswer = await knex('activity-answers').where({ id: record.id }).first();
 
@@ -62,9 +55,6 @@ describe('Integration | UseCases | correct-answer', function () {
         activityAnswerRepository,
         activityRepository,
       });
-
-      // For cleanup purpose
-      createdAnswerRecordId = record.id;
 
       const savedAnswer = await knex('activity-answers').where({ id: record.id }).first();
 

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 const { pick } = lodash;
 
-import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
 
 import * as authenticationMethodRepository from '../../../../lib/infrastructure/repositories/authentication-method-repository.js';
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
@@ -103,10 +103,6 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
       }).code;
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
     });
 
     context('When association is already done', function () {

--- a/api/tests/integration/domain/usecases/create-badge_test.js
+++ b/api/tests/integration/domain/usecases/create-badge_test.js
@@ -53,11 +53,6 @@ describe('Integration | UseCases | create-badge', function () {
     };
   });
 
-  afterEach(async function () {
-    await knex('badge-criteria').delete();
-    await knex('badges').delete();
-  });
-
   it('should not save a new badge if there are no associated criteria', async function () {
     // when
     const error = await catchErr(createBadge)({

--- a/api/tests/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/integration/domain/usecases/create-campaign_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, mockLearningContent, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent } from '../../../test-helper.js';
 import _ from 'lodash';
 
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
@@ -32,10 +32,6 @@ describe('Integration | UseCases | create-campaign', function () {
     };
 
     mockLearningContent(learningContent);
-  });
-
-  afterEach(function () {
-    return knex('campaigns').delete();
   });
 
   it('should save a new campaign of type ASSESSMENT', async function () {

--- a/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -12,10 +12,6 @@ describe('Integration | UseCases | create-certification-center-membership-by-ema
   let user;
   let email;
 
-  afterEach(async function () {
-    await knex('certification-center-memberships').delete();
-  });
-
   it("should throw UserNotFoundError if user's email does not exist", async function () {
     // given
     email = 'notExist@example.net';

--- a/api/tests/integration/domain/usecases/create-certification-center-membership-for-sco-organization-member_test.js
+++ b/api/tests/integration/domain/usecases/create-certification-center-membership-for-sco-organization-member_test.js
@@ -8,10 +8,6 @@ import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { createCertificationCenterMembershipForScoOrganizationMember } from '../../../../lib/domain/usecases/create-certification-center-membership-for-sco-organization-member.js';
 
 describe('Integration | UseCases | create-certification-center-membership-for-sco-organization-member', function () {
-  afterEach(function () {
-    return knex('certification-center-memberships').delete();
-  });
-
   describe('when the organizationRole is ADMIN', function () {
     describe('when the SCO organization has a certification center', function () {
       it('it should create a certification center membership', async function () {

--- a/api/tests/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/integration/domain/usecases/create-organization_test.js
@@ -1,4 +1,4 @@
-import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { databaseBuilder, expect } from '../../../test-helper.js';
 import * as schoolRepository from '../../../../src/school/infrastructure/repositories/school-repository.js';
 import * as organizationForAdminRepository from '../../../../lib/infrastructure/repositories/organization-for-admin-repository.js';
 import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure/repositories/data-protection-officer-repository.js';
@@ -7,12 +7,6 @@ import * as organizationCreationValidator from '../../../../lib/domain/validator
 import { createOrganization } from '../../../../lib/domain/usecases/create-organization.js';
 
 describe('Integration | UseCases | create-organization', function () {
-  afterEach(async function () {
-    await knex('schools').delete();
-    await knex('data-protection-officers').delete();
-    await knex('organizations').delete();
-  });
-
   it('returns newly created organization', async function () {
     // given
     const superAdminUserId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -35,14 +35,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     await databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('organization-invitations').delete();
-    await knex('organization-tags').delete();
-    await knex('target-profile-shares').delete();
-    await knex('organizations').delete();
-    await knex('users').delete();
-  });
-
   describe('validation error cases', function () {
     context('when there is more than one occurrence of the same organization in data file', function () {
       it('throws an error', async function () {

--- a/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
@@ -1,4 +1,4 @@
-import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
 
 import * as mailService from '../../../../lib/domain/services/mail-service.js';
 import * as resetPasswordService from '../../../../lib/domain/services/reset-password-service.js';
@@ -16,10 +16,6 @@ describe('Integration | UseCases | create-password-reset-demand', function () {
     const userId = databaseBuilder.factory.buildUser({ email }).id;
     databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
     await databaseBuilder.commit();
-  });
-
-  afterEach(function () {
-    return knex('reset-password-demands').delete();
   });
 
   it('should return a password reset demand', async function () {

--- a/api/tests/integration/domain/usecases/create-preview-assessment_test.js
+++ b/api/tests/integration/domain/usecases/create-preview-assessment_test.js
@@ -5,9 +5,6 @@ import { Assessment } from '../../../../lib/domain/models/index.js';
 
 describe('Integration | UseCases | create-preview-assessment', function () {
   let assessmentId;
-  afterEach(function () {
-    return knex('assessments').where({ id: assessmentId }).delete();
-  });
 
   it('should create a preview assessment', async function () {
     // when

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -169,14 +169,6 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
       token = tokenService.createIdTokenForUserReconciliation(externalUser);
     });
 
-    afterEach(async function () {
-      await knex('authentication-methods').delete();
-      await knex('organization-learners').delete();
-      await knex('campaigns').delete();
-      await knex('user-logins').delete();
-      await knex('users').delete();
-    });
-
     it('creates the external user, reconciles it and creates GAR authentication method', async function () {
       // given
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({

--- a/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
@@ -109,10 +109,6 @@ describe('Integration | Usecase | Handle Badge Acquisition', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('badge-acquisitions').delete();
-    });
-
     context('when domain transaction is not committed yet', function () {
       it('should not affect the database', async function () {
         await DomainTransaction.execute(async (domainTransaction) => {

--- a/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -103,10 +103,6 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
         return databaseBuilder.commit();
       });
 
-      afterEach(async function () {
-        await knex(STAGE_ACQUISITIONS_TABLE_NAME).delete();
-      });
-
       context('when stage acquisitions are already present', function () {
         it('should not try to insert already existing stages', async function () {
           // given
@@ -242,10 +238,6 @@ describe('Integration | Usecase | Handle Stage Acquisition', function () {
         databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
 
         return databaseBuilder.commit();
-      });
-
-      afterEach(async function () {
-        await knex(STAGE_ACQUISITIONS_TABLE_NAME).delete();
       });
 
       it('should not insert first-skill', async function () {

--- a/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -34,10 +34,6 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
     return databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('pole-emploi-sendings').delete();
-  });
-
   it('should save success of this notification', async function () {
     // given
     poleEmploiNotifier.notify.resolves({ isSuccessful: true, code: responseCode });

--- a/api/tests/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/start-campaign-participation_test.js
@@ -1,14 +1,8 @@
-import { expect, databaseBuilder, knex, mockLearningContent } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent } from '../../../test-helper.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 
 describe('Integration | UseCases | startCampaignParticipation', function () {
-  afterEach(async function () {
-    await knex('assessments').delete();
-    await knex('campaign-participations').delete();
-    await knex('organization-learners').delete();
-  });
-
   it('start a new participation', async function () {
     const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', idPixLabel: null });
     const { id: userId } = databaseBuilder.factory.buildUser();

--- a/api/tests/integration/domain/usecases/update-certification-center-data-protection-officer-information_test.js
+++ b/api/tests/integration/domain/usecases/update-certification-center-data-protection-officer-information_test.js
@@ -1,13 +1,9 @@
-import { knex, expect, databaseBuilder } from '../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../test-helper.js';
 import { DataProtectionOfficer } from '../../../../lib/domain/models/DataProtectionOfficer.js';
 import { updateCertificationCenterDataProtectionOfficerInformation } from '../../../../lib/domain/usecases/update-certification-center-data-protection-officer-information.js';
 import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure/repositories/data-protection-officer-repository.js';
 
 describe('Integration | UseCases | update-certification-center-data-protection-officer-information', function () {
-  afterEach(async function () {
-    await knex('data-protection-officers').delete();
-  });
-
   it('should add data protection officer information for a certification center', async function () {
     // given
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;

--- a/api/tests/integration/domain/usecases/update-certification-center_test.js
+++ b/api/tests/integration/domain/usecases/update-certification-center_test.js
@@ -1,4 +1,4 @@
-import { databaseBuilder, domainBuilder, expect, knex } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
 import { CertificationCenterForAdmin } from '../../../../lib/domain/models/CertificationCenterForAdmin.js';
 import { updateCertificationCenter } from '../../../../lib/domain/usecases/update-certification-center.js';
 import * as certificationCenterForAdminRepository from '../../../../lib/infrastructure/repositories/certification-center-for-admin-repository.js';
@@ -6,11 +6,6 @@ import * as complementaryCertificationHabilitationRepository from '../../../../l
 import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure/repositories/data-protection-officer-repository.js';
 
 describe('Integration | UseCases | update-certification-center', function () {
-  afterEach(async function () {
-    await knex('complementary-certification-habilitations').delete();
-    await knex('data-protection-officers').delete();
-  });
-
   it('should update certification center and his data protection officer information', async function () {
     // given
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;

--- a/api/tests/integration/domain/usecases/update-organization-data-protection-officer-information_test.js
+++ b/api/tests/integration/domain/usecases/update-organization-data-protection-officer-information_test.js
@@ -1,13 +1,9 @@
-import { knex, expect, databaseBuilder } from '../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../test-helper.js';
 import { DataProtectionOfficer } from '../../../../lib/domain/models/DataProtectionOfficer.js';
 import { updateOrganizationDataProtectionOfficerInformation } from '../../../../lib/domain/usecases/update-organization-data-protection-officer-information.js';
 import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure/repositories/data-protection-officer-repository.js';
 
 describe('Integration | UseCases | update-organization-data-protection-officer-information', function () {
-  afterEach(async function () {
-    await knex('data-protection-officers').delete();
-  });
-
   it('should add data protection officer information for an organization', async function () {
     // given
     const organizationId = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob_test.js
@@ -2,10 +2,6 @@ import { expect, knex } from '../../../../test-helper.js';
 import { ParticipationResultCalculationJob } from '../../../../../lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob.js';
 
 describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationResultCalculation', function () {
-  afterEach(async function () {
-    await knex('pgboss.job').delete();
-  });
-
   describe('#schedule', function () {
     it('creates the results calculation job', async function () {
       const handler = new ParticipationResultCalculationJob(knex);

--- a/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
@@ -2,10 +2,6 @@ import { expect, knex } from '../../../../test-helper.js';
 import { SendSharedParticipationResultsToPoleEmploiJob } from '../../../../../lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
 
 describe('Integration | Infrastructure | Jobs | CampaignResult | SendSharedParticipationResultsToPoleEmploiJob', function () {
-  afterEach(async function () {
-    await knex('pgboss.job').delete();
-  });
-
   describe('#schedule', function () {
     it('creates the send results job', async function () {
       const job = new SendSharedParticipationResultsToPoleEmploiJob(knex);

--- a/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/account-recovery-demand-repository_test.js
@@ -7,10 +7,6 @@ import lodash from 'lodash';
 const { omit } = lodash;
 
 describe('Integration | Infrastructure | Repository | account-recovery-demand-repository', function () {
-  afterEach(function () {
-    return knex('account-recovery-demands').delete();
-  });
-
   describe('#findByTemporaryKey', function () {
     context('when demand does not exist', function () {
       it('should throw a not found error', async function () {

--- a/api/tests/integration/infrastructure/repositories/activity-answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/activity-answer-repository_test.js
@@ -65,11 +65,6 @@ describe('Integration | Repository | activityAnswerRepository', function () {
   });
 
   describe('#save', function () {
-    let answerId;
-    afterEach(async function () {
-      await knex('activity-answers').where('id', answerId).delete();
-    });
-
     it('should save and return the activity answer', async function () {
       // given
 
@@ -86,7 +81,7 @@ describe('Integration | Repository | activityAnswerRepository', function () {
 
       // when
       const savedAnswer = await activityAnswerRepository.save(answerToSave);
-      answerId = savedAnswer.id;
+
       // then
       const answerInDB = await knex('activity-answers').where('id', savedAnswer.id).first();
       expect(_.pick(savedAnswer, ['challengeId', 'activityId', 'value', 'resultDetails'])).to.deep.equal(

--- a/api/tests/integration/infrastructure/repositories/activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/activity-repository_test.js
@@ -6,9 +6,6 @@ import { NotFoundError } from '../../../../lib/domain/errors.js';
 describe('Integration | Repository | activityRepository', function () {
   describe('#save', function () {
     let activityId;
-    afterEach(async function () {
-      await knex('activities').where('id', activityId).delete();
-    });
 
     it('should save and return the activity', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -344,10 +344,6 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
   });
 
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('pix-admin-roles').delete();
-    });
-
     it('should persist admin member role', async function () {
       // given
       const user = databaseBuilder.factory.buildUser();

--- a/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -6,11 +6,6 @@ import { MissingAssessmentId } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | AssessmentResult', function () {
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('certification-courses-last-assessment-results').delete();
-      return knex('assessment-results').delete();
-    });
-
     context('when save is successful', function () {
       it('should return the saved assessment result', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -11,10 +11,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
   const newHashedPassword = '1234ABCDEF';
 
   describe('#create', function () {
-    afterEach(function () {
-      return knex('authentication-methods').delete();
-    });
-
     context('when creating a AuthenticationMethod containing an external identifier', function () {
       it('should return an AuthenticationMethod', async function () {
         // given
@@ -633,10 +629,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('authentication-methods').delete();
     });
 
     it('should create and return a Pix authentication method with given password in database and set shouldChangePassword to true', async function () {

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -20,10 +20,6 @@ describe('Integration | Repository | Badge Acquisition', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('badge-acquisitions').delete();
-    });
-
     it('should persist the badge acquisition in db', async function () {
       // when
       await DomainTransaction.execute(async (domainTransaction) => {

--- a/api/tests/integration/infrastructure/repositories/badge-criteria-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-criteria-repository_test.js
@@ -2,11 +2,6 @@ import { knex, expect, databaseBuilder } from '../../../test-helper.js';
 import * as badgeCriteriaRepository from '../../../../lib/infrastructure/repositories/badge-criteria-repository.js';
 
 describe('Integration | Repository | Badge Criteria Repository', function () {
-  afterEach(async function () {
-    await knex('badge-criteria').delete();
-    await knex('badges').delete();
-  });
-
   describe('#save', function () {
     it('should save CampaignParticipation badge-criterion', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -32,12 +32,6 @@ describe('Integration | Repository | Badge', function () {
     await databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('badge-acquisitions').delete();
-    await knex('complementary-certification-badges').delete();
-    await knex('badges').delete();
-  });
-
   describe('#findByCampaignId', function () {
     it('should return two badges for same target profile', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-analysis-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import * as campaignAnalysisRepository from '../../../../lib/infrastructure/repositories/campaign-analysis-repository.js';
 import { CampaignAnalysis } from '../../../../lib/domain/read-models/CampaignAnalysis.js';
 import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
@@ -46,10 +46,6 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
 
 describe('Integration | Repository | Campaign analysis repository', function () {
   describe('#getCampaignAnalysis', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     context('in a rich context close to reality', function () {
       let learningContent;
       let campaignId;
@@ -416,10 +412,6 @@ describe('Integration | Repository | Campaign analysis repository', function () 
   });
 
   describe('#getCampaignParticipationAnalysis', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     context('in a rich context close to reality', function () {
       let learningContent;
       let campaignId;

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, mockLearningContent, knex, catchErr } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent, catchErr } from '../../../test-helper.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
 import { CampaignAssessmentParticipation } from '../../../../lib/domain/read-models/CampaignAssessmentParticipation.js';
@@ -10,10 +10,6 @@ const { STARTED } = CampaignParticipationStatuses;
 
 describe('Integration | Repository | Campaign Assessment Participation', function () {
   describe('#getByCampaignIdAndCampaignParticipationId', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     let campaignId, campaignParticipationId, userId;
 
     context('When there is an assessment for another campaign and another participation', function () {

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, knex, mockLearningContent, learningContentBuilder } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent, learningContentBuilder } from '../../../test-helper.js';
 import * as campaignAssessmentParticipationResultListRepository from '../../../../lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js';
 import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
 
@@ -6,10 +6,6 @@ const { STARTED } = CampaignParticipationStatuses;
 
 describe('Integration | Repository | Campaign Assessment Participation Result List', function () {
   describe('#findPaginatedByCampaignId', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     let campaign;
 
     context('when participants have not retried', function () {

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, mockLearningContent, knex, catchErr } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent, catchErr } from '../../../test-helper.js';
 import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
 import * as campaignAssessmentParticipationResultRepository from '../../../../lib/infrastructure/repositories/campaign-assessment-participation-result-repository.js';
 import { LOCALE } from '../../../../src/shared/domain/constants.js';
@@ -78,10 +78,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
 
       mockLearningContent(learningContent);
       return databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
     });
 
     context('When campaign participation is shared', function () {

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import * as campaignCollectiveResultRepository from '../../../../lib/infrastructure/repositories/campaign-collective-result-repository.js';
 import { CampaignCollectiveResult } from '../../../../lib/domain/read-models/CampaignCollectiveResult.js';
 import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
@@ -44,10 +44,6 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
 
 describe('Integration | Repository | Campaign collective result repository', function () {
   describe('#getCampaignCollectiveResults', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     context('in a rich context close to reality', function () {
       let learningContent;
       let campaignId;

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -30,12 +30,6 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
       userIdentity = { id: user.id, firstName: user.firstName, lastName: user.lastName };
     });
 
-    afterEach(async function () {
-      await knex('assessments').delete();
-      await knex('campaign-participations').delete();
-      await knex('organization-learners').delete();
-    });
-
     it('returns campaign participation id', async function () {
       const campaignParticipant = await makeCampaignParticipant({
         campaignAttributes: { idPixLabel: null },

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -715,7 +715,6 @@ describe('Integration | Repository | Campaign Participation', function () {
 
     afterEach(function () {
       clock.restore();
-      return knex('knowledge-element-snapshots').delete();
     });
 
     it('persists the campaign-participation changes', async function () {

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, mockLearningContent, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder, mockLearningContent } from '../../../test-helper.js';
 import { CampaignProfilesCollectionParticipationSummary } from '../../../../lib/domain/read-models/CampaignProfilesCollectionParticipationSummary.js';
 import * as campaignProfilesCollectionParticipationSummaryRepository from '../../../../lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js';
 import { CampaignParticipationStatuses } from '../../../../lib/domain/models/CampaignParticipationStatuses.js';
@@ -20,10 +20,6 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       organizationId = databaseBuilder.factory.buildOrganization().id;
       campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
     });
 
     it('should return empty array if no participant', async function () {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -222,11 +222,6 @@ describe('Integration | Repository | Campaign', function () {
   });
 
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('campaign_skills').delete();
-      return knex('campaigns').delete();
-    });
-
     context('when campaign is of type ASSESSMENT', function () {
       it('should save the given campaign with type ASSESSMENT', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -10,10 +10,6 @@ import _ from 'lodash';
 
 describe('Integration | Repository | CertificationCandidate', function () {
   describe('#saveInSession', function () {
-    afterEach(function () {
-      return knex('certification-candidates').delete();
-    });
-
     context('when a proper candidate is being saved', function () {
       it('should save the Certification candidate in session', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -138,10 +138,6 @@ describe('Integration | Repository | certification-center-for-admin', function (
   });
 
   describe('#save', function () {
-    afterEach(async function () {
-      await databaseBuilder.knex('certification-centers').delete();
-    });
-
     it('should save the given certification center', async function () {
       // given
       const certificationCenter = new CertificationCenterForAdmin({

--- a/api/tests/integration/infrastructure/repositories/certification-center-invited-user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-invited-user-repository_test.js
@@ -107,10 +107,6 @@ describe('Integration | Repository | CertificationCenterInvitedUserRepository', 
   describe('#save', function () {
     let clock;
 
-    afterEach(async function () {
-      await knex('certification-center-memberships').delete();
-    });
-
     it('should create membership', async function () {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -24,10 +24,6 @@ describe('Integration | Repository | Certification Center Membership', function 
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('certification-center-memberships').delete();
-    });
-
     it('should add a new membership in database', async function () {
       // given
       const countCertificationCenterMembershipsBeforeCreate = await BookshelfCertificationCenterMembership.count();

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, knex, domainBuilder, databaseBuilder } from '../../../test-helper.js';
+import { expect, domainBuilder, databaseBuilder } from '../../../test-helper.js';
 import { CertificationChallenge } from '../../../../lib/domain/models/CertificationChallenge.js';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
 import * as certificationChallengeRepository from '../../../../lib/infrastructure/repositories/certification-challenge-repository.js';
@@ -18,10 +18,6 @@ describe('Integration | Repository | Certification Challenge', function () {
       });
       certificationChallenge.id = undefined;
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('certification-challenges').delete();
     });
 
     it('should return certification challenge object', async function () {

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { catchErr, expect, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { catchErr, expect, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import * as certificationCourseRepository from '../../../../lib/infrastructure/repositories/certification-course-repository.js';
 import { BookshelfCertificationCourse } from '../../../../lib/infrastructure/orm-models/CertificationCourse.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
@@ -10,12 +10,6 @@ describe('Integration | Repository | Certification Course', function () {
     let certificationCourse;
     let complementaryCertificationId;
     let complementaryCertificationBadgeId;
-
-    afterEach(async function () {
-      await knex('complementary-certification-courses').delete();
-      await knex('certification-challenges').delete();
-      return knex('certification-courses').delete();
-    });
 
     describe('when the session is V2', function () {
       beforeEach(function () {
@@ -149,10 +143,6 @@ describe('Integration | Repository | Certification Course', function () {
 
   describe('#getCreationDate', function () {
     let certificationCourse;
-
-    afterEach(function () {
-      return knex('certification-courses').delete();
-    });
 
     beforeEach(async function () {
       certificationCourse = databaseBuilder.factory.buildCertificationCourse({});

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -1,5 +1,5 @@
 import * as certificationLsRepository from '../../../../lib/infrastructure/repositories/certification-livret-scolaire-repository.js';
-import { expect, databaseBuilder, knex } from '../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../test-helper.js';
 import { status } from '../../../../lib/domain/read-models/livret-scolaire/CertificateStatus.js';
 
 import {
@@ -28,17 +28,6 @@ describe('Integration | Repository | Certification-ls ', function () {
       level: 4,
     },
   ];
-
-  afterEach(async function () {
-    await knex('competence-marks').delete();
-    await knex('certification-candidates').delete();
-    await knex('certification-courses-last-assessment-results').delete();
-    await knex('complementary-certification-course-results').delete();
-    await knex('assessment-results').delete();
-    await knex('assessments').delete();
-    await knex('certification-courses').delete();
-    return knex('sessions').delete();
-  });
 
   describe('#getCertificatesByOrganizationUAI', function () {
     it('should return validated certification results for a given UAI', async function () {

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { databaseBuilder, domainBuilder, expect, catchErr, knex } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, catchErr } from '../../../test-helper.js';
 import { CertificationReport } from '../../../../lib/domain/models/CertificationReport.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import * as certificationReportRepository from '../../../../lib/infrastructure/repositories/certification-report-repository.js';
@@ -77,10 +77,6 @@ describe('Integration | Repository | CertificationReport', function () {
 
   describe('#finalizeAll', function () {
     let sessionId;
-
-    afterEach(function () {
-      return knex('certification-issue-reports').delete();
-    });
 
     beforeEach(function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -21,11 +21,6 @@ describe('Integration | Repository | CompetenceMark', function () {
       });
     });
 
-    afterEach(async function () {
-      await knex('competence-marks').delete();
-      await knex('assessment-results').delete();
-    });
-
     it('should persist the mark in db', async function () {
       // when
       await competenceMarkRepository.save(competenceMark);

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -112,9 +112,6 @@ describe('Integration | Repository | complementary-certification-courses-result-
   });
 
   describe('#save', function () {
-    afterEach(function () {
-      return knex('complementary-certification-course-results').delete();
-    });
     describe('when the ComplementaryCertificationCourseResult does not exist', function () {
       it('saves the ComplementaryCertificationCourseResult', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-habilitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-habilitation-repository_test.js
@@ -4,10 +4,6 @@ import { knex } from '../../../../lib/infrastructure/bookshelf.js';
 
 describe('Integration | Infrastructure | Repository | complementary-certification-habilitation-repository', function () {
   context('#save', function () {
-    afterEach(function () {
-      return knex('complementary-certification-habilitations').delete();
-    });
-
     it('should create the complementary certitification habilitation', async function () {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;

--- a/api/tests/integration/infrastructure/repositories/data-protection-officer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/data-protection-officer-repository_test.js
@@ -5,10 +5,6 @@ import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure
 describe('Integration | Repository | data-protection-officer', function () {
   const now = new Date('2022-09-27T16:30:00Z');
 
-  afterEach(async function () {
-    await knex('data-protection-officers').delete();
-  });
-
   describe('#batchAddDataProtectionOfficerToOrganization', function () {
     it('should add rows in the table "data-protection-officers"', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
@@ -2,10 +2,6 @@ import { expect, knex, databaseBuilder } from '../../../test-helper.js';
 import * as flashAssessmentResultRepository from '../../../../lib/infrastructure/repositories/flash-assessment-result-repository.js';
 
 describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepository', function () {
-  afterEach(async function () {
-    await knex('flash-assessment-results').delete();
-  });
-
   describe('#getLatestByAssessmentId', function () {
     let assessmentId;
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -5,10 +5,6 @@ import * as knowledgeElementRepository from '../../../../lib/infrastructure/repo
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 
 describe('Integration | Repository | knowledgeElementRepository', function () {
-  afterEach(function () {
-    return knex('knowledge-elements').delete();
-  });
-
   describe('#save', function () {
     let knowledgeElementToSave;
 
@@ -333,10 +329,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     it('should return knowledge elements within respective dates grouped by userId the competenceId', async function () {
       // given
       const competence1 = 'competenceId1';
@@ -492,10 +484,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#countValidatedByCompetencesForOneUserWithinCampaign', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     it('should return count of validated knowledge elements within limit date for the given user grouped by competences within target profile of campaign', async function () {
       // given
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
@@ -734,10 +722,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#countValidatedByCompetencesForUsersWithinCampaign', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     it('should return count of validated knowledge elements within limit date for the given users grouped by competences within target profile of campaign', async function () {
       // given
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
@@ -956,10 +940,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#findGroupedByCompetencesForUsersWithinLearningContent', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     it('should return knowledge elements within respective dates grouped by userId the competenceId within target profile of campaign', async function () {
       // given
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
@@ -1242,10 +1222,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#findValidatedGroupedByTubesWithinCampaign', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     it('should return knowledge elements within respective dates grouped by userId and tubeId within target profile of campaign', async function () {
       // given
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
@@ -1496,10 +1472,6 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       userId2 = databaseBuilder.factory.buildUser().id;
       sandbox = sinon.createSandbox();
       return databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
     });
 
     it('should return knowledge elements within respective dates and users', async function () {

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -6,10 +6,6 @@ import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransact
 
 describe('Integration | Repository | KnowledgeElementSnapshotRepository', function () {
   describe('#save', function () {
-    afterEach(function () {
-      return knex('knowledge-element-snapshots').delete();
-    });
-
     it('should save knowledge elements snapshot for a userId and a date', async function () {
       // given
       const snappedAt = new Date('2019-04-01');

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -15,7 +15,6 @@ describe('Integration | Infrastructure | Repository | membership-repository', fu
   });
   afterEach(function () {
     clock.restore();
-    return knex('memberships').delete();
   });
 
   describe('#create', function () {

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -209,12 +209,6 @@ describe('Integration | Repository | Organization-for-admin', function () {
   });
 
   describe('#update', function () {
-    afterEach(async function () {
-      await knex('organization-features').delete();
-      await knex('organization-tags').delete();
-      await knex('data-protection-officers').delete();
-    });
-
     it('should enable feature', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
@@ -616,10 +610,6 @@ describe('Integration | Repository | Organization-for-admin', function () {
   });
 
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('organizations').delete();
-    });
-
     it('saves the given organization', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, knex, databaseBuilder, catchErr, sinon } from '../../../test-helper.js';
+import { expect, databaseBuilder, catchErr, sinon } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { OrganizationInvitation } from '../../../../lib/domain/models/OrganizationInvitation.js';
@@ -13,10 +13,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', function
     beforeEach(async function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      return knex('organization-invitations').delete();
     });
 
     it('should save the organization invitation in db', async function () {

--- a/api/tests/integration/infrastructure/repositories/organization-invited-user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invited-user-repository_test.js
@@ -5,11 +5,6 @@ import { OrganizationInvitation } from '../../../../lib/domain/models/Organizati
 import { OrganizationInvitedUser } from '../../../../lib/domain/models/OrganizationInvitedUser.js';
 
 describe('Integration | Repository | OrganizationInvitedUserRepository', function () {
-  afterEach(async function () {
-    await knex('user-orga-settings').delete();
-    await knex('memberships').delete();
-  });
-
   describe('#get', function () {
     it('should return an OrganizationInvitedUser userId', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -653,10 +653,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
     context(
       'when imported organization learner is in a different organization as an existing organization learner with the same national student id',
       function () {
-        afterEach(function () {
-          return knex('organization-learners').delete();
-        });
-
         context('and same birthday', function () {
           it('should save the imported organization learner with the user id of the existing one', async function () {
             // given
@@ -792,10 +788,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         });
 
         organizationLearners = [firstOrganizationLearner];
-      });
-
-      afterEach(function () {
-        return knex('organization-learners').delete();
       });
 
       it('should create all organizationLearners', async function () {
@@ -1137,10 +1129,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         organizationLearners = [organizationLearnerFromFile];
       });
 
-      afterEach(function () {
-        return knex('organization-learners').delete();
-      });
-
       it('should create organizationLearner and reconcile it with the help of another organizationLearner', async function () {
         // given
         databaseBuilder.factory.buildOrganizationLearner({ nationalStudentId, birthdate, userId });
@@ -1259,10 +1247,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         organizationLearners = [organizationLearnerUpdated, organizationLearnerToCreate];
       });
 
-      afterEach(function () {
-        return knex('organization-learners').delete();
-      });
-
       it('should update and create all organizationLearners', async function () {
         // when
         await DomainTransaction.execute((domainTransaction) => {
@@ -1311,10 +1295,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         });
 
         organizationLearners = [firstOrganizationLearner, secondOrganizationLearner];
-      });
-
-      afterEach(function () {
-        return knex('organization-learners').delete();
       });
 
       it('should return a OrganizationLearnersCouldNotBeSavedError on unicity errors', async function () {
@@ -1673,10 +1653,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
   });
 
   describe('#reconcileUserToOrganizationLearner', function () {
-    afterEach(function () {
-      return knex('organization-learners').delete();
-    });
-
     let organization;
     let organizationLearner;
     let user;
@@ -1757,10 +1733,6 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
   });
 
   describe('#reconcileUserAndOrganization', function () {
-    afterEach(function () {
-      return knex('organization-learners').delete();
-    });
-
     context('when the organizationLearner is active', function () {
       let organization;
       let organizationLearner;

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -8,10 +8,6 @@ import { ORGANIZATION_FEATURE } from '../../../../lib/domain/constants.js';
 
 describe('Integration | Repository | Organization', function () {
   describe('#create', function () {
-    afterEach(async function () {
-      await knex('organizations').delete();
-    });
-
     it('should return an Organization domain object', async function () {
       // given
       const organization = domainBuilder.buildOrganization();
@@ -991,11 +987,6 @@ describe('Integration | Repository | Organization', function () {
         ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY,
       ).id;
       await databaseBuilder.commit();
-    });
-    afterEach(async function () {
-      await knex('organization-features').delete();
-      await knex('organization-learners').delete();
-      await knex('organizations').delete();
     });
 
     it('should add rows in the table "organizations"', async function () {

--- a/api/tests/integration/infrastructure/repositories/organization-tag-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-tag-repository_test.js
@@ -7,10 +7,6 @@ const { omit } = lodash;
 
 describe('Integration | Repository | OrganizationTagRepository', function () {
   describe('#create', function () {
-    afterEach(async function () {
-      await knex('organization-tags').delete();
-    });
-
     it('should create an OrganizationTag', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -76,10 +72,6 @@ describe('Integration | Repository | OrganizationTagRepository', function () {
   });
 
   describe('#batchCreate', function () {
-    afterEach(async function () {
-      await knex('organization-tags').delete();
-    });
-
     it('should add rows in the table "organizations-tags"', async function () {
       // given
       const organizationId1 = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/integration/infrastructure/repositories/organizations-to-attach-to-target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organizations-to-attach-to-target-profile-repository_test.js
@@ -4,10 +4,6 @@ import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | Organizations-to-attach-to-target-profile', function () {
   describe('#attachOrganizations', function () {
-    afterEach(function () {
-      return knex('target-profile-shares').delete();
-    });
-
     it('should return attachedIds', async function () {
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const organization1 = databaseBuilder.factory.buildOrganization();

--- a/api/tests/integration/infrastructure/repositories/organizations/organization-places-lot-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organizations/organization-places-lot-repository_test.js
@@ -210,10 +210,6 @@ describe('Integration | Repository | Organization Place', function () {
   });
 
   describe('#create', function () {
-    afterEach(function () {
-      return knex('organization-places').delete();
-    });
-
     it('should create the given lot of places', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -6,17 +6,8 @@ import { ComplementaryCertificationCourseResult } from '../../../../lib/domain/m
 
 describe('Integration | Repository | Partner Certification Scoring', function () {
   const COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE_NAME = 'complementary-certification-course-results';
-  const COMPLEMENTARY_CERTIFICATION_COURSES_TABLE_NAME = 'complementary-certification-courses';
 
   describe('#save', function () {
-    afterEach(async function () {
-      await knex(COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE_NAME).delete();
-      await knex(COMPLEMENTARY_CERTIFICATION_COURSES_TABLE_NAME).delete();
-      await knex('certification-courses').delete();
-      await knex('complementary-certification-badges').delete();
-      await knex('badges').delete();
-    });
-
     it('should insert the complementary certification course results in db if it does not already exists by partnerKey', async function () {
       // given
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -6,10 +6,6 @@ const poleEmploiSendingFactory = databaseBuilder.factory.poleEmploiSendingFactor
 
 describe('Integration | Repository | PoleEmploiSending', function () {
   describe('#create', function () {
-    afterEach(function () {
-      return knex('pole-emploi-sendings').delete();
-    });
-
     it('should save PoleEmploiSending', async function () {
       // given
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;

--- a/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -3,10 +3,6 @@ import * as resetPasswordDemandsRepository from '../../../../lib/infrastructure/
 import { PasswordResetDemandNotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Infrastructure | Repository | reset-password-demands-repository', function () {
-  afterEach(function () {
-    return knex('reset-password-demands').delete();
-  });
-
   describe('#create', function () {
     it('should create a password reset demand', async function () {
       // when

--- a/api/tests/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/school-repository_test.js
@@ -1,14 +1,10 @@
-import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
 import * as schoolRepository from '../../../../src/school/infrastructure/repositories/school-repository.js';
 import { School } from '../../../../src/school/domain/models/School.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | School', function () {
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('schools').delete();
-    });
-
     it('saves the given organization', async function () {
       // given
       const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
@@ -22,10 +18,6 @@ describe('Integration | Repository | School', function () {
     });
   });
   describe('#getByCode', function () {
-    afterEach(async function () {
-      await knex('schools').delete();
-    });
-
     it('returns the organization corresponding to the code', async function () {
       // given
       const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D', name: 'École des fans' });

--- a/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -13,10 +13,6 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('certification-candidates').delete();
-    });
-
     it('adds only the unenrolled candidates', async function () {
       // given
       const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner().id;

--- a/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
@@ -1,14 +1,10 @@
-import { expect, databaseBuilder, knex, catchErr } from '../../../../test-helper.js';
+import { expect, databaseBuilder, catchErr } from '../../../../test-helper.js';
 import * as finalizedSessionRepository from '../../../../../lib/infrastructure/repositories/sessions/finalized-session-repository.js';
 import { FinalizedSession } from '../../../../../lib/domain/models/FinalizedSession.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | Finalized-session', function () {
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('finalized-sessions').delete();
-    });
-
     context('When the session does not exist', function () {
       it('saves a finalized session', async function () {
         // given
@@ -95,10 +91,6 @@ describe('Integration | Repository | Finalized-session', function () {
   });
 
   describe('#get', function () {
-    afterEach(function () {
-      return knex('finalized-sessions').delete();
-    });
-
     context('When the session does exist', function () {
       it('retrieves a finalized session', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/stage-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-acquisition-repository_test.js
@@ -17,10 +17,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('stage-acquisitions').delete();
-    });
-
     it('should return the expected stage', async function () {
       // when
       const result = await getByCampaignParticipation(stageAcquisition.campaignParticipationId);
@@ -56,10 +52,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('stage-acquisitions').delete();
-    });
-
     it('should return the expected stage ids', async function () {
       // when
       const result = await getStageIdsByCampaignParticipation(campaignParticipation.id);
@@ -82,10 +74,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       secondStage = databaseBuilder.factory.buildStageAcquisition();
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('stage-acquisitions').delete();
     });
 
     it('should return StageAcquisition instances', async function () {
@@ -135,10 +123,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('stage-acquisitions').delete();
-    });
-
     it('should return StageAcquisition instances', async function () {
       // when
       const result = await getByCampaignIdAndUserId(campaign.id, user.id);
@@ -175,10 +159,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('stage-acquisitions').delete();
     });
 
     it('return the expected stage', async function () {

--- a/api/tests/integration/infrastructure/repositories/stage-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-repository_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, knex, catchErr } from '../../../test-helper.js';
+import { expect, databaseBuilder, catchErr } from '../../../test-helper.js';
 import {
   get,
   getByCampaignIds,
@@ -12,10 +12,6 @@ import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 
 describe('Integration | Repository | Stage Acquisition', function () {
   describe('get', function () {
-    afterEach(async function () {
-      await knex('stages').delete();
-    });
-
     it('should return a stage for a given id', async function () {
       // given
       const stage1 = databaseBuilder.factory.buildStage({ id: 1 });
@@ -62,10 +58,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('stages').delete();
-    });
-
     it('should return Stage instances', async function () {
       const result = await getByCampaignIds(campaigns.map((campaign) => campaign.id));
       expect(result[0]).to.be.instanceof(Stage);
@@ -95,10 +87,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       ];
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('stages').delete();
     });
 
     it('should return Stage instances', async function () {
@@ -132,10 +120,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('stages').delete();
     });
 
     it('should return Stage instances', async function () {
@@ -175,10 +159,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('stages').delete();
-    });
-
     it('should return Stage instances', async function () {
       const result = await getByTargetProfileIds([targetProfile1.id, targetProfile2.id]);
       expect(result[0]).to.be.instanceof(Stage);
@@ -191,9 +171,6 @@ describe('Integration | Repository | Stage Acquisition', function () {
   });
 
   describe('update', function () {
-    afterEach(async function () {
-      await knex('stages').delete();
-    });
     it('should update the stage', async function () {
       // given
       const stage = databaseBuilder.factory.buildStage({

--- a/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
@@ -3,10 +3,6 @@ import * as supervisorAccessRepository from '../../../../lib/infrastructure/repo
 
 describe('Integration | Repository | supervisor-access-repository', function () {
   describe('#create', function () {
-    afterEach(function () {
-      return knex('supervisor-accesses').delete();
-    });
-
     it('should save a supervisor access', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;

--- a/api/tests/integration/infrastructure/repositories/tag-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tag-repository_test.js
@@ -1,14 +1,10 @@
-import { expect, knex, domainBuilder, databaseBuilder, catchErr } from '../../../test-helper.js';
+import { expect, domainBuilder, databaseBuilder, catchErr } from '../../../test-helper.js';
 import { AlreadyExistingEntityError } from '../../../../lib/domain/errors.js';
 import { Tag } from '../../../../lib/domain/models/Tag.js';
 import * as tagRepository from '../../../../lib/infrastructure/repositories/tag-repository.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 
 describe('Integration | Repository | TagRepository', function () {
-  afterEach(async function () {
-    await knex('tags').delete();
-  });
-
   describe('#create', function () {
     it('should create a Tag', async function () {
       // given

--- a/api/tests/integration/infrastructure/repositories/target-profile-management/stage-collection-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-management/stage-collection-repository_test.js
@@ -4,10 +4,6 @@ import * as stageCollectionRepository from '../../../../../lib/infrastructure/re
 import { StageCollectionUpdate } from '../../../../../lib/domain/models/target-profile-management/StageCollectionUpdate.js';
 
 describe('Integration | Infrastructure | Repository | target-profile-management | stage-collection-repository', function () {
-  afterEach(async function () {
-    await knex('stages').delete();
-  });
-
   describe('#getByTargetProfileId', function () {
     context('when no stage exists in database', function () {
       it('should return an empty array', async function () {

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -7,11 +7,6 @@ import { NotFoundError, ObjectValidationError } from '../../../../lib/domain/err
 
 describe('Integration | Repository | Target-profile', function () {
   describe('#create', function () {
-    afterEach(async function () {
-      await knex('target-profile_tubes').delete();
-      await knex('target-profiles').delete();
-    });
-
     it('should return the id and create the target profile in database', async function () {
       // given
       databaseBuilder.factory.buildOrganization({ id: 1 });

--- a/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
@@ -9,10 +9,6 @@ describe('Integration | Repository | Target-profile-share', function () {
     let targetProfileIdB;
     let targetProfileIdC;
 
-    afterEach(function () {
-      return knex('target-profile-shares').delete();
-    });
-
     beforeEach(function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
       targetProfileIdA = databaseBuilder.factory.buildTargetProfile().id;
@@ -81,10 +77,6 @@ describe('Integration | Repository | Target-profile-share', function () {
     let targetProfileIdA;
     let targetProfileIdB;
     let targetProfileIdC;
-
-    afterEach(function () {
-      return knex('target-profile-shares').delete();
-    });
 
     beforeEach(function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;

--- a/api/tests/integration/infrastructure/repositories/target-profile-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-training-repository_test.js
@@ -12,7 +12,6 @@ describe('Integration | Repository | target-profile-training-repository', functi
     });
 
     afterEach(async function () {
-      await databaseBuilder.knex('target-profile-trainings').delete();
       clock.restore();
     });
 

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -570,10 +570,6 @@ describe('Integration | Repository | training-repository', function () {
   });
 
   describe('#create', function () {
-    afterEach(async function () {
-      await databaseBuilder.knex('trainings').delete();
-    });
-
     it('should create a training', async function () {
       // given
       const training = {

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -112,11 +112,6 @@ describe('Integration | Repository | training-trigger-repository', function () {
   });
 
   describe('#createOrUpdate', function () {
-    afterEach(async function () {
-      await databaseBuilder.knex('training-trigger-tubes').delete();
-      await databaseBuilder.knex('training-triggers').delete();
-    });
-
     context('when trigger does not exist', function () {
       it('should create training trigger', async function () {
         // when

--- a/api/tests/integration/infrastructure/repositories/tutorial-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-evaluation-repository_test.js
@@ -12,11 +12,6 @@ describe('Integration | Infrastructure | Repository | tutorialEvaluationReposito
     await databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('tutorial-evaluations').delete();
-    await knex('user-saved-tutorials').delete();
-  });
-
   describe('#createOrUpdate', function () {
     it('should store the tutorialId in the users list', async function () {
       // when

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -34,10 +34,6 @@ describe('Integration | Repository | UserLoginRepository', function () {
   });
 
   describe('#create', function () {
-    afterEach(async function () {
-      await knex(USER_LOGINS_TABLE_NAME).delete();
-    });
-
     it('should return the created user-login', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
@@ -151,7 +147,6 @@ describe('Integration | Repository | UserLoginRepository', function () {
     });
 
     afterEach(async function () {
-      await knex(USER_LOGINS_TABLE_NAME).delete();
       clock.restore();
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -5,10 +5,6 @@ import { UserRecommendedTraining } from '../../../../lib/domain/read-models/User
 
 describe('Integration | Repository | user-recommended-training-repository', function () {
   describe('#save', function () {
-    afterEach(async function () {
-      await knex('user-recommended-trainings').delete();
-    });
-
     it('should persist userRecommendedTraining', async function () {
       // given
       const userRecommendedTraining = {

--- a/api/tests/integration/infrastructure/repositories/user-saved-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-saved-tutorial-repository_test.js
@@ -10,10 +10,6 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
     await databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('user-saved-tutorials').delete();
-  });
-
   describe('#addTutorial', function () {
     const tutorialId = 'tutorialId';
 

--- a/api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js
@@ -6,10 +6,6 @@ import { UserToCreate } from '../../../../lib/domain/models/UserToCreate.js';
 
 describe('Integration | Infrastructure | Repository | UserToCreateRepository', function () {
   describe('#create', function () {
-    afterEach(async function () {
-      await knex('users').delete();
-    });
-
     it('returns a domain User object', async function () {
       // given
       const email = 'my-email-to-save@example.net';

--- a/api/tests/integration/scripts/add-tags-to-organizations_test.js
+++ b/api/tests/integration/scripts/add-tags-to-organizations_test.js
@@ -61,10 +61,6 @@ describe('Integration | Scripts | add-tags-to-organizations.js', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(function () {
-      return knex('organization-tags').delete();
-    });
-
     it('should add tags to organizations', async function () {
       // given
       const tagsByName = new Map([

--- a/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
@@ -15,7 +15,6 @@ describe('Integration | Scripts | Certification | fill-latest-assessment-result-
 
   afterEach(function () {
     clock.restore();
-    return knex(ASSOC_TABLE_NAME).delete();
   });
 
   describe('#addLastAssessmentResultCertificationCourse', function () {

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -1,4 +1,4 @@
-import { expect, databaseBuilder, knex } from '../../test-helper.js';
+import { expect, databaseBuilder } from '../../test-helper.js';
 import { Membership } from '../../../lib/domain/models/Membership.js';
 import { BookshelfCertificationCenterMembership } from '../../../lib/infrastructure/orm-models/CertificationCenterMembership.js';
 
@@ -11,14 +11,6 @@ import {
 } from '../../../scripts/create-certification-center-memberships-from-organization-admins.js';
 
 describe('Integration | Scripts | create-certification-center-memberships-from-organization-admins.js', function () {
-  afterEach(async function () {
-    await knex('certification-center-memberships').delete();
-    await knex('certification-centers').delete();
-    await knex('memberships').delete();
-    await knex('organizations').delete();
-    await knex('users').delete();
-  });
-
   function _buildUserWithAdminMembership(organizationId) {
     const userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildMembership({

--- a/api/tests/integration/scripts/data-generation/generate-campaign-with-participant_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-campaign-with-participant_test.js
@@ -43,13 +43,4 @@ describe('Integration | Scripts | generate-campaign-with-participants', function
 
     expect(participants.length).to.equal(2);
   });
-
-  afterEach(async function () {
-    await knex('answers').delete();
-    await knex('assessments').delete();
-    await knex('campaign-participations').delete();
-    await knex('organization-learners').delete();
-    await knex('campaigns').delete();
-    await knex('target-profiles').delete();
-  });
 });

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -173,10 +173,6 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       return databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('badge-acquisitions').delete();
-    });
-
     it('should compute badge acquisition for all campaign participations', async function () {
       // when
       const numberOfCreatedBadges = await computeAllBadgeAcquisitions({
@@ -318,10 +314,6 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       mockLearningContent(learningContentObjects);
 
       return databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('badge-acquisitions').delete();
     });
 
     it('should save only the validated badges not yet acquired', async function () {

--- a/api/tests/integration/scripts/prod/enable-compute-certificability-on-sco-aefe-organizations_test.js
+++ b/api/tests/integration/scripts/prod/enable-compute-certificability-on-sco-aefe-organizations_test.js
@@ -3,10 +3,6 @@ import { enableComputeCertificabilityOnScoAefeOrganizations } from '../../../../
 import * as apps from '../../../../lib/domain/constants.js';
 
 describe('Integration | Scripts | enable-compute-certificability-on-sco-organizations-that-manages-students_test.js', function () {
-  afterEach(function () {
-    return knex('organization-features').delete();
-  });
-
   it('should enable COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY feature on organizations of type SCO with tag AEFE to true', async function () {
     // given
     databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);

--- a/api/tests/integration/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students_test.js
+++ b/api/tests/integration/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students_test.js
@@ -3,10 +3,6 @@ import { enableComputeCertificabilityOnScoOrganizationsThatManageStudents } from
 import * as apps from '../../../../lib/domain/constants.js';
 
 describe('Integration | Scripts | enable-compute-certificability-on-sco-organizations-that-manages-students_test.js', function () {
-  afterEach(function () {
-    return knex('organization-features').delete();
-  });
-
   it('should enable COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY feature on organizations of type SCO with isManagingStudents to true', async function () {
     // given
     databaseBuilder.factory.buildFeature(apps.ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);

--- a/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
+++ b/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
@@ -17,10 +17,6 @@ describe('Integration | Scripts | select-category-for-target-profiles.js', funct
     await databaseBuilder.commit();
   });
 
-  afterEach(async function () {
-    await knex('target-profiles').delete();
-  });
-
   describe('#setCategoryToTargetProfiles', function () {
     it('should set category on target profiles', async function () {
       const targetProfilesId = [firstTargetProfileId, secondTargetProfileId];

--- a/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sup-organization-learners_test.js
@@ -16,10 +16,6 @@ describe('Acceptance | Application | organization-controller-import-sup-organiza
     server = await createServer();
   });
 
-  afterEach(function () {
-    return knex('organization-learners').delete();
-  });
-
   describe('POST organizations/:id/sup-organization-learners/import-csv', function () {
     let connectedUser;
     beforeEach(async function () {

--- a/api/tests/prescription/learner-management/acceptance/application/organization-controller-replace-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-controller-replace-sup-organization-learners_test.js
@@ -16,10 +16,6 @@ describe('Acceptance | Application | organization-controller-replace-sup-organiz
     server = await createServer();
   });
 
-  afterEach(function () {
-    return knex('organization-learners').delete();
-  });
-
   describe('POST organizations/:id/sup-organization-learners/replace-csv', function () {
     let connectedUser;
     beforeEach(async function () {

--- a/api/tests/prescription/learner-management/integration/domain/usecases/import-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/integration/domain/usecases/import-sup-organization-learners_test.js
@@ -14,10 +14,6 @@ const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeade
   .join(';');
 
 describe('Integration | UseCase | ImportSupOrganizationLearner', function () {
-  afterEach(function () {
-    return knex('organization-learners').delete();
-  });
-
   context('when there is no organization learners for the organization', function () {
     it('parses the csv received and creates the SupOrganizationLearner', async function () {
       const input = `${supOrganizationLearnerImportHeader}

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/sup-organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/sup-organization-learner-repository_test.js
@@ -205,10 +205,6 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
   });
 
   describe('#addStudents', function () {
-    afterEach(function () {
-      return knex('organization-learners').delete();
-    });
-
     context('when there is no organization learners for the given organizationId and student number', function () {
       it('creates the organization-learner', async function () {
         const organization = databaseBuilder.factory.buildOrganization();
@@ -338,11 +334,6 @@ describe('Integration | Infrastructure | Repository | sup-organization-learner-r
       organization = databaseBuilder.factory.buildOrganization();
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('campaign-participations').delete();
-      return knex('organization-learners').delete();
     });
 
     context('when there is no organization learners for the given organizationId and student number', function () {

--- a/api/tests/school/integration/domain/usecases/create-mission-assessment_test.js
+++ b/api/tests/school/integration/domain/usecases/create-mission-assessment_test.js
@@ -16,11 +16,6 @@ describe('Integration | UseCases | create-mission-assessment', function () {
     };
   });
 
-  afterEach(async function () {
-    await knex('mission-assessments').where({ missionId }).delete();
-    await knex('assessments').delete();
-  });
-
   it('should save a new assessment for Pix1D', async function () {
     const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
     await databaseBuilder.commit();

--- a/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
@@ -89,13 +89,6 @@ describe('Integration | Usecase | get-next-challenge', function () {
       mockLearningContent(learningContent);
     });
 
-    afterEach(async function () {
-      await knex('activity-answers').delete();
-      await knex('activities').delete();
-      await knex('mission-assessments').where({ assessmentId }).delete();
-      await knex('assessments').where({ id: assessmentId }).delete();
-    });
-
     context('when the user starts a mission with a challenge without alternative version', function () {
       beforeEach(async function () {
         assessmentId = databaseBuilder.factory.buildMissionAssessment({ missionId }).assessmentId;

--- a/api/tests/school/integration/scripts/create-school-learners_tests.js
+++ b/api/tests/school/integration/scripts/create-school-learners_tests.js
@@ -8,11 +8,6 @@ import { Organization } from '../../../../lib/domain/models/Organization.js';
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 
 describe('Integration | Script | create school learners', function () {
-  afterEach(async function () {
-    await knex('organization-learners').delete();
-    await knex('schools').delete();
-    await knex('organizations').delete();
-  });
   describe('#buildSchool', function () {
     it('should create a school with a code', async function () {
       const organization = await buildSchoolOrganization({ name: 'Bambino' });

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -8,12 +8,6 @@ import { Assessment } from '../../../../../src/shared/domain/models/Assessment.j
 import { AssessmentResult } from '../../../../../lib/domain/models/AssessmentResult.js';
 
 describe('Integration | Infrastructure | Repositories | assessment-repository', function () {
-  afterEach(async function () {
-    await knex('answers').delete();
-    await knex('assessment-results').delete();
-    return knex('assessments').delete();
-  });
-
   describe('#getWithAnswers', function () {
     let assessmentId;
 

--- a/api/tests/shared/prescriber-management/integration/domain/usecases/get-prescriber_test.js
+++ b/api/tests/shared/prescriber-management/integration/domain/usecases/get-prescriber_test.js
@@ -8,10 +8,6 @@ import { getPrescriber } from '../../../../../../src/shared/prescriber-managemen
 
 describe('Integration | UseCases | get-prescriber', function () {
   context('When prescriber does not have a userOrgaSettings', function () {
-    afterEach(function () {
-      return knex('user-orga-settings').delete();
-    });
-
     it("should create it with the first membership's organization", async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/shared/prescriber-management/integration/infrasctructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/shared/prescriber-management/integration/infrasctructure/repositories/user-orga-settings-repository_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { catchErr, expect, knex, databaseBuilder } from '../../../../../test-helper.js';
+import { catchErr, expect, databaseBuilder } from '../../../../../test-helper.js';
 import { UserOrgaSettings } from '../../../../../../lib/domain/models/UserOrgaSettings.js';
 import { BookshelfUserOrgaSettings } from '../../../../../../lib/infrastructure/orm-models/UserOrgaSettings.js';
 import { UserOrgaSettingsCreationError } from '../../../../../../lib/domain/errors.js';
@@ -41,10 +41,6 @@ describe('Integration | Repository | UserOrgaSettings', function () {
     user = databaseBuilder.factory.buildUser();
     organization = databaseBuilder.factory.buildOrganization();
     await databaseBuilder.commit();
-  });
-
-  afterEach(async function () {
-    await knex('user-orga-settings').delete();
   });
 
   describe('#create', function () {

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import { expect, sinon, hFake } from '../../../test-helper.js';
-// eslint-disable-next-line  import/no-restricted-paths
 import { knex } from '../../../../db/knex-database-connection.js';
 import { redisMonitor } from '../../../../lib/infrastructure/utils/redis-monitor.js';
 import { healthcheckController } from '../../../../lib/application/healthcheck/healthcheck-controller.js';

--- a/api/tests/unit/tooling/database-builder/database-buffer_test.js
+++ b/api/tests/unit/tooling/database-builder/database-buffer_test.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import { expect } from '../../../test-helper.js';
-// eslint-disable-next-line  import/no-restricted-paths
 import { databaseBuffer } from '../../../../db/database-builder/database-buffer.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-buffer', function () {

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, catchErr } from '../../../test-helper.js';
-// eslint-disable-next-line  import/no-restricted-paths
+
 import { DatabaseBuilder } from '../../../../db/database-builder/database-builder.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
@@ -10,7 +10,7 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
 
     beforeEach(function () {
       sandbox = sinon.createSandbox();
-      knex = { raw: sinon.stub().resolves() };
+      knex = { raw: sinon.stub().resolves(), on: sinon.stub() };
       databaseBuilder = new DatabaseBuilder({ knex });
       sandbox.spy(databaseBuilder.databaseBuffer);
     });
@@ -22,7 +22,6 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
 
     it('should delete content of all tables in databaseBuffer set for deletion when there are some', async function () {
       // given
-      const knex = { raw: sinon.stub().resolves() };
       const databaseBuilder = new DatabaseBuilder({ knex });
       databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [
         {
@@ -48,7 +47,6 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
 
     it('should avoid deleting anything if not table are set for deletion in database buffer', async function () {
       // given
-      const knex = { raw: sinon.stub().resolves() };
       const databaseBuilder = new DatabaseBuilder({ knex });
 
       // when
@@ -60,7 +58,6 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
 
     it('should reset the dirtyness map', async function () {
       // given
-      const knex = { raw: sinon.stub().resolves() };
       const databaseBuilder = new DatabaseBuilder({ knex });
       databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [
         {
@@ -99,7 +96,6 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
 
     it('should purge the databasebuffer', async function () {
       // given
-      const knex = { raw: sinon.stub().resolves() };
       const databaseBuilder = new DatabaseBuilder({ knex });
 
       // when
@@ -137,6 +133,7 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
           raw: sinon.stub(),
           client: { database: sinon.stub().returns() },
           transaction: sinon.stub().resolves(trxStub),
+          on: sinon.stub(),
         };
         knex.raw.onCall(0).resolves({
           rows: [{ table_name: 'table2' }, { table_name: 'knex_migrations' }, { table_name: 'table1' }],

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
 import { expect, sinon, catchErr } from '../../../test-helper.js';
-
 import { DatabaseBuilder } from '../../../../db/database-builder/database-builder.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, lors d'un test d'intégration ou d'acceptance, si une insertion est faite en base de données via un repository, le databaseBuilder n'a pas connaissance de cette modification et donc ne mettra pas cette table en `dirty` pour le nettoyage à la fin du test.

Cela entraîne l'ajout d'un `afterEach` pour supprimer manuellement la table.

Il serait agréable pour l'expérience des développeurs.euses de ne pas devoir penser à faire ce nettoyage manuel.

## :robot: Proposition

Ajouter un `listener` sur knex pour mettre la table où une action d'insertion est faite en `dirty` au niveau du databaseBuilder, pour permettre au databaseBuilder de faire le nettoyage automatiquement.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Vérifier que tous les tests passent ✅ 
