### PR TITLE
[TECH] JSDoc pour naviguer vers les dépendances injectées automatiquement (PIX-9938).

### DIFF
--- a/api/src/certification/session/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/src/certification/session/domain/usecases/add-certification-candidate-to-session.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ */
+
 import {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateOnFinalizedSessionError,
@@ -6,6 +10,14 @@ import {
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../lib/domain/constants/certification-candidates-errors.js';
 
+/**
+ * @param {Object} params
+ * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {deps['certificationCandidateRepository']} params.certificationCandidateRepository
+ * @param {deps['certificationCpfService']} params.certificationCpfService
+ * @param {deps['certificationCpfCountryRepository']} params.certificationCpfCountryRepository
+ * @param {deps['certificationCpfCityRepository']} params.certificationCpfCityRepository
+ */
 const addCertificationCandidateToSession = async function ({
   sessionId,
   certificationCandidate,

--- a/api/src/certification/session/domain/usecases/create-session.js
+++ b/api/src/certification/session/domain/usecases/create-session.js
@@ -1,9 +1,5 @@
 /**
- * @typedef {import ('../../../shared/infrastructure/repositories/certification-center-repository.js')} certificationCenterRepository
- * @typedef {import ('../../../session/infrastructure/repositories/session-repository.js')} sessionRepository
- * @typedef {import ('../../../../../src/shared/infrastructure/repositories/user-repository.js')} userRepository
- * @typedef {import ('../../../session/domain/validators/session-validator.js')} sessionValidator
- * @typedef {import ('../../../session/domain/services/session-code-service.js')} sessionCodeService
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 
 import { Session } from '../models/Session.js';
@@ -11,12 +7,12 @@ import { CertificationVersion } from '../../../../shared/domain/models/Certifica
 import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} deps
- * @param {certificationCenterRepository} deps.certificationCenterRepository
- * @param {sessionRepository} deps.sessionRepository
- * @param {userRepository} deps.userRepository
- * @param {sessionValidator} deps.sessionValidator
- * @param {sessionCodeService} deps.sessionCodeService
+ * @param {Object} params
+ * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
+ * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {deps['userRepository']} params.userRepository
+ * @param {deps['sessionValidator']} params.sessionValidator
+ * @param {deps['sessionCodeService']} params.sessionCodeService
  */
 const createSession = async function ({
   userId,

--- a/api/src/certification/session/domain/usecases/create-session.js
+++ b/api/src/certification/session/domain/usecases/create-session.js
@@ -1,7 +1,23 @@
+/**
+ * @typedef {import ('../../../shared/infrastructure/repositories/certification-center-repository.js')} certificationCenterRepository
+ * @typedef {import ('../../../session/infrastructure/repositories/session-repository.js')} sessionRepository
+ * @typedef {import ('../../../../../src/shared/infrastructure/repositories/user-repository.js')} userRepository
+ * @typedef {import ('../../../session/domain/validators/session-validator.js')} sessionValidator
+ * @typedef {import ('../../../session/domain/services/session-code-service.js')} sessionCodeService
+ */
+
 import { Session } from '../models/Session.js';
 import { CertificationVersion } from '../../../../shared/domain/models/CertificationVersion.js';
 import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
 
+/**
+ * @param {Object} deps
+ * @param {certificationCenterRepository} deps.certificationCenterRepository
+ * @param {sessionRepository} deps.sessionRepository
+ * @param {userRepository} deps.userRepository
+ * @param {sessionValidator} deps.sessionValidator
+ * @param {sessionCodeService} deps.sessionCodeService
+ */
 const createSession = async function ({
   userId,
   session,

--- a/api/src/certification/session/domain/usecases/dismiss-live-alert.js
+++ b/api/src/certification/session/domain/usecases/dismiss-live-alert.js
@@ -1,12 +1,12 @@
 /**
- * @typedef {import ('../../../session//infrastructure/repositories/certification-challenge-live-alert-repository.js')} certificationChallengeLiveAlertRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
 /**
- * @param {Object} deps
- * @param {certificationChallengeLiveAlertRepository} deps.certificationChallengeLiveAlertRepository
+ * @param {Object} params
+ * @param {deps['certificationChallengeLiveAlertRepository']} params.certificationChallengeLiveAlertRepository
  */
 export const dismissLiveAlert = async ({ userId, sessionId, certificationChallengeLiveAlertRepository }) => {
   const certificationChallengeLiveAlert =

--- a/api/src/certification/session/domain/usecases/dismiss-live-alert.js
+++ b/api/src/certification/session/domain/usecases/dismiss-live-alert.js
@@ -1,5 +1,13 @@
+/**
+ * @typedef {import ('../../../session//infrastructure/repositories/certification-challenge-live-alert-repository.js')} certificationChallengeLiveAlertRepository
+ */
+
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
+/**
+ * @param {Object} deps
+ * @param {certificationChallengeLiveAlertRepository} deps.certificationChallengeLiveAlertRepository
+ */
 export const dismissLiveAlert = async ({ userId, sessionId, certificationChallengeLiveAlertRepository }) => {
   const certificationChallengeLiveAlert =
     await certificationChallengeLiveAlertRepository.getOngoingBySessionIdAndUserId({

--- a/api/src/certification/session/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/session/domain/usecases/get-attendance-sheet.js
@@ -1,18 +1,14 @@
 /**
- * @typedef {import ('../../../../../lib/infrastructure/plugins/i18n.js')} i18n
- * @typedef {import ('../../../session/infrastructure/repositories/session-repository.js')} sessionRepository
- * @typedef {import ('../../../session/infrastructure/repositories/session-for-attendance-sheet-repository.js')} sessionForAttendanceSheetRepository
- * @typedef {import ('../../../session/infrastructure/utils/pdf/attendance-sheet-pdf.js')} attendanceSheetPdfUtils
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} deps
- * @param {i18n} deps.i18n
- * @param {sessionRepository} deps.sessionRepository
- * @param {sessionForAttendanceSheetRepository} deps.sessionForAttendanceSheetRepository
- * @param {attendanceSheetPdfUtils} deps.attendanceSheetPdfUtils
+ * @param {Object} params
+ * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {deps['sessionForAttendanceSheetRepository']} params.sessionForAttendanceSheetRepository
+ * @param {deps['attendanceSheetPdfUtils']} params.attendanceSheetPdfUtils
  */
 const getAttendanceSheet = async function ({
   userId,

--- a/api/src/certification/session/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/session/domain/usecases/get-attendance-sheet.js
@@ -1,5 +1,19 @@
+/**
+ * @typedef {import ('../../../../../lib/infrastructure/plugins/i18n.js')} i18n
+ * @typedef {import ('../../../session/infrastructure/repositories/session-repository.js')} sessionRepository
+ * @typedef {import ('../../../session/infrastructure/repositories/session-for-attendance-sheet-repository.js')} sessionForAttendanceSheetRepository
+ * @typedef {import ('../../../session/infrastructure/utils/pdf/attendance-sheet-pdf.js')} attendanceSheetPdfUtils
+ */
+
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
+/**
+ * @param {Object} deps
+ * @param {i18n} deps.i18n
+ * @param {sessionRepository} deps.sessionRepository
+ * @param {sessionForAttendanceSheetRepository} deps.sessionForAttendanceSheetRepository
+ * @param {attendanceSheetPdfUtils} deps.attendanceSheetPdfUtils
+ */
 const getAttendanceSheet = async function ({
   userId,
   sessionId,

--- a/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
+++ b/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
@@ -1,5 +1,15 @@
+/**
+ * @typedef {import ('../../../session/infrastructure/repositories/session-repository.js')} sessionRepository
+ * @typedef {import ('../../../session/infrastructure/repositories/session-for-invigilator-kit-repository.js')} sessionForInvigilatorKitRepository
+ */
+
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
+/**
+ * @param {Object} deps
+ * @param {sessionRepository} deps.sessionRepository
+ * @param {sessionForInvigilatorKitRepository} deps.sessionForInvigilatorKitRepository
+ */
 const getInvigilatorKitSessionInfo = async function ({
   userId,
   sessionId,

--- a/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
+++ b/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
@@ -1,14 +1,13 @@
 /**
- * @typedef {import ('../../../session/infrastructure/repositories/session-repository.js')} sessionRepository
- * @typedef {import ('../../../session/infrastructure/repositories/session-for-invigilator-kit-repository.js')} sessionForInvigilatorKitRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
 /**
- * @param {Object} deps
- * @param {sessionRepository} deps.sessionRepository
- * @param {sessionForInvigilatorKitRepository} deps.sessionForInvigilatorKitRepository
+ * @param {Object} params
+ * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {deps['sessionForInvigilatorKitRepository']} params.sessionForInvigilatorKitRepository
  */
 const getInvigilatorKitSessionInfo = async function ({
   userId,

--- a/api/src/certification/session/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session/domain/usecases/validate-live-alert.js
@@ -1,19 +1,16 @@
 /**
- * @typedef {import ('../../../session/infrastructure/repositories/certification-challenge-live-alert-repository.js')} certificationChallengeLiveAlertRepository
- * @typedef {import ('../../../../../src/shared/infrastructure/repositories/assessment-repository.js')} assessmentRepository
- * @typedef {import ('../../../shared/infrastructure/repositories/issue-report-category-repository.js')} issueReportCategoryRepository
- * @typedef {import ('../../../shared/infrastructure/repositories/certification-issue-report-repository.js')} certificationIssueReportRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { CertificationIssueReport, CertificationIssueReportCategory } from '../../../../../lib/domain/models/index.js';
 
 /**
- * @param {Object} deps
- * @param {certificationChallengeLiveAlertRepository} deps.certificationChallengeLiveAlertRepository
- * @param {assessmentRepository} deps.assessmentRepository
- * @param {issueReportCategoryRepository} deps.issueReportCategoryRepository
- * @param {certificationIssueReportRepository} deps.certificationIssueReportRepository
+ * @param {Object} params
+ * @param {deps['certificationChallengeLiveAlertRepository']} params.certificationChallengeLiveAlertRepository
+ * @param {deps['assessmentRepository']} params.assessmentRepository
+ * @param {deps['issueReportCategoryRepository']} params.issueReportCategoryRepository
+ * @param {deps['certificationIssueReportRepository']} params.certificationIssueReportRepository
  */
 export const validateLiveAlert = async ({
   userId,

--- a/api/src/certification/session/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session/domain/usecases/validate-live-alert.js
@@ -1,6 +1,20 @@
+/**
+ * @typedef {import ('../../../session/infrastructure/repositories/certification-challenge-live-alert-repository.js')} certificationChallengeLiveAlertRepository
+ * @typedef {import ('../../../../../src/shared/infrastructure/repositories/assessment-repository.js')} assessmentRepository
+ * @typedef {import ('../../../shared/infrastructure/repositories/issue-report-category-repository.js')} issueReportCategoryRepository
+ * @typedef {import ('../../../shared/infrastructure/repositories/certification-issue-report-repository.js')} certificationIssueReportRepository
+ */
+
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { CertificationIssueReport, CertificationIssueReportCategory } from '../../../../../lib/domain/models/index.js';
 
+/**
+ * @param {Object} deps
+ * @param {certificationChallengeLiveAlertRepository} deps.certificationChallengeLiveAlertRepository
+ * @param {assessmentRepository} deps.assessmentRepository
+ * @param {issueReportCategoryRepository} deps.issueReportCategoryRepository
+ * @param {certificationIssueReportRepository} deps.certificationIssueReportRepository
+ */
 export const validateLiveAlert = async ({
   userId,
   sessionId,

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -31,6 +31,37 @@ import * as userRepository from '../../../../../src/shared/infrastructure/reposi
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ *
+ * @typedef {{
+ *  assessmentRepository : assessmentRepository,
+ *  attendanceSheetPdfUtils : attendanceSheetPdfUtils,
+ *  badgeRepository : badgeRepository,
+ *  certificationCandidateRepository : certificationCandidateRepository,
+ *  certificationCenterRepository : certificationCenterRepository,
+ *  certificationChallengeLiveAlertRepository : certificationChallengeLiveAlertRepository,
+ *  certificationCpfService : certificationCpfService,
+ *  certificationIssueReportRepository : certificationIssueReportRepository,
+ *  challengeRepository : challengeRepository,
+ *  certificationCpfCityRepository : certificationCpfCityRepository,
+ *  certificationCpfCountryRepository : certificationCpfCountryRepository,
+ *  complementaryCertificationBadgesRepository : complementaryCertificationBadgesRepository,
+ *  complementaryCertificationRepository : complementaryCertificationRepository,
+ *  complementaryCertificationForTargetProfileAttachmentRepository : complementaryCertificationForTargetProfileAttachmentRepository,
+ *  complementaryCertificationTargetProfileHistoryRepository : complementaryCertificationTargetProfileHistoryRepository,
+ *  flashAlgorithmService : flashAlgorithmService,
+ *  issueReportCategoryRepository : issueReportCategoryRepository,
+ *  mailService : mailService,
+ *  organizationRepository : organizationRepository,
+ *  sessionCodeService : sessionCodeService,
+ *  sessionForAttendanceSheetRepository : sessionForAttendanceSheetRepository,
+ *  sessionForInvigilatorKitRepository : sessionForInvigilatorKitRepository,
+ *  sessionRepository : sessionRepository,
+ *  sessionValidator : sessionValidator,
+ *  userRepository : userRepository,
+ * }} dependencies
+ */
 const dependencies = {
   assessmentRepository,
   attendanceSheetPdfUtils,
@@ -81,4 +112,7 @@ const usecasesWithoutInjectedDependencies = {
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
+/**
+ * @typedef {dependencies} dependencies
+ */
 export { usecases };


### PR DESCRIPTION
## :unicorn: Problème
Les usecases ont des dépendances qui sont injectés.

Le manque d'import fait qu'il est long de retrouver le fichier d'une dépendance injectée. De même l'auto-complétion est hasardeuse, si pas non fonctionnelle.

Il est parfois compliqué de retrouver le fichier, qui plus est la méthode, que l'on utilise dans un usecase quand cela vient d'un paramètre injecté.

## :robot: Proposition

Utiliser JSDoc pour indiquer aux outils (et à nous développeurs) quel chemin suivre pour accéder aux references sortantes quand elles sont injectées.

Avec usage de la fonction import trouvée ici: https://github.com/jsdoc/jsdoc/issues/1537

Ca tire partie de la version TypeScript de la JSDoc, qui est supporté out-of-the-box par les IDE. La documentation se trouve alors là : https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html

Il y a une suggestion pour une implémentation "pure" JSDOC dans l'issue, qui pointe ici : https://stackoverflow.com/a/55767692 
Je n'ai pas tenté la version pure JSDoc du coup, car la version import me convenait bien et que ça apportait la flexibilité de le nommage et l'aliasing des dépendances dans le fichier d'injection des dépendances.

## :rainbow: Remarques
* Le but n'est pas d'apporter du typage, mais de pointer vers des références qui s'auto documentent actuellement
* Cette PR couvre le contexte de session du bounded context certification
* Refonte complète suite au [commentaire](https://github.com/1024pix/pix/pull/7445#discussion_r1392600035) de @Sims07 ; je garde cela en deux commit pour voir l'évolution de la solution proposée
## :100: Pour tester

* Ouvrir un usecase qui ne contient pas de `@typedef`, par exemple `api/lib/domain/usecases/abort-certification-course.js`
  * A partir de ce fichier naviguer vers  les implémentations des dépendances injectées, par exemple `abort` et `get`
  * Tenter de répondre aux questions suivantes, et mémoriser l'expérience pour y répondre
    * pouvez-vous savoir le type de retour de `const certificationCourse` sans aller dans le repository ?
    * essayez désormais de naviguer jusqu'au repository pour y répondre, comment avez-vous trouvé le repository ?
    * depuis le usecase, sans regarder le repository, pouvez-vous trouver la fin via de l'auto-complétion de ceci : `certificationCourseRepository.findOneCertificationCourseByU` ?
    * essayez désormais de répondre à la question en naviguant jusqu'au repository
  
* Ouvrir l'un des fichiers de cette PR contenant des `@typedef`
  * Répétez le même exercice, par exemple `api/src/certification/session/domain/usecases/validate-live-alert.js`
  * Testez de voir si vous pouvez suivre les liens
    * dans les imports en haut du fichier (les `@typedef`)
    * dans le corps du usecase, survolez les méthodes, par exemple sur `getOngoingBySessionIdAndUserId`
    *  voyez si vous pouvez désormais voir les types de retours attendus, et les paramètres des méthodes
    * survolez les variables, par exemple qui await une dépendance, et voyez si vous pouvez savoir quel est leur type supposé
    * tentez éventuellement des autocomplétions, par exemple, essayez d'appeler `certificationChallengeLiveAlertRepository.getByAssessmentId` via autocomplétion de votre outil
    
  
### Exemple sous VSCode


![image](https://github.com/1024pix/pix/assets/170271/046fee17-d2b6-4008-8bb6-d238447649dc)

![image](https://github.com/1024pix/pix/assets/170271/4350b5bb-3a1c-47bd-bd18-bc84eef03fa8)

![image](https://github.com/1024pix/pix/assets/170271/c106c52d-0b96-4e48-9e4d-e287ea9c60ca)

![image](https://github.com/1024pix/pix/assets/170271/a8f2f325-1d06-4e30-8553-a768b4d81a66)

