### PR TITLE
[BUGFIX] Corriger les seeds

### DIFF
--- a/api/db/seeds/data/common/tooling/learning-content.js
+++ b/api/db/seeds/data/common/tooling/learning-content.js
@@ -16,7 +16,7 @@ async function getAllCompetences() {
 
 async function getAllChallenges() {
   if (!ALL_CHALLENGES) {
-    ALL_CHALLENGES = await challengeRepository.list();
+    ALL_CHALLENGES = await challengeRepository.list('fr-fr');
   }
   return ALL_CHALLENGES;
 }


### PR DESCRIPTION
## :unicorn: Problème
Les seeds sont actuellement cassé car un appel a `challengeRepository.list` n'inclue pas de locale, rendu obligatoire dans #7396.

## :robot: Proposition
Injecter la locale `fr-fr` qui contient tout les challenges nécessaire pour les seeds.

## :100: Pour tester

`npm run db:seed`
