### PR TITLE
[FEATURE] Cacher l'onglet "Neutralisation" pour les certifs v3 dans Pix Admin (PIX-9942)

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -102,6 +102,10 @@ export default class Certification extends Model {
     return !this.sex;
   }
 
+  get isV3() {
+    return this.version === 3;
+  }
+
   wasBornInFrance() {
     return this.birthCountry === 'FRANCE';
   }

--- a/admin/app/templates/authenticated/certifications/certification.hbs
+++ b/admin/app/templates/authenticated/certifications/certification.hbs
@@ -3,9 +3,11 @@
   <LinkTo @route="authenticated.certifications.certification.informations" @model={{@model.id}} class="navbar-item">
     Informations
   </LinkTo>
-  <LinkTo @route="authenticated.certifications.certification.neutralization" class="navbar-item">
-    Neutralisation
-  </LinkTo>
+  {{#unless @model.isV3}}
+    <LinkTo @route="authenticated.certifications.certification.neutralization" class="navbar-item">
+      Neutralisation
+    </LinkTo>
+  {{/unless}}
   <LinkTo @route="authenticated.certifications.certification.details" @model={{@model.id}} class="navbar-item">
     Détails
   </LinkTo>

--- a/admin/app/templates/authenticated/certifications/certification.hbs
+++ b/admin/app/templates/authenticated/certifications/certification.hbs
@@ -9,11 +9,11 @@
   <LinkTo @route="authenticated.certifications.certification.details" @model={{@model.id}} class="navbar-item">
     Détails
   </LinkTo>
-  {{#if (eq @model.version 2)}}
+  {{#unless @model.isV3}}
     <LinkTo @route="authenticated.certifications.certification.profile" @model={{@model.id}} class="navbar-item">
       Profil
     </LinkTo>
-  {{/if}}
+  {{/unless}}
 </nav>
 <section>
   {{outlet}}

--- a/admin/tests/acceptance/authenticated/certifications/certification/certification_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/certification_test.js
@@ -39,6 +39,37 @@ module('Acceptance | Route | routes/authenticated/certifications/certification',
       // then
       assert.dom(screen.queryByRole('link', { name: 'Profil' })).doesNotExist();
     });
+
+    test('it should not display the neutralization tab', async function (assert) {
+      // given
+      this.server.create('user', { id: 888 });
+
+      const certification = this.server.create('certification', {
+        id: 123,
+        firstName: 'Bora Horza',
+        lastName: 'Gobuchul',
+        birthdate: '1987-07-24',
+        birthplace: 'Sorpen',
+        userId: 888,
+        sex: 'M',
+        isCancelled: false,
+        birthCountry: 'JAPON',
+        birthInseeCode: '99217',
+        birthPostalCode: null,
+        competencesWithMark: [],
+        listChallengesAndAnswers: [],
+        createdAt: new Date('2020-01-01'),
+        version: 3,
+      });
+
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: 'Neutralisation' })).doesNotExist();
+    });
   });
 
   module('when certification is V2', function () {
@@ -71,6 +102,37 @@ module('Acceptance | Route | routes/authenticated/certifications/certification',
 
       // then
       assert.dom(screen.getByRole('link', { name: 'Profil' })).exists();
+    });
+
+    test('it should display the neutralization tab', async function (assert) {
+      // given
+      this.server.create('user', { id: 888 });
+
+      const certification = this.server.create('certification', {
+        id: 123,
+        firstName: 'Bora Horza',
+        lastName: 'Gobuchul',
+        birthdate: '1987-07-24',
+        birthplace: 'Sorpen',
+        userId: 888,
+        sex: 'M',
+        isCancelled: false,
+        birthCountry: 'JAPON',
+        birthInseeCode: '99217',
+        birthPostalCode: null,
+        competencesWithMark: [],
+        listChallengesAndAnswers: [],
+        createdAt: new Date('2020-01-01'),
+        version: 2,
+      });
+
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Neutralisation' })).exists();
     });
   });
 });

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -250,6 +250,24 @@ module('Unit | Model | certification', function (hooks) {
     });
   });
 
+  module('#get isV3', function () {
+    test('it should return false if version is not 3', function (assert) {
+      // given
+      const certification = store.createRecord('certification', { version: 2 });
+
+      // then
+      assert.false(certification.isV3);
+    });
+
+    test('it should return true if version is 3', function (assert) {
+      // given
+      const certification = store.createRecord('certification', { version: 3 });
+
+      // then
+      assert.true(certification.isV3);
+    });
+  });
+
   module('#getInformation', function () {
     test('it should return the certification candidate information', function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la nouvelle certification, les signalements en cas de problème technique sur une question se font directement en session. Si un signalement est accepté, le candidat se voit proposer une nouvelle question. Il n’est donc plus nécessaire de pouvoir neutraliser une question a posteriori car tout se fait en direct pendant la session.

## :robot: Proposition
Dans Pix admin > page de détails d’une certification > uniquement pour les certif v3 (ne rien modifier pour les certifs v2) : supprimer l’onglet “Neutralisation”

## :100: Pour tester
- Se connecter sur pix admin
- Vérifier le détail d'une certification v3
- Constater que l'onglet Neutralisation ne s'affiche pas 

Avant: 

![image](https://github.com/1024pix/pix/assets/37305474/d4401718-3414-45e4-b74a-ff49cb7f3057)


Après :

![image](https://github.com/1024pix/pix/assets/37305474/a37006aa-d5d9-410b-a7ca-4985db76070d)
