### PR TITLE
[TECH] Migration du modèle challenge et challenge-repository de shared certif vers le global (PIX-9966).

### DIFF
--- a/api/db/seeds/data/common/tooling/learning-content.js
+++ b/api/db/seeds/data/common/tooling/learning-content.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as challengeRepository from '../../../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { skillDatasource } from '../../../../../lib/infrastructure/datasources/learning-content/skill-datasource.js';
 
 let ALL_COMPETENCES, ALL_ACTIVE_SKILLS, ALL_CHALLENGES, ACTIVE_SKILLS_BY_COMPETENCE, ACTIVE_SKILLS_BY_TUBE;

--- a/api/lib/application/challenges/challenge-controller.js
+++ b/api/lib/application/challenges/challenge-controller.js
@@ -1,4 +1,4 @@
-import * as challengeRepository from '../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as challengeSerializer from '../../infrastructure/serializers/jsonapi/challenge-serializer.js';
 
 const get = async function (request, h, dependencies = { challengeRepository, challengeSerializer }) {

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -20,7 +20,7 @@ import * as certificationAssessmentRepository from '../../infrastructure/reposit
 import * as certificationCenterRepository from '../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
-import * as challengeRepository from '../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceMarkRepository from '../../infrastructure/repositories/competence-mark-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';

--- a/api/lib/domain/models/CertificationChallengeWithType.js
+++ b/api/lib/domain/models/CertificationChallengeWithType.js
@@ -1,4 +1,4 @@
-import { Type } from './Challenge.js';
+import { Type } from '../../../src/shared/domain/models/Challenge.js';
 
 class CertificationChallengeWithType {
   constructor({

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -54,7 +54,7 @@ import { CertificationReport } from './CertificationReport.js';
 import { CertificationResult } from './CertificationResult.js';
 import { CertifiedLevel } from './CertifiedLevel.js';
 import { CertifiedScore } from './CertifiedScore.js';
-import { Challenge } from './Challenge.js';
+import { Challenge } from '../../../src/shared/domain/models/Challenge.js';
 import { Competence } from '../../../src/shared/domain/models/Competence.js';
 import { CompetenceEvaluation } from '../../../src/evaluation/domain/models/CompetenceEvaluation.js';
 import { CompetenceMark } from './CompetenceMark.js';

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -11,7 +11,7 @@ import {
 import { KnowledgeElement } from '../models/KnowledgeElement.js';
 import { Challenge } from '../models/Challenge.js';
 
-import * as challengeRepository from '../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as answerRepository from '../../../src/evaluation/infrastructure/repositories/answer-repository.js';
 import * as knowledgeElementRepository from '../../infrastructure/repositories/knowledge-element-repository.js';
 import * as learningContentRepository from '../../infrastructure/repositories/learning-content-repository.js';

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -9,7 +9,7 @@ import {
 } from '../constants.js';
 
 import { KnowledgeElement } from '../models/KnowledgeElement.js';
-import { Challenge } from '../models/Challenge.js';
+import { Challenge } from '../../../src/shared/domain/models/Challenge.js';
 
 import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as answerRepository from '../../../src/evaluation/infrastructure/repositories/answer-repository.js';

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -74,7 +74,7 @@ import * as certificationPointOfContactRepository from '../../infrastructure/rep
 import * as certificationReportRepository from '../../infrastructure/repositories/certification-report-repository.js';
 import * as certificationRepository from '../../infrastructure/repositories/certification-repository.js';
 import * as certificationResultRepository from '../../infrastructure/repositories/certification-result-repository.js';
-import * as challengeRepository from '../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as cleaCertifiedCandidateRepository from '../../infrastructure/repositories/clea-certified-candidate-repository.js';
 import * as codeUtils from '../../infrastructure/utils/code-utils.js';
 import * as competenceEvaluationRepository from '../../../src/evaluation/infrastructure/repositories/competence-evaluation-repository.js';

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -3,7 +3,7 @@ import { DomainTransaction } from '../DomainTransaction.js';
 import { CertificationAssessment } from '../../domain/models/CertificationAssessment.js';
 import { CertificationChallengeWithType } from '../../domain/models/CertificationChallengeWithType.js';
 import { Answer } from '../../../src/evaluation/domain/models/Answer.js';
-import * as challengeRepository from '../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as answerStatusDatabaseAdapter from '../adapters/answer-status-database-adapter.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../domain/errors.js';

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -5,7 +5,7 @@ import { Hint } from '../../domain/models/Hint.js';
 import { challengeDatasource } from '../datasources/learning-content/challenge-datasource.js';
 import { skillDatasource } from '../datasources/learning-content/skill-datasource.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
-import { Challenge } from '../../domain/models/Challenge.js';
+import { Challenge } from '../../../src/shared/domain/models/Challenge.js';
 import { Answer } from '../../../src/evaluation/domain/models/Answer.js';
 
 const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -4,7 +4,7 @@ import { Assessment } from '../../domain/models/index.js';
 import { AssessmentResult } from '../../domain/read-models/participant-results/AssessmentResult.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as answerRepository from '../../../src/evaluation/infrastructure/repositories/answer-repository.js';
-import * as challengeRepository from '../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as areaRepository from './area-repository.js';
 import * as knowledgeElementRepository from './knowledge-element-repository.js';
 import * as flashAssessmentResultRepository from './flash-assessment-result-repository.js';

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -4,7 +4,7 @@ dotenv.config();
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import { SessionFinalized } from '../../lib/domain/events/SessionFinalized.js';
 import * as certificationAssessmentRepository from '../../lib/infrastructure/repositories/certification-assessment-repository.js';
-import * as challengeRepository from '../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as certificationCourseRepository from '../../lib/infrastructure/repositories/certification-course-repository.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';

--- a/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
+++ b/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
@@ -4,7 +4,7 @@ import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';
 import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as certificationAssessmentRepository from '../../lib/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCourseRepository from '../../lib/infrastructure/repositories/certification-course-repository.js';
-import * as challengeRepository from '../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { logger } from '../../lib/infrastructure/logger.js';
 import { SessionFinalized } from '../../lib/domain/events/SessionFinalized.js';
 import { eventDispatcher } from '../../lib/domain/events/index.js';

--- a/api/scripts/extract-challenge-with-skills.js
+++ b/api/scripts/extract-challenge-with-skills.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import * as challengeRepository from '../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as skillsRepository from '../lib/infrastructure/repositories/skill-repository.js';
 import * as competencesRepository from '../src/shared/infrastructure/repositories/competence-repository.js';
 

--- a/api/scripts/tooling/tooling.js
+++ b/api/scripts/tooling/tooling.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import bluebird from 'bluebird';
 import * as skillRepository from '../../lib/infrastructure/repositories/skill-repository.js';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as challengeRepository from '../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as campaignRepository from '../../lib/infrastructure/repositories/campaign-repository.js';
 import { logger } from '../../lib/infrastructure/logger.js';
 import { knex } from '../../db/knex-database-connection.js';

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -255,7 +255,7 @@ function _getInferredChallenges({ challenges, estimatedLevel }) {
  * the challenge with the lowest minimum capability,
  * prioritizing validated challenges over archived ones.
  *
- * @param {import('../../../../../../lib/domain/models/Challenge.js')[]} challenges
+ * @param {import('../../../../../shared/domain/models/Challenge.js')[]} challenges
  * @returns A list of challenges for scoring inferrence
  */
 function _findChallengesForInferrence(challenges) {

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -8,7 +8,7 @@ import * as certificationCenterRepository from '../../../shared/infrastructure/r
 import * as certificationCandidateRepository from '../../../shared/infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationChallengeLiveAlertRepository from '../../../session/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 import * as certificationIssueReportRepository from '../../../shared/infrastructure/repositories/certification-issue-report-repository.js';
-import * as challengeRepository from '../../../shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as certificationCpfCountryRepository from '../../../shared/infrastructure/repositories/certification-cpf-country-repository.js';
 import * as certificationCpfCityRepository from '../../../shared/infrastructure/repositories/certification-cpf-city-repository.js';
 import * as complementaryCertificationBadgesRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';

--- a/api/src/shared/domain/models/Challenge.js
+++ b/api/src/shared/domain/models/Challenge.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
-import { Validator } from './Validator.js';
-import { ValidatorQCM } from './ValidatorQCM.js';
-import { ValidatorQCU } from './ValidatorQCU.js';
-import { ValidatorQROC } from './ValidatorQROC.js';
-import { ValidatorQROCMDep } from './ValidatorQROCMDep.js';
-import { ValidatorQROCMInd } from './ValidatorQROCMInd.js';
+import { Validator } from '../../../../lib/domain/models/Validator.js';
+import { ValidatorQCM } from '../../../../lib/domain/models/ValidatorQCM.js';
+import { ValidatorQCU } from '../../../../lib/domain/models/ValidatorQCU.js';
+import { ValidatorQROC } from '../../../../lib/domain/models/ValidatorQROC.js';
+import { ValidatorQROCMDep } from '../../../../lib/domain/models/ValidatorQROCMDep.js';
+import { ValidatorQROCMInd } from '../../../../lib/domain/models/ValidatorQROCMInd.js';
 
 const ChallengeType = Object.freeze({
   QCU: 'QCU',

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -1,14 +1,14 @@
 import _ from 'lodash';
-import { Challenge } from '../../../../../lib/domain/models/index.js';
-import * as skillAdapter from '../../../../../lib/infrastructure/adapters/skill-adapter.js';
-import * as solutionAdapter from '../../../../../lib/infrastructure/adapters/solution-adapter.js';
-import { LearningContentResourceNotFound } from '../../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
-import { config } from '../../../../../lib/config.js';
+import { Challenge } from '../../../../lib/domain/models/index.js';
+import * as skillAdapter from '../../../../lib/infrastructure/adapters/skill-adapter.js';
+import * as solutionAdapter from '../../../../lib/infrastructure/adapters/solution-adapter.js';
+import { LearningContentResourceNotFound } from '../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { config } from '../../../../lib/config.js';
 import {
   challengeDatasource,
   skillDatasource,
-} from '../../../../../lib/infrastructure/datasources/learning-content/index.js';
+} from '../../../../lib/infrastructure/datasources/learning-content/index.js';
 
 const get = async function (id) {
   try {

--- a/api/tests/integration/domain/services/pick-certification-challenge_test.js
+++ b/api/tests/integration/domain/services/pick-certification-challenge_test.js
@@ -3,7 +3,7 @@ import * as placementProfileService from '../../../../lib/domain/services/placem
 import * as certificationChallengesService from '../../../../lib/domain/services/certification-challenges-service.js';
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as answerRepository from '../../../../src/evaluation/infrastructure/repositories/answer-repository.js';
-import * as challengeRepository from '../../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { PIX_COUNT_BY_LEVEL } from '../../../../lib/domain/constants.js';
 
 describe('Integration | CertificationChallengeService | pickCertificationChallenge', function () {

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -2,7 +2,7 @@ import { expect, databaseBuilder, mockLearningContent, catchErr } from '../../..
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import * as certificationAssessmentRepository from '../../../../lib/infrastructure/repositories/certification-assessment-repository.js';
 import { CertificationAssessment } from '../../../../lib/domain/models/CertificationAssessment.js';
-import { Challenge } from '../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 import { AnswerStatus } from '../../../../lib/domain/models/AnswerStatus.js';
 import _ from 'lodash';
 

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { catchErr, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
 import { Challenge } from '../../../../lib/domain/models/Challenge.js';
 import { Validator } from '../../../../lib/domain/models/Validator.js';
-import * as challengeRepository from '../../../../src/certification/shared/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | challenge-repository', function () {

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { catchErr, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
-import { Challenge } from '../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 import { Validator } from '../../../../lib/domain/models/Validator.js';
 import * as challengeRepository from '../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';

--- a/api/tests/school/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { catchErr, domainBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
-import { Challenge } from '../../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../../src/shared/domain/models/Challenge.js';
 import { Validator } from '../../../../../lib/domain/models/Validator.js';
 import * as challengeRepository from '../../../../../src/school/infrastructure/repositories/challenge-repository.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge-with-type.js
@@ -1,5 +1,5 @@
 import { CertificationChallengeWithType } from '../../../../lib/domain/models/CertificationChallengeWithType.js';
-import { Challenge } from '../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 
 const buildCertificationChallengeWithType = function ({
   id = 123,

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -1,4 +1,4 @@
-import { Challenge } from '../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 import { Validator } from '../../../../lib/domain/models/Validator.js';
 import { buildSkill } from './build-skill.js';
 

--- a/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
+++ b/api/tests/unit/domain/models/CertificationChallengeWithType_test.js
@@ -1,6 +1,6 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
 import { CertificationChallengeWithType } from '../../../../lib/domain/models/index.js';
-import { Type } from '../../../../lib/domain/models/Challenge.js';
+import { Type } from '../../../../src/shared/domain/models/Challenge.js';
 
 describe('Unit | Domain | Models | CertificationChallengeWithType', function () {
   describe('#constructor', function () {

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -1,5 +1,5 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
-import { Challenge } from '../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 import { Skill } from '../../../../lib/domain/models/Skill.js';
 import { Validator } from '../../../../lib/domain/models/Validator.js';
 import { ValidatorQCM } from '../../../../lib/domain/models/ValidatorQCM.js';

--- a/api/tests/unit/domain/usecases/correct-answer_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer_test.js
@@ -1,6 +1,6 @@
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { correctAnswer } from '../../../../lib/domain/usecases/correct-answer.js';
-import { Challenge } from '../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../src/shared/domain/models/Challenge.js';
 import { ActivityAnswer } from '../../../../lib/domain/models/ActivityAnswer.js';
 import { AnswerStatus } from '../../../../lib/domain/models/index.js';
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -1,6 +1,6 @@
 import { expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
-import { Challenge } from '../../../../../lib/domain/models/Challenge.js';
+import { Challenge } from '../../../../../src/shared/domain/models/Challenge.js';
 
 describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
   describe('#serialize()', function () {


### PR DESCRIPTION
## :unicorn: Problème

Le challenge-repository a été déplacé dans le shared de certification plutôt que dans le global par mégarde

## :robot: Proposition

Le remettre dans le shared global

## :rainbow: Remarques

On en profite pour migrer le modèle Challenge dans cette PR

## :100: Pour tester

Tests au vert
