### PR TITLE
[FEATURE] Améliorer la sauvegarde en base d'un feedback utilisateur (PIX-8867).

### DIFF
--- a/api/src/evaluation/application/feedbacks/index.js
+++ b/api/src/evaluation/application/feedbacks/index.js
@@ -15,7 +15,9 @@ const register = async function (server) {
             data: Joi.object({
               type: Joi.string().valid('feedbacks'),
               attributes: Joi.object({
-                content: Joi.string().allow('').required(),
+                content: Joi.string().max(10000).allow('').required(),
+                category: Joi.string().allow(null).optional(),
+                answer: Joi.string().allow(null).optional(),
               }),
               relationships: Joi.object({
                 assessment: Joi.object({

--- a/api/src/evaluation/infrastructure/repositories/feedback-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/feedback-repository.js
@@ -1,7 +1,11 @@
+import omit from 'lodash/omit.js';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { Feedback } from '../../domain/models/Feedback.js';
 
 export const save = async function (feedback) {
-  const result = await knex('feedbacks').insert(feedback).returning('*');
+  const dataToInsert = omit(feedback, ['id']);
+
+  const result = await knex('feedbacks').insert(dataToInsert).returning('*');
+
   return new Feedback(result[0]);
 };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -5,7 +5,7 @@ const { Serializer, Deserializer } = jsonapiSerializer;
 
 const serialize = function (feedbacks) {
   return new Serializer('feedbacks', {
-    attributes: ['createdAt', 'content', 'assessment', 'challenge'],
+    attributes: ['createdAt', 'content', 'category', 'answer', 'assessment', 'challenge'],
     assessment: { ref: 'id' },
     challenge: { ref: 'id' },
     transform(json) {

--- a/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/feedbacks/feedback-controller_test.js
@@ -25,7 +25,9 @@ describe('Acceptance | Controller | feedback-controller', function () {
           data: {
             type: 'feedbacks',
             attributes: {
-              content: 'Some content',
+              content: 'Dummy content',
+              category: 'Dummy category',
+              answer: 'Dummy answer',
             },
             relationships: {
               assessment: {
@@ -108,7 +110,9 @@ describe('Acceptance | Controller | feedback-controller', function () {
       const assessment = response.result.data.relationships.assessment.data;
 
       // then
+      expect(feedback.attributes.answer).to.deep.equal(expectedFeedback.answer);
       expect(feedback.attributes.content).to.deep.equal(expectedFeedback.content);
+      expect(feedback.attributes.category).to.deep.equal(expectedFeedback.category);
       expect(challenge.id).to.deep.equal(expectedChallengeId);
       expect(assessment.id).to.deep.equal(expectedAssessmentId);
     });

--- a/api/tests/evaluation/integration/infrastructure/repositories/feedback-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/feedback-repository_test.js
@@ -6,7 +6,13 @@ describe('Integration | Repository | Feedback', function () {
   describe('save', function () {
     it('should save a feedback in database', async function () {
       // given
-      const feedbackToSave = { content: 'test', challengeId: '123' };
+      const feedbackToSave = {
+        id: 969,
+        content: 'test',
+        answer: 'dummy answer',
+        category: 'dummy category',
+        challengeId: '123',
+      };
 
       // when
       const savedFeedback = await save(feedbackToSave);
@@ -16,11 +22,12 @@ describe('Integration | Repository | Feedback', function () {
       expect(savedFeedback).to.include({
         content: feedbackToSave.content,
         challengeId: feedbackToSave.challengeId,
-        category: null,
-        answer: null,
+        category: feedbackToSave.category,
+        answer: feedbackToSave.answer,
         assessmentId: null,
         userAgent: null,
       });
+      expect(savedFeedback.id).to.not.equal(969);
     });
   });
 });

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/feedback-serializer_test.js
@@ -8,6 +8,8 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
       const feedback = {
         id: 'feedback_id',
         content: 'Lorem ipsum dolor sit amet consectetur adipiscet.',
+        category: 'category name',
+        answer: 'user answer',
         assessmentId: 'assessment_id',
         challengeId: 'challenge_id',
         createdAt: new Date('2017-09-01T12:14:33Z'),
@@ -19,6 +21,8 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
           id: 'feedback_id',
           attributes: {
             content: feedback.content,
+            category: feedback.category,
+            answer: feedback.answer,
             'created-at': feedback.createdAt,
           },
           relationships: {
@@ -50,6 +54,8 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
       const simpleFeedback = {
         id: 'simple_feedback',
         content: 'Simple feedback',
+        category: 'Simple category',
+        answer: 'Simple answer',
         createdAt: new Date('2015-09-06T15:00:00Z'),
         assessmentId: 1,
         challengeId: 11,
@@ -81,6 +87,8 @@ describe('Unit | Serializer | JSONAPI | feedback-serializer', function () {
             id: simpleFeedback.id,
             attributes: {
               content: simpleFeedback.content,
+              category: simpleFeedback.category,
+              answer: simpleFeedback.answer,
               'created-at': simpleFeedback.createdAt,
             },
             relationships: {


### PR DESCRIPTION
## :unicorn: Problème

1. On laissait la possibilité de forcer l'ID d'un feedback ([voir ici](https://github.com/1024pix/pix/pull/6251#pullrequestreview-1560505255))
2. On ne validait pas les champs `category` et `answer` de la payload de sauvegarde d'un feedback ([voir ici](https://github.com/1024pix/pix/pull/6251#discussion_r1282851357))

## :robot: Proposition

1. Omettre explicitement l'ID dans le repository
2. Ajouter une validation JOI des champs `category` et `answer` et les prendre en compte dans le serializer

## :rainbow: Remarques

ℹ️ Pour info, le `max(10000)` de la validation JOI du champ `content` vient du textarea permettant de la renseigner en front et de [son attribut `maxlength`](https://github.com/1024pix/pix/blob/dev/mon-pix/app/components/feedback-panel.hbs#L79).

## :100: Pour tester

- Tests verts 🟢
- Sur la RA, faire un feedback sur une épreuve et vérifier que tout se passe comme prévu.
