### PR TITLE
[TECH] déplacement de l'`ActivityRepository` vers le domain `School` (pix-9973)

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -10,7 +10,7 @@ import { repositories } from '../../infrastructure/repositories/index.js';
 
 import * as accountRecoveryDemandRepository from '../../infrastructure/repositories/account-recovery-demand-repository.js';
 import * as activityAnswerRepository from '../../infrastructure/repositories/activity-answer-repository.js';
-import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
+import * as activityRepository from '../../../src/school/infrastructure/repositories/activity-repository.js';
 import * as adminMemberRepository from '../../infrastructure/repositories/admin-member-repository.js';
 import * as algorithmDataFetcherService from '../../domain/services/algorithm-methods/data-fetcher.js';
 import * as answerRepository from '../../../src/evaluation/infrastructure/repositories/answer-repository.js';

--- a/api/src/school/infrastructure/repositories/activity-repository.js
+++ b/api/src/school/infrastructure/repositories/activity-repository.js
@@ -1,6 +1,6 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { Activity } from '../../../src/school/domain/models/Activity.js';
-import { NotFoundError } from '../../../lib/domain/errors.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { Activity } from '../../domain/models/Activity.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 const save = async function (activity) {
   const [savedAttributes] = await knex('activities').insert(activity).returning('*');

--- a/api/src/school/shared/usecases/index.js
+++ b/api/src/school/shared/usecases/index.js
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import * as activityAnswerRepository from '../../../../lib/infrastructure/repositories/activity-answer-repository.js';
-import * as activityRepository from '../../../../lib/infrastructure/repositories/activity-repository.js';
+import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../school/infrastructure/repositories/challenge-repository.js';
 import * as schoolRepository from '../../../school/infrastructure/repositories/school-repository.js';

--- a/api/tests/integration/domain/usecases/correct-answer_test.js
+++ b/api/tests/integration/domain/usecases/correct-answer_test.js
@@ -1,7 +1,7 @@
 import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../test-helper.js';
 import { correctAnswer } from '../../../../lib/domain/usecases/correct-answer.js';
 import * as activityAnswerRepository from '../../../../lib/infrastructure/repositories/activity-answer-repository.js';
-import * as activityRepository from '../../../../lib/infrastructure/repositories/activity-repository.js';
+import * as activityRepository from '../../../../src/school/infrastructure/repositories/activity-repository.js';
 
 describe('Integration | UseCases | correct-answer', function () {
   context('when there is assessmentId', function () {

--- a/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/school/integration/domain/usecases/get-next-challenge_test.js
@@ -1,7 +1,7 @@
 import { databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../test-helper.js';
 import { Assessment, Challenge } from '../../../../../lib/domain/models/index.js';
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
-import * as activityRepository from '../../../../../lib/infrastructure/repositories/activity-repository.js';
+import * as activityRepository from '../../../../../src/school/infrastructure/repositories/activity-repository.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../../../../src/school/infrastructure/repositories/challenge-repository.js';
 import * as activityAnswerRepository from '../../../../../lib/infrastructure/repositories/activity-answer-repository.js';

--- a/api/tests/school/integration/infrastructure/repositories/activity-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/activity-repository_test.js
@@ -1,7 +1,7 @@
-import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
-import * as activityRepository from '../../../../lib/infrastructure/repositories/activity-repository.js';
-import { Activity } from '../../../../src/school/domain/models/Activity.js';
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import * as activityRepository from '../../../../../src/school/infrastructure/repositories/activity-repository.js';
+import { Activity } from '../../../../../src/school/domain/models/Activity.js';
+import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | activityRepository', function () {
   describe('#save', function () {


### PR DESCRIPTION
## :unicorn: Problème

cf https://1024pix.atlassian.net/wiki/spaces/DEV/pages/3791323137/API+Arborescence à propos de la migration vers une structuration portant des informations sur le domaine.

## :robot: Proposition

Déplacement de `ActivityRepository`

## :rainbow: Remarques


## :100: Pour tester

les tests sont :heavy_check_mark: et rien n'a changé sur pix 1d (ou ailleurs)
