### PR TITLE
[BUGFIX] Isoler les usages de i18n au sein des tests (PIX-9975).

### DIFF
--- a/api/tests/tooling/i18n/i18n.js
+++ b/api/tests/tooling/i18n/i18n.js
@@ -1,20 +1,16 @@
 import path from 'path';
-import i18n from 'i18n';
+import { options } from '../../../lib/infrastructure/plugins/i18n.js';
+import { I18n } from 'i18n';
 import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 function getI18n() {
   const directory = path.resolve(path.join(__dirname, '../../../translations'));
+
+  const i18n = new I18n();
   i18n.configure({
-    locales: ['fr', 'en'],
-    defaultLocale: 'fr',
+    ...options,
     directory,
-    objectNotation: true,
-    updateFiles: false,
-    mustacheConfig: {
-      tags: ['{', '}'],
-      disable: false,
-    },
   });
   return i18n;
 }

--- a/api/tests/unit/domain/usecases/send-verification-code_test.js
+++ b/api/tests/unit/domain/usecases/send-verification-code_test.js
@@ -94,7 +94,7 @@ describe('Unit | UseCase | send-verification-code', function () {
     const code = '999999';
     const locale = 'fr';
     const i18n = getI18n();
-    const translate = getI18n().__;
+    const translate = i18n.__;
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
     userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves(newEmail);


### PR DESCRIPTION
## :unicorn: Problème

Il y a un soucis d’isolation des tests, l’instance de i18n utilisée dans les tests unitaire et d’intégration (donc sans lancer de serveur), est la même pour tous les tests.
Si un test quelque part change la config i18n (exemple : i18n.setLocale(...) ) par exemple dans un test unitaire (ce qui est tout à fait entendable), cela vient du coup changer la config de manière globale pour des autres tests qui n’ont rien à voir.

## :robot: Proposition

Assurer l’isolation des tests en assurant que le i18n de test est remis à zéro quand on s’en sert, en créant une nouvelle instance configurée avec les règles par défaut.

## :rainbow: Remarques

La modification aussi assure un meilleur alignement entre la config "réelle" de l'api (serveur Hapi) et les tests en utilisant par défaut pour les tests la configuration du serveur.

## :100: Pour tester
* Les tests passent
