### PR TITLE
[TECH] Supprimer les messages lors des tests d'intégration.

### DIFF
--- a/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
+++ b/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
@@ -25,7 +25,9 @@ function _logProgression(totalCount) {
   process.stdout.write(`${Math.round((progression * 100) / totalCount, 2)} %`);
 }
 
-const updatePixCertificationStatus = async ({ count, concurrency }) => {
+const updatePixCertificationStatus = async (
+  { count, concurrency, logProgression } = { logProgression: _logProgression },
+) => {
   logger.info('\tRécupération des certifications éligibles...');
   const eligibleCertificationIds = await _findEligibleCertifications(count);
   logger.info(`\tOK : ${eligibleCertificationIds.length} certifications récupérées`);
@@ -41,7 +43,7 @@ const updatePixCertificationStatus = async ({ count, concurrency }) => {
         ++failedGenerations;
         logger.error(`Went wrong for certification ${certificationId}`);
       }
-      _logProgression(count);
+      logProgression(count);
     },
     { concurrency },
   );

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -101,7 +101,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
     const createdAt = new Date('2023-09-19T01:02:03Z');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(createdAt);
+      clock = sinon.useFakeTimers({ now: createdAt, toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/certification/complementary-certification/unit/domain/models/BadgeToAttach_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/models/BadgeToAttach_test.js
@@ -6,7 +6,7 @@ describe('Unit | Domain | Models | BadgeToAttach', function () {
   let clock;
   const now = new Date('2023-02-02');
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
   afterEach(function () {
     clock.restore();

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | attach-badges', function () {
     complementaryCertificationBadgesRepository = {
       findAttachableBadgesByIds: sinon.stub(),
     };
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
   afterEach(function () {
     clock.restore();

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -9,7 +9,7 @@ describe('Integration | Repository | Certification Center', function () {
 
   beforeEach(function () {
     now = new Date('2021-11-16');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/integration/domain/services/organization-invitation-service_test.js
+++ b/api/tests/integration/domain/services/organization-invitation-service_test.js
@@ -17,7 +17,7 @@ describe('Integration | Service | Organization-Invitation Service', function () 
     const now = new Date('2021-01-02');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/integration/domain/usecases/cancel-certification-center-invitation_test.js
+++ b/api/tests/integration/domain/usecases/cancel-certification-center-invitation_test.js
@@ -10,7 +10,7 @@ describe('Integration | UseCases | cancel-certification-center-invitation', func
     const now = new Date('2022-09-25');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now.getTime());
+      clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -10,7 +10,7 @@ describe('Integration | UseCase | create-or-update-certification-center-invitati
   const now = new Date('2022-09-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now.getTime());
+    clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     sinon.stub(mailService, 'sendCertificationCenterInvitationEmail');
   });
 

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -30,7 +30,7 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
 
   beforeEach(function () {
     const now = dayjs('2022-01-02T10:43:27Z').tz('Europe/Paris').toDate();
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     logger = { error: noop, info: noop, trace: noop };
     uuidService = { randomUUID: sinon.stub() };
   });

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -118,7 +118,7 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
       const now = new Date('2022-02-16');
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(async function () {
@@ -192,7 +192,7 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
       const now = new Date('2022-02-16');
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(async function () {
@@ -232,7 +232,7 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
     const now = new Date('2022-02-16');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {
@@ -294,7 +294,7 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
     const now = new Date('2022-02-16');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -143,7 +143,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     let clock;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(new Date('2020-01-02'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
       userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
     });
@@ -436,7 +436,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       let clock;
 
       beforeEach(async function () {
-        clock = sinon.useFakeTimers(new Date('2020-01-02'));
+        clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
       });
 
       afterEach(function () {
@@ -515,7 +515,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     let clock;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(new Date('2020-01-02'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
       userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
     });
@@ -711,7 +711,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     let clock;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(new Date('2020-01-02'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
       userId = databaseBuilder.factory.buildUser({ shouldChangePassword: true }).id;
       databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
         id: 123,
@@ -783,7 +783,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       let clock;
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(new Date('2020-01-02'));
+        clock = sinon.useFakeTimers({ now: new Date('2020-01-02'), toFake: ['Date'] });
         const userId = databaseBuilder.factory.buildUser().id;
         authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
           id: 123,
@@ -1105,7 +1105,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     const now = new Date('2022-02-16');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {
@@ -1144,7 +1144,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
     it('should update authentication method complement', async function () {
       // given
       const now = new Date('2022-03-15');
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const userId = databaseBuilder.factory.buildUser().id;
       const authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -708,7 +708,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         userId: campaignParticipation.userId,
         createdAt: new Date('1985-09-01T00:00:00Z'),
       });
-      clock = sinon.useFakeTimers(frozenTime);
+      clock = sinon.useFakeTimers({ now: frozenTime, toFake: ['Date'] });
 
       await databaseBuilder.commit();
     });

--- a/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Repository | certification-center-for-admin', function (
   const now = new Date('2021-11-16');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now, shouldClearNativeTimers: true });
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-invitation-repository_test.js
@@ -15,7 +15,7 @@ describe('Integration | Infrastructure | Repositories | CertificationCenterInvit
       await databaseBuilder.commit();
 
       const now = new Date('2023-10-13');
-      const clock = sinon.useFakeTimers(now);
+      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       // when
       await certificationCenterInvitationRepository.updateModificationDate(certificationCenterInvitation.id);

--- a/api/tests/integration/infrastructure/repositories/certification-center-invited-user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-invited-user-repository_test.js
@@ -139,7 +139,7 @@ describe('Integration | Repository | CertificationCenterInvitedUserRepository', 
     it('should mark certification center invitation as accepted', async function () {
       // given
       const now = new Date('2021-05-27');
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ id: 123 }).id;
       const user = databaseBuilder.factory.buildUser({ id: 6789, email: 'user@example.net' });

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -170,7 +170,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     it('should return certification center membership associated to the certification center', async function () {
       // given
       const now = new Date('2021-01-02');
-      const clock = sinon.useFakeTimers(now);
+      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ updatedAt: now });
       const user = databaseBuilder.factory.buildUser();
@@ -460,7 +460,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(function () {
@@ -637,7 +637,7 @@ describe('Integration | Repository | Certification Center Membership', function 
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -11,7 +11,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', fu
   const now = new Date('2022-12-01');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers({ now });
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
   afterEach(function () {
     clock.restore();

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -12,7 +12,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
   const now = new Date('2022-02-02');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -158,7 +158,7 @@ describe('Integration | Repository | OrganizationInvitationRepository', function
     it('should return the cancelled organization invitation', async function () {
       // given
       const now = new Date('2021-01-02');
-      const clock = sinon.useFakeTimers(now);
+      const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
         updatedAt: new Date('2020-01-01T00:00:00Z'),
         status: OrganizationInvitation.StatusType.PENDING,
@@ -312,7 +312,7 @@ describe('Integration | Repository | OrganizationInvitationRepository', function
     const now = new Date('2021-01-02');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/organization-invited-user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invited-user-repository_test.js
@@ -204,7 +204,7 @@ describe('Integration | Repository | OrganizationInvitedUserRepository', functio
       const now = new Date('2021-05-27');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(function () {
@@ -346,7 +346,7 @@ describe('Integration | Repository | OrganizationInvitedUserRepository', functio
       const now = new Date('2021-05-27');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -172,7 +172,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(afterBeginningOfThe2020SchoolYear);
+      clock = sinon.useFakeTimers({ now: afterBeginningOfThe2020SchoolYear, toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Infrastructure | Repository | OrganizationPlacesCapacity
     let clock;
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(new Date(Date.parse('10/10/2021')));
+      clock = sinon.useFakeTimers({ now: new Date(Date.parse('10/10/2021')), toFake: ['Date'] });
       organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
     });

--- a/api/tests/integration/infrastructure/repositories/target-profile-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-training-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Repository | target-profile-training-repository', functi
 
     beforeEach(function () {
       now = new Date('2022-02-13');
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -181,7 +181,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
       beforeEach(function () {
         now = new Date('2022-02-02');
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(function () {

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -57,7 +57,7 @@ describe('Integration | Repository | UserLoginRepository', function () {
     const now = new Date('2022-11-24');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers({ now });
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(function () {
@@ -143,7 +143,7 @@ describe('Integration | Repository | UserLoginRepository', function () {
     const now = new Date('2020-01-02');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/integration/migration/20231003140113_delete-sup-organization-learners-disabled_test.js
+++ b/api/tests/integration/migration/20231003140113_delete-sup-organization-learners-disabled_test.js
@@ -9,7 +9,7 @@ describe('Integration | Scripts | delete-sup-organization-learners-disabled', fu
 
   beforeEach(function () {
     deletedById = databaseBuilder.factory.buildUser().id;
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
@@ -10,7 +10,7 @@ describe('Integration | Scripts | Certification | fill-latest-assessment-result-
   let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(NEW_UPDATED_AT);
+    clock = sinon.useFakeTimers({ now: NEW_UPDATED_AT, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
@@ -9,7 +9,7 @@ describe('Integration | Scripts | Certification | fill-pix-certification-status-
   let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(NEW_UPDATED_AT);
+    clock = sinon.useFakeTimers({ now: NEW_UPDATED_AT, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
@@ -19,6 +19,7 @@ describe('Integration | Scripts | Certification | fill-pix-certification-status-
   describe('#updatePixCertificationStatus', function () {
     it('do what expected', async function () {
       // given
+      const logProgessionStub = sinon.stub();
       _buildAlreadyFilledPixCertificationStatus({
         id: 1,
         assessmentResultStatus: status.VALIDATED,
@@ -34,7 +35,7 @@ describe('Integration | Scripts | Certification | fill-pix-certification-status-
       await databaseBuilder.commit();
 
       // when
-      await updatePixCertificationStatus({ count: 10, concurrency: 1 });
+      await updatePixCertificationStatus({ count: 10, concurrency: 1, logProgression: logProgessionStub });
 
       // then
       const certificationDTOs = await knex('certification-courses')

--- a/api/tests/integration/scripts/prod/archive-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/archive-campaigns_test.js
@@ -13,7 +13,7 @@ describe('Script | Prod | Archive Campaign', function () {
 
   beforeEach(function () {
     now = new Date('2022-01-01');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
   afterEach(function () {
     clock.restore();

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -1272,7 +1272,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         const now = new Date('2022-02-02');
 
         beforeEach(function () {
-          clock = sinon.useFakeTimers(now);
+          clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
         });
 
         afterEach(function () {
@@ -1314,7 +1314,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       const now = new Date('2021-01-02');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(function () {
@@ -1520,7 +1520,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       const now = new Date('2021-01-02');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(function () {
@@ -1561,7 +1561,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       const now = new Date('2021-01-02');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       });
 
       afterEach(function () {
@@ -1773,7 +1773,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
     const now = new Date('2022-12-24');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -7,7 +7,7 @@ describe('Integration | Repository | Organization Learners Management | Campaign
     let clock;
     const now = new Date('2023-02-02');
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
     afterEach(function () {
       clock.restore();

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -7,7 +7,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     let clock;
     const now = new Date('2023-02-02');
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
     afterEach(function () {
       clock.restore();

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -286,7 +286,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
           let clock;
 
           beforeEach(function () {
-            clock = sinon.useFakeTimers(now);
+            clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
           });
 
           afterEach(function () {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -794,7 +794,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
     const now = new Date('2019-01-01T05:06:07Z');
     let clock;
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
     afterEach(function () {
       clock.restore();
@@ -841,7 +841,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
     const now = new Date('2019-01-01T05:06:07Z');
     let clock;
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
     afterEach(function () {
       clock.restore();

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -947,7 +947,7 @@ describe('Unit | Controller | user-controller', function () {
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-08-17'));
+      clock = sinon.useFakeTimers({ now: new Date('2023-08-17'), toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/unit/domain/events/UserAnonymized_test.js
+++ b/api/tests/unit/domain/events/UserAnonymized_test.js
@@ -7,7 +7,7 @@ describe('Unit | Domain | Events | UserAnonymized', function () {
 
   beforeEach(function () {
     const now = new Date('2023-08-17');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -21,7 +21,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
   let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
     certificationAssessmentRepository = { get: sinon.stub() };

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -91,7 +91,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
       const now = new Date('2021-09-25');
 
       beforeEach(function () {
-        clock = sinon.useFakeTimers(now.getTime());
+        clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
       });
 
       afterEach(function () {
@@ -244,7 +244,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
     const now = new Date('2021-09-25');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now.getTime());
+      clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/unit/domain/models/CertificationCenterMembership_test.js
+++ b/api/tests/unit/domain/models/CertificationCenterMembership_test.js
@@ -6,7 +6,7 @@ describe('Unit | Domain | Models | CertificationCenterMembership', function () {
   let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/unit/domain/models/KnowledgeElement_test.js
@@ -329,7 +329,7 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
 
     beforeEach(function () {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
-      sinon.useFakeTimers(testCurrentDate.getTime());
+      sinon.useFakeTimers({ now: testCurrentDate.getTime(), toFake: ['Date'] });
     });
 
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -271,7 +271,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
 
     beforeEach(function () {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
-      sinon.useFakeTimers(testCurrentDate.getTime());
+      sinon.useFakeTimers({ now: testCurrentDate.getTime(), toFake: ['Date'] });
     });
 
     before(function () {
@@ -316,7 +316,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
 
     beforeEach(function () {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
-      sinon.useFakeTimers(testCurrentDate.getTime());
+      sinon.useFakeTimers({ now: testCurrentDate.getTime(), toFake: ['Date'] });
     });
 
     before(function () {

--- a/api/tests/unit/domain/models/SessionJuryComment_test.js
+++ b/api/tests/unit/domain/models/SessionJuryComment_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | SessionJuryComment', function () {
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2003-04-05T03:04:05Z'));
+      clock = sinon.useFakeTimers({ now: new Date('2003-04-05T03:04:05Z'), toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -353,7 +353,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is not a college', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['COLLEGEee', 'some_other_tag'],
@@ -368,7 +368,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is also a lycee', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['COLLEGE', 'LYCEE', 'some_other_tag'],
@@ -383,7 +383,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         externalId: 'WHITELISTED',
@@ -398,7 +398,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the college date limit', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2022-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess(validData);
 
       // when
@@ -410,7 +410,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess(validData);
 
       // when
@@ -442,7 +442,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is not a lycee', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE PROU', 'some_other_tag'],
@@ -457,7 +457,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         externalId: 'WHITELISTED',
@@ -472,7 +472,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the lycee date limit', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2022-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess(validData);
 
       // when
@@ -484,7 +484,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccessLycee = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE'],
@@ -525,7 +525,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is not AEFE', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE PROU', 'some_other_tag'],
@@ -540,7 +540,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         externalId: 'WHITELISTED',
@@ -555,7 +555,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the lycee date limit', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2022-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess(validData);
 
       // when
@@ -567,7 +567,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccessAEFE = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['AEFE'],
@@ -602,7 +602,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is not AGRICULTURE', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['LYCEE PROU', 'some_other_tag'],
@@ -617,7 +617,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when certification center is whitelisted', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         externalId: 'WHITELISTED',
@@ -632,7 +632,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when current date is after the lycee date limit', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2022-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2022-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess(validData);
 
       // when
@@ -644,7 +644,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return true otherwise all above conditions', function () {
       // given
-      clock = sinon.useFakeTimers(new Date('2020-01-01'));
+      clock = sinon.useFakeTimers({ now: new Date('2020-01-01'), toFake: ['Date'] });
       const allowedCertificationCenterAccessAgri = domainBuilder.buildAllowedCertificationCenterAccess({
         ...validData,
         relatedOrganizationTags: ['AGRICULTURE'],

--- a/api/tests/unit/domain/read-models/OrganizationPlacesLotManagement_test.js
+++ b/api/tests/unit/domain/read-models/OrganizationPlacesLotManagement_test.js
@@ -39,7 +39,7 @@ describe('Unit | Domain | ReadModels | organizationPlacesLotManagement', functio
     const now = new Date('2021-05-01');
 
     beforeEach(async function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(async function () {

--- a/api/tests/unit/domain/read-models/PreviousCampaignParticipation_test.js
+++ b/api/tests/unit/domain/read-models/PreviousCampaignParticipation_test.js
@@ -41,7 +41,7 @@ describe('Unit | Domain | Read-Models | PreviousCampaignParticipation', function
     beforeEach(function () {
       originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
       now = new Date('2020-01-07T05:06:07Z');
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(4);
 
       baseProps = {

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -404,7 +404,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     beforeEach(function () {
       originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
       now = new Date('2020-01-05T05:06:07Z');
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(4);
     });
 
@@ -692,7 +692,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     beforeEach(function () {
       originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
       now = new Date('2020-01-05T05:06:07Z');
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       sinon.stub(constants, 'MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING').value(4);
     });
 
@@ -910,7 +910,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     });
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(assessmentCreatedAt);
+      clock = sinon.useFakeTimers({ now: assessmentCreatedAt, toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -1046,7 +1046,7 @@ describe('Unit | Service | Certification Challenge Service', function () {
     }
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
       const tube1Area1 = _createTubeWithSkills({
         maxLevel: 5,
         tubeName: 'faireDesCourses',

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -22,7 +22,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
 
   beforeEach(function () {
     const now = dayjs('2022-02-01T10:43:27Z').tz('Europe/Paris').toDate();
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     uuidService = { randomUUID: sinon.stub() };
   });
 

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -55,7 +55,7 @@ describe('Unit | UseCase | session-publication-service', function () {
       ],
       publishedAt: null,
     });
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
@@ -36,7 +36,7 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
       findByUserId: sinon.stub(),
     };
     now = new Date();
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | anonymize-user', function () {
   const now = new Date('2003-04-05T03:04:05Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/archive-campaign-from-campaign-code_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign-from-campaign-code_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | archive-campaign', function () {
 
   beforeEach(function () {
     now = new Date('2022-01-01');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     campaignForArchivingRepository = {
       getByCode: sinon.stub(),
       save: sinon.stub(),

--- a/api/tests/unit/domain/usecases/archive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | archive-campaign', function () {
 
   beforeEach(function () {
     now = new Date('2022-01-01');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     campaignForArchivingRepository = {
       get: sinon.stub(),
       save: sinon.stub(),

--- a/api/tests/unit/domain/usecases/archive-organization_test.js
+++ b/api/tests/unit/domain/usecases/archive-organization_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | archive-organization', function () {
       get: sinon.stub(),
     };
     const now = new Date('2022-02-22');
-    const clock = sinon.useFakeTimers(now);
+    const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     const organizationId = 1;
     const superAdminUser = domainBuilder.buildUser({
       id: 123,

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -25,7 +25,7 @@ describe('Unit | UseCase | complete-assessment', function () {
       update: _.noop,
     };
 
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/create-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/create-oidc-user_test.js
@@ -12,7 +12,7 @@ describe('Unit | UseCase | create-oidc-user', function () {
   const now = new Date('2021-01-02');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     authenticationMethodRepository = {
       findOneByExternalIdentifierAndIdentityProvider: sinon.stub(),

--- a/api/tests/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
   const now = new Date('2021-09-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now.getTime());
+    clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/delete-campaign-participation_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
   const now = new Date('2021-09-25');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now.getTime());
+    clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -210,7 +210,7 @@ describe('Unit | UseCase | finalize-session', function () {
 
       it('should finalize session with expected arguments', async function () {
         // given
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
         const validReportForFinalization = domainBuilder.buildCertificationReport({
           examinerComment: 'signalement sur le candidat',
           hasSeenEndTestScreen: false,
@@ -262,7 +262,7 @@ describe('Unit | UseCase | finalize-session', function () {
           date: '2019-12-12',
           time: '16:00:00',
         });
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
         const validReportForFinalization = domainBuilder.buildCertificationReport({
           examinerComment: 'signalement sur le candidat',
           hasSeenEndTestScreen: false,

--- a/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
@@ -55,7 +55,7 @@ describe('Unit | UseCase | flag-session-results-as-sent-to-prescriber', function
 
       beforeEach(function () {
         updatedSession = Symbol('updatedSession');
-        clock = sinon.useFakeTimers(now);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
         notFlaggedSession = new Session({ resultsSentToPrescriberAt: null });
         sessionRepository.get.withArgs(sessionId).resolves(notFlaggedSession);
       });

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -72,7 +72,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
     const now = new Date('2022-03-13');
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     });
 
     afterEach(function () {

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -6,7 +6,7 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   const now = new Date(2020, 1, 1);
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     complementaryCertificationCourseRepository = {
       findByUserId: sinon.stub(),
     };

--- a/api/tests/unit/domain/usecases/remember-user-has-seen-last-data-protection-policy-information_test.js
+++ b/api/tests/unit/domain/usecases/remember-user-has-seen-last-data-protection-policy-information_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | remember-user-has-seen-data-protection-policy-informa
 
   beforeEach(function () {
     now = new Date('2022-12-24');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     userRepository = {
       updateLastDataProtectionPolicySeenAt: sinon.stub(),
     };

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -50,7 +50,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
   beforeEach(function () {
     now = new Date('2019-01-01T05:06:07Z');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     domainTransaction = Symbol('someDomainTransaction');
     verificationCode = Symbol('verificationCode');
 

--- a/api/tests/unit/domain/usecases/set-certification-center-membership-role-to-admin_test.js
+++ b/api/tests/unit/domain/usecases/set-certification-center-membership-role-to-admin_test.js
@@ -9,7 +9,7 @@ describe('Unit | Domain | UseCases | set-certification-center-memberships-role-t
   const now = new Date();
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
     certificationCenterMembershipRepository = {
       findOneWithCertificationCenterIdAndUserId: sinon.stub(),
       update: sinon.stub(),

--- a/api/tests/unit/domain/usecases/update-certification-center-membership_test.js
+++ b/api/tests/unit/domain/usecases/update-certification-center-membership_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | update-certification-center-membership', function () 
   let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/domain/usecases/update-user-email-with-validation_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email-with-validation_test.js
@@ -38,7 +38,7 @@ describe('Unit | UseCase | update-user-email-with-validation', function () {
     });
 
     const now = new Date();
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     userRepository.get.withArgs(userId).resolves({ email });
     userEmailRepository.getEmailModificationDemandByUserId.withArgs(userId).resolves(emailModificationDemand);

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -37,7 +37,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     const authenticationMethod = { authenticationComplement: { accessToken, expiredDate, refreshToken } };
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(Date.now());
+      clock = sinon.useFakeTimers({ now: Date.now(), toFake: ['Date'] });
       httpAgent = {
         post: sinon.stub(),
       };

--- a/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler_test.js
@@ -8,7 +8,7 @@ describe('Unit | Infrastructure | Jobs | audit-log | ', function () {
 
   beforeEach(function () {
     const now = new Date('2023-08-18');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -24,7 +24,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
 
   beforeEach(function () {
     const now = dayjs('2022-01-01T10:43:27Z').tz('Europe/Paris').toDate();
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
     cpfCertificationResultRepository = {
       findByBatchId: sinon.stub(),

--- a/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler_test.js
@@ -27,7 +27,7 @@ describe('Unit | Infrastructure | Jobs | scheduleComputeOrganizationLearnersCert
         });
 
       const now = dayjs('2023-10-02T21:00:01').tz('Europe/Paris').toDate();
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
 
       config = {
         features: {

--- a/api/tests/unit/infrastructure/repositories/audit-logger-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/audit-logger-repository_test.js
@@ -10,7 +10,7 @@ describe('Unit | Infrastructure | Repositories | audit-logger-repository', funct
   let clock;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(new Date('2023-08-18T08:31:21Z'));
+    clock = sinon.useFakeTimers({ now: new Date('2023-08-18T08:31:21Z'), toFake: ['Date'] });
   });
 
   afterEach(function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -10,7 +10,7 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
 
   beforeEach(function () {
     const now = new Date('2020-01-02');
-    clock = sinon.useFakeTimers(now);
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
   });
 
   let profileSharedForCampaign;

--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -12,7 +12,7 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers({ toFake: ['Date'] });
     });
 
     afterEach(function () {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on lance les tests d'intégration, on constate plusieurs messages qui viennent "polluer" le rapport de test.
Les 2 messages affichés sont
```
30%
```

```
Error: FakeTimers: clearTimeout was invoked to clear a native timer instead of one created by this library.
To automatically clean-up native timers, use `shouldClearNativeTimers`.
```

## :robot: Proposition

Concernant le message `30%`, celui vient du script `fill-pix-certification-status-column-in-certification-courses-table` qui affiche sa progression avec un `process.stdout.write`.
Pour éviter d'écrire un message inutile pendant les tests d'intégration, on injecte une fonction de log.

Pour le message sur les fake timers, le problème d'origine est que lorsqu'on utilise `sinon.useFakeTimers`, toutes les méthodes globales sont stubbées : https://sinonjs.org/releases/latest/fake-timers/.
> Causes Sinon to replace the global setTimeout, clearTimeout, setInterval, clearInterval, setImmediate, clearImmediate, process.hrtime, performance.now(when available) and Date with a custom implementation which is bound to the returned clock object.

Ainsi, le code (dans les dépendances ou non) qui appelle une des fonctions stubbées entraine le message d'avertissement et la fonction globale n'est pas executée.

Pour corriger cela, on spécifie explicitement que seule la fonction `Date` doit être stubbée en ajoutant la propriété `toFake: ['Date']` à l'appel de `sinon.useFakeTimers`.

## :rainbow: Remarques

On peut envisager une règle de lint qui prévient l'usage de `useFakeTimers` sans spécifier la propriété `toFake`.

## :100: Pour tester

Une CI verte avec des tests d'intégration sans messages.
