### PR TITLE
[BUGFIX] Corriger la version française de la double mire lors d'une connexion SSO OIDC et permettre son affichage en anglais

### DIFF
--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
@@ -16,7 +16,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
         // given
         const screen = await visit('/connexion/oidc-partner?code=code&state=state');
         await click(screen.getByLabelText(this.intl.t('common.cgu.label')));
-        await click(screen.getByRole('button', { name: 'Je créé mon compte' }));
+        await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
         await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
 
         // when

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner_test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner_test.js
@@ -107,7 +107,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         // when
         const screen = await visit(`/connexion/oidc?authenticationKey=key&identityProviderSlug=oidc-partner`);
         await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
-        await click(screen.getByRole('button', { name: 'Je créé mon compte' }));
+        await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
 
         // then
         assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1143,7 +1143,7 @@
       }
     },
     "login-or-register-oidc": {
-      "title": "Créez votre compte Pix",
+      "title": "Create your Account",
       "error": {
         "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support.",
         "data-sharing-refused": "We inform you that the transmission of your data, specified on the previous page, is essential to access and use the service.",
@@ -1153,19 +1153,19 @@
         "login-unauthorized-error": "There was an error in the email address or password entered."
       },
       "login-form": {
-        "title": "I already have a Pix account.",
+        "title": "I already have a Pix account",
         "button": "Log in",
-        "description": "Connectez-vous pour lier votre compte existant et récupérer vos compétences déjà évaluées",
+        "description": "Log in to link your existing account and retrieve the skills that you have already assessed.",
         "email": "Email address",
         "password": "Password"
       },
       "register-form": {
-        "title": "Je n’ai pas de compte Pix",
-        "button": "Je créé mon compte",
-        "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
+        "title": "Sign up",
+        "button": "Create my account",
+        "description": "An account will be created based on the information sent by the organisation",
         "information": {
-          "family-name": "Nom : {familyName}",
-          "given-name": "Prénom : {givenName}"
+          "family-name": "Last name  : {familyName}",
+          "given-name": "First name : {givenName}"
         }
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1161,7 +1161,7 @@
       },
       "register-form": {
         "title": "Je n’ai pas de compte Pix",
-        "button": "Je créé mon compte",
+        "button": "Je crée mon compte",
         "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
         "information": {
           "family-name": "Nom : {familyName}",


### PR DESCRIPTION
## :unicorn: Problème
- Actuellement il y a une erreur de traduction `fr` sur la double mire du formulaire de création de compte dans le contexte OIDC : 
"Je créé mon compte" au lieu de "Je crée mon compte".
- Sur la même page, en anglais, il y a sept traductions `en` manquantes et donc un mélange d'anglais et de français.

## :robot: Proposition
Corriger ces erreurs.

## :rainbow: Remarques
Il reste dans le fichier `en` plusieurs traductions manquantes pour couvrir tout le champ OIDC. Cela fera l'objet d'une autre PR.

## :100: Pour tester
**Avec les RA**

Au niveau des RA il n'est pas facile de tester les SSO, donc on ne teste pas dans cet environnement.

**En local**

Pour tester la traduction `fr`:
1. Aller sur http://app.dev.pix.fr 
2. Choisir "Se connecter avec Pôle Emploi"
3. S'authentifier avec un utilisateur de test
4. Constater que le navigateur est redirigé sur le double mire en français
5. Constater la présence du bouton "Je crée mon compte" et non "Je créé mon compte"

Pour tester la traduction `en`:
1. Aller sur https://app.dev.pix.org
2. Choisir "Se connecter avec la FWB"
3. S'authentifier avec un utilisateur de test
4. Constater que le navigateur est redirigé sur le double mire en français
5. Dans la barre d'adresse du navigateur modifier l'url de la double mire en y ajouant le `&lang=en`
6. Constater que tout le texte de la double mire est en anglais

