### PR TITLE
[TECH] Enlever le missionId de la table assessment (Pix-9774)

### DIFF
--- a/api/db/migrations/20231115145631_remove-mission-id-in-assessments.js
+++ b/api/db/migrations/20231115145631_remove-mission-id-in-assessments.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'assessments';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('missionId');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('missionId').defaultTo(null);
+  });
+};
+
+export { up, down };

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -49,7 +49,6 @@ const serialize = function (assessments) {
       'competenceId',
       'lastQuestionState',
       'method',
-      'missionId',
     ],
     answers: {
       ref: 'id',

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -63,7 +63,6 @@ class Assessment {
     campaignParticipationId,
     method,
     campaignCode,
-    missionId,
     liveAlerts,
   } = {}) {
     this.id = id;
@@ -86,7 +85,6 @@ class Assessment {
     this.campaignParticipationId = campaignParticipationId;
     this.method = method || Assessment.computeMethodFromType(this.type);
     this.campaignCode = campaignCode;
-    this.missionId = missionId;
     this.liveAlerts = liveAlerts;
   }
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -73,7 +73,6 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'last-question-state': Assessment.statesOfLastQuestion.ASKED,
           'competence-id': 'recCompetenceId',
           method: Assessment.methods.CHOSEN,
-          'mission-id': null,
         },
         relationships: {
           course: {
@@ -200,7 +199,6 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'competence-id': 'recCompetenceId',
           'last-question-state': Assessment.statesOfLastQuestion.ASKED,
           method: Assessment.methods.CHOSEN,
-          'mission-id': null,
         },
         relationships: {
           course: { data: { type: 'courses', id: courseId } },

--- a/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
@@ -7,7 +7,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
   describe('#getByAssessmentId', function () {
     it('returns the missionAssessment corresponding to the assessmentId', async function () {
       const missionId = 'flute78';
-      const assessmentId = databaseBuilder.factory.buildPix1dAssessment({ missionId }).id;
+      const assessmentId = databaseBuilder.factory.buildPix1dAssessment().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
       databaseBuilder.factory.buildMissionAssessment({ missionId, assessmentId, organizationLearnerId });
       await databaseBuilder.commit();

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -318,7 +318,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
           competenceId: johnAssessmentToRemember.competenceId,
           assessmentResults: [],
           method: Assessment.methods.SMART_RANDOM,
-          missionId: null,
         }),
       ];
 

--- a/api/tests/tooling/domain-builder/factory/build-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment.js
@@ -27,7 +27,6 @@ function buildAssessment({
   lastQuestionState = Assessment.statesOfLastQuestion.ASKED,
   method,
   campaignCode,
-  missionId = null,
 } = {}) {
   return new Assessment({
     id,
@@ -50,7 +49,6 @@ function buildAssessment({
     campaignParticipation,
     method,
     campaignCode,
-    missionId,
   });
 }
 
@@ -74,7 +72,6 @@ buildAssessment.ofTypeCampaign = function ({
   title = 'campaignTitle',
   method,
   campaignCode,
-  missionId,
 } = {}) {
   if (!_.isNil(campaignParticipation) && _.isNil(campaignParticipationId)) {
     campaignParticipationId = campaignParticipation.id;
@@ -108,7 +105,6 @@ buildAssessment.ofTypeCampaign = function ({
     campaignParticipation,
     method,
     campaignCode,
-    missionId,
   });
 };
 
@@ -131,7 +127,6 @@ buildAssessment.ofTypeCompetenceEvaluation = function ({
   knowledgeElements = [buildKnowledgeElement()],
   campaignParticipation = null,
   competenceId = 789,
-  missionId,
 } = {}) {
   return new Assessment({
     id,
@@ -155,7 +150,6 @@ buildAssessment.ofTypeCompetenceEvaluation = function ({
     knowledgeElements,
     campaignParticipation,
     campaignCode: null,
-    missionId,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -21,7 +21,6 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
             'competence-id': assessment.competenceId,
             'last-question-state': Assessment.statesOfLastQuestion.ASKED,
             method: Assessment.methods.CERTIFICATION_DETERMINED,
-            'mission-id': assessment.missionId,
           },
           relationships: {
             answers: {


### PR DESCRIPTION
## :unicorn: Problème
Avec l'ajout de la table 'mission-assessments', on a plus besoin de renseigner le missionId dans l'assessment

## :robot: Proposition
Faire la migration et nettoyer les missionId qui restent

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
faire un tour sur la plateforme et vérifier que tout va bien 