### PR TITLE
[FEATURE] Améliorer le endpoint de validation de réponse (PIX-9974)

### DIFF
--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -11,8 +11,8 @@ const getBySlug = async function (request, h, dependencies = { moduleSerializer,
 
 const validateAnswer = async function (request, h, dependencies = { correctionResponseSerializer, usecases }) {
   const { moduleSlug, elementId } = request.params;
-  const { answerId } = request.payload.data.attributes;
-  const module = await dependencies.usecases.validateAnswer({ moduleSlug, answerId, elementId });
+  const { 'user-response': userResponse } = request.payload.data.attributes;
+  const module = await dependencies.usecases.validateAnswer({ moduleSlug, userResponse, elementId });
 
   return dependencies.correctionResponseSerializer.serialize(module);
 };

--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -1,5 +1,5 @@
 import * as moduleSerializer from '../../infrastructure/serializers/jsonapi/module-serializer.js';
-import * as correctionResponseSerializer from '../../infrastructure/serializers/jsonapi/correction-response-serializer.js';
+import * as elementAnswerSerializer from '../../infrastructure/serializers/jsonapi/element-answer-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const getBySlug = async function (request, h, dependencies = { moduleSerializer, usecases }) {
@@ -9,12 +9,12 @@ const getBySlug = async function (request, h, dependencies = { moduleSerializer,
   return dependencies.moduleSerializer.serialize(module);
 };
 
-const validateAnswer = async function (request, h, dependencies = { correctionResponseSerializer, usecases }) {
+const validateAnswer = async function (request, h, dependencies = { elementAnswerSerializer, usecases }) {
   const { moduleSlug, elementId } = request.params;
   const { 'user-response': userResponse } = request.payload.data.attributes;
-  const module = await dependencies.usecases.validateAnswer({ moduleSlug, userResponse, elementId });
+  const answer = await dependencies.usecases.validateAnswer({ moduleSlug, userResponse, elementId });
 
-  return dependencies.correctionResponseSerializer.serialize(module);
+  return dependencies.elementAnswerSerializer.serialize(answer);
 };
 
 const modulesController = { getBySlug, validateAnswer };

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -30,7 +30,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                answerId: Joi.string().required(),
+                'user-response': Joi.array().required(),
               }).required(),
             }).required(),
           }).required(),

--- a/api/src/devcomp/domain/models/ElementAnswer.js
+++ b/api/src/devcomp/domain/models/ElementAnswer.js
@@ -1,0 +1,18 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class ElementAnswer {
+  constructor({ elementId, userResponseValue, correction }) {
+    assertNotNullOrUndefined(elementId, "L'id de l'élément est obligatoire pour une réponse d'élément");
+    assertNotNullOrUndefined(
+      userResponseValue,
+      "La réponse de l'utilisateur est obligatoire pour une réponse d'élément",
+    );
+    assertNotNullOrUndefined(correction, "La correction est obligatoire pour une réponse d'élément");
+
+    this.elementId = elementId;
+    this.userResponseValue = userResponseValue;
+    this.correction = correction;
+  }
+}
+
+export { ElementAnswer };

--- a/api/src/devcomp/domain/models/QcuCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/QcuCorrectionResponse.js
@@ -1,12 +1,12 @@
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class QcuCorrectionResponse {
-  constructor({ globalResult, feedback, solutionId }) {
-    assertNotNullOrUndefined(globalResult, 'Le résultat global est obligatoire pour une réponse de QCU');
+  constructor({ status, feedback, solutionId }) {
+    assertNotNullOrUndefined(status, 'Le résultat est obligatoire pour une réponse de QCU');
     assertNotNullOrUndefined(feedback, 'Le feedback est obligatoire pour une réponse de QCU');
     assertNotNullOrUndefined(solutionId, "L'id de la proposition correcte est obligatoire pour une réponse de QCU");
 
-    this.globalResult = globalResult;
+    this.status = status;
     this.feedback = feedback;
     this.solutionId = solutionId;
   }

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -33,7 +33,7 @@ class QCU extends Element {
     const validation = this.validator.assess({ answer: { value: userResponse[0] } });
 
     return new QcuCorrectionResponse({
-      globalResult: validation.result,
+      status: validation.result,
       feedback: validation.result.OK ? this.feedbacks.valid : this.feedbacks.invalid,
       solutionId: this.solution,
     });

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -29,8 +29,8 @@ class QCU extends Element {
     }
   }
 
-  assess(answer) {
-    const validation = this.validator.assess({ answer: { value: answer } });
+  assess(userResponse) {
+    const validation = this.validator.assess({ answer: { value: userResponse[0] } });
 
     return new QcuCorrectionResponse({
       globalResult: validation.result,

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -36,7 +36,7 @@ class QCU extends Element {
 
     const correction = new QcuCorrectionResponse({
       status: validation.result,
-      feedback: validation.result.OK ? this.feedbacks.valid : this.feedbacks.invalid,
+      feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
       solutionId: this.solution,
     });
 

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -3,6 +3,7 @@ import { Feedbacks } from '../Feedbacks.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { ValidatorQCU } from '../validator/ValidatorQCU.js';
 import { QcuCorrectionResponse } from '../QcuCorrectionResponse.js';
+import { ElementAnswer } from '../ElementAnswer.js';
 
 class QCU extends Element {
   constructor({ id, instruction, locales, proposals, solution, feedbacks, validator }) {
@@ -32,10 +33,16 @@ class QCU extends Element {
   assess(userResponse) {
     const validation = this.validator.assess({ answer: { value: userResponse[0] } });
 
-    return new QcuCorrectionResponse({
+    const correction = new QcuCorrectionResponse({
       status: validation.result,
       feedback: validation.result.OK ? this.feedbacks.valid : this.feedbacks.invalid,
       solutionId: this.solution,
+    });
+
+    return new ElementAnswer({
+      elementId: this.id,
+      userResponseValue: userResponse[0],
+      correction,
     });
   }
 

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -31,7 +31,8 @@ class QCU extends Element {
   }
 
   assess(userResponse) {
-    const validation = this.validator.assess({ answer: { value: userResponse[0] } });
+    const selectedQcuProposalId = userResponse[0];
+    const validation = this.validator.assess({ answer: { value: selectedQcuProposalId } });
 
     const correction = new QcuCorrectionResponse({
       status: validation.result,
@@ -41,7 +42,7 @@ class QCU extends Element {
 
     return new ElementAnswer({
       elementId: this.id,
-      userResponseValue: userResponse[0],
+      userResponseValue: selectedQcuProposalId,
       correction,
     });
   }

--- a/api/src/devcomp/domain/usecases/validate-answer.js
+++ b/api/src/devcomp/domain/usecases/validate-answer.js
@@ -1,7 +1,7 @@
-async function validateAnswer({ moduleSlug, answerId, elementId, moduleRepository }) {
+async function validateAnswer({ moduleSlug, userResponse, elementId, moduleRepository }) {
   const foundModule = await moduleRepository.getBySlug({ slug: moduleSlug });
   const element = foundModule.getElementById(elementId);
-  return element.assess(answerId);
+  return element.assess(userResponse);
 }
 
 export { validateAnswer };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js
@@ -8,10 +8,10 @@ function serialize(correctionResponse) {
       return {
         ...correctionResponse,
         id: correctionResponse.solutionId,
-        globalResult: correctionResponse.globalResult.status,
+        status: correctionResponse.status.status,
       };
     },
-    attributes: ['globalResult', 'feedback', 'solutionId'],
+    attributes: ['status', 'feedback', 'solutionId'],
   }).serialize(correctionResponse);
 }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
@@ -1,0 +1,28 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+import { randomUUID } from 'crypto';
+
+const { Serializer } = jsonapiSerializer;
+
+function serialize(elementAnswer) {
+  return new Serializer('element-answer', {
+    transform(elementAnswer) {
+      return {
+        ...elementAnswer,
+        id: randomUUID(),
+        correction: {
+          ...elementAnswer.correction,
+          id: randomUUID(),
+          status: elementAnswer.correction.status.status,
+        },
+      };
+    },
+    attributes: ['elementId', 'correction', 'userResponseValue'],
+    correction: {
+      ref: 'id',
+      includes: true,
+      attributes: ['feedback', 'status', 'solutionId'],
+    },
+  }).serialize(elementAnswer);
+}
+
+export { serialize };

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -29,8 +29,9 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
 
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.type).to.equal('element-answers');
-        expect(response.result.data.attributes['value']).to.equal('a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6');
+        expect(response.result.data.attributes['user-response-value']).to.equal('a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6');
         expect(response.result.data.attributes['element-id']).to.equal('z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7');
+        expect(response.result.included[0].attributes.status).to.equal('ok');
       });
     });
 
@@ -54,7 +55,7 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
 
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.type).to.equal('element-answers');
-        expect(response.result.data.attributes['global-result']).to.equal('ko');
+        expect(response.result.included[0].attributes.status).to.equal('ko');
       });
     });
   });

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -28,8 +28,9 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
         const response = await server.inject(options);
 
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data.type).to.equal('correction-responses');
-        expect(response.result.data.attributes['global-result']).to.equal('ok');
+        expect(response.result.data.type).to.equal('element-answers');
+        expect(response.result.data.attributes['value']).to.equal('a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6');
+        expect(response.result.data.attributes['element-id']).to.equal('z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7');
       });
     });
 
@@ -52,7 +53,7 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
         const response = await server.inject(options);
 
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data.type).to.equal('correction-responses');
+        expect(response.result.data.type).to.equal('element-answers');
         expect(response.result.data.attributes['global-result']).to.equal('ko');
       });
     });

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
           payload: {
             data: {
               attributes: {
-                answerId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+                'user-response': ['a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6'],
               },
             },
           },
@@ -43,7 +43,7 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
           payload: {
             data: {
               attributes: {
-                answerId: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
+                'user-response': ['b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6'],
               },
             },
           },

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -36,16 +36,16 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       };
       usecases.validateAnswer.withArgs({ moduleSlug, userResponse, elementId }).returns(correctionResponse);
 
-      const correctionResponseSerializer = {
+      const elementAnswerSerializer = {
         serialize: sinon.stub(),
       };
-      correctionResponseSerializer.serialize.withArgs(correctionResponse).returns(serializedCorrection);
+      elementAnswerSerializer.serialize.withArgs(correctionResponse).returns(serializedCorrection);
 
       // When
       const result = await modulesController.validateAnswer(
         { payload: { data: { attributes: { 'user-response': userResponse } } }, params: { moduleSlug, elementId } },
         null,
-        { correctionResponseSerializer, usecases },
+        { elementAnswerSerializer, usecases },
       );
 
       // Then

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -27,14 +27,14 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       // Given
       const moduleSlug = 'slug';
       const serializedCorrection = Symbol('serialized correction');
-      const answerId = Symbol('answerId');
+      const userResponse = Symbol('user-response');
       const elementId = Symbol('elementId');
       const correctionResponse = Symbol('correction');
 
       const usecases = {
         validateAnswer: sinon.stub(),
       };
-      usecases.validateAnswer.withArgs({ moduleSlug, answerId, elementId }).returns(correctionResponse);
+      usecases.validateAnswer.withArgs({ moduleSlug, userResponse, elementId }).returns(correctionResponse);
 
       const correctionResponseSerializer = {
         serialize: sinon.stub(),
@@ -43,7 +43,7 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
 
       // When
       const result = await modulesController.validateAnswer(
-        { payload: { data: { attributes: { answerId } } }, params: { moduleSlug, elementId } },
+        { payload: { data: { attributes: { 'user-response': userResponse } } }, params: { moduleSlug, elementId } },
         null,
         { correctionResponseSerializer, usecases },
       );

--- a/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
+++ b/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
@@ -1,0 +1,41 @@
+import { ElementAnswer } from '../../../../../src/devcomp/domain/models/ElementAnswer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Models | ElementAnswer', function () {
+  describe('#constructor', function () {
+    it('should create an element answer and keep attributes', function () {
+      // given
+      const elementId = 1;
+      const userResponseValue = 'foo';
+      const correction = Symbol('correction');
+
+      // when
+      const answer = new ElementAnswer({ elementId, userResponseValue: 'foo', correction });
+
+      // then
+      expect(answer.elementId).to.equal(elementId);
+      expect(answer.userResponseValue).to.equal(userResponseValue);
+      expect(answer.correction).to.equal(correction);
+    });
+
+    describe('An element answer without element id', function () {
+      it('should throw an error', function () {
+        expect(() => new ElementAnswer({})).to.throw("L'id de l'élément est obligatoire pour une réponse d'élément");
+      });
+    });
+    describe('An element answer without user response value', function () {
+      it('should throw an error', function () {
+        expect(() => new ElementAnswer({ elementId: 'elementId' })).to.throw(
+          "La réponse de l'utilisateur est obligatoire pour une réponse d'élément",
+        );
+      });
+    });
+    describe('An element answer without correction', function () {
+      it('should throw an error', function () {
+        expect(() => new ElementAnswer({ elementId: 'elementId', userResponseValue: 'userResponseValue' })).to.throw(
+          "La correction est obligatoire pour une réponse d'élément",
+        );
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
@@ -6,32 +6,30 @@ describe('Unit | Devcomp | Models | QcuCorrectionResponse', function () {
   describe('#constructor', function () {
     it('should create a QCU correction response and keep attributes', function () {
       // given
-      const globalResult = AnswerStatus.OK;
+      const status = AnswerStatus.OK;
       const feedback = 'Bien joué !';
       const proposalId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
 
       // when
-      const qcuCorrectionResponse = new QcuCorrectionResponse({ globalResult, feedback, solutionId: proposalId });
+      const qcuCorrectionResponse = new QcuCorrectionResponse({ status, feedback, solutionId: proposalId });
 
       // then
       expect(qcuCorrectionResponse).not.to.be.undefined;
-      expect(qcuCorrectionResponse.globalResult).to.deep.equal(globalResult);
+      expect(qcuCorrectionResponse.status).to.deep.equal(status);
       expect(qcuCorrectionResponse.feedback).to.equal(feedback);
       expect(qcuCorrectionResponse.solutionId).to.equal(proposalId);
     });
   });
 
-  describe('A QCU correction response without global result', function () {
+  describe('A QCU correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({})).to.throw(
-        'Le résultat global est obligatoire pour une réponse de QCU',
-      );
+      expect(() => new QcuCorrectionResponse({})).to.throw('Le résultat est obligatoire pour une réponse de QCU');
     });
   });
 
   describe('A QCU correction response without feedback', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({ globalResult: AnswerStatus.OK })).to.throw(
+      expect(() => new QcuCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
         'Le feedback est obligatoire pour une réponse de QCU',
       );
     });
@@ -39,7 +37,7 @@ describe('Unit | Devcomp | Models | QcuCorrectionResponse', function () {
 
   describe('A QCU correction response without proposal id', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({ globalResult: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
+      expect(() => new QcuCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
         "L'id de la proposition correcte est obligatoire pour une réponse de QCU",
       );
     });

--- a/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
@@ -7,8 +7,8 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
     it('should return a QcuCorrectionResponse for a valid answer', function () {
       // given
       const assessResult = { result: { OK: 'ok' } };
-      const givenAnswer = Symbol('givenAnswer');
-      const qcuSolution = givenAnswer;
+      const qcuSolution = Symbol('correctSolution');
+      const userResponse = [qcuSolution];
 
       const validator = {
         assess: sinon.stub(),
@@ -16,14 +16,14 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       validator.assess
         .withArgs({
           answer: {
-            value: givenAnswer,
+            value: userResponse[0],
           },
         })
         .returns(assessResult);
       const qcu = new QCU({
         id: '',
         instruction: '',
-        proposals: [{ id: givenAnswer }],
+        proposals: [{ id: qcuSolution }],
         feedbacks: { valid: 'OK', invalid: 'KO' },
         solution: qcuSolution,
         validator,
@@ -36,7 +36,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       };
 
       // when
-      const result = qcu.assess(givenAnswer);
+      const result = qcu.assess(userResponse);
 
       // then
       expect(result).to.deep.equal(expectedResult);
@@ -46,8 +46,8 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
     it('should return a QcuCorrectionResponse for a invalid answer', function () {
       // given
       const assessResult = { result: { KO: 'ko' } };
-      const givenAnswer = Symbol('givenAnswer');
-      const qcuSolutionId = Symbol('qcuSolution');
+      const qcuSolution = Symbol('correctSolution');
+      const userResponse = ['wrongAnswer'];
 
       const validator = {
         assess: sinon.stub(),
@@ -55,27 +55,27 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       validator.assess
         .withArgs({
           answer: {
-            value: givenAnswer,
+            value: userResponse[0],
           },
         })
         .returns(assessResult);
       const qcu = new QCU({
         id: '',
         instruction: '',
-        proposals: [{ id: givenAnswer }, { id: qcuSolutionId }],
+        proposals: [{ id: qcuSolution }],
         feedbacks: { valid: 'OK', invalid: 'KO' },
-        solution: qcuSolutionId,
+        solution: qcuSolution,
         validator,
       });
 
       const expectedResult = {
         globalResult: assessResult.result,
         feedback: qcu.feedbacks.invalid,
-        solutionId: qcuSolutionId,
+        solutionId: qcuSolution,
       };
 
       // when
-      const result = qcu.assess(givenAnswer);
+      const result = qcu.assess(userResponse);
 
       // then
       expect(result).to.deep.equal(expectedResult);

--- a/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
@@ -7,7 +7,8 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
   describe('#assess', function () {
     it('should return a QcuCorrectionResponse for a valid answer', function () {
       // given
-      const assessResult = { result: { OK: 'ok' } };
+      const stubedIsOk = sinon.stub().returns(true);
+      const assessResult = { result: { isOK: stubedIsOk } };
       const qcuSolution = Symbol('correctSolution');
       const userResponse = [qcuSolution];
 
@@ -51,7 +52,8 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
 
     it('should return a QcuCorrectionResponse for a invalid answer', function () {
       // given
-      const assessResult = { result: { KO: 'ko' } };
+      const stubedIsOk = sinon.stub().returns(false);
+      const assessResult = { result: { isOK: stubedIsOk } };
       const qcuSolution = Symbol('correctSolution');
       const userResponse = ['wrongAnswer'];
 

--- a/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
@@ -1,5 +1,6 @@
 import { expect, sinon } from '../../../../test-helper.js';
 import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
+import { ElementAnswer } from '../../../../../src/devcomp/domain/models/ElementAnswer.js';
 import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 
 describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
@@ -21,7 +22,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
         })
         .returns(assessResult);
       const qcu = new QCU({
-        id: '',
+        id: 'qcu-id',
         instruction: '',
         proposals: [{ id: qcuSolution }],
         feedbacks: { valid: 'OK', invalid: 'KO' },
@@ -30,9 +31,13 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       });
 
       const expectedResult = {
-        status: assessResult.result,
-        feedback: qcu.feedbacks.valid,
-        solutionId: qcuSolution,
+        elementId: 'qcu-id',
+        userResponseValue: userResponse[0],
+        correction: {
+          status: assessResult.result,
+          feedback: qcu.feedbacks.valid,
+          solutionId: qcuSolution,
+        },
       };
 
       // when
@@ -40,7 +45,8 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
 
       // then
       expect(result).to.deep.equal(expectedResult);
-      expect(result).to.be.instanceOf(QcuCorrectionResponse);
+      expect(result).to.be.instanceOf(ElementAnswer);
+      expect(result.correction).to.be.instanceOf(QcuCorrectionResponse);
     });
 
     it('should return a QcuCorrectionResponse for a invalid answer', function () {
@@ -60,7 +66,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
         })
         .returns(assessResult);
       const qcu = new QCU({
-        id: '',
+        id: 'qcu-id',
         instruction: '',
         proposals: [{ id: qcuSolution }],
         feedbacks: { valid: 'OK', invalid: 'KO' },
@@ -69,9 +75,13 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       });
 
       const expectedResult = {
-        status: assessResult.result,
-        feedback: qcu.feedbacks.invalid,
-        solutionId: qcuSolution,
+        elementId: 'qcu-id',
+        userResponseValue: userResponse[0],
+        correction: {
+          status: assessResult.result,
+          feedback: qcu.feedbacks.invalid,
+          solutionId: qcuSolution,
+        },
       };
 
       // when
@@ -79,7 +89,8 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
 
       // then
       expect(result).to.deep.equal(expectedResult);
-      expect(result).to.be.instanceOf(QcuCorrectionResponse);
+      expect(result).to.be.instanceOf(ElementAnswer);
+      expect(result.correction).to.be.instanceOf(QcuCorrectionResponse);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuForCorrection_test.js
@@ -30,7 +30,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       });
 
       const expectedResult = {
-        globalResult: assessResult.result,
+        status: assessResult.result,
         feedback: qcu.feedbacks.valid,
         solutionId: qcuSolution,
       };
@@ -69,7 +69,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
       });
 
       const expectedResult = {
-        globalResult: assessResult.result,
+        status: assessResult.result,
         feedback: qcu.feedbacks.invalid,
         solutionId: qcuSolution,
       };

--- a/api/tests/devcomp/unit/domain/usecases/validate-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/validate-answer_test.js
@@ -8,7 +8,7 @@ describe('Unit | Devcomp | Usecases | validate-answer', function () {
         // given
         const moduleSlug = 'moduleSlug';
         const elementId = 'elementId';
-        const answerId = 'totoId';
+        const userResponse = ['totoId'];
 
         const mockedModuleRepo = {
           getBySlug: sinon.stub(),
@@ -26,13 +26,13 @@ describe('Unit | Devcomp | Usecases | validate-answer', function () {
         expectedModule.getElementById.withArgs(elementId).returns(stubElement);
 
         const expectedQcuResponse = Symbol('answer');
-        stubElement.assess.withArgs(answerId).returns(expectedQcuResponse);
+        stubElement.assess.withArgs(userResponse).returns(expectedQcuResponse);
 
         // when
         const validateQcu = await validateAnswer({
           moduleSlug: moduleSlug,
           elementId: elementId,
-          answerId: answerId,
+          userResponse: userResponse,
           moduleRepository: mockedModuleRepo,
         });
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
@@ -8,7 +8,7 @@ describe('Unit | DevComp | Serializers | CorrectionResponseSerializer', function
     it('should return a serialized CorrectionReponse', function () {
       // given
       const givenCorrectionResponse = new QcuCorrectionResponse({
-        globalResult: AnswerStatus.OK,
+        status: AnswerStatus.OK,
         feedback: 'Good job!',
         solutionId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
       });
@@ -16,7 +16,7 @@ describe('Unit | DevComp | Serializers | CorrectionResponseSerializer', function
         data: {
           attributes: {
             feedback: 'Good job!',
-            'global-result': 'ok',
+            status: 'ok',
             'solution-id': 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
           },
           id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
@@ -1,0 +1,59 @@
+import { expect } from '../../../../../test-helper.js';
+import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
+import { AnswerStatus } from '../../../../../../lib/domain/models/index.js';
+import * as elementAnswerSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js';
+import { ElementAnswer } from '../../../../../../src/devcomp/domain/models/ElementAnswer.js';
+import omit from 'lodash/omit.js';
+
+describe('Unit | DevComp | Serializers | ElementAnswerSerializer', function () {
+  describe('#serialize', function () {
+    it('should return a serialized ElementAnswer', function () {
+      // given
+      const givenCorrectionResponse = new QcuCorrectionResponse({
+        status: AnswerStatus.OK,
+        feedback: 'Good job!',
+        solutionId: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+      });
+
+      const elementAnswer = new ElementAnswer({
+        elementId: '123',
+        userResponseValue: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+        correction: givenCorrectionResponse,
+      });
+      const expectedResult = {
+        data: {
+          attributes: {
+            'element-id': '123',
+            'user-response-value': 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+          },
+          relationships: {
+            correction: {
+              data: {
+                type: 'corrections',
+              },
+            },
+          },
+          type: 'element-answers',
+        },
+        included: [
+          {
+            attributes: {
+              feedback: 'Good job!',
+              status: 'ok',
+              'solution-id': givenCorrectionResponse.solutionId,
+            },
+            type: 'corrections',
+          },
+        ],
+      };
+
+      // when
+      const result = elementAnswerSerializer.serialize(elementAnswer);
+
+      // then
+      expect(omit(result, ['data.id', 'data.relationships.correction.data.id', 'included[0].id'])).to.deep.equal(
+        expectedResult,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Notre endpoint de vérification de réponse était trop axé "QCU". Il n'était pas REST compliant.

## :robot: Proposition
Le POST sur `/api/modules/{moduleSlug}/elements/{elementId}/answers` nous renvoie la même ressource que ce qu'on demande `ElementAnswer`.

## :rainbow: Remarques
On conserve le `correctionResponseSerializer` qui devrait pouvoir nous servir dans le futur pour nous envoyer la correction sans besoin de passer d'answer.

## :100: Pour tester
POST sur le endpoint d'answer vérifie qu'on récupère bien un type `element-answers` avec un `included` qui contient la correction : `status`, `solution-id` et `feedback`.
