### PR TITLE
[FEATURE] Plafonner le niveau "Positionné" sur la page de détails d'une certif. (PIX-9177)

### DIFF
--- a/api/lib/domain/usecases/get-certification-details.js
+++ b/api/lib/domain/usecases/get-certification-details.js
@@ -40,6 +40,7 @@ async function _computeCertificationDetailsOnTheFly(
     userId: certificationAssessment.userId,
     limitDate: certificationAssessment.createdAt,
     version: CertificationVersion.V2,
+    allowExcessPixAndLevels: false,
   });
 
   return CertificationDetails.fromCertificationAssessmentScore({
@@ -58,6 +59,7 @@ async function _retrievePersistedCertificationDetails(
     userId: certificationAssessment.userId,
     limitDate: certificationAssessment.createdAt,
     version: CertificationVersion.V2,
+    allowExcessPixAndLevels: false,
   });
 
   return CertificationDetails.from({

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -1,4 +1,4 @@
-import { sinon, expect, domainBuilder } from '../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { getCertificationDetails } from '../../../../lib/domain/usecases/get-certification-details.js';
 import { CertificationDetails } from '../../../../lib/domain/read-models/CertificationDetails.js';
 import { states as CertificationAssessmentStates } from '../../../../lib/domain/models/CertificationAssessment.js';
@@ -69,6 +69,7 @@ describe('Unit | UseCase | get-certification-details', function () {
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
           version: certificationAssessment.version,
+          allowExcessPixAndLevels: false,
         })
         .resolves(placementProfile);
 
@@ -174,6 +175,7 @@ describe('Unit | UseCase | get-certification-details', function () {
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
           version: certificationAssessment.version,
+          allowExcessPixAndLevels: false,
         })
         .resolves(placementProfile);
 


### PR DESCRIPTION
## :unicorn: Problème
Si le niveau de positionnement est plafonné à 7 sur Pix App, cela n’est pas le cas sur la page de détails d’une certif > onglet “Détails” de Pix Admin.
On peut donc se retrouver avec un positionnement affiché au dessus de 7.
![image](https://github.com/1024pix/pix/assets/103997660/fc591b2b-ee1a-4290-afc3-41f971c58a85)

## :robot: Proposition
Lors de la récupération du positionnement dans Pix Admin, bloquer le paramètre `allowExcessPixAndLevels`. Cela permet de caper au niveau `MAX_REACHABLE_LEVEL`, renseigné dans les variables d'env.

## :100: Pour tester
- Se connecter à Pix Admin avec le compte `superadmin`
- Aller sur le detail de cette certif : [certifications/144410/details](https://admin-pr7466.review.pix.fr/certifications/144410/details)
- Observer que le positionnement est sur 7
![Capture d’écran 2023-11-15 à 18 19 14](https://github.com/1024pix/pix/assets/103997660/2ed973b5-a1cd-430e-9b08-85eb28c9a7d8)
-  Changer la valeur de la variable d'env `MAX_REACHABLE_LEVEL` à un niv inférieur comme 4
- Relancer manuellement le déploiement de l'api
- Retourner sur la page détail et observer que la barre du positionnement est passée à 4.
![Capture d’écran 2023-11-15 à 18 10 39](https://github.com/1024pix/pix/assets/103997660/01eb47b0-818d-46eb-9864-e21a94677edb)
- Remettre la var d'env à 7 et relancer le déploiement pour les suivants qui veulent tester 😘 