### PR TITLE
[BUGFIX] Améliore l'accessibilité du QCU (PIX-9984)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -13,17 +13,17 @@
             {
               "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
               "type": "text",
-              "content": "<h3 class='sr-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='sr-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>"
+              "content": "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>"
             },
             {
               "id": "d9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a",
               "type": "text",
-              "content": "<h3 class='sr-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>"
+              "content": "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>"
             },
             {
               "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6",
               "type": "text",
-              "content": "<h3 class='sr-only'>Le fournisseur d’adresse mail</h3><h4><span aria-hidden='true'>2️⃣</span><span class='sr-only'>2</span> Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail : </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><span aria-hidden='true'>🧐</span> L’avez-vous remarqué ? Cette partie est en 2 morceaux : le nom du fournisseur (par exemple “laposte”) et une extension (dans notre exemple, “.net”).</p>"
+              "content": "<h3 class='screen-reader-only'>Le fournisseur d’adresse mail</h3><h4><span aria-hidden='true'>2️⃣</span><span class='screen-reader-only'>2</span> Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail : </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><span aria-hidden='true'>🧐</span> L’avez-vous remarqué ? Cette partie est en 2 morceaux : le nom du fournisseur (par exemple “laposte”) et une extension (dans notre exemple, “.net”).</p>"
             }
           ]
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -108,7 +108,7 @@
               ],
               "feedbacks": {
                 "valid": "<p>Bien vu ! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>et La Poste (laposte.net).</li><ul>",
-                "invalid": "<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><ul>Il y en a énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>de chez Free (free.fr)</li><li>ou de chez La Poste (laposte.net).</li></ul>"
+                "invalid": "<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>de chez Free (free.fr)</li><li>ou de chez La Poste (laposte.net).</li></ul>"
               },
               "solution": "f56bb715-714e-4a94-ba34-eef5ccd755d0"
             }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -19,19 +19,19 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
               elements: [
                 {
                   content:
-                    "<h3 class='sr-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='sr-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>",
+                    "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>",
                   id: 'c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
                   type: 'text',
                 },
                 {
                   content:
-                    "<h3 class='sr-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                   id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                   type: 'text',
                 },
                 {
                   content:
-                    "<h3 class='sr-only'>Le fournisseur d’adresse mail</h3><h4><span aria-hidden='true'>2️⃣</span><span class='sr-only'>2</span> Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail : </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><span aria-hidden='true'>🧐</span> L’avez-vous remarqué ? Cette partie est en 2 morceaux : le nom du fournisseur (par exemple “laposte”) et une extension (dans notre exemple, “.net”).</p>",
+                    "<h3 class='screen-reader-only'>Le fournisseur d’adresse mail</h3><h4><span aria-hidden='true'>2️⃣</span><span class='screen-reader-only'>2</span> Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail : </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><span aria-hidden='true'>🧐</span> L’avez-vous remarqué ? Cette partie est en 2 morceaux : le nom du fournisseur (par exemple “laposte”) et une extension (dans notre exemple, “.net”).</p>",
                   id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
                   type: 'text',
                 },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -111,7 +111,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
                 {
                   feedbacks: {
                     invalid:
-                      '<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><ul>Il y en a énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>de chez Free (free.fr)</li><li>ou de chez La Poste (laposte.net).</li></ul>',
+                      '<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>de chez Free (free.fr)</li><li>ou de chez La Poste (laposte.net).</li></ul>',
                     valid:
                       '<p>Bien vu ! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>et La Poste (laposte.net).</li><ul>',
                   },

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -5,7 +5,7 @@
     <h1>{{@module.title}}</h1>
   </div>
 
-  <div class="module__content" aria-live="assertive">
+  <div class="module__content">
     <article class="grain">
       {{#each @module.grains as |grain|}}
         {{#each grain.elements as |element|}}

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -8,6 +8,7 @@
   <div class="module__content">
     <article class="grain">
       {{#each @module.grains as |grain|}}
+        <h2 class="screen-reader-only">{{grain.title}}</h2>
         {{#each grain.elements as |element|}}
           {{#if element.isText}}
             <Module::Text @text={{element}} />

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -1,17 +1,21 @@
 <form class="element-qcu">
-  <div class="element-qcu__header">
-    <p class="element-qcu-header__instruction">
-      {{html-safe @qcu.instruction}}
-    </p>
-    <p class="element-qcu-header__direction">
-      {{t "pages.modulix.qcu.direction"}}
-    </p>
-  </div>
-  <div class="element-qcu__proposals">
-    {{#each @qcu.proposals as |proposal|}}
-      <PixRadioButton name={{@qcu.id}} @value={{proposal.id}} {{on "click" (fn this.radioClicked proposal)}}>
-        {{proposal.content}}
-      </PixRadioButton>
-    {{/each}}
-  </div>
+  <fieldset>
+    <div class="element-qcu__header">
+      <div class="element-qcu-header__instruction">
+        {{html-safe @qcu.instruction}}
+      </div>
+
+      <legend class="element-qcu-header__direction">
+        {{t "pages.modulix.qcu.direction"}}
+      </legend>
+    </div>
+
+    <div class="element-qcu__proposals">
+      {{#each @qcu.proposals as |proposal|}}
+        <PixRadioButton name={{@qcu.id}} @value={{proposal.id}} {{on "click" (fn this.radioClicked proposal.id)}}>
+          {{proposal.content}}
+        </PixRadioButton>
+      {{/each}}
+    </div>
+  </fieldset>
 </form>


### PR DESCRIPTION
## :unicorn: Problème
On a quelques erreurs d'accessibilité sur le module et notamment sur les QCU.

## :robot: Proposition
Reprendre les éléments tirés de https://codepen.io/yannbertrand/pen/ZEwLeBP : 
- Ajouter un `fieldset` et son `legend` autour du QCU
- Supprimer le `aria-live="assertive"` qui pollue la lecture d'écran
- Ajouter un petit titre sur les grains pour améliorer la navigation au lecteur d'écran

J'en profite pour des ajustements sur le contenu du module : 
- Corriger une ouverture de `ul` qui se ferme par un `p` (c'est un `p`)
- Utiliser la bonne classe CSS [`screen-reader-only`](https://ui.pix.fr/?path=/docs/utiliser-pix-ui-classes-css-utilitaires--docs)

## :rainbow: Remarques
Je ne suis pas certain de l'usage de `fieldset` et `legend`, j'aimerai valider l'usage en panel à l'occasion.

## :100: Pour tester
Faire un petit tour de [Wave](https://wave.webaim.org/extension/) sur l'intégration et constater qu'on a 4 alertes à cause de `fieldset` manquants sur les formulaires QCU. Comparer avec le résultat de cette RA. Ces alertes se transforment en "feature".

La dernière alerte est liée à "Skipped heading level" qui n'est plus une vraie erreur du RGAA depuis la dernière version mais qui reste importante à corriger pour faciliter la navigation au lecteur d'écran.

Constater aussi la disparition d'un `aria` `live` inutile pour le moment.