### PR TITLE
[BUGFIX] Retourner les httpErrors dans l'error manager du dossier shared de src (PIX-10002).

### DIFF
--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -117,6 +117,8 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.NoCertificationAttestationForDivisionError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+
+  return new HttpErrors.BaseHttpError(error.message);
 }
 
 function handle(request, h, error) {

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -10,7 +10,7 @@ import {
   NoCertificationAttestationForDivisionError,
 } from '../../../../src/shared/domain/errors.js';
 
-import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
+import { HttpErrors, UnauthorizedError } from '../../../../src/shared/application/http-errors.js';
 import { handle } from '../../../../src/shared/application/error-manager.js';
 import { AdminMemberError } from '../../../../src/authorization/domain/errors.js';
 import {
@@ -269,6 +269,19 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
         'Aucune attestation de certification pour la classe 1.',
       );
+    });
+
+    it('should instantiate BaseHttpError when UnauthorizedError', async function () {
+      // given
+      const error = new UnauthorizedError();
+      sinon.stub(HttpErrors, 'BaseHttpError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BaseHttpError).to.have.been.calledOnce;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la route /token retourne une 500 lorsqu'une erreur http est retournée. 
Ce problème survient depuis la migration des fichiers de l'authentification standard : https://github.com/1024pix/pix/pull/7436
Un service appelle l'erreur `UnauthorizedError` depuis le dossier shared. Mais le error-manager coté shared ne gère pas encore les erreurs de type http.

## :robot: Proposition
Retourner les httpErrors dans l'error manager du dossier shared de src

## :rainbow: Remarques
D'autres routes déplacés ont pu être impactés par cet oubli mais cette PR fixera le reste.

## :100: Pour tester

- modifier les variables suivantes : `ACCESS_TOKEN_LIFESPAN=10s, REFRESH_TOKEN_LIFESPAN=10s` (déjà modifié en RA)
- se connecter à une app (ex: certif avec certif-sco@example.net )
- La modification des variables va entraîner un UnauthorizedError de l'API car le refresh token n'est plus bon. 
- Constater que la route /token retourne une 400. ✅ 
- Testez ça sur dev ou une autre branche, et vous constaterez qu'elle retourne une 500
