### PR TITLE
[FEATURE] Ajouter le tri par date de dernière participation sur les organisations sans import (Pix-9867)

### DIFF
--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -27,6 +27,7 @@ const register = async function (server) {
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
             'sort[participationCount]': Joi.string().empty(''),
             'sort[lastnameSort]': Joi.string().empty(''),
+            'sort[latestParticipationOrder]': Joi.string().empty(''),
           }),
         },
         handler: learnerListController.getPaginatedParticipantsForAnOrganization,

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-participant-repository.js
@@ -30,16 +30,23 @@ async function getParticipantsByOrganizationId({ organizationId, page, filters =
     'view-active-organization-learners.firstName',
     'view-active-organization-learners.id',
   ];
-  if (sort?.participationCount) {
+  if (sort.participationCount) {
     orderByClause.unshift({
       column: 'participationCount',
       order: sort.participationCount === 'desc' ? 'desc' : 'asc',
     });
   }
-  if (sort?.lastnameSort) {
+  if (sort.lastnameSort) {
     orderByClause.unshift({
       column: 'view-active-organization-learners.lastName',
       order: sort.lastnameSort === 'desc' ? 'desc' : 'asc',
+    });
+  }
+
+  if (sort.latestParticipationOrder) {
+    orderByClause.unshift({
+      column: 'lastParticipationDate',
+      order: sort.latestParticipationOrder === 'desc' ? 'desc' : 'asc',
     });
   }
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -376,59 +376,132 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
         context('sort by participant count', function () {
           let organizationLearnerId1, organizationLearnerId2, organizationLearnerId3, organizationId;
 
-          beforeEach(async function () {
-            organizationId = databaseBuilder.factory.buildOrganization().id;
+          context('common case', function () {
+            beforeEach(async function () {
+              organizationId = databaseBuilder.factory.buildOrganization().id;
+              const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+              const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+              const campaignId3 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+              const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+                organizationId,
+              });
+              const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+                organizationId,
+              });
+              const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({
+                organizationId,
+              });
+
+              organizationLearnerId1 = organizationLearner1.id;
+              organizationLearnerId2 = organizationLearner2.id;
+              organizationLearnerId3 = organizationLearner3.id;
+
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId1,
+                organizationLearnerId: organizationLearnerId1,
+                userId: organizationLearner1.userId,
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId2,
+                organizationLearnerId: organizationLearnerId1,
+                userId: organizationLearner1.userId,
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId3,
+                organizationLearnerId: organizationLearnerId1,
+                userId: organizationLearner1.userId,
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId1,
+                organizationLearnerId: organizationLearnerId3,
+                userId: organizationLearner3.userId,
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId2,
+                organizationLearnerId: organizationLearnerId3,
+                userId: organizationLearner3.userId,
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId1,
+                organizationLearnerId: organizationLearnerId2,
+                userId: organizationLearner2.userId,
+              });
+              await databaseBuilder.commit();
+            });
+
+            it('should return participants sorted by ascendant participation count', async function () {
+              // when
+              const { organizationParticipants } =
+                await organizationParticipantRepository.getParticipantsByOrganizationId({
+                  organizationId,
+                  sort: {
+                    participationCount: 'asc',
+                  },
+                });
+
+              // then
+              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
+              expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+              expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
+            });
+
+            it('should return participants sorted by descendant participation count', async function () {
+              // when
+              const { organizationParticipants } =
+                await organizationParticipantRepository.getParticipantsByOrganizationId({
+                  organizationId,
+                  sort: {
+                    participationCount: 'desc',
+                  },
+                });
+
+              // then
+              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
+              expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+              expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
+            });
+          });
+
+          it('should return participants sorted by name if participation count are identical', async function () {
+            const organizationId = databaseBuilder.factory.buildOrganization().id;
             const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
             const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-            const campaignId3 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-            const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+            const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
               organizationId,
+              lastName: 'Aaaah',
             });
-            const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+            const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
               organizationId,
+              lastName: 'Dupont',
             });
-            const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({
+            const { id: organizationLearnerId3, userId: userId3 } = databaseBuilder.factory.buildOrganizationLearner({
               organizationId,
+              lastName: 'Dupond',
             });
-
-            organizationLearnerId1 = organizationLearner1.id;
-            organizationLearnerId2 = organizationLearner2.id;
-            organizationLearnerId3 = organizationLearner3.id;
 
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId: campaignId1,
               organizationLearnerId: organizationLearnerId1,
-              userId: organizationLearner1.userId,
+              userId: userId1,
             });
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId: campaignId2,
               organizationLearnerId: organizationLearnerId1,
-              userId: organizationLearner1.userId,
-            });
-            databaseBuilder.factory.buildCampaignParticipation({
-              campaignId: campaignId3,
-              organizationLearnerId: organizationLearnerId1,
-              userId: organizationLearner1.userId,
-            });
-            databaseBuilder.factory.buildCampaignParticipation({
-              campaignId: campaignId1,
-              organizationLearnerId: organizationLearnerId3,
-              userId: organizationLearner3.userId,
-            });
-            databaseBuilder.factory.buildCampaignParticipation({
-              campaignId: campaignId2,
-              organizationLearnerId: organizationLearnerId3,
-              userId: organizationLearner3.userId,
+              userId: userId1,
             });
             databaseBuilder.factory.buildCampaignParticipation({
               campaignId: campaignId1,
               organizationLearnerId: organizationLearnerId2,
-              userId: organizationLearner2.userId,
+              userId: userId2,
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId1,
+              organizationLearnerId: organizationLearnerId3,
+              userId: userId3,
             });
             await databaseBuilder.commit();
-          });
-
-          it('should return participants sorted by ascendant participation count', async function () {
             // when
             const { organizationParticipants } =
               await organizationParticipantRepository.getParticipantsByOrganizationId({
@@ -440,80 +513,138 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
 
             // then
             expect(organizationParticipants.length).to.equal(3);
-            expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
-            expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+            expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
+            expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
             expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
           });
+        });
 
-          it('should return participants sorted by descendant participation count', async function () {
+        context('sort by participation date', function () {
+          let organizationLearnerId1, organizationLearnerId2, organizationLearnerId3, organizationId;
+          context('common case', function () {
+            beforeEach(async function () {
+              organizationId = databaseBuilder.factory.buildOrganization().id;
+              const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+              const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+                organizationId,
+              });
+              const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+                organizationId,
+              });
+              const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({
+                organizationId,
+              });
+
+              organizationLearnerId1 = organizationLearner1.id;
+              organizationLearnerId2 = organizationLearner2.id;
+              organizationLearnerId3 = organizationLearner3.id;
+
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId1,
+                organizationLearnerId: organizationLearnerId1,
+                userId: organizationLearner1.userId,
+                createdAt: new Date('2023-05-01'),
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId1,
+                organizationLearnerId: organizationLearnerId3,
+                userId: organizationLearner3.userId,
+                createdAt: new Date('2022-05-01'),
+              });
+              databaseBuilder.factory.buildCampaignParticipation({
+                campaignId: campaignId1,
+                organizationLearnerId: organizationLearnerId2,
+                userId: organizationLearner2.userId,
+                createdAt: new Date('2021-05-01'),
+              });
+              await databaseBuilder.commit();
+            });
+
+            it('should return participants sorted by ascendant participation date', async function () {
+              // when
+              const { organizationParticipants } =
+                await organizationParticipantRepository.getParticipantsByOrganizationId({
+                  organizationId,
+                  sort: {
+                    latestParticipationOrder: 'asc',
+                  },
+                });
+
+              // then
+              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
+              expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+              expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
+            });
+
+            it('should return participants sorted by descendant participation date', async function () {
+              // when
+              const { organizationParticipants } =
+                await organizationParticipantRepository.getParticipantsByOrganizationId({
+                  organizationId,
+                  sort: {
+                    latestParticipationOrder: 'desc',
+                  },
+                });
+
+              // then
+              expect(organizationParticipants.length).to.equal(3);
+              expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
+              expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+              expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
+            });
+          });
+
+          it('should return participants sorted by name if participation date are identical', async function () {
+            const organizationId = databaseBuilder.factory.buildOrganization().id;
+            const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+            const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+              lastName: 'Aaaah',
+            });
+            const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+              lastName: 'Dupont',
+            });
+            const { id: organizationLearnerId3, userId: userId3 } = databaseBuilder.factory.buildOrganizationLearner({
+              organizationId,
+              lastName: 'Dupond',
+            });
+
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId1,
+              organizationLearnerId: organizationLearnerId1,
+              userId: userId1,
+              createdAt: new Date('2023-05-01'),
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId1,
+              organizationLearnerId: organizationLearnerId2,
+              userId: userId2,
+              createdAt: new Date('2023-05-01'),
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId1,
+              organizationLearnerId: organizationLearnerId3,
+              userId: userId3,
+              createdAt: new Date('2021-04-02'),
+            });
+            await databaseBuilder.commit();
             // when
             const { organizationParticipants } =
               await organizationParticipantRepository.getParticipantsByOrganizationId({
                 organizationId,
                 sort: {
-                  participationCount: 'desc',
+                  latestParticipationOrder: 'asc',
                 },
               });
 
             // then
             expect(organizationParticipants.length).to.equal(3);
-            expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
-            expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+            expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
+            expect(organizationParticipants[1].id).to.equal(organizationLearnerId1);
             expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
           });
-        });
-
-        it('should return participants sorted by name if participation count are identical', async function () {
-          const organizationId = databaseBuilder.factory.buildOrganization().id;
-          const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-          const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
-            organizationId,
-            lastName: 'Aaaah',
-          });
-          const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
-            organizationId,
-            lastName: 'Dupont',
-          });
-          const { id: organizationLearnerId3, userId: userId3 } = databaseBuilder.factory.buildOrganizationLearner({
-            organizationId,
-            lastName: 'Dupond',
-          });
-
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId1,
-            organizationLearnerId: organizationLearnerId1,
-            userId: userId1,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId2,
-            organizationLearnerId: organizationLearnerId1,
-            userId: userId1,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId1,
-            organizationLearnerId: organizationLearnerId2,
-            userId: userId2,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId: campaignId1,
-            organizationLearnerId: organizationLearnerId3,
-            userId: userId3,
-          });
-          await databaseBuilder.commit();
-          // when
-          const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
-            organizationId,
-            sort: {
-              participationCount: 'asc',
-            },
-          });
-
-          // then
-          expect(organizationParticipants.length).to.equal(3);
-          expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
-          expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
-          expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
         });
 
         context('sort by lastname', function () {

--- a/api/tests/prescription/organization-learner/unit/application/learner-list-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/learner-list-controller_test.js
@@ -85,6 +85,7 @@ describe('Unit | Application | learner-list-controller', function () {
         query: {
           'sort[participationCount]': 'asc',
           'sort[lastnameSort]': 'asc',
+          'sort[latestParticipationOrder]': 'asc',
         },
       };
       usecases.getPaginatedParticipantsForAnOrganization.resolves({});
@@ -101,6 +102,7 @@ describe('Unit | Application | learner-list-controller', function () {
         sort: {
           participationCount: 'asc',
           lastnameSort: 'asc',
+          latestParticipationOrder: 'asc',
         },
       });
     });

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -13,12 +13,14 @@
               @allSelected={{allSelected}}
               @someSelected={{someSelected}}
               @showCheckbox={{this.showCheckbox}}
-              @lastnameSort={{@lastnameSort}}
               @hasParticipants={{this.hasParticipants}}
-              @participationCountOrder={{@participationCountOrder}}
               @onToggleAll={{toggleAll}}
+              @lastnameSort={{@lastnameSort}}
+              @participationCountOrder={{@participationCountOrder}}
+              @latestParticipationOrder={{@latestParticipationOrder}}
               @onSortByLastname={{(fn this.addResetOnFunction @sortByLastname reset)}}
               @onSortByParticipationCount={{(fn this.addResetOnFunction @sortByParticipationCount reset)}}
+              @onSortByLatestParticipation={{(fn this.addResetOnFunction @sortByLatestParticipation reset)}}
             />
           </InElement>
           {{#if someSelected}}

--- a/orga/app/components/organization-participant/table-headers.hbs
+++ b/orga/app/components/organization-participant/table-headers.hbs
@@ -33,9 +33,17 @@
   >
     {{t "pages.organization-participants.table.column.participation-count.label"}}
   </Table::HeaderSort>
-  <Table::Header @size="medium" @align="center">
-    {{t "pages.organization-participants.table.column.latest-participation"}}
-  </Table::Header>
+  <Table::HeaderSort
+    @size="medium"
+    @align="center"
+    @onSort={{@onSortByLatestParticipation}}
+    @order={{@latestParticipationOrder}}
+    @ariaLabelDefaultSort={{t "pages.organization-participants.table.column.latest-participation.ariaLabelDefaultSort"}}
+    @ariaLabelSortUp={{t "pages.organization-participants.table.column.latest-participation.ariaLabelSortUp"}}
+    @ariaLabelSortDown={{t "pages.organization-participants.table.column.latest-participation.ariaLabelSortDown"}}
+  >
+    {{t "pages.organization-participants.table.column.latest-participation.label"}}
+  </Table::HeaderSort>
   <Table::Header @size="medium" @align="center">
     <div class="organization-participant-list-page__certificability-header">
       {{t "pages.organization-participants.table.column.is-certifiable.label"}}

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -15,6 +15,7 @@ export default class ListController extends Controller {
   @tracked fullName = null;
   @tracked certificability = [];
   @tracked participationCountOrder = null;
+  @tracked latestParticipationOrder = null;
   @tracked lastnameSort = 'asc';
 
   @action
@@ -27,14 +28,24 @@ export default class ListController extends Controller {
   sortByParticipationCount(value) {
     this.participationCountOrder = value || null;
     this.pageNumber = null;
+    this.latestParticipationOrder = null;
+    this.lastnameSort = null;
+  }
+
+  @action
+  sortByLatestParticipation(value) {
+    this.latestParticipationOrder = value || null;
+    this.pageNumber = null;
+    this.participationCountOrder = null;
     this.lastnameSort = null;
   }
 
   @action
   sortByLastname(value) {
     this.lastnameSort = value || null;
-    this.participationCountOrder = null;
     this.pageNumber = null;
+    this.participationCountOrder = null;
+    this.latestParticipationOrder = null;
   }
 
   @action

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -9,6 +9,7 @@ export default class ListRoute extends Route {
     fullName: { refreshModel: true },
     certificability: { refreshModel: true },
     participationCountOrder: { refreshModel: true },
+    latestParticipationOrder: { refreshModel: true },
     lastnameSort: { refreshModel: true },
   };
 
@@ -24,6 +25,7 @@ export default class ListRoute extends Route {
       },
       sort: {
         participationCount: params.participationCountOrder,
+        latestParticipationOrder: params.latestParticipationOrder,
         lastnameSort: params.lastnameSort,
       },
       page: {
@@ -40,6 +42,7 @@ export default class ListRoute extends Route {
       controller.fullName = null;
       controller.certificability = [];
       controller.participationCountOrder = null;
+      controller.latestParticipationOrder = null;
       controller.lastnameSort = 'asc';
     }
   }

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -12,8 +12,10 @@
       @onClickLearner={{this.goToLearnerPage}}
       @participationCountOrder={{this.participationCountOrder}}
       @sortByParticipationCount={{this.sortByParticipationCount}}
+      @sortByLatestParticipation={{this.sortByLatestParticipation}}
       @sortByLastname={{this.sortByLastname}}
       @lastnameSort={{this.lastnameSort}}
+      @latestParticipationOrder={{this.latestParticipationOrder}}
       @deleteParticipants={{this.deleteOrganizationLearners}}
     />
   {{else}}

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -374,26 +374,27 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   });
 
   module('when user is sorting the table', function () {
-    test('it should trigger ascending sort on participation count column', async function (assert) {
-      // given
-      this.set('participationCountOrder', null);
+    module('sort by participation count', function () {
+      test('it should trigger ascending sort on participation count column', async function (assert) {
+        // given
+        this.set('participationCountOrder', null);
 
-      const sortByParticipationCount = sinon.spy();
+        const sortByParticipationCount = sinon.spy();
 
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-        },
-      ];
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
 
-      this.set('participants', participants);
-      this.set('sortByParticipationCount', sortByParticipationCount);
-      this.set('certificabilityFilter', []);
-      this.set('fullNameFilter', null);
+        this.set('participants', participants);
+        this.set('sortByParticipationCount', sortByParticipationCount);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
 
-      const screen = await render(
-        hbs`<OrganizationParticipant::List
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onClickLearner={{this.noop}}
@@ -402,40 +403,40 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @participationCountOrder={{this.participationCountOrder}}
   @sortByParticipationCount={{this.sortByParticipationCount}}
 />`,
-      );
+        );
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort'),
-        ),
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort'),
+          ),
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
-      // given
-      this.set('participationCountOrder', 'desc');
+      test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
+        // given
+        this.set('participationCountOrder', 'desc');
 
-      const sortByParticipationCount = sinon.spy();
+        const sortByParticipationCount = sinon.spy();
 
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-        },
-      ];
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
 
-      this.set('participants', participants);
-      this.set('sortByParticipationCount', sortByParticipationCount);
-      this.set('certificabilityFilter', []);
-      this.set('fullNameFilter', null);
+        this.set('participants', participants);
+        this.set('sortByParticipationCount', sortByParticipationCount);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
 
-      const screen = await render(
-        hbs`<OrganizationParticipant::List
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onClickLearner={{this.noop}}
@@ -444,40 +445,40 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @participationCountOrder={{this.participationCountOrder}}
   @sortByParticipationCount={{this.sortByParticipationCount}}
 />`,
-      );
+        );
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelSortDown'),
-        ),
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelSortDown'),
+          ),
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
-      // given
-      this.set('participationCountOrder', 'asc');
+      test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
+        // given
+        this.set('participationCountOrder', 'asc');
 
-      const sortByParticipationCount = sinon.spy();
+        const sortByParticipationCount = sinon.spy();
 
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-        },
-      ];
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
 
-      this.set('participants', participants);
-      this.set('sortByParticipationCount', sortByParticipationCount);
-      this.set('certificabilityFilter', []);
-      this.set('fullNameFilter', null);
+        this.set('participants', participants);
+        this.set('sortByParticipationCount', sortByParticipationCount);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
 
-      const screen = await render(
-        hbs`<OrganizationParticipant::List
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onClickLearner={{this.noop}}
@@ -486,41 +487,43 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @participationCountOrder={{this.participationCountOrder}}
   @sortByParticipationCount={{this.sortByParticipationCount}}
 />`,
-      );
+        );
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelSortUp'),
-        ),
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelSortUp'),
+          ),
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
-      assert.ok(true);
+        // then
+        sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
+        assert.ok(true);
+      });
     });
 
-    test('it should trigger ascending sort on lastname column', async function (assert) {
-      // given
+    module('sort by lastname', function () {
+      test('it should trigger ascending sort on lastname column', async function (assert) {
+        // given
 
-      this.set('lastnameSort', null);
+        this.set('lastnameSort', null);
 
-      const sortByLastname = sinon.spy();
+        const sortByLastname = sinon.spy();
 
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-        },
-      ];
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
 
-      this.set('participants', participants);
-      this.set('sortByLastname', sortByLastname);
-      this.set('certificabilityFilter', []);
-      this.set('fullNameFilter', null);
+        this.set('participants', participants);
+        this.set('sortByLastname', sortByLastname);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
 
-      const screen = await render(
-        hbs`<OrganizationParticipant::List
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onFilter={{this.noop}}
@@ -530,40 +533,40 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @lastnameSort={{this.lastnameSort}}
   @sortByLastname={{this.sortByLastname}}
 />`,
-      );
+        );
 
-      // when
-      await click(
-        screen.getByLabelText(
-          this.intl.t('pages.organization-participants.table.column.last-name.ariaLabelDefaultSort'),
-        ),
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.last-name.ariaLabelDefaultSort'),
+          ),
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByLastname, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByLastname, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger ascending sort on lastname column when it is already sort descending', async function (assert) {
-      // given
-      this.set('lastnameSort', 'desc');
+      test('it should trigger ascending sort on lastname column when it is already sort descending', async function (assert) {
+        // given
+        this.set('lastnameSort', 'desc');
 
-      const sortByLastname = sinon.spy();
+        const sortByLastname = sinon.spy();
 
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-        },
-      ];
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
 
-      this.set('participants', participants);
-      this.set('sortByLastname', sortByLastname);
-      this.set('certificabilityFilter', []);
-      this.set('fullNameFilter', null);
+        this.set('participants', participants);
+        this.set('sortByLastname', sortByLastname);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
 
-      const screen = await render(
-        hbs`<OrganizationParticipant::List
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onFilter={{this.noop}}
@@ -573,38 +576,40 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @lastnameSort={{this.lastnameSort}}
   @sortByLastname={{this.sortByLastname}}
 />`,
-      );
+        );
 
-      // when
-      await click(
-        screen.getByLabelText(this.intl.t('pages.organization-participants.table.column.last-name.ariaLabelSortDown')),
-      );
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.last-name.ariaLabelSortDown'),
+          ),
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByLastname, 'asc');
-      assert.ok(true);
-    });
+        // then
+        sinon.assert.calledWithExactly(sortByLastname, 'asc');
+        assert.ok(true);
+      });
 
-    test('it should trigger descending sort on lastname column when it is already sort ascending', async function (assert) {
-      // given
-      this.set('lastnameSort', 'asc');
+      test('it should trigger descending sort on lastname column when it is already sort ascending', async function (assert) {
+        // given
+        this.set('lastnameSort', 'asc');
 
-      const sortByLastname = sinon.spy();
+        const sortByLastname = sinon.spy();
 
-      const participants = [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-        },
-      ];
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
 
-      this.set('participants', participants);
-      this.set('sortByLastname', sortByLastname);
-      this.set('certificabilityFilter', []);
-      this.set('fullNameFilter', null);
+        this.set('participants', participants);
+        this.set('sortByLastname', sortByLastname);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
 
-      const screen = await render(
-        hbs`<OrganizationParticipant::List
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
   @onFilter={{this.noop}}
@@ -614,16 +619,149 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
   @lastnameSort={{this.lastnameSort}}
   @sortByLastname={{this.sortByLastname}}
 />`,
-      );
+        );
 
-      // when
-      await click(
-        screen.getByLabelText(this.intl.t('pages.organization-participants.table.column.last-name.ariaLabelSortUp')),
-      );
+        // when
+        await click(
+          screen.getByLabelText(this.intl.t('pages.organization-participants.table.column.last-name.ariaLabelSortUp')),
+        );
 
-      // then
-      sinon.assert.calledWithExactly(sortByLastname, 'desc');
-      assert.ok(true);
+        // then
+        sinon.assert.calledWithExactly(sortByLastname, 'desc');
+        assert.ok(true);
+      });
+    });
+
+    module('sort by latestParticipation', function () {
+      test('it should trigger ascending sort on latestParticipation column', async function (assert) {
+        // given
+
+        this.set('latestParticipationOrder', null);
+
+        const sortByLatestParticipation = sinon.spy();
+
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
+
+        this.set('participants', participants);
+        this.set('sortByLatestParticipation', sortByLatestParticipation);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
+
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.noop}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+  @latestParticipationOrder={{this.latestParticipationOrder}}
+  @sortByLatestParticipation={{this.sortByLatestParticipation}}
+/>`,
+        );
+
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.latest-participation.ariaLabelDefaultSort'),
+          ),
+        );
+
+        // then
+        sinon.assert.calledWithExactly(sortByLatestParticipation, 'asc');
+        assert.ok(true);
+      });
+
+      test('it should trigger ascending sort on latestParticipation column when it is already sort descending', async function (assert) {
+        // given
+        this.set('latestParticipationOrder', 'desc');
+
+        const sortByLatestParticipation = sinon.spy();
+
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
+
+        this.set('participants', participants);
+        this.set('sortByLatestParticipation', sortByLatestParticipation);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
+
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.noop}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+  @latestParticipationOrder={{this.latestParticipationOrder}}
+  @sortByLatestParticipation={{this.sortByLatestParticipation}}
+/>`,
+        );
+
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.latest-participation.ariaLabelSortDown'),
+          ),
+        );
+
+        // then
+        sinon.assert.calledWithExactly(sortByLatestParticipation, 'asc');
+        assert.ok(true);
+      });
+
+      test('it should trigger descending sort on latestParticipation column when it is already sort ascending', async function (assert) {
+        // given
+        this.set('latestParticipationOrder', 'asc');
+
+        const sortByLatestParticipation = sinon.spy();
+
+        const participants = [
+          {
+            lastName: 'La Terreur',
+            firstName: 'Gigi',
+          },
+        ];
+
+        this.set('participants', participants);
+        this.set('sortByLatestParticipation', sortByLatestParticipation);
+        this.set('certificabilityFilter', []);
+        this.set('fullNameFilter', null);
+
+        const screen = await render(
+          hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.noop}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @fullName={{this.fullNameFilter}}
+  @certificabilityFilter={{this.certificabilityFilter}}
+  @latestParticipationOrder={{this.latestParticipationOrder}}
+  @sortByLatestParticipation={{this.sortByLatestParticipation}}
+/>`,
+        );
+
+        // when
+        await click(
+          screen.getByLabelText(
+            this.intl.t('pages.organization-participants.table.column.latest-participation.ariaLabelSortUp'),
+          ),
+        );
+
+        // then
+        sinon.assert.calledWithExactly(sortByLatestParticipation, 'desc');
+        assert.ok(true);
+      });
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
@@ -129,12 +129,31 @@ module('Unit | Controller | authenticated/organization-participants', function (
       // given
       controller.lastnameSort = null;
       controller.participationCountOrder = 'Godzilla';
+      controller.latestParticipationOrder = 'Obi wan';
       controller.pageNumber = 9999;
       // when
       controller.sortByLastname('desc');
 
       // then
       assert.strictEqual(controller.lastnameSort, 'desc');
+      assert.strictEqual(controller.participationCountOrder, null);
+      assert.strictEqual(controller.latestParticipationOrder, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#sortByLatestParticipation', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.lastnameSort = 'toto';
+      controller.participationCountOrder = 'Godzilla';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByLatestParticipation('desc');
+
+      // then
+      assert.strictEqual(controller.latestParticipationOrder, 'desc');
+      assert.strictEqual(controller.lastnameSort, null);
       assert.strictEqual(controller.participationCountOrder, null);
       assert.strictEqual(controller.pageNumber, null);
     });
@@ -145,12 +164,14 @@ module('Unit | Controller | authenticated/organization-participants', function (
       // given
       controller.participationCountOrder = null;
       controller.lastnameSort = 'T-Rex';
+      controller.latestParticipationOrder = 'Obi wan';
       controller.pageNumber = 9999;
       // when
       controller.sortByParticipationCount('desc');
 
       // then
       assert.strictEqual(controller.participationCountOrder, 'desc');
+      assert.strictEqual(controller.latestParticipationOrder, null);
       assert.strictEqual(controller.lastnameSort, null);
       assert.strictEqual(controller.pageNumber, null);
     });

--- a/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
@@ -7,6 +7,14 @@ module('Unit | Controller | authenticated/organization-participants', function (
   setupTest(hooks);
   setupIntl(hooks);
 
+  let controller;
+
+  hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
+    this.intl.setLocale('fr');
+    controller = this.owner.lookup('controller:authenticated/organization-participants/list');
+  });
+
   module('#triggerFiltering', function () {
     module('when the filters contain the field fullName', function () {
       test('updates the fullName value', async function (assert) {
@@ -113,6 +121,38 @@ module('Unit | Controller | authenticated/organization-participants', function (
           }),
         ),
       );
+    });
+  });
+
+  module('#sortByLastname', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.lastnameSort = null;
+      controller.participationCountOrder = 'Godzilla';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByLastname('desc');
+
+      // then
+      assert.strictEqual(controller.lastnameSort, 'desc');
+      assert.strictEqual(controller.participationCountOrder, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#sortByParticipationCount', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.participationCountOrder = null;
+      controller.lastnameSort = 'T-Rex';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByParticipationCount('desc');
+
+      // then
+      assert.strictEqual(controller.participationCountOrder, 'desc');
+      assert.strictEqual(controller.lastnameSort, null);
+      assert.strictEqual(controller.pageNumber, null);
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/sup-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-organization-participants/list_test.js
@@ -136,4 +136,36 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
       );
     });
   });
+
+  module('#sortByLastname', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.lastnameSort = null;
+      controller.participationCountOrder = 'Godzilla';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByLastname('desc');
+
+      // then
+      assert.strictEqual(controller.lastnameSort, 'desc');
+      assert.strictEqual(controller.participationCountOrder, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#sortByParticipationCount', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.participationCountOrder = null;
+      controller.lastnameSort = 'T-Rex';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByParticipationCount('desc');
+
+      // then
+      assert.strictEqual(controller.participationCountOrder, 'desc');
+      assert.strictEqual(controller.lastnameSort, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -820,7 +820,12 @@
             "ariaLabelSortUp": "The table is sorted by last name, in alphabetical order. Click to sort by reverse alphabetical order.",
             "label": "Last name"
           },
-          "latest-participation": "Latest participation",
+          "latest-participation": {
+            "ariaLabelDefaultSort": "The array is not yet sorted by latest participations. Click to sort ascending.",
+            "ariaLabelSortDown": "The array is sorted by descending latest participations. Click to sort ascending.",
+            "ariaLabelSortUp": "The array is sorted by ascending latest participations. Click to sort descending.",
+            "label": "Latest participation"
+          },
           "mainCheckbox": "Select/Unselect whole column",
           "participation-count": {
             "ariaLabelDefaultSort": "The array is not yet sorted by number of participations. Click to sort ascending.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -823,7 +823,12 @@
             "ariaLabelSortUp": "Le tableau est trié par nom, dans l'ordre alphabétique. Cliquez pour trier par ordre alphabétique inverse.",
             "label": "Nom"
           },
-          "latest-participation": "Dernière participation",
+          "latest-participation": {
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par date de participations. Cliquez pour trier par ordre croissant.",
+            "ariaLabelSortDown": "Le tableau est trié par date de participation décroissante. Cliquez pour trier en ordre croissant.",
+            "ariaLabelSortUp": "Le tableau est trié par date de participation croissante. Cliquez pour trier en ordre décroissant.",
+            "label": "Dernière participation"
+          },
           "mainCheckbox": "Selectionner/Deselectionner toute la colonne",
           "participation-count": {
             "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par nombre de participations. Cliquez pour trier par ordre croissant.",


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de savoir quel prescrit supprimer facilement depuis l'ajout de la fonctionnalité de suppression des prescrits

## :robot: Proposition
Ajouter le tri par date de dernière participation afin de pouvoir trier les participants par date de dernière participation. Ce qui permettra aux prescripteurs de supprimer plus facilement ceux n'ayant pas fait de campagne depuis longtemps

## :rainbow: Remarques
bsr ajout de test manquant côté front orga

## :100: Pour tester
Se connecter avec avec une orga sans import et vérifier que le tri par date de dernière participation fonctionne correctement.