### PR TITLE
[FEATURE] Modifier l'information des candidats présents dans l'espace surveillant sur Pix Certif (PIX-9961).

### DIFF
--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -478,7 +478,7 @@
         }
       },
       "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} attending",
         "clear-field": "Clear the field",
         "indicate-candidates-attendance": "Please confirm the attendance of each candidate to allow them to start their certification exam.",
         "no-candidate": "No candidate enrolled in this session",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -478,7 +478,7 @@
         }
       },
       "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}",
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat présent} other {candidats présents}}",
         "clear-field": "Vider le champ",
         "indicate-candidates-attendance": "Confirmez la présence de chaque candidat pour l'autoriser à commencer son test de certification.",
         "no-candidate": "Aucun candidat inscrit à cette session",


### PR DESCRIPTION
## :unicorn: Problème
Depuis l'épix sur l’amélioration de l’espace surveillant, la confirmation de la présence des candidats depuis l’espace surveillant se fait différemment.
En effet, nous sommes passés d’une case à cocher à un bouton “Confirmer la présence”.

## :robot: Proposition
Changer la mention "candidat sélectionné" pour "candidat présent"

## :rainbow: Remarques
Pas besoin de changer le test associé car il se base sur la clé de traduction :) 

## :100: Pour tester

- Se connecter sur Pix certif avec certif-pro@example.net
- sélectionner une session
- cliquer sur l'espace surveillant dans un nouvel onglet
- Renseigner les infos se trouvant dans le détail de la session pour se connecter à l'espace surveillant
- Constater que la phrase à changer
- Passer en anglais, et constater que la traduction a également été modifié.

<img width="527" alt="Capture d’écran 2023-11-17 à 15 12 21" src="https://github.com/1024pix/pix/assets/58915422/d7fb87a4-8bf8-4866-9b2f-d05f07d4365e">