### PR TITLE
[FEATURE] Afficher uniquement un grain à la fois (PIX-9894)

### DIFF
--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -1,10 +1,30 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class ModuleDetails extends Component {
+  @tracked grainsToDisplay = [this.args.module.grains.objectAt(0)];
+
+  get hasNextGrain() {
+    return this.grainsToDisplay.length < this.args.module.grains.length;
+  }
+
+  get lastIndex() {
+    return this.grainsToDisplay.length - 1;
+  }
+
   @action
-  continueToNextGrain() {
-    // eslint-disable-next-line no-console
-    console.info('Continue to next grain');
+  addNextGrainToDisplay() {
+    if (!this.hasNextGrain) {
+      return;
+    }
+
+    const nextGrain = this.args.module.grains.objectAt(this.lastIndex + 1);
+    this.grainsToDisplay = [...this.grainsToDisplay, nextGrain];
+  }
+
+  @action
+  grainCanDisplayContinueButton(index) {
+    return this.lastIndex === index && this.hasNextGrain;
   }
 }

--- a/mon-pix/app/pods/components/module/details/styles.scss
+++ b/mon-pix/app/pods/components/module/details/styles.scss
@@ -17,15 +17,3 @@
     justify-content: center;
   }
 }
-
-.grain {
-  background: $pix-neutral-0;
-  border: 1px solid $pix-neutral-22;
-  border-radius: $pix-spacing-s;
-
-  &__footer {
-    padding: $pix-spacing-s;
-    background: $pix-tertiary-5;
-    border-radius: 0 0 $pix-spacing-s $pix-spacing-s;
-  }
-}

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -6,26 +6,13 @@
   </div>
 
   <div class="module__content">
-    <article class="grain">
-      {{#each @module.grains as |grain|}}
-        <h2 class="screen-reader-only">{{grain.title}}</h2>
-        {{#each grain.elements as |element|}}
-          {{#if element.isText}}
-            <Module::Text @text={{element}} />
-          {{else if element.isQcu}}
-            <Module::Qcu
-              @qcu={{element}}
-              @submitAnswer={{@submitAnswer}}
-              @correctionResponse={{get @correctionResponse element.id}}
-            />
-          {{/if}}
-        {{/each}}
-      {{/each}}
-      <footer class="grain__footer">
-        <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{this.continueToNextGrain}}>
-          {{t "pages.modulix.buttons.grain.continue"}}
-        </PixButton>
-      </footer>
-    </article>
+    {{#each this.grainsToDisplay as |grain index|}}
+      <Module::Grain
+        @grain={{grain}}
+        @submitAnswer={{@submitAnswer}}
+        @canDisplayContinueButton={{this.grainCanDisplayContinueButton index}}
+        @continueAction={{this.addNextGrainToDisplay}}
+      />
+    {{/each}}
   </div>
 </main>

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 export default class ModuleGrain extends Component {
   get shouldDisplayContinueButton() {
-    return this.args.shouldDisplayContinueButton && this.allElementsAreAnswered;
+    return this.args.canDisplayContinueButton && this.allElementsAreAnswered;
   }
 
   get allElementsAreAnswered() {

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -1,11 +1,26 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class ModuleGrain extends Component {
+  @service metrics;
+
   get shouldDisplayContinueButton() {
     return this.args.canDisplayContinueButton && this.allElementsAreAnswered;
   }
 
   get allElementsAreAnswered() {
     return this.args.grain.allElementsAreAnswered;
+  }
+
+  @action
+  async continueAction() {
+    await this.args.continueAction();
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.grain.module.id}`,
+      'pix-event-name': `Click sur le bouton continuer du grain : ${this.args.grain.id}`,
+    });
   }
 }

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class ModuleGrain extends Component {
+  get shouldDisplayContinueButton() {
+    return this.args.shouldDisplayContinueButton && this.allElementsAreAnswered;
+  }
+
+  get allElementsAreAnswered() {
+    return this.args.grain.allElementsAreAnswered;
+  }
+}

--- a/mon-pix/app/pods/components/module/grain/style.scss
+++ b/mon-pix/app/pods/components/module/grain/style.scss
@@ -1,0 +1,11 @@
+.grain {
+  background: $pix-neutral-0;
+  border: 1px solid $pix-neutral-22;
+  border-radius: $pix-spacing-s;
+
+  &__footer {
+    padding: $pix-spacing-s;
+    background: $pix-tertiary-5;
+    border-radius: 0 0 $pix-spacing-s $pix-spacing-s;
+  }
+}

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -10,7 +10,7 @@
 
   {{#if this.shouldDisplayContinueButton}}
     <footer class="grain__footer">
-      <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{@continueAction}}>
+      <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{this.continueAction}}>
         {{t "pages.modulix.buttons.grain.continue"}}
       </PixButton>
     </footer>

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -1,0 +1,18 @@
+<article class="grain">
+  <h2 class="screen-reader-only">{{@grain.title}}</h2>
+  {{#each @grain.elements as |element|}}
+    {{#if element.isText}}
+      <Module::Text @text={{element}} />
+    {{else if element.isQcu}}
+      <Module::Qcu @qcu={{element}} @submitAnswer={{@submitAnswer}} />
+    {{/if}}
+  {{/each}}
+
+  {{#if this.shouldDisplayContinueButton}}
+    <footer class="grain__footer">
+      <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{@continueAction}}>
+        {{t "pages.modulix.buttons.grain.continue"}}
+      </PixButton>
+    </footer>
+  {{/if}}
+</article>

--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -5,12 +5,18 @@ import { action } from '@ember/object';
 export default class ModuleQcu extends Component {
   @tracked selectedAnswerId = null;
 
+  qcu = this.args.qcu;
+
   get feedbackType() {
-    return this.args.correctionResponse?.isOk ? 'success' : 'error';
+    return this.qcu.lastCorrection?.isOk ? 'success' : 'error';
   }
 
   get disableInput() {
-    return !!this.args.correctionResponse;
+    return !!this.qcu.lastCorrection;
+  }
+
+  get shouldDisplayFeedback() {
+    return !!this.qcu.lastCorrection;
   }
 
   @action
@@ -21,8 +27,7 @@ export default class ModuleQcu extends Component {
   @action
   async submitAnswer(event) {
     event.preventDefault();
-    const elementId = this.args.qcu.id;
-    const answerData = { elementId, userResponse: [this.selectedAnswerId] };
+    const answerData = { userResponse: [this.selectedAnswerId], element: this.qcu };
     await this.args.submitAnswer(answerData);
   }
 }

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -24,16 +24,16 @@
     </div>
   </fieldset>
 
-  {{#unless @correctionResponse}}
+  {{#unless this.qcu.lastCorrection}}
     <PixButton @backgroundColor="green" @shape="rounded" @type="submit" class="element-qcu__verify_button">
       {{t "pages.modulix.buttons.activity.verify"}}
     </PixButton>
   {{/unless}}
 
   <div role="status" tabindex="-1">
-    {{#if @correctionResponse}}
+    {{#if this.shouldDisplayFeedback}}
       <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qcu__feedback">
-        {{html-safe @correctionResponse.feedback}}
+        {{html-safe this.qcu.lastCorrection.feedback}}
       </PixMessage>
     {{/if}}
   </div>

--- a/mon-pix/app/pods/correction-response/model.js
+++ b/mon-pix/app/pods/correction-response/model.js
@@ -1,10 +1,9 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 export default class CorrectionResponse extends Model {
   @attr('string') status;
   @attr('string') feedback;
   @attr('string') solutionId;
-  @belongsTo('element') element;
 
   get isOk() {
     return this.status === 'ok';

--- a/mon-pix/app/pods/element-answer/model.js
+++ b/mon-pix/app/pods/element-answer/model.js
@@ -2,5 +2,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class ElementAnswer extends Model {
   @attr('array') userResponse;
-  @belongsTo('correction-response') correction;
+  @belongsTo('correction-response', { async: false }) correction;
+
+  @belongsTo('element', { polymorphic: true }) element;
 }

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -1,8 +1,10 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class Element extends Model {
-  @belongsTo('grain') grain;
   @attr('string') type;
+
+  @belongsTo('grain', { inverse: 'elements' }) grain;
+  @hasMany('element-answer', { inverse: 'element' }) elementAnswers;
 
   get isText() {
     return this.type === 'texts';

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -13,4 +13,12 @@ export default class Element extends Model {
   get isQcu() {
     return this.type === 'qcus';
   }
+
+  get isAnswered() {
+    return this.elementAnswers.length > 0;
+  }
+
+  get lastCorrection() {
+    return this.isAnswered ? this.elementAnswers.lastObject.correction : undefined;
+  }
 }

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -14,6 +14,10 @@ export default class Element extends Model {
     return this.type === 'qcus';
   }
 
+  get isAnswerable() {
+    return this.isQcu;
+  }
+
   get isAnswered() {
     return this.elementAnswers.length > 0;
   }

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -1,7 +1,8 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class Grain extends Model {
   @attr('string') title;
 
   @hasMany('element', { polymorphic: true }) elements;
+  @belongsTo('module', { async: false }) module;
 }

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -5,4 +5,16 @@ export default class Grain extends Model {
 
   @hasMany('element', { polymorphic: true }) elements;
   @belongsTo('module', { async: false }) module;
+
+  get answerableElements() {
+    return this.elements.filter((element) => {
+      return element.isAnswerable;
+    });
+  }
+
+  get allElementsAreAnswered() {
+    return this.answerableElements.every((element) => {
+      return element.isAnswered;
+    });
+  }
 }

--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -1,29 +1,21 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 export default class GetController extends Controller {
   @service store;
   @service metrics;
 
-  @tracked correctionResponse = {};
-
   @action
   async submitAnswer(answerData) {
-    const elementAnswer = await this.store
+    await this.store
       .createRecord('element-answer', {
         userResponse: answerData.userResponse,
+        element: answerData.element,
       })
       .save({
-        adapterOptions: { elementId: answerData.elementId, moduleSlug: this.model.id },
+        adapterOptions: { elementId: answerData.element.id, moduleSlug: this.model.id },
       });
-
-    // Change ref to refresh the component
-    this.correctionResponse = {
-      ...this.correctionResponse,
-    };
-    this.correctionResponse[answerData.elementId] = await elementAnswer.correction;
 
     this.metrics.add({
       event: 'custom-event',

--- a/mon-pix/app/pods/module/get/template.hbs
+++ b/mon-pix/app/pods/module/get/template.hbs
@@ -1,7 +1,3 @@
 <div class="modulix">
-  <Module::Details
-    @module={{@model}}
-    @submitAnswer={{this.submitAnswer}}
-    @correctionResponse={{this.correctionResponse}}
-  />
+  <Module::Details @module={{@model}} @submitAnswer={{this.submitAnswer}} />
 </div>

--- a/mon-pix/app/pods/module/model.js
+++ b/mon-pix/app/pods/module/model.js
@@ -3,5 +3,5 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class Module extends Model {
   @attr('string') title;
 
-  @hasMany('grain') grains;
+  @hasMany('grain', { async: false }) grains;
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module_test.js
@@ -1,0 +1,122 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Acceptance | Module | Routes | navigateIntoTheModule', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('when user arrive on the module page', function () {
+    test('should display only the first lesson grain', async function (assert) {
+      // given
+      const grains = _createGrains(server);
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains,
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail');
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
+      assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
+      assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
+      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+    });
+  });
+
+  module('when user click on continue button', function () {
+    module('when the grain displayed is not the last', function () {
+      test('should display the continue button', async function (assert) {
+        // given
+        const grains = _createGrains(server);
+
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains,
+        });
+
+        // when
+        const screen = await visit('/modules/bien-ecrire-son-adresse-mail');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+
+        // when
+        await clickByName('Continuer');
+
+        // then
+        const secondGrain = grains[1];
+        assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+      });
+    });
+
+    module('when the grain displayed is the last', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const grains = _createGrains(server);
+
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains,
+        });
+
+        // when
+        const screen = await visit('/modules/bien-ecrire-son-adresse-mail');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+
+        // when
+        await clickByName('Continuer');
+        await clickByName('Continuer');
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+    });
+  });
+});
+
+function _createGrains(server) {
+  const text1 = server.create('text', {
+    id: 'elementId-1',
+    type: 'texts',
+    content: 'content-1',
+  });
+  const text2 = server.create('text', {
+    id: 'elementId-2',
+    type: 'texts',
+    content: 'content-2',
+  });
+  const text3 = server.create('text', {
+    id: 'elementId-3',
+    type: 'texts',
+    content: 'content-3',
+  });
+
+  const grain1 = server.create('grain', {
+    id: 'grainId-1',
+    title: 'title grain 1',
+    elements: [text1],
+  });
+  const grain2 = server.create('grain', {
+    id: 'grainId-2',
+    title: 'title grain 2',
+    elements: [text2],
+  });
+  const grain3 = server.create('grain', {
+    id: 'grainId-3',
+    title: 'title grain 3',
+    elements: [text3],
+  });
+
+  return [grain1, grain2, grain3];
+}

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -7,7 +7,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Details', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display given module', async function (assert) {
+  test('should display given module with one grain', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
     const textElement = store.createRecord('text', { content: 'content', type: 'texts' });
@@ -30,6 +30,32 @@ module('Integration | Component | Module | Details', function (hooks) {
     assert.strictEqual(findAll('.element-text').length, 1);
     assert.strictEqual(findAll('.element-qcu').length, 1);
 
-    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+  });
+
+  test('should display given module with more than one grain', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const textElement = store.createRecord('text', { content: 'content', type: 'texts' });
+    const qcuElement = store.createRecord('qcu', {
+      instruction: 'instruction',
+      proposals: ['radio1', 'radio2'],
+      type: 'qcus',
+    });
+    const grain1 = store.createRecord('grain', { elements: [textElement] });
+    const grain2 = store.createRecord('grain', { elements: [qcuElement] });
+
+    const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+    this.set('module', module);
+
+    // when
+    const screen = await render(hbs`<Module::Details @module={{this.module}} />`);
+
+    // then
+    assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+    assert.strictEqual(findAll('.element-text').length, 1);
+    assert.strictEqual(findAll('.element-qcu').length, 0);
+
+    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Grain', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display given grain', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const grain = store.createRecord('grain', { title: 'Grain title' });
+    this.set('grain', grain);
+
+    // when
+    const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+
+    // then
+    assert.ok(screen.getByRole('heading', { name: grain.title, level: 2 }));
+  });
+
+  module('when element is a text', function () {
+    test('should display text element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = store.createRecord('text', { content: 'element content', type: 'texts' });
+      const elements = [textElement];
+      const grain = store.createRecord('grain', { title: 'Grain title', elements });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.ok(screen.getByText('element content'));
+    });
+  });
+
+  module('when element is a qcu', function () {
+    test('should display qcu element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const qcuElement = store.createRecord('qcu', {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcus',
+      });
+      const elements = [qcuElement];
+      const grain = store.createRecord('grain', { title: 'Grain title', elements });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
+    });
+  });
+
+  module('when shouldDisplayContinueButton is true', function () {
+    test('should display continue button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const grain = store.createRecord('grain', { title: 'Grain title' });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @shouldDisplayContinueButton={{true}} />`);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists();
+    });
+  });
+
+  module('when shouldDisplayContinueButton is false', function () {
+    test('should not display continue button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const grain = store.createRecord('grain', { title: 'Grain title' });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @shouldDisplayContinueButton={{false}} />`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -57,33 +57,83 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when shouldDisplayContinueButton is true', function () {
-    test('should display continue button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const grain = store.createRecord('grain', { title: 'Grain title' });
-      this.set('grain', grain);
+  module('when canDisplayContinueButton is true', function () {
+    module('when all elements are answered', function () {
+      test('should display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
 
-      // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @shouldDisplayContinueButton={{true}} />`);
+        const correction = store.createRecord('correction-response');
+        store.createRecord('element-answer', { element, correction });
+        assert.true(grain.allElementsAreAnswered);
 
-      // then
-      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists();
+        // when
+        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+      });
+    });
+
+    module('when not any element are answered', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        assert.false(grain.allElementsAreAnswered);
+
+        // when
+        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
     });
   });
 
-  module('when shouldDisplayContinueButton is false', function () {
-    test('should not display continue button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const grain = store.createRecord('grain', { title: 'Grain title' });
-      this.set('grain', grain);
+  module('when canDisplayContinueButton is false', function () {
+    module('when all elements are answered', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
 
-      // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @shouldDisplayContinueButton={{false}} />`);
+        const correction = store.createRecord('correction-response');
+        store.createRecord('element-answer', { element, correction });
+        assert.true(grain.allElementsAreAnswered);
 
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        // when
+        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+    });
+
+    module('when not any element are answered', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        assert.false(grain.allElementsAreAnswered);
+
+        // when
+        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/components/module/qcu_test.js
+++ b/mon-pix/tests/unit/components/module/qcu_test.js
@@ -11,7 +11,9 @@ module('Unit | Component | Module | QCU', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const correctionResponse = store.createRecord('correction-response', { status: 'ko' });
-        const component = createPodsComponent('module/qcu', { correctionResponse });
+        const elementAnswer = store.createRecord('element-answer', { correction: correctionResponse });
+        const qcuElement = store.createRecord('qcu', { elementAnswers: [elementAnswer] });
+        const component = createPodsComponent('module/qcu', { qcu: qcuElement });
 
         // when
         const feedbackType = component.feedbackType;
@@ -26,7 +28,9 @@ module('Unit | Component | Module | QCU', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const correctionResponse = store.createRecord('correction-response', { status: 'ok' });
-        const component = createPodsComponent('module/qcu', { correctionResponse });
+        const elementAnswer = store.createRecord('element-answer', { correction: correctionResponse });
+        const qcuElement = store.createRecord('qcu', { elementAnswers: [elementAnswer] });
+        const component = createPodsComponent('module/qcu', { qcu: qcuElement });
 
         // when
         const feedbackType = component.feedbackType;

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -12,18 +12,22 @@ module('Unit | Module | Controller | get', function (hooks) {
       const expectedCorrection = 'correction';
       const userResponse = 'userResponse';
       const elementId = 'elementId';
+      const element = 'element';
       const moduleSlug = 'moduleSlug';
 
       const answerData = {
         userResponse,
         elementId,
         moduleSlug,
+        element,
       };
 
       const metricAddStub = sinon.stub();
+
       class MetricsStubService extends Service {
         add = metricAddStub;
       }
+
       this.owner.register('service:metrics', MetricsStubService);
       const metricsService = this.owner.lookup('service:metrics');
 
@@ -39,6 +43,7 @@ module('Unit | Module | Controller | get', function (hooks) {
       controller.store.createRecord
         .withArgs('element-answer', {
           userResponse,
+          element,
         })
         .returns({
           save: saveStub,
@@ -57,13 +62,13 @@ module('Unit | Module | Controller | get', function (hooks) {
       await controller.submitAnswer(answerData);
 
       // then
-      assert.strictEqual(controller.correctionResponse[elementId], expectedCorrection);
       sinon.assert.calledWith(metricsService.add, {
         event: 'custom-event',
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${moduleSlug}`,
         'pix-event-name': `Click sur le bouton vérifier de l'élément : ${elementId}`,
       });
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/models/modules/element_test.js
+++ b/mon-pix/tests/unit/models/modules/element_test.js
@@ -66,6 +66,37 @@ module('Unit | Model | Element', function (hooks) {
     });
   });
 
+  module('#isAnswerable', function () {
+    module('when element is answerable', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+
+        // when
+        const isAnswerable = element.isAnswerable;
+
+        // then
+        assert.true(isAnswerable);
+      });
+    });
+
+    module('when element is not answerable', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        ['texts'].forEach((type) => {
+          // when
+          const element = store.createRecord('element', { type });
+          const isAnswerable = element.isAnswerable;
+
+          // then
+          assert.false(isAnswerable);
+        });
+      });
+    });
+  });
+
   module('#isAnswered', function () {
     module('when element is answered', function () {
       test('should return true', function (assert) {

--- a/mon-pix/tests/unit/models/modules/element_test.js
+++ b/mon-pix/tests/unit/models/modules/element_test.js
@@ -1,0 +1,136 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | Element', function (hooks) {
+  setupTest(hooks);
+
+  module('#isText', function () {
+    module('when type is texts', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'texts' });
+
+        // when
+        const isText = element.isText;
+
+        // then
+        assert.true(isText);
+      });
+    });
+
+    module('when type is not texts', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        ['qcus'].forEach((type) => {
+          // when
+          const element = store.createRecord('element', { type });
+          const isText = element.isText;
+
+          // then
+          assert.false(isText);
+        });
+      });
+    });
+  });
+
+  module('#isQcu', function () {
+    module('when type is qcus', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+
+        // when
+        const isQcu = element.isQcu;
+
+        // then
+        assert.true(isQcu);
+      });
+    });
+
+    module('when type is not qcus', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        ['texts'].forEach((type) => {
+          // when
+          const element = store.createRecord('element', { type });
+          const isQcu = element.isQcu;
+
+          // then
+          assert.false(isQcu);
+        });
+      });
+    });
+  });
+
+  module('#isAnswered', function () {
+    module('when element is answered', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+        store.createRecord('element-answer', { element });
+
+        // when
+        const isAnswered = element.isAnswered;
+
+        // then
+        assert.true(isAnswered);
+      });
+    });
+
+    module('when element is not answered', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+
+        // when
+        const isAnswered = element.isAnswered;
+
+        // then
+        assert.false(isAnswered);
+      });
+    });
+  });
+
+  module('#lastCorrection', function () {
+    module('when element is answered', function () {
+      test('should return last correction', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const elementAnswer = store.createRecord('element-answer');
+        const lastCorrection = store.createRecord('correction-response', {});
+        const lastElementAnswer = store.createRecord('element-answer', { correction: lastCorrection });
+
+        const element = store.createRecord('element', {
+          type: 'qcus',
+          elementAnswers: [elementAnswer, lastElementAnswer],
+        });
+
+        // when
+        const result = element.lastCorrection;
+
+        // then
+        assert.strictEqual(result, lastCorrection);
+      });
+    });
+
+    module('when element is not answered', function () {
+      test('should return undefined', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus' });
+
+        // when
+        const lastCorrection = element.lastCorrection;
+
+        // then
+        assert.strictEqual(lastCorrection, undefined);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | Grain', function (hooks) {
+  setupTest(hooks);
+
+  module('#answerableElements', function () {
+    module('when there are answerable elements in elements', function () {
+      test('should return only answerable elements', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = store.createRecord('qcu', { type: 'qcus' });
+        const text = store.createRecord('text', { type: 'texts' });
+        const grain = store.createRecord('grain', {
+          elements: [qcu, text],
+        });
+
+        // when
+        const answerableElements = grain.answerableElements;
+
+        // then
+        assert.strictEqual(answerableElements.length, 1);
+        assert.deepEqual(answerableElements, [qcu]);
+      });
+    });
+
+    module('when there are no answerable elements in elements', function () {
+      test('should return an empty array', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text = store.createRecord('text', { type: 'texts' });
+        const grain = store.createRecord('grain', {
+          elements: [text],
+        });
+
+        // when
+        const answerableElements = grain.answerableElements;
+
+        // then
+        assert.strictEqual(answerableElements.length, 0);
+      });
+    });
+  });
+
+  module('#allElementsAreAnswered', function () {
+    module('when all answerable elements are answered', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = store.createRecord('qcu', { type: 'qcus' });
+        store.createRecord('element-answer', {
+          element: qcu,
+        });
+        const grain = store.createRecord('grain', {
+          elements: [qcu],
+        });
+
+        // when
+        const allElementsAreAnswered = grain.allElementsAreAnswered;
+
+        // then
+        assert.true(allElementsAreAnswered);
+      });
+    });
+
+    module('when all answerable elements are not answered', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = store.createRecord('qcu', { type: 'qcus' });
+        const grain = store.createRecord('grain', {
+          elements: [qcu],
+        });
+
+        // when
+        const allElementsAreAnswered = grain.allElementsAreAnswered;
+
+        // then
+        assert.false(allElementsAreAnswered);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, dans le contexte des modules sur Pix App, nous affichons tous les grains en même temps. Cela peut être impressionnant et rebuter les utilisateurs à poursuivre leur apprentissage.

## :robot: Proposition
Nous décidons d'afficher un grain à la fois, et d'afficher le bouton continuer uniquement quand les activités du grain sont finies. 

## :rainbow: Remarques
- Nous décidons de focus dès le premier grain, nous itérerons par la suite pour améliorer ce comportement

## :100: Pour tester
- Su Pix App, se rendre sur [`/modules/bien-ecrire-son-adresse-mail`](https://app-pr7476.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
- Constater qu'après avoir cliqué sur le bouton "Continuer" le grain suivant s'affiche
- Quand il s'agit du dernier grain le bouton "continuer" ne s'affiche pas