### PR TITLE
[TECH] api: ajout du seuil en pix dans la table complementary-certification-badges (PIX-9953)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-badge.js
+++ b/api/db/database-builder/factory/build-complementary-certification-badge.js
@@ -16,6 +16,7 @@ const buildComplementaryCertificationBadge = function ({
   stickerUrl = 'http://stiker-url.fr',
   detachedAt = null,
   createdBy,
+  minimumEarnedPix = 0,
 } = {}) {
   complementaryCertificationId = _.isNull(complementaryCertificationId)
     ? buildComplementaryCertification().id
@@ -35,6 +36,7 @@ const buildComplementaryCertificationBadge = function ({
     stickerUrl,
     detachedAt,
     createdBy,
+    minimumEarnedPix,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'complementary-certification-badges',

--- a/api/db/migrations/20231116154702_create_minimum_earned_pix_on_complementary_certification_badge.js
+++ b/api/db/migrations/20231116154702_create_minimum_earned_pix_on_complementary_certification_badge.js
@@ -1,0 +1,33 @@
+const COMPLEMENTARY_CERTIFICATION_BADGES = 'complementary-certification-badges';
+const COMPLEMENTARY_CERTIFICATIONS = 'complementary-certifications';
+const MINIMUM_EARNED_PIX = 'minimumEarnedPix';
+
+const up = async function (knex) {
+  await knex.schema.table(COMPLEMENTARY_CERTIFICATION_BADGES, function (table) {
+    table.integer(MINIMUM_EARNED_PIX).defaultTo(0);
+  });
+
+  const mappings = await knex
+    .select(`${COMPLEMENTARY_CERTIFICATIONS}.${MINIMUM_EARNED_PIX}`, `${COMPLEMENTARY_CERTIFICATION_BADGES}.id`)
+    .from(COMPLEMENTARY_CERTIFICATION_BADGES)
+    .join(
+      COMPLEMENTARY_CERTIFICATIONS,
+      `${COMPLEMENTARY_CERTIFICATIONS}.id`,
+      `${COMPLEMENTARY_CERTIFICATION_BADGES}.complementaryCertificationId`,
+    )
+    .whereNotNull(`${COMPLEMENTARY_CERTIFICATIONS}.${MINIMUM_EARNED_PIX}`);
+
+  for (const { [MINIMUM_EARNED_PIX]: minimumEarnedPix, id: complementaryCertificationBadgeId } of mappings) {
+    await knex(COMPLEMENTARY_CERTIFICATION_BADGES)
+      .update({ minimumEarnedPix })
+      .where(`${COMPLEMENTARY_CERTIFICATION_BADGES}.id`, complementaryCertificationBadgeId);
+  }
+};
+
+const down = async function (knex) {
+  await knex.schema.table(COMPLEMENTARY_CERTIFICATION_BADGES, function (table) {
+    table.dropColumn(MINIMUM_EARNED_PIX);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -296,6 +296,7 @@ function _createClea(databaseBuilder) {
     createdAt: new Date('2020-01-01'),
     detachedAt: new Date('2021-01-01'),
     createdBy: REAL_PIX_SUPER_ADMIN_ID,
+    minimumEarnedPix: 70,
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     id: CLEA_V2_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
@@ -309,6 +310,7 @@ function _createClea(databaseBuilder) {
     stickerUrl: 'https://images.pix.fr/stickers/macaron_clea.pdf',
     createdAt: new Date('2021-01-01'),
     createdBy: REAL_PIX_SUPER_ADMIN_ID,
+    minimumEarnedPix: 70,
   });
 }
 

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -117,6 +117,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         certificateMessage: null,
         temporaryCertificateMessage: null,
         detachedAt: null,
+        minimumEarnedPix: 0,
       });
       expect(complementaryCertificationBadgesDetached[0].id).to.equal(888);
     });

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -166,6 +166,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           label: 'PIX+ Toto',
           imageUrl: 'svg.pix.toto.com',
           stickerUrl: 'pdf.pix.toto.com',
+          minimumEarnedPix: 0,
         },
         {
           badgeId: badgeId2,
@@ -179,6 +180,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           label: 'PIX+ Toto 2',
           imageUrl: '2.svg.pix.toto.com',
           stickerUrl: '2.pdf.pix.toto.com',
+          minimumEarnedPix: 0,
         },
       ]);
     });


### PR DESCRIPTION
## :unicorn: Problème
Il existe actuellement la colonne "minimumEarnedPix" sur la table complementary-certification, qui correspond à un seuil déjà existant/appliqué pour le CléA.

Cette colonne et cette table ne peuvent pas être utilisées pour les certifications dont les profils cibles comprennent plusieurs RT à moins de fixer le même seuil pour tous. Ce n’est pas ce qu’on souhaite.

## :robot: Proposition
Ajouter une colonne pour le seuil minimal en pix pour chaque RT dans les complementary-certification-badges avec une valeur par défaut à 0

Migrer les données CléA de la colonne "minimumEarnedPix" sur la table complementary-certification vers cette nouvelle colonne dans la table complementary-certification-badges

## :rainbow: Remarques
Nope :v:

## :100: Pour tester
Y'a pas vraiment de test à réaliser sur une app, mais:
Non-régression de la présence d'un seuil CLEA: 
- Se connecter sur admin (superadmin@example.net/pix123)
- Aller sur une [certification complémentaire cléa d'un candidat ayant obtenu sa certif](https://admin-pr7478.review.pix.fr/certifications/136226)
- neutraliser une question et voir le score descendre en dessous du seuil
- la certification complémentaire est rejetée
(la dé-neutralisation ne semblait pas rescorer correctement la session.. Je sais pas comment tester plus de 1 fois 🤔 )

Pour tester la migration:
- Pull la branche en local 
- `npm run db:prepare`
- `npm run db:rollback:latest`
- La table ccbadges n'a pas de minimumEarnedPix
- `npm run db:migrate`
- La table ccbadges a un minimumEarnedPix à 0 sauf pour les deux certifs complémentaires CLEA à 70.
