### PR TITLE
[TECH] Ajouter une API interne pour récupérer les profils cibles d'une organisation (PIX-10003)

### DIFF
--- a/api/src/prescription/campaigns/application/api/SavedCampaign.js
+++ b/api/src/prescription/campaigns/application/api/SavedCampaign.js
@@ -1,0 +1,6 @@
+export class SavedCampaign {
+  constructor({ id, code }) {
+    this.id = id;
+    this.code = code;
+  }
+}

--- a/api/src/prescription/campaigns/application/api/campaigns-api.js
+++ b/api/src/prescription/campaigns/application/api/campaigns-api.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../../../../lib/domain/usecases/index.js';
+import { SavedCampaign } from './SavedCampaign.js';
 
 /**
  * @typedef CampaignApi
@@ -24,13 +25,6 @@ import { usecases } from '../../../../../lib/domain/usecases/index.js';
  */
 
 /**
- * @typedef SavedCampaignResponse
- * @type {object}
- * @property {number} id
- * @property {string} code
- */
-
-/**
  * @function
  * @name save
  *
@@ -47,8 +41,6 @@ export const save = async (campaign) => {
       multipleSendings: false,
     },
   });
-  return {
-    id: savedCampaign.id,
-    code: savedCampaign.code,
-  };
+
+  return new SavedCampaign(savedCampaign);
 };

--- a/api/src/prescription/target-profile/application/api/TargetProfile.js
+++ b/api/src/prescription/target-profile/application/api/TargetProfile.js
@@ -1,0 +1,7 @@
+export class TargetProfile {
+  constructor({ id, name, category }) {
+    this.id = id;
+    this.name = name;
+    this.category = category;
+  }
+}

--- a/api/src/prescription/target-profile/application/api/target-profile-api.js
+++ b/api/src/prescription/target-profile/application/api/target-profile-api.js
@@ -1,0 +1,21 @@
+import { usecases } from '../../../../../lib/domain/usecases/index.js';
+import { TargetProfile } from './TargetProfile.js';
+
+/**
+ * @typedef TargetProfileApi
+ * @type {object}
+ * @function getByOrganizationId
+ */
+
+/**
+ * @function
+ * @name getByOrganizationId
+ *
+ * @param {number} organizationId
+ * @returns {Promise<Array<TargetProfile>>}
+ */
+export const getByOrganizationId = async (organizationId) => {
+  const targetProfiles = await usecases.getAvailableTargetProfilesForOrganization({ organizationId });
+
+  return targetProfiles.map((targetProfileForSpecifier) => new TargetProfile(targetProfileForSpecifier));
+};

--- a/api/tests/prescription/target-profile/acceptance/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/api/target-profile-api_test.js
@@ -1,0 +1,13 @@
+import { expect, databaseBuilder } from '../../../../../test-helper.js';
+
+import * as targetProfileApi from '../../../../../../src/prescription/target-profile/application/api/target-profile-api.js';
+
+describe('Acceptance | Application | target-profile-api', function () {
+  it('should not fail', async function () {
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+
+    const result = await targetProfileApi.getByOrganizationId(organizationId);
+    expect(result).to.be.ok;
+  });
+});

--- a/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
@@ -1,0 +1,55 @@
+import { usecases } from '../../../../../../lib/domain/usecases/index.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { TargetProfileForSpecifier } from '../../../../../../lib/domain/read-models/campaign/TargetProfileForSpecifier.js';
+import * as targetProfileApi from '../../../../../../src/prescription/target-profile/application/api/target-profile-api.js';
+
+describe('Unit | API | TargetProfile', function () {
+  describe('#getByOrganizationId', function () {
+    it('should return target profiles from organization', async function () {
+      const organizationId = domainBuilder.buildOrganization().id;
+
+      const targetProfile = new TargetProfileForSpecifier({ name: 'Mon target profile' });
+
+      const getAvailableTargetProfilesForOrganizationStub = sinon.stub(
+        usecases,
+        'getAvailableTargetProfilesForOrganization',
+      );
+      getAvailableTargetProfilesForOrganizationStub
+        .withArgs({
+          organizationId,
+        })
+        .resolves([targetProfile]);
+
+      // when
+      const result = await targetProfileApi.getByOrganizationId(organizationId);
+
+      // then
+      expect(result[0].id).to.equal(targetProfile.id);
+      expect(result[0].name).to.equal(targetProfile.name);
+      expect(result[0].category).to.equal(targetProfile.category);
+      expect(result[0]).not.to.be.instanceOf(TargetProfileForSpecifier);
+    });
+
+    it('should return empty array if organization does not exist', async function () {
+      const notExistingOrganizationId = 'NOT EXISTING ID';
+
+      const getAvailableTargetProfilesForOrganizationStub = sinon.stub(
+        usecases,
+        'getAvailableTargetProfilesForOrganization',
+      );
+
+      getAvailableTargetProfilesForOrganizationStub
+        .withArgs({
+          organizationId: notExistingOrganizationId,
+        })
+        .resolves([]);
+
+      // when
+      const result = await targetProfileApi.getByOrganizationId(notExistingOrganizationId);
+
+      // then
+      expect(result.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix sur les parcours autonome la team ExpEval a besoin de créer des campagnes. Pour créer des campagnes ils ont besoin d'accèder à la liste des profils cibles d'une organisation. Les profils cibles sont actuellement géré par la team Prescription. Utiliser directement les usecases de la team Prescription fait fuiter le domain hors du bounded context. Nous avons besoin d'établir une limite clair entre le code des parcours autonomes et celui des profils cibles.

## :robot: Proposition
Dans cette PR, on ajoute l'API target profile. la team Prescription fournit une API à partir de la couche application du sous domain targetprofile qui pourrait être consommé depuis la couche infrastructure du sous domain autonomous-courses par la team ExpEval.

## :rainbow: Remarques
RAS

## :100: Pour tester
le CI passe
