### PR TITLE
[FEATURE] Affichage du bloc personnalisé de fin de parcours pour les campagnes isForAbsoluteNovice (PIX-10020)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -244,103 +244,104 @@
       </div>
     </PixBlock>
   {{/if}}
+  {{#if this.showHeavyBlock}}
+    <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
 
-  <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
-
-    {{#if this.showCertifiableBadges}}
-      <div class="badge-certifiable-container">
-        {{#each this.certifiableBadgesOrderedByValidity as |badge|}}
-          <BadgeCardCertifiable
-            @title={{badge.title}}
-            @message={{badge.message}}
-            @imageUrl={{badge.imageUrl}}
-            @altMessage={{badge.altMessage}}
-            @isAcquired={{badge.isAcquired}}
-            @isValid={{badge.isValid}}
-            @isCertifiable={{badge.isCertifiable}}
-            @isAlwaysVisible={{badge.isAlwaysVisible}}
-            @acquisitionPercentage={{badge.acquisitionPercentage}}
-          />
-        {{/each}}
-      </div>
-    {{/if}}
-
-    {{#if this.showNotCertifiableBadges}}
-      <h2 class="skill-review-result-detail__badge-subtitle">
-        {{t "pages.skill-review.badges-title"}}
-      </h2>
-      <div class="badge-container">
-        {{#each this.notCertifiableBadges as |badge|}}
-          <BadgeCard
-            @title={{badge.title}}
-            @message={{badge.message}}
-            @isAlwaysVisible={{badge.isAlwaysVisible}}
-            @acquisitionPercentage={{badge.acquisitionPercentage}}
-            @imageUrl={{badge.imageUrl}}
-            @altMessage={{badge.altMessage}}
-            @isAcquired={{badge.isAcquired}}
-          />
-        {{/each}}
-      </div>
-    {{/if}}
-
-    {{#if this.showImproveButton}}
-      <SkillReviewImprove @improve={{this.improve}} />
-    {{/if}}
-
-    {{#unless @model.campaign.isForAbsoluteNovice}}
-      {{#if this.showStagesWithStars}}
-        <section class="skill-review-result-detail__content">
-          <h2 class="skill-review-competence-stages-result__title">
-            {{t "pages.skill-review.stage.title"}}
-          </h2>
-          {{#each-in this.competenceResultsGroupedByAreas as |area competenceResults|}}
-            <div class="skill-review-competence-stages-result__content">
-              <div class="skill-review-competence-stages-result__area">
-                <span
-                  class="skill-review-competence-stages-result__border skill-review-competence__border--{{competenceResults.areaColor}}"
-                  aria-hidden="true"
-                ></span>
-                <h3 class="skill-review-competence-stages-result__subtitle">{{area}}</h3>
-              </div>
-              <Campaigns::Assessment::SkillReview::CompetenceStagesResult
-                @competenceResults={{competenceResults}}
-                @totalStage={{this.reachedStage.totalStage}}
-              />
-            </div>
-          {{/each-in}}
-        </section>
-      {{else}}
-        <section class="skill-review-result-detail__content">
-          <div class="skill-review-result-detail__table-header">
-            <h2 class="skill-review-result-detail__subtitle">
-              {{t "pages.skill-review.details.title"}}
-            </h2>
-            {{#unless this.isFlashCampaign}}
-              <CircleChart @value={{this.masteryPercentage}}>
-                <span
-                  aria-label="{{t 'pages.skill-review.details.result'}}"
-                  class="skill-review-table-header__circle-chart-value"
-                >
-                  {{t "pages.skill-review.details.percentage" rate=this.masteryRate}}
-                </span>
-              </CircleChart>
-            {{/unless}}
-          </div>
-          <Campaigns::Assessment::CampaignSkillReviewCompetenceResult
-            @competenceResults={{@model.campaignParticipationResult.competenceResults}}
-          />
-        </section>
+      {{#if this.showCertifiableBadges}}
+        <div class="badge-certifiable-container">
+          {{#each this.certifiableBadgesOrderedByValidity as |badge|}}
+            <BadgeCardCertifiable
+              @title={{badge.title}}
+              @message={{badge.message}}
+              @imageUrl={{badge.imageUrl}}
+              @altMessage={{badge.altMessage}}
+              @isAcquired={{badge.isAcquired}}
+              @isValid={{badge.isValid}}
+              @isCertifiable={{badge.isCertifiable}}
+              @isAlwaysVisible={{badge.isAlwaysVisible}}
+              @acquisitionPercentage={{badge.acquisitionPercentage}}
+            />
+          {{/each}}
+        </div>
       {{/if}}
 
-      {{#unless this.isFlashCampaign}}
-        <div class="skill-review-result-detail__information">
-          <FaIcon @icon="circle-info" class="skill-review-information__info-icon" aria-hidden="true" />
-          <div class="skill-review-information__text">
-            {{t "pages.skill-review.information"}}
-          </div>
+      {{#if this.showNotCertifiableBadges}}
+        <h2 class="skill-review-result-detail__badge-subtitle">
+          {{t "pages.skill-review.badges-title"}}
+        </h2>
+        <div class="badge-container">
+          {{#each this.notCertifiableBadges as |badge|}}
+            <BadgeCard
+              @title={{badge.title}}
+              @message={{badge.message}}
+              @isAlwaysVisible={{badge.isAlwaysVisible}}
+              @acquisitionPercentage={{badge.acquisitionPercentage}}
+              @imageUrl={{badge.imageUrl}}
+              @altMessage={{badge.altMessage}}
+              @isAcquired={{badge.isAcquired}}
+            />
+          {{/each}}
         </div>
+      {{/if}}
+
+      {{#if this.showImproveButton}}
+        <SkillReviewImprove @improve={{this.improve}} />
+      {{/if}}
+
+      {{#unless @model.campaign.isForAbsoluteNovice}}
+        {{#if this.showStagesWithStars}}
+          <section class="skill-review-result-detail__content">
+            <h2 class="skill-review-competence-stages-result__title">
+              {{t "pages.skill-review.stage.title"}}
+            </h2>
+            {{#each-in this.competenceResultsGroupedByAreas as |area competenceResults|}}
+              <div class="skill-review-competence-stages-result__content">
+                <div class="skill-review-competence-stages-result__area">
+                  <span
+                    class="skill-review-competence-stages-result__border skill-review-competence__border--{{competenceResults.areaColor}}"
+                    aria-hidden="true"
+                  ></span>
+                  <h3 class="skill-review-competence-stages-result__subtitle">{{area}}</h3>
+                </div>
+                <Campaigns::Assessment::SkillReview::CompetenceStagesResult
+                  @competenceResults={{competenceResults}}
+                  @totalStage={{this.reachedStage.totalStage}}
+                />
+              </div>
+            {{/each-in}}
+          </section>
+        {{else}}
+          <section class="skill-review-result-detail__content">
+            <div class="skill-review-result-detail__table-header">
+              <h2 class="skill-review-result-detail__subtitle">
+                {{t "pages.skill-review.details.title"}}
+              </h2>
+              {{#unless this.isFlashCampaign}}
+                <CircleChart @value={{this.masteryPercentage}}>
+                  <span
+                    aria-label="{{t 'pages.skill-review.details.result'}}"
+                    class="skill-review-table-header__circle-chart-value"
+                  >
+                    {{t "pages.skill-review.details.percentage" rate=this.masteryRate}}
+                  </span>
+                </CircleChart>
+              {{/unless}}
+            </div>
+            <Campaigns::Assessment::CampaignSkillReviewCompetenceResult
+              @competenceResults={{@model.campaignParticipationResult.competenceResults}}
+            />
+          </section>
+        {{/if}}
+
+        {{#unless this.isFlashCampaign}}
+          <div class="skill-review-result-detail__information">
+            <FaIcon @icon="circle-info" class="skill-review-information__info-icon" aria-hidden="true" />
+            <div class="skill-review-information__text">
+              {{t "pages.skill-review.information"}}
+            </div>
+          </div>
+        {{/unless}}
       {{/unless}}
-    {{/unless}}
-  </PixBlock>
+    </PixBlock>
+  {{/if}}
 </main>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -98,7 +98,10 @@ export default class SkillReview extends Component {
   }
 
   get displayOrganizationCustomMessage() {
-    return Boolean((this.showOrganizationMessage || this.showOrganizationButton) && this.isShared);
+    const hasCustomBlock = this.showOrganizationMessage || this.showOrganizationButton;
+    const showCustomBlock = this.isShared || this.args.model.campaign.isForAbsoluteNovice;
+
+    return hasCustomBlock && showCustomBlock;
   }
 
   get showOrganizationMessage() {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -174,6 +174,15 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipationResult.canImprove && !this.isShareButtonClicked;
   }
 
+  get showHeavyBlock() {
+    return (
+      this.showCertifiableBadges ||
+      this.showNotCertifiableBadges ||
+      this.showImproveButton ||
+      !this.args.model.campaign.isForAbsoluteNovice
+    );
+  }
+
   get competenceResultsGroupedByAreas() {
     const competenceResults = this.args.model.campaignParticipationResult.get('competenceResults').toArray();
     return competenceResults.reduce((acc, competenceResult) => {

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -63,6 +63,156 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Remettre à zéro et tout retenter' })).doesNotExist();
   });
 
+  module('#displayOrganizationCustomMessage', function () {
+    test('display Organization Custom Message when participation is shared', async function (assert) {
+      const customResultPageText = 'Je suis Iron Man';
+      model.campaignParticipationResult.set('isShared', true);
+      model.campaign.set('customResultPageText', customResultPageText);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.ok(screen.getByText(customResultPageText));
+    });
+
+    test('display Organization Custom Message when campaign isForAbsoluteNovice', async function (assert) {
+      const customResultPageText = "je s'appelle groot";
+      model.campaignParticipationResult.set('isShared', false);
+      model.campaign.set('customResultPageText', customResultPageText);
+      model.campaign.set('isForAbsoluteNovice', true);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.ok(screen.getByText(customResultPageText));
+    });
+
+    test('display Organization Custom button when participation is shared', async function (assert) {
+      const customResultPageButtonText = 'Je suis Iron Man';
+      const customResultPageButtonUrl = 'http://jesuisunbouton.fr/';
+      model.campaignParticipationResult.set('isShared', true);
+      model.campaign.set('customResultPageButtonUrl', customResultPageButtonUrl);
+      model.campaign.set('customResultPageButtonText', customResultPageButtonText);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert
+        .dom(screen.getByRole('link', { name: customResultPageButtonText }))
+        .hasAttribute('href', customResultPageButtonUrl);
+    });
+
+    test('display Organization Custom button when campaign isForAbsoluteNovice', async function (assert) {
+      const customResultPageButtonText = 'je suis un bouton';
+      const customResultPageButtonUrl = 'http://jesuisunbouton.fr/';
+      model.campaignParticipationResult.set('isShared', false);
+      model.campaign.set('customResultPageButtonUrl', customResultPageButtonUrl);
+      model.campaign.set('customResultPageButtonText', customResultPageButtonText);
+      model.campaign.set('isForAbsoluteNovice', true);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert
+        .dom(screen.getByRole('link', { name: customResultPageButtonText }))
+        .hasAttribute('href', customResultPageButtonUrl);
+    });
+
+    test('display Organization Custom button and Text when campaign isForAbsoluteNovice', async function (assert) {
+      const customResultPageText = "je s'appelle groot";
+      const customResultPageButtonText = 'je suis un bouton';
+      const customResultPageButtonUrl = 'http://jesuisunbouton.fr/';
+      model.campaign.set('customResultPageText', customResultPageText);
+      model.campaign.set('customResultPageButtonUrl', customResultPageButtonUrl);
+      model.campaign.set('customResultPageButtonText', customResultPageButtonText);
+      model.campaignParticipationResult.set('isShared', false);
+      model.campaign.set('isForAbsoluteNovice', true);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert
+        .dom(screen.getByRole('link', { name: customResultPageButtonText }))
+        .hasAttribute('href', customResultPageButtonUrl);
+      assert.ok(screen.getByText(customResultPageText));
+    });
+
+    test('display Organization Custom button and Text when campaign participation isShared', async function (assert) {
+      const customResultPageText = "je s'appelle groot";
+      const customResultPageButtonText = 'je suis un bouton';
+      const customResultPageButtonUrl = 'http://jesuisunbouton.fr/';
+      model.campaign.set('customResultPageText', customResultPageText);
+      model.campaign.set('customResultPageButtonUrl', customResultPageButtonUrl);
+      model.campaign.set('customResultPageButtonText', customResultPageButtonText);
+      model.campaignParticipationResult.set('isShared', true);
+      model.campaign.set('isForAbsoluteNovice', false);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert
+        .dom(screen.getByRole('link', { name: customResultPageButtonText }))
+        .hasAttribute('href', customResultPageButtonUrl);
+      assert.ok(screen.getByText(customResultPageText));
+    });
+
+    test('not display Organization Custom Message when campaign isForAbsoluteForNovice and isShared are false', async function (assert) {
+      const customResultPageText = "je s'appelle groot";
+      model.campaignParticipationResult.set('isShared', false);
+      model.campaign.set('customResultPageText', customResultPageText);
+      model.campaign.set('isForAbsoluteNovice', false);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.notOk(screen.queryByText(customResultPageText));
+    });
+
+    test('not display Organization Custom Message or Url when not set and campaign participation isShared', async function (assert) {
+      model.campaignParticipationResult.set('isShared', true);
+      model.campaign.set('isForAbsoluteNovice', false);
+      model.campaign.set('customResultPageText', null);
+      model.campaign.set('customResultPageButtonUrl', null);
+      model.campaign.set('customResultPageButtonText', null);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.organization-message')));
+    });
+
+    test('not display Organization Custom Message or Url when not set and campaign isForAbsoluteNovice', async function (assert) {
+      model.campaignParticipationResult.set('isShared', false);
+      model.campaign.set('isForAbsoluteNovice', true);
+      model.campaign.set('customResultPageText', null);
+      model.campaign.set('customResultPageButtonUrl', null);
+      model.campaign.set('customResultPageButtonText', null);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.organization-message')));
+    });
+  });
+
   module('Reset button', function (hooks) {
     hooks.beforeEach(function () {
       model.campaignParticipationResult.set('canReset', true);

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -253,4 +253,14 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
       assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     });
   });
+
+  test('it should not display skill review infos if isForabsoluteNovice is true', async function (assert) {
+    model.campaign.set('isForAbsoluteNovice', true);
+    this.set('model', model);
+
+    const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+    assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.stage.title')));
+    assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.details.title')));
+  });
 });

--- a/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
@@ -5,7 +5,7 @@ import EmberObject from '@ember/object';
 import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
 
-module('Integration | component | Campaigns | Evaluation | Skill Review', function (hooks) {
+module('Unit | component | Campaigns | Evaluation | Skill Review', function (hooks) {
   setupTest(hooks);
 
   let component, adapter, possibleBadgesCombinations, store;
@@ -608,227 +608,229 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
     });
   });
 
-  module('#showOrganizationMessage', function () {
-    test('should return true when the campaign has a customResultPageText', function (assert) {
-      // given
-      component.args.model.campaign.customResultPageText =
-        'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.';
-
-      // when
-      const result = component.showOrganizationMessage;
-
-      // then
-      assert.true(result);
-    });
-
-    test('should return false when the campaign has no customResultPageText ', function (assert) {
-      // given
-      component.args.model.campaign.customResultPageText = null;
-
-      // when
-      const result = component.showOrganizationMessage;
-
-      // then
-      assert.false(result);
-    });
-  });
-
-  module('#showOrganizationButton', function () {
-    test('should return true when the organization has a customResultPageButtonText and a customResultPageButtonUrl', async function (assert) {
-      // given
-      component.args.model.campaign.customResultPageButtonText = 'Go to the next step';
-      component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
-
-      // when
-      const result = await component.showOrganizationButton;
-
-      // then
-      assert.true(result);
-    });
-
-    test('should return false when the organization has no a customResultPageButtonText ', function (assert) {
-      // given
-      component.args.model.campaign.customResultPageButtonText = null;
-      component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
-
-      // when
-      const result = component.showOrganizationButton;
-
-      // then
-      assert.false(result);
-    });
-
-    test('should return false when the organization has noa customResultPageButtonUrl', function (assert) {
-      // given
-      component.args.model.campaign.customResultPageButtonText = 'Next step';
-      component.args.model.campaign.customResultPageButtonUrl = null;
-
-      // when
-      const result = component.showOrganizationButton;
-
-      // then
-      assert.false(result);
-    });
-  });
-
-  module('#customButtonUrl', function () {
-    module('when there is a customResultPageButtonUrl', function () {
-      module('when the participant has finished a campaign with stages', function () {
-        test('should add the stage to the url ', function (assert) {
-          // given
-          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
-          reachedStage.get.withArgs('threshold').returns(6);
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.reachedStage = reachedStage;
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(url, 'http://www.my-url.net/resultats?stage=6');
-        });
-      });
-
-      module('when the participant has a mastery percentage', function () {
-        test('should add the masteryPercentage to the url', function (assert) {
-          // given
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.masteryRate = '0.56';
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56');
-        });
-      });
-
-      module('when the participant has a mastery percentage equals to 0', function () {
-        test('should add the masteryPercentage to the url', function (assert) {
-          // given
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.masteryRate = '0.0';
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=0');
-        });
-      });
-
-      module('when the participant has a participantExternalId', function () {
-        test('should add the externalId to the url', function (assert) {
-          // given
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(url, 'http://www.my-url.net/resultats?externalId=1234F56');
-        });
-      });
-
-      module('when the participant has a participantExternalId, a mastery percentage and stages ', function () {
-        test('should add all params to the url', function (assert) {
-          // given
-          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
-          reachedStage.get.withArgs('threshold').returns(6);
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-          component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-          component.args.model.campaignParticipationResult.masteryRate = '0.56';
-          component.args.model.campaignParticipationResult.reachedStage = reachedStage;
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
-        });
-      });
-
-      module('when the url already has query params', function () {
-        test('should add the new parameters to the other query params', function (assert) {
-          // given
-          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
-          reachedStage.get.withArgs('threshold').returns(6);
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats?foo=bar';
-          component.args.model.campaignParticipationResult.reachedStage = reachedStage;
-          component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-          component.args.model.campaignParticipationResult.masteryRate = '0.56';
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(
-            url,
-            'http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6',
-          );
-        });
-      });
-
-      module('when the url has an ancor', function () {
-        test('should add the new parameters before the ancor', function (assert) {
-          // given
-          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
-          reachedStage.get.withArgs('threshold').returns(6);
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/#page1';
-          component.args.model.campaignParticipationResult.reachedStage = reachedStage;
-          component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
-          component.args.model.campaignParticipationResult.masteryRate = '0.56';
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-
-          assert.strictEqual(url, 'http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
-        });
-      });
-
-      module('when there is no params', function () {
-        test('should return the url of the custom button', function (assert) {
-          // given
-          component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
-          component.args.model.campaignParticipationResult.reachedStage = null;
-
-          // when
-          const url = component.customButtonUrl;
-
-          // then
-          assert.strictEqual(url, 'http://www.my-url.net/');
-        });
-      });
-    });
-
-    module('when there is no customResultPageButtonUrl', function () {
-      test('should return nothing', function (assert) {
+  module('display custom result block', function () {
+    module('#showOrganizationMessage', function () {
+      test('should return true when the campaign has a customResultPageText', function (assert) {
         // given
-        component.args.model.campaign.customResultPageButtonUrl = null;
-        component.args.model.campaignParticipationResult.reachedStage = 80;
+        component.args.model.campaign.customResultPageText =
+          'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.';
 
         // when
-        const url = component.customButtonUrl;
+        const result = component.showOrganizationMessage;
 
         // then
-        assert.strictEqual(url, null);
+        assert.true(result);
+      });
+
+      test('should return false when the campaign has no customResultPageText ', function (assert) {
+        // given
+        component.args.model.campaign.customResultPageText = null;
+
+        // when
+        const result = component.showOrganizationMessage;
+
+        // then
+        assert.false(result);
       });
     });
-  });
 
-  module('#customButtonText', function () {
-    test('should return the text of the custom button', function (assert) {
-      // given
-      component.args.model.campaign.customResultPageButtonText = 'Next step';
+    module('#showOrganizationButton', function () {
+      test('should return true when the organization has a customResultPageButtonText and a customResultPageButtonUrl', async function (assert) {
+        // given
+        component.args.model.campaign.customResultPageButtonText = 'Go to the next step';
+        component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
 
-      // when
-      const result = component.customButtonText;
+        // when
+        const result = await component.showOrganizationButton;
 
-      // then
-      assert.strictEqual(result, 'Next step');
+        // then
+        assert.true(result);
+      });
+
+      test('should return false when the organization has no a customResultPageButtonText ', function (assert) {
+        // given
+        component.args.model.campaign.customResultPageButtonText = null;
+        component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
+
+        // when
+        const result = component.showOrganizationButton;
+
+        // then
+        assert.false(result);
+      });
+
+      test('should return false when the organization has noa customResultPageButtonUrl', function (assert) {
+        // given
+        component.args.model.campaign.customResultPageButtonText = 'Next step';
+        component.args.model.campaign.customResultPageButtonUrl = null;
+
+        // when
+        const result = component.showOrganizationButton;
+
+        // then
+        assert.false(result);
+      });
+    });
+
+    module('#customButtonUrl', function () {
+      module('when there is a customResultPageButtonUrl', function () {
+        module('when the participant has finished a campaign with stages', function () {
+          test('should add the stage to the url ', function (assert) {
+            // given
+            const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+            reachedStage.get.withArgs('threshold').returns(6);
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+            component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(url, 'http://www.my-url.net/resultats?stage=6');
+          });
+        });
+
+        module('when the participant has a mastery percentage', function () {
+          test('should add the masteryPercentage to the url', function (assert) {
+            // given
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+            component.args.model.campaignParticipationResult.masteryRate = '0.56';
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56');
+          });
+        });
+
+        module('when the participant has a mastery percentage equals to 0', function () {
+          test('should add the masteryPercentage to the url', function (assert) {
+            // given
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+            component.args.model.campaignParticipationResult.masteryRate = '0.0';
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=0');
+          });
+        });
+
+        module('when the participant has a participantExternalId', function () {
+          test('should add the externalId to the url', function (assert) {
+            // given
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+            component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(url, 'http://www.my-url.net/resultats?externalId=1234F56');
+          });
+        });
+
+        module('when the participant has a participantExternalId, a mastery percentage and stages ', function () {
+          test('should add all params to the url', function (assert) {
+            // given
+            const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+            reachedStage.get.withArgs('threshold').returns(6);
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+            component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
+            component.args.model.campaignParticipationResult.masteryRate = '0.56';
+            component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
+          });
+        });
+
+        module('when the url already has query params', function () {
+          test('should add the new parameters to the other query params', function (assert) {
+            // given
+            const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+            reachedStage.get.withArgs('threshold').returns(6);
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats?foo=bar';
+            component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+            component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
+            component.args.model.campaignParticipationResult.masteryRate = '0.56';
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(
+              url,
+              'http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6',
+            );
+          });
+        });
+
+        module('when the url has an ancor', function () {
+          test('should add the new parameters before the ancor', function (assert) {
+            // given
+            const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+            reachedStage.get.withArgs('threshold').returns(6);
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net/#page1';
+            component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+            component.args.model.campaignParticipationResult.participantExternalId = '1234F56';
+            component.args.model.campaignParticipationResult.masteryRate = '0.56';
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+
+            assert.strictEqual(url, 'http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
+          });
+        });
+
+        module('when there is no params', function () {
+          test('should return the url of the custom button', function (assert) {
+            // given
+            component.args.model.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
+            component.args.model.campaignParticipationResult.reachedStage = null;
+
+            // when
+            const url = component.customButtonUrl;
+
+            // then
+            assert.strictEqual(url, 'http://www.my-url.net/');
+          });
+        });
+      });
+
+      module('when there is no customResultPageButtonUrl', function () {
+        test('should return nothing', function (assert) {
+          // given
+          component.args.model.campaign.customResultPageButtonUrl = null;
+          component.args.model.campaignParticipationResult.reachedStage = 80;
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          assert.strictEqual(url, null);
+        });
+      });
+    });
+
+    module('#customButtonText', function () {
+      test('should return the text of the custom button', function (assert) {
+        // given
+        component.args.model.campaign.customResultPageButtonText = 'Next step';
+
+        // when
+        const result = component.customButtonText;
+
+        // then
+        assert.strictEqual(result, 'Next step');
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Pix va utiliser une campagne isForAbsoluteNovice dans le cadre d'un questionnaire particulier. 
Cependant le bloc de fin de parcours personnalisé pour l’organisation ne s’affiche que si la participation est au statut SHARED. 
Les campagnes isForAbsoluteNovice n’affichant pas le bouton de partage de résultat les participations restent donc au statut TO_SHARE et ce bloc n’est jamais affiché. 

On veut donc afficher ce bloc dans deux cas de figure si les informations de personnalisation sont fournies :

- Si la participation est au statut SHARED
- Si la campagne est isForAbsoluteNovice

## :robot: Proposition
Ajout de la condition isForAbsoluteNovice dans l'affichage du bloc de fin de parcours

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Utiliser le script pour passer une campagne (avec des infos remplies pour le bloc de fin de parcours) en isForAbsoluteNovice : 
`node scripts/toggle-is-for-absolute-novice-campaign-attribute.js {idCampagne}`
- Participer à cette campagne  (sans être connecté à Pix)
- Vérifier à la fin du parcours, que les informations de l'organisation : message, bouton custom (ou non) et url sont bien affichés
- 🐱 
