### PR TITLE
[FEATURE] Enregistrer qui a fait l'action de désactivation d'un membre Pix Certif depuis Pix Admin (PIX-9381)

### DIFF
--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -3,10 +3,13 @@ import * as requestResponseUtils from '../../infrastructure/utils/request-respon
 import * as certificationCenterMembershipSerializer from '../../infrastructure/serializers/jsonapi/certification-center-membership-serializer.js';
 import { BadRequestError } from '../http-errors.js';
 
-const disable = async function (request, h) {
+const disable = async function (request, h, dependencies = { requestResponseUtils }) {
   const certificationCenterMembershipId = request.params.id;
+  const pixAgentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+
   await usecases.disableCertificationCenterMembership({
     certificationCenterMembershipId,
+    updatedByUserId: pixAgentUserId,
   });
   return h.response().code(204);
 };

--- a/api/lib/domain/usecases/disable-certification-center-membership.js
+++ b/api/lib/domain/usecases/disable-certification-center-membership.js
@@ -1,8 +1,9 @@
 const disableCertificationCenterMembership = async function ({
   certificationCenterMembershipId,
+  updatedByUserId,
   certificationCenterMembershipRepository,
 }) {
-  return certificationCenterMembershipRepository.disableById({ certificationCenterMembershipId });
+  return certificationCenterMembershipRepository.disableById({ certificationCenterMembershipId, updatedByUserId });
 };
 
 export { disableCertificationCenterMembership };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -183,12 +183,12 @@ const isMemberOfCertificationCenter = async function ({ userId, certificationCen
   return Boolean(certificationCenterMembershipId);
 };
 
-const disableById = async function ({ certificationCenterMembershipId }) {
+const disableById = async function ({ certificationCenterMembershipId, updatedByUserId }) {
   try {
     const now = new Date();
     const result = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
       .where({ id: certificationCenterMembershipId })
-      .update({ disabledAt: now })
+      .update({ disabledAt: now, updatedByUserId })
       .returning('*');
 
     if (result.length === 0) {

--- a/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
@@ -210,5 +210,92 @@ describe('Acceptance | API | Certification Center Membership', function () {
         });
       });
     });
+
+    describe('DELETE /api/admin/certification-center-memberships/{id}', function () {
+      let certificationCenter;
+      let certificationCenterMembership;
+      let user;
+
+      beforeEach(async function () {
+        certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        user = databaseBuilder.factory.buildUser();
+        certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId: user.id,
+        });
+        await databaseBuilder.commit();
+      });
+
+      context('Success cases', function () {
+        context('when parameters are valid', function () {
+          it('returns a 204 HTTP status code', async function () {
+            const pixAgentWithCertifRole = databaseBuilder.factory.buildUser.withRole({ role: 'CERTIF' });
+
+            const request = {
+              method: 'DELETE',
+              url: `/api/admin/certification-center-memberships/${certificationCenterMembership.id}`,
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(pixAgentWithCertifRole.id),
+              },
+            };
+
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(204);
+          });
+        });
+      });
+
+      context('Error cases', function () {
+        context('when user does not have a valid role', function () {
+          it('returns a 403 HTTP status code', async function () {
+            const userWithoutRole = databaseBuilder.factory.buildUser();
+
+            const request = {
+              method: 'DELETE',
+              url: `/api/admin/certification-center-memberships/${certificationCenterMembership.id}`,
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(userWithoutRole.id),
+              },
+            };
+
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(403);
+          });
+        });
+
+        context('when certification-center-membership does not exist', function () {
+          it('returns a 400 HTTP status code', async function () {
+            const pixAgentWithAdminRole = databaseBuilder.factory.buildUser.withRole({ role: 'SUPER_ADMIN' });
+            const nonexistentCertificationCenterMembershipId = 'TEST';
+
+            const request = {
+              method: 'DELETE',
+              url: `/api/admin/certification-center-memberships/${nonexistentCertificationCenterMembershipId}`,
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(pixAgentWithAdminRole.id),
+              },
+            };
+
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(400);
+          });
+        });
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -606,8 +606,9 @@ describe('Integration | Repository | Certification Center Membership', function 
         // given
         const certificationCenterMembershipId = 7;
         const userId = databaseBuilder.factory.buildUser().id;
+        const updatedByUserId = databaseBuilder.factory.buildUser().id;
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-        const certiciationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+        const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
           id: certificationCenterMembershipId,
           userId,
           certificationCenterId,
@@ -618,12 +619,14 @@ describe('Integration | Repository | Certification Center Membership', function 
         // when
         await certificationCenterMembershipRepository.disableById({
           certificationCenterMembershipId,
+          updatedByUserId,
         });
 
         // then
         const updatedCertificationCenterMembership = await knex('certification-center-memberships').first();
-        expect(updatedCertificationCenterMembership.id).to.equal(certiciationCenterMembership.id);
+        expect(updatedCertificationCenterMembership.id).to.equal(certificationCenterMembership.id);
         expect(updatedCertificationCenterMembership.disabledAt).to.deep.equal(now);
+        expect(updatedCertificationCenterMembership.updatedByUserId).to.equal(updatedByUserId);
       });
     });
 

--- a/api/tests/unit/domain/usecases/disable-certification-center-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-certification-center-membership_test.js
@@ -12,16 +12,19 @@ describe('Unit | UseCase | disable-certification-center-membership', function ()
   it('should disable certification center membership', async function () {
     // given
     const certificationCenterMembershipId = 100;
+    const updatedByUserId = 10;
 
     // when
     await disableCertificationCenterMembership({
       certificationCenterMembershipId,
+      updatedByUserId,
       certificationCenterMembershipRepository,
     });
 
     // then
     expect(certificationCenterMembershipRepository.disableById).to.have.been.calledWithExactly({
       certificationCenterMembershipId,
+      updatedByUserId,
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un agent Pix désactive un membre d'un centre de certif, depuis Pix Admin, l'information de qui l'a fait n'est pas sauvegardée.

## :robot: Proposition
Mettre à jour la colonne `updatedByUserId` de la table `certification-center-memberships` avec l'id du compte utlisateur l'ayant désactivé.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter sur Pix Admin avec par exemple le compte superadmin
- Cliquer sur l'onglet _Centres de certification_ et sélectionner _Accèssorium_ pour arriver sur la page de détail de ce centre.
- Dans la section _Membres_, récupérer l'id du membre Marc-Alex Terrieur
- Dans la section _Membres_, cliquer sur le bouton désactiver du membre _Marc-Alex Terrieur_
- Vérifier que le membre n'est plus affiché sur la page
- Vérifier en base de donnée, dans la table `certification-center-memberships`, que la ligne comportant `userId`= id récupéré plus haut, a bien le champ `updatedByUserId` avec comme valeur 90000 (si vous vous êtes connecté avec `superadmin` 😄)
