### PR TITLE
[FEATURE] Afficher le nombre minimum de Pix dans la page de détails d'une certification sur Pix Admin (PIX-9963).

### DIFF
--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.hbs
@@ -12,6 +12,9 @@
               {{t "components.complementary-certifications.target-profiles.badges-list.header.name"}}
             </th>
             <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.level"}}</th>
+            <th>
+              {{t "components.complementary-certifications.target-profiles.badges-list.header.minimum-earned-pix"}}
+            </th>
             <th>{{t "components.complementary-certifications.target-profiles.badges-list.header.id"}}</th>
           </tr>
         </thead>
@@ -28,6 +31,7 @@
               </td>
               <td>{{badge.label}}</td>
               <td>{{badge.level}}</td>
+              <td>{{this.getMinimumEarnedPixValue badge.minimumEarnedPix}}</td>
               <td>
                 <LinkTo
                   @route="authenticated.target-profiles.target-profile.badges.badge"

--- a/admin/app/components/complementary-certifications/target-profiles/badges-list.js
+++ b/admin/app/components/complementary-certifications/target-profiles/badges-list.js
@@ -4,4 +4,8 @@ export default class BadgesList extends Component {
   get currentTargetProfileBadges() {
     return this.args.currentTargetProfile?.badges;
   }
+
+  getMinimumEarnedPixValue(minimumEarnedPix) {
+    return minimumEarnedPix <= 0 ? '' : minimumEarnedPix;
+  }
 }

--- a/admin/tests/unit/components/complementary-certifications/target-profiles/badges-list_test.js
+++ b/admin/tests/unit/components/complementary-certifications/target-profiles/badges-list_test.js
@@ -13,13 +13,22 @@ module('Unit | Component | complementary-certifications/target-profiles/badges-l
       currentTargetProfile: {
         id: 1,
         name: 'current target',
-        badges: [{ id: 1, level: 2, label: 'badge Pluie', imageUrl: 'http://badge-pluie.net' }],
+        badges: [{ id: 1, level: 2, label: 'badge Pluie', imageUrl: 'http://badge-pluie.net', minimumEarnedPix: 0 }],
       },
     };
 
     // when & then
     assert.deepEqual(component.currentTargetProfileBadges, [
-      { id: 1, level: 2, label: 'badge Pluie', imageUrl: 'http://badge-pluie.net' },
+      { id: 1, level: 2, label: 'badge Pluie', imageUrl: 'http://badge-pluie.net', minimumEarnedPix: 0 },
     ]);
+  });
+
+  test('it should not display minimum earned pix if it is zero ', async function (assert) {
+    // given
+    const component = createGlimmerComponent('component:complementary-certifications/target-profiles/badges-list');
+    const minimumEarnedPix = 0;
+
+    // when & then
+    assert.strictEqual(component.getMinimumEarnedPixValue(minimumEarnedPix), '');
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -46,7 +46,7 @@
       "membership-item-role": {
         "select-role": "Select role"
       },
-      "table-headers" : {
+      "table-headers": {
         "roleLabel": "Role"
       }
     },
@@ -64,6 +64,7 @@
             "id": "ID du RT certifiant",
             "image-url": "Image du badge certifié",
             "level": "Niveau du badge certifié",
+            "minimum-earned-pix": "Nombre de pix minimum",
             "name": "Nom du badge certifié"
           }
         }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -54,7 +54,7 @@
       "membership-item-role": {
         "select-role": "Sélectionner un rôle"
       },
-      "table-headers" : {
+      "table-headers": {
         "roleLabel": "Rôle"
       }
     },
@@ -72,6 +72,7 @@
             "id": "ID du RT certifiant",
             "image-url": "Image du badge certifié",
             "level": "Niveau du badge certifié",
+            "minimum-earned-pix": "Nombre de pix minimum",
             "name": "Nom du badge certifié"
           }
         }
@@ -152,10 +153,10 @@
     "user-details": {
       "navbar": {
         "certification-centers-list": "Pix Certif",
-        "details" : "Détails",
+        "details": "Détails",
         "organizations-list": "Pix Orga",
         "participations-list": "Participations",
-        "profile" : "Profil"
+        "profile": "Profil"
       }
     }
   }

--- a/api/lib/domain/models/ComplementaryCertificationBadgeForAdmin.js
+++ b/api/lib/domain/models/ComplementaryCertificationBadgeForAdmin.js
@@ -1,9 +1,10 @@
 class ComplementaryCertificationBadgeForAdmin {
-  constructor({ id, label, level, imageUrl }) {
+  constructor({ id, label, level, imageUrl, minimumEarnedPix }) {
     this.id = id;
     this.label = label;
     this.level = level;
     this.imageUrl = imageUrl;
+    this.minimumEarnedPix = minimumEarnedPix;
   }
 }
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-target-profile-history-repository.js
@@ -65,6 +65,7 @@ async function _getBadgesForCurrentTargetProfiles({ targetProfile }) {
       label: 'complementary-certification-badges.label',
       level: 'complementary-certification-badges.level',
       imageUrl: 'complementary-certification-badges.imageUrl',
+      minimumEarnedPix: 'complementary-certification-badges.minimumEarnedPix',
     })
     .innerJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
     .where('targetProfileId', targetProfile.id)

--- a/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/src/certification/complementary-certification/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -8,7 +8,7 @@ const serializeForAdmin = function (complementaryCertification) {
     targetProfilesHistory: {
       attributes: ['id', 'name', 'attachedAt', 'detachedAt', 'badges'],
       badges: {
-        attributes: ['id', 'label', 'level', 'imageUrl'],
+        attributes: ['id', 'label', 'level', 'imageUrl', 'minimumEarnedPix'],
       },
     },
   }).serialize(complementaryCertification);

--- a/api/tests/certification/complementary-certification/acceptance/application/complementary-certification-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/complementary-certification-controller_test.js
@@ -54,6 +54,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
         label: 'another badge label',
         complementaryCertificationId: complementaryCertification.id,
         createdAt: attachedAt,
+        minimumEarnedPix: 100,
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -61,6 +62,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
         label: 'badge label',
         complementaryCertificationId: complementaryCertification.id,
         createdAt: attachedAt,
+        minimumEarnedPix: 150,
       });
 
       await databaseBuilder.commit();
@@ -89,12 +91,14 @@ describe('Acceptance | API | complementary-certification-controller', function (
                     level: 1,
                     label: 'another badge label',
                     imageUrl: 'http://badge-image-url.fr',
+                    minimumEarnedPix: 100,
                   },
                   {
                     id: 298,
                     level: 1,
                     label: 'badge label',
                     imageUrl: 'http://badge-image-url.fr',
+                    minimumEarnedPix: 150,
                   },
                 ],
               },

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-target-profile-history-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-target-profile-history-repository_test.js
@@ -31,6 +31,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           label: 'goodBadge2',
           level: 2,
           imageUrl: 'http://good-badge-2-url.net',
+          minimumEarnedPix: 20,
         });
         const currentBadgeId = _createComplementaryCertificationBadge({
           targetProfileId: currentTarget.id,
@@ -39,6 +40,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           label: 'goodBadge',
           level: 1,
           imageUrl: 'http://good-badge-url.net',
+          minimumEarnedPix: 10,
         });
         _createComplementaryCertificationBadge({
           targetProfileId: oldTargetProfile.id,
@@ -72,12 +74,14 @@ describe('Integration | Repository | complementary-certification-target-profile-
                 level: 1,
                 label: 'goodBadge',
                 imageUrl: 'http://good-badge-url.net',
+                minimumEarnedPix: 10,
               }),
               new ComplementaryCertificationBadgeForAdmin({
                 id: currentBadgeId2,
                 level: 2,
                 label: 'goodBadge2',
                 imageUrl: 'http://good-badge-2-url.net',
+                minimumEarnedPix: 20,
               }),
             ],
           }),
@@ -122,6 +126,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           createdAt: new Date('2023-10-10'),
           label: 'badgeReattached',
           level: 1,
+          minimumEarnedPix: 30,
         });
         _createComplementaryCertificationBadge({
           targetProfileId: oldReattachedTargetProfile.id,
@@ -155,6 +160,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
                 level: 1,
                 label: 'badgeReattached',
                 imageUrl: 'http://badge-image-url.fr',
+                minimumEarnedPix: 30,
               }),
             ],
           }),
@@ -190,6 +196,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           createdAt: new Date('2023-10-10'),
           label: 'badgeGood',
           level: 1,
+          minimumEarnedPix: 40,
         });
         const currentBadgeId2 = _createComplementaryCertificationBadge({
           targetProfileId: currentTargetProfile.id,
@@ -197,6 +204,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           createdAt: new Date('2023-10-10'),
           label: 'badgeGood2',
           level: 1,
+          minimumEarnedPix: 50,
         });
         const currentBadgeId3 = _createComplementaryCertificationBadge({
           targetProfileId: anotherCurrentTargetProfile.id,
@@ -204,6 +212,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           createdAt: new Date('2020-10-10'),
           label: 'anotherCurrentBadge',
           level: 1,
+          minimumEarnedPix: 60,
         });
 
         await databaseBuilder.commit();
@@ -229,12 +238,14 @@ describe('Integration | Repository | complementary-certification-target-profile-
                 level: 1,
                 label: 'badgeGood',
                 imageUrl: 'http://badge-image-url.fr',
+                minimumEarnedPix: 40,
               }),
               new ComplementaryCertificationBadgeForAdmin({
                 id: currentBadgeId2,
                 level: 1,
                 label: 'badgeGood2',
                 imageUrl: 'http://badge-image-url.fr',
+                minimumEarnedPix: 50,
               }),
             ],
           }),
@@ -249,6 +260,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
                 level: 1,
                 label: 'anotherCurrentBadge',
                 imageUrl: 'http://badge-image-url.fr',
+                minimumEarnedPix: 60,
               }),
             ],
           }),
@@ -279,6 +291,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           label: 'goodBadge2',
           level: 2,
           imageUrl: 'http://good-badge-2-url.net',
+          minimumEarnedPix: 80,
         });
         const currentBadgeId = _createComplementaryCertificationBadge({
           targetProfileId: currentTarget.id,
@@ -287,6 +300,7 @@ describe('Integration | Repository | complementary-certification-target-profile-
           label: 'goodBadge',
           level: 1,
           imageUrl: 'http://good-badge-url.net',
+          minimumEarnedPix: 70,
         });
 
         await databaseBuilder.commit();
@@ -312,12 +326,14 @@ describe('Integration | Repository | complementary-certification-target-profile-
                 level: 1,
                 label: 'goodBadge',
                 imageUrl: 'http://good-badge-url.net',
+                minimumEarnedPix: 70,
               }),
               new ComplementaryCertificationBadgeForAdmin({
                 id: currentBadgeId2,
                 level: 2,
                 label: 'goodBadge2',
                 imageUrl: 'http://good-badge-2-url.net',
+                minimumEarnedPix: 80,
               }),
             ],
           }),
@@ -490,6 +506,7 @@ function _createComplementaryCertificationBadge({
   label,
   level,
   imageUrl,
+  minimumEarnedPix,
 }) {
   const badgeId = databaseBuilder.factory.buildBadge({
     targetProfileId,
@@ -504,6 +521,7 @@ function _createComplementaryCertificationBadge({
     label,
     level,
     imageUrl,
+    minimumEarnedPix,
   });
 
   return badgeId;

--- a/api/tests/certification/complementary-certification/unit/infrastructure/serializers/complementary-certification-serializer_test.js
+++ b/api/tests/certification/complementary-certification/unit/infrastructure/serializers/complementary-certification-serializer_test.js
@@ -11,12 +11,14 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
           label: 'badge 1',
           level: 1,
           imageUrl: 'http://badge-image-url.fr',
+          minimumEarnedPix: 10,
         }),
         domainBuilder.buildComplementaryCertificationBadgeForAdmin({
           id: 2,
           label: 'badge 2',
           level: 2,
           imageUrl: 'http://badge-image-url.fr',
+          minimumEarnedPix: 20,
         }),
       ];
 
@@ -63,8 +65,8 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
                 attachedAt: new Date('2023-10-10'),
                 detachedAt: null,
                 badges: [
-                  { id: 1, label: 'badge 1', level: 1, imageUrl: 'http://badge-image-url.fr' },
-                  { id: 2, label: 'badge 2', level: 2, imageUrl: 'http://badge-image-url.fr' },
+                  { id: 1, label: 'badge 1', level: 1, imageUrl: 'http://badge-image-url.fr', minimumEarnedPix: 10 },
+                  { id: 2, label: 'badge 2', level: 2, imageUrl: 'http://badge-image-url.fr', minimumEarnedPix: 20 },
                 ],
               },
               {

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-badge-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-badge-for-admin.js
@@ -5,8 +5,9 @@ const buildComplementaryCertificationBadgeForAdmin = function ({
   label = 'badge Cascade',
   level = 1,
   imageUrl = 'http://badge-image-url.fr',
+  minimumEarnedPix = 0,
 }) {
-  return new ComplementaryCertificationBadgeForAdmin({ id, label, level, imageUrl });
+  return new ComplementaryCertificationBadgeForAdmin({ id, label, level, imageUrl, minimumEarnedPix });
 };
 
 export { buildComplementaryCertificationBadgeForAdmin };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, sur la page de détails d'une certification complémentaire, il n'est pas possible de voir le seuil minimal en pix à atteindre (pour valider une certification complémentaire) sur les badges certifiants. 

Pour info, ce seuil est propre à chaque résultat thématique certifiant et à chaque certification complémentaire.

## :robot: Proposition
Afficher une nouvelle colonne "Nombre minimum de Pix" dans le tableau des badges certifiants.

## :rainbow: Remarques
Condition : Si aucune valeur renseignée actuellement pour le seuil en Pix, ne rien afficher.

## :100: Pour tester
- Se connecter sur pix Admin avec superadmin
- Aller dans les certif complémentaire
- Aller sur le CléA et constater la nouvelle colonne du nombre minimum de Pix (à 70 pour le CléA)
- Aller sur une autre certif, et constater que la colonne est vide si rien n'est renseigné en BDD

<img width="1666" alt="Capture d’écran 2023-11-20 à 16 11 19" src="https://github.com/1024pix/pix/assets/58915422/68339436-6165-43a0-8808-6f4f243baf48">
