### PR TITLE
[BUGFIX] Corriger les pétouilles du module `bien-ecrire-son-adresse-mail` (PIX-10026)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -107,7 +107,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Bien vu ! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>et La Poste (laposte.net).</li><ul>",
+                "valid": "<p>Bien vu ! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>et La Poste (laposte.net).</li></ul>",
                 "invalid": "<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>de chez Free (free.fr)</li><li>ou de chez La Poste (laposte.net).</li></ul>"
               },
               "solution": "f56bb715-714e-4a94-ba34-eef5ccd755d0"

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -13,7 +13,7 @@
             {
               "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
               "type": "text",
-              "content": "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>"
+              "content": "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
             },
             {
               "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
@@ -47,8 +47,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>",
-                "invalid": "<p>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>"
+                "valid": "<p>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+                "invalid": "<p>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
               },
               "solution": "27244df5-7871-4096-b51d-8b1dbd65d2ad"
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -6,7 +6,7 @@
       "title": "Bien écrire son adresse mail",
       "grains": [
         {
-          "id": "z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
+          "id": "af860b1e-0566-4b06-bcb4-a68a5151d621",
           "type": "lesson",
           "title": "Explications : les parties d’une adresse mail",
           "elements": [
@@ -16,12 +16,12 @@
               "content": "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>"
             },
             {
-              "id": "d9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a",
+              "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
               "type": "text",
               "content": "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>"
             },
             {
-              "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6",
+              "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
               "type": "text",
               "content": "<h3 class='screen-reader-only'>Le fournisseur d’adresse mail</h3><h4><span aria-hidden='true'>2️⃣</span><span class='screen-reader-only'>2</span> Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail : </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><span aria-hidden='true'>🧐</span> L’avez-vous remarqué ? Cette partie est en 2 morceaux : le nom du fournisseur (par exemple “laposte”) et une extension (dans notre exemple, “.net”).</p>"
             }
@@ -33,16 +33,16 @@
           "title": "Diversité des identifiants et des fournisseurs d’adresse mail",
           "elements": [
             {
-              "id": "z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7",
+              "id": "29195dde-b603-488f-a554-f391fbdf3b24",
               "type": "qcu",
               "instruction": "<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>",
               "proposals": [
                 {
-                  "id": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6",
+                  "id": "27244df5-7871-4096-b51d-8b1dbd65d2ad",
                   "content": "Vrai"
                 },
                 {
-                  "id": "b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6",
+                  "id": "d2c27595-39ed-4af6-8401-1a082874d97e",
                   "content": "Faux"
                 }
               ],
@@ -50,7 +50,7 @@
                 "valid": "<p>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>",
                 "invalid": "<p>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>"
               },
-              "solution": "a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6"
+              "solution": "27244df5-7871-4096-b51d-8b1dbd65d2ad"
             },
             {
               "id": "ba78dead-a806-4954-b408-e8ef28d28fab",

--- a/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-validateAnswer_test.js
@@ -12,14 +12,14 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
     context('when given proposal is the correct answer', function () {
       it('should return valid CorrectionResponse', async function () {
         const moduleSlug = 'bien-ecrire-son-adresse-mail';
-        const elementId = 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7';
+        const elementId = '29195dde-b603-488f-a554-f391fbdf3b24';
         const options = {
           method: 'POST',
           url: `/api/modules/${moduleSlug}/elements/${elementId}/answers`,
           payload: {
             data: {
               attributes: {
-                'user-response': ['a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6'],
+                'user-response': ['27244df5-7871-4096-b51d-8b1dbd65d2ad'],
               },
             },
           },
@@ -29,8 +29,8 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
 
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.type).to.equal('element-answers');
-        expect(response.result.data.attributes['user-response-value']).to.equal('a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6');
-        expect(response.result.data.attributes['element-id']).to.equal('z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7');
+        expect(response.result.data.attributes['user-response-value']).to.equal('27244df5-7871-4096-b51d-8b1dbd65d2ad');
+        expect(response.result.data.attributes['element-id']).to.equal('29195dde-b603-488f-a554-f391fbdf3b24');
         expect(response.result.included[0].attributes.status).to.equal('ok');
       });
     });
@@ -38,14 +38,14 @@ describe('Acceptance | Controller | modules-controller-validateAnswer', function
     context('when given proposal is the wrong answer', function () {
       it('should return invalid CorrectionResponse', async function () {
         const moduleSlug = 'bien-ecrire-son-adresse-mail';
-        const elementId = 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7';
+        const elementId = '29195dde-b603-488f-a554-f391fbdf3b24';
         const options = {
           method: 'POST',
           url: `/api/modules/${moduleSlug}/elements/${elementId}/answers`,
           payload: {
             data: {
               attributes: {
-                'user-response': ['b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6'],
+                'user-response': ['d2c27595-39ed-4af6-8401-1a082874d97e'],
               },
             },
           },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -1,146 +1,68 @@
 import moduleDatasource from '../../../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import { expect } from '../../../../../test-helper.js';
 import { LearningContentResourceNotFound } from '../../../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import Joi from 'joi';
 
 describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasource', function () {
   describe('#getBySlug', function () {
     describe('when exists', function () {
-      it('should return a Module instance', async function () {
-        // given
-        const slug = 'bien-ecrire-son-adresse-mail';
+      let moduleSchema;
 
-        // when
+      before(function () {
+        const uuidSchema = Joi.string().guid().required();
+
+        const textElementSchema = Joi.object({
+          id: uuidSchema,
+          type: Joi.string().valid('text').required(),
+          content: Joi.string().required(),
+        }).required();
+
+        const qcuElementSchema = Joi.object({
+          id: uuidSchema,
+          type: Joi.string().valid('qcu').required(),
+          instruction: Joi.string().required(),
+          proposals: Joi.array()
+            .items({
+              id: uuidSchema,
+              content: Joi.string().required(),
+            })
+            .required(),
+          feedbacks: Joi.object({
+            valid: Joi.string().required(),
+            invalid: Joi.string().required(),
+          }).required(),
+          solution: uuidSchema,
+        }).required();
+
+        moduleSchema = Joi.object({
+          id: uuidSchema,
+          slug: Joi.string()
+            .regex(/^[a-z0-9-]+$/)
+            .required(),
+          title: Joi.string().required(),
+          grains: Joi.array()
+            .items(
+              Joi.object({
+                id: uuidSchema,
+                type: Joi.string().valid('lesson', 'activity').required(),
+                title: Joi.string().required(),
+                elements: Joi.array().items(Joi.alternatives().try(textElementSchema, qcuElementSchema)).required(),
+              }).required(),
+            )
+            .required(),
+        }).required();
+      });
+
+      it('should contain a valid structure', async function () {
+        // Given
+        const slug = 'bien-ecrire-son-adresse-mail';
         const module = await moduleDatasource.getBySlug(slug);
 
-        // then
-        const expectedModuleData = {
-          grains: [
-            {
-              elements: [
-                {
-                  content:
-                    "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>",
-                  id: 'c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-                  type: 'text',
-                },
-                {
-                  content:
-                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                  type: 'text',
-                },
-                {
-                  content:
-                    "<h3 class='screen-reader-only'>Le fournisseur d’adresse mail</h3><h4><span aria-hidden='true'>2️⃣</span><span class='screen-reader-only'>2</span> Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail : </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><span aria-hidden='true'>🧐</span> L’avez-vous remarqué ? Cette partie est en 2 morceaux : le nom du fournisseur (par exemple “laposte”) et une extension (dans notre exemple, “.net”).</p>",
-                  id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-                  type: 'text',
-                },
-              ],
-              id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              title: 'Explications : les parties d’une adresse mail',
-              type: 'lesson',
-            },
-            {
-              elements: [
-                {
-                  feedbacks: {
-                    invalid:
-                      '<p>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>',
-                    valid:
-                      '<p>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>',
-                  },
-                  id: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
-                  instruction: '<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>',
-                  proposals: [
-                    {
-                      content: 'Vrai',
-                      id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-                    },
-                    {
-                      content: 'Faux',
-                      id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
-                    },
-                  ],
-                  solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-                  type: 'qcu',
-                },
-                {
-                  feedbacks: {
-                    invalid:
-                      '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                    valid:
-                      '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                  },
-                  id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
-                  instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
-                  proposals: [
-                    {
-                      content: 'Vrai',
-                      id: '6d4db7f8-b783-473d-a1cc-73dac8411855',
-                    },
-                    {
-                      content: 'Faux',
-                      id: '26d27fa3-3269-4d78-916c-3aa066976592',
-                    },
-                  ],
-                  solution: '6d4db7f8-b783-473d-a1cc-73dac8411855',
-                  type: 'qcu',
-                },
-                {
-                  feedbacks: {
-                    invalid:
-                      '<p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @.</p>',
-                    valid:
-                      '<p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @.</p>',
-                  },
-                  id: '4231af7b-dca5-4d79-acfe-b485e0127ae1',
-                  instruction: '<p>Il faut toujours un symbole @ dans une adresse mail ?</p>',
-                  proposals: [
-                    {
-                      content: 'Vrai',
-                      id: 'beba4b60-cd4c-49d7-ae1f-2783c14f7c71',
-                    },
-                    {
-                      content: 'Faux',
-                      id: 'd784b9f6-5d5a-47ba-ae17-da15b712ab24',
-                    },
-                  ],
-                  solution: 'beba4b60-cd4c-49d7-ae1f-2783c14f7c71',
-                  type: 'qcu',
-                },
-                {
-                  feedbacks: {
-                    invalid:
-                      '<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>de chez Free (free.fr)</li><li>ou de chez La Poste (laposte.net).</li></ul>',
-                    valid:
-                      '<p>Bien vu ! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses</p><ul><li>de chez Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>et La Poste (laposte.net).</li><ul>',
-                  },
-                  id: '9bd65c37-ea5d-49a9-a59c-4e07ab3f1049',
-                  instruction: '<p>Toutes les adresses mails se terminent par gmail.com ?</p>',
-                  proposals: [
-                    {
-                      content: 'Vrai',
-                      id: '7ebabab5-6acd-4660-bf33-5cc7206e7288',
-                    },
-                    {
-                      content: 'Faux',
-                      id: 'f56bb715-714e-4a94-ba34-eef5ccd755d0',
-                    },
-                  ],
-                  solution: 'f56bb715-714e-4a94-ba34-eef5ccd755d0',
-                  type: 'qcu',
-                },
-              ],
-              id: '71792e45-966a-4070-b4fc-9e8a773c3f6f',
-              title: 'Diversité des identifiants et des fournisseurs d’adresse mail',
-              type: 'activity',
-            },
-          ],
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-        };
-        expect(module).to.deep.equal(expectedModuleData);
+        // When
+        const result = moduleSchema.validate(module);
+
+        // Then
+        expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Quelques pétouilles : 
- Les listes non ordonnées non exhaustives ne doivent pas se terminer par le caractère "points de suspension"
- Une balise `<ul>` était mal fermée

## :robot: Proposition
- Utiliser `etc` qui sera mieux vocalisé
- Fermer correctement la balise.

Je propose également remplacer le test du contenu de module pour être plus safe sur nos contenus. Je n'ai pas encore été jusqu'à la validation de l'HTML mais j'aimerai bien.

## :rainbow: Remarques
Certains UUIDs ne respectent pas [le format attendu par Joi](https://joi.dev/api/?v=17.9.1#stringguid---aliases-uuid), je les ai corrigé.

## :100: Pour tester
Vérifier que le rendu du module `bien-ecrire-son-adresse-mail` est mieux qu'avant. Le validateur HTML W3C devrait passer.
