### PR TITLE
[FEATURE] Pouvoir définir un nombre de pix minimum lors du rattachement d'un profil cible sur Pix Admin (PIX-9951).

### DIFF
--- a/admin/app/components/complementary-certifications/attach-badges/badges/header.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/header.hbs
@@ -1,6 +1,9 @@
 <th class="attach-badges-header">
   <span class="attach-badges-header__content">
     {{yield}}
+    {{#unless @isOptionnal}}
+      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
+    {{/unless}}
     {{#if (has-block "tooltip")}}
       <PixTooltip role="tooltip" @isLight={{true}} @isWide={{true}} @position="bottom-left" class="content_tooltip">
         <:triggerElement><FaIcon @icon="circle-info" /></:triggerElement>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
@@ -9,7 +9,9 @@
     <h1>Résultats thématiques certifiants</h1>
 
     <div class="complementary-certification-attach-badges-section__table">
-      <p>Tous les champs sont obligatoires.</p>
+      <p>
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
+      </p>
 
       <table aria-label="Liste des résultats thématiques">
         <thead>
@@ -26,7 +28,7 @@
                 Renseignez un chiffre unique pour chaque RT, niveau minimum = 1 niveau maximum = nombre total de RT.
               </:tooltip>
             </ComplementaryCertifications::AttachBadges::Badges::Header>
-            <ComplementaryCertifications::AttachBadges::Badges::Header>
+            <ComplementaryCertifications::AttachBadges::Badges::Header @isOptionnal="true">
               <:default>Nombre de pix minimum</:default>
             </ComplementaryCertifications::AttachBadges::Badges::Header>
             <ComplementaryCertifications::AttachBadges::Badges::Header>

--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.hbs
@@ -27,6 +27,9 @@
               </:tooltip>
             </ComplementaryCertifications::AttachBadges::Badges::Header>
             <ComplementaryCertifications::AttachBadges::Badges::Header>
+              <:default>Nombre de pix minimum</:default>
+            </ComplementaryCertifications::AttachBadges::Badges::Header>
+            <ComplementaryCertifications::AttachBadges::Badges::Header>
               <:default>Image svg certificat Pix App</:default>
               <:tooltip>
                 Renseignez l’URL de l’image au format .svg (fournie par les devs) pour le certificat Pix App du

--- a/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/row.hbs
@@ -19,6 +19,17 @@
   </td>
   <td>
     <PixInput
+      @id="{{@badgeId}}-minimum-earned-pix"
+      name="minimum-earned-pix"
+      placeholder="Ex : 150"
+      @ariaLabel="{{@badgeId}} {{@badgeLabel}} Nombre de pix minimum"
+      title="{{@badgeId}} {{@badgeLabel}} Nombre de pix minimum"
+      type="number"
+      {{on "input" (fn @onFieldUpdate @badgeId)}}
+    />
+  </td>
+  <td>
+    <PixInput
       @id="{{@badgeId}}-certificate-image"
       name="certificate-image"
       placeholder="Ex : https://images.pix.fr/..."

--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -84,6 +84,7 @@ export default class AttachTargetProfileController extends Controller {
           certificateMessage: badge['certificate-message'],
           temporaryCertificateMessage: badge['certificate-temporary-message'],
           stickerUrl: badge['certificate-sticker'],
+          minimumEarnedPix: badge['minimum-earned-pix'],
         });
         complementaryCertification.complementaryCertificationBadges.pushObject(aBadge);
       });

--- a/admin/app/models/complementary-certification-badge.js
+++ b/admin/app/models/complementary-certification-badge.js
@@ -5,6 +5,7 @@ export default class ComplementaryCertificationBadge extends Model {
 
   @attr('number') badgeId;
   @attr('number') level;
+  @attr('number') minimumEarnedPix;
   @attr('string') imageUrl;
   @attr('string') label;
   @attr('string') certificateMessage;

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/header_test.js
@@ -32,4 +32,18 @@ module('Integration | Component | ComplementaryCertifications::AttachBadges::Bad
     // then
     assert.dom(screen.getByRole('tooltip')).exists();
   });
+
+  module('if header is required', function () {
+    test('it should display the mandatory mark', async function (assert) {
+      // given & when
+      const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::Header>
+          LABEL
+        </ComplementaryCertifications::AttachBadges::Badges::Header>
+      `);
+
+      // then
+      assert.dom(screen.getByText('LABEL')).exists();
+      assert.dom(screen.getByTitle('obligatoire')).exists();
+    });
+  });
 });

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/index_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/index_test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import hbs from 'htmlbars-inline-precompile';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 
 module('Integration | Component | complementary-certifications/attach-badges/badges', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when data are loading', function () {
     test('it should display the loader', async function (assert) {

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
@@ -42,6 +42,7 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
       assert.dom(getByText(firstRow, 'ID')).exists();
       assert.dom(getByText(firstRow, 'Nom')).exists();
       assert.dom(getByText(firstRow, 'Niveau')).exists();
+      assert.dom(getByText(firstRow, 'Nombre de pix minimum')).exists();
       assert.dom(getByText(firstRow, 'Image svg certificat Pix App')).exists();
       assert.dom(getByText(firstRow, 'Label du certificat')).exists();
       assert.dom(getByText(firstRow, "Macaron de l'attestation PDF")).exists();

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render, getByText, queryByText } from '@1024pix/ember-testing-library';
+import { render, getByText, queryByText, getByTextWithHtml } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
@@ -10,12 +10,12 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
   setupIntlRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('[a11y] it should display a message that all inputs are required', async function (assert) {
+  test('[a11y] it should display a message that some inputs are required', async function (assert) {
     // given & when
-    const screen = await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::List />`);
+    await render(hbs`<ComplementaryCertifications::AttachBadges::Badges::List />`);
 
     // then
-    assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
+    assert.dom(getByTextWithHtml(this.intl.t('common.forms.mandatory-fields'))).exists();
   });
 
   module('Without badges', function () {
@@ -53,7 +53,7 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
     module('When there are badges', function () {
       test('it should display the list of badges with required inputs', async function (assert) {
         // given
-        const badges = [{ id: 12, label: 'BoyNextDoor One And Only' }];
+        const badges = [{ id: 12, label: 'BoyNextDoor' }];
         this.set('options', badges);
         this.set('noop', () => {});
 
@@ -66,26 +66,27 @@ module('Integration | Component | complementary-certifications/attach-badges/lis
 
         // then
         assert.strictEqual(screen.getAllByRole('row').length, 2);
-        assert.dom(screen.getByRole('row', { name: 'Résultat thématique 12 BoyNextDoor One And Only' })).exists();
+        assert.dom(screen.getByRole('row', { name: 'Résultat thématique 12 BoyNextDoor' })).exists();
         assert.dom(screen.getByText('12')).exists();
-        assert.dom(screen.getByText('BoyNextDoor One And Only')).exists();
+        assert.dom(screen.getByText('BoyNextDoor')).exists();
+        assert.dom(screen.getByRole('spinbutton', { name: '12 BoyNextDoor Niveau' })).hasAttribute('required');
         assert
-          .dom(screen.getByRole('spinbutton', { name: '12 BoyNextDoor One And Only Niveau' }))
+          .dom(screen.getByRole('spinbutton', { name: '12 BoyNextDoor Nombre de pix minimum' }))
+          .doesNotHaveAttribute('required');
+        assert
+          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor Image svg certificat Pix App' }))
           .hasAttribute('required');
         assert
-          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Image svg certificat Pix App' }))
+          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor Label du certificat' }))
           .hasAttribute('required');
         assert
-          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Label du certificat' }))
+          .dom(screen.getByRole('textbox', { name: "12 BoyNextDoor Macaron de l'attestation PDF" }))
           .hasAttribute('required');
         assert
-          .dom(screen.getByRole('textbox', { name: "12 BoyNextDoor One And Only Macaron de l'attestation PDF" }))
+          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor Message du certificat' }))
           .hasAttribute('required');
         assert
-          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Message du certificat' }))
-          .hasAttribute('required');
-        assert
-          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor One And Only Message temporaire certificat' }))
+          .dom(screen.getByRole('textbox', { name: '12 BoyNextDoor Message temporaire certificat' }))
           .hasAttribute('required');
       });
     });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -13,6 +13,9 @@
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please '<'a href=\"{url}\"'>'contact us'</a>' to unblock it.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'."
     },
+    "forms": {
+      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required"
+    },
     "notifications": {
       "generic-error": "An error occurred."
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -13,6 +13,9 @@
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, '<'a href=\"{url}\"'>'contactez-nous'</a>'.",
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser."
     },
+    "forms": {
+      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
+    },
     "notifications": {
       "generic-error": "Une erreur est survenue."
     },

--- a/api/src/certification/complementary-certification/application/attach-target-profile-route.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-route.js
@@ -42,6 +42,7 @@ const register = async function (server) {
                           'sticker-url': Joi.string().required(),
                           'certificate-message': Joi.string().empty(['', null]).optional(),
                           'temporary-certificate-message': Joi.string().empty(['', null]).optional(),
+                          'minimum-earned-pix': Joi.number().empty(['', null]).optional(),
                         }),
                         relationships: Joi.object().required(),
                         type: Joi.string(),

--- a/api/src/certification/complementary-certification/domain/models/BadgeToAttach.js
+++ b/api/src/certification/complementary-certification/domain/models/BadgeToAttach.js
@@ -9,6 +9,7 @@ class BadgeToAttach {
     temporaryCertificateMessage,
     stickerUrl,
     createdBy,
+    minimumEarnedPix,
   }) {
     this.level = level;
     this.complementaryCertificationId = complementaryCertificationId;
@@ -19,6 +20,7 @@ class BadgeToAttach {
     this.temporaryCertificateMessage = temporaryCertificateMessage;
     this.stickerUrl = stickerUrl;
     this.createdBy = createdBy;
+    this.minimumEarnedPix = minimumEarnedPix ?? 0;
   }
 
   static from({
@@ -31,6 +33,7 @@ class BadgeToAttach {
     temporaryCertificateMessage,
     stickerUrl,
     userId,
+    minimumEarnedPix,
   }) {
     return new BadgeToAttach({
       id: undefined,
@@ -44,6 +47,7 @@ class BadgeToAttach {
       stickerUrl,
       detachedAt: null,
       createdBy: userId,
+      minimumEarnedPix: minimumEarnedPix,
     });
   }
 }

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -124,6 +124,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           label: 'PIX+ Toto',
           imageUrl: 'svg.pix.toto.com',
           stickerUrl: 'pdf.pix.toto.com',
+          minimumEarnedPix: 50,
         }),
 
         domainBuilder.buildBadgeToAttach({
@@ -134,6 +135,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           label: 'PIX+ Toto 2',
           imageUrl: '2.svg.pix.toto.com',
           stickerUrl: '2.pdf.pix.toto.com',
+          minimumEarnedPix: 80,
         }),
       ];
 
@@ -166,7 +168,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           label: 'PIX+ Toto',
           imageUrl: 'svg.pix.toto.com',
           stickerUrl: 'pdf.pix.toto.com',
-          minimumEarnedPix: 0,
+          minimumEarnedPix: 50,
         },
         {
           badgeId: badgeId2,
@@ -180,7 +182,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           label: 'PIX+ Toto 2',
           imageUrl: '2.svg.pix.toto.com',
           stickerUrl: '2.pdf.pix.toto.com',
-          minimumEarnedPix: 0,
+          minimumEarnedPix: 80,
         },
       ]);
     });

--- a/api/tests/certification/complementary-certification/unit/domain/models/BadgeToAttach_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/models/BadgeToAttach_test.js
@@ -26,6 +26,7 @@ describe('Unit | Domain | Models | BadgeToAttach', function () {
         temporaryCertificateMessage: null,
         complementaryCertificationId: 789,
         userId: 1234,
+        minimumEarnedPix: 70,
       };
 
       // when
@@ -44,8 +45,48 @@ describe('Unit | Domain | Models | BadgeToAttach', function () {
           temporaryCertificateMessage: null,
           complementaryCertificationId: 789,
           createdBy: 1234,
+          minimumEarnedPix: 70,
         }),
       );
+    });
+
+    describe('when minimum earned pix is not set', function () {
+      it('should build a Badge to attach with 0 minimumEarnedPix', function () {
+        // given
+        const rawData = {
+          badgeId: 123,
+          createdAt: undefined,
+          label: 'badge_1',
+          level: 1,
+          imageUrl: 'svg.pix.toto.com',
+          stickerUrl: 'svg.pix.toto.com',
+          certificateMessage: null,
+          temporaryCertificateMessage: null,
+          complementaryCertificationId: 789,
+          userId: 1234,
+          minimumEarnedPix: null,
+        };
+
+        // when
+        const badgeToAttach = BadgeToAttach.from(rawData);
+
+        // then
+        expect(badgeToAttach).to.deepEqualInstance(
+          domainBuilder.buildBadgeToAttach({
+            badgeId: 123,
+            createdAt: now,
+            label: 'badge_1',
+            level: 1,
+            imageUrl: 'svg.pix.toto.com',
+            stickerUrl: 'svg.pix.toto.com',
+            certificateMessage: null,
+            temporaryCertificateMessage: null,
+            complementaryCertificationId: 789,
+            createdBy: 1234,
+            minimumEarnedPix: 0,
+          }),
+        );
+      });
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-badge-to-attach.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-to-attach.js
@@ -10,6 +10,7 @@ const buildBadgeToAttach = function ({
   temporaryCertificateMessage = null,
   stickerUrl = 'http://stiker-url.fr',
   createdBy = null,
+  minimumEarnedPix = 0,
 }) {
   return new BadgeToAttach({
     level,
@@ -21,6 +22,7 @@ const buildBadgeToAttach = function ({
     temporaryCertificateMessage,
     stickerUrl,
     createdBy,
+    minimumEarnedPix,
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, le nombre de pix minimum pour chaque badge certifiant est visible sur la page de détails d'une certification complémentaire. Mais il n'existe pour l'instant aucun moyen de le définir lors du rattachement d'un nouveau profil cible.

## :robot: Proposition
Définir un seuil minimal en pix à atteindre, propre à chaque résultat thématique certifiant, lors du rattachement.

## :rainbow: Remarques
Cette colonne, facultative, modifie l'affichage de la page. 
En effet il faut ajouter pour chaque colonne obligatoire un astérisque et modifier la mention "Tous les champs sont obligatoire" en "Les champs marqués de * sont obligatoires."

## :100: Pour tester
- depuis pix admin
- rattacher un nouveau profile cible à une certification complémentaire
- indiquer un seuil en pix pour les badge de certification complémentaire
- constater la mise à jour du profile cible avec les seuils en pix 

![image](https://github.com/1024pix/pix/assets/37305474/b4b82d01-b5fa-4cef-bf23-d1053a7f4d43)

