### PR TITLE
[BUGFIX] Comportement du scrolling sur la sélection du centre de certif (PIX-9935).

### DIFF
--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -57,6 +57,7 @@
   max-width: 600px;
   max-height: 600px;
   overflow: auto;
+  overscroll-behavior: contain;
 
   &-item {
     text-decoration: none;

--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -54,8 +54,9 @@
   top: 60px;
   right: 0;
   min-width: 400px;
+  max-width: 600px;
   max-height: 600px;
-  overflow: scroll;
+  overflow: auto;
 
   &-item {
     text-decoration: none;


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Certif, dans le menu de sélection des centres en haut à droite, des scrollbars apparaissent quelque soit la liste à afficher.

Est souhaité : 
* Afficher la scrollbar verticale que si la liste est trop longue (600px)

## :robot: Proposition
* Revue du CSS

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

⚠️ Sur Mac OS le comportement était déjà OK, il faut être sous un autre système d'exploitation.

* Se connecter sur Pix Certif avec `certif-pro@example.net`, afficher le menu et constater que la scrollbar n'apparait pas
* Se connecter avec `certif-sco@example.net`, la liste des centres est longue, la scrollbar apparait
* Vérifier sous les navigateurs supportés
