### PR TITLE
[FEATURE] Sauvegarder la configuration de l'algo de choix des épreuves en BDD. (PIX-9967)

### DIFF
--- a/api/db/database-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/db/database-builder/factory/build-flash-algorithm-configuration.js
@@ -1,0 +1,32 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildFlashAlgorithmConfiguration = function ({
+  warmUpLength = null,
+  forcedCompetences = [],
+  maximumAssessmentLength = null,
+  challengesBetweenSameCompetence = null,
+  minimumEstimatedSuccessRateRanges = [],
+  limitToOneQuestionPerTube = null,
+  enablePassageByAllCompetences = false,
+  variationPercent = null,
+  doubleMeasuresUntil = null,
+} = {}) {
+  const values = {
+    warmUpLength,
+    maximumAssessmentLength,
+    challengesBetweenSameCompetence,
+    forcedCompetences: JSON.stringify(forcedCompetences),
+    minimumEstimatedSuccessRateRanges: JSON.stringify(minimumEstimatedSuccessRateRanges),
+    limitToOneQuestionPerTube,
+    enablePassageByAllCompetences,
+    variationPercent,
+    doubleMeasuresUntil,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'flash-algorithm-configurations',
+    values,
+  });
+};
+
+export { buildFlashAlgorithmConfiguration };

--- a/api/db/migrations/20231120160609_add-configuration-get-next-challenge-for-flash-algorithm.js
+++ b/api/db/migrations/20231120160609_add-configuration-get-next-challenge-for-flash-algorithm.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'flash-algorithm-configurations';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (t) {
+    t.increments().primary();
+    t.integer('warmUpLength');
+    t.jsonb('forcedCompetences');
+    t.integer('maximumAssessmentLength');
+    t.integer('challengesBetweenSameCompetence');
+    t.jsonb('minimumEstimatedSuccessRateRanges');
+    t.boolean('limitToOneQuestionPerTube');
+    t.boolean('enablePassageByAllCompetences');
+    t.integer('variationPercent');
+    t.integer('doubleMeasuresUntil');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -1,6 +1,7 @@
 import { AssessmentEndedError } from '../errors.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
 import { config } from '../../../src/shared/config.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const getNextChallengeForCampaignAssessment = async function ({
   challengeRepository,
@@ -31,12 +32,14 @@ const getNextChallengeForCampaignAssessment = async function ({
 
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,
-      maximumAssessmentLength: config.features.numberOfChallengesForFlashMethod,
-      warmUpLength,
-      forcedCompetences,
-      limitToOneQuestionPerTube,
-      minimumEstimatedSuccessRateRanges,
-      enablePassageByAllCompetences,
+      configuration: new FlashAssessmentAlgorithmConfiguration({
+        warmUpLength,
+        forcedCompetences,
+        limitToOneQuestionPerTube,
+        minimumEstimatedSuccessRateRanges,
+        enablePassageByAllCompetences,
+        maximumAssessmentLength: config.features.numberOfChallengesForFlashMethod,
+      }),
     });
 
     const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -1,11 +1,11 @@
 import { AssessmentEndedError } from '../errors.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
-import { config } from '../../../src/shared/config.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const getNextChallengeForCampaignAssessment = async function ({
   challengeRepository,
   answerRepository,
+  flashAlgorithmConfigurationRepository,
   flashAssessmentResultRepository,
   assessment,
   pickChallengeService,
@@ -13,11 +13,6 @@ const getNextChallengeForCampaignAssessment = async function ({
   algorithmDataFetcherService,
   smartRandom,
   flashAlgorithmService,
-  warmUpLength = 0,
-  forcedCompetences = [],
-  limitToOneQuestionPerTube = false,
-  minimumEstimatedSuccessRateRanges = [],
-  enablePassageByAllCompetences = false,
 }) {
   let algoResult;
 
@@ -30,16 +25,11 @@ const getNextChallengeForCampaignAssessment = async function ({
       locale,
     });
 
+    const configuration = (await flashAlgorithmConfigurationRepository.get()) ?? _createDefaultAlgorithmConfiguration();
+
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,
-      configuration: new FlashAssessmentAlgorithmConfiguration({
-        warmUpLength,
-        forcedCompetences,
-        limitToOneQuestionPerTube,
-        minimumEstimatedSuccessRateRanges,
-        enablePassageByAllCompetences,
-        maximumAssessmentLength: config.features.numberOfChallengesForFlashMethod,
-      }),
+      configuration,
     });
 
     const possibleChallenges = assessmentAlgorithm.getPossibleNextChallenges({
@@ -62,6 +52,16 @@ const getNextChallengeForCampaignAssessment = async function ({
       locale,
     });
   }
+};
+
+const _createDefaultAlgorithmConfiguration = () => {
+  return new FlashAssessmentAlgorithmConfiguration({
+    warmUpLength: 0,
+    forcedCompetences: [],
+    limitToOneQuestionPerTube: false,
+    minimumEstimatedSuccessRateRanges: [],
+    enablePassageByAllCompetences: false,
+  });
 };
 
 export { getNextChallengeForCampaignAssessment };

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -1,6 +1,6 @@
 import { CertificationVersion } from '../../../src/shared/domain/models/CertificationVersion.js';
 import { CertificationChallenge, FlashAssessmentAlgorithm } from '../models/index.js';
-import { config } from '../../config.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const getNextChallengeForCertification = async function ({
   algorithmDataFetcherService,
@@ -14,11 +14,6 @@ const getNextChallengeForCertification = async function ({
   locale,
   pickChallengeService,
   flashAlgorithmService,
-  warmUpLength = 0,
-  forcedCompetences = [],
-  limitToOneQuestionPerTube = false,
-  minimumEstimatedSuccessRateRanges = [],
-  enablePassageByAllCompetences = false,
 }) {
   const certificationCourse = await certificationCourseRepository.get(assessment.certificationCourseId);
 
@@ -53,14 +48,11 @@ const getNextChallengeForCertification = async function ({
       locale,
     });
 
+    const algorithmConfiguration = _createDefaultAlgorithmConfiguration();
+
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
-      maximumAssessmentLength: config.v3Certification.numberOfChallengesPerCourse,
       flashAlgorithmImplementation: flashAlgorithmService,
-      warmUpLength,
-      forcedCompetences,
-      limitToOneQuestionPerTube,
-      minimumEstimatedSuccessRateRanges,
-      enablePassageByAllCompetences,
+      configuration: algorithmConfiguration,
     });
 
     const activeChallenges = challenges.filter((challenge) => !validatedLiveAlertChallengeIds.includes(challenge.id));
@@ -105,6 +97,16 @@ const _getAlreadyAnsweredChallengeIds = async ({ assessmentId, answerRepository 
 
 const _getValidatedLiveAlertChallengeIds = async ({ assessmentId, certificationChallengeLiveAlertRepository }) => {
   return certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId(assessmentId);
+};
+
+const _createDefaultAlgorithmConfiguration = () => {
+  return new FlashAssessmentAlgorithmConfiguration({
+    warmUpLength: 0,
+    forcedCompetences: [],
+    limitToOneQuestionPerTube: false,
+    minimumEstimatedSuccessRateRanges: [],
+    enablePassageByAllCompetences: false,
+  });
 };
 
 export { getNextChallengeForCertification };

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -14,6 +14,7 @@ const getNextChallengeForCertification = async function ({
   locale,
   pickChallengeService,
   flashAlgorithmService,
+  flashAlgorithmConfigurationRepository,
 }) {
   const certificationCourse = await certificationCourseRepository.get(assessment.certificationCourseId);
 
@@ -48,7 +49,8 @@ const getNextChallengeForCertification = async function ({
       locale,
     });
 
-    const algorithmConfiguration = _createDefaultAlgorithmConfiguration();
+    const algorithmConfiguration =
+      (await flashAlgorithmConfigurationRepository.get()) ?? _createDefaultAlgorithmConfiguration();
 
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -91,6 +91,7 @@ import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole
 import * as divisionRepository from '../../infrastructure/repositories/division-repository.js';
 import * as encryptionService from '../../../src/shared/domain/services/encryption-service.js';
 import * as finalizedSessionRepository from '../../infrastructure/repositories/sessions/finalized-session-repository.js';
+import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
 import * as flashAssessmentResultRepository from '../../infrastructure/repositories/flash-assessment-result-repository.js';
 import * as frameworkRepository from '../../infrastructure/repositories/framework-repository.js';
@@ -296,6 +297,7 @@ const dependencies = {
   divisionRepository,
   encryptionService,
   finalizedSessionRepository,
+  flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   flashAssessmentResultRepository,
   frameworkRepository,

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
@@ -4,27 +4,8 @@ import { FlashAssessmentAlgorithmNonAnsweredSkillsRule } from './FlashAssessment
 import { FlashAssessmentAlgorithmPassageByAllCompetencesRule } from './FlashAssessmentAlgorithmPassageByAllCompetencesRule.js';
 import { FlashAssessmentAlgorithmForcedCompetencesRule } from './FlashAssessmentAlgorithmForcedCompetencesRule.js';
 import { FlashAssessmentAlgorithmChallengesBetweenCompetencesRule } from './FlashAssessmentAlgorithmChallengesBetweenCompetencesRule.js';
-import { FlashAssessmentSuccessRateHandler } from './FlashAssessmentSuccessRateHandler.js';
 import { AssessmentEndedError } from '../../../../shared/domain/errors.js';
 import { config } from '../../../../shared/config.js';
-
-const defaultMinimumEstimatedSuccessRateRanges = [
-  // Between question 1 and question 8 included, we set the minimum estimated
-  // success rate to 80%
-  FlashAssessmentSuccessRateHandler.createFixed({
-    startingChallengeIndex: 0,
-    endingChallengeIndex: 7,
-    value: 0.8,
-  }),
-  // Between question 9 and question 16 included, we linearly decrease the
-  // minimum estimated success rate from 80% to 50%
-  FlashAssessmentSuccessRateHandler.createLinear({
-    startingChallengeIndex: 8,
-    endingChallengeIndex: 15,
-    startingValue: 0.8,
-    endingValue: 0.5,
-  }),
-];
 
 const availableRules = [
   FlashAssessmentAlgorithmOneQuestionPerTubeRule,
@@ -38,42 +19,18 @@ class FlashAssessmentAlgorithm {
   /**
    * Model to interact with the flash algorithm
    * @param warmUpLength - define a warmup when the algorithm do not go through the competences
-   * @param forcedCompetences - force the algorithm to ask questions on the specified competences
-   * @param maximumAssessmentLength - override the default limit for an assessment length
-   * @param challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
-   * @param minimumEstimatedSuccessRateRanges - force a minimal estimated success rate for challenges chosen at specific indexes
-   * @param limitToOneQuestionPerTube - limits questions to one per tube
-   * @param flashImplementation - the flash algorithm implementation
-   * @param enablePassageByAllCompetences - enable or disable the passage through all competences
-   * @param variationPercent - maximum variation of estimated level between two answers
-   * @param doubleMeasuresUntil - use the double measure strategy for specified number of challenges
+   * @param configuration - options to configure algorithm challenge selection and behaviour
    */
-  constructor({
-    warmUpLength,
-    forcedCompetences,
-    maximumAssessmentLength,
-    challengesBetweenSameCompetence = config.v3Certification.challengesBetweenSameCompetence,
-    minimumEstimatedSuccessRateRanges = defaultMinimumEstimatedSuccessRateRanges,
-    limitToOneQuestionPerTube,
-    flashAlgorithmImplementation,
-    enablePassageByAllCompetences,
-    variationPercent,
-    doubleMeasuresUntil,
-  } = {}) {
-    this.maximumAssessmentLength = maximumAssessmentLength || config.v3Certification.numberOfChallengesPerCourse;
-    this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
-    this.minimumEstimatedSuccessRateRanges = minimumEstimatedSuccessRateRanges;
-    this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
+  constructor({ flashAlgorithmImplementation, configuration = {} } = {}) {
+    this.configuration = configuration;
     this.flashAlgorithmImplementation = flashAlgorithmImplementation;
-    this.variationPercent = variationPercent;
-    this.doubleMeasuresUntil = doubleMeasuresUntil;
 
     this.ruleEngine = new FlashAssessmentAlgorithmRuleEngine(availableRules, {
-      limitToOneQuestionPerTube,
-      challengesBetweenSameCompetence,
-      forcedCompetences,
-      warmUpLength,
-      enablePassageByAllCompetences,
+      limitToOneQuestionPerTube: configuration.limitToOneQuestionPerTube,
+      challengesBetweenSameCompetence: configuration.challengesBetweenSameCompetence,
+      forcedCompetences: configuration.forcedCompetences,
+      warmUpLength: configuration.warmUpLength,
+      enablePassageByAllCompetences: configuration.enablePassageByAllCompetences,
     });
   }
 
@@ -83,7 +40,7 @@ class FlashAssessmentAlgorithm {
     initialCapacity = config.v3Certification.defaultCandidateCapacity,
     answersForComputingEstimatedLevel,
   }) {
-    if (assessmentAnswers.length >= this.maximumAssessmentLength) {
+    if (assessmentAnswers.length >= this.configuration.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }
 
@@ -91,7 +48,7 @@ class FlashAssessmentAlgorithm {
       allAnswers: answersForComputingEstimatedLevel ?? assessmentAnswers,
       challenges,
       initialCapacity,
-      variationPercent: this.variationPercent,
+      variationPercent: this.configuration.variationPercent,
     });
 
     const challengesAfterRulesApplication = this._applyChallengeSelectionRules(assessmentAnswers, challenges);
@@ -106,7 +63,7 @@ class FlashAssessmentAlgorithm {
       availableChallenges: challengesAfterRulesApplication,
       estimatedLevel,
       options: {
-        challengesBetweenSameCompetence: this.challengesBetweenSameCompetence,
+        challengesBetweenSameCompetence: this.configuration.challengesBetweenSameCompetence,
         minimalSuccessRate,
       },
     });
@@ -130,7 +87,7 @@ class FlashAssessmentAlgorithm {
   }
 
   _findApplicableSuccessRateConfiguration(questionIndex) {
-    return this.minimumEstimatedSuccessRateRanges.find((successRateRange) =>
+    return this.configuration.minimumEstimatedSuccessRateRanges.find((successRateRange) =>
       successRateRange.isApplicable(questionIndex),
     );
   }
@@ -144,8 +101,8 @@ class FlashAssessmentAlgorithm {
       allAnswers,
       challenges,
       estimatedLevel: initialCapacity,
-      variationPercent: this.variationPercent,
-      doubleMeasuresUntil: this.doubleMeasuresUntil,
+      variationPercent: this.configuration.variationPercent,
+      doubleMeasuresUntil: this.configuration.doubleMeasuresUntil,
     });
   }
 

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
@@ -1,0 +1,55 @@
+import { config } from '../../../../shared/config.js';
+import { FlashAssessmentSuccessRateHandler } from './FlashAssessmentSuccessRateHandler.js';
+
+const defaultMinimumEstimatedSuccessRateRanges = [
+  // Between question 1 and question 8 included, we set the minimum estimated
+  // success rate to 80%
+  FlashAssessmentSuccessRateHandler.createFixed({
+    startingChallengeIndex: 0,
+    endingChallengeIndex: 7,
+    value: 0.8,
+  }),
+  // Between question 9 and question 16 included, we linearly decrease the
+  // minimum estimated success rate from 80% to 50%
+  FlashAssessmentSuccessRateHandler.createLinear({
+    startingChallengeIndex: 8,
+    endingChallengeIndex: 15,
+    startingValue: 0.8,
+    endingValue: 0.5,
+  }),
+];
+
+/**
+ * @param forcedCompetences - force the algorithm to ask questions on the specified competences
+ * @param maximumAssessmentLength - override the default limit for an assessment length
+ * @param challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
+ * @param minimumEstimatedSuccessRateRanges - force a minimal estimated success rate for challenges chosen at specific indexes
+ * @param limitToOneQuestionPerTube - limits questions to one per tube
+ * @param flashImplementation - the flash algorithm implementation
+ * @param enablePassageByAllCompetences - enable or disable the passage through all competences
+ * @param variationPercent - maximum variation of estimated level between two answers
+ * @param doubleMeasuresUntil - use the double measure strategy for specified number of challenges
+ */
+export class FlashAssessmentAlgorithmConfiguration {
+  constructor({
+    warmUpLength,
+    forcedCompetences,
+    maximumAssessmentLength = config.v3Certification.numberOfChallengesPerCourse,
+    challengesBetweenSameCompetence = config.v3Certification.challengesBetweenSameCompetence,
+    minimumEstimatedSuccessRateRanges = defaultMinimumEstimatedSuccessRateRanges,
+    limitToOneQuestionPerTube,
+    enablePassageByAllCompetences,
+    variationPercent,
+    doubleMeasuresUntil,
+  }) {
+    this.warmUpLength = warmUpLength;
+    this.forcedCompetences = forcedCompetences;
+    this.maximumAssessmentLength = maximumAssessmentLength;
+    this.challengesBetweenSameCompetence = challengesBetweenSameCompetence;
+    this.minimumEstimatedSuccessRateRanges = minimumEstimatedSuccessRateRanges;
+    this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
+    this.enablePassageByAllCompetences = enablePassageByAllCompetences;
+    this.variationPercent = variationPercent;
+    this.doubleMeasuresUntil = doubleMeasuresUntil;
+  }
+}

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -2,6 +2,7 @@ import { FlashAssessmentAlgorithm } from '../model/FlashAssessmentAlgorithm.js';
 import { AssessmentSimulator } from '../model/AssessmentSimulator.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../model/AssessmentSimulatorSingleMeasureStrategy.js';
 import { AssessmentSimulatorDoubleMeasureStrategy } from '../model/AssessmentSimulatorDoubleMeasureStrategy.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../model/FlashAssessmentAlgorithmConfiguration.js';
 
 export async function simulateFlashDeterministicAssessmentScenario({
   challengeRepository,
@@ -24,16 +25,18 @@ export async function simulateFlashDeterministicAssessmentScenario({
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
   const flashAssessmentAlgorithm = new FlashAssessmentAlgorithm({
-    warmUpLength,
-    forcedCompetences,
-    maximumAssessmentLength: stopAtChallenge,
-    challengesBetweenSameCompetence,
-    limitToOneQuestionPerTube,
-    minimumEstimatedSuccessRateRanges,
     flashAlgorithmImplementation: flashAlgorithmService,
-    enablePassageByAllCompetences,
-    variationPercent,
-    doubleMeasuresUntil,
+    configuration: new FlashAssessmentAlgorithmConfiguration({
+      warmUpLength,
+      forcedCompetences,
+      limitToOneQuestionPerTube,
+      minimumEstimatedSuccessRateRanges,
+      enablePassageByAllCompetences,
+      variationPercent,
+      doubleMeasuresUntil,
+      challengesBetweenSameCompetence,
+      maximumAssessmentLength: stopAtChallenge,
+    }),
   });
 
   const singleMeasureStrategy = new AssessmentSimulatorSingleMeasureStrategy({

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -1,0 +1,14 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+
+const TABLE_NAME = 'flash-algorithm-configurations';
+
+const save = async function (flashAlgorithmConfiguration) {
+  const data = {
+    ...flashAlgorithmConfiguration,
+    forcedCompetences: JSON.stringify(flashAlgorithmConfiguration.forcedCompetences),
+    minimumEstimatedSuccessRateRanges: JSON.stringify(flashAlgorithmConfiguration.minimumEstimatedSuccessRateRanges),
+  };
+  return knex(TABLE_NAME).insert(data);
+};
+
+export { save };

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const TABLE_NAME = 'flash-algorithm-configurations';
 
@@ -11,4 +12,14 @@ const save = async function (flashAlgorithmConfiguration) {
   return knex(TABLE_NAME).insert(data);
 };
 
-export { save };
+const get = async function () {
+  const flashAlgorithmConfiguration = await knex(TABLE_NAME).first();
+
+  if (!flashAlgorithmConfiguration) {
+    return null;
+  }
+
+  return new FlashAssessmentAlgorithmConfiguration(flashAlgorithmConfiguration);
+};
+
+export { save, get };

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -1,0 +1,109 @@
+import { expect, knex } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import * as flashAlgorithmConfigurationRepository from '../../../../../../../api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
+
+describe('Integration | Infrastructure | Repository | FlashAlgorithmConfigurationRepository', function () {
+  describe('#save', function () {
+    it('should create a flash algorithm configuration', async function () {
+      // given
+      const flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+        warmUpLength: 1,
+        maximumAssessmentLength: 2,
+        challengesBetweenSameCompetence: 3,
+        variationPercent: 4,
+        doubleMeasuresUntil: 5,
+        forcedCompetences: ['comp1', 'comp2'],
+        minimumEstimatedSuccessRateRanges: [
+          { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
+        ],
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: false,
+      });
+
+      // when
+      await flashAlgorithmConfigurationRepository.save(flashAlgorithmConfiguration);
+
+      // then
+      const createdConfiguration = await knex('flash-algorithm-configurations').first();
+      expect(createdConfiguration).to.deep.contains({
+        warmUpLength: 1,
+        forcedCompetences: ['comp1', 'comp2'],
+        minimumEstimatedSuccessRateRanges: [
+          { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
+        ],
+        maximumAssessmentLength: 2,
+        challengesBetweenSameCompetence: 3,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: false,
+        variationPercent: 4,
+        doubleMeasuresUntil: 5,
+      });
+    });
+
+    it('should create a flash algorithm configuration without forced competences', async function () {
+      // given
+      const flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+        warmUpLength: 1,
+        maximumAssessmentLength: 2,
+        challengesBetweenSameCompetence: 3,
+        variationPercent: 4,
+        doubleMeasuresUntil: 5,
+        minimumEstimatedSuccessRateRanges: [
+          { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
+        ],
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: false,
+      });
+
+      // when
+      await flashAlgorithmConfigurationRepository.save(flashAlgorithmConfiguration);
+
+      // then
+      const createdConfiguration = await knex('flash-algorithm-configurations').first();
+      expect(createdConfiguration).to.deep.contains({
+        warmUpLength: 1,
+        forcedCompetences: null,
+        minimumEstimatedSuccessRateRanges: [
+          { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
+        ],
+        maximumAssessmentLength: 2,
+        challengesBetweenSameCompetence: 3,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: false,
+        variationPercent: 4,
+        doubleMeasuresUntil: 5,
+      });
+    });
+
+    it('should create a flash algorithm configuration without minimum estimated success rate ranges', async function () {
+      // given
+      const flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+        warmUpLength: 1,
+        maximumAssessmentLength: 2,
+        challengesBetweenSameCompetence: 3,
+        variationPercent: 4,
+        doubleMeasuresUntil: 5,
+        forcedCompetences: ['comp1', 'comp2'],
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: false,
+      });
+
+      // when
+      await flashAlgorithmConfigurationRepository.save(flashAlgorithmConfiguration);
+
+      // then
+      const createdConfiguration = await knex('flash-algorithm-configurations').first();
+      expect(createdConfiguration).to.deep.contains({
+        warmUpLength: 1,
+        forcedCompetences: ['comp1', 'comp2'],
+        minimumEstimatedSuccessRateRanges: null,
+        maximumAssessmentLength: 2,
+        challengesBetweenSameCompetence: 3,
+        limitToOneQuestionPerTube: true,
+        enablePassageByAllCompetences: false,
+        variationPercent: 4,
+        doubleMeasuresUntil: 5,
+      });
+    });
+  });
+});

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -3,17 +3,18 @@ import { AssessmentEndedError } from '../../../../../../lib/domain/errors.js';
 import { config } from '../../../../../../lib/config.js';
 import { FlashAssessmentSuccessRateHandler } from '../../../../../../src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandler.js';
 import { FlashAssessmentAlgorithm } from '../../../../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
+
+const baseFlashAssessmentAlgorithmConfig = {
+  warmUpLength: 0,
+  forcedCompetences: [],
+  minimumEstimatedSuccessRateRanges: [],
+  limitToOneQuestionPerTube: false,
+  enablePassageByAllCompetences: false,
+};
 
 describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlgorithm', function () {
   let flashAlgorithmImplementation;
-
-  const baseFlashAssessmentAlgorithmConfig = {
-    warmUpLength: 0,
-    forcedCompetences: [],
-    minimumEstimatedSuccessRateRanges: [],
-    limitToOneQuestionPerTube: false,
-    enablePassageByAllCompetences: false,
-  };
 
   const baseGetNextChallengeOptions = {
     challengesBetweenSameCompetence: 2,
@@ -39,9 +40,10 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
         ];
         const estimatedLevel = 0;
         const algorithm = new FlashAssessmentAlgorithm({
-          maximumAssessmentLength: 2,
           flashAlgorithmImplementation,
-          ...baseFlashAssessmentAlgorithmConfig,
+          configuration: _getAlgorithmConfig({
+            maximumAssessmentLength: 2,
+          }),
         });
 
         expect(() =>
@@ -64,9 +66,10 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           config.features.numberOfChallengesForFlashMethod = 20;
           const algorithm = new FlashAssessmentAlgorithm({
             flashAlgorithmImplementation,
-            maximumAssessmentLength: alreadyAnsweredChallengesCount + remainingAnswersToGive,
-            ...baseFlashAssessmentAlgorithmConfig,
-            limitToOneQuestionPerTube: true,
+            configuration: _getAlgorithmConfig({
+              maximumAssessmentLength: alreadyAnsweredChallengesCount + remainingAnswersToGive,
+              limitToOneQuestionPerTube: true,
+            }),
           });
 
           const skill1Tube1 = domainBuilder.buildSkill({
@@ -138,8 +141,9 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           config.features.numberOfChallengesForFlashMethod = 20;
           const algorithm = new FlashAssessmentAlgorithm({
             flashAlgorithmImplementation,
-            maximumAssessmentLength: alreadyAnsweredChallengesCount + remainingAnswersToGive,
-            ...baseFlashAssessmentAlgorithmConfig,
+            configuration: _getAlgorithmConfig({
+              maximumAssessmentLength: alreadyAnsweredChallengesCount + remainingAnswersToGive,
+            }),
           });
 
           const skill1Tube1 = domainBuilder.buildSkill({
@@ -245,7 +249,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
         // when
         const algorithm = new FlashAssessmentAlgorithm({
           flashAlgorithmImplementation,
-          ...baseFlashAssessmentAlgorithmConfig,
+          configuration: _getAlgorithmConfig(),
         });
 
         flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
@@ -316,15 +320,16 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           // when
           const algorithm = new FlashAssessmentAlgorithm({
             flashAlgorithmImplementation,
-            ...baseFlashAssessmentAlgorithmConfig,
-            limitToOneQuestionPerTube: true,
-            minimumEstimatedSuccessRateRanges: [
-              FlashAssessmentSuccessRateHandler.createFixed({
-                startingChallengeIndex: 0,
-                endingChallengeIndex: 1,
-                value: 0.8,
-              }),
-            ],
+            configuration: _getAlgorithmConfig({
+              limitToOneQuestionPerTube: true,
+              minimumEstimatedSuccessRateRanges: [
+                FlashAssessmentSuccessRateHandler.createFixed({
+                  startingChallengeIndex: 0,
+                  endingChallengeIndex: 1,
+                  value: 0.8,
+                }),
+              ],
+            }),
           });
 
           flashAlgorithmImplementation.getEstimatedLevelAndErrorRate.returns({
@@ -399,16 +404,17 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           // when
           const algorithm = new FlashAssessmentAlgorithm({
             flashAlgorithmImplementation,
-            ...baseFlashAssessmentAlgorithmConfig,
-            limitToOneQuestionPerTube: false,
-            minimumEstimatedSuccessRateRanges: [
-              FlashAssessmentSuccessRateHandler.createLinear({
-                startingChallengeIndex: 0,
-                endingChallengeIndex: 2,
-                startingValue: 0.8,
-                endingValue: 0.4,
-              }),
-            ],
+            configuration: _getAlgorithmConfig({
+              limitToOneQuestionPerTube: false,
+              minimumEstimatedSuccessRateRanges: [
+                FlashAssessmentSuccessRateHandler.createLinear({
+                  startingChallengeIndex: 0,
+                  endingChallengeIndex: 2,
+                  startingValue: 0.8,
+                  endingValue: 0.4,
+                }),
+              ],
+            }),
           });
 
           const expectedChallenges = [easyChallenge, hardChallenge2];
@@ -439,6 +445,13 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
     });
   });
 });
+
+const _getAlgorithmConfig = (options) => {
+  return new FlashAssessmentAlgorithmConfiguration({
+    ...baseFlashAssessmentAlgorithmConfig,
+    ...options,
+  });
+};
 
 const _getEstimatedLevelAndErrorRateParams = (params) => ({
   variationPercent: undefined,

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -8,7 +8,7 @@ export const buildFlashAlgorithmConfiguration = ({
   enablePassageByAllCompetences,
   variationPercent,
   doubleMeasuresUntil,
-}) => {
+} = {}) => {
   return {
     warmUpLength,
     forcedCompetences,

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -1,9 +1,9 @@
 export const buildFlashAlgorithmConfiguration = ({
   warmUpLength,
-  forcedCompetences,
+  forcedCompetences = [],
   maximumAssessmentLength,
   challengesBetweenSameCompetence,
-  minimumEstimatedSuccessRateRanges,
+  minimumEstimatedSuccessRateRanges = [],
   limitToOneQuestionPerTube,
   enablePassageByAllCompetences,
   variationPercent,

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -1,0 +1,23 @@
+export const buildFlashAlgorithmConfiguration = ({
+  warmUpLength,
+  forcedCompetences,
+  maximumAssessmentLength,
+  challengesBetweenSameCompetence,
+  minimumEstimatedSuccessRateRanges,
+  limitToOneQuestionPerTube,
+  enablePassageByAllCompetences,
+  variationPercent,
+  doubleMeasuresUntil,
+}) => {
+  return {
+    warmUpLength,
+    forcedCompetences,
+    maximumAssessmentLength,
+    challengesBetweenSameCompetence,
+    minimumEstimatedSuccessRateRanges,
+    limitToOneQuestionPerTube,
+    enablePassageByAllCompetences,
+    variationPercent,
+    doubleMeasuresUntil,
+  };
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -80,6 +80,7 @@ import { buildCourse } from './build-course.js';
 import { buildCpfCertificationResult } from './build-cpf-certification-result.js';
 import * as buildDataProtectionOfficer from './build-data-protection-officer.js';
 import { buildFinalizedSession } from './build-finalized-session.js';
+import { buildFlashAlgorithmConfiguration } from './build-flash-algorithm-configuration.js';
 import {
   buildFlashAssessmentAlgorithmSuccessRateHandlerFixed,
   buildFlashAssessmentAlgorithmSuccessRateHandlerLinear,
@@ -245,6 +246,7 @@ export {
   buildDataProtectionOfficer,
   buildFeedback,
   buildFinalizedSession,
+  buildFlashAlgorithmConfiguration,
   buildFlashAssessmentAlgorithmSuccessRateHandlerLinear,
   buildFlashAssessmentAlgorithmSuccessRateHandlerFixed,
   buildFramework,


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, chaque modification sur ces options nécessitent une modification en dur dans le code, ce qui n’est pas idéal puisqu’en phase de test/pilote, on souhaitera potentiellement changer les paramètres/activer/désactiver les ajustements à plusieurs reprises.

## :robot: Proposition
Sauvegarder en BDD la configuration de l’algo de choix des épreuves.

## :rainbow: Remarques


## :100: Pour tester

Se connecter à la DB de la RA et ajouter une configuration dans la table `flash-algorithm-configurations` via la commande suivante : 
```
insert into "flash-algorithm-configurations" ("forcedCompetences", "minimumEstimatedSuccessRateRanges", "variationPercent") values ('[]', '[]', 0.5);
```

- Créer une session de certification (`certifv3@example.net`) ou utiliser la session existante
- Passer la certification en vérifiant que les données passées en configuration soient utilisées lors de la certif.
