### PR TITLE
[TECH] Standardisation des config de tests en fonction de la typologie

### DIFF
--- a/1d/app/helpers/tests/index.js
+++ b/1d/app/helpers/tests/index.js
@@ -1,36 +1,15 @@
-import {
-  setupApplicationTest as upstreamSetupApplicationTest,
-  setupRenderingTest as upstreamSetupRenderingTest,
-  setupTest as upstreamSetupTest,
-} from 'ember-qunit';
+import { setupRenderingTest as upstreamSetupRenderingTest, setupTest as upstreamSetupTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
 
 // This file exists to provide wrappers around ember-qunit's / ember-mocha's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
 
-function setupApplicationTest(hooks, options) {
-  upstreamSetupApplicationTest(hooks, options);
-
-  // Additional setup for application tests can be done here.
-  //
-  // For example, if you need an authenticated session for each
-  // application test, you could do:
-  //
-  // hooks.beforeEach(async function () {
-  //   await authenticateSession(); // ember-simple-auth
-  // });
-  //
-  // This is also a good place to call test setup functions coming
-  // from other addons:
-  //
-  // setupIntl(hooks); // ember-intl
-  // setupMirage(hooks); // ember-cli-mirage
-}
-
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
 
   // Additional setup for rendering tests can be done here.
+  setupIntl(hooks); // ember-intl
 }
 
 function setupTest(hooks, options) {
@@ -39,6 +18,4 @@ function setupTest(hooks, options) {
   // Additional setup for unit tests can be done here.
 }
 
-import { setupIntl } from 'ember-intl/test-support';
-
-export { setupApplicationTest, setupRenderingTest, setupTest, setupIntl };
+export { setupRenderingTest, setupTest };

--- a/1d/app/pods/assessment/challenge/unit_test.js
+++ b/1d/app/pods/assessment/challenge/unit_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '../../../helpers/tests/index';
+import { setupTest } from '../../../helpers/tests';
 import sinon from 'sinon';
 
 module('Unit | Route | AssessmentChallengeRoute', function (hooks) {

--- a/1d/app/pods/components/bubble/integration_test.js
+++ b/1d/app/pods/components/bubble/integration_test.js
@@ -1,13 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from '../../../helpers/tests';
+import { setupRenderingTest } from '../../../helpers/tests';
 
 module('Integration | Component | Bubble', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
-
   test('displays message in a bubble', async function (assert) {
     this.set('message', 'Bim');
 

--- a/1d/app/pods/components/challenge/item/integration_test.js
+++ b/1d/app/pods/components/challenge/item/integration_test.js
@@ -1,13 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from '../../../../helpers/tests';
+import { setupRenderingTest } from '../../../../helpers/tests';
 
 module('Integration | Component | challenge', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
-
   test('displays embed', async function (assert) {
     this.set('challenge', { hasValidEmbedDocument: true, autoReply: true });
     this.set('assessment', {});

--- a/1d/app/pods/components/robot-dialog/integration_test.js
+++ b/1d/app/pods/components/robot-dialog/integration_test.js
@@ -1,13 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from '../../../helpers/tests';
+import { setupRenderingTest } from '../../../helpers/tests';
 
 module('Integration | Component | Robot dialog', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
-
   test('displays robot dialog when there is an instruction', async function (assert) {
     this.set('instruction', 'Hello chaton !');
 

--- a/1d/tests/acceptance/access-school_test.js
+++ b/1d/tests/acceptance/access-school_test.js
@@ -1,16 +1,11 @@
 import { clickByText, visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import identifyLearner from '../helpers/identify-learner';
+import { setupApplicationTest } from '../../tests/helpers';
 
 module('Acceptance | School', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   hooks.afterEach(async function () {
     localStorage.clear();
   });

--- a/1d/tests/acceptance/challenge-item-qcm_test.js
+++ b/1d/tests/acceptance/challenge-item-qcm_test.js
@@ -1,14 +1,10 @@
 import { click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit } from '@1024pix/ember-testing-library';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Displaying a QCM challenge', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
   let assessment;
 
   hooks.beforeEach(async function () {

--- a/1d/tests/acceptance/challenge-item-qcu_test.js
+++ b/1d/tests/acceptance/challenge-item-qcu_test.js
@@ -1,14 +1,10 @@
 import { click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit } from '@1024pix/ember-testing-library';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Displaying a QCU challenge', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
   let assessment;
 
   hooks.beforeEach(async function () {

--- a/1d/tests/acceptance/challenge-item-qroc_test.js
+++ b/1d/tests/acceptance/challenge-item-qroc_test.js
@@ -1,14 +1,10 @@
 import { click, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Displaying a QROC challenge', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
   let assessment;
 
   module('with input format', function (hooks) {

--- a/1d/tests/acceptance/challenge-item-qrocm_test.js
+++ b/1d/tests/acceptance/challenge-item-qrocm_test.js
@@ -1,15 +1,10 @@
 import { click, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Displaying a QROCM challenge', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   let assessment;
 
   hooks.beforeEach(async function () {

--- a/1d/tests/acceptance/challenge-workflow_test.js
+++ b/1d/tests/acceptance/challenge-workflow_test.js
@@ -1,15 +1,10 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click } from '@ember/test-helpers';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Challenge workflow', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   module('when user click on skip button', function () {
     test('redirects to next challenge', async function (assert) {
       const assessment = this.server.create('assessment');

--- a/1d/tests/acceptance/display-challenge-preview_test.js
+++ b/1d/tests/acceptance/display-challenge-preview_test.js
@@ -1,11 +1,9 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | ChallengePreview', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
 
   test('displays challenge preview', async function (assert) {
     // given

--- a/1d/tests/acceptance/display-challenge_test.js
+++ b/1d/tests/acceptance/display-challenge_test.js
@@ -1,14 +1,9 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Challenge', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   test('displays challenge page', async function (assert) {
     const assessment = this.server.create('assessment');
     const challenge = this.server.create('challenge');

--- a/1d/tests/acceptance/display-mission-info_test.js
+++ b/1d/tests/acceptance/display-mission-info_test.js
@@ -1,15 +1,10 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
-import { setupIntl } from 'ember-intl/test-support';
 import identifyLearner from '../helpers/identify-learner';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Display informations about the mission', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   test('displays mission page', async function (assert) {
     // given
     identifyLearner(this.owner);

--- a/1d/tests/acceptance/display-missions-list_test.js
+++ b/1d/tests/acceptance/display-missions-list_test.js
@@ -1,15 +1,10 @@
 import { visit, within } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
-import { setupIntl } from 'ember-intl/test-support';
 import identifyLearner from '../helpers/identify-learner';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Display missions list', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   test('displays missions list page', async function (assert) {
     // given
     identifyLearner(this.owner);

--- a/1d/tests/acceptance/end-mission_test.js
+++ b/1d/tests/acceptance/end-mission_test.js
@@ -1,16 +1,11 @@
 import { clickByText, visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
-import { setupIntl } from 'ember-intl/test-support';
 import identifyLearner from '../helpers/identify-learner';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | End mission', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   test('redirect to home page after clicking on return button', async function (assert) {
     // given
     const mission = this.server.create('mission');

--- a/1d/tests/acceptance/start-mission_test.js
+++ b/1d/tests/acceptance/start-mission_test.js
@@ -1,16 +1,11 @@
 import { clickByText, visit } from '@1024pix/ember-testing-library';
 import { module, skip } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 import { currentURL } from '@ember/test-helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import identifyLearner from '../helpers/identify-learner';
+import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | Start mission', function (hooks) {
   setupApplicationTest(hooks);
-  setupMirage(hooks);
-  setupIntl(hooks);
-
   //À CREUSER APRÈS LES PANELS
 
   skip('redirect to first challenge page after clicking on start mission', async function (assert) {

--- a/1d/tests/helpers/index.js
+++ b/1d/tests/helpers/index.js
@@ -1,8 +1,6 @@
-import {
-  setupApplicationTest as upstreamSetupApplicationTest,
-  setupRenderingTest as upstreamSetupRenderingTest,
-  setupTest as upstreamSetupTest,
-} from 'ember-qunit';
+import { setupApplicationTest as upstreamSetupApplicationTest, setupTest as upstreamSetupTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 // This file exists to provide wrappers around ember-qunit's / ember-mocha's
 // test setup functions. This way, you can easily extend the setup that is
@@ -23,14 +21,8 @@ function setupApplicationTest(hooks, options) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
-  // setupMirage(hooks); // ember-cli-mirage
-}
-
-function setupRenderingTest(hooks, options) {
-  upstreamSetupRenderingTest(hooks, options);
-
-  // Additional setup for rendering tests can be done here.
+  setupIntl(hooks); // ember-intl
+  setupMirage(hooks); // ember-cli-mirage
 }
 
 function setupTest(hooks, options) {
@@ -39,4 +31,4 @@ function setupTest(hooks, options) {
   // Additional setup for unit tests can be done here.
 }
 
-export { setupApplicationTest, setupRenderingTest, setupTest };
+export { setupApplicationTest, setupTest };


### PR DESCRIPTION
## :unicorn: Problème
On initialise les hooks des tests, test par test, en fonction des besoins.

## :robot: Proposition
Mutualiser les initialisations.

## :100: Pour tester
Les tests passent.