### PR TITLE
[FEATURE] Créer le modèle `QcuForAnswerVerification` (PIX-9858)

### DIFF
--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -9,14 +9,14 @@ const getBySlug = async function (request, h, dependencies = { moduleSerializer,
   return dependencies.moduleSerializer.serialize(module);
 };
 
-const validateAnswer = async function (request, h, dependencies = { elementAnswerSerializer, usecases }) {
+const verifyAnswer = async function (request, h, dependencies = { elementAnswerSerializer, usecases }) {
   const { moduleSlug, elementId } = request.params;
   const { 'user-response': userResponse } = request.payload.data.attributes;
-  const answer = await dependencies.usecases.validateAnswer({ moduleSlug, userResponse, elementId });
+  const answer = await dependencies.usecases.verifyAnswer({ moduleSlug, userResponse, elementId });
 
   return dependencies.elementAnswerSerializer.serialize(answer);
 };
 
-const modulesController = { getBySlug, validateAnswer };
+const modulesController = { getBySlug, verifyAnswer };
 
 export { modulesController };

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -21,7 +21,7 @@ const register = async function (server) {
       path: '/api/modules/{moduleSlug}/elements/{elementId}/answers',
       config: {
         auth: false,
-        handler: modulesController.validateAnswer,
+        handler: modulesController.verifyAnswer,
         validate: {
           params: Joi.object({
             moduleSlug: Joi.string().required(),

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -1,0 +1,45 @@
+import { QCU } from './QCU.js';
+import { Feedbacks } from '../Feedbacks.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ValidatorQCU } from '../validator/ValidatorQCU.js';
+import { QcuCorrectionResponse } from '../QcuCorrectionResponse.js';
+import { ElementAnswer } from '../ElementAnswer.js';
+
+class QCUForAnswerVerification extends QCU {
+  constructor({ id, instruction, locales, proposals, solution, feedbacks, validator }) {
+    super({ id, instruction, locales, proposals });
+
+    assertNotNullOrUndefined(solution, 'La solution est obligatoire pour un QCU de vérification');
+
+    this.solution = solution;
+
+    if (feedbacks) {
+      this.feedbacks = new Feedbacks(feedbacks);
+    }
+
+    if (validator) {
+      this.validator = validator;
+    } else {
+      this.validator = new ValidatorQCU({ solution: { value: this.solution } });
+    }
+  }
+
+  assess(userResponse) {
+    const selectedQcuProposalId = userResponse[0];
+    const validation = this.validator.assess({ answer: { value: selectedQcuProposalId } });
+
+    const correction = new QcuCorrectionResponse({
+      status: validation.result,
+      feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
+      solutionId: this.solution,
+    });
+
+    return new ElementAnswer({
+      elementId: this.id,
+      userResponseValue: selectedQcuProposalId,
+      correction,
+    });
+  }
+}
+
+export { QCUForAnswerVerification };

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -1,50 +1,17 @@
 import { Element } from './Element.js';
-import { Feedbacks } from '../Feedbacks.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
-import { ValidatorQCU } from '../validator/ValidatorQCU.js';
-import { QcuCorrectionResponse } from '../QcuCorrectionResponse.js';
-import { ElementAnswer } from '../ElementAnswer.js';
 
 class QCU extends Element {
-  constructor({ id, instruction, locales, proposals, solution, feedbacks, validator }) {
+  constructor({ id, instruction, locales, proposals }) {
     super({ id });
 
     assertNotNullOrUndefined(instruction, "L'instruction est obligatoire pour un QCU");
     this.#assertProposalsIsAnArray(proposals);
     this.#assertProposalsAreNotEmpty(proposals);
-    assertNotNullOrUndefined(solution, 'La solution est obligatoire pour un QCU');
 
     this.instruction = instruction;
     this.locales = locales;
     this.proposals = proposals;
-    this.solution = solution;
-
-    if (feedbacks) {
-      this.feedbacks = new Feedbacks(feedbacks);
-    }
-
-    if (validator) {
-      this.validator = validator;
-    } else {
-      this.validator = new ValidatorQCU({ solution: { value: this.solution } });
-    }
-  }
-
-  assess(userResponse) {
-    const selectedQcuProposalId = userResponse[0];
-    const validation = this.validator.assess({ answer: { value: selectedQcuProposalId } });
-
-    const correction = new QcuCorrectionResponse({
-      status: validation.result,
-      feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solutionId: this.solution,
-    });
-
-    return new ElementAnswer({
-      elementId: this.id,
-      userResponseValue: selectedQcuProposalId,
-      correction,
-    });
   }
 
   #assertProposalsAreNotEmpty(proposals) {

--- a/api/src/devcomp/domain/usecases/validate-answer.js
+++ b/api/src/devcomp/domain/usecases/validate-answer.js
@@ -1,5 +1,5 @@
 async function validateAnswer({ moduleSlug, userResponse, elementId, moduleRepository }) {
-  const foundModule = await moduleRepository.getBySlug({ slug: moduleSlug });
+  const foundModule = await moduleRepository.getBySlugForVerification({ slug: moduleSlug });
   const element = foundModule.getElementById(elementId);
   return element.assess(userResponse);
 }

--- a/api/src/devcomp/domain/usecases/verify-answer.js
+++ b/api/src/devcomp/domain/usecases/verify-answer.js
@@ -1,7 +1,7 @@
-async function validateAnswer({ moduleSlug, userResponse, elementId, moduleRepository }) {
+async function verifyAnswer({ moduleSlug, userResponse, elementId, moduleRepository }) {
   const foundModule = await moduleRepository.getBySlugForVerification({ slug: moduleSlug });
   const element = foundModule.getElementById(elementId);
   return element.assess(userResponse);
 }
 
-export { validateAnswer };
+export { verifyAnswer };

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -5,12 +5,26 @@ import { QCU } from '../../domain/models/element/QCU.js';
 import { QcuProposal } from '../../domain/models/QcuProposal.js';
 import { Grain } from '../../domain/models/Grain.js';
 import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { QCUForAnswerVerification } from '../../domain/models/element/QCU-for-answer-verification.js';
 
 async function getBySlug({ slug, moduleDatasource }) {
   try {
     const moduleData = await moduleDatasource.getBySlug(slug);
 
     return _toDomain(moduleData);
+  } catch (e) {
+    if (e instanceof LearningContentResourceNotFound) {
+      throw new NotFoundError();
+    }
+    throw e;
+  }
+}
+
+async function getBySlugForVerification({ slug, moduleDatasource }) {
+  try {
+    const moduleData = await moduleDatasource.getBySlug(slug);
+
+    return _toDomainForVerification(moduleData);
   } catch (e) {
     if (e instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();
@@ -41,6 +55,41 @@ function _toDomain(moduleData) {
                   content: proposal.content,
                 });
               }),
+            });
+          }
+
+          return new Text({
+            id: element.id,
+            content: element.content,
+          });
+        }),
+      });
+    }),
+  });
+}
+
+function _toDomainForVerification(moduleData) {
+  return new Module({
+    id: moduleData.id,
+    slug: moduleData.slug,
+    title: moduleData.title,
+    grains: moduleData.grains.map((grain) => {
+      return new Grain({
+        id: grain.id,
+        title: grain.title,
+        type: grain.type,
+        elements: grain.elements.map((element) => {
+          if (element.type === 'qcu') {
+            return new QCUForAnswerVerification({
+              id: element.id,
+              instruction: element.instruction,
+              locales: element.locales,
+              proposals: element.proposals.map((proposal) => {
+                return new QcuProposal({
+                  id: proposal.id,
+                  content: proposal.content,
+                });
+              }),
               feedbacks: element.feedbacks,
               solution: element.solution,
             });
@@ -56,4 +105,4 @@ function _toDomain(moduleData) {
   });
 }
 
-export { getBySlug };
+export { getBySlug, getBySlugForVerification };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -20,7 +20,6 @@ function serialize(module) {
                   id: element.id,
                   instruction: element.instruction,
                   proposals: element.proposals,
-                  solution: element.solution,
                   type: 'qcus',
                 };
               }

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -4,6 +4,7 @@ import * as moduleRepository from '../../../../src/devcomp/infrastructure/reposi
 import { Module } from '../../../../src/devcomp/domain/models/Module.js';
 import { Grain } from '../../../../src/devcomp/domain/models/Grain.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
+import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
   describe('#getBySlug', function () {
@@ -53,6 +54,65 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       // then
       expect(module).to.be.instanceOf(Module);
       expect(module.grains.every((grain) => grain instanceof Grain)).to.be.true;
+    });
+  });
+
+  describe('#getBySlugForVerification', function () {
+    it('should throw a NotFoundError if the module does not exist', async function () {
+      // given
+      const nonExistingModuleSlug = 'dresser-des-pokemons';
+
+      // when
+      const error = await catchErr(moduleRepository.getBySlugForVerification)({
+        slug: nonExistingModuleSlug,
+        moduleDatasource,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    it('should throw a Error if the module instanciation throw an error', async function () {
+      // given
+      const moduleSlug = 'incomplete-module';
+      const moduleDatasourceStub = {
+        getBySlugForVerification: async () => {
+          return {
+            id: 1,
+            slug: moduleSlug,
+          };
+        },
+      };
+
+      // when
+      const error = await catchErr(moduleRepository.getBySlugForVerification)({
+        slug: moduleSlug,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(error).not.to.be.instanceOf(NotFoundError);
+    });
+
+    it('should return a module if it exists', async function () {
+      // given
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+
+      // when
+      const module = await moduleRepository.getBySlugForVerification({
+        slug: existingModuleSlug,
+        moduleDatasource,
+      });
+
+      // then
+      expect(module).to.be.instanceOf(Module);
+      expect(
+        module.grains.every((grain) =>
+          grain.elements
+            .filter((element) => element.type === 'qcu')
+            .every((qcu) => qcu instanceof QCUForAnswerVerification),
+        ),
+      ).to.be.true;
     });
   });
 });

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -22,8 +22,8 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
     });
   });
 
-  describe('#validate-answer', function () {
-    it('should call validateAnswer use-case and return the serialized CorrectionResponse', async function () {
+  describe('#verify-answer', function () {
+    it('should call verifyAnswer use-case and return the serialized CorrectionResponse', async function () {
       // Given
       const moduleSlug = 'slug';
       const serializedCorrection = Symbol('serialized correction');
@@ -32,9 +32,9 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       const correctionResponse = Symbol('correction');
 
       const usecases = {
-        validateAnswer: sinon.stub(),
+        verifyAnswer: sinon.stub(),
       };
-      usecases.validateAnswer.withArgs({ moduleSlug, userResponse, elementId }).returns(correctionResponse);
+      usecases.verifyAnswer.withArgs({ moduleSlug, userResponse, elementId }).returns(correctionResponse);
 
       const elementAnswerSerializer = {
         serialize: sinon.stub(),
@@ -42,7 +42,7 @@ describe('Devcomp | Unit | Application | Module | Module Controller', function (
       elementAnswerSerializer.serialize.withArgs(correctionResponse).returns(serializedCorrection);
 
       // When
-      const result = await modulesController.validateAnswer(
+      const result = await modulesController.verifyAnswer(
         { payload: { data: { attributes: { 'user-response': userResponse } } }, params: { moduleSlug, elementId } },
         null,
         { elementAnswerSerializer, usecases },

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -1,9 +1,46 @@
-import { expect, sinon } from '../../../../test-helper.js';
-import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
-import { ElementAnswer } from '../../../../../src/devcomp/domain/models/ElementAnswer.js';
-import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { QCUForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
+import { ElementAnswer } from '../../../../../../src/devcomp/domain/models/ElementAnswer.js';
+import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
+import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 
-describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
+describe('Unit | Devcomp | Domain | Models | QcuForAnswerVerification', function () {
+  describe('#constructor', function () {
+    it('should instanciate a QCU For Verification with right attributes', function () {
+      // Given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+      const feedbacks = { valid: 'valid', invalid: 'invalid' };
+      const solution = Symbol('solution');
+
+      // When
+      const qcu = new QCUForAnswerVerification({
+        id: '123',
+        instruction: 'instruction',
+        locales: ['fr-FR'],
+        proposals: [proposal1, proposal2],
+        feedbacks,
+        solution,
+      });
+
+      // Then
+      expect(qcu.id).equal('123');
+      expect(qcu.instruction).equal('instruction');
+      expect(qcu.locales).deep.equal(['fr-FR']);
+      expect(qcu.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcu.solution).deep.equal(solution);
+      expect(qcu.feedbacks).to.be.instanceof(Feedbacks);
+    });
+
+    describe('A QCU For Verification without a solution', function () {
+      it('should throw an error', function () {
+        expect(
+          () => new QCUForAnswerVerification({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')] }),
+        ).to.throw('La solution est obligatoire pour un QCU de vérification');
+      });
+    });
+  });
+
   describe('#assess', function () {
     it('should return a QcuCorrectionResponse for a valid answer', function () {
       // given
@@ -22,7 +59,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
           },
         })
         .returns(assessResult);
-      const qcu = new QCU({
+      const qcu = new QCUForAnswerVerification({
         id: 'qcu-id',
         instruction: '',
         proposals: [{ id: qcuSolution }],
@@ -67,7 +104,7 @@ describe('Unit | Devcomp | Domain | Models | QcuForCorrection', function () {
           },
         })
         .returns(assessResult);
-      const qcu = new QCU({
+      const qcu = new QCUForAnswerVerification({
         id: 'qcu-id',
         instruction: '',
         proposals: [{ id: qcuSolution }],

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,6 +1,5 @@
 import { expect } from '../../../../../test-helper.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
-import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 
 describe('Unit | Devcomp | Domain | Models | QCU', function () {
   describe('#constructor', function () {
@@ -8,7 +7,6 @@ describe('Unit | Devcomp | Domain | Models | QCU', function () {
       // Given
       const proposal1 = Symbol('proposal1');
       const proposal2 = Symbol('proposal2');
-      const solution = Symbol('solution');
 
       // When
       const qcu = new QCU({
@@ -16,7 +14,6 @@ describe('Unit | Devcomp | Domain | Models | QCU', function () {
         instruction: 'instruction',
         locales: ['fr-FR'],
         proposals: [proposal1, proposal2],
-        solution,
       });
 
       // Then
@@ -24,34 +21,7 @@ describe('Unit | Devcomp | Domain | Models | QCU', function () {
       expect(qcu.instruction).equal('instruction');
       expect(qcu.locales).deep.equal(['fr-FR']);
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
-      expect(qcu.solution).deep.equal(solution);
       expect(qcu.feedbacks).to.be.undefined;
-    });
-
-    it('should instanciate a QCU with feedbacks if given', function () {
-      // Given
-      const proposal1 = Symbol('proposal1');
-      const proposal2 = Symbol('proposal2');
-      const feedbacks = { valid: 'valid', invalid: 'invalid' };
-      const solution = Symbol('solution');
-
-      // When
-      const qcu = new QCU({
-        id: '123',
-        instruction: 'instruction',
-        locales: ['fr-FR'],
-        proposals: [proposal1, proposal2],
-        feedbacks,
-        solution,
-      });
-
-      // Then
-      expect(qcu.id).equal('123');
-      expect(qcu.instruction).equal('instruction');
-      expect(qcu.locales).deep.equal(['fr-FR']);
-      expect(qcu.proposals).deep.equal([proposal1, proposal2]);
-      expect(qcu.solution).deep.equal(solution);
-      expect(qcu.feedbacks).to.be.instanceof(Feedbacks);
     });
   });
 
@@ -79,14 +49,6 @@ describe('Unit | Devcomp | Domain | Models | QCU', function () {
     it('should throw an error', function () {
       expect(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
         'Les propositions doivent apparaître dans une liste',
-      );
-    });
-  });
-
-  describe('A QCU without a solution', function () {
-    it('should throw an error', function () {
-      expect(() => new QCU({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')] })).to.throw(
-        'La solution est obligatoire pour un QCU',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/usecases/verify-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-answer_test.js
@@ -1,8 +1,8 @@
-import { validateAnswer } from '../../../../../src/devcomp/domain/usecases/validate-answer.js';
+import { verifyAnswer } from '../../../../../src/devcomp/domain/usecases/verify-answer.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Usecases | validate-answer', function () {
-  describe('#validateAnswer', function () {
+describe('Unit | Devcomp | Usecases | verify-answer', function () {
+  describe('#verifyAnswer', function () {
     describe('When the selected proposal is valid', function () {
       it('should return a valid Correction Response', async function () {
         // given
@@ -29,7 +29,7 @@ describe('Unit | Devcomp | Usecases | validate-answer', function () {
         stubElement.assess.withArgs(userResponse).returns(expectedQcuResponse);
 
         // when
-        const validateQcu = await validateAnswer({
+        const validateQcu = await verifyAnswer({
           moduleSlug: moduleSlug,
           elementId: elementId,
           userResponse: userResponse,

--- a/api/tests/devcomp/unit/domain/usecases/verify-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-answer_test.js
@@ -11,14 +11,14 @@ describe('Unit | Devcomp | Usecases | validate-answer', function () {
         const userResponse = ['totoId'];
 
         const mockedModuleRepo = {
-          getBySlug: sinon.stub(),
+          getBySlugForVerification: sinon.stub(),
         };
 
         const expectedModule = {
           getElementById: sinon.stub(),
         };
 
-        mockedModuleRepo.getBySlug.withArgs({ slug: moduleSlug }).resolves(expectedModule);
+        mockedModuleRepo.getBySlugForVerification.withArgs({ slug: moduleSlug }).resolves(expectedModule);
 
         const stubElement = {
           assess: sinon.stub(),


### PR DESCRIPTION
## :unicorn: Problème
Nous avons ajouté de la dette technique car jusque là notre modèle `QCU` était à la fois un modèle spécifique à l'affichage de l'activité mais nous y avions ajouté la logique liée à la vérification des réponses (problème de séparation des responsabilités).

## :robot: Proposition
Nous avons donc implémenté un modèle `QcuForAnswerVerification` dans lequel on a déporté la logique de la méthode `assess` qui se trouvait dans `QCU`, ainsi que les attributs `feedbacks` et `solution`.

Désormais, le `ModuleRepository` possède une méthode `getBySlugForVerification` qui sera appelé par le usecase de vérification et qui retournera une instance de `QcuForAnswerVerification`.

Dans la même optique afin de rester cohérent sur les notions métiers, nous avons renommé le usecase `ValidateAnswer` en `VerifyAnswer`.

## :rainbow: Remarques


## :100: Pour tester
La CI passe
