### PR TITLE
[TECH] Ajouter le fournisseur d'identité Google pour Pix Admin (PIX-10069)

### DIFF
--- a/admin/app/adapters/oidc-identity-provider.js
+++ b/admin/app/adapters/oidc-identity-provider.js
@@ -1,7 +1,12 @@
 import ApplicationAdapter from './application';
 
+const PIX_ADMIN_AUDIENCE = 'admin';
+
 export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
-  urlForFindAll() {
+  urlForFindAll(_, snapshot) {
+    if (snapshot.adapterOptions?.readyIdentityProviders) {
+      return `${this.host}/${this.namespace}/oidc/identity-providers?audience=${PIX_ADMIN_AUDIENCE}`;
+    }
     return `${this.host}/${this.namespace}/admin/oidc/identity-providers`;
   }
 }

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -8,12 +8,15 @@ export default class ApplicationRoute extends Route {
   @service intl;
   @service currentUser;
   @service featureToggles;
+  @service oidcIdentityProviders;
 
   async beforeModel() {
     await this.session.setup();
     this.intl.setLocale([defaultLocale]);
 
     await this.featureToggles.load();
+
+    await this.oidcIdentityProviders.loadReadyIdentityProviders();
 
     return this._loadCurrentUser();
   }

--- a/admin/app/services/oidc-identity-providers.js
+++ b/admin/app/services/oidc-identity-providers.js
@@ -11,4 +11,11 @@ export default class OidcIdentityProviders extends Service {
     const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider');
     oidcIdentityProviders.map((oidcIdentityProvider) => (this[oidcIdentityProvider.id] = oidcIdentityProvider));
   }
+
+  async loadReadyIdentityProviders() {
+    const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider', {
+      adapterOptions: { readyIdentityProviders: true },
+    });
+    oidcIdentityProviders.map((oidcIdentityProvider) => (this[oidcIdentityProvider.id] = oidcIdentityProvider));
+  }
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -564,4 +564,21 @@ function routes() {
       ],
     };
   });
+
+  this.get('/oidc/identity-providers', () => {
+    return {
+      data: [
+        {
+          type: 'oidc-identity-providers',
+          id: 'oidc-partner',
+          attributes: {
+            code: 'OIDC_PARTNER',
+            'organization-name': 'Partenaire OIDC',
+            'has-logout-url': false,
+            source: 'oidc-externe',
+          },
+        },
+      ],
+    };
+  });
 }

--- a/admin/tests/unit/adapters/oidc-identity-provider_test.js
+++ b/admin/tests/unit/adapters/oidc-identity-provider_test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | OidcIdentityProvider', function (hooks) {
+  setupTest(hooks);
+  module('#urlForFindAll', function () {
+    test('returns correct url for ready providers including audience parameter', function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:oidc-identity-provider');
+
+      // when
+      const url = adapter.urlForFindAll(null, {
+        adapterOptions: {
+          readyIdentityProviders: true,
+        },
+      });
+
+      // then
+      assert.ok(url.endsWith('/oidc/identity-providers?audience=admin'));
+    });
+
+    test('returns correct url for all available providers', function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:oidc-identity-provider');
+
+      // when
+      const url = adapter.urlForFindAll(null, {
+        adapterOptions: {},
+      });
+
+      // then
+      assert.ok(url.endsWith('/admin/oidc/identity-providers'));
+    });
+  });
+});

--- a/admin/tests/unit/services/oidc-identity-providers_test.js
+++ b/admin/tests/unit/services/oidc-identity-providers_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupTest } from 'ember-qunit';
+
+import Object from '@ember/object';
+import Service from '@ember/service';
+
+module('Unit | Service | oidc-identity-providers', function (hooks) {
+  setupTest(hooks);
+  let oidcIdentityProvidersService, oidcPartner;
+
+  hooks.beforeEach(function () {
+    // given
+    oidcPartner = {
+      id: 'oidc-partner',
+      code: 'OIDC_PARTNER',
+      organizationName: 'Partenaire OIDC',
+      hasLogoutUrl: false,
+      source: 'oidc-externe',
+    };
+    const oidcPartnerObject = Object.create(oidcPartner);
+    const storeStub = Service.create({
+      findAll: sinon.stub().resolves([oidcPartnerObject]),
+      peekAll: sinon.stub().returns([oidcPartnerObject]),
+    });
+    oidcIdentityProvidersService = this.owner.lookup('service:oidcIdentityProviders');
+    oidcIdentityProvidersService.set('store', storeStub);
+  });
+
+  module('loadAllAvailableIdentityProviders', function () {
+    test('should contain identity providers by id and retrieve the whole list', async function (assert) {
+      // when
+      await oidcIdentityProvidersService.loadAllAvailableIdentityProviders();
+
+      // then
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].code, oidcPartner.code);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].organizationName, oidcPartner.organizationName);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl, oidcPartner.hasLogoutUrl);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].source, oidcPartner.source);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].source, oidcPartner.source);
+    });
+  });
+
+  module('loadReadyIdentityProviders', function () {
+    test('should contain identity providers by id and retrieve the whole list', async function (assert) {
+      // when
+      await oidcIdentityProvidersService.loadReadyIdentityProviders();
+
+      // then
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].code, oidcPartner.code);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].organizationName, oidcPartner.organizationName);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl, oidcPartner.hasLogoutUrl);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].source, oidcPartner.source);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].source, oidcPartner.source);
+    });
+  });
+});

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -26,6 +26,11 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/oidc/identity-providers',
       config: {
+        validate: {
+          query: Joi.object({
+            audience: Joi.string().optional(),
+          }),
+        },
         auth: false,
         handler: oidcController.getIdentityProviders,
         notes: [

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -10,7 +10,8 @@ const getAllIdentityProvidersForAdmin = async function (request, h) {
 };
 
 const getIdentityProviders = async function (request, h) {
-  const identityProviders = usecases.getReadyIdentityProviders();
+  const audience = request.query.audience;
+  const identityProviders = usecases.getReadyIdentityProviders({ audience });
   return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
 };
 

--- a/api/lib/domain/constants/oidc-identity-providers.js
+++ b/api/lib/domain/constants/oidc-identity-providers.js
@@ -10,14 +10,17 @@ const FWB = {
   code: 'FWB',
   configKey: 'fwb',
 };
-
+const GOOGLE = {
+  code: 'GOOGLE',
+  configKey: 'google',
+};
 const PAYSDELALOIRE = {
   code: 'PAYSDELALOIRE',
   configKey: 'paysdelaloire',
 };
 
 function getValidOidcProviderCodes() {
-  return [POLE_EMPLOI.code, CNAV.code, FWB.code, PAYSDELALOIRE.code];
+  return [POLE_EMPLOI.code, CNAV.code, FWB.code, GOOGLE.code, PAYSDELALOIRE.code];
 }
 
-export { getValidOidcProviderCodes, POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE };
+export { getValidOidcProviderCodes, POLE_EMPLOI, CNAV, FWB, GOOGLE, PAYSDELALOIRE };

--- a/api/lib/domain/services/authentication/GoogleOidcAuthenticationService.js
+++ b/api/lib/domain/services/authentication/GoogleOidcAuthenticationService.js
@@ -1,0 +1,28 @@
+import { config } from '../../../config.js';
+import { OidcAuthenticationService } from './oidc-authentication-service.js';
+import { GOOGLE } from '../../constants/oidc-identity-providers.js';
+
+const configKey = GOOGLE.configKey;
+
+class GoogleOidcAuthenticationService extends OidcAuthenticationService {
+  constructor() {
+    super({
+      identityProvider: GOOGLE.code,
+      configKey,
+      source: 'google',
+      slug: 'google',
+      organizationName: 'Google',
+      jwtOptions: { expiresIn: config.google.accessTokenLifespanMs / 1000 },
+      clientSecret: config.google.clientSecret,
+      clientId: config.google.clientId,
+      tokenUrl: config.google.tokenUrl,
+      authenticationUrl: config.google.authenticationUrl,
+      authenticationUrlParameters: [{ key: 'scope', value: 'openid profile' }],
+      userInfoUrl: config.google.userInfoUrl,
+    });
+
+    this.temporaryStorage = config.google.temporaryStorage;
+  }
+}
+
+export { GoogleOidcAuthenticationService };

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -14,9 +14,16 @@ const allOidcProviderServices = [
 ];
 
 const readyOidcProviderServices = allOidcProviderServices.filter((oidcProvider) => oidcProvider.isReady);
+const readyOidcProviderServicesForPixAdmin = allOidcProviderServices.filter(
+  (oidcProvider) => oidcProvider.isReadyForPixAdmin,
+);
 
 function getReadyOidcProviderServices() {
   return readyOidcProviderServices;
+}
+
+function getReadyOidcProviderServicesForPixAdmin() {
+  return readyOidcProviderServicesForPixAdmin;
 }
 
 function getAllOidcProviderServices() {
@@ -32,4 +39,9 @@ function getOidcProviderServiceByCode(identityProvider) {
   return oidcProviderService;
 }
 
-export { getReadyOidcProviderServices, getOidcProviderServiceByCode, getAllOidcProviderServices };
+export {
+  getReadyOidcProviderServices,
+  getOidcProviderServiceByCode,
+  getAllOidcProviderServices,
+  getReadyOidcProviderServicesForPixAdmin,
+};

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -3,12 +3,14 @@ import { PoleEmploiOidcAuthenticationService } from './pole-emploi-oidc-authenti
 import { CnavOidcAuthenticationService } from './cnav-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
 import { PaysdelaloireOidcAuthenticationService } from './paysdelaloire-oidc-authentication-service.js';
+import { GoogleOidcAuthenticationService } from './GoogleOidcAuthenticationService.js';
 
 const allOidcProviderServices = [
   new PoleEmploiOidcAuthenticationService(),
   new CnavOidcAuthenticationService(),
   new FwbOidcAuthenticationService(),
   new PaysdelaloireOidcAuthenticationService(),
+  new GoogleOidcAuthenticationService(),
 ];
 
 const readyOidcProviderServices = allOidcProviderServices.filter((oidcProvider) => oidcProvider.isReady);

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -28,6 +28,7 @@ const defaultSessionTemporaryStorage = temporaryStorage.withPrefix('oidc-session
 
 class OidcAuthenticationService {
   #isReady = false;
+  #isReadyForPixAdmin = false;
 
   #requiredClaims = Array.from(DEFAULT_REQUIRED_CLAIMS);
 
@@ -81,7 +82,8 @@ class OidcAuthenticationService {
     }
 
     const isEnabledInConfig = config[this.configKey].isEnabled;
-    if (!isEnabledInConfig) {
+    const isEnabledForPixAdmin = config[this.configKey].isEnabledForPixAdmin;
+    if (!isEnabledInConfig && !isEnabledForPixAdmin) {
       return;
     }
 
@@ -106,7 +108,8 @@ class OidcAuthenticationService {
     }
 
     this.temporaryStorageConfig = config[this.configKey].temporaryStorage;
-    this.#isReady = true;
+    this.#isReady = isEnabledInConfig;
+    this.#isReadyForPixAdmin = isEnabledForPixAdmin;
   }
 
   get code() {
@@ -115,6 +118,10 @@ class OidcAuthenticationService {
 
   get isReady() {
     return this.#isReady;
+  }
+
+  get isReadyForPixAdmin() {
+    return this.#isReadyForPixAdmin;
   }
 
   createAccessToken(userId) {

--- a/api/lib/domain/usecases/get-ready-identity-providers.js
+++ b/api/lib/domain/usecases/get-ready-identity-providers.js
@@ -1,4 +1,7 @@
-const getReadyIdentityProviders = function ({ authenticationServiceRegistry }) {
+const getReadyIdentityProviders = function ({ audience = 'app', authenticationServiceRegistry }) {
+  if (audience === 'admin') {
+    return authenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
+  }
   return authenticationServiceRegistry.getReadyOidcProviderServices();
 };
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -769,6 +769,13 @@ AUTH_SECRET=Change me!
 # default: `false`
 # GOOGLE_ENABLED=false
 
+# Enable Google provider for Pix Admin
+#
+# presence: optional
+# type: boolean
+# default: `false`
+# GOOGLE_ENABLED_FOR_PIX_ADMIN=false
+
 # Client ID
 #
 # presence: required for GOOGLE authentication, optional otherwise

--- a/api/sample.env
+++ b/api/sample.env
@@ -759,6 +759,54 @@ AUTH_SECRET=Change me!
 
 
 # ===================
+# GOOGLE CONFIGURATION
+# ===================
+
+# Enable connection to the OIDC provider
+#
+# presence: optional
+# type: boolean
+# default: `false`
+# GOOGLE_ENABLED=false
+
+# Client ID
+#
+# presence: required for GOOGLE authentication, optional otherwise
+# type: string
+# sample: GOOGLE_CLIENT_ID=
+
+# Client secret
+#
+# presence: required for GOOGLE authentication, optional otherwise
+# type: string
+# sample: GOOGLE_CLIENT_SECRET=
+
+# Token URL
+#
+# presence: required for GOOGLE authentication, optional otherwise
+# type: URL
+# sample: GOOGLE_TOKEN_URL=
+
+# Authentication URL
+#
+# presence: required for GOOGLE authentication, optional otherwise
+# type: URL
+# sample: GOOGLE_AUTHENTICATION_URL=
+
+# User info URL
+#
+# presence: required for GOOGLE authentication, optional otherwise
+# type: URL
+# sample: GOOGLE_USER_INFO_URL=
+
+# Temporary storage idToken expiration delay in milliseconds
+#
+# presence: optional
+# type: Integer
+# default: 7d
+# sample: GOOGLE_ACCESS_TOKEN_LIFESPAN=
+
+# ===================
 # AUTHENTICATION SESSION CONFIGURATION
 # ===================
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -205,6 +205,15 @@ const configuration = (function () {
         idTokenLifespanMs: ms(process.env.FWB_ID_TOKEN_LIFESPAN || '7d'),
       },
     },
+    google: {
+      isEnabled: false,
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      tokenUrl: process.env.GOOGLE_TOKEN_URL,
+      authenticationUrl: process.env.GOOGLE_AUTHENTICATION_URL,
+      userInfoUrl: process.env.GOOGLE_USER_INFO_URL,
+      accessTokenLifespanMs: ms(process.env.GOOGLE_ACCESS_TOKEN_LIFESPAN || '7d'),
+    },
     hapi: {
       options: {},
       enableRequestMonitoring: isFeatureEnabled(process.env.ENABLE_REQUEST_MONITORING),
@@ -433,6 +442,14 @@ const configuration = (function () {
 
     config.fwb.isEnabled = false;
     config.fwb.logoutUrl = 'http://logout-url.org';
+
+    config.google.isEnabled = false;
+    config.google.isEnabledInPixAdmin = true;
+    config.google.clientId = 'PIX_google_CLIENT_ID';
+    config.google.authenticationUrl = 'http://idp.google/auth';
+    config.google.userInfoUrl = 'http://userInfoUrl.fr';
+    config.google.tokenUrl = 'http://idp.google/token';
+    config.google.clientSecret = 'PIX_GOOGLE_CLIENT_SECRET';
 
     config.saml.accessTokenLifespanMs = 1000;
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -108,6 +108,7 @@ const configuration = (function () {
       redisCacheLockedWaitBeforeRetry: parseInt(process.env.REDIS_CACHE_LOCKED_WAIT_BEFORE_RETRY, 10) || 1000,
     },
     cnav: {
+      isEnabledForPixAdmin: false,
       isEnabled: isFeatureEnabled(process.env.CNAV_ENABLED),
       clientId: process.env.CNAV_CLIENT_ID,
       authenticationUrl: process.env.CNAV_AUTHENTICATION_URL,
@@ -192,6 +193,7 @@ const configuration = (function () {
       isPixPlusLowerLeverEnabled: isFeatureEnabled(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
     },
     fwb: {
+      isEnabledForPixAdmin: false,
       isEnabled: isFeatureEnabled(process.env.FWB_ENABLED),
       clientId: process.env.FWB_CLIENT_ID,
       clientSecret: process.env.FWB_CLIENT_SECRET,
@@ -207,6 +209,7 @@ const configuration = (function () {
     },
     google: {
       isEnabled: false,
+      isEnabledForPixAdmin: isFeatureEnabled(process.env.GOOGLE_ENABLED_FOR_PIX_ADMIN),
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       tokenUrl: process.env.GOOGLE_TOKEN_URL,
@@ -282,6 +285,7 @@ const configuration = (function () {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
     paysdelaloire: {
+      isEnabledForPixAdmin: false,
       isEnabled: isFeatureEnabled(process.env.PAYSDELALOIRE_ENABLED),
       clientId: process.env.PAYSDELALOIRE_CLIENT_ID,
       clientSecret: process.env.PAYSDELALOIRE_CLIENT_SECRET,
@@ -302,6 +306,7 @@ const configuration = (function () {
       monitorStateIntervalSeconds: _getNumber(process.env.PGBOSS_MONITOR_STATE_INTERVAL_SECONDS, undefined),
     },
     poleEmploi: {
+      isEnabledForPixAdmin: false,
       isEnabled: isFeatureEnabled(process.env.POLE_EMPLOI_ENABLED),
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
@@ -444,7 +449,7 @@ const configuration = (function () {
     config.fwb.logoutUrl = 'http://logout-url.org';
 
     config.google.isEnabled = false;
-    config.google.isEnabledInPixAdmin = true;
+    config.google.isEnabledForPixAdmin = true;
     config.google.clientId = 'PIX_google_CLIENT_ID';
     config.google.authenticationUrl = 'http://idp.google/auth';
     config.google.userInfoUrl = 'http://userInfoUrl.fr';

--- a/api/tests/integration/domain/services/authentication/GoogleOidcAuthenticationService_test.js
+++ b/api/tests/integration/domain/services/authentication/GoogleOidcAuthenticationService_test.js
@@ -1,0 +1,17 @@
+import { expect } from '../../../../test-helper.js';
+import { GoogleOidcAuthenticationService } from '../../../../../lib/domain/services/authentication/GoogleOidcAuthenticationService.js';
+
+describe('Integration | Domain | Service | google-oidc-authentication-service', function () {
+  describe('instantiate', function () {
+    it('has specific properties related to this identity provider', async function () {
+      // when
+      const authenticationService = new GoogleOidcAuthenticationService();
+
+      // then
+      expect(authenticationService.source).to.equal('google');
+      expect(authenticationService.identityProvider).to.equal('GOOGLE');
+      expect(authenticationService.slug).to.equal('google');
+      expect(authenticationService.organizationName).to.equal('Google');
+    });
+  });
+});

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -74,7 +74,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       ]);
 
       // when
-      const response = await oidcController.getIdentityProviders(null, hFake);
+      const response = await oidcController.getIdentityProviders({ query: { audience: null } }, hFake);
 
       // then
       expect(usecases.getReadyIdentityProviders).to.have.been.called;

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -13,6 +13,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
       expect(serviceCodes).to.contain('POLE_EMPLOI');
       expect(serviceCodes).to.contain('CNAV');
       expect(serviceCodes).to.contain('FWB');
+      expect(serviceCodes).to.contain('GOOGLE');
     });
   });
 
@@ -26,6 +27,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
       expect(serviceCodes).to.contain('POLE_EMPLOI');
       expect(serviceCodes).to.contain('CNAV');
       expect(serviceCodes).not.to.contain('FWB');
+      expect(serviceCodes).not.to.contain('GOOGLE');
     });
   });
 

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -27,7 +27,17 @@ describe('Unit | Domain | Services | authentication registry', function () {
       expect(serviceCodes).to.contain('POLE_EMPLOI');
       expect(serviceCodes).to.contain('CNAV');
       expect(serviceCodes).not.to.contain('FWB');
-      expect(serviceCodes).not.to.contain('GOOGLE');
+    });
+  });
+
+  describe('#getReadyOidcProviderServicesForPixAdmin', function () {
+    it('returns ready OIDC Providers for Pix Admin', function () {
+      // when
+      const services = authenticationRegistry.getReadyOidcProviderServicesForPixAdmin();
+
+      // then
+      const serviceCodes = services.map((service) => service.code);
+      expect(serviceCodes).to.contain('GOOGLE');
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
@@ -2,7 +2,32 @@ import { expect, sinon } from '../../../test-helper.js';
 import { getReadyIdentityProviders } from '../../../../lib/domain/usecases/get-ready-identity-providers.js';
 
 describe('Unit | UseCase | get-ready-identity-providers', function () {
-  it('returns oidc providers from authenticationServiceRegistry', function () {
+  describe('when an audience is provided', function () {
+    describe('when the provided audience is equal to "admin"', function () {
+      it('returns oidc providers from getReadyOidcProviderServicesForPixAdmin', function () {
+        // given
+        const oneOidcProviderService = {};
+        const anotherOidcProviderService = {};
+        const authenticationServiceRegistryStub = {
+          getReadyOidcProviderServicesForPixAdmin: sinon
+            .stub()
+            .returns([oneOidcProviderService, anotherOidcProviderService]),
+        };
+
+        // when
+        const identityProviders = getReadyIdentityProviders({
+          audience: 'admin',
+          authenticationServiceRegistry: authenticationServiceRegistryStub,
+        });
+
+        // then
+        expect(authenticationServiceRegistryStub.getReadyOidcProviderServicesForPixAdmin).to.have.been.calledOnce;
+        expect(identityProviders).to.deep.equal([oneOidcProviderService, anotherOidcProviderService]);
+      });
+    });
+  });
+
+  it('returns oidc providers from getReadyOidcProviderServices', function () {
     // given
     const oneOidcProviderService = {};
     const anotherOidcProviderService = {};
@@ -12,10 +37,12 @@ describe('Unit | UseCase | get-ready-identity-providers', function () {
 
     // when
     const identityProviders = getReadyIdentityProviders({
+      audience: null,
       authenticationServiceRegistry: authenticationServiceRegistryStub,
     });
 
     // then
+    expect(authenticationServiceRegistryStub.getReadyOidcProviderServices).to.have.been.calledOnce;
     expect(identityProviders).to.deep.equal([oneOidcProviderService, anotherOidcProviderService]);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

La combinaison e-mail / mot de passe est aujourd'hui la seule manière de se connecter à Pix Admin. Tous les agents Pix ayant un compte Google (pix.fr), l'ajout à Pix Admin d'un SSO Google obligatoire permettrait de renforcer la sécurité des accès. 

Aujourd’hui, la route `/api/oidc/identity-providers` renvoie les mêmes fournisseurs d’identité quelque soit l’application et le domaine. Or Pix Admin et Pix App n'utiliseront pas les mêmes fournisseurs, il faut donc un moyen de filtrer les fournisseurs par application.

## :robot: Proposition

- Ajouter le fournisseur d'identité Google côté API
- Ajouter un query parameter `audience` qui précise l’application, par exemple `app` ou `admin`.

## :rainbow: Remarques

- Le fournisseur d'identité Google est ajouté mais inactif pour le moment.
- 
## :100: Pour tester

- Configurer le fournisseur d'identité à l'aide de la page confluence https://1024pix.atlassian.net/wiki/spaces/DA/pages/3854303245/SSO+Google+dans+Pix+Admin.

### Test de non régression sur Pix Admin
- Se connecter avec un compte utilisateur (ex: superadmin@example.net)
- Aller sur la page d'un utilisateur 
- Vérifier que la liste des fournisseurs d'identité apparaît.

### Test de non régression sur Pix App
- Ouvrir l'onglet Network
- Aller sur la mire de connexion de l'app Pix App
- Vérifier que l'appel /oidc/identity-providers fonctionne bien et que Google n'apparaît pas dans la réponse.

### Test Pix Admin
- Ouvrir l'onglet Network
- Aller sur la mire de connexion de Pix Admin
- Vérifier que l'appel /oidc/identity-providers fonctionne bien et que seul Google apparaît dans la réponse.