### PR TITLE
[TECH] Permet l'utilisation du plugin docker compose dans configure.sh

### DIFF
--- a/high-level-tests/e2e/README.md
+++ b/high-level-tests/e2e/README.md
@@ -5,7 +5,7 @@ Il est utilisé ici pour les tests de non-régression sur les chemins fonctionne
 
 ### Je veux lancer les tests rapidement, comment faire ?
 
-Si tu es sous Linux et que tu a `docker` et `docker-compose`, alors le plus simple est de lancer a la racine.
+Si tu es sous Linux et que tu as `docker` et `docker compose`, alors le plus simple est de lancer à la racine.
 
     ./scripts/tests-e2e
 

--- a/scripts/tests-e2e
+++ b/scripts/tests-e2e
@@ -9,12 +9,20 @@ if [ "$1" == "open" ]; then
     DC_CYPRESS_ARGS=" --volume /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix:0"
 fi
 
+function dockercompose() {
+  if $( docker compose version > /dev/null ); then
+    docker compose "$@"
+    else
+    docker-compose "$@"
+    fi
+}
+
 npm run ci:all
 cd high-level-tests/e2e
-docker-compose stop
-docker-compose up -d postgres redis api monpix certif orga
-docker-compose run --name pix-e2e-run-prepare --rm api npm run db:prepare
-docker-compose exec redis redis-cli flushdb
-docker-compose run --name pix-e2e-run-wait --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201 http://certif:4203
-docker-compose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
-docker-compose down
+dockercompose stop
+dockercompose up -d postgres redis api monpix orga
+dockercompose run --name pix-e2e-run-prepare --rm api npm run db:prepare
+dockercompose exec redis redis-cli flushdb
+dockercompose run --name pix-e2e-run-wait --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201
+dockercompose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
+dockercompose down

--- a/scripts/tests-e2e
+++ b/scripts/tests-e2e
@@ -24,5 +24,5 @@ dockercompose up -d postgres redis api monpix orga
 dockercompose run --name pix-e2e-run-prepare --rm api npm run db:prepare
 dockercompose exec redis redis-cli flushdb
 dockercompose run --name pix-e2e-run-wait --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201
-dockercompose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
+dockercompose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env APP_URL=http://monpix:4200,API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
 dockercompose down


### PR DESCRIPTION
## :unicorn: Problème
En tant que nouveau, j'ai suivi la doc d'installation du projet https://github.com/1024pix/pix/blob/dev/INSTALLATION.md et lancé la commande  `npm run configure`. Malheureusement, n'ayant plus `docker-compose` mais la commande  `docker compose` le script échoue. Le projet `docker-compose` a été ajouté au cli docker depuis la version 20 sous forme de plugin.

## :robot: Proposition
Modifier le script pour qu'il s'exécute sans erreur (et qu'il supporte `docker-compose` ou `docker compose`.

## :rainbow: Remarques
On profite de la PR pour modifier un autre script (`./scripts/tests-e2e.sh`) qui utilise aussi la commande docker-compose
:thread: Une fois modifié, j'ai pu lancer les tests pour m'apercevoir que ces derniers ne passent pas. J'ai fait une première modif pour corriger le problème (un ajout de variable d'env) mais 3 tests sont encore dans le rouge... 
 
![sad_panda(1)](https://github.com/1024pix/pix/assets/160320/e5eb9624-52cd-428d-a5a3-b75918d95644)

 
## :100: Pour tester
- faire un clone du projet sur une machine ne disposant pas du cli `docker-compose`
- lancer la commande  `npm run configure`
et pour les tests
lancer `./scripts/tests-e2e.sh`
