### PR TITLE
[TECH] Amélioration databasebuilder

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -16,6 +16,18 @@ class DatabaseBuilder {
     this.#addListeners();
   }
 
+  static async create({ knex, emptyFirst = true, beforeEmptyDatabase = () => undefined }) {
+    const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst, beforeEmptyDatabase });
+
+    try {
+      await databaseBuilder._init();
+    } catch (_) {
+      // Error thrown only with unit tests
+    }
+
+    return databaseBuilder;
+  }
+
   async commit() {
     if (this.isFirstCommit) {
       await this._init();

--- a/api/tests/integration/tooling/database-builder/database-builder_test.js
+++ b/api/tests/integration/tooling/database-builder/database-builder_test.js
@@ -1,0 +1,16 @@
+import { expect, knex } from '../../../test-helper.js';
+import { DatabaseBuilder } from '../../../../db/database-builder/database-builder.js';
+
+describe('Integration | Tooling | DatabaseBuilder | database-builder', function () {
+  describe('#create', function () {
+    it('returns an initialised instance of DatabaseBuilder', async function () {
+      // given
+      // when
+      const databaseBuilder = await DatabaseBuilder.create({ knex });
+
+      // then
+      expect(databaseBuilder).to.be.an.instanceOf(DatabaseBuilder);
+      expect(databaseBuilder.isFirstCommit).to.be.false;
+    });
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -37,7 +37,7 @@ const { apimRegisterApplicationsCredentials, jwtConfig } = config;
 import { knex, disconnect } from '../db/knex-database-connection.js';
 import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 
-const databaseBuilder = new DatabaseBuilder({
+const databaseBuilder = await DatabaseBuilder.create({
   knex,
   beforeEmptyDatabase: () => {
     // Sometimes, truncating tables may cause the first ran test to timeout, so

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable import/no-restricted-paths */
-import { expect, sinon, catchErr } from '../../../test-helper.js';
+import { expect, sinon, catchErr, knex } from '../../../test-helper.js';
 import { DatabaseBuilder } from '../../../../db/database-builder/database-builder.js';
 
 describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
@@ -447,6 +447,18 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
         await databaseBuilder.fixSequences();
         expect(knexFn.raw).not.to.have.been.called;
       });
+    });
+  });
+
+  describe('#create', function () {
+    it('returns an instance of DatabaseBuilder', async function () {
+      // given
+      // when
+      const databaseBuilder = await DatabaseBuilder.create({ knex });
+
+      // then
+      expect(databaseBuilder).to.be.an.instanceOf(DatabaseBuilder);
+      expect(databaseBuilder.isFirstCommit).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Suite à l'amélioration du nettoyage de la base de données #7438, un cas n'a pas été pris en compte.

Lorsque l'on exécute un test qui va ajouter une nouvelle entrée en base de données, étant donnée que l'on ne fait pas appel à la méthode `commit`, l'attribut `tablesOrderedByDependencyWithDirtinessMap` n'est pas initialisé avec la liste des tables.

Dans ce cas, le listener précédemment ajouté ne peut pas modifier le statut `isDirty` de la table car l'attribut `tablesOrderedByDependencyWithDirtinessMap` est vide (tableau vide pour être plus précis).

Il faudrait que l'attribut `tablesOrderedByDependencyWithDirtinessMap` soit initialisé lorsque l'on exécute un seul test.

## :robot: Proposition

Initialiser complètement l'état de l'instance de DatabaseBuilder partagée par le fichier `api/tests/test-helper.js` importé par tous les fichiers de tests. Cette initialisation inclus l'initialisation de la liste des tables de la base de données via l'attribut `tablesOrderedByDependencyWithDirtinessMap`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

#### CI

Tous les tests de la CI sont ✅ 

#### Local

Tester en local un test d'intégration qui crée un nouvelle entrée en base de données, comme la création d'un compte utilisateur :
  - fichier : `api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js`
  - contexte : `#create`
  - test : `returns a domain User object`

1. Exécuter le test
2. Constater que le test est ✅ 
3. Vérifier en base de données que la table utilisée par le test est bien vide