### PR TITLE
[TECH] Flaky sur integrate-cpf-processing-receipts_test.js (PIX-10064).

### DIFF
--- a/api/tests/certification/session/integration/domain/usecases/integrate-cpf-processing-receipts_test.js
+++ b/api/tests/certification/session/integration/domain/usecases/integrate-cpf-processing-receipts_test.js
@@ -64,7 +64,7 @@ describe('Integration | UseCase | integrate-cpf-processing-receipts ', function 
         'importStatus',
         'filename',
       );
-      expect(results).to.deep.equal([
+      expect(results).to.deep.members([
         { certificationCourseId: 1234, filename: 'pix-cpf-export-20221003-324234.xml', importStatus: 'REJECTED' },
         { certificationCourseId: 4567, filename: 'pix-cpf-export-20221003-324234.xml', importStatus: 'SUCCESS' },
         { certificationCourseId: 891011, filename: 'pix-cpf-export-20221003-324234.xml', importStatus: 'SUCCESS' },


### PR DESCRIPTION
## :unicorn: Problème

il semble qu'il y ai un flaky sur api/tests/certification/session/integration/domain/usecases/integrate-cpf-processing-receipts_test.js . A première vue on dirait un deep.equals au lieu d'un deep.members ( les ids de certificationSessionId sont inversé dans le expected/actual )

## :robot: Proposition

Corriger le test

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Les tests passent
