### PR TITLE
[TECH] Mettre à jour pix-ui pour avoir la modif du composant pix input code (Pix-10074)

### DIFF
--- a/1d/package-lock.json
+++ b/1d/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-testing-library": "^1.0.0",
         "@1024pix/eslint-config": "^1.0.3",
         "@1024pix/eslint-plugin": "^1.0.0",
-        "@1024pix/pix-ui": "^41.0.0",
+        "@1024pix/pix-ui": "^41.1.0",
         "@1024pix/stylelint-config": "^5.0.0",
         "@babel/eslint-parser": "^7.11.0",
         "@ember/optional-features": "^2.0.0",
@@ -114,9 +114,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "41.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-41.0.0.tgz",
-      "integrity": "sha512-wfdCyYILUZN1A1CWmYYW7l9CKY/Kc9RXefeWUqwN/JqnR+eRtdItFiekrSgVAQG6kSlAxjwP/1CbVTmixdITaw==",
+      "version": "41.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-41.1.0.tgz",
+      "integrity": "sha512-Shhh4Pumnv5uWsJIm/gCdLoJoAfoXO9n31EImNp7WyzHn0FwJoh0oa9TXDC+tO3Szs4GtYZkEX1JoL86Yyfy8Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -131,7 +131,7 @@
         "lodash.debounce": "^4.0.8"
       },
       "engines": {
-        "node": "^20"
+        "node": "^20.9.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {

--- a/1d/package.json
+++ b/1d/package.json
@@ -37,7 +37,7 @@
     "@1024pix/ember-testing-library": "^1.0.0",
     "@1024pix/eslint-config": "^1.0.3",
     "@1024pix/eslint-plugin": "^1.0.0",
-    "@1024pix/pix-ui": "^41.0.0",
+    "@1024pix/pix-ui": "^41.1.0",
     "@1024pix/stylelint-config": "^5.0.0",
     "@babel/eslint-parser": "^7.11.0",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème
On a fait un correctif sur les composant pix input code mais il est tjr pas sur pix1d

## :robot: Proposition
Mettre à  jour pix-ui pour avoir les changements du composant.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- faire un tour sur l'appli
particulièrement sur la page `organization-code` en essayant de supprimer des lettre des inputs