### PR TITLE
[FEATURE] Ajouter un élément Image (PIX-9903)

### DIFF
--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -1,0 +1,18 @@
+import { Element } from './Element.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+class Image extends Element {
+  constructor({ id, url, alt, alternativeInstruction }) {
+    super({ id });
+
+    assertNotNullOrUndefined(url, "L'URL est obligatoire pour une image");
+    assertNotNullOrUndefined(alt, 'Le contenu alt est obligatoire pour une image');
+    assertNotNullOrUndefined(alternativeInstruction, "L'instruction alternative est obligatoire pour une image");
+
+    this.url = url;
+    this.alt = alt;
+    this.alternativeInstruction = alternativeInstruction;
+  }
+}
+
+export { Image };

--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -2,16 +2,16 @@ import { Element } from './Element.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Image extends Element {
-  constructor({ id, url, alt, alternativeInstruction }) {
+  constructor({ id, url, alt, alternativeText }) {
     super({ id });
 
     assertNotNullOrUndefined(url, "L'URL est obligatoire pour une image");
     assertNotNullOrUndefined(alt, 'Le contenu alt est obligatoire pour une image');
-    assertNotNullOrUndefined(alternativeInstruction, "L'instruction alternative est obligatoire pour une image");
+    assertNotNullOrUndefined(alternativeText, "L'instruction alternative est obligatoire pour une image");
 
     this.url = url;
     this.alt = alt;
-    this.alternativeInstruction = alternativeInstruction;
+    this.alternativeText = alternativeText;
   }
 }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -11,6 +11,13 @@
           "title": "Explications : les parties d’une adresse mail",
           "elements": [
             {
+              "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
+              "type": "image",
+              "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg",
+              "alt": "Schéma de la syntaxe d'une adresse mail, en trois blocs distincts, décrit dans l'alternative textuelle",
+              "alternativeInstruction": "Bloc 1 : Identifiant, exemple : mickael.aubert123<br/>Bloc 2 : Arobase<br/>Bloc 3 : Fournisseur d'adresse mail, exemple : laposte.net "
+            },
+            {
               "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
               "type": "text",
               "content": "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -15,7 +15,7 @@
               "type": "image",
               "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg",
               "alt": "Schéma de la syntaxe d'une adresse mail, en trois blocs distincts, décrit dans l'alternative textuelle",
-              "alternativeInstruction": "Bloc 1 : Identifiant, exemple : mickael.aubert123<br/>Bloc 2 : Arobase<br/>Bloc 3 : Fournisseur d'adresse mail, exemple : laposte.net "
+              "alternativeText": "Bloc 1 : Identifiant, exemple : mickael.aubert123<br/>Bloc 2 : Arobase<br/>Bloc 3 : Fournisseur d'adresse mail, exemple : laposte.net "
             },
             {
               "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -94,7 +94,7 @@ function _toImageDomain(element) {
     id: element.id,
     url: element.url,
     alt: element.alt,
-    alternativeInstruction: element.alternativeInstruction,
+    alternativeText: element.alternativeText,
   });
 }
 

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -1,6 +1,7 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Module } from '../../domain/models/Module.js';
 import { Text } from '../../domain/models/element/Text.js';
+import { Image } from '../../domain/models/element/Image.js';
 import { QCU } from '../../domain/models/element/QCU.js';
 import { QcuProposal } from '../../domain/models/QcuProposal.js';
 import { Grain } from '../../domain/models/Grain.js';
@@ -45,23 +46,12 @@ function _toDomain(moduleData) {
         type: grain.type,
         elements: grain.elements.map((element) => {
           if (element.type === 'qcu') {
-            return new QCU({
-              id: element.id,
-              instruction: element.instruction,
-              locales: element.locales,
-              proposals: element.proposals.map((proposal) => {
-                return new QcuProposal({
-                  id: proposal.id,
-                  content: proposal.content,
-                });
-              }),
-            });
+            return _toQCUDomain(element);
+          } else if (element.type === 'image') {
+            return _toImageDomain(element);
           }
 
-          return new Text({
-            id: element.id,
-            content: element.content,
-          });
+          return _toTextDomain(element);
         }),
       });
     }),
@@ -80,26 +70,59 @@ function _toDomainForVerification(moduleData) {
         type: grain.type,
         elements: grain.elements.map((element) => {
           if (element.type === 'qcu') {
-            return new QCUForAnswerVerification({
-              id: element.id,
-              instruction: element.instruction,
-              locales: element.locales,
-              proposals: element.proposals.map((proposal) => {
-                return new QcuProposal({
-                  id: proposal.id,
-                  content: proposal.content,
-                });
-              }),
-              feedbacks: element.feedbacks,
-              solution: element.solution,
-            });
+            return _toQCUForAnswerVerificationDomain(element);
+          } else if (element.type === 'image') {
+            return _toImageDomain(element);
           }
 
-          return new Text({
-            id: element.id,
-            content: element.content,
-          });
+          return _toTextDomain(element);
         }),
+      });
+    }),
+  });
+}
+
+function _toTextDomain(element) {
+  return new Text({
+    id: element.id,
+    content: element.content,
+  });
+}
+
+function _toImageDomain(element) {
+  return new Image({
+    id: element.id,
+    url: element.url,
+    alt: element.alt,
+    alternativeInstruction: element.alternativeInstruction,
+  });
+}
+
+function _toQCUForAnswerVerificationDomain(element) {
+  return new QCUForAnswerVerification({
+    id: element.id,
+    instruction: element.instruction,
+    locales: element.locales,
+    proposals: element.proposals.map((proposal) => {
+      return new QcuProposal({
+        id: proposal.id,
+        content: proposal.content,
+      });
+    }),
+    feedbacks: element.feedbacks,
+    solution: element.solution,
+  });
+}
+
+function _toQCUDomain(element) {
+  return new QCU({
+    id: element.id,
+    instruction: element.instruction,
+    locales: element.locales,
+    proposals: element.proposals.map((proposal) => {
+      return new QcuProposal({
+        id: proposal.id,
+        content: proposal.content,
       });
     }),
   });

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -44,16 +44,7 @@ function serialize(module) {
       elements: {
         ref: 'id',
         includes: true,
-        attributes: [
-          'content',
-          'instruction',
-          'proposals',
-          'type',
-          'url',
-          'alt',
-          'alternativeInstruction',
-          'isAnswerable',
-        ],
+        attributes: ['content', 'instruction', 'proposals', 'type', 'url', 'alt', 'alternativeText', 'isAnswerable'],
       },
     },
     typeForAttribute(attribute, { type }) {

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -1,5 +1,6 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 import { QCU } from '../../../domain/models/element/QCU.js';
+import { Image } from '../../../domain/models/element/Image.js';
 
 const { Serializer } = jsonapiSerializer;
 
@@ -20,6 +21,11 @@ function serialize(module) {
                   ...element,
                   type: 'qcus',
                 };
+              } else if (element instanceof Image) {
+                return {
+                  ...element,
+                  type: 'images',
+                };
               }
               return {
                 ...element,
@@ -38,7 +44,16 @@ function serialize(module) {
       elements: {
         ref: 'id',
         includes: true,
-        attributes: ['content', 'instruction', 'proposals', 'type', 'isAnswerable'],
+        attributes: [
+          'content',
+          'instruction',
+          'proposals',
+          'type',
+          'url',
+          'alt',
+          'alternativeInstruction',
+          'isAnswerable',
+        ],
       },
     },
     typeForAttribute(attribute, { type }) {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -197,7 +197,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                 type: 'image',
                 url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
                 alt: 'missing alt',
-                alternativeInstruction: 'missing alternative instructions',
+                alternativeText: 'missing alternative instructions',
               },
             ],
           },

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -1,8 +1,11 @@
-import { catchErr, expect } from '../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import * as moduleRepository from '../../../../src/devcomp/infrastructure/repositories/module-repository.js';
 import { Module } from '../../../../src/devcomp/domain/models/Module.js';
 import { Grain } from '../../../../src/devcomp/domain/models/Grain.js';
+import { Text } from '../../../../src/devcomp/domain/models/element/Text.js';
+import { QCU } from '../../../../src/devcomp/domain/models/element/QCU.js';
+import { Image } from '../../../../src/devcomp/domain/models/element/Image.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 
@@ -41,7 +44,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       expect(error).not.to.be.instanceOf(NotFoundError);
     });
 
-    it('should return a module if it exists', async function () {
+    it('should return a module with grains if it exists', async function () {
       // given
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
 
@@ -54,6 +57,165 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       // then
       expect(module).to.be.instanceOf(Module);
       expect(module.grains.every((grain) => grain instanceof Grain)).to.be.true;
+    });
+
+    it('should return a module which contains elements of type Text if it exists', async function () {
+      // given
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            elements: [
+              {
+                id: 'c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'text',
+                content:
+                  "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>",
+              },
+              {
+                id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                type: 'text',
+                content:
+                  "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
+
+      // when
+      const module = await moduleRepository.getBySlug({
+        slug: existingModuleSlug,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof Text))).to.be.true;
+    });
+
+    it('should return a module which contains elements of type QCU if it exists', async function () {
+      // given
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            elements: [
+              {
+                id: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
+                type: 'qcu',
+                instruction: '<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>',
+                proposals: [
+                  {
+                    id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+                    content: 'Vrai',
+                  },
+                  {
+                    id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
+                    content: 'Faux',
+                  },
+                ],
+                feedbacks: {
+                  valid:
+                    '<p>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>',
+                  invalid:
+                    '<p>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>',
+                },
+                solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+              },
+              {
+                id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
+                type: 'qcu',
+                instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
+                proposals: [
+                  {
+                    id: '6d4db7f8-b783-473d-a1cc-73dac8411855',
+                    content: 'Vrai',
+                  },
+                  {
+                    id: '26d27fa3-3269-4d78-916c-3aa066976592',
+                    content: 'Faux',
+                  },
+                ],
+                feedbacks: {
+                  valid:
+                    '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                  invalid:
+                    '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                },
+                solution: '6d4db7f8-b783-473d-a1cc-73dac8411855',
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
+
+      // when
+      const module = await moduleRepository.getBySlug({
+        slug: existingModuleSlug,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof QCU))).to.be.true;
+    });
+
+    it('should return a module which contains elements of type Image if it exists', async function () {
+      // given
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            elements: [
+              {
+                id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                type: 'image',
+                url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+                alt: 'missing alt',
+                alternativeInstruction: 'missing alternative instructions',
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
+
+      // when
+      const module = await moduleRepository.getBySlug({
+        slug: existingModuleSlug,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof Image))).to.be.true;
     });
   });
 

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../../test-helper.js';
 import { modulesController } from '../../../../../src/devcomp/application/modules/controller.js';
 
-describe('Devcomp | Unit | Application | Module | Module Controller', function () {
+describe('Unit | Devcomp | Application | Modules | Module Controller', function () {
   describe('#getBySlug', function () {
     it('should call getModule use-case and return serialized modules', async function () {
       const slug = 'slug';

--- a/api/tests/devcomp/unit/application/trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/trainings/index_test.js
@@ -3,7 +3,7 @@ import { securityPreHandlers } from '../../../../../lib/application/security-pre
 import { trainingController } from '../../../../../src/devcomp/application/trainings/training-controller.js';
 import * as moduleUnderTest from '../../../../../src/devcomp/application/trainings/index.js';
 
-describe('Unit | Router | training-router', function () {
+describe('Unit | Devcomp | Application | Trainings | Router | training-router', function () {
   describe('GET /api/admin/trainings/${trainingId}', function () {
     describe('Security Prehandlers', function () {
       it('should allow user if its role is SUPER_ADMIN', async function () {

--- a/api/tests/devcomp/unit/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/unit/application/trainings/training-controller_test.js
@@ -1,11 +1,11 @@
-import { sinon, expect, hFake } from '../../../../test-helper.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
 import { trainingController } from '../../../../../src/devcomp/application/trainings/training-controller.js';
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
 import { TrainingTrigger } from '../../../../../src/devcomp/domain/models/TrainingTrigger.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 
-describe('Unit | Controller | training-controller', function () {
+describe('Unit | Devcomp | Application | Trainings | Controller | training-controller', function () {
   describe('#findPaginatedTrainingSummaries', function () {
     it('should call the training findPaginatedTrainingSummaries use-case', async function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
+++ b/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
@@ -1,7 +1,7 @@
 import { ElementAnswer } from '../../../../../src/devcomp/domain/models/ElementAnswer.js';
 import { expect } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Models | ElementAnswer', function () {
+describe('Unit | Devcomp | Domain | Models | ElementAnswer', function () {
   describe('#constructor', function () {
     it('should create an element answer and keep attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -1,7 +1,7 @@
 import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { expect } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Models | Grain', function () {
+describe('Unit | Devcomp | Domain | Models | Grain', function () {
   describe('#constructor', function () {
     it('should create a grain and keep attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/Module_test.js
@@ -2,7 +2,7 @@ import { Module } from '../../../../../src/devcomp/domain/models/Module.js';
 import { catchErrSync, expect } from '../../../../test-helper.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 
-describe('Unit | Devcomp | Models | Module', function () {
+describe('Unit | Devcomp | Domain | Models | Module', function () {
   describe('#constructor', function () {
     it('should create a module and keep attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
@@ -2,7 +2,7 @@ import { expect } from '../../../../test-helper.js';
 import { QcuCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 
-describe('Unit | Devcomp | Models | QcuCorrectionResponse', function () {
+describe('Unit | Devcomp | Domain | Models | QcuCorrectionResponse', function () {
   describe('#constructor', function () {
     it('should create a QCU correction response and keep attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -1,7 +1,7 @@
 import { expect } from '../../../../test-helper.js';
 import { QcuProposal } from '../../../../../src/devcomp/domain/models/QcuProposal.js';
 
-describe('Unit | Devcomp | Models | QcuProposal', function () {
+describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
   describe('#constructor', function () {
     it('should create a QCU proposal with correct attributes', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/TrainingTriggerTube_test.js
+++ b/api/tests/devcomp/unit/domain/models/TrainingTriggerTube_test.js
@@ -1,7 +1,7 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 import { TrainingTriggerTube } from '../../../../../src/devcomp/domain/models/TrainingTriggerTube.js';
 
-describe('Unit | Domain | Models | TrainingTriggerTube', function () {
+describe('Unit | Devcomp | Domain | Models | TrainingTriggerTube', function () {
   describe('#constructor', function () {
     it('should be a valid type', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/Training_test.js
+++ b/api/tests/devcomp/unit/domain/models/Training_test.js
@@ -1,7 +1,7 @@
-import { expect, domainBuilder, sinon } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 import { Training } from '../../../../../src/devcomp/domain/models/Training.js';
 
-describe('Unit | Domain | Models | Training', function () {
+describe('Unit | Devcomp | Domain | Models | Training', function () {
   describe('#constructor', function () {
     it('should be a valid type', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/element/Element_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Element_test.js
@@ -1,6 +1,7 @@
 import { expect } from '../../../../../test-helper.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
+import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 
 describe('Unit | Devcomp | Domain | Models | Element', function () {
   describe('#isAnswerable', function () {
@@ -22,8 +23,9 @@ describe('Unit | Devcomp | Domain | Models | Element', function () {
     it('should instanciate non answerable elements', function () {
       // Given
       const text = new Text({ id: 'id', content: 'content' });
+      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeInstruction: 'alternativeInstruction' });
 
-      const nonAnswerableElements = [text];
+      const nonAnswerableElements = [text, image];
 
       // Then
       nonAnswerableElements.forEach((element) => expect(element.isAnswerable).to.be.false);

--- a/api/tests/devcomp/unit/domain/models/element/Element_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Element_test.js
@@ -23,7 +23,7 @@ describe('Unit | Devcomp | Domain | Models | Element', function () {
     it('should instanciate non answerable elements', function () {
       // Given
       const text = new Text({ id: 'id', content: 'content' });
-      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeInstruction: 'alternativeInstruction' });
+      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeText: 'alternativeText' });
 
       const nonAnswerableElements = [text, image];
 

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -5,13 +5,13 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
   describe('#constructor', function () {
     it('should create an image and keep attributes', function () {
       // when
-      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeInstruction: 'alternativeInstruction' });
+      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeText: 'alternativeText' });
 
       // then
       expect(image.id).to.equal('id');
       expect(image.url).to.equal('url');
       expect(image.alt).to.equal('alt');
-      expect(image.alternativeInstruction).to.equal('alternativeInstruction');
+      expect(image.alternativeText).to.equal('alternativeText');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -1,7 +1,7 @@
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { expect } from '../../../../../test-helper.js';
 
-describe('Unit | Devcomp | Domain | Models | Image', function () {
+describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
   describe('#constructor', function () {
     it('should create an image and keep attributes', function () {
       // when

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -1,0 +1,43 @@
+import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Image', function () {
+  describe('#constructor', function () {
+    it('should create an image and keep attributes', function () {
+      // when
+      const image = new Image({ id: 'id', url: 'url', alt: 'alt', alternativeInstruction: 'alternativeInstruction' });
+
+      // then
+      expect(image.id).to.equal('id');
+      expect(image.url).to.equal('url');
+      expect(image.alt).to.equal('alt');
+      expect(image.alternativeInstruction).to.equal('alternativeInstruction');
+    });
+  });
+
+  describe('An image without id', function () {
+    it('should throw an error', function () {
+      expect(() => new Image({})).to.throw("L'id est obligatoire pour un élément");
+    });
+  });
+
+  describe('An image without url', function () {
+    it('should throw an error', function () {
+      expect(() => new Image({ id: 'id' })).to.throw("L'URL est obligatoire pour une image");
+    });
+  });
+
+  describe('An image without alt', function () {
+    it('should throw an error', function () {
+      expect(() => new Image({ id: 'id', url: 'url' })).to.throw('Le contenu alt est obligatoire pour une image');
+    });
+  });
+
+  describe('An image without an alternative Instruction', function () {
+    it('should throw an error', function () {
+      expect(() => new Image({ id: 'id', url: 'url', alt: 'alt' })).to.throw(
+        "L'instruction alternative est obligatoire pour une image",
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -4,7 +4,7 @@ import { ElementAnswer } from '../../../../../../src/devcomp/domain/models/Eleme
 import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcuCorrectionResponse.js';
 import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
 
-describe('Unit | Devcomp | Domain | Models | QcuForAnswerVerification', function () {
+describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification', function () {
   describe('#constructor', function () {
     it('should instanciate a QCU For Verification with right attributes', function () {
       // Given

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -1,7 +1,7 @@
 import { expect } from '../../../../../test-helper.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 
-describe('Unit | Devcomp | Domain | Models | QCU', function () {
+describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
   describe('#constructor', function () {
     it('should instanciate a QCU with right properties', function () {
       // Given

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -1,5 +1,5 @@
-import { Text } from '../../../../../src/devcomp/domain/models/element/Text.js';
-import { expect } from '../../../../test-helper.js';
+import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
+import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Text', function () {
   describe('#constructor', function () {

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -1,7 +1,7 @@
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
 import { expect } from '../../../../../test-helper.js';
 
-describe('Unit | Devcomp | Domain | Models | Text', function () {
+describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
   describe('#constructor', function () {
     it('should create a text and keep attributes', function () {
       // when

--- a/api/tests/devcomp/unit/domain/models/validator/AnswerStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/AnswerStatus_test.js
@@ -3,7 +3,7 @@ import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/valida
 
 const { expect } = chai;
 
-describe('Unit | Devcomp | Domain | Models | AnswerStatus', function () {
+describe('Unit | Devcomp | Domain | Models | Validator | AnswerStatus', function () {
   context('AnswerStatus#isOK', function () {
     it('should be true with AnswerStatus.OK', function () {
       expect(AnswerStatus.OK.isOK()).to.be.true;

--- a/api/tests/devcomp/unit/domain/models/validator/ValidatorQCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/ValidatorQCU_test.js
@@ -1,9 +1,9 @@
 import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
 import { ValidatorQCU } from '../../../../../../src/devcomp/domain/models/validator/ValidatorQCU.js';
-import { expect, domainBuilder, sinon } from '../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
-describe('Unit | Devcomp | Domain | Models | ValidatorQCU', function () {
+describe('Unit | Devcomp | Domain | Models | Validator | ValidatorQCU', function () {
   let solutionServiceQCUStub;
 
   beforeEach(function () {

--- a/api/tests/devcomp/unit/domain/models/validator/Validator_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/Validator_test.js
@@ -1,9 +1,9 @@
 import { AnswerStatus } from '../../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import { Validator } from '../../../../../../src/devcomp/domain/models/validator/Validator.js';
 import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
-import { expect, domainBuilder } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
-describe('Unit | Devcomp | Domain | Models | Validator', function () {
+describe('Unit | Devcomp | Domain | Models | Validator | Validator', function () {
   describe('#assess', function () {
     let uncorrectedAnswer;
     let validation;

--- a/api/tests/devcomp/unit/domain/services/solution-service-qcu_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qcu_test.js
@@ -2,7 +2,7 @@ import { expect } from '../../../../test-helper.js';
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
 import * as service from '../../../../../src/devcomp/domain/services/solution-service-qcu.js';
 
-describe('Unit | Devcomp | Domain | Service | SolutionServiceQCU ', function () {
+describe('Unit | Devcomp | Domain | Services | SolutionServiceQCU ', function () {
   describe('if solution type is QCU', function () {
     it('should return `AnswerStatus.OK` when answer and solution are equal', function () {
       expect(service.match('same value', 'same value')).to.deep.equal(AnswerStatus.OK);

--- a/api/tests/devcomp/unit/domain/usecases/attach-target-profiles-to-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/attach-target-profiles-to-training_test.js
@@ -1,8 +1,8 @@
-import { expect, sinon, catchErr } from '../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { attachTargetProfilesToTraining } from '../../../../../src/devcomp/domain/usecases/attach-target-profiles-to-training.js';
 
-describe('Unit | UseCase | attach-target-profiles-to-training', function () {
+describe('Unit | Devcomp | Domain | UseCases | attach-target-profiles-to-training', function () {
   let targetProfileRepository;
   let targetProfileTrainingRepository;
   const trainingId = 1;

--- a/api/tests/devcomp/unit/domain/usecases/create-or-update-training-trigger_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-or-update-training-trigger_test.js
@@ -1,7 +1,7 @@
 import { createOrUpdateTrainingTrigger } from '../../../../../src/devcomp/domain/usecases/create-or-update-training-trigger.js';
-import { expect, catchErr, sinon } from '../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | UseCase | create-or-update-training-trigger', function () {
+describe('Unit | Devcomp | Domain | UseCases | create-or-update-training-trigger', function () {
   let trainingRepository;
   let trainingTriggerRepository;
 

--- a/api/tests/devcomp/unit/domain/usecases/create-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-training_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../../test-helper.js';
 import { createTraining } from '../../../../../src/devcomp/domain/usecases/create-training.js';
 
-describe('Unit | UseCase | create-training', function () {
+describe('Unit | Devcomp | Domain | UseCases | create-training', function () {
   it('should call training repository to create the training', async function () {
     // given
     const training = Symbol('training');

--- a/api/tests/devcomp/unit/domain/usecases/find-campaign-participation-trainings_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-campaign-participation-trainings_test.js
@@ -1,8 +1,8 @@
-import { sinon, expect, domainBuilder, catchErr } from '../../../../test-helper.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 import { findCampaignParticipationTrainings } from '../../../../../src/devcomp/domain/usecases/find-campaign-participation-trainings.js';
 import { UserNotAuthorizedToFindTrainings } from '../../../../../src/devcomp/domain/errors.js';
 
-describe('Unit | UseCase | find-campaign-participation-trainings', function () {
+describe('Unit | Devcomp | Domain | UseCases | find-campaign-participation-trainings', function () {
   let campaignParticipationRepository;
   let userRecommendedTrainingRepository;
 

--- a/api/tests/devcomp/unit/domain/usecases/find-paginated-target-profile-training-summaries_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-paginated-target-profile-training-summaries_test.js
@@ -1,7 +1,7 @@
-import { sinon, expect } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 import { findPaginatedTargetProfileTrainingSummaries as findPaginatedTargetProfileTrainings } from '../../../../../src/devcomp/domain/usecases/find-paginated-target-profile-training-summaries.js';
 
-describe('Unit | UseCase | findPaginatedTargetProfileTrainingSummaries', function () {
+describe('Unit | Devcomp | Domain | UseCases | findPaginatedTargetProfileTrainingSummaries', function () {
   it('should call the repository with the right arguments and return summaries', async function () {
     // given
     const page = Symbol('page');

--- a/api/tests/devcomp/unit/domain/usecases/find-paginated-trainings-summary_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-paginated-trainings-summary_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../../test-helper.js';
 import { findPaginatedTrainingSummaries } from '../../../../../src/devcomp/domain/usecases/find-paginated-training-summaries.js';
 
-describe('Unit | UseCase | find-paginated-training-summaries', function () {
+describe('Unit | Devcomp | Domain | UseCases | find-paginated-training-summaries', function () {
   it('should find filtered training summaries with pagination', async function () {
     // given
     const filter = { id: 1 };

--- a/api/tests/devcomp/unit/domain/usecases/find-paginated-user-recommended-trainings_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-paginated-user-recommended-trainings_test.js
@@ -1,7 +1,7 @@
-import { sinon, expect } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 import { findPaginatedUserRecommendedTrainings } from '../../../../../src/devcomp/domain/usecases/find-paginated-user-recommended-trainings.js';
 
-describe('Unit | UseCase | find-user-recommended-trainings', function () {
+describe('Unit | Devcomp | Domain | UseCases | find-user-recommended-trainings', function () {
   it('should return paginated recommended trainings', async function () {
     // given
     const userId = 123;

--- a/api/tests/devcomp/unit/domain/usecases/get-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module_test.js
@@ -1,7 +1,7 @@
 import { getModule } from '../../../../../src/devcomp/domain/usecases/get-module.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Usecases | get-module', function () {
+describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
   describe('#getModule', function () {
     it('should get and return a Module', async function () {
       // given

--- a/api/tests/devcomp/unit/domain/usecases/get-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-training_test.js
@@ -1,8 +1,8 @@
-import { expect, sinon, catchErr } from '../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 import { getTraining } from '../../../../../src/devcomp/domain/usecases/get-training.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
-describe('Unit | UseCase | get-training', function () {
+describe('Unit | Devcomp | Domain | UseCases | get-training', function () {
   let trainingRepository;
 
   beforeEach(function () {

--- a/api/tests/devcomp/unit/domain/usecases/handle-training-recommendation_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/handle-training-recommendation_test.js
@@ -1,7 +1,7 @@
 import { handleTrainingRecommendation } from '../../../../../src/devcomp/domain/usecases/handle-training-recommendation.js';
-import { expect, sinon, domainBuilder } from '../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | UseCase | handle-training-recommendation', function () {
+describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', function () {
   let trainingRepository;
   let userRecommendedTrainingRepository;
   let findWithTriggersByCampaignParticipationIdAndLocaleStub;

--- a/api/tests/devcomp/unit/domain/usecases/update-training_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/update-training_test.js
@@ -2,7 +2,7 @@ import { catchErr, expect, sinon } from '../../../../test-helper.js';
 import { updateTraining } from '../../../../../src/devcomp/domain/usecases/update-training.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
-describe('Unit | UseCase | update-training', function () {
+describe('Unit | Devcomp | Domain | UseCases | update-training', function () {
   let trainingRepository;
 
   beforeEach(function () {

--- a/api/tests/devcomp/unit/domain/usecases/verify-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-answer_test.js
@@ -1,7 +1,7 @@
 import { verifyAnswer } from '../../../../../src/devcomp/domain/usecases/verify-answer.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Usecases | verify-answer', function () {
+describe('Unit | Devcomp | Domain | UseCases | verify-answer', function () {
   describe('#verifyAnswer', function () {
     describe('When the selected proposal is valid', function () {
       it('should return a valid Correction Response', async function () {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -22,7 +22,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
           type: Joi.string().valid('image').required(),
           url: Joi.string().required(),
           alt: Joi.string().required(),
-          alternativeInstruction: Joi.string().required(),
+          alternativeText: Joi.string().required(),
         }).required();
 
         const qcuElementSchema = Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -17,6 +17,14 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
           content: Joi.string().required(),
         }).required();
 
+        const imageElementSchema = Joi.object({
+          id: uuidSchema,
+          type: Joi.string().valid('image').required(),
+          url: Joi.string().required(),
+          alt: Joi.string().required(),
+          alternativeInstruction: Joi.string().required(),
+        }).required();
+
         const qcuElementSchema = Joi.object({
           id: uuidSchema,
           type: Joi.string().valid('qcu').required(),
@@ -46,7 +54,9 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasour
                 id: uuidSchema,
                 type: Joi.string().valid('lesson', 'activity').required(),
                 title: Joi.string().required(),
-                elements: Joi.array().items(Joi.alternatives().try(textElementSchema, qcuElementSchema)).required(),
+                elements: Joi.array()
+                  .items(Joi.alternatives().try(textElementSchema, imageElementSchema, qcuElementSchema))
+                  .required(),
               }).required(),
             )
             .required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -3,7 +3,7 @@ import { expect } from '../../../../../test-helper.js';
 import { LearningContentResourceNotFound } from '../../../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import Joi from 'joi';
 
-describe('Unit | Infrastructure | Datasource | Learning Content | ModuleDatasource', function () {
+describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasource', function () {
   describe('#getBySlug', function () {
     describe('when exists', function () {
       let moduleSchema;

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-response-serializer_test.js
@@ -3,7 +3,7 @@ import { QcuCorrectionResponse } from '../../../../../../src/devcomp/domain/mode
 import { AnswerStatus } from '../../../../../../lib/domain/models/index.js';
 import * as correctionResponseSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/correction-response-serializer.js';
 
-describe('Unit | DevComp | Serializers | CorrectionResponseSerializer', function () {
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | CorrectionResponseSerializer', function () {
   describe('#serialize', function () {
     it('should return a serialized CorrectionReponse', function () {
       // given

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
@@ -5,7 +5,7 @@ import * as elementAnswerSerializer from '../../../../../../src/devcomp/infrastr
 import { ElementAnswer } from '../../../../../../src/devcomp/domain/models/ElementAnswer.js';
 import omit from 'lodash/omit.js';
 
-describe('Unit | DevComp | Serializers | ElementAnswerSerializer', function () {
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ElementAnswerSerializer', function () {
   describe('#serialize', function () {
     it('should return a serialized ElementAnswer', function () {
       // given

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -111,6 +111,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
               alt: 'alt',
               'alternative-instruction': 'alternativeInstruction',
               type: 'images',
+              'is-answerable': false,
             },
             id: '3',
             type: 'images',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -57,7 +57,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
                 instruction: 'hello',
                 solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
               }),
-              new Image({ id: '3', url: 'url', alt: 'alt', alternativeInstruction: 'alternativeInstruction' }),
+              new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
             ],
           },
         ],
@@ -109,7 +109,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             attributes: {
               url: 'url',
               alt: 'alt',
-              'alternative-instruction': 'alternativeInstruction',
+              'alternative-text': 'alternativeText',
               type: 'images',
               'is-answerable': false,
             },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -2,6 +2,7 @@ import { expect } from '../../../../../test-helper.js';
 import { Module } from '../../../../../../src/devcomp/domain/models/Module.js';
 import * as moduleSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js';
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
+import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 
 describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
@@ -56,6 +57,7 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
                 instruction: 'hello',
                 solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
               }),
+              new Image({ id: '3', url: 'url', alt: 'alt', alternativeInstruction: 'alternativeInstruction' }),
             ],
           },
         ],
@@ -105,6 +107,16 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
           },
           {
             attributes: {
+              url: 'url',
+              alt: 'alt',
+              'alternative-instruction': 'alternativeInstruction',
+              type: 'images',
+            },
+            id: '3',
+            type: 'images',
+          },
+          {
+            attributes: {
               title: 'Grain 1',
               type: 'activity',
             },
@@ -119,6 +131,10 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
                   {
                     id: '2',
                     type: 'qcus',
+                  },
+                  {
+                    id: '3',
+                    type: 'images',
                   },
                 ],
               },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -5,7 +5,7 @@ import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.j
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 
-describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerializer', function () {
   describe('#serialize', function () {
     it('should serialize with empty list', function () {
       // given

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -1,7 +1,7 @@
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
 
-describe('Unit | Serializer | JSONAPI | training-serializer', function () {
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-serializer', function () {
   describe('#serializeForAdmin', function () {
     it('should convert a training model to JSON API with specific learning content tree for each trigger', function () {
       // given

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -1,7 +1,7 @@
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-trigger-serializer.js';
 
-describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function () {
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-trigger-serializer', function () {
   describe('#serialize', function () {
     it('should convert a training trigger model to JSON', function () {
       // given

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -3,6 +3,8 @@
   {{#each @grain.elements as |element|}}
     {{#if element.isText}}
       <Module::Text @text={{element}} />
+    {{else if element.isImage}}
+      <Module::Image @image={{element}} />
     {{else if element.isQcu}}
       <Module::Qcu @qcu={{element}} @submitAnswer={{@submitAnswer}} />
     {{/if}}

--- a/mon-pix/app/pods/components/module/image/component.js
+++ b/mon-pix/app/pods/components/module/image/component.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ModuleImage extends Component {
+  @tracked modalIsOpen = false;
+
+  @action
+  showModal() {
+    this.modalIsOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.modalIsOpen = false;
+  }
+}

--- a/mon-pix/app/pods/components/module/image/styles.scss
+++ b/mon-pix/app/pods/components/module/image/styles.scss
@@ -1,0 +1,18 @@
+.element-image {
+  margin: $pix-spacing-s;
+
+  img {
+    display: block;
+    margin: 0 auto;
+  }
+}
+
+.image__modal-instruction {
+  // revert the reset
+  ul,
+  ol {
+    margin: revert;
+    padding: revert;
+    list-style: revert;
+  }
+}

--- a/mon-pix/app/pods/components/module/image/styles.scss
+++ b/mon-pix/app/pods/components/module/image/styles.scss
@@ -1,10 +1,16 @@
 .element-image {
   margin: $pix-spacing-s;
 
-  img {
-    display: block;
-    margin: 0 auto;
+  &-container {
+    aspect-ratio: auto 16 / 9;
+    margin: 0 auto $pix-spacing-xxs auto;
+
+    img {
+      display: block;
+      height: 100%;
+    }
   }
+
 }
 
 .image__modal-instruction {

--- a/mon-pix/app/pods/components/module/image/template.hbs
+++ b/mon-pix/app/pods/components/module/image/template.hbs
@@ -13,7 +13,7 @@
     {{t "pages.modulix.buttons.element.alternativeInstruction"}}
   </PixButton>
   <PixModal
-    @title="Quel titre ?"
+    @title={{t "pages.modulix.modals.alternativeInstruction.title"}}
     @showModal={{this.modalIsOpen}}
     @onCloseButtonClick={{this.closeModal}}
     class="element__image-modal"

--- a/mon-pix/app/pods/components/module/image/template.hbs
+++ b/mon-pix/app/pods/components/module/image/template.hbs
@@ -1,0 +1,24 @@
+<div class="element-image">
+  <img alt={{@image.alt}} src={{@image.url}} />
+  <PixButton
+    @backgroundColor="transparent-light"
+    @shape="rounded"
+    @size="small"
+    @type="button"
+    @triggerAction={{this.showModal}}
+  >
+    {{t "pages.modulix.buttons.element.alternativeInstruction"}}
+  </PixButton>
+  <PixModal
+    @title="Quel titre ?"
+    @showModal={{this.modalIsOpen}}
+    @onCloseButtonClick={{this.closeModal}}
+    class="element__image-modal"
+  >
+    <:content>
+      <p class="image__modal-instruction">
+        {{html-safe @image.alternativeInstruction}}
+      </p>
+    </:content>
+  </PixModal>
+</div>

--- a/mon-pix/app/pods/components/module/image/template.hbs
+++ b/mon-pix/app/pods/components/module/image/template.hbs
@@ -1,10 +1,13 @@
 <div class="element-image">
-  <img alt={{@image.alt}} src={{@image.url}} />
+  <div class="element-image-container">
+    <img alt={{@image.alt}} src={{@image.url}} />
+  </div>
   <PixButton
     @backgroundColor="transparent-light"
     @shape="rounded"
     @size="small"
     @type="button"
+    @isBorderVisible={{true}}
     @triggerAction={{this.showModal}}
   >
     {{t "pages.modulix.buttons.element.alternativeInstruction"}}

--- a/mon-pix/app/pods/components/module/image/template.hbs
+++ b/mon-pix/app/pods/components/module/image/template.hbs
@@ -10,17 +10,17 @@
     @isBorderVisible={{true}}
     @triggerAction={{this.showModal}}
   >
-    {{t "pages.modulix.buttons.element.alternativeInstruction"}}
+    {{t "pages.modulix.buttons.element.alternativeText"}}
   </PixButton>
   <PixModal
-    @title={{t "pages.modulix.modals.alternativeInstruction.title"}}
+    @title={{t "pages.modulix.modals.alternativeText.title"}}
     @showModal={{this.modalIsOpen}}
     @onCloseButtonClick={{this.closeModal}}
     class="element__image-modal"
   >
     <:content>
       <p class="image__modal-instruction">
-        {{html-safe @image.alternativeInstruction}}
+        {{html-safe @image.alternativeText}}
       </p>
     </:content>
   </PixModal>

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -11,6 +11,10 @@ export default class Element extends Model {
     return this.type === 'texts';
   }
 
+  get isImage() {
+    return this.type === 'images';
+  }
+
   get isQcu() {
     return this.type === 'qcus';
   }

--- a/mon-pix/app/pods/image/model.js
+++ b/mon-pix/app/pods/image/model.js
@@ -4,5 +4,5 @@ import Element from '../element/model';
 export default class Image extends Element {
   @attr('string') url;
   @attr('string') alt;
-  @attr('string') alternativeInstruction;
+  @attr('string') alternativeText;
 }

--- a/mon-pix/app/pods/image/model.js
+++ b/mon-pix/app/pods/image/model.js
@@ -1,0 +1,8 @@
+import { attr } from '@ember-data/model';
+import Element from '../element/model';
+
+export default class Image extends Element {
+  @attr('string') url;
+  @attr('string') alt;
+  @attr('string') alternativeInstruction;
+}

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -63,6 +63,30 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
+  module('when element is an image', function () {
+    test('should display image element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const url =
+        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+      const imageElement = store.createRecord('image', {
+        url,
+        alt: 'alt text',
+        alternativeInstruction: 'alternative instruction',
+        type: 'images',
+      });
+      const elements = [imageElement];
+      const grain = store.createRecord('grain', { title: 'Grain title', elements });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+    });
+  });
+
   module('when canDisplayContinueButton is true', function () {
     module('when all elements are answered', function () {
       test('should display continue button', async function (assert) {

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -72,7 +72,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const imageElement = store.createRecord('image', {
         url,
         alt: 'alt text',
-        alternativeInstruction: 'alternative instruction',
+        alternativeText: 'alternative instruction',
         type: 'images',
       });
       const elements = [imageElement];

--- a/mon-pix/tests/integration/components/module/image_test.js
+++ b/mon-pix/tests/integration/components/module/image_test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { click, findAll } from '@ember/test-helpers';
+
+module('Integration | Component | Module | Image', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display an image', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const url =
+      'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+
+    const imageElement = store.createRecord('image', {
+      url,
+      alt: 'alt text',
+      alternativeInstruction: 'alternative instruction',
+    });
+
+    this.set('image', imageElement);
+
+    //  when
+    const screen = await render(hbs`<Module::Image @image={{this.image}}/>`);
+
+    // then
+    assert.ok(screen);
+    assert.strictEqual(findAll('.element-image').length, 1);
+    assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+    assert.ok(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
+  });
+
+  test('should be able to use the modal for alternative instruction', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const alternativeInstruction = 'alternative instruction';
+
+    const imageElement = store.createRecord('image', {
+      url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      alt: 'alt text',
+      alternativeInstruction,
+    });
+
+    this.set('image', imageElement);
+
+    //  when
+    const screen = await render(hbs`<Module::Image @image={{this.image}}/>`);
+
+    // then
+    await click(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
+    assert.strictEqual(findAll('.element__image-modal').length, 1);
+    assert.ok(screen.getByText(alternativeInstruction));
+  });
+});

--- a/mon-pix/tests/integration/components/module/image_test.js
+++ b/mon-pix/tests/integration/components/module/image_test.js
@@ -16,7 +16,7 @@ module('Integration | Component | Module | Image', function (hooks) {
     const imageElement = store.createRecord('image', {
       url,
       alt: 'alt text',
-      alternativeInstruction: 'alternative instruction',
+      alternativeText: 'alternative instruction',
     });
 
     this.set('image', imageElement);
@@ -34,12 +34,12 @@ module('Integration | Component | Module | Image', function (hooks) {
   test('should be able to use the modal for alternative instruction', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
-    const alternativeInstruction = 'alternative instruction';
+    const alternativeText = 'alternative instruction';
 
     const imageElement = store.createRecord('image', {
       url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
       alt: 'alt text',
-      alternativeInstruction,
+      alternativeText,
     });
 
     this.set('image', imageElement);
@@ -50,6 +50,6 @@ module('Integration | Component | Module | Image', function (hooks) {
     // then
     await click(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
     assert.strictEqual(findAll('.element__image-modal').length, 1);
-    assert.ok(screen.getByText(alternativeInstruction));
+    assert.ok(screen.getByText(alternativeText));
   });
 });

--- a/mon-pix/tests/unit/components/module/image_test.js
+++ b/mon-pix/tests/unit/components/module/image_test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createPodsComponent from '../../../helpers/create-pods-component';
+
+module('Unit | Component | Module | Image', function (hooks) {
+  setupTest(hooks);
+
+  module('#closeModal', function () {
+    module('When we want to close the modal', function () {
+      test('should switch the #modalIsOpen boolean', async function (assert) {
+        // given
+        const component = createPodsComponent('module/image');
+        assert.false(component.modalIsOpen);
+
+        component.showModal();
+
+        // when
+        assert.true(component.modalIsOpen);
+        component.closeModal();
+
+        // then
+        assert.false(component.modalIsOpen);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/models/modules/element_test.js
+++ b/mon-pix/tests/unit/models/modules/element_test.js
@@ -23,13 +23,44 @@ module('Unit | Model | Module | Element', function (hooks) {
       test('should return false', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        ['qcus'].forEach((type) => {
+        ['qcus', 'image'].forEach((type) => {
           // when
           const element = store.createRecord('element', { type });
           const isText = element.isText;
 
           // then
           assert.false(isText);
+        });
+      });
+    });
+  });
+
+  module('#isImage', function () {
+    module('when type is images', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'images' });
+
+        // when
+        const isImage = element.isImage;
+
+        // then
+        assert.true(isImage);
+      });
+    });
+
+    module('when type is not images', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        ['texts', 'qcus'].forEach((type) => {
+          // when
+          const element = store.createRecord('element', { type });
+          const isImage = element.isImage;
+
+          // then
+          assert.false(isImage);
         });
       });
     });
@@ -54,7 +85,7 @@ module('Unit | Model | Module | Element', function (hooks) {
       test('should return false', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        ['texts'].forEach((type) => {
+        ['texts', 'image'].forEach((type) => {
           // when
           const element = store.createRecord('element', { type });
           const isQcu = element.isQcu;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1181,6 +1181,11 @@
           "continue": "Continue"
         }
       },
+      "modals": {
+        "alternativeInstruction": {
+          "title": "Alternative text"
+        }
+      },
       "qcu": {
         "direction": "Select one answer."
       }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1174,6 +1174,9 @@
         "activity": {
           "verify": "Verify"
         },
+        "element": {
+          "alternativeInstruction": "Show alternative text"
+        },
         "grain": {
           "continue": "Continue"
         }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1175,14 +1175,14 @@
           "verify": "Verify"
         },
         "element": {
-          "alternativeInstruction": "Show alternative text"
+          "alternativeText": "Show alternative text"
         },
         "grain": {
           "continue": "Continue"
         }
       },
       "modals": {
-        "alternativeInstruction": {
+        "alternativeText": {
           "title": "Alternative text"
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1175,14 +1175,14 @@
           "verify": "Vérifier"
         },
         "element": {
-          "alternativeInstruction": "Afficher l'alternative textuelle"
+          "alternativeText": "Afficher l'alternative textuelle"
         },
         "grain": {
           "continue": "Continuer"
         }
       },
       "modals": {
-        "alternativeInstruction": {
+        "alternativeText": {
           "title": "Alternative textuelle"
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1174,6 +1174,9 @@
         "activity": {
           "verify": "Vérifier"
         },
+        "element": {
+          "alternativeInstruction": "Afficher l'alternative textuelle"
+        },
         "grain": {
           "continue": "Continuer"
         }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1181,6 +1181,11 @@
           "continue": "Continuer"
         }
       },
+      "modals": {
+        "alternativeInstruction": {
+          "title": "Alternative textuelle"
+        }
+      },
       "qcu": {
         "direction": "Choisissez une seule réponse."
       }


### PR DESCRIPTION
## :unicorn: Problème
En tant qu’apprenant je souhaite que mon apprentissage soit étayé d’un visuel.

## :robot: Proposition
Côté API, nous avons ajouté le domain model `Image`.
Côté front, nous avons rajouté le composant `Image` qui étend `Element`, et nous utilisons `PixModal` pour l'affichage de l'alternative textuelle.

## :rainbow: Remarques
> _..._

## :100: Pour tester
Aller sur [ce lien](https://app-pr7508.review.pix.fr/modules/bien-ecrire-son-adresse-mail). Vérifier que :
- Je vois bien l’image
- Je peux accéder à l’alternative textuelle dans une modal en cliquant sur un bouton “_Afficher l'alternative textuelle_” sous l’image.
