### PR TITLE
[FEATURE] Rejeter une certification si le candidat n'a pas répondu à assez de questions (PIX-9980).

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -38,6 +38,7 @@ async function handleCertificationRescoring({
         answerRepository,
         certificationAssessment,
         assessmentResultRepository,
+        certificationCourseRepository,
         flashAlgorithmService,
       });
     }
@@ -70,16 +71,20 @@ async function _handleV3Certification({
   answerRepository,
   certificationAssessment,
   assessmentResultRepository,
+  certificationCourseRepository,
   flashAlgorithmService,
 }) {
   const allAnswers = await answerRepository.findByAssessment(certificationAssessment.id);
   const challengeIds = allAnswers.map(({ challengeId }) => challengeId);
   const challenges = await challengeRepository.getManyFlashParameters(challengeIds);
 
+  const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     challenges,
     allAnswers,
     flashAlgorithmService,
+    abortReason: certificationCourse.isAbortReasonCandidateRelated() ? 'candidate' : 'technical',
   });
 
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult({

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -10,6 +10,7 @@ import { CertificationJuryDone } from './CertificationJuryDone.js';
 import { checkEventTypes } from './check-event-types.js';
 import { CertificationVersion } from '../../../src/shared/domain/models/CertificationVersion.js';
 import { CertificationAssessmentScoreV3 } from '../models/CertificationAssessmentScoreV3.js';
+import { ABORT_REASONS } from '../models/CertificationCourse.js';
 
 const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized, CertificationJuryDone];
 const EMITTER = 'PIX-ALGO';
@@ -80,11 +81,15 @@ async function _handleV3Certification({
 
   const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
 
+  const abortReason = certificationCourse.isAbortReasonCandidateRelated()
+    ? ABORT_REASONS.CANDIDATE
+    : ABORT_REASONS.TECHNICAL;
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     challenges,
     allAnswers,
     flashAlgorithmService,
-    abortReason: certificationCourse.isAbortReasonCandidateRelated() ? 'candidate' : 'technical',
+    abortReason,
   });
 
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult({

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -7,6 +7,7 @@ import { AssessmentCompleted } from './AssessmentCompleted.js';
 import { checkEventTypes } from './check-event-types.js';
 import { CertificationVersion } from '../../../src/shared/domain/models/CertificationVersion.js';
 import { CertificationAssessmentScoreV3 } from '../models/CertificationAssessmentScoreV3.js';
+import { ABORT_REASONS } from '../models/CertificationCourse.js';
 
 const eventTypes = [AssessmentCompleted];
 const EMITTER = 'PIX-ALGO';
@@ -111,11 +112,15 @@ async function _handleV3CertificationScoring({
 
   const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
 
+  const abortReason = certificationCourse.isAbortReasonCandidateRelated()
+    ? ABORT_REASONS.CANDIDATE
+    : ABORT_REASONS.TECHNICAL;
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     challenges,
     allAnswers,
     flashAlgorithmService,
-    abortReason: certificationCourse.isAbortReasonCandidateRelated() ? 'candidate' : 'technical',
+    abortReason,
   });
 
   await _saveResult({

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,5 +1,6 @@
 import { status as CertificationStatus } from './AssessmentResult.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
+import { config } from '../../../src/shared/config.js';
 
 const MINIMUM_ESTIMATED_LEVEL = -8;
 const MAXIMUM_ESTIMATED_LEVEL = 8;
@@ -112,7 +113,7 @@ const _computeScore = (estimatedLevel) => {
 };
 
 const _isCertificationRejected = ({ answers }) => {
-  return answers.length < 10;
+  return answers.length < config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
 };
 
 export { CertificationAssessmentScoreV3 };

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,6 +1,7 @@
 import { status as CertificationStatus } from './AssessmentResult.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
 import { config } from '../../../src/shared/config.js';
+import { ABORT_REASONS } from './CertificationCourse.js';
 
 const MINIMUM_ESTIMATED_LEVEL = -8;
 const MAXIMUM_ESTIMATED_LEVEL = 8;
@@ -115,7 +116,7 @@ const _computeScore = (estimatedLevel) => {
 const _isCertificationRejected = ({ answers, abortReason }) => {
   return (
     answers.length < config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification &&
-    abortReason === 'candidate'
+    abortReason === ABORT_REASONS.CANDIDATE
   );
 };
 

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,4 +1,4 @@
-import { status } from './AssessmentResult.js';
+import { status as CertificationStatus } from './AssessmentResult.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
 
 const MINIMUM_ESTIMATED_LEVEL = -8;
@@ -47,9 +47,10 @@ const MAX_PIX_SCORE = 1024;
 const INTERVAL_HEIGHT = MAX_PIX_SCORE / scoreIntervals.length;
 
 class CertificationAssessmentScoreV3 {
-  constructor({ nbPix, percentageCorrectAnswers = 100 }) {
+  constructor({ nbPix, percentageCorrectAnswers = 100, status = CertificationStatus.VALIDATED }) {
     this.nbPix = nbPix;
     this.percentageCorrectAnswers = percentageCorrectAnswers;
+    this._status = status;
   }
 
   static fromChallengesAndAnswers({ challenges, allAnswers, flashAlgorithmService }) {
@@ -63,13 +64,18 @@ class CertificationAssessmentScoreV3 {
 
     const nbPix = _computeScore(estimatedLevel);
 
+    const status = _isCertificationRejected({ answers: allAnswers })
+      ? CertificationStatus.REJECTED
+      : CertificationStatus.VALIDATED;
+
     return new CertificationAssessmentScoreV3({
       nbPix,
+      status,
     });
   }
 
   get status() {
-    return status.VALIDATED;
+    return this._status;
   }
 
   get competenceMarks() {
@@ -103,6 +109,10 @@ const _computeScore = (estimatedLevel) => {
   const score = INTERVAL_HEIGHT * (intervalIndex + 1 + (normalizedEstimatedLevel - intervalMaxValue) / intervalWidth);
 
   return Math.round(score);
+};
+
+const _isCertificationRejected = ({ answers }) => {
+  return answers.length < 10;
 };
 
 export { CertificationAssessmentScoreV3 };

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -54,7 +54,7 @@ class CertificationAssessmentScoreV3 {
     this._status = status;
   }
 
-  static fromChallengesAndAnswers({ challenges, allAnswers, flashAlgorithmService }) {
+  static fromChallengesAndAnswers({ challenges, allAnswers, flashAlgorithmService, abortReason }) {
     const algorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,
     });
@@ -65,7 +65,7 @@ class CertificationAssessmentScoreV3 {
 
     const nbPix = _computeScore(estimatedLevel);
 
-    const status = _isCertificationRejected({ answers: allAnswers })
+    const status = _isCertificationRejected({ answers: allAnswers, abortReason })
       ? CertificationStatus.REJECTED
       : CertificationStatus.VALIDATED;
 
@@ -112,8 +112,11 @@ const _computeScore = (estimatedLevel) => {
   return Math.round(score);
 };
 
-const _isCertificationRejected = ({ answers }) => {
-  return answers.length < config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
+const _isCertificationRejected = ({ answers, abortReason }) => {
+  return (
+    answers.length < config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification &&
+    abortReason === 'candidate'
+  );
 };
 
 export { CertificationAssessmentScoreV3 };

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -5,7 +5,10 @@ const Joi = BaseJoi.extend(JoiDate);
 import { EntityValidationError } from '../../../src/shared/domain/errors.js';
 import { CertificationVersion } from '../../../src/shared/domain/models/CertificationVersion.js';
 
-const ABORT_REASONS = ['candidate', 'technical'];
+export const ABORT_REASONS = {
+  CANDIDATE: 'candidate',
+  TECHNICAL: 'technical',
+};
 
 class CertificationCourse {
   constructor({
@@ -115,7 +118,7 @@ class CertificationCourse {
 
   abort(reason) {
     const { error } = Joi.string()
-      .valid(...ABORT_REASONS)
+      .valid(...Object.values(ABORT_REASONS))
       .validate(reason);
     if (error)
       throw new EntityValidationError({
@@ -192,11 +195,11 @@ class CertificationCourse {
   }
 
   isAbortReasonCandidateRelated() {
-    return this._abortReason === 'candidate';
+    return this._abortReason === ABORT_REASONS.CANDIDATE;
   }
 
   isAbortReasonCandidateUnrelated() {
-    return this._abortReason === 'technical';
+    return this._abortReason === ABORT_REASONS.TECHNICAL;
   }
 
   isPublished() {

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -346,6 +346,9 @@ const configuration = (function () {
       defaultProbabilityToPickChallenge: parseInt(process.env.DEFAULT_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
       defaultCandidateCapacity: -3,
       challengesBetweenSameCompetence: 2,
+      scoring: {
+        minimumAnswersRequiredToValidateACertification: 10,
+      },
     },
     version: process.env.CONTAINER_VERSION || 'development',
     autonomousCourse: {

--- a/api/tests/certification/shared/fixtures/challenges.js
+++ b/api/tests/certification/shared/fixtures/challenges.js
@@ -1,0 +1,16 @@
+import _ from 'lodash';
+import { domainBuilder } from '../../../test-helper.js';
+
+export const generateChallengeList = ({ length }) =>
+  _.range(0, length).map((index) =>
+    domainBuilder.buildChallenge({
+      id: `chall${index}`,
+    }),
+  );
+
+export const generateAnswersForChallenges = ({ challenges }) =>
+  challenges.map(({ id: challengeId }) =>
+    domainBuilder.buildAnswer({
+      challengeId,
+    }),
+  );

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment-score-v3.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment-score-v3.js
@@ -1,7 +1,9 @@
 import { CertificationAssessmentScoreV3 } from '../../../../lib/domain/models/CertificationAssessmentScoreV3.js';
+import { status as CertificationStatus } from '../../../../lib/domain/models/AssessmentResult.js';
 
-const buildCertificationAssessmentScoreV3 = function ({ nbPix = 100 } = {}) {
+const buildCertificationAssessmentScoreV3 = function ({ nbPix = 100, status = CertificationStatus.VALIDATED } = {}) {
   return new CertificationAssessmentScoreV3({
+    status,
     nbPix,
   });
 };

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -8,6 +8,7 @@ import {
   CertificationIssueReportSubcategories,
   CertificationIssueReportCategory,
 } from '../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse.js';
 
 describe('Unit | Domain | Events | handle-auto-jury', function () {
   it('fails when event is not of correct type', async function () {
@@ -221,7 +222,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         sessionId: 1234,
         id: 4567,
         completedAt: null,
-        abortReason: 'candidate',
+        abortReason: ABORT_REASONS.CANDIDATE,
       });
       certificationCourseRepository.findCertificationCoursesBySessionId
         .withArgs({ sessionId: 1234 })
@@ -281,7 +282,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         });
         const certificationCourse = domainBuilder.buildCertificationCourse({
           completedAt: null,
-          abortReason: 'candidate',
+          abortReason: ABORT_REASONS.CANDIDATE,
         });
         certificationCourseRepository.findCertificationCoursesBySessionId
           .withArgs({ sessionId: 1234 })
@@ -349,7 +350,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         });
         const certificationCourse = domainBuilder.buildCertificationCourse({
           completedAt: null,
-          abortReason: 'technical',
+          abortReason: ABORT_REASONS.TECHNICAL,
         });
         certificationCourseRepository.findCertificationCoursesBySessionId
           .withArgs({ sessionId: 1234 })
@@ -419,7 +420,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
       });
       const certificationCourse = domainBuilder.buildCertificationCourse({
         completedAt: null,
-        abortReason: 'candidate',
+        abortReason: ABORT_REASONS.CANDIDATE,
       });
       certificationCourseRepository.findCertificationCoursesBySessionId
         .withArgs({ sessionId: 1234 })

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -34,12 +34,20 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           getManyFlashParameters: sinon.stub(),
         };
 
+        const certificationCourseRepository = {
+          get: sinon.stub(),
+        };
+
         const flashAlgorithmService = {
           getEstimatedLevelAndErrorRate: sinon.stub(),
         };
 
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           version: CertificationVersion.V3,
+        });
+
+        const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
+          abortReason: 'candidate',
         });
 
         const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
@@ -58,6 +66,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
         challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
+
+        certificationCourseRepository.get
+          .withArgs(certificationAssessment.certificationCourseId)
+          .resolves(abortedCertificationCourse);
 
         flashAlgorithmService.getEstimatedLevelAndErrorRate
           .withArgs({
@@ -80,6 +92,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           answerRepository,
           challengeRepository,
           assessmentResultRepository,
+          certificationCourseRepository,
           flashAlgorithmService,
         };
 
@@ -112,6 +125,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         expect(result).to.deep.equal(expectedEvent);
       });
     });
+
     it('should save the score', async function () {
       const assessmentResultRepository = {
         save: sinon.stub(),
@@ -126,12 +140,20 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         getManyFlashParameters: sinon.stub(),
       };
 
+      const certificationCourseRepository = {
+        get: sinon.stub(),
+      };
+
       const flashAlgorithmService = {
         getEstimatedLevelAndErrorRate: sinon.stub(),
       };
 
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         version: CertificationVersion.V3,
+      });
+
+      const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
+        abortReason: 'technical',
       });
 
       const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });
@@ -150,6 +172,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
       challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
+
+      certificationCourseRepository.get
+        .withArgs(certificationAssessment.certificationCourseId)
+        .resolves(abortedCertificationCourse);
 
       flashAlgorithmService.getEstimatedLevelAndErrorRate
         .withArgs({
@@ -171,6 +197,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         certificationAssessmentRepository,
         answerRepository,
         challengeRepository,
+        certificationCourseRepository,
         assessmentResultRepository,
         flashAlgorithmService,
       };

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -12,6 +12,7 @@ import {
   generateAnswersForChallenges,
   generateChallengeList,
 } from '../../../certification/shared/fixtures/challenges.js';
+import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse.js';
 
 const CERTIFICATION_RESULT_EMITTER_AUTOJURY = CertificationResult.emitters.PIX_ALGO_AUTO_JURY;
 const CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION = CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION;
@@ -47,7 +48,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         });
 
         const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
-          abortReason: 'candidate',
+          abortReason: ABORT_REASONS.CANDIDATE,
         });
 
         const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
@@ -153,7 +154,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       });
 
       const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
-        abortReason: 'technical',
+        abortReason: ABORT_REASONS.TECHNICAL,
       });
 
       const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -309,7 +309,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         const competenceMarkRepository = { save: sinon.stub() };
         const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
         const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
-        sinon.spy(certificationCourse, 'cancel');
 
         const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
         const certificationAssessment = new CertificationAssessment({
@@ -370,13 +369,16 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         });
 
         // then
+        const expectedCertificationCourse = domainBuilder.buildCertificationCourse({
+          id: certificationCourse.getId(),
+          isCancelled: true,
+        });
 
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
           certificationCourseId: 789,
           assessmentResult: assessmentResultToBeSaved,
         });
-        expect(certificationCourse.cancel).to.have.been.calledOnce;
-        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedCertificationCourse);
       });
     });
 
@@ -391,8 +393,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
         const competenceMarkRepository = { save: sinon.stub() };
         const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
-        sinon.spy(certificationCourse, 'uncancel');
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789, isCancelled: true });
 
         const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
         const certificationAssessment = new CertificationAssessment({
@@ -454,12 +455,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         });
 
         // then
+        const expectedCertificationCourse = domainBuilder.buildCertificationCourse({ id: 789, isCancelled: false });
+
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
           certificationCourseId: 789,
           assessmentResult: assessmentResultToBeSaved,
         });
-        expect(certificationCourse.uncancel).to.have.been.calledOnce;
-        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedCertificationCourse);
       });
     });
 

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -8,10 +8,14 @@ import { CertificationAssessment, CertificationResult, AssessmentResult } from '
 import { CertificationComputeError } from '../../../../lib/domain/errors.js';
 import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
 import { config } from '../../../../src/shared/config.js';
-import _ from 'lodash';
+import {
+  generateAnswersForChallenges,
+  generateChallengeList,
+} from '../../../certification/shared/fixtures/challenges.js';
 
 const CERTIFICATION_RESULT_EMITTER_AUTOJURY = CertificationResult.emitters.PIX_ALGO_AUTO_JURY;
 const CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION = CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION;
+const { minimumAnswersRequiredToValidateACertification } = config.v3Certification.scoring;
 
 describe('Unit | Domain | Events | handle-certification-rescoring', function () {
   describe('when handling a v3 certification', function () {
@@ -38,22 +42,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           version: CertificationVersion.V3,
         });
 
-        const challenges = _.range(
-          0,
-          config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1,
-        ).map((index) =>
-          domainBuilder.buildChallenge({
-            id: `chall${index}`,
-          }),
-        );
-
+        const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
         const challengeIds = challenges.map(({ id }) => id);
 
-        const answers = challenges.map(({ id: challengeId }) =>
-          domainBuilder.buildAnswer({
-            challengeId,
-          }),
-        );
+        const answers = generateAnswersForChallenges({ challenges });
 
         const expectedEstimatedLevel = 2;
         const scoreForEstimatedLevel = 592;
@@ -142,20 +134,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         version: CertificationVersion.V3,
       });
 
-      const challenges = _.range(0, config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification).map(
-        (index) =>
-          domainBuilder.buildChallenge({
-            id: `chall${index}`,
-          }),
-      );
-
+      const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });
       const challengeIds = challenges.map(({ id }) => id);
 
-      const answers = challenges.map(({ id: challengeId }) =>
-        domainBuilder.buildAnswer({
-          challengeId,
-        }),
-      );
+      const answers = generateAnswersForChallenges({ challenges });
 
       const expectedEstimatedLevel = 2;
       const scoreForEstimatedLevel = 592;

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -311,11 +311,15 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         };
       });
 
-      describe('when less than the minimum number of answers required by the config has been answered', function () {
+      describe('when less than the minimum number of answers required by the config has been answered and the candidate abandoned', function () {
         it('should build and save an assessment result with the expected arguments', async function () {
           // given
           const expectedEstimatedLevel = 2;
           const scoreForEstimatedLevel = 592;
+          const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
+            id: certificationCourseId,
+            abortReason: 'candidate',
+          });
 
           const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
           const challengeIds = challenges.map(({ id }) => id);
@@ -324,7 +328,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
           challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
           answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
-          certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
+          certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
@@ -373,6 +377,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             new CertificationCourse({
               ...certificationCourse.toDTO(),
               completedAt: now,
+              abortReason: 'candidate',
             }),
           );
         });

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { AnswerStatus } from '../../../../lib/domain/models/index.js';
 import { CertificationAssessmentScoreV3 } from '../../../../lib/domain/models/CertificationAssessmentScoreV3.js';
+import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { config } from '../../../../src/shared/config.js';
 
 describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function () {
   const assessmentId = 1234;
@@ -158,6 +160,65 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
       // then
       expect(score.nbPix).to.equal(1024);
+    });
+  });
+
+  describe('status', function () {
+    describe('when a certification has 10 or more answers', function () {
+      it('should be validated', function () {
+        const difficulty = 0;
+        const numberOfChallenges = 10;
+        const challenges = _buildChallenges(difficulty, numberOfChallenges);
+        const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
+
+        flashAlgorithmService.getEstimatedLevelAndErrorRate
+          .withArgs(
+            _getEstimatedLevelAndErrorRateParams({
+              challenges,
+              allAnswers,
+              estimatedLevel: sinon.match.number,
+            }),
+          )
+          .returns({
+            estimatedLevel: 0,
+          });
+
+        const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+          challenges,
+          allAnswers,
+          flashAlgorithmService,
+        });
+
+        expect(score.status).to.equal(status.VALIDATED);
+      });
+    });
+
+    describe('when a certification has less than 10 answers', function () {
+      it('should be rejected', function () {
+        const difficulty = 0;
+        const numberOfChallenges = 9;
+        const challenges = _buildChallenges(difficulty, numberOfChallenges);
+        const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
+        flashAlgorithmService.getEstimatedLevelAndErrorRate
+          .withArgs(
+            _getEstimatedLevelAndErrorRateParams({
+              challenges,
+              allAnswers,
+              estimatedLevel: sinon.match.number,
+            }),
+          )
+          .returns({
+            estimatedLevel: 0,
+          });
+
+        const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+          challenges,
+          allAnswers,
+          flashAlgorithmService,
+        });
+
+        expect(score.status).to.equal(status.REJECTED);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -215,9 +215,40 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           challenges,
           allAnswers,
           flashAlgorithmService,
+          abortReason: 'candidate',
         });
 
         expect(score.status).to.equal(status.REJECTED);
+      });
+    });
+
+    describe('when less than the minimum number of answers required by the config has been answered and the candidate didnt quit', function () {
+      it('should be validated', function () {
+        const difficulty = 0;
+        const certificationCourseAbortReason = 'technical';
+        const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
+        const challenges = _buildChallenges(difficulty, numberOfChallenges);
+        const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
+        flashAlgorithmService.getEstimatedLevelAndErrorRate
+          .withArgs(
+            _getEstimatedLevelAndErrorRateParams({
+              challenges,
+              allAnswers,
+              estimatedLevel: sinon.match.number,
+            }),
+          )
+          .returns({
+            estimatedLevel: 0,
+          });
+
+        const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+          challenges,
+          allAnswers,
+          flashAlgorithmService,
+          certificationCourseAbortReason,
+        });
+
+        expect(score.status).to.equal(status.VALIDATED);
       });
     });
   });

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -164,7 +164,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   });
 
   describe('status', function () {
-    describe('when a certification has config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification or more answers', function () {
+    describe('when at least the minimum number of answers required by the config has been answered', function () {
       it('should be validated', function () {
         const difficulty = 0;
         const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
@@ -193,7 +193,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       });
     });
 
-    describe('when a certification has less than config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification answers', function () {
+    describe('when less than the minimum number of answers required by the config has been answered', function () {
       it('should be rejected', function () {
         const difficulty = 0;
         const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -164,10 +164,10 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   });
 
   describe('status', function () {
-    describe('when a certification has 10 or more answers', function () {
+    describe('when a certification has config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification or more answers', function () {
       it('should be validated', function () {
         const difficulty = 0;
-        const numberOfChallenges = 10;
+        const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
@@ -193,10 +193,10 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       });
     });
 
-    describe('when a certification has less than 10 answers', function () {
+    describe('when a certification has less than config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification answers', function () {
       it('should be rejected', function () {
         const difficulty = 0;
-        const numberOfChallenges = 9;
+        const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
         flashAlgorithmService.getEstimatedLevelAndErrorRate


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la nouvelle certification, des nouvelles règles de scoring ont été décidées, afin de coller avec la nouvelle philosophie de la certif.

## :robot: Proposition
Pour une certification non terminée, avec moins de 10 questions, et dont la raison de l’abandon sélectionnée lors de la finalisation de la session est “_Abandon : manque de temps ou départ prématuré_” :

## :100: Pour tester
- créer une session v3 et inscrire un candidat en renseignant un destinataire des résultats = soi-même (pour recevoir le csv des résultats après publication 😉 )
- lancer le test avec le candidat, et ne répondre qu'à 1 question
- dans Pix certif, cliquer sur “Finaliser la session”
- sélectionner l’option “_Abandon : manque de temps ou départ prématuré_” comme raison de l’abandon puis confirmer la finalisation
- dans Pix admin > ouvrir la page de détails de la certif 
- résultat : le statut de la certif est “Rejetée”
- publier la session
- sur le compte app du candidat, ouvrir la page 'Mes certifications”
- résultat : la certif est au statut rejetée
- ouvrir le mail reçu avec les résultat de la certif
- résultat : pour cette certification, il est indiqué “Rejetée” dans la colonne “Statut”