### PR TITLE
[BUG] Le manque de référent Pix pour CLEA ne doit pas bloquer l'envoi de résultats de certifications (PIX-10013).

### DIFF
--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -1,3 +1,6 @@
+/**
+ * @typedef {import ('../../../lib/domain/usecases/index.js').dependencies} deps
+ */
 import {
   SendingEmailToResultRecipientError,
   SessionAlreadyPublishedError,
@@ -10,6 +13,12 @@ const { some, uniqBy } = lodash;
 
 import { logger } from '../../infrastructure/logger.js';
 
+/**
+ * @param {Object} params
+ * @param {deps['certificationRepository']} params.certificationRepository
+ * @param {deps['finalizedSessionRepository']} params.finalizedSessionRepository
+ * @param {deps['sessionRepository']} params.sessionRepository
+ */
 async function publishSession({
   publishedAt = new Date(),
   sessionId,
@@ -31,6 +40,13 @@ async function publishSession({
   return session;
 }
 
+/**
+ * @param {Object} params
+ * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
+ * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {Object} params.dependencies
+ * @param {deps['mailService']} params.dependencies.mailService
+ */
 async function manageEmails({
   i18n,
   session,
@@ -82,6 +98,10 @@ async function manageEmails({
   }
 }
 
+/**
+ * @param {Object} params
+ * @param {deps['mailService']} params.mailService
+ */
 async function _sendPrescriberEmails({ session, mailService, i18n }) {
   const recipientEmails = _distinctCandidatesResultRecipientEmails(session.certificationCandidates);
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -208,6 +208,18 @@ function requirePoleEmploiNotifier() {
   }
 }
 
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ *
+ * @typedef {{
+ *  certificationCenterRepository : certificationCenterRepository,
+ *  certificationRepository : certificationRepository,
+ *  finalizedSessionRepository : finalizedSessionRepository,
+ *  mailService : mailService,
+ *  sessionPublicationService : sessionPublicationService,
+ *  sessionRepository : sessionRepository,
+ * }} dependencies
+ */
 const dependencies = {
   accountRecoveryDemandRepository,
   activityAnswerRepository,

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -1,3 +1,15 @@
+/**
+ * @typedef {import ('../../../lib/domain/usecases/index.js').dependencies} deps
+ */
+
+/**
+ * @param {Object} params
+ * @param {deps['certificationRepository']} params.certificationRepository
+ * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
+ * @param {deps['finalizedSessionRepository']} params.finalizedSessionRepository
+ * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {deps['sessionPublicationService']} params.sessionPublicationService
+ */
 const publishSession = async function ({
   i18n,
   sessionId,

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -389,6 +389,7 @@ describe('Unit | UseCase | session-publication-service', function () {
           // then
           expect(sessionRepository.hasSomeCleaAcquired).to.have.been.calledOnce;
           expect(certificationCenterRepository.getRefererEmails).to.have.been.calledOnce;
+          expect(mailService.sendNotificationToCertificationCenterRefererForCleaResults).to.not.have.been.called;
           expect(mailService.sendCertificationResultEmail).to.have.been.calledTwice;
         });
       });

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -369,6 +369,29 @@ describe('Unit | UseCase | session-publication-service', function () {
           });
         });
       });
+
+      context('when there is no referer', function () {
+        it('should send result emails', async function () {
+          // given
+          mailService.sendCertificationResultEmail.resolves(EmailingAttempt.success(recipient1));
+          sessionRepository.hasSomeCleaAcquired.withArgs(originalSession.id).resolves(true);
+          certificationCenterRepository.getRefererEmails.withArgs(originalSession.certificationCenterId).resolves([]);
+
+          // when
+          await manageEmails({
+            i18n,
+            session: originalSession,
+            certificationCenterRepository,
+            sessionRepository,
+            dependencies: { mailService },
+          });
+
+          // then
+          expect(sessionRepository.hasSomeCleaAcquired).to.have.been.calledOnce;
+          expect(certificationCenterRepository.getRefererEmails).to.have.been.calledOnce;
+          expect(mailService.sendCertificationResultEmail).to.have.been.calledTwice;
+        });
+      });
     });
 
     context('When at least one of the e-mail sending fails', function () {


### PR DESCRIPTION
## :unicorn: Problème

Si aucun référent CléA Numérique n’a été désigné pour un centre de certification pourtant habilité à les délivrer, alors aucun mail de résultats ne part en direction des éventuels destinataires des résultats pourtant bien désignés lors de l’inscription des candidats.

## :robot: Proposition

Appliquer les règles suivantes à la place du `warn` actuel :

* Pas de référent CléA = mail(s) envoyé(s) au(x) destinataire(s) de résultats
* Un référent CléA désigné = mail(s) envoyé(s) au(x) destinataire(s) de résultats (y compris si référent CléA en fait partie) + mail unique envoyé au référent CléA
* Cas particulier si référent CléA = destinataire de résultats, alors il reçoit 2 mails : l'un pour les résultats et l'autre pour la partie CléA (ce sont 2 templates de mails différents avec des informations différentes, je peux te les montrer si besoin).

## :rainbow: Remarques
* Les dépendances de `session-publication-service` est confusante, elle contient des couplages forts à l'infra et ne passe par le moteur d'injection de dépendances
  * Est-ce que l'on profite de cette PR pour refactorer cela ? 

## :100: Pour tester

* Sur Pix certif, avec `certif-pro@example.net`, vérifiez que dans Equipe il n'y a pas de Référent Pix
  * Si cela existe, alors c'est que quelqu'un a déjà testé, vous pouvez toujours enlever le flag en base de donnée dans la table `certification-center-memberships` pour recommencer le test fonctionnel
* Créer une nouvelle session (ne pas utiliser l'existante, les seeds sont cassés)
  * inscrivez un candidat avec un certif Cléa, et **>> ajoutez-vous en destinataire des résultats <<**
* Démarrer la session, espace surveillant + confirmation de la présence du candidat
* Basculer sur mon-pix, avec le user `user-1-7003@example.net` qui est prêt à passer le CLEA
  * Passer la certification CLEA, **>> faites en sorte de l'obtenir <<**, car pour la non-régression vous devez avoir acquis la CLEA
* Retour sur Pix Certif, finalisez la session
* Basculer sur Pix Admin, chercher la session avec votre utilisateur
  * Publier les résultats
  * Vérifier que en l'absence de Referent Pix sur Pix Certif, vous recevez bien l'email de résultats
* Non régression
  * Sur Pix Admin, dépubliez la session précèdemment publiée
  * Ensuite sur Pix Certif dans Equipe, ajoutez vous référent Pix, il vous faudra vous mettre en membre côté Pix Admin
  * Sur Pix Admin republiez la session
  * Vérifiez que vous recevez toujours l'email des résultats     
