### PR TITLE
[BUGFIX] Corrige un crash de la certification v3 avec les configurations forcedCompetences et enablePassageByAllCompetences

### DIFF
--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
@@ -52,4 +52,46 @@ export class FlashAssessmentAlgorithmConfiguration {
     this.variationPercent = variationPercent;
     this.doubleMeasuresUntil = doubleMeasuresUntil;
   }
+
+  toDTO() {
+    return {
+      warmUpLength: this.warmUpLength,
+      forcedCompetences: JSON.stringify(this.forcedCompetences),
+      maximumAssessmentLength: this.maximumAssessmentLength,
+      challengesBetweenSameCompetence: this.challengesBetweenSameCompetence,
+      minimumEstimatedSuccessRateRanges: JSON.stringify(
+        this.minimumEstimatedSuccessRateRanges.map((successRateRange) => successRateRange.toDTO()),
+      ),
+      limitToOneQuestionPerTube: this.limitToOneQuestionPerTube,
+      enablePassageByAllCompetences: this.enablePassageByAllCompetences,
+      variationPercent: this.variationPercent,
+      doubleMeasuresUntil: this.doubleMeasuresUntil,
+    };
+  }
+
+  static fromDTO({
+    warmUpLength,
+    forcedCompetences,
+    maximumAssessmentLength,
+    challengesBetweenSameCompetence,
+    minimumEstimatedSuccessRateRanges,
+    limitToOneQuestionPerTube,
+    enablePassageByAllCompetences,
+    variationPercent,
+    doubleMeasuresUntil,
+  }) {
+    return new FlashAssessmentAlgorithmConfiguration({
+      warmUpLength,
+      forcedCompetences,
+      maximumAssessmentLength,
+      challengesBetweenSameCompetence,
+      minimumEstimatedSuccessRateRanges: minimumEstimatedSuccessRateRanges
+        ? minimumEstimatedSuccessRateRanges.map((config) => FlashAssessmentSuccessRateHandler.fromDTO(config))
+        : minimumEstimatedSuccessRateRanges,
+      limitToOneQuestionPerTube,
+      enablePassageByAllCompetences,
+      variationPercent,
+      doubleMeasuresUntil,
+    });
+  }
 }

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmRuleEngine.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmRuleEngine.js
@@ -5,14 +5,21 @@ export class FlashAssessmentAlgorithmRuleEngine {
   }
 
   execute({ assessmentAnswers, allChallenges }) {
-    const applicableRules = this._getApplicableRules();
+    const applicableRules = this._getApplicableRules({
+      answers: assessmentAnswers,
+    });
 
     return applicableRules.reduce((availableChallenges, rule) => {
       return rule.execute({ assessmentAnswers, allChallenges, availableChallenges });
     }, allChallenges);
   }
 
-  _getApplicableRules() {
-    return this._availableRules.filter((rule) => rule.isApplicable(this._configuration));
+  _getApplicableRules({ answers }) {
+    return this._availableRules.filter((rule) =>
+      rule.isApplicable({
+        answers,
+        ...this._configuration,
+      }),
+    );
   }
 }

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandler.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandler.js
@@ -46,6 +46,18 @@ class FlashAssessmentSuccessRateHandler {
       }),
     });
   }
+
+  toDTO() {
+    return {
+      startingChallengeIndex: this.startingChallengeIndex,
+      endingChallengeIndex: this.endingChallengeIndex,
+      ...this._strategy.toDTO(),
+    };
+  }
+
+  static fromDTO(config) {
+    return FlashAssessmentSuccessRateHandler.create(config);
+  }
 }
 
 export { FlashAssessmentSuccessRateHandler };

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandlerFixedStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandlerFixedStrategy.js
@@ -6,4 +6,11 @@ export class FlashAssessmentSuccessRateHandlerFixedStrategy {
   getMinimalSuccessRate() {
     return this.value;
   }
+
+  toDTO() {
+    return {
+      type: 'fixed',
+      value: this.value,
+    };
+  }
 }

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandlerLinearStrategy.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandlerLinearStrategy.js
@@ -11,4 +11,12 @@ export class FlashAssessmentSuccessRateHandlerLinearStrategy {
 
     return this.startingValue + successRateSlope * (challengeIndex - startingChallengeIndex);
   }
+
+  toDTO() {
+    return {
+      type: 'linear',
+      startingValue: this.startingValue,
+      endingValue: this.endingValue,
+    };
+  }
 }

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -4,12 +4,7 @@ import { FlashAssessmentAlgorithmConfiguration } from '../../domain/model/FlashA
 const TABLE_NAME = 'flash-algorithm-configurations';
 
 const save = async function (flashAlgorithmConfiguration) {
-  const data = {
-    ...flashAlgorithmConfiguration,
-    forcedCompetences: JSON.stringify(flashAlgorithmConfiguration.forcedCompetences),
-    minimumEstimatedSuccessRateRanges: JSON.stringify(flashAlgorithmConfiguration.minimumEstimatedSuccessRateRanges),
-  };
-  return knex(TABLE_NAME).insert(data);
+  return knex(TABLE_NAME).insert(flashAlgorithmConfiguration.toDTO());
 };
 
 const get = async function () {
@@ -19,7 +14,7 @@ const get = async function () {
     return null;
   }
 
-  return new FlashAssessmentAlgorithmConfiguration(flashAlgorithmConfiguration);
+  return FlashAssessmentAlgorithmConfiguration.fromDTO(flashAlgorithmConfiguration);
 };
 
 export { save, get };

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -1,6 +1,5 @@
 import { databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 import * as flashAlgorithmConfigurationRepository from '../../../../../../../api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 describe('Integration | Infrastructure | Repository | FlashAlgorithmConfigurationRepository', function () {
   describe('#save', function () {
@@ -125,7 +124,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
           enablePassageByAllCompetences: false,
         });
 
-        const expectedFlashAlgorithmConfiguration = new FlashAssessmentAlgorithmConfiguration({
+        const expectedFlashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
           ...flashAlgorithmConfiguration,
           forcedCompetences: JSON.parse(flashAlgorithmConfiguration.forcedCompetences),
           minimumEstimatedSuccessRateRanges: JSON.parse(flashAlgorithmConfiguration.minimumEstimatedSuccessRateRanges),
@@ -137,7 +136,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         const configResult = await flashAlgorithmConfigurationRepository.get();
 
         // then
-        expect(configResult).to.deep.equal(expectedFlashAlgorithmConfiguration);
+        expect(configResult.toDTO()).to.deep.equal(expectedFlashAlgorithmConfiguration.toDTO());
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -1,3 +1,5 @@
+import { FlashAssessmentSuccessRateHandler } from '../../../../src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandler.js';
+
 export const buildFlashAlgorithmConfiguration = ({
   warmUpLength,
   forcedCompetences = [],
@@ -14,7 +16,9 @@ export const buildFlashAlgorithmConfiguration = ({
     forcedCompetences,
     maximumAssessmentLength,
     challengesBetweenSameCompetence,
-    minimumEstimatedSuccessRateRanges,
+    minimumEstimatedSuccessRateRanges: minimumEstimatedSuccessRateRanges.map((successRateConfig) =>
+      FlashAssessmentSuccessRateHandler.create(successRateConfig),
+    ),
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
     variationPercent,

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -1,4 +1,5 @@
 import { FlashAssessmentSuccessRateHandler } from '../../../../src/certification/flash-certification/domain/model/FlashAssessmentSuccessRateHandler.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 export const buildFlashAlgorithmConfiguration = ({
   warmUpLength,
@@ -11,7 +12,7 @@ export const buildFlashAlgorithmConfiguration = ({
   variationPercent,
   doubleMeasuresUntil,
 } = {}) => {
-  return {
+  return new FlashAssessmentAlgorithmConfiguration({
     warmUpLength,
     forcedCompetences,
     maximumAssessmentLength,
@@ -23,5 +24,5 @@ export const buildFlashAlgorithmConfiguration = ({
     enablePassageByAllCompetences,
     variationPercent,
     doubleMeasuresUntil,
-  };
+  });
 };


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les paramètres forcedCompetences ou enablePassageByAllCompetences sont activés, la certification v3 crash.

## :100: Pour tester
- Se connecter sur pix certif avec le compte certifv3@example.net // pix123
- Insérer la configuration en base de données :
```
scalingo -a pix-api-review-pr7515 pgsql-console

insert into "flash-algorithm-configurations" ("forcedCompetences", "minimumEstimatedSuccessRateRanges", "limitToOneQuestionPerTube", "enablePassageByAllCompetences", "maximumAssessmentLength") VALUES ('[]','[]',true,true, 32);
```
- Créer une session de certif et y ajouter un candidat
- Se connecter sur pix app avec un compte certifiable (certifiable-contenu-user@example.net // pix123)
- Rejoindre la session de certification
- Si la première question s'affiche, le bug est corrigé 🌴 