### PR TITLE
[FEATURE] Sauvegarder le créateur d'une session de certification (PIX-8002)

### DIFF
--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -1,6 +1,7 @@
 import { buildCertificationCenter } from './build-certification-center.js';
 import { databaseBuffer } from '../database-buffer.js';
 import _ from 'lodash';
+import { buildUser } from './build-user.js';
 
 const buildSession = function ({
   id = databaseBuffer.getNextId(),
@@ -26,11 +27,15 @@ const buildSession = function ({
   juryCommentedAt = null,
   supervisorPassword = 'PIX12',
   version = 2,
+  createdBy = null,
 } = {}) {
   if (_.isUndefined(certificationCenterId)) {
     const builtCertificationCenter = buildCertificationCenter();
     certificationCenter = builtCertificationCenter.name;
     certificationCenterId = builtCertificationCenter.id;
+  }
+  if (_.isUndefined(createdBy)) {
+    createdBy = buildUser();
   }
   const values = {
     id,
@@ -56,6 +61,7 @@ const buildSession = function ({
     juryCommentedAt,
     supervisorPassword,
     version,
+    createdBy,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/db/migrations/20231123195424_add-session-createdBy.js
+++ b/api/db/migrations/20231123195424_add-session-createdBy.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'createdBy';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).defaultTo(null).references('users.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
@@ -35,7 +35,7 @@ const createSessions = async function ({
       } else {
         const { id } = await _saveNewSessionReturningId({
           sessionRepository,
-          sessionDTO,
+          sessionDTO: { ...sessionDTO, createdBy: userId },
           domainTransaction,
           isV3Pilot,
         });

--- a/api/src/certification/session/domain/models/Session.js
+++ b/api/src/certification/session/domain/models/Session.js
@@ -42,6 +42,7 @@ class Session {
     assignedCertificationOfficerId,
     supervisorPassword = Session.generateSupervisorPassword(),
     version = CertificationVersion.V2,
+    createdBy,
   } = {}) {
     this.id = id;
     this.accessCode = accessCode;
@@ -63,6 +64,7 @@ class Session {
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
     this.supervisorPassword = supervisorPassword;
     this.version = version;
+    this.createdBy = createdBy;
   }
 
   areResultsFlaggedAsSent() {

--- a/api/src/certification/session/domain/usecases/create-session.js
+++ b/api/src/certification/session/domain/usecases/create-session.js
@@ -42,6 +42,7 @@ const createSession = async function ({
     accessCode,
     certificationCenter: certificationCenterName,
     version,
+    createdBy: userId,
   });
 
   return sessionRepository.save(domainSession);

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -6,10 +6,11 @@ import * as sessionRepository from '../../../../../../src/certification/session/
 
 describe('Integration | Repository | Session', function () {
   describe('#save', function () {
-    let session, certificationCenter;
+    let session, certificationCenter, sessionCreator;
 
     beforeEach(async function () {
       certificationCenter = databaseBuilder.factory.buildCertificationCenter({});
+      sessionCreator = databaseBuilder.factory.buildUser({});
       session = new Session({
         certificationCenter: certificationCenter.name,
         certificationCenterId: certificationCenter.id,
@@ -29,6 +30,7 @@ describe('Integration | Repository | Session', function () {
         accessCode: 'XXXX',
         supervisorPassword: 'AB2C7',
         version: 2,
+        createdBy: sessionCreator.id,
       });
 
       await databaseBuilder.commit();
@@ -85,9 +87,11 @@ describe('Integration | Repository | Session', function () {
   describe('#get', function () {
     let session;
     let expectedSessionValues;
+    let sessionCreator;
 
     beforeEach(async function () {
       // given
+      sessionCreator = databaseBuilder.factory.buildUser({});
       session = databaseBuilder.factory.buildSession({
         certificationCenter: 'Tour Gamma',
         address: 'rue de Bercy',
@@ -97,6 +101,7 @@ describe('Integration | Repository | Session', function () {
         time: '12:00:00',
         description: 'CertificationPix pour les jeunes',
         accessCode: 'NJR10',
+        createdBy: sessionCreator.id,
       });
       expectedSessionValues = {
         id: session.id,
@@ -108,6 +113,7 @@ describe('Integration | Repository | Session', function () {
         time: session.time,
         description: session.description,
         accessCode: session.accessCode,
+        createdBy: sessionCreator.id,
       };
       await databaseBuilder.commit();
     });
@@ -133,6 +139,8 @@ describe('Integration | Repository | Session', function () {
   describe('#getWithCertificationCandidates', function () {
     it('should return session information in a session Object', async function () {
       // given
+
+      const sessionCreator = databaseBuilder.factory.buildUser();
       const session = databaseBuilder.factory.buildSession({
         certificationCenter: 'Tour Gamma',
         address: 'rue de Bercy',
@@ -143,6 +151,7 @@ describe('Integration | Repository | Session', function () {
         description: 'CertificationPix pour les jeunes',
         accessCode: 'NJR10',
         version: 2,
+        createdBy: sessionCreator.id,
       });
       await databaseBuilder.commit();
 

--- a/api/tests/certification/session/unit/domain/models/Session_test.js
+++ b/api/tests/certification/session/unit/domain/models/Session_test.js
@@ -23,6 +23,7 @@ const SESSION_PROPS = [
   'assignedCertificationOfficerId',
   'supervisorPassword',
   'version',
+  'createdBy',
 ];
 
 describe('Unit | Domain | Models | Session', function () {
@@ -50,6 +51,7 @@ describe('Unit | Domain | Models | Session', function () {
       // references
       certificationCenterId: '',
       assignedCertificationOfficerId: '',
+      createdBy: '',
     });
   });
 

--- a/api/tests/certification/session/unit/domain/usecases/create-session_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/create-session_test.js
@@ -111,6 +111,7 @@ describe('Unit | UseCase | create-session', function () {
             accessCode,
             supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
             version: 2,
+            createdBy: userId,
           });
 
           expect(sessionRepository.save).to.have.been.calledWithExactly(expectedSession);
@@ -146,6 +147,7 @@ describe('Unit | UseCase | create-session', function () {
             accessCode,
             supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
             version: 3,
+            createdBy: userId,
           });
 
           expect(sessionRepository.save).to.have.been.calledWithExactly(expectedSession);

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -21,6 +21,7 @@ const buildSession = function ({
   supervisorPassword = 'PIX12',
   certificationCandidates = [],
   version = 2,
+  createdBy = null,
 } = {}) {
   return new Session({
     id,
@@ -43,6 +44,7 @@ const buildSession = function ({
     supervisorPassword,
     certificationCandidates,
     version,
+    createdBy,
   });
 };
 
@@ -59,6 +61,7 @@ buildSession.created = function ({
   time,
   certificationCandidates,
   version = 2,
+  createBy,
 } = {}) {
   return buildSession({
     id,
@@ -80,6 +83,7 @@ buildSession.created = function ({
     publishedAt: null,
     assignedCertificationOfficerId: null,
     version,
+    createBy,
   });
 };
 
@@ -95,6 +99,7 @@ buildSession.finalized = function ({
   room,
   time,
   certificationCandidates,
+  createBy,
 } = {}) {
   return buildSession({
     id,
@@ -115,6 +120,7 @@ buildSession.finalized = function ({
     resultsSentToPrescriberAt: null,
     publishedAt: null,
     assignedCertificationOfficerId: null,
+    createBy,
   });
 };
 
@@ -130,6 +136,7 @@ buildSession.inProcess = function ({
   room,
   time,
   certificationCandidates,
+  createBy,
 } = {}) {
   return buildSession({
     id,
@@ -150,6 +157,7 @@ buildSession.inProcess = function ({
     resultsSentToPrescriberAt: null,
     publishedAt: null,
     assignedCertificationOfficerId: 123,
+    createBy,
   });
 };
 
@@ -165,6 +173,7 @@ buildSession.processed = function ({
   room,
   time,
   certificationCandidates,
+  createBy,
 } = {}) {
   return buildSession({
     id,
@@ -185,6 +194,7 @@ buildSession.processed = function ({
     resultsSentToPrescriberAt: new Date('2020-01-02'),
     publishedAt: new Date('2020-01-02'),
     assignedCertificationOfficerId: 123,
+    createBy,
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Le pôle certification doit souvent relancer le CDC pour la finalisation des sessions. Les relances ne sont pas toujours efficaces car elles ne sont pas adressées à la personne qui a créé la session en question.

## :robot: Proposition
Enregistrer le user id du membre du CDC qui a créé chaque session (permet de conserver l’info même s’il change d’adresse mail) en BDD

## :rainbow: Remarques

## :100: Pour tester
- Creer une session via l'interface pix-certif
- Creer une/des session via l'import en masse
i.e.
```csv
Numéro de session préexistante,* Nom du site,* Nom de la salle,* Date de début (format: JJ/MM/AAAA),* Heure de début (heure locale format: HH:MM),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: JJ/MM/AAAA),* Sexe (M ou F),Code INSEE de la commune de naissance,Code postal de la commune de naissance,Nom de la commune de naissance,* Pays de naissance,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant externe,Temps majoré ? (exemple format: 33%),"* Tarification part Pix (Gratuite, Prépayée ou Payante)",Code de prépaiement (si Tarification part Pix Prépayée),CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide),Pix+ Édu 1er degré ('oui' ou laisser vide),Pix+ Édu 2nd degré ('oui' ou laisser vide)
,site3,salle2,01/12/2023,10:11,kiki,,,,,,,,,,,,,,,,,,,
,site4,salle3,01/12/2023,10:11,kiki,,,,,,,,,,,,,,,,,,,
```


S'assurer que l'ID de l'utilisateur est bien sauvegardé
```select "createdBy", "createdAt" from sessions order by "createdAt" desc limit 10;```
