### PR TITLE
[TECH] Exposer une API afin de récupérer les informations d'une campagne (Pix-10062)

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -37,6 +37,7 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/campaigns/{id}',
       config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToAccessCampaign }],
         validate: {
           params: Joi.object({
             id: identifiersType.campaignId,

--- a/api/lib/application/preHandlers/models/CampaignAuthorization.js
+++ b/api/lib/application/preHandlers/models/CampaignAuthorization.js
@@ -8,6 +8,10 @@ class CampaignAuthorization {
   static isAllowedToManage({ prescriberRole }) {
     return prescriberRole === prescriberRoles.ADMIN || prescriberRole === prescriberRoles.OWNER;
   }
+
+  static isAllowedToAccess({ prescriberRole }) {
+    return Object.values(prescriberRoles).includes(prescriberRole);
+  }
 }
 
 export { CampaignAuthorization, prescriberRoles };

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -20,6 +20,7 @@ import * as checkUserIsAdminOfCertificationCenterUsecase from './usecases/checkU
 import * as checkUserIsMemberOfCertificationCenterUsecase from './usecases/checkUserIsMemberOfCertificationCenter.js';
 import * as checkUserIsMemberOfCertificationCenterSessionUsecase from './usecases/checkUserIsMemberOfCertificationCenterSession.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
+import * as checkAuthorizationToAccessCampaignUsecase from './usecases/checkAuthorizationToAccessCampaign.js';
 import * as checkOrganizationIsScoAndManagingStudentUsecase from './usecases/checkOrganizationIsScoAndManagingStudent.js';
 import * as checkPix1dEnabled from './usecases/checkPix1dEnabled.js';
 import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
@@ -548,6 +549,22 @@ async function checkAuthorizationToManageCampaign(
   return _replyForbiddenError(h);
 }
 
+async function checkAuthorizationToAccessCampaign(
+  request,
+  h,
+  dependencies = { checkAuthorizationToAccessCampaignUsecase },
+) {
+  const userId = request.auth.credentials.userId;
+  const campaignId = request.params.id;
+  const belongsToOrganization = await dependencies.checkAuthorizationToAccessCampaignUsecase.execute({
+    userId,
+    campaignId,
+  });
+
+  if (belongsToOrganization) return h.response(true);
+  return _replyForbiddenError(h);
+}
+
 function adminMemberHasAtLeastOneAccessOf(securityChecks) {
   return async (request, h) => {
     const responses = await bluebird.map(securityChecks, (securityCheck) => securityCheck(request, h));
@@ -626,6 +643,7 @@ const securityPreHandlers = {
   checkAdminMemberHasRoleSuperAdmin,
   checkAdminMemberHasRoleSupport,
   checkAuthorizationToManageCampaign,
+  checkAuthorizationToAccessCampaign,
   checkCertificationCenterIsNotScoManagingStudents,
   checkIfUserIsBlocked,
   checkPix1dActivated,

--- a/api/lib/application/usecases/checkAuthorizationToAccessCampaign.js
+++ b/api/lib/application/usecases/checkAuthorizationToAccessCampaign.js
@@ -1,0 +1,9 @@
+import * as prescriberRoleRepository from '../../infrastructure/repositories/prescriber-role-repository.js';
+import { CampaignAuthorization } from '../preHandlers/models/CampaignAuthorization.js';
+
+const execute = async function ({ userId, campaignId }) {
+  const prescriberRole = await prescriberRoleRepository.getForCampaign({ userId, campaignId });
+  return CampaignAuthorization.isAllowedToAccess({ prescriberRole });
+};
+
+export { execute };

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,33 +1,16 @@
-import { NotFoundError, UserNotAuthorizedToAccessEntityError } from '../../domain/errors.js';
-
 const getCampaign = async function ({
   campaignId,
-  userId,
   badgeRepository,
-  campaignRepository,
   campaignReportRepository,
   stageCollectionRepository,
 }) {
-  const integerCampaignId = parseInt(campaignId);
-  if (!Number.isFinite(integerCampaignId)) {
-    throw new NotFoundError(`Campaign not found for ID ${campaignId}`);
-  }
-
-  const userHasAccessToCampaign = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(
-    campaignId,
-    userId,
-  );
-  if (!userHasAccessToCampaign) {
-    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
-  }
-
-  const campaignReport = await campaignReportRepository.get(integerCampaignId);
+  const campaignReport = await campaignReportRepository.get(campaignId);
 
   if (campaignReport.isAssessment) {
     const [badges, stageCollection, aggregatedResults] = await Promise.all([
-      badgeRepository.findByCampaignId(integerCampaignId),
-      stageCollectionRepository.findStageCollection({ campaignId: integerCampaignId }),
-      campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(integerCampaignId),
+      badgeRepository.findByCampaignId(campaignId),
+      stageCollectionRepository.findStageCollection({ campaignId: campaignId }),
+      campaignReportRepository.findMasteryRatesAndValidatedSkillsCount(campaignId),
     ]);
 
     campaignReport.setBadges(badges);

--- a/api/src/prescription/campaigns/application/api/Campaign.js
+++ b/api/src/prescription/campaigns/application/api/Campaign.js
@@ -1,0 +1,11 @@
+export class Campaign {
+  constructor({ id, code, name, title, createdAt, archivedAt, customLandingPageText }) {
+    this.id = id;
+    this.code = code;
+    this.name = name;
+    this.title = title;
+    this.createdAt = createdAt;
+    this.archivedAt = archivedAt;
+    this.customLandingPageText = customLandingPageText;
+  }
+}

--- a/api/src/prescription/campaigns/application/api/campaigns-api.js
+++ b/api/src/prescription/campaigns/application/api/campaigns-api.js
@@ -1,10 +1,11 @@
 import { usecases } from '../../../../../lib/domain/usecases/index.js';
 import { SavedCampaign } from './SavedCampaign.js';
-
+import { Campaign } from './Campaign.js';
 /**
  * @typedef CampaignApi
  * @type {object}
  * @function save
+ * @function get
  */
 
 /**
@@ -29,7 +30,7 @@ import { SavedCampaign } from './SavedCampaign.js';
  * @name save
  *
  * @param {CampaignPayload} campaign
- * @returns {Promise<SavedCampaignResponse>}
+ * @returns {Promise<SavedCampaign>}
  * @throws {UserNotAuthorizedToCreateCampaignError} to be improved to handle different error types
  */
 export const save = async (campaign) => {
@@ -43,4 +44,16 @@ export const save = async (campaign) => {
   });
 
   return new SavedCampaign(savedCampaign);
+};
+
+/**
+ * @function
+ * @name get
+ *
+ * @param {number} campaignId
+ * @returns {Promise<Campaign>}
+ */
+export const get = async (campaignId) => {
+  const getCampaign = await usecases.getCampaign({ campaignId });
+  return new Campaign(getCampaign);
 };

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -1360,21 +1360,6 @@ describe('Acceptance | API | Campaign Controller', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.id).to.equal(campaign.id.toString());
-      expect(response.result.data.attributes.name).to.equal(campaign.name);
-    });
-
-    it('should return HTTP code 403 if the authenticated user is not authorize to access the campaign', async function () {
-      // given
-      userId = databaseBuilder.factory.buildUser().id;
-      options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(403);
     });
   });
 

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -48,16 +48,6 @@ describe('Integration | Application | Route | campaignRouter', function () {
     });
   });
 
-  describe('GET /api/campaigns/{id}', function () {
-    it('should return a 200', async function () {
-      // when
-      const response = await httpTestServer.request('GET', '/api/campaigns/1');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('GET /api/campaigns/{id}/analyses', function () {
     it('should return 200', async function () {
       // given

--- a/api/tests/integration/application/usecases/checkAuthorizationToAccessCampaign_test.js
+++ b/api/tests/integration/application/usecases/checkAuthorizationToAccessCampaign_test.js
@@ -1,0 +1,40 @@
+import { expect, databaseBuilder, catchErr } from '../../../test-helper.js';
+import * as checkAuthorizationToAccessCampaign from '../../../../lib/application/usecases/checkAuthorizationToAccessCampaign.js';
+
+describe('Integration | API | checkAuthorizationToAccessCampaign', function () {
+  describe('when the user belongs to organization', function () {
+    it('returns true', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
+      const campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const hasAccess = await checkAuthorizationToAccessCampaign.execute({ campaignId: campaign.id, userId: user.id });
+
+      // then
+      expect(hasAccess).to.be.true;
+    });
+  });
+
+  describe('when the user does not belong to organization', function () {
+    it('throws', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const hasAccess = await catchErr(checkAuthorizationToAccessCampaign.execute)({
+        campaignId: campaign.id,
+        userId: user.id,
+      });
+
+      // then
+      expect(hasAccess).to.throws;
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign_test.js
@@ -1,43 +1,10 @@
-import { expect, databaseBuilder, catchErr, mockLearningContent } from '../../../test-helper.js';
-import { NotFoundError, UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
+import { expect, databaseBuilder, mockLearningContent } from '../../../test-helper.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import * as badgeRepository from '../../../../lib/infrastructure/repositories/badge-repository.js';
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as campaignReportRepository from '../../../../lib/infrastructure/repositories/campaign-report-repository.js';
 
 describe('Integration | UseCase | get-campaign', function () {
-  context('Error case', function () {
-    it('should throw a NotFoundError when the campaign not exist', async function () {
-      const error = await catchErr(usecases.getCampaign)({
-        campaignId: 'invalid Campaign Id',
-        userId: 'whateverId',
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
-      });
-
-      expect(error).to.be.instanceOf(NotFoundError);
-    });
-
-    it("UserNotAuthorizedToAccessEntityError when user does not belong to organization's campaign", async function () {
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-
-      await databaseBuilder.commit();
-
-      const error = await catchErr(usecases.getCampaign)({
-        campaignId,
-        userId,
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
-      });
-
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-    });
-  });
-
   context('Type Assessment', function () {
     let userId;
     let campaign;

--- a/api/tests/prescription/campaigns/application/api/unit/campaigns-api_test.js
+++ b/api/tests/prescription/campaigns/application/api/unit/campaigns-api_test.js
@@ -2,8 +2,8 @@ import { usecases } from '../../../../../../lib/domain/usecases/index.js';
 import * as campaignApi from '../../../../../../src/prescription/campaigns/application/api/campaigns-api.js';
 import { expect, sinon, catchErr } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
-import { Campaign } from '../../../../../../lib/domain/models/index.js';
 import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../lib/domain/errors.js';
+import { Campaign } from '../../../../../../lib/domain/models/Campaign.js';
 
 describe('Unit | API | Campaigns', function () {
   describe('#save', function () {
@@ -75,6 +75,36 @@ describe('Unit | API | Campaigns', function () {
         // then
         expect(error).is.instanceOf(UserNotAuthorizedToCreateCampaignError);
       });
+    });
+  });
+
+  describe('#get', function () {
+    it('should return campaign informations', async function () {
+      const campaignInformation = domainBuilder.buildCampaign({
+        id: '777',
+        code: 'SOMETHING',
+        name: 'Godzilla',
+        title: 'is Biohazard',
+        customLandingPageText: 'Pika pika pikaCHUUUUUUUUUUUUUUUUUU',
+        createdAt: new Date('2020-01-01'),
+        archivedAt: new Date('2023-01-01'),
+      });
+
+      const getCampaignStub = sinon.stub(usecases, 'getCampaign');
+      getCampaignStub.withArgs({ campaignId: campaignInformation.id }).resolves(campaignInformation);
+
+      // when
+      const result = await campaignApi.get(campaignInformation.id);
+
+      // then
+      expect(result.id).to.equal(campaignInformation.id);
+      expect(result.code).to.equal(campaignInformation.code);
+      expect(result.name).to.equal(campaignInformation.name);
+      expect(result.title).to.equal(campaignInformation.title);
+      expect(result.createdAt).to.equal(campaignInformation.createdAt);
+      expect(result.archivedAt).to.equal(campaignInformation.archivedAt);
+      expect(result.customLandingPageText).to.equal(campaignInformation.customLandingPageText);
+      expect(result).not.to.be.instanceOf(Campaign);
     });
   });
 });

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -57,6 +57,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
     it('should return 200', async function () {
       // given
       sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response(true));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -65,6 +66,22 @@ describe('Unit | Application | Router | campaign-router ', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403', async function () {
+      // given
+      sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1');
+
+      // then
+      expect(response.statusCode).to.equal(403);
     });
 
     it('should return 400 with an invalid campaign id', async function () {

--- a/api/tests/unit/application/preHandlers/models/CampaignAuthorization_test.js
+++ b/api/tests/unit/application/preHandlers/models/CampaignAuthorization_test.js
@@ -36,4 +36,50 @@ describe('Unit | Domain | models | CampaignAuthorization', function () {
       expect(hasAccess).to.be.true;
     });
   });
+
+  describe('#isAllowedToAccess', function () {
+    it('should be true if user is member of organization', function () {
+      // given
+      const prescriberRole = 'MEMBER';
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToAccess({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.true;
+    });
+
+    it('should be true if user is admin of organization', function () {
+      // given
+      const prescriberRole = 'ADMIN';
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToAccess({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.true;
+    });
+
+    it('should be true if user is owner of the campaign', function () {
+      // given
+      const prescriberRole = 'OWNER';
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToAccess({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.true;
+    });
+
+    it('should be false if user has no role of the campaign', function () {
+      // given
+      const prescriberRole = null;
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToAccess({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix sur les parcours autonome la team ExpEval a besoin de récupérer une campagne.Utiliser directement les usecases de la team Prescription fait fuiter le domain hors du bounded context. Nous avons besoin d'établir une limite clair entre le code des parcours autonomes et celui des campagnes.

## :robot: Proposition
Dans cette PR, on ajoute l'API get campaigns. la team Prescription fournit une API à partir de la couche application du sous domain campaign qui pourrait être consommé depuis la couche infrastructure du sous domain autonomous-courses par la team ExpEval.

## :rainbow: Remarques
RAS

## :100: Pour tester
le CI passe
