### PR TITLE
[FEATURE] Ajouter le formulaire de création d'un parcours autonome dans PixAdmin (PIX-9807).

### DIFF
--- a/admin/app/adapters/autonomous-course-target-profile.js
+++ b/admin/app/adapters/autonomous-course-target-profile.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class AutonomousCourseTargetProfile extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForFindAll() {
+    return `${this.host}/${this.namespace}/autonomous-courses/target-profiles`;
+  }
+}

--- a/admin/app/adapters/autonomous-course.js
+++ b/admin/app/adapters/autonomous-course.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class AutonomousCourse extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/autonomous-courses/create-autonomous-course-form.hbs
+++ b/admin/app/components/autonomous-courses/create-autonomous-course-form.hbs
@@ -1,0 +1,72 @@
+<form class="form create-autonomous-course" {{on "submit" this.onSubmit}}>
+  <section class="form-section">
+    <p class="create-autonomous-course__mandatory-text">Les champs marqués de
+      <span class="mandatory-mark">*</span>
+      sont obligatoires.</p>
+    <Card class="create-autonomous-course__card" @title="Informations techniques">
+      <PixInput
+        class="form-field"
+        @id="autonomousCourseName"
+        @label="Nom interne : "
+        required="true"
+        @requiredLabel="Champ obligatoire"
+        {{on "change" (fn this.updateAutonomousCourseValue "internalTitle")}}
+      />
+      <PixFilterableAndSearchableSelect
+        @label="Quel profil cible voulez-vous associer à ce parcours autonome ?"
+        @placeholder="Choisir un profil cible"
+        @options={{this.targetProfileListOptions}}
+        @hideDefaultOption={{true}}
+        @onChange={{this.selectTargetProfile}}
+        @categoriesLabel="Sélectionner une ou plusieurs catégories de profils cibles"
+        @categoriesPlaceholder="Filtres"
+        @value={{@autonomousCourse.targetProfileId}}
+        @requiredText="Champ obligatoire"
+        @errorMessage={{if @errors.autonomousCourse (t "api-error-messages.campaign-creation.target-profile-required")}}
+        @isSearchable={{true}}
+        @searchLabel="Recherchez un profil cible"
+        @subLabel="Le profil cible doit être relié à l’organisation &quot;Organisation pour les parcours autonomes&quot;"
+        required={{true}}
+      />
+    </Card>
+    <Card class="create-autonomous-course__card" @title="Informations pour les utilisateurs">
+      <PixInput
+        @id="nom-public"
+        class="form-field"
+        @label="Nom public : "
+        placeholder="Exemple : Le super nom de mon parcours autonome"
+        required={{true}}
+        @requiredLabel="Champ obligatoire"
+        @information="Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
+        {{on "change" (fn this.updateAutonomousCourseValue "publicTitle")}}
+      />
+      <PixTextarea
+        @id="text-page-accueil"
+        class="form-field"
+        @maxlength="5000"
+        @label="Texte de la page d'accueil : "
+        placeholder="Exemple : description, objectifs..."
+        {{on "change" (fn this.updateAutonomousCourseValue "customLandingPageText")}}
+      />
+    </Card>
+
+  </section>
+  <section class="form-section form-actions form-section--actions">
+    <PixButton
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @size="big"
+      @triggerAction={{@onCancel}}
+    >Annuler
+    </PixButton>
+    <PixButton
+      @backgroundColor="green"
+      @size="big"
+      @type="submit"
+      @isLoading={{this.submitting}}
+      @triggerAction={{this.noop}}
+    >
+      Créer le parcours autonome
+    </PixButton>
+  </section>
+</form>

--- a/admin/app/components/autonomous-courses/create-autonomous-course-form.hbs
+++ b/admin/app/components/autonomous-courses/create-autonomous-course-form.hbs
@@ -25,7 +25,7 @@
         @errorMessage={{if @errors.autonomousCourse (t "api-error-messages.campaign-creation.target-profile-required")}}
         @isSearchable={{true}}
         @searchLabel="Recherchez un profil cible"
-        @subLabel="Le profil cible doit être relié à l’organisation &quot;Organisation pour les parcours autonomes&quot;"
+        @subLabel="Le profil cible doit être en accès simplifié et relié à l’organisation &quot;Organisation pour les parcours autonomes&quot;"
         required={{true}}
       />
     </Card>

--- a/admin/app/components/autonomous-courses/create-autonomous-course-form.js
+++ b/admin/app/components/autonomous-courses/create-autonomous-course-form.js
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class CreateAutonomousCourseForm extends Component {
+  @tracked submitting = false;
+  constructor() {
+    super(...arguments);
+  }
+
+  @action
+  updateAutonomousCourseValue(key, event) {
+    this.args.autonomousCourse[key] = event.target.value;
+  }
+
+  @action
+  selectTargetProfile(targetProfileId) {
+    this.args.autonomousCourse.targetProfileId = targetProfileId;
+  }
+
+  get targetProfileListOptions() {
+    const options = this.args.targetProfiles.map((targetProfile) => ({
+      value: targetProfile.id,
+      label: targetProfile.name,
+      category: targetProfile.category,
+      order: 'OTHER' === targetProfile.category ? 1 : 0,
+    }));
+
+    options.sort((targetProfileA, targetProfileB) => {
+      if (targetProfileA.order !== targetProfileB.order) {
+        return targetProfileA.order - targetProfileB.order;
+      }
+      if (targetProfileA.category !== targetProfileB.category) {
+        return targetProfileA.category.localeCompare(targetProfileB.category);
+      }
+      return targetProfileA.label.localeCompare(targetProfileB.label);
+    });
+
+    return options;
+  }
+
+  @action
+  async onSubmit(event) {
+    const autonomousCourse = {
+      internalTitle: this.args.autonomousCourse.internalTitle,
+      publicTitle: this.args.autonomousCourse.publicTitle,
+      targetProfileId: this.args.autonomousCourse.targetProfileId,
+      customLandingPageText: this.args.autonomousCourse.customLandingPageText,
+    };
+    try {
+      this.submitting = true;
+      await this.args.onSubmit(event, autonomousCourse);
+    } finally {
+      this.submitting = false;
+    }
+  }
+}

--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -74,6 +74,26 @@
         </PixTooltip>
       </li>
     {{/if}}
+
+    {{#if
+      (or
+        this.currentUser.adminMember.isSuperAdmin
+        this.currentUser.adminMember.isMetier
+        this.currentUser.adminMember.isSupport
+      )
+    }}
+      <li class="menu-bar__entry">
+        <PixTooltip @position="right">
+          <:triggerElement>
+            <LinkTo @route="authenticated.autonomous-courses" class="menu-bar__link">
+              <FaIcon @icon="signs-post" @title="Parcours autonomes" />
+            </LinkTo>
+          </:triggerElement>
+          <:tooltip>Parcours autonomes</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/if}}
+
     {{#if this.currentUser.adminMember.isSuperAdmin}}
       <li class="menu-bar__entry">
         <PixTooltip @position="right">
@@ -122,6 +142,7 @@
         </PixTooltip>
       </li>
     {{/if}}
+
     <li class="menu-bar__entry">
       <PixTooltip @position="right" @inline={{true}}>
         <:triggerElement>

--- a/admin/app/controllers/authenticated/autonomous-courses/list.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/list.js
@@ -1,0 +1,2 @@
+import Controller from '@ember/controller';
+export default class ListController extends Controller {}

--- a/admin/app/controllers/authenticated/autonomous-courses/new.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/new.js
@@ -23,6 +23,10 @@ export default class NewController extends Controller {
       if (!autonomousCourse.targetProfileId) {
         return this.notifications.error('Aucun profil cible sélectionné !');
       }
+      const badRequestError = error.errors.find((error) => error.status === '400');
+      if (badRequestError) {
+        return this.notifications.error(error.errors[0].detail);
+      }
       return this.notifications.error('Une erreur est survenue.');
     }
   }

--- a/admin/app/controllers/authenticated/autonomous-courses/new.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/new.js
@@ -1,0 +1,29 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class NewController extends Controller {
+  @service notifications;
+  @service store;
+  @service router;
+
+  @action
+  goBackToAutonomousCoursesList() {
+    this.router.transitionTo('authenticated.autonomous-courses.list');
+  }
+
+  @action
+  async createAutonomousCourse(event, autonomousCourse) {
+    event.preventDefault();
+    try {
+      await this.store.createRecord('autonomous-course', autonomousCourse).save();
+      this.notifications.success('Le parcours autonome a été créé avec succès.');
+      this.goBackToAutonomousCoursesList();
+    } catch (error) {
+      if (!autonomousCourse.targetProfileId) {
+        return this.notifications.error('Aucun profil cible sélectionné !');
+      }
+      return this.notifications.error('Une erreur est survenue.');
+    }
+  }
+}

--- a/admin/app/models/autonomous-course-target-profile.js
+++ b/admin/app/models/autonomous-course-target-profile.js
@@ -1,0 +1,11 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+import { service } from '@ember/service';
+
+export default class AutonomousCourseTargetProfile extends Model {
+  @service session;
+
+  @attr('nullable-string') name;
+  @attr('string') category;
+
+  @belongsTo('organization') organization;
+}

--- a/admin/app/models/autonomous-course.js
+++ b/admin/app/models/autonomous-course.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+export default class AutonomousCourse extends Model {
+  @attr('string') internalTitle;
+  @attr('string') publicTitle;
+  @attr('string') targetProfileId;
+  @attr('nullable-string') customLandingPageText;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -116,6 +116,11 @@ Router.map(function () {
       });
     });
 
+    this.route('autonomous-courses', function () {
+      this.route('list');
+      this.route('new');
+    });
+
     this.route('trainings', function () {
       this.route('list');
       this.route('new');

--- a/admin/app/routes/authenticated/autonomous-courses/autonomous-course.js
+++ b/admin/app/routes/authenticated/autonomous-courses/autonomous-course.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AutonomousCoursesRoute extends Route {
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+}

--- a/admin/app/routes/authenticated/autonomous-courses/index.js
+++ b/admin/app/routes/authenticated/autonomous-courses/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.transitionTo('authenticated.autonomous-courses.list');
+  }
+}

--- a/admin/app/routes/authenticated/autonomous-courses/list.js
+++ b/admin/app/routes/authenticated/autonomous-courses/list.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ListRoute extends Route {
+  @service accessControl;
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+}

--- a/admin/app/routes/authenticated/autonomous-courses/new.js
+++ b/admin/app/routes/authenticated/autonomous-courses/new.js
@@ -1,0 +1,16 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+export default class ListRoute extends Route {
+  @service accessControl;
+  @service store;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+
+  async model() {
+    const autonomousCourse = await this.store.createRecord('autonomous-course');
+    const targetProfiles = await this.store.findAll('autonomous-course-target-profile');
+    return { autonomousCourse, targetProfiles };
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -78,6 +78,7 @@
 @import 'components/target-profiles/target-profile';
 @import 'components/target-profiles/badge-form';
 @import 'components/target-profiles/create-target-profile-form';
+@import 'components/autonomous-courses/create-autonomous-course-form';
 @import 'components/trainings/create-or-update-training-form';
 @import 'components/trainings/training-details-card';
 @import 'components/trainings/training-triggers-tab';

--- a/admin/app/styles/components/autonomous-courses/create-autonomous-course-form.scss
+++ b/admin/app/styles/components/autonomous-courses/create-autonomous-course-form.scss
@@ -1,0 +1,20 @@
+.create-autonomous-course {
+  color: $pix-neutral-70;
+  counter-reset: title;
+
+  &__mandatory-text {
+    margin-bottom: $pix-spacing-m;
+  }
+
+  &__card {
+    margin-bottom: $pix-spacing-m;
+  }
+
+  .card__title {
+    counter-increment: title;
+
+    &::before {
+      content: counter(title) '.\00a0';
+    }
+  }
+}

--- a/admin/app/templates/authenticated/autonomous-courses.hbs
+++ b/admin/app/templates/authenticated/autonomous-courses.hbs
@@ -1,0 +1,4 @@
+{{page-title "Parcours autonomes"}}
+<div class="page">
+  {{outlet}}
+</div>

--- a/admin/app/templates/authenticated/autonomous-courses/list.hbs
+++ b/admin/app/templates/authenticated/autonomous-courses/list.hbs
@@ -1,0 +1,14 @@
+<header class="page-header">
+  <h1 class="page-title">Tous les parcours autonomes</h1>
+  <PixButtonLink
+    @route="authenticated.autonomous-courses.new"
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+  >
+    Nouveau parcours autonome
+  </PixButtonLink>
+</header>
+
+<main class="page-body">
+  Liste des parcours autonomes
+</main>

--- a/admin/app/templates/authenticated/autonomous-courses/new.hbs
+++ b/admin/app/templates/authenticated/autonomous-courses/new.hbs
@@ -1,0 +1,17 @@
+{{page-title "Nouveau parcours autonome"}}
+<header class="page-header">
+  <div class="page-title">
+    <h1>Nouveau parcours autonome</h1>
+  </div>
+</header>
+
+<main class="page-body">
+  <section class="page-section">
+    <AutonomousCourses::CreateAutonomousCourseForm
+      @autonomousCourse={{this.model.autonomousCourse}}
+      @targetProfiles={{this.model.targetProfiles}}
+      @onSubmit={{this.createAutonomousCourse}}
+      @onCancel={{this.goBackToAutonomousCoursesList}}
+    />
+  </section>
+</main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -40,6 +40,7 @@ import {
 import { findFrameworkAreas } from './handlers/frameworks';
 import { getWithRequiredActionSessions } from './handlers/get-with-required-action-sessions';
 import { getToBePublishedSessions } from './handlers/get-to-be-published-sessions';
+import { findAutonomousCourseTargetProfiles, createAutonomousCourse } from './handlers/autonomous-courses';
 
 export default function makeServer(config) {
   const finalConfig = {
@@ -60,6 +61,9 @@ function routes() {
   this.get('feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
+
+  this.get('/admin/autonomous-courses/target-profiles', findAutonomousCourseTargetProfiles);
+  this.post('/admin/autonomous-courses', createAutonomousCourse);
 
   this.get('/admin/campaigns/:id');
   this.get('/admin/campaigns/:id/participations', (schema) => {

--- a/admin/mirage/handlers/autonomous-courses.js
+++ b/admin/mirage/handlers/autonomous-courses.js
@@ -1,0 +1,11 @@
+export const findAutonomousCourseTargetProfiles = (schema) => {
+  return schema.autonomousCourseTargetProfiles.all();
+};
+
+export const createAutonomousCourse = (schema, request) => {
+  const params = JSON.parse(request.requestBody);
+
+  return schema.create('autonomous-course', {
+    ...params.data.attributes,
+  });
+};

--- a/admin/tests/acceptance/authenticated/autonomous-crouses/autonomous-courses_test.js
+++ b/admin/tests/acceptance/authenticated/autonomous-crouses/autonomous-courses_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../../../helpers/setup-intl';
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { currentURL, click } from '@ember/test-helpers';
+
+module('Acceptance | Autonomous courses | Autonomous course', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('When admin member is logged in', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      server.create('autonomous-course-target-profile', {
+        name: 'Profil cible de Guigui',
+        category: 'category',
+        organization: server.create('organization'),
+      });
+    });
+
+    module('creation page', function () {
+      test('it should set autonomous course menubar item active', async function (assert) {
+        // when
+        const screen = await visit('/autonomous-courses/new');
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Parcours autonomes' })).hasClass('active');
+      });
+      test('it should create an autonomous course', async function (assert) {
+        // given
+        const screen = await visit('/autonomous-courses/new');
+
+        // when
+        await fillByLabel(/Nom interne/, 'Parcours de Guigui');
+
+        const button = screen.getByLabelText(/Quel profil cible voulez-vous associer à ce parcours autonome ?/);
+        await click(button);
+        await click(await screen.findByRole('option', { name: 'Profil cible de Guigui' }));
+
+        await fillByLabel(/Nom public/, 'Parcours professionalisant de Guillaume');
+        const submitButton = screen.getByRole('button', { name: 'Créer le parcours autonome' });
+        await click(submitButton);
+
+        //then
+        assert.strictEqual(currentURL(), '/autonomous-courses/list');
+      });
+    });
+
+    module('list page', function () {
+      test('it should set autonomous course menubar item active', async function (assert) {
+        // when
+        const screen = await visit('/autonomous-courses/list');
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Parcours autonomes' })).hasClass('active');
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/autonomous-courses/create-autonomous-course-form_test.js
+++ b/admin/tests/integration/components/autonomous-courses/create-autonomous-course-form_test.js
@@ -41,9 +41,12 @@ module('Integration | Component | AutonomousCourses::CreateAutonomousCourseForm'
     assert.dom(screen.getByText(/Quel profil cible voulez-vous associer à ce parcours autonome ?/)).exists();
     assert
       .dom(
-        screen.getByText(/Le profil cible doit être relié à l’organisation "Organisation pour les parcours autonomes"/),
+        screen.getByText(
+          /Le profil cible doit être en accès simplifié et relié à l’organisation "Organisation pour les parcours autonomes"/,
+        ),
       )
       .exists();
+
     assert.dom(screen.getByText(/Nom public/)).exists();
     assert
       .dom(screen.getByText(/Le nom du parcours autonome sera affiché sur la page de démarrage du candidat./))

--- a/admin/tests/integration/components/autonomous-courses/create-autonomous-course-form_test.js
+++ b/admin/tests/integration/components/autonomous-courses/create-autonomous-course-form_test.js
@@ -1,0 +1,89 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { triggerEvent } from '@ember/test-helpers';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | AutonomousCourses::CreateAutonomousCourseForm', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let autonomousCourse, targetProfiles, onSubmit, onCancel;
+
+  hooks.beforeEach(function () {
+    autonomousCourse = {};
+    targetProfiles = [];
+
+    onSubmit = sinon.stub();
+    onCancel = sinon.stub();
+
+    this.set('autonomousCourse', autonomousCourse);
+    this.set('targetProfiles', targetProfiles);
+    this.set('onSubmit', onSubmit);
+    this.set('onCancel', onCancel);
+  });
+
+  test('it renders the autonomous-courses creation form component', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<AutonomousCourses::CreateAutonomousCourseForm
+        @autonomousCourse={{this.autonomousCourse}}
+        @targetProfiles={{this.targetProfiles}}
+        @onSubmit={{this.onSubmit}}
+        @onCancel={{this.onCancel}}
+      />`,
+    );
+
+    // then
+    assert.dom(screen.getByText(/Les champs marqués de * sont obligatoires./)).exists();
+    assert.dom(screen.getByText(/Informations techniques/)).exists();
+    assert.dom(screen.getByText(/Nom interne/)).exists();
+    assert.dom(screen.getByText(/Quel profil cible voulez-vous associer à ce parcours autonome ?/)).exists();
+    assert
+      .dom(
+        screen.getByText(/Le profil cible doit être relié à l’organisation "Organisation pour les parcours autonomes"/),
+      )
+      .exists();
+    assert.dom(screen.getByText(/Nom public/)).exists();
+    assert
+      .dom(screen.getByText(/Le nom du parcours autonome sera affiché sur la page de démarrage du candidat./))
+      .exists();
+    assert.dom(screen.getByText(/Texte de la page d'accueil :/)).exists();
+    assert.dom(screen.getByRole('button', { name: 'Créer le parcours autonome' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+  });
+
+  test('it should call onSubmit when form is valid', async function (assert) {
+    // when
+    await render(
+      hbs`<AutonomousCourses::CreateAutonomousCourseForm
+        @autonomousCourse={{this.autonomousCourse}}
+        @targetProfiles={{this.targetProfiles}}
+        @onSubmit={{this.onSubmit}}
+        @onCancel={{this.onCancel}}
+      />`,
+    );
+
+    await triggerEvent('form', 'submit');
+
+    // then
+    assert.ok(onSubmit.called);
+  });
+
+  test('it should call onCancel when form is cancel', async function (assert) {
+    // when
+    await render(
+      hbs`<AutonomousCourses::CreateAutonomousCourseForm
+        @autonomousCourse={{this.autonomousCourse}}
+        @targetProfiles={{this.targetProfiles}}
+        @onSubmit={{this.onSubmit}}
+        @onCancel={{this.onCancel}}
+      />`,
+    );
+
+    await clickByName('Annuler');
+
+    // then
+    assert.ok(onCancel.called);
+  });
+});

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -61,6 +61,64 @@ module('Integration | Component | menu-bar', function (hooks) {
     });
   });
 
+  module('Autonomous course tab', function () {
+    module('when admin member has "SUPER_ADMIN" as role', function () {
+      test('should contain link to "Autonomous course" page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSuperAdmin: true };
+
+        // when
+        const screen = await render(hbs`<MenuBar />`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Parcours autonomes' })).exists();
+      });
+    });
+
+    module('when admin member has "SUPPORT" as role', function () {
+      test('should contain link to "Autonomous course" page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSupport: true };
+
+        // when
+        const screen = await render(hbs`<MenuBar />`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Parcours autonomes' })).exists();
+      });
+    });
+
+    module('when admin member has "METIER" as role', function () {
+      test('should contain link to "Autonomous course" page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isMetier: true };
+
+        // when
+        const screen = await render(hbs`<MenuBar />`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Parcours autonomes' })).exists();
+      });
+    });
+
+    module('when admin member has "CERTIF" as role', function () {
+      test('should not contain link to "Autonomous course" management page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isCertif: true };
+
+        // when
+        const screen = await render(hbs`<MenuBar />`);
+
+        // then
+        assert.dom(screen.queryByRole('link', { name: 'Parcours autonomes' })).doesNotExist();
+      });
+    });
+  });
+
   module('Trainings tab', function () {
     module('when admin member have "SUPER_ADMIN", "SUPPORT" or "METIER" as role', function () {
       test('should contain link to "Trainings" page', async function (assert) {

--- a/admin/tests/unit/components/autonomous-courses/create-autonomous-course-form_test.js
+++ b/admin/tests/unit/components/autonomous-courses/create-autonomous-course-form_test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+import createComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Autonomous courses | CreateAutonomousCourseForm', function (hooks) {
+  setupTest(hooks);
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createComponent('component:autonomous-courses/create-autonomous-course-form', {
+      onSubmit: sinon.stub(),
+      autonomousCourse: {
+        internalTitle: '',
+        publicTitle: '',
+        targetProfileId: '',
+        customLandingPageText: '',
+      },
+    });
+  });
+
+  module('#updateAutonomousCourseValue', function () {
+    test('it should update appropriate form attribute', function (assert) {
+      // given
+      const keyToUpdate = 'internalTitle';
+      const formEvent = { target: { value: 'New Title' } };
+
+      // when
+      component.updateAutonomousCourseValue(keyToUpdate, formEvent);
+
+      // then
+      assert.strictEqual(component.args.autonomousCourse.internalTitle, 'New Title');
+    });
+  });
+
+  module('#selectTargetProfile', function () {
+    test('it should update target profile attribute', function (assert) {
+      // given
+      const targetProfileId = 32;
+
+      // when
+      component.selectTargetProfile(targetProfileId);
+
+      // then
+      assert.strictEqual(component.args.autonomousCourse.targetProfileId, 32);
+    });
+  });
+
+  module('#onSubmit', function () {
+    let submitEvent;
+
+    test('is should call the onSubmit method', async function (assert) {
+      // when
+      await component.onSubmit(submitEvent);
+
+      // then
+      assert.ok(component.args.onSubmit.called);
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/autonomous-courses/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/autonomous-courses/new_test.js
@@ -1,0 +1,117 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/autonomous-courses/new', function (hooks) {
+  setupTest(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/autonomous-courses/new');
+  });
+
+  module('#goBackToAutonomousCoursesList', function () {
+    test('should go back to autonomous courses list page', async function (assert) {
+      // given
+      controller.router.transitionTo = sinon.stub();
+
+      // when
+      controller.goBackToAutonomousCoursesList();
+
+      // then
+      assert.ok(controller.router.transitionTo.calledWith('authenticated.autonomous-courses.list'));
+    });
+  });
+
+  module('#createAutonomousCourse', function () {
+    test('it should save autonomous course', async function (assert) {
+      // given
+      const autonomousCourse = {
+        internalTitle: 'un nom interne',
+        publicTitle: 'un nom public',
+        targetProfileId: 32,
+        customLandingPageText: "un texte de page d'accueil",
+      };
+
+      const saveStub = sinon.stub().resolves({ id: autonomousCourse.id });
+
+      controller.store.createRecord = sinon
+        .stub()
+        .withArgs('autonomous-course', autonomousCourse)
+        .returns({ save: saveStub });
+
+      controller.router.transitionTo = sinon.stub();
+
+      controller.notifications = {
+        success: sinon.stub(),
+      };
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      // when
+      await controller.createAutonomousCourse(event, autonomousCourse);
+
+      // then
+      assert.ok(saveStub.called);
+      assert.ok(controller.notifications.success.calledWith('Le parcours autonome a été créé avec succès.'));
+      assert.ok(controller.router.transitionTo.calledWith('authenticated.autonomous-courses.list'));
+    });
+
+    test('it should display error notification when autonomous-course cannot be saved', async function (assert) {
+      // given
+      const autonomousCourse = {
+        targetProfileId: 32,
+      };
+      controller.notifications = {
+        error: sinon.stub(),
+      };
+
+      const saveStub = sinon.stub().rejects();
+
+      controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      // when
+      await controller.createAutonomousCourse(event, autonomousCourse);
+
+      // then
+      assert.ok(saveStub.called);
+      assert.ok(controller.notifications.error.calledWith('Une erreur est survenue.'));
+    });
+
+    test('it should display not selected target profile error notification when autonomous-course is saved without target profile', async function (assert) {
+      // given
+
+      const autonomousCourse = {
+        internalTitle: 'un nom interne',
+        publicTitle: 'un nom public',
+        customLandingPageText: "un texte de page d'accueil",
+      };
+
+      controller.notifications = {
+        error: sinon.stub(),
+      };
+
+      const saveStub = sinon.stub().rejects();
+
+      controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      // when
+      await controller.createAutonomousCourse(event, autonomousCourse);
+
+      // then
+      assert.ok(saveStub.called);
+      assert.ok(controller.notifications.error.calledWith('Aucun profil cible sélectionné !'));
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/autonomous-courses/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/autonomous-courses/new_test.js
@@ -69,7 +69,7 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
         error: sinon.stub(),
       };
 
-      const saveStub = sinon.stub().rejects();
+      const saveStub = sinon.stub().rejects({ errors: [] });
 
       controller.store.createRecord = sinon.stub().returns({ save: saveStub });
 
@@ -83,6 +83,35 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
       // then
       assert.ok(saveStub.called);
       assert.ok(controller.notifications.error.calledWith('Une erreur est survenue.'));
+    });
+
+    test('it should display error message from API when it receives a "bad request" error', async function (assert) {
+      // given
+      const autonomousCourse = {
+        targetProfileId: 32,
+      };
+      controller.notifications = {
+        error: sinon.stub(),
+      };
+
+      const errors = {
+        errors: [{ status: '400', detail: 'Le profil cible ne correspond pas' }],
+      };
+
+      const saveStub = sinon.stub().rejects(errors);
+
+      controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      // when
+      await controller.createAutonomousCourse(event, autonomousCourse);
+
+      // then
+      assert.ok(saveStub.called);
+      assert.ok(controller.notifications.error.calledWith('Le profil cible ne correspond pas'));
     });
 
     test('it should display not selected target profile error notification when autonomous-course is saved without target profile', async function (assert) {

--- a/admin/tests/unit/routes/authenticated/autonomous-courses/autonomous-course_test.js
+++ b/admin/tests/unit/routes/authenticated/autonomous-courses/autonomous-course_test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/autonomous-courses/autonomous-course', function (hooks) {
+  setupTest(hooks);
+
+  module('#beforeModel', function () {
+    test('it should check if current user is "SUPER_ADMIN", "METIER" or "SUPPORT"', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/autonomous-courses/autonomous-course');
+
+      const restrictAccessToStub = sinon.stub().returns();
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated'));
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/autonomous-courses/new_test.js
+++ b/admin/tests/unit/routes/authenticated/autonomous-courses/new_test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/autonomous-courses/new', function (hooks) {
+  setupTest(hooks);
+
+  module('#beforeModel', function () {
+    test('it should check if current user is "SUPER_ADMIN", "SUPPORT" or "METIER"', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/autonomous-courses/new');
+
+      const restrictAccessToStub = sinon.stub().returns();
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated'));
+    });
+  });
+});

--- a/api/db/seeds/data/team-evaluation/build-seeds-for-autonomous-courses.js
+++ b/api/db/seeds/data/team-evaluation/build-seeds-for-autonomous-courses.js
@@ -1,0 +1,53 @@
+import { createTargetProfile } from '../common/tooling/target-profile-tooling.js';
+import { organization } from '../common/tooling/index.js';
+import { REAL_PIX_SUPER_ADMIN_ID } from '../common/common-builder.js';
+import {
+  ALL_ORGANIZATION_USER_ID,
+  FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID,
+  SCO_ORGANIZATION_USER_ID,
+} from '../common/constants.js';
+
+export default async function createSeedsForAutonomousCourse(teamOffset, databaseBuilder) {
+  const ALL_PURPOSE_ID = teamOffset + 8;
+  const AUTONOMOUS_COURSES_ORGANIZATION_ID = process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+
+  await organization.createOrganization({
+    databaseBuilder,
+    organizationId: AUTONOMOUS_COURSES_ORGANIZATION_ID,
+    type: 'SCO',
+    name: 'Organisation pour les parcours autonomes',
+    isManagingStudents: true,
+    externalId: 'SCO_MANAGING',
+    adminIds: [SCO_ORGANIZATION_USER_ID],
+    memberIds: [ALL_ORGANIZATION_USER_ID],
+    featureIds: [FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID],
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: REAL_PIX_SUPER_ADMIN_ID,
+    organizationId: AUTONOMOUS_COURSES_ORGANIZATION_ID,
+    organizationRole: 'ADMIN',
+  });
+
+  const configTargetProfile = {
+    frameworks: [
+      {
+        chooseCoreFramework: true,
+        countTubes: 5,
+        minLevel: 3,
+        maxLevel: 5,
+      },
+    ],
+  };
+
+  await createTargetProfile({
+    databaseBuilder,
+    targetProfileId: ALL_PURPOSE_ID,
+    ownerOrganizationId: AUTONOMOUS_COURSES_ORGANIZATION_ID,
+    name: 'Profil cible pour parcours autonomes',
+    isPublic: true,
+    isSimplifiedAccess: true,
+    description: 'Profil cible pour parcours autonomes',
+    configTargetProfile,
+  });
+}

--- a/api/db/seeds/data/team-evaluation/data-builder.js
+++ b/api/db/seeds/data/team-evaluation/data-builder.js
@@ -1,6 +1,7 @@
 import * as tooling from '../common/tooling/index.js';
 import evalCampaignWithBadgesUser from './users/eval-campaign-with-badges.js';
 import evalCampaignWithStagesUser from './users/eval-campaign-with-stages.js';
+import createSeedsForAutonomousCourse from './build-seeds-for-autonomous-courses.js';
 
 const TEAM_EVALUATION_OFFSET_ID = 1000000;
 /// USERS
@@ -23,6 +24,7 @@ export async function teamEvaluationDataBuilder({ databaseBuilder }) {
   // Other users
   await evalCampaignWithBadgesUser(TEAM_EVALUATION_OFFSET_ID, databaseBuilder);
   await evalCampaignWithStagesUser(TEAM_EVALUATION_OFFSET_ID, databaseBuilder);
+  await createSeedsForAutonomousCourse(TEAM_EVALUATION_OFFSET_ID, databaseBuilder);
 }
 
 function createScoOrganization(databaseBuilder) {

--- a/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
+++ b/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
@@ -4,8 +4,11 @@ import * as autonomousCourseSerializer from '../../infrastructure/serializers/js
 
 const save = async (request, h, dependencies = { requestResponseUtils, usecases, autonomousCourseSerializer }) => {
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+
+  const deserializedPayload = await dependencies.autonomousCourseSerializer.deserialize(request.payload);
+
   const autonomousCourseForCreation = {
-    ...request.payload.data.attributes,
+    ...deserializedPayload,
     ownerId: userId,
   };
   const autonomousCourseId = await dependencies.usecases.saveAutonomousCourse({

--- a/api/src/evaluation/application/autonomous-courses/index.js
+++ b/api/src/evaluation/application/autonomous-courses/index.js
@@ -8,7 +8,7 @@ const register = async function (server) {
   server.route([
     {
       method: 'POST',
-      path: '/api/autonomous-courses',
+      path: '/api/admin/autonomous-courses',
       config: {
         pre: [
           {

--- a/api/src/evaluation/application/autonomous-courses/index.js
+++ b/api/src/evaluation/application/autonomous-courses/index.js
@@ -27,10 +27,10 @@ const register = async function (server) {
             data: Joi.object({
               type: Joi.string().valid('autonomous-courses'),
               attributes: Joi.object({
-                targetProfileId: identifiersType.targetProfileId,
-                internalTitle: Joi.string().required(),
-                publicTitle: Joi.string().required(),
-                customLandingPageText: Joi.string().allow(null).optional(),
+                'target-profile-id': identifiersType.targetProfileId.required(),
+                'internal-title': Joi.string().required(),
+                'public-title': Joi.string().required(),
+                'custom-landing-page-text': Joi.string().allow(null).optional(),
               }),
             }),
           }),

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -11,21 +11,4 @@ class StageWithLinkedCampaignError extends DomainError {
   }
 }
 
-class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
-  constructor() {
-    super('Autonomous course requires a target profile with simplified access.');
-  }
-}
-
-class TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization extends DomainError {
-  constructor() {
-    super('Target profile requires to be linked to autonomous course organization.');
-  }
-}
-
-export {
-  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
-  DomainError,
-  StageWithLinkedCampaignError,
-  TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
-};
+export { DomainError, StageWithLinkedCampaignError };

--- a/api/src/evaluation/domain/usecases/save-autonomous-course.js
+++ b/api/src/evaluation/domain/usecases/save-autonomous-course.js
@@ -1,8 +1,8 @@
-import { NotFoundError } from '../../../shared/domain/errors.js';
 import {
   AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  NotFoundError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
-} from '../errors.js';
+} from '../../../shared/domain/errors.js';
 import { constants } from '../../../../lib/domain/constants.js';
 
 /**
@@ -10,6 +10,7 @@ import { constants } from '../../../../lib/domain/constants.js';
  * @param autonomousCourseRepository
  * @param targetProfileRepository
  * @param targetProfileForAdminRepository
+ *
  * @returns {Promise<*>}
  */
 const saveAutonomousCourse = async ({

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-serializer.js
@@ -1,7 +1,13 @@
 import jsonapiSerializer from 'jsonapi-serializer';
-const { Serializer } = jsonapiSerializer;
+const { Serializer, Deserializer } = jsonapiSerializer;
 const serializeId = function (autonomousCourseId) {
   return new Serializer('autonomous-course', {}).serialize({ id: autonomousCourseId });
 };
 
-export { serializeId };
+const deserialize = function (payload) {
+  return new Deserializer({
+    keyForAttribute: 'camelCase',
+  }).deserialize(payload);
+};
+
+export { serializeId, deserialize };

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -1,7 +1,11 @@
 import * as errorSerializer from '../infrastructure/serializers/jsonapi/error-serializer.js';
 import { HttpErrors } from './http-errors.js';
 import * as DomainErrors from '../domain/errors.js';
-import { EntityValidationError } from '../domain/errors.js';
+import {
+  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  EntityValidationError,
+  TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+} from '../domain/errors.js';
 import jsonapiSerializer from 'jsonapi-serializer';
 import { extractLocaleFromRequest } from '../../../lib/infrastructure/utils/request-response-utils.js';
 import _ from 'lodash';
@@ -107,6 +111,14 @@ function _mapToHttpError(error) {
   }
   if (error instanceof SessionStartedDeletionError) {
     return new HttpErrors.ConflictError(error.message);
+  }
+
+  if (error instanceof AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+
+  if (error instanceof TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization) {
+    return new HttpErrors.BadRequestError(error.message);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -128,6 +128,18 @@ class NoCertificationAttestationForDivisionError extends DomainError {
   }
 }
 
+class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
+  constructor() {
+    super('Autonomous course requires a target profile with simplified access.');
+  }
+}
+
+class TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization extends DomainError {
+  constructor() {
+    super('Target profile requires to be linked to autonomous course organization.');
+  }
+}
+
 export {
   DomainError,
   AssessmentEndedError,
@@ -144,4 +156,6 @@ export {
   NoCertificationAttestationForDivisionError,
   LocaleFormatError,
   LocaleNotSupportedError,
+  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
 };

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -57,10 +57,10 @@ describe('Acceptance | API | Autonomous Course', function () {
         it('should return 201', async function () {
           // when
           const autonomousCourseAttributes = {
-            internalTitle: 'Titre pour usage interne',
-            publicTitle: 'Titre pour usage public',
-            targetProfileId,
-            customLandingPageText: 'customLandingPageText',
+            'internal-title': 'Titre pour usage interne',
+            'public-title': 'Titre pour usage public',
+            'target-profile-id': targetProfileId,
+            'custom-landing-page-text': 'customLandingPageText',
           };
           const payload = {
             data: {

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -71,7 +71,7 @@ describe('Acceptance | API | Autonomous Course', function () {
 
           const options = {
             method: 'POST',
-            url: '/api/autonomous-courses',
+            url: '/api/admin/autonomous-courses',
             headers: {
               authorization: generateValidRequestAuthorizationHeader(userId),
             },

--- a/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
@@ -8,8 +8,10 @@ import {
   sinon,
 } from '../../../../test-helper.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization } from '../../../../../src/evaluation/domain/errors.js';
+import {
+  NotFoundError,
+  TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+} from '../../../../../src/shared/domain/errors.js';
 import { constants } from '../../../../../lib/domain/constants.js';
 
 describe('Integration | Usecases | Save autonomous course', function () {

--- a/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
@@ -6,10 +6,10 @@ describe('Unit | Controller | autonomous-course-controller', function () {
     it('should return autonomous course created Id', async function () {
       // given
       const autonomousCourseAttributes = {
-        internalTitle: 'Titre pour usage interne',
-        publicTitle: 'Titre pour usage public',
-        targetProfileId: 'targetProfileId',
-        customLandingPageText: 'customLandingPageText',
+        'internal-title': 'Titre pour usage interne',
+        'public-title': 'Titre pour usage public',
+        'target-profile-id': '3',
+        'custom-landing-page-text': 'customLandingPageText',
       };
       const payload = {
         data: {
@@ -24,16 +24,32 @@ describe('Unit | Controller | autonomous-course-controller', function () {
       const h = {
         ...hFake,
       };
+
       const userId = '123';
+
       const requestResponseUtils = {
         extractUserIdFromRequest: sinon.stub().returns(userId),
       };
+
       const expectedAutonomousCourseId = 123;
+
       const usecases = {
         saveAutonomousCourse: sinon.stub().resolves(expectedAutonomousCourseId),
       };
+
       const serializedAutonomousCourseId = Symbol('serializedAutonomousCourseId');
-      const autonomousCourseSerializer = { serializeId: sinon.stub().returns(serializedAutonomousCourseId) };
+
+      const expectedDeserializedPayloadAttributes = {
+        internalTitle: 'Titre pour usage interne',
+        publicTitle: 'Titre pour usage public',
+        targetProfileId: 3,
+        customLandingPageText: 'customLandingPageText',
+      };
+
+      const autonomousCourseSerializer = {
+        serializeId: sinon.stub().returns(serializedAutonomousCourseId),
+        deserialize: sinon.stub().returns(expectedDeserializedPayloadAttributes),
+      };
       const dependencies = {
         requestResponseUtils,
         usecases,
@@ -46,7 +62,7 @@ describe('Unit | Controller | autonomous-course-controller', function () {
       // then
       expect(requestResponseUtils.extractUserIdFromRequest).to.have.been.called;
       expect(usecases.saveAutonomousCourse).to.have.been.calledWithExactly({
-        autonomousCourse: { ...autonomousCourseAttributes, ownerId: userId },
+        autonomousCourse: { ...expectedDeserializedPayloadAttributes, ownerId: userId },
       });
       expect(autonomousCourseSerializer.serializeId).to.have.been.calledWithExactly(expectedAutonomousCourseId);
     });

--- a/api/tests/evaluation/unit/domain/usecases/save-autonomous-course_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-autonomous-course_test.js
@@ -1,7 +1,9 @@
 import { expect, sinon, domainBuilder, catchErr } from '../../../../test-helper.js';
 import { saveAutonomousCourse } from '../../../../../src/evaluation/domain/usecases/save-autonomous-course.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError } from '../../../../../src/evaluation/domain/errors.js';
+import {
+  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  NotFoundError,
+} from '../../../../../src/shared/domain/errors.js';
 import { constants } from '../../../../../lib/domain/constants.js';
 
 describe('Unit | UseCase | save-autonomous-course', function () {

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-serializer_test.js
@@ -17,4 +17,32 @@ describe('Unit | Serializer | JSONAPI | autonomous-course-serializer', function 
       return expect(serializedAutonomousCourse).to.deep.equal(expectedSerializedAutonomousCourse);
     });
   });
+
+  describe('#deserialize', function () {
+    it('should convert JSON API data to Autonomous Course object', async function () {
+      // given
+      const jsonTraining = {
+        data: {
+          type: 'autonomous-courses',
+          attributes: {
+            'target-profile-id': 30,
+            'internal-title': 'internal title',
+            'public-title': 'public title',
+            'custom-landing-page-text': 'Custom landing page text',
+          },
+        },
+      };
+
+      // when
+      const autonomousCourse = await serializer.deserialize(jsonTraining);
+
+      // then
+      expect(autonomousCourse).to.deep.equal({
+        internalTitle: 'internal title',
+        publicTitle: 'public title',
+        targetProfileId: 30,
+        customLandingPageText: 'Custom landing page text',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin d'un formulaire de création de parcours autonomes sur pix-admin.

## :robot: Proposition
Ajouter le formulaire ainsi que des seeds pour pouvoir créer des parcours autonomes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter avec `superadmin@example.net`.
Créer un parcours autonomes avec le profil cible correspondant "Profil cible pour parcours autonomes" et vérifier sa présence en base de données.
Vérifier qu'on revient bien des erreurs lorsqu'un des champs obligatoires n'est pas ajouté ou lorsqu'un profil cible qui n'est pas associé à l'organisation des parcours autonomes est ajouté.
