### PR TITLE
[BUGFIX] Mettre à jour la contrainte d'unicité pour valider la mise à jour ou la création d'un OrganizationLearner SUP (PIX-10112)

### DIFF
--- a/api/db/migrations/20231124145156_add-deletedAt-sup-learner-unicity-constraint.js
+++ b/api/db/migrations/20231124145156_add-deletedAt-sup-learner-unicity-constraint.js
@@ -1,0 +1,43 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-learners';
+const NEW_CONSTRAINT_NAME = 'one_active_sup_organization_learner';
+const DELETEDAT_COLUMN = 'deletedAt';
+const DELETEDBY_COLUMN = 'deletedBy';
+const STUDENT_NUMBER_COLUMN = 'studentNumber';
+const ORGANIZATIONID_COLUMN = 'organizationId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique(['organizationId', 'studentNumber']);
+  });
+
+  return knex.raw(
+    `CREATE UNIQUE INDEX :name: ON :table: (:studentNumber:, :organizationId: ) WHERE :deletedAt: IS NULL AND :deletedBy: IS NULL;`,
+    {
+      name: NEW_CONSTRAINT_NAME,
+      table: TABLE_NAME,
+      studentNumber: STUDENT_NUMBER_COLUMN,
+      organizationId: ORGANIZATIONID_COLUMN,
+      deletedAt: DELETEDAT_COLUMN,
+      deletedBy: DELETEDBY_COLUMN,
+    },
+  );
+};
+
+const down = async function (knex) {
+  await knex.raw(`DROP INDEX :name:;`, { name: NEW_CONSTRAINT_NAME });
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(['organizationId', 'studentNumber']);
+  });
+};
+
+export { up, down };

--- a/api/src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js
@@ -91,7 +91,7 @@ async function _upsertStudents(queryBuilder, supOrganizationLearners) {
   try {
     await queryBuilder('organization-learners')
       .insert(supOrganizationLearnersToInsert)
-      .onConflict(['organizationId', 'studentNumber'])
+      .onConflict(knex.raw('("studentNumber", "organizationId") where "deletedAt" is NULL and "deletedBy" is NULL'))
       .merge();
   } catch (error) {
     throw new OrganizationLearnersCouldNotBeSavedError();


### PR DESCRIPTION
## :unicorn: Problème
Des organismes SUP font des imports et ne voit pas leur étudiants. Il s'avère que la contrainte actuelle met à jour les learners deleted. alors que ne ne voulons pas de ce comportement

## :robot: Proposition
Modifier la contraintes afin de prendre en compte le fait que le learner a été supprimé

## :rainbow: Remarques
RAS

## :100: Pour tester
- Aller sur Pix Orga en sup-orga@example.net .
- Supprimer un learner de la list
- Faire un import SUP qui ajoutes ce learner.
- Vérifier qu'il apparaît à nouveau