### PR TITLE
[BUGFIX] Modification du format de données de variationPercent en BDD (PIX-10116).

### DIFF
--- a/api/db/migrations/20231124153100_change-variation-format-from-integer-to-float.js
+++ b/api/db/migrations/20231124153100_change-variation-format-from-integer-to-float.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'flash-algorithm-configurations';
+const COLUMN_NAME = 'variationPercent';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.float(COLUMN_NAME).alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).alter();
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'ajout ou modification d'une configuration de l'algorithme flash, le paramètre `variationPercent` doit être au format `float`. Il est actuellement au format `integer`

## :robot: Proposition

Modification de la colonne en BDD

## :rainbow: Remarques

On ne s'occupe pas des données existantes. Il n'y en a à l'heure actuelle aucune.

## :100: Pour tester

Vérifier en BDD que la colonne `variationPercent` ait le bon format
