### PR TITLE
[FEATURE] détache un profil cible target depuis la page organisation (PIX-9983)

### DIFF
--- a/admin/app/components/organizations/target-profiles-section.hbs
+++ b/admin/app/components/organizations/target-profiles-section.hbs
@@ -28,6 +28,9 @@
           <tr>
             <th class="table__column table__column--id">ID</th>
             <th>Nom du profil cible</th>
+            {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+              <th>Actions</th>
+            {{/if}}
           </tr>
         </thead>
 
@@ -41,6 +44,13 @@
                     {{summary.name}}
                   </LinkTo>
                 </td>
+                {{#if (this.canDetachTargetProfile summary)}}
+                  <td>
+                    <PixButton @backgroundColor="red" @size="small" @triggerAction={{(fn this.openModal summary)}}>
+                      Détacher
+                    </PixButton>
+                  </td>
+                {{/if}}
               </tr>
             {{/each}}
           </tbody>
@@ -53,3 +63,29 @@
     </div>
   </div>
 </section>
+
+<PixModal
+  @title="Détacher le profil cible de l'organisation"
+  @onCloseButtonClick={{this.closeModal}}
+  @showModal={{this.showModal}}
+  aria-hidden="{{(not this.showModal)}}"
+>
+  <:content>
+    <p>
+      Etes-vous sûr de vouloir détacher le profil cible
+      <strong>{{this.targetProfileToDetach.name}}</strong>
+      de l'organisation
+      <strong>{{@targetProfileName}}</strong>
+      ?
+    </p>
+  </:content>
+  <:footer>
+    <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.closeModal}}>
+      Annuler
+    </PixButton>
+    <PixButton
+      @backgroundColor="red"
+      @triggerAction={{fn this.detachTargetProfile this.targetProfileToDetach.id}}
+    >Confirmer</PixButton>
+  </:footer>
+</PixModal>

--- a/admin/app/models/target-profile-summary.js
+++ b/admin/app/models/target-profile-summary.js
@@ -2,6 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TargetProfileSummary extends Model {
   @attr() name;
+  @attr() isPublic;
   @attr() outdated;
   @attr() createdAt;
 }

--- a/admin/tests/unit/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/unit/components/organizations/target-profiles-section_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 import createComponent from '../../../helpers/create-glimmer-component';
 
@@ -160,6 +161,57 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
           assert.ok(component.notifications.error.calledWith('Une erreur est survenue.'));
         });
       });
+    });
+  });
+
+  module('#canDetachTargetProfile', () => {
+    test('should return false if target profile is public and user can has access to organization action', function (assert) {
+      //given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const component = createComponent('component:organizations/target-profiles-section');
+
+      // then
+      assert.notOk(component.canDetachTargetProfile({ isPublic: true }));
+    });
+    test("should return false if target profile is public and user don't has access to organization action", function (assert) {
+      //given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const component = createComponent('component:organizations/target-profiles-section');
+
+      // then
+      assert.notOk(component.canDetachTargetProfile({ isPublic: true }));
+    });
+    test("should return false if target profile is private and user don't has access to organization action", function (assert) {
+      //given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const component = createComponent('component:organizations/target-profiles-section');
+
+      // then
+      assert.notOk(component.canDetachTargetProfile({ isPublic: false }));
+    });
+    test('should return true if target profile is private and user  has access to organization action', function (assert) {
+      //given
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const component = createComponent('component:organizations/target-profiles-section');
+
+      // then
+      assert.ok(component.canDetachTargetProfile({ isPublic: false }));
     });
   });
 });

--- a/api/lib/domain/models/TargetProfileSummaryForAdmin.js
+++ b/api/lib/domain/models/TargetProfileSummaryForAdmin.js
@@ -1,8 +1,9 @@
 class TargetProfileSummaryForAdmin {
-  constructor({ id, name, outdated, createdAt } = {}) {
+  constructor({ id, name, isPublic, outdated, createdAt } = {}) {
     this.id = id;
     this.name = name;
     this.outdated = outdated;
+    this.isPublic = isPublic;
     this.createdAt = createdAt;
   }
 }

--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -22,6 +22,7 @@ const findByOrganization = async function ({ organizationId }) {
       id: 'target-profiles.id',
       name: 'target-profiles.name',
       outdated: 'target-profiles.outdated',
+      isPublic: 'target-profiles.isPublic',
     })
     .leftJoin('target-profile-shares', function () {
       this.on('target-profile-shares.targetProfileId', 'target-profiles.id').on(

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (targetProfileSummaries, meta) {
   return new Serializer('target-profile-summary', {
-    attributes: ['name', 'outdated', 'createdAt'],
+    attributes: ['name', 'isPublic', 'outdated', 'createdAt'],
     meta,
   }).serialize(targetProfileSummaries);
 };

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1202,6 +1202,7 @@ describe('Acceptance | Application | organization-controller', function () {
             attributes: {
               name: 'Super profil cible',
               outdated: false,
+              'is-public': true,
               'created-at': undefined,
             },
           },

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -437,8 +437,8 @@ describe('Acceptance | Controller | training-controller', function () {
       const targetProfile = databaseBuilder.factory.buildTargetProfile({
         id: 1,
         name: 'Super profil cible',
-        isPublic: true,
         outdated: false,
+        'is-public': undefined,
         'created-at': undefined,
       });
       databaseBuilder.factory.buildTargetProfileTraining({
@@ -453,6 +453,7 @@ describe('Acceptance | Controller | training-controller', function () {
         attributes: {
           name: targetProfile.name,
           outdated: false,
+          'is-public': undefined,
           'created-at': undefined,
         },
       };

--- a/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -21,7 +21,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       });
 
       // then
-      expect(actualTargetProfileSummary).to.deep.equal(targetProfile);
+      expect(actualTargetProfileSummary).to.deep.equal({ ...targetProfile, isPublic: undefined });
     });
 
     context('ordered target profile list', function () {
@@ -148,7 +148,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
             { id: 1, name: 'paTtErN', outdated: false, createdAt: new Date('2021-01-01') },
             { id: 2, name: 'AApatterNOo', outdated: true, createdAt: new Date('2021-01-01') },
             { id: 3, name: 'NotUnderTheRadar', outdated: false, createdAt: new Date('2021-01-01') },
-            { id: 4, name: 'PaTternXXXX', outdated: true, createdAt: new Date('2021-01-01') },
+            { id: 4, name: 'PaTternXXXX', outdated: true, isPublic: true, createdAt: new Date('2021-01-01') },
           ];
           targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
           return databaseBuilder.commit();
@@ -339,8 +339,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: false, outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -368,7 +368,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: false, outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -407,8 +407,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: false, outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -442,8 +442,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', isPublic: true, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: true, outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -471,7 +471,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: true, outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -513,9 +513,9 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'A_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'B_tp', outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 12, name: 'C_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'A_tp', isPublic: true, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'B_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 12, name: 'C_tp', isPublic: false, outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -553,8 +553,16 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
       // then
       const expectedTargetProfileSummaries = [
-        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile1, createdAt: undefined }),
-        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile2, createdAt: undefined }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({
+          ...targetProfile1,
+          isPublic: undefined,
+          createdAt: undefined,
+        }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({
+          ...targetProfile2,
+          isPublic: undefined,
+          createdAt: undefined,
+        }),
       ];
       expect(targetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
     });

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
@@ -4,12 +4,14 @@ const buildTargetProfileSummaryForAdmin = function ({
   id = 123,
   name = 'Profil cible super cool',
   outdated = false,
+  isPublic,
   createdAt,
 } = {}) {
   return new TargetProfileSummaryForAdmin({
     id,
     name,
     outdated,
+    isPublic,
     createdAt,
   });
 };

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -531,6 +531,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
             attributes: {
               name: 'Super profil cible',
               outdated: false,
+              'is-public': undefined,
               'created-at': undefined,
             },
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -9,12 +9,14 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 1,
           name: 'TPA',
+          isPublic: false,
           outdated: false,
           createdAt: new Date('2021-01-01'),
         }),
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 2,
           name: 'TPB',
+          isPublic: true,
           outdated: true,
           createdAt: new Date('2021-01-01'),
         }),
@@ -33,6 +35,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPA',
               outdated: false,
+              'is-public': false,
               'created-at': new Date('2021-01-01'),
             },
           },
@@ -42,6 +45,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPB',
               outdated: true,
+              'is-public': true,
               'created-at': new Date('2021-01-01'),
             },
           },


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas détacher un profil cible d'une organisation depuis la liste des profils cible d'une organisation. 

## :robot: Proposition
Rajouter un bouton "Détacher" sur la page des profils cible d'une organisation

## :rainbow: Remarques
ras

## :100: Pour tester

- Se connecter sur pix admin
- Ajouter le profil cible 6001 à l'organisation 1003
- séléctionner l'organisation `1003 SCO Orga - Not Managing Students` (recharger la page si besoin le fetch vers l'api n'est pas fait lors du clique depuis la page profil cible sur une orga)
- afficher les profils cibles
- cliquer sur Détacher / confirmer
- Ne plus voir le profil cible de la liste