### PR TITLE
[TECH] Créer et retourner le champ `isAnswerable` via l'API (PIX-10094)

### DIFF
--- a/api/src/devcomp/domain/models/element/Element.js
+++ b/api/src/devcomp/domain/models/element/Element.js
@@ -5,6 +5,7 @@ class Element {
     assertNotNullOrUndefined(id, "L'id est obligatoire pour un élément");
 
     this.id = id;
+    this.isAnswerable = false;
   }
 }
 

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -12,6 +12,7 @@ class QCU extends Element {
     this.instruction = instruction;
     this.locales = locales;
     this.proposals = proposals;
+    this.isAnswerable = true;
   }
 
   #assertProposalsAreNotEmpty(proposals) {

--- a/api/src/devcomp/domain/models/element/Text.js
+++ b/api/src/devcomp/domain/models/element/Text.js
@@ -2,18 +2,12 @@ import { Element } from './Element.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Text extends Element {
-  #content;
-
   constructor({ id, content }) {
     super({ id });
 
     assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour un texte');
 
-    this.#content = content;
-  }
-
-  get content() {
-    return this.#content;
+    this.content = content;
   }
 }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -17,15 +17,12 @@ function serialize(module) {
             elements: grain.elements.map((element) => {
               if (element instanceof QCU) {
                 return {
-                  id: element.id,
-                  instruction: element.instruction,
-                  proposals: element.proposals,
+                  ...element,
                   type: 'qcus',
                 };
               }
               return {
-                id: element.id,
-                content: element.content,
+                ...element,
                 type: 'texts',
               };
             }),
@@ -41,7 +38,7 @@ function serialize(module) {
       elements: {
         ref: 'id',
         includes: true,
-        attributes: ['content', 'instruction', 'proposals', 'type'],
+        attributes: ['content', 'instruction', 'proposals', 'type', 'isAnswerable'],
       },
     },
     typeForAttribute(attribute, { type }) {

--- a/api/tests/devcomp/unit/domain/models/element/Element_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Element_test.js
@@ -1,0 +1,32 @@
+import { expect } from '../../../../../test-helper.js';
+import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
+import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
+
+describe('Unit | Devcomp | Domain | Models | Element', function () {
+  describe('#isAnswerable', function () {
+    it('should instanciate answerable elements', function () {
+      // Given
+      const qcu = new QCU({
+        id: '123',
+        instruction: 'instruction',
+        locales: ['fr-FR'],
+        proposals: [Symbol('proposal1'), Symbol('proposal2')],
+      });
+
+      const answerableElements = [qcu];
+
+      // Then
+      answerableElements.forEach((element) => expect(element.isAnswerable).to.be.true);
+    });
+
+    it('should instanciate non answerable elements', function () {
+      // Given
+      const text = new Text({ id: 'id', content: 'content' });
+
+      const nonAnswerableElements = [text];
+
+      // Then
+      nonAnswerableElements.forEach((element) => expect(element.isAnswerable).to.be.false);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -49,10 +49,10 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
             title: 'Grain 1',
             type: 'activity',
             elements: [
-              new Text({ id: '1', content: '' }),
+              new Text({ id: '1', content: 'toto' }),
               new QCU({
                 id: '2',
-                proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: '' }],
+                proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
                 instruction: 'hello',
                 solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
               }),
@@ -81,7 +81,8 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
         included: [
           {
             attributes: {
-              content: '',
+              content: 'toto',
+              'is-answerable': false,
               type: 'texts',
             },
             id: '1',
@@ -90,9 +91,10 @@ describe('Unit | DevComp | Serializers | ModuleSerializer', function () {
           {
             attributes: {
               instruction: 'hello',
+              'is-answerable': true,
               proposals: [
                 {
-                  content: '',
+                  content: 'toto',
                   id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
                 },
               ],

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -2,6 +2,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class Element extends Model {
   @attr('string') type;
+  @attr('boolean') isAnswerable;
 
   @belongsTo('grain', { inverse: 'elements' }) grain;
   @hasMany('element-answer', { inverse: 'element' }) elementAnswers;
@@ -12,10 +13,6 @@ export default class Element extends Model {
 
   get isQcu() {
     return this.type === 'qcus';
-  }
-
-  get isAnswerable() {
-    return this.isQcu;
   }
 
   get isAnswered() {

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -24,7 +24,11 @@ module('Integration | Component | Module | Grain', function (hooks) {
     test('should display text element', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const textElement = store.createRecord('text', { content: 'element content', type: 'texts' });
+      const textElement = store.createRecord('text', {
+        content: 'element content',
+        type: 'texts',
+        isAnswerable: false,
+      });
       const elements = [textElement];
       const grain = store.createRecord('grain', { title: 'Grain title', elements });
       this.set('grain', grain);
@@ -45,6 +49,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         instruction: 'instruction',
         proposals: ['radio1', 'radio2'],
         type: 'qcus',
+        isAnswerable: true,
       });
       const elements = [qcuElement];
       const grain = store.createRecord('grain', { title: 'Grain title', elements });
@@ -63,7 +68,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       test('should display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = store.createRecord('element', { type: 'qcus' });
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
 
@@ -83,7 +88,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = store.createRecord('element', { type: 'qcus' });
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
 
@@ -103,7 +108,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = store.createRecord('element', { type: 'qcus' });
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
 
@@ -123,7 +128,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = store.createRecord('element', { type: 'qcus' });
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
 
@@ -142,7 +147,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
     test('should call continueAction pass in argument and push event', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const element = store.createRecord('text', { type: 'texts' });
+      const element = store.createRecord('text', { type: 'texts', isAnswerable: false });
       const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);

--- a/mon-pix/tests/unit/models/modules/element_test.js
+++ b/mon-pix/tests/unit/models/modules/element_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | Element', function (hooks) {
+module('Unit | Model | Module | Element', function (hooks) {
   setupTest(hooks);
 
   module('#isText', function () {

--- a/mon-pix/tests/unit/models/modules/element_test.js
+++ b/mon-pix/tests/unit/models/modules/element_test.js
@@ -66,37 +66,6 @@ module('Unit | Model | Element', function (hooks) {
     });
   });
 
-  module('#isAnswerable', function () {
-    module('when element is answerable', function () {
-      test('should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = store.createRecord('element', { type: 'qcus' });
-
-        // when
-        const isAnswerable = element.isAnswerable;
-
-        // then
-        assert.true(isAnswerable);
-      });
-    });
-
-    module('when element is not answerable', function () {
-      test('should return false', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        ['texts'].forEach((type) => {
-          // when
-          const element = store.createRecord('element', { type });
-          const isAnswerable = element.isAnswerable;
-
-          // then
-          assert.false(isAnswerable);
-        });
-      });
-    });
-  });
-
   module('#isAnswered', function () {
     module('when element is answered', function () {
       test('should return true', function (assert) {

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | Grain', function (hooks) {
+module('Unit | Model | Module | Grain', function (hooks) {
   setupTest(hooks);
 
   module('#answerableElements', function () {

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -9,8 +9,8 @@ module('Unit | Model | Grain', function (hooks) {
       test('should return only answerable elements', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const qcu = store.createRecord('qcu', { type: 'qcus' });
-        const text = store.createRecord('text', { type: 'texts' });
+        const qcu = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
+        const text = store.createRecord('text', { type: 'texts', isAnswerable: false });
         const grain = store.createRecord('grain', {
           elements: [qcu, text],
         });
@@ -67,7 +67,7 @@ module('Unit | Model | Grain', function (hooks) {
       test('should return false', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const qcu = store.createRecord('qcu', { type: 'qcus' });
+        const qcu = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', {
           elements: [qcu],
         });

--- a/mon-pix/tests/unit/models/modules/module_test.js
+++ b/mon-pix/tests/unit/models/modules/module_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | Module', function (hooks) {
+module('Unit | Model | Module | Module', function (hooks) {
   setupTest(hooks);
 
   test('Module model should exist with the right properties', function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le front se charge de calculer se champ alors que c’est du métier, l’API devrait se charger de le renvoyer.

## :robot: Proposition
- Création du champ dans l’API côté `Element` domain model
- Changer le serializer de module pour retourner ce nouveau champ
- Supprimer le getter dans le modèle `Element` du front => Attention il faudra rajouter le champ à tous les `createRecord('qcu')` des tests

## :rainbow: Remarques
Il faudrait mettre à jour les unit test côté API pour la classe Element quand nous aurons mergé la PR sur l'élément `Image`.

## :100: Pour tester
La CI passe.
