### PR TITLE
[FEATURE] Dégrader le score d'une certification avec plus de V questions et SANS problème technique. (PIX-9979)

### DIFF
--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -9,7 +9,6 @@ import { CertificationVersion } from '../../../src/shared/domain/models/Certific
 import { CertificationAssessmentScoreV3 } from '../models/CertificationAssessmentScoreV3.js';
 import { ABORT_REASONS } from '../models/CertificationCourse.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const eventTypes = [AssessmentCompleted];
 const EMITTER = 'PIX-ALGO';
@@ -121,8 +120,7 @@ async function _handleV3CertificationScoring({
     ? ABORT_REASONS.CANDIDATE
     : ABORT_REASONS.TECHNICAL;
 
-  const configuration =
-    (await flashAlgorithmConfigurationRepository.get()) ?? new FlashAssessmentAlgorithmConfiguration();
+  const configuration = await flashAlgorithmConfigurationRepository.get();
 
   const algorithm = new FlashAssessmentAlgorithm({
     flashAlgorithmImplementation: flashAlgorithmService,

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -8,6 +8,8 @@ import { checkEventTypes } from './check-event-types.js';
 import { CertificationVersion } from '../../../src/shared/domain/models/CertificationVersion.js';
 import { CertificationAssessmentScoreV3 } from '../models/CertificationAssessmentScoreV3.js';
 import { ABORT_REASONS } from '../models/CertificationCourse.js';
+import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const eventTypes = [AssessmentCompleted];
 const EMITTER = 'PIX-ALGO';
@@ -22,6 +24,7 @@ async function handleCertificationScoring({
   scoringCertificationService,
   answerRepository,
   challengeRepository,
+  flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
 }) {
   checkEventTypes(event, eventTypes);
@@ -38,6 +41,7 @@ async function handleCertificationScoring({
         assessmentResultRepository,
         certificationCourseRepository,
         competenceMarkRepository,
+        flashAlgorithmConfigurationRepository,
         flashAlgorithmService,
         locale: event.locale,
       });
@@ -103,6 +107,7 @@ async function _handleV3CertificationScoring({
   assessmentResultRepository,
   certificationCourseRepository,
   competenceMarkRepository,
+  flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   locale,
 }) {
@@ -116,10 +121,18 @@ async function _handleV3CertificationScoring({
     ? ABORT_REASONS.CANDIDATE
     : ABORT_REASONS.TECHNICAL;
 
+  const configuration =
+    (await flashAlgorithmConfigurationRepository.get()) ?? new FlashAssessmentAlgorithmConfiguration();
+
+  const algorithm = new FlashAssessmentAlgorithm({
+    flashAlgorithmImplementation: flashAlgorithmService,
+    configuration,
+  });
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+    algorithm,
     challenges,
     allAnswers,
-    flashAlgorithmService,
     abortReason,
   });
 
@@ -201,5 +214,6 @@ async function _saveResultAfterCertificationComputeError({
   certificationCourse.complete({ now: new Date() });
   return certificationCourseRepository.update(certificationCourse);
 }
+
 handleCertificationScoring.eventTypes = eventTypes;
 export { handleCertificationScoring };

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -47,7 +47,7 @@ import { handlePoleEmploiParticipationFinished } from './handle-pole-emploi-part
 import { handlePoleEmploiParticipationStarted } from './handle-pole-emploi-participation-started.js';
 import { handleSessionFinalized } from './handle-session-finalized.js';
 import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
-
+import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 const { performance } = perf_hooks;
 
 function requirePoleEmploiNotifier() {
@@ -78,6 +78,7 @@ const dependencies = {
   complementaryCertificationCourseResultRepository,
   complementaryCertificationScoringCriteriaRepository,
   finalizedSessionRepository,
+  flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   juryCertificationSummaryRepository,
   knowledgeElementRepository,

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -64,7 +64,7 @@ class CertificationAssessmentScoreV3 {
 
     const rawScore = _computeScore(estimatedLevel);
 
-    const nbPix = _shouldDowngradeScore({ maximumAssessmentLength, answers: allAnswers })
+    const nbPix = _shouldDowngradeScore({ maximumAssessmentLength, answers: allAnswers, abortReason })
       ? _downgradeScore(rawScore)
       : rawScore;
 
@@ -117,10 +117,11 @@ const _computeScore = (estimatedLevel) => {
 
 const _downgradeScore = (score) => Math.round(score * 0.8);
 
-const _shouldDowngradeScore = ({ maximumAssessmentLength, answers }) => {
+const _shouldDowngradeScore = ({ maximumAssessmentLength, answers, abortReason }) => {
   return (
     _hasCandidateAnsweredEnoughQuestions({ answers }) &&
-    !_hasCandidateCompletedTheCertification({ answers, maximumAssessmentLength })
+    !_hasCandidateCompletedTheCertification({ answers, maximumAssessmentLength }) &&
+    abortReason === ABORT_REASONS.CANDIDATE
   );
 };
 

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,5 +1,4 @@
 import { status as CertificationStatus } from './AssessmentResult.js';
-import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
 import { config } from '../../../src/shared/config.js';
 import { ABORT_REASONS } from './CertificationCourse.js';
 
@@ -55,10 +54,7 @@ class CertificationAssessmentScoreV3 {
     this._status = status;
   }
 
-  static fromChallengesAndAnswers({ challenges, allAnswers, flashAlgorithmService, abortReason }) {
-    const algorithm = new FlashAssessmentAlgorithm({
-      flashAlgorithmImplementation: flashAlgorithmService,
-    });
+  static fromChallengesAndAnswers({ algorithm, challenges, allAnswers, abortReason }) {
     const { estimatedLevel } = algorithm.getEstimatedLevelAndErrorRate({
       challenges,
       allAnswers,
@@ -114,10 +110,11 @@ const _computeScore = (estimatedLevel) => {
 };
 
 const _isCertificationRejected = ({ answers, abortReason }) => {
-  return (
-    answers.length < config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification &&
-    abortReason === ABORT_REASONS.CANDIDATE
-  );
+  return !_hasCandidateAnsweredEnoughQuestions({ answers }) && abortReason === ABORT_REASONS.CANDIDATE;
+};
+
+const _hasCandidateAnsweredEnoughQuestions = ({ answers }) => {
+  return answers.length >= config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification;
 };
 
 export { CertificationAssessmentScoreV3 };

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -1,6 +1,5 @@
 import { CertificationVersion } from '../../../src/shared/domain/models/CertificationVersion.js';
 import { CertificationChallenge, FlashAssessmentAlgorithm } from '../models/index.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 const getNextChallengeForCertification = async function ({
   algorithmDataFetcherService,
@@ -49,8 +48,7 @@ const getNextChallengeForCertification = async function ({
       locale,
     });
 
-    const algorithmConfiguration =
-      (await flashAlgorithmConfigurationRepository.get()) ?? _createDefaultAlgorithmConfiguration();
+    const algorithmConfiguration = await flashAlgorithmConfigurationRepository.get();
 
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,
@@ -99,16 +97,6 @@ const _getAlreadyAnsweredChallengeIds = async ({ assessmentId, answerRepository 
 
 const _getValidatedLiveAlertChallengeIds = async ({ assessmentId, certificationChallengeLiveAlertRepository }) => {
   return certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId(assessmentId);
-};
-
-const _createDefaultAlgorithmConfiguration = () => {
-  return new FlashAssessmentAlgorithmConfiguration({
-    warmUpLength: 0,
-    forcedCompetences: [],
-    limitToOneQuestionPerTube: false,
-    minimumEstimatedSuccessRateRanges: [],
-    enablePassageByAllCompetences: false,
-  });
 };
 
 export { getNextChallengeForCertification };

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
@@ -22,7 +22,7 @@ class FlashAssessmentAlgorithm {
    * @param configuration - options to configure algorithm challenge selection and behaviour
    */
   constructor({ flashAlgorithmImplementation, configuration = {} } = {}) {
-    this.configuration = configuration;
+    this._configuration = configuration;
     this.flashAlgorithmImplementation = flashAlgorithmImplementation;
 
     this.ruleEngine = new FlashAssessmentAlgorithmRuleEngine(availableRules, {
@@ -40,7 +40,7 @@ class FlashAssessmentAlgorithm {
     initialCapacity = config.v3Certification.defaultCandidateCapacity,
     answersForComputingEstimatedLevel,
   }) {
-    if (assessmentAnswers.length >= this.configuration.maximumAssessmentLength) {
+    if (assessmentAnswers.length >= this._configuration.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }
 
@@ -48,7 +48,7 @@ class FlashAssessmentAlgorithm {
       allAnswers: answersForComputingEstimatedLevel ?? assessmentAnswers,
       challenges,
       initialCapacity,
-      variationPercent: this.configuration.variationPercent,
+      variationPercent: this._configuration.variationPercent,
     });
 
     const challengesAfterRulesApplication = this._applyChallengeSelectionRules(assessmentAnswers, challenges);
@@ -63,7 +63,7 @@ class FlashAssessmentAlgorithm {
       availableChallenges: challengesAfterRulesApplication,
       estimatedLevel,
       options: {
-        challengesBetweenSameCompetence: this.configuration.challengesBetweenSameCompetence,
+        challengesBetweenSameCompetence: this._configuration.challengesBetweenSameCompetence,
         minimalSuccessRate,
       },
     });
@@ -87,7 +87,7 @@ class FlashAssessmentAlgorithm {
   }
 
   _findApplicableSuccessRateConfiguration(questionIndex) {
-    return this.configuration.minimumEstimatedSuccessRateRanges.find((successRateRange) =>
+    return this._configuration.minimumEstimatedSuccessRateRanges.find((successRateRange) =>
       successRateRange.isApplicable(questionIndex),
     );
   }
@@ -101,13 +101,17 @@ class FlashAssessmentAlgorithm {
       allAnswers,
       challenges,
       estimatedLevel: initialCapacity,
-      variationPercent: this.configuration.variationPercent,
-      doubleMeasuresUntil: this.configuration.doubleMeasuresUntil,
+      variationPercent: this._configuration.variationPercent,
+      doubleMeasuresUntil: this._configuration.doubleMeasuresUntil,
     });
   }
 
   getReward({ estimatedLevel, discriminant, difficulty }) {
     return this.flashAlgorithmImplementation.getReward({ estimatedLevel, discriminant, difficulty });
+  }
+
+  getConfiguration() {
+    return this._configuration;
   }
 }
 

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
@@ -41,7 +41,7 @@ export class FlashAssessmentAlgorithmConfiguration {
     enablePassageByAllCompetences,
     variationPercent,
     doubleMeasuresUntil,
-  }) {
+  } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
     this.maximumAssessmentLength = maximumAssessmentLength;

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
@@ -1,24 +1,6 @@
 import { config } from '../../../../shared/config.js';
 import { FlashAssessmentSuccessRateHandler } from './FlashAssessmentSuccessRateHandler.js';
 
-const defaultMinimumEstimatedSuccessRateRanges = [
-  // Between question 1 and question 8 included, we set the minimum estimated
-  // success rate to 80%
-  FlashAssessmentSuccessRateHandler.createFixed({
-    startingChallengeIndex: 0,
-    endingChallengeIndex: 7,
-    value: 0.8,
-  }),
-  // Between question 9 and question 16 included, we linearly decrease the
-  // minimum estimated success rate from 80% to 50%
-  FlashAssessmentSuccessRateHandler.createLinear({
-    startingChallengeIndex: 8,
-    endingChallengeIndex: 15,
-    startingValue: 0.8,
-    endingValue: 0.5,
-  }),
-];
-
 /**
  * @param forcedCompetences - force the algorithm to ask questions on the specified competences
  * @param maximumAssessmentLength - override the default limit for an assessment length
@@ -32,13 +14,13 @@ const defaultMinimumEstimatedSuccessRateRanges = [
  */
 export class FlashAssessmentAlgorithmConfiguration {
   constructor({
-    warmUpLength,
-    forcedCompetences,
+    warmUpLength = 0,
+    forcedCompetences = [],
     maximumAssessmentLength = config.v3Certification.numberOfChallengesPerCourse,
     challengesBetweenSameCompetence = config.v3Certification.challengesBetweenSameCompetence,
-    minimumEstimatedSuccessRateRanges = defaultMinimumEstimatedSuccessRateRanges,
-    limitToOneQuestionPerTube,
-    enablePassageByAllCompetences,
+    minimumEstimatedSuccessRateRanges = [],
+    limitToOneQuestionPerTube = false,
+    enablePassageByAllCompetences = false,
     variationPercent,
     doubleMeasuresUntil,
   } = {}) {

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmRuleEngine.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmRuleEngine.js
@@ -10,7 +10,7 @@ export class FlashAssessmentAlgorithmRuleEngine {
     });
 
     return applicableRules.reduce((availableChallenges, rule) => {
-      return rule.execute({ assessmentAnswers, allChallenges, availableChallenges });
+      return rule.execute({ assessmentAnswers, allChallenges, availableChallenges, ...this._configuration });
     }, allChallenges);
   }
 

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -11,7 +11,7 @@ const get = async function () {
   const flashAlgorithmConfiguration = await knex(TABLE_NAME).first();
 
   if (!flashAlgorithmConfiguration) {
-    return null;
+    return new FlashAssessmentAlgorithmConfiguration();
   }
 
   return FlashAssessmentAlgorithmConfiguration.fromDTO(flashAlgorithmConfiguration);

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -1,5 +1,6 @@
 import { databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 import * as flashAlgorithmConfigurationRepository from '../../../../../../../api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js';
 
 describe('Integration | Infrastructure | Repository | FlashAlgorithmConfigurationRepository', function () {
   describe('#save', function () {
@@ -141,12 +142,12 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
     });
 
     describe('when there is no saved configuration', function () {
-      it('should return null', async function () {
+      it('should return default configuration', async function () {
         // when
         const configResult = await flashAlgorithmConfigurationRepository.get();
 
         // then
-        expect(configResult).to.equal(null);
+        expect(configResult).to.be.instanceOf(FlashAssessmentAlgorithmConfiguration);
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -3,7 +3,7 @@ import { FlashAssessmentAlgorithmConfiguration } from '../../../../src/certifica
 
 export const buildFlashAlgorithmConfiguration = ({
   warmUpLength,
-  forcedCompetences = [],
+  forcedCompetences,
   maximumAssessmentLength,
   challengesBetweenSameCompetence,
   minimumEstimatedSuccessRateRanges = [],

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -1,10 +1,9 @@
-import { expect, sinon, domainBuilder } from '../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { _forTestOnly } from '../../../../lib/domain/events/index.js';
-const { handleCertificationRescoring } = _forTestOnly.handlers;
 import { ChallengeNeutralized } from '../../../../lib/domain/events/ChallengeNeutralized.js';
 import { ChallengeDeneutralized } from '../../../../lib/domain/events/ChallengeDeneutralized.js';
 import { CertificationJuryDone } from '../../../../lib/domain/events/CertificationJuryDone.js';
-import { CertificationAssessment, CertificationResult, AssessmentResult } from '../../../../lib/domain/models/index.js';
+import { AssessmentResult, CertificationAssessment, CertificationResult } from '../../../../lib/domain/models/index.js';
 import { CertificationComputeError } from '../../../../lib/domain/errors.js';
 import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
 import { config } from '../../../../src/shared/config.js';
@@ -14,35 +13,63 @@ import {
 } from '../../../certification/shared/fixtures/challenges.js';
 import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse.js';
 
+const { handleCertificationRescoring } = _forTestOnly.handlers;
+
 const CERTIFICATION_RESULT_EMITTER_AUTOJURY = CertificationResult.emitters.PIX_ALGO_AUTO_JURY;
 const CERTIFICATION_RESULT_EMITTER_NEUTRALIZATION = CertificationResult.emitters.PIX_ALGO_NEUTRALIZATION;
 const { minimumAnswersRequiredToValidateACertification } = config.v3Certification.scoring;
 
 describe('Unit | Domain | Events | handle-certification-rescoring', function () {
   describe('when handling a v3 certification', function () {
+    let assessmentResultRepository,
+      certificationAssessmentRepository,
+      answerRepository,
+      challengeRepository,
+      certificationCourseRepository,
+      flashAlgorithmConfigurationRepository,
+      flashAlgorithmService;
+
+    let dependencies;
+
+    beforeEach(function () {
+      assessmentResultRepository = {
+        save: sinon.stub(),
+      };
+      certificationAssessmentRepository = {
+        getByCertificationCourseId: sinon.stub(),
+      };
+      answerRepository = {
+        findByAssessment: sinon.stub(),
+      };
+      challengeRepository = {
+        getManyFlashParameters: sinon.stub(),
+      };
+
+      certificationCourseRepository = {
+        get: sinon.stub(),
+      };
+
+      flashAlgorithmConfigurationRepository = {
+        get: sinon.stub(),
+      };
+
+      flashAlgorithmService = {
+        getEstimatedLevelAndErrorRate: sinon.stub(),
+      };
+
+      dependencies = {
+        certificationAssessmentRepository,
+        answerRepository,
+        challengeRepository,
+        assessmentResultRepository,
+        certificationCourseRepository,
+        flashAlgorithmConfigurationRepository,
+        flashAlgorithmService,
+      };
+    });
+
     describe('when less than the minimum number of answers required by the config has been answered', function () {
       it('should save the score with a rejected status', async function () {
-        const assessmentResultRepository = {
-          save: sinon.stub(),
-        };
-        const certificationAssessmentRepository = {
-          getByCertificationCourseId: sinon.stub(),
-        };
-        const answerRepository = {
-          findByAssessment: sinon.stub(),
-        };
-        const challengeRepository = {
-          getManyFlashParameters: sinon.stub(),
-        };
-
-        const certificationCourseRepository = {
-          get: sinon.stub(),
-        };
-
-        const flashAlgorithmService = {
-          getEstimatedLevelAndErrorRate: sinon.stub(),
-        };
-
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           version: CertificationVersion.V3,
         });
@@ -88,15 +115,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           certificationCourseId,
         });
 
-        const dependencies = {
-          certificationAssessmentRepository,
-          answerRepository,
-          challengeRepository,
-          assessmentResultRepository,
-          certificationCourseRepository,
-          flashAlgorithmService,
-        };
-
         const result = await handleCertificationRescoring({
           ...dependencies,
           event,
@@ -128,27 +146,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     });
 
     it('should save the score', async function () {
-      const assessmentResultRepository = {
-        save: sinon.stub(),
-      };
-      const certificationAssessmentRepository = {
-        getByCertificationCourseId: sinon.stub(),
-      };
-      const answerRepository = {
-        findByAssessment: sinon.stub(),
-      };
-      const challengeRepository = {
-        getManyFlashParameters: sinon.stub(),
-      };
-
-      const certificationCourseRepository = {
-        get: sinon.stub(),
-      };
-
-      const flashAlgorithmService = {
-        getEstimatedLevelAndErrorRate: sinon.stub(),
-      };
-
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         version: CertificationVersion.V3,
       });
@@ -193,15 +190,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       const event = new CertificationJuryDone({
         certificationCourseId,
       });
-
-      const dependencies = {
-        certificationAssessmentRepository,
-        answerRepository,
-        challengeRepository,
-        certificationCourseRepository,
-        assessmentResultRepository,
-        flashAlgorithmService,
-      };
 
       const result = await handleCertificationRescoring({
         ...dependencies,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -1,6 +1,5 @@
-import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { _forTestOnly } from '../../../../lib/domain/events/index.js';
-const { handleCertificationScoring } = _forTestOnly.handlers;
 import { AssessmentResult, status } from '../../../../lib/domain/models/AssessmentResult.js';
 import { CertificationComputeError } from '../../../../lib/domain/errors.js';
 import { AssessmentCompleted } from '../../../../lib/domain/events/AssessmentCompleted.js';
@@ -12,6 +11,8 @@ import {
   generateChallengeList,
 } from '../../../certification/shared/fixtures/challenges.js';
 
+const { handleCertificationScoring } = _forTestOnly.handlers;
+
 const { minimumAnswersRequiredToValidateACertification } = config.v3Certification.scoring;
 
 describe('Unit | Domain | Events | handle-certification-scoring', function () {
@@ -22,6 +23,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
   let competenceMarkRepository;
   let challengeRepository;
   let answerRepository;
+  let flashAlgorithmConfigurationRepository;
   let flashAlgorithmService;
 
   const now = new Date('2019-01-01T05:06:07Z');
@@ -41,6 +43,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
     competenceMarkRepository = { save: sinon.stub() };
     challengeRepository = { getMany: sinon.stub() };
     answerRepository = { findByAssessment: sinon.stub() };
+    flashAlgorithmConfigurationRepository = { get: sinon.stub() };
   });
 
   afterEach(function () {
@@ -352,6 +355,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             competenceMarkRepository,
             scoringCertificationService,
             certificationAssessmentRepository,
+            flashAlgorithmConfigurationRepository,
             flashAlgorithmService,
           });
 
@@ -418,6 +422,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             competenceMarkRepository,
             scoringCertificationService,
             certificationAssessmentRepository,
+            flashAlgorithmConfigurationRepository,
             flashAlgorithmService,
           });
 
@@ -478,6 +483,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           answerRepository,
           assessmentResultRepository,
           certificationCourseRepository,
+          flashAlgorithmConfigurationRepository,
           flashAlgorithmService,
         });
 

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -11,7 +11,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
   let answerRepository;
   let challengeRepository;
-  let flashAlgorithmService;
+  let algorithm;
 
   let baseChallenges;
   let baseAnswers;
@@ -24,7 +24,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     challengeRepository = {
       findFlashCompatible: sinon.stub(),
     };
-    flashAlgorithmService = {
+    algorithm = {
       getEstimatedLevelAndErrorRate: sinon.stub(),
     };
 
@@ -76,14 +76,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
     answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
     challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
-    flashAlgorithmService.getEstimatedLevelAndErrorRate
-      .withArgs(
-        _getEstimatedLevelAndErrorRateParams({
-          challenges: baseChallenges,
-          allAnswers: baseAnswers,
-          estimatedLevel: sinon.match.number,
-        }),
-      )
+    algorithm.getEstimatedLevelAndErrorRate
+      .withArgs({
+        challenges: baseChallenges,
+        allAnswers: baseAnswers,
+      })
       .returns({
         estimatedLevel: expectedEstimatedLevel,
       });
@@ -91,7 +88,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
       challenges: baseChallenges,
       allAnswers: baseAnswers,
-      flashAlgorithmService,
+      algorithm,
     });
 
     expect(score.nbPix).to.equal(expectedScoreForEstimatedLevel);
@@ -106,14 +103,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const challenges = _buildChallenges(veryEasyDifficulty, numberOfChallenges);
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.KO);
 
-      flashAlgorithmService.getEstimatedLevelAndErrorRate
-        .withArgs(
-          _getEstimatedLevelAndErrorRateParams({
-            challenges,
-            allAnswers,
-            estimatedLevel: sinon.match.number,
-          }),
-        )
+      algorithm.getEstimatedLevelAndErrorRate
+        .withArgs({
+          challenges,
+          allAnswers,
+        })
         .returns({
           estimatedLevel: veryLowEstimatedLevel,
         });
@@ -122,7 +116,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
         challenges,
         allAnswers,
-        flashAlgorithmService,
+        algorithm,
       });
 
       // then
@@ -139,14 +133,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const challenges = _buildChallenges(veryHardDifficulty, numberOfChallenges);
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
-      flashAlgorithmService.getEstimatedLevelAndErrorRate
-        .withArgs(
-          _getEstimatedLevelAndErrorRateParams({
-            challenges,
-            allAnswers,
-            estimatedLevel: sinon.match.number,
-          }),
-        )
+      algorithm.getEstimatedLevelAndErrorRate
+        .withArgs({
+          challenges,
+          allAnswers,
+        })
         .returns({
           estimatedLevel: veryHighEstimatedLevel,
         });
@@ -155,7 +146,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
         challenges,
         allAnswers,
-        flashAlgorithmService,
+        algorithm,
       });
 
       // then
@@ -171,14 +162,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
-          .withArgs(
-            _getEstimatedLevelAndErrorRateParams({
-              challenges,
-              allAnswers,
-              estimatedLevel: sinon.match.number,
-            }),
-          )
+        algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            challenges,
+            allAnswers,
+          })
           .returns({
             estimatedLevel: 0,
           });
@@ -186,7 +174,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
           challenges,
           allAnswers,
-          flashAlgorithmService,
+          algorithm,
         });
 
         expect(score.status).to.equal(status.VALIDATED);
@@ -199,14 +187,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
-          .withArgs(
-            _getEstimatedLevelAndErrorRateParams({
-              challenges,
-              allAnswers,
-              estimatedLevel: sinon.match.number,
-            }),
-          )
+        algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            challenges,
+            allAnswers,
+          })
           .returns({
             estimatedLevel: 0,
           });
@@ -214,7 +199,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
           challenges,
           allAnswers,
-          flashAlgorithmService,
+          algorithm,
           abortReason: 'candidate',
         });
 
@@ -229,14 +214,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
-          .withArgs(
-            _getEstimatedLevelAndErrorRateParams({
-              challenges,
-              allAnswers,
-              estimatedLevel: sinon.match.number,
-            }),
-          )
+        algorithm.getEstimatedLevelAndErrorRate
+          .withArgs({
+            challenges,
+            allAnswers,
+          })
           .returns({
             estimatedLevel: 0,
           });
@@ -244,7 +226,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
           challenges,
           allAnswers,
-          flashAlgorithmService,
+          algorithm,
           certificationCourseAbortReason,
         });
 
@@ -265,12 +247,6 @@ const _buildChallenges = (difficulty, numberOfChallenges) => {
     }),
   );
 };
-
-const _getEstimatedLevelAndErrorRateParams = (params) => ({
-  ...params,
-  doubleMeasuresUntil: undefined,
-  variationPercent: undefined,
-});
 
 const _buildAnswersForChallenges = (challenges, answerResult) => {
   return challenges.map(({ id: challengeId }) =>


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la nouvelle certification, des nouvelles règles de scoring ont été décidées, afin de coller avec la nouvelle philosophie de la certif.

## :robot: Proposition
Implémenter la règles cas 2a - certif avec plus de V questions et SANS problème technique

Pour une certification non terminée, avec plus de V questions, et dont la raison de l’abandon sélectionnée lors de la finalisation de la session est “Abandon : manque de temps ou départ prématuré” : 
- passer la certification au statut “Validée”
- dégrader le score en Pix 

> Mettre V à 10 questions pour le moment, ce nombre évoluera surement par la suite  
> Dégrader le score = appliquer un malus de 20%, la solution pour dégrader le score pourra évoluer par la suite

## :rainbow: Remarques

## :100: Pour tester

1. créer une session v3 et inscrire un candidat en renseignant un destinataire des résultats = soi-même (pour recevoir le csv des résultats après publication 😉 )
2. lancer le test avec le candidat, et répondre à plus de 10 questions
3. dans Pix certif, cliquer sur “Finaliser la session”
4. sélectionner l’option “Abandon : manque de temps ou départ prématuré” comme raison de l’abandon puis confirmer la finalisation
5. dans Pix admin > ouvrir la page de détails de la certif 
6. résultat : le statut de la certif est “Validée”
7. le score en Pix a été dégradé de 20%
8. publier la session
9. sur le compte app du candidat, ouvrir la page 'Mes certifications”
10. résultat : la certif est au statut “Validée”, avec le même score en Pix dégradé
11. ouvrir le mail reçu avec les résultat de la certif
12. résultat : pour cette certification, il est indiqué “Validée” dans la colonne “Statut”, et le score en Pix dans la colonne “Nombre de Pix” est le score dégradé