### PR TITLE
[TECH] Renome des fichiers du domaine « school » qui on été mal nomé (PIX-10131)

### DIFF
--- a/api/src/school/application/assessment-controller.js
+++ b/api/src/school/application/assessment-controller.js
@@ -1,6 +1,6 @@
-import * as challengeSerializer from '../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
-import { usecases } from '../../shared/usecases/index.js';
-import * as assessmentSerializer from '../../../../src/school/infrastructure/serializers/assessment.js';
+import * as challengeSerializer from '../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
+import { usecases } from '../shared/usecases/index.js';
+import * as assessmentSerializer from '../../../src/school/infrastructure/serializers/assessment.js';
 
 const getNextChallengeForPix1d = async function (request, h, dependencies = { challengeSerializer }) {
   const assessmentId = request.params.id;

--- a/api/src/school/application/assessment-route.js
+++ b/api/src/school/application/assessment-route.js
@@ -1,7 +1,7 @@
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
 import Joi from 'joi';
-import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
-import { assessmentController } from './controller.js';
+import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
+import { assessmentController } from './assessment-controller.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/school/application/organization-learner-controller.js
+++ b/api/src/school/application/organization-learner-controller.js
@@ -1,5 +1,5 @@
-import { usecases } from '../../shared/usecases/index.js';
-import * as organizationLearnerSerializer from '../../infrastructure/serializers/organization-learner.js';
+import { usecases } from '../shared/usecases/index.js';
+import * as organizationLearnerSerializer from '../infrastructure/serializers/organization-learner.js';
 
 const getById = async function (request) {
   const organizationLearnerId = request.params.id;

--- a/api/src/school/application/organization-learner-route.js
+++ b/api/src/school/application/organization-learner-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
-import { organizationLearnerController } from './controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
-import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
+import { organizationLearnerController } from './organization-learner-controller.js';
+import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/school/application/school-controller.js
+++ b/api/src/school/application/school-controller.js
@@ -1,5 +1,5 @@
-import { usecases } from '../../shared/usecases/index.js';
-import * as schoolSerializer from '../../infrastructure/serializers/school-serializer.js';
+import { usecases } from '../shared/usecases/index.js';
+import * as schoolSerializer from '../infrastructure/serializers/school-serializer.js';
 
 const getSchool = async function (request) {
   const { code } = request.params;

--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
-import { schoolController } from './controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
-import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
+import { schoolController } from './school-controller.js';
+import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/school/routes.js
+++ b/api/src/school/routes.js
@@ -1,6 +1,6 @@
-import * as assessment from './application/assessments/route.js';
-import * as organizationLearner from './application/organization-learner/index.js';
-import * as school from './application/school/index.js';
+import * as assessment from './application/assessment-route.js';
+import * as organizationLearner from './application/organization-learner-route.js';
+import * as school from './application/school-route.js';
 const schoolRoutes = [assessment, school, organizationLearner];
 
 export { schoolRoutes };

--- a/api/tests/school/integration/application/assessment-controller_test.js
+++ b/api/tests/school/integration/application/assessment-controller_test.js
@@ -1,7 +1,7 @@
-import { expect, hFake, sinon } from '../../../../test-helper.js';
-import { assessmentController } from '../../../../../src/school/application/assessments/controller.js';
-import { usecases } from '../../../../../src/school/shared/usecases/index.js';
-import { Assessment } from '../../../../../src/school/domain/models/Assessment.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+import { assessmentController } from '../../../../src/school/application/assessment-controller.js';
+import { usecases } from '../../../../src/school/shared/usecases/index.js';
+import { Assessment } from '../../../../src/school/domain/models/Assessment.js';
 
 describe('Integration | Controller | assessment-controller', function () {
   describe('#createForPix1d', function () {

--- a/api/tests/school/unit/application/assessment-controller_test.js
+++ b/api/tests/school/unit/application/assessment-controller_test.js
@@ -1,6 +1,6 @@
-import { expect, hFake, sinon } from '../../../../test-helper.js';
-import { assessmentController } from '../../../../../src/school/application/assessments/controller.js';
-import { usecases } from '../../../../../src/school/shared/usecases/index.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+import { assessmentController } from '../../../../src/school/application/assessment-controller.js';
+import { usecases } from '../../../../src/school/shared/usecases/index.js';
 
 describe('Unit | Controller | assessment-controller', function () {
   describe('#getNextChallengeForPix1d', function () {

--- a/api/tests/school/unit/application/assessment-route_test.js
+++ b/api/tests/school/unit/application/assessment-route_test.js
@@ -1,7 +1,7 @@
-import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { assessmentController } from '../../../../../src/school/application/assessments/controller.js';
-import * as moduleUnderTest from '../../../../../src/school/application/assessments/route.js';
-import { AssessmentEndedError } from '../../../../../src/shared/domain/errors.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { assessmentController } from '../../../../src/school/application/assessment-controller.js';
+import * as moduleUnderTest from '../../../../src/school/application/assessment-route.js';
+import { AssessmentEndedError } from '../../../../src/shared/domain/errors.js';
 
 describe('Unit | Application | Router | assessment-router', function () {
   describe('GET /api/pix1d/assessments/{id}/next', function () {

--- a/api/tests/school/unit/application/organization-learner-controller_test.js
+++ b/api/tests/school/unit/application/organization-learner-controller_test.js
@@ -1,7 +1,7 @@
-import { expect, hFake, sinon } from '../../../../test-helper.js';
-import { usecases } from '../../../../../src/school/shared/usecases/index.js';
-import { organizationLearnerController } from '../../../../../src/school/application/organization-learner/controller.js';
-import { OrganizationLearner } from '../../../../../src/school/domain/models/OrganizationLearner.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+import { usecases } from '../../../../src/school/shared/usecases/index.js';
+import { organizationLearnerController } from '../../../../src/school/application/organization-learner-controller.js';
+import { OrganizationLearner } from '../../../../src/school/domain/models/OrganizationLearner.js';
 
 describe('Unit | Controller | organization-learner-controller', function () {
   describe('#getById', function () {

--- a/api/tests/school/unit/application/organization-learner-route_test.js
+++ b/api/tests/school/unit/application/organization-learner-route_test.js
@@ -1,7 +1,7 @@
-import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
-import { organizationLearnerController } from '../../../../../src/school/application/organization-learner/controller.js';
-import * as moduleUnderTest from '../../../../../src/school/application/organization-learner/index.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { organizationLearnerController } from '../../../../src/school/application/organization-learner-controller.js';
+import * as moduleUnderTest from '../../../../src/school/application/organization-learner-route.js';
 
 describe('Unit | Router | organization-learner-router', function () {
   describe('GET /api/pix1d/organization-learners/:id', function () {

--- a/api/tests/school/unit/application/school-controller_test.js
+++ b/api/tests/school/unit/application/school-controller_test.js
@@ -1,8 +1,8 @@
-import { expect, hFake, sinon } from '../../../../test-helper.js';
-import { usecases } from '../../../../../src/school/shared/usecases/index.js';
-import { schoolController } from '../../../../../src/school/application/school/controller.js';
-import { School } from '../../../../../src/school/domain/models/School.js';
-import { OrganizationLearner } from '../../../../../src/school/domain/models/OrganizationLearner.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+import { usecases } from '../../../../src/school/shared/usecases/index.js';
+import { schoolController } from '../../../../src/school/application/school-controller.js';
+import { School } from '../../../../src/school/domain/models/School.js';
+import { OrganizationLearner } from '../../../../src/school/domain/models/OrganizationLearner.js';
 
 describe('Unit | Controller | school-controller', function () {
   describe('#getSchool', function () {

--- a/api/tests/school/unit/application/school-route_test.js
+++ b/api/tests/school/unit/application/school-route_test.js
@@ -1,7 +1,7 @@
-import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
-import { schoolController } from '../../../../../src/school/application/school/controller.js';
-import * as moduleUnderTest from '../../../../../src/school/application/school/index.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { schoolController } from '../../../../src/school/application/school-controller.js';
+import * as moduleUnderTest from '../../../../src/school/application/school-route.js';
 
 describe('Unit | Router | school-router', function () {
   describe('GET /api/pix1d/schools/:code', function () {


### PR DESCRIPTION
## :unicorn: Problème

Des répertoires qui porte un nom « métier » sont placé sous le répertoire `application`

## :robot: Proposition

Remettre à plat les noms pour remplacer
> `/src/school/application/assessments/controller.js
en
> `/src/school/application/assessments-controller.js

## :rainbow: Remarques

_rien_

## :100: Pour tester

Rien ne change.