### PR TITLE
[FEATURE] Ajouter 3 nouveaux types de contenus formatif (PIX-10173).

### DIFF
--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -5,6 +5,9 @@ import { memberAction } from 'ember-api-actions';
 export const typeCategories = {
   webinaire: 'Webinaire',
   autoformation: "Parcours d'autoformation",
+  'e-learning': 'Formation en ligne',
+  'hybrid-training': 'Formation hybride',
+  'in-person-training': 'Formation en présentiel',
 };
 
 export const optionsTypeList = formatList(typeCategories);

--- a/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', functi
     form = {
       title: 'Un contenu formatif',
       link: 'https://un-contenu-formatif',
-      type: 'Webinaire',
+      type: 'webinaire',
       locale: 'fr-fr',
       editorName: 'Un éditeur de contenu formatif',
       editorLogoUrl: 'un-logo.svg',

--- a/admin/tests/integration/components/trainings/training-details-card_test.js
+++ b/admin/tests/integration/components/trainings/training-details-card_test.js
@@ -10,7 +10,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     this.set('training', {
       title: 'Un contenu formatif',
       link: 'https://un-contenu-formatif',
-      type: 'Webinaire',
+      type: 'webinaire',
       locale: 'fr-fr',
       editorName: 'Un éditeur de contenu formatif',
       editorLogoUrl: 'un-logo.svg',
@@ -28,7 +28,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     // then
     assert.dom(screen.getByText('Un contenu formatif')).exists();
     assert.dom(screen.getByText('https://un-contenu-formatif')).exists();
-    assert.dom(screen.getByText('Webinaire')).exists();
+    assert.dom(screen.getByText('webinaire')).exists();
     assert.dom(screen.getByText('2j')).exists();
     assert.dom(screen.getByText('Franco-français (fr-fr)')).exists();
     assert.dom(screen.getByText('Un éditeur de contenu formatif')).exists();

--- a/admin/tests/unit/controllers/authenticated/trainings/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/new_test.js
@@ -27,7 +27,7 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
         id: 3,
         title: 'Ma formation',
         link: 'https://mon-lien',
-        type: 'Webinaire',
+        type: 'webinaire',
         locale: 'fr-fr',
         editorLogoUrl: 'https//images.fr/mon-logo.svg',
         editorName: 'Un éditeur de contenu formatif',

--- a/api/db/seeds/data/team-contenu/data-builder.js
+++ b/api/db/seeds/data/team-contenu/data-builder.js
@@ -343,7 +343,7 @@ async function _createTraining(databaseBuilder) {
     trainingId: TEAM_CONTENU_OFFSET_ID,
     title: 'Contenu formatif / équipe contenu',
     link: 'https://www.youtube.com/watch?v=qq09UkPRdFY',
-    type: 'Webinaire',
+    type: 'webinaire',
     duration: '00:04:08',
     locale: 'fr-fr',
     editorName: 'Mariah Carey',

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -125,7 +125,9 @@ const register = async function (server) {
                   hours: Joi.number().min(0).max(23).default(0),
                   minutes: Joi.number().min(0).max(59).default(0),
                 }).required(),
-                type: Joi.string().valid('autoformation', 'webinaire').required(),
+                type: Joi.string()
+                  .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'webinaire')
+                  .required(),
                 locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').required(),
                 'editor-name': Joi.string().required(),
                 'editor-logo-url': Joi.string().uri().required(),
@@ -169,7 +171,9 @@ const register = async function (server) {
                   hours: Joi.number().min(0).max(23).required(),
                   minutes: Joi.number().min(0).max(59).required(),
                 }).allow(null),
-                type: Joi.string().valid('autoformation', 'webinaire').allow(null),
+                type: Joi.string()
+                  .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'webinaire')
+                  .allow(null),
                 locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').allow(null),
                 'editor-name': Joi.string().allow(null),
                 'editor-logo-url': Joi.string().allow(null),

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1510,6 +1510,9 @@
       "editor": "Training provided by",
       "type": {
         "autoformation": "Autoformation course",
+        "e-learning": "E-Learning",
+        "hybrid-training": "Hybrid training",
+        "in-person-training": "In person training",
         "webinaire": "Webinar"
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1510,6 +1510,9 @@
       "editor": "Contenu formatif proposé par",
       "type": {
         "autoformation": "Parcours d'autoformation",
+        "e-learning": "Formation à distance",
+        "hybrid-training": "Formation hybride",
+        "in-person-training": "Formation en présentiel",
         "webinaire": "Webinaire"
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Les types présents de contenu formatif ne couvrent pas tous les usages possibles. 

## :robot: Proposition
Ajouter des nouveaux types de contenu formatif. Pour ça, il faut ajouter dans le select sur Pix Admin ces nouveaux types, puis faire en sorte que l'API accepte ces derniers. 
Ensuite côté Pix App, il faut ajouter les clés de trad qui vont bien. 
Hop le tour est joué. 

## :rainbow: Remarques
1. Actuellement, nous ne faisons rien pour afficher correctement dans le détail d'un CF sur Pix Admin la bonne traduction
2. Nous n'avons pas de couleur de tag pour ces types de formations ni d'image 

## :100: Pour tester
### Pix Admin
- Se rendre sur Pix Admin 
- Constater que le select comporte les nouveaux types : `Formation à distance`, `Formation hybride` et `Formation en présentiel`
- Enregistrer le CF 
- Voir le CF est constater le bon type (PAS TRADUIT)

### Pix App
- Se connecter 
- Passer la campagne `EDUMULTIP`
- A la fin voir les CF 
