### PR TITLE
[TECH] Corriger les seeds pour la session "started" (PIX-10139)

### DIFF
--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -238,6 +238,8 @@ async function createStartedSession({
     supervisorPassword,
   });
 
+  _buildSupervisorAccess({ databaseBuilder, sessionId });
+
   const certificationCandidates = await _registerSomeCandidatesToSession({
     databaseBuilder,
     sessionId,
@@ -387,6 +389,8 @@ async function createPublishedScoSession({
     assignedCertificationOfficerName: 'Mariah Carey',
   });
 
+  _buildSupervisorAccess({ databaseBuilder, sessionId });
+
   const certificationCandidates = await _registerOrganizationLearnersToSession({
     databaseBuilder,
     sessionId,
@@ -503,6 +507,8 @@ async function createPublishedSession({
     publishedAt,
     assignedCertificationOfficerName: 'Mariah Carey',
   });
+
+  _buildSupervisorAccess({ databaseBuilder, sessionId });
 
   const certificationCandidates = await _registerCandidatesToSession({
     databaseBuilder,
@@ -1201,4 +1207,13 @@ function _buildChallenges({ databaseBuilder, competenceData, assessmentId, certi
       resultDetails: 'dummy value',
     });
   }
+}
+
+function _buildSupervisorAccess({ databaseBuilder, sessionId }) {
+  const supervisor = databaseBuilder.factory.buildUser({ firstName: `supervisor${sessionId}` });
+  databaseBuilder.factory.buildSupervisorAccess({
+    sessionId,
+    userId: supervisor.id,
+    authorizedAt: new Date(),
+  });
 }


### PR DESCRIPTION
## :unicorn: Problème
La session "started“ dans les seeds (#7005) n’est coherente
Les certifs sont
-  published
- completedAt avec une valeur
Les assessments sont pourtant en started
Ils n’ont pas de certifications challenges, bref, la session n’est pas du tout publiable

## :robot: Proposition
Corriger tout ce mic-mac

## :rainbow: Remarques
Ajout d'un acces surveillant pour toutes les sessions dans ces seeds et dans le cli

## :100: Pour tester
Aller sur la session 7005, finaliser, constater qu'il n'y a pas d'erreur!
