### PR TITLE
[FEATURE] Afficher une bannière de gestion des rôles sur Pix Certif (PIX-10079).

### DIFF
--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -22,7 +22,10 @@ export default class AuthenticatedController extends Controller {
   }
 
   get displayRoleManagementBanner() {
-    return !this.currentUser.currentAllowedCertificationCenterAccess.isSco;
+    return (
+      this.currentUser.currentAllowedCertificationCenterAccess.isPro ||
+      this.currentUser.currentAllowedCertificationCenterAccess.isSup
+    );
   }
 
   get documentationLink() {

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -21,6 +21,10 @@ export default class AuthenticatedController extends Controller {
     );
   }
 
+  get displayRoleManagementBanner() {
+    return !this.currentUser.currentAllowedCertificationCenterAccess.isSco;
+  }
+
   get documentationLink() {
     if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
       return LINK_SCO;

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -24,6 +24,14 @@ export default class AllowedCertificationCenterAccess extends Model {
     return this.type === CERTIFICATION_CENTER_TYPES.SCO;
   }
 
+  get isPro() {
+    return this.type === CERTIFICATION_CENTER_TYPES.PRO;
+  }
+
+  get isSup() {
+    return this.type === CERTIFICATION_CENTER_TYPES.SUP;
+  }
+
   get isScoManagingStudents() {
     return this.type === CERTIFICATION_CENTER_TYPES.SCO && this.isRelatedToManagingStudentsOrganization;
   }

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -1,5 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 
+const CERTIFICATION_CENTER_TYPES = {
+  SUP: 'SUP',
+  SCO: 'SCO',
+  PRO: 'PRO',
+};
+
 export default class AllowedCertificationCenterAccess extends Model {
   @attr() name;
   @attr() externalId;
@@ -15,11 +21,11 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() pixCertifScoBlockedAccessDateCollege;
 
   get isSco() {
-    return this.type === 'SCO';
+    return this.type === CERTIFICATION_CENTER_TYPES.SCO;
   }
 
   get isScoManagingStudents() {
-    return this.type === 'SCO' && this.isRelatedToManagingStudentsOrganization;
+    return this.type === CERTIFICATION_CENTER_TYPES.SCO && this.isRelatedToManagingStudentsOrganization;
   }
 
   get isAccessRestricted() {

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -65,7 +65,16 @@
       >
         {{t "pages.sco.banner.information"}}
       </PixBanner>
+    {{/if}}
 
+    {{#if this.displayRoleManagementBanner}}
+      <PixBanner
+        @actionLabel={{t "pages.sup-and-pro.banner.url-label"}}
+        @actionUrl="https://cloud.pix.fr/s/xfPrK5n7K73kmbz"
+        @canCloseBanner="true"
+      >
+        {{t "pages.sup-and-pro.banner.information" htmlSafe=true}}
+      </PixBanner>
     {{/if}}
 
     <div class="page">

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -133,6 +133,56 @@ module('Acceptance | authenticated', function (hooks) {
         });
       });
     });
+
+    module('role management banner', function () {
+      module('when certification center is SCO', function () {
+        test('it should not display the banner', async function (assert) {
+          // given
+          const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+            'SCO',
+            'Scoule',
+          );
+          await authenticateSession(certificationPointOfContact.id);
+
+          // when
+          const screen = await visitScreen('/sessions/liste');
+
+          // then
+          assert
+            .dom(
+              screen.queryByText(
+                'Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification.',
+              ),
+            )
+            .doesNotExist();
+          assert.dom(screen.queryByRole('link', { name: 'Plus d’information ici' })).doesNotExist();
+        });
+      });
+
+      module('when certification center is SUP or PRO', function () {
+        test('it should not display the banner', async function (assert) {
+          // given
+          const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+            'SUP',
+            'Soupère',
+          );
+          await authenticateSession(certificationPointOfContact.id);
+
+          // when
+          const screen = await visitScreen('/sessions/liste');
+
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                'Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification.',
+              ),
+            )
+            .exists();
+          assert.dom(screen.getByRole('link', { name: 'Plus d’information ici' })).exists();
+        });
+      });
+    });
   });
 
   module('When user changes current certification center', function () {

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -159,27 +159,31 @@ module('Acceptance | authenticated', function (hooks) {
         });
       });
 
-      module('when certification center is SUP or PRO', function () {
-        test('it should not display the banner', async function (assert) {
-          // given
-          const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
-            'SUP',
-            'Soupère',
-          );
-          await authenticateSession(certificationPointOfContact.id);
+      const nonSchoolCertificationCentersTypes = ['SUP', 'PRO'];
 
-          // when
-          const screen = await visitScreen('/sessions/liste');
+      nonSchoolCertificationCentersTypes.forEach((type) => {
+        module(`when certification center is ${type}`, function () {
+          test('it should not display the banner', async function (assert) {
+            // given
+            const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+              type,
+              'Soupère',
+            );
+            await authenticateSession(certificationPointOfContact.id);
 
-          // then
-          assert
-            .dom(
-              screen.getByText(
-                'Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification.',
-              ),
-            )
-            .exists();
-          assert.dom(screen.getByRole('link', { name: 'Plus d’information ici' })).exists();
+            // when
+            const screen = await visitScreen('/sessions/liste');
+
+            // then
+            assert
+              .dom(
+                screen.getByText(
+                  'Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification.',
+                ),
+              )
+              .exists();
+            assert.dom(screen.getByRole('link', { name: 'Plus d’information ici' })).exists();
+          });
         });
       });
     });

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -92,40 +92,46 @@ module('Acceptance | authenticated', function (hooks) {
     });
   });
 
-  module('SCO temporary banner', function () {
-    test('it should display the banner when User is SCO isManagingStudent', async function (assert) {
-      // given
-      const certificationPointOfContact =
-        createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted();
-      await authenticateSession(certificationPointOfContact.id);
+  module('banners', function () {
+    module('certification opening dates banner', function () {
+      module('when certification center is SCO isManagingStudent', function () {
+        test('it should display the banner', async function (assert) {
+          // given
+          const certificationPointOfContact =
+            createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted();
+          await authenticateSession(certificationPointOfContact.id);
 
-      // when
-      const screen = await visitScreen('/sessions/liste');
+          // when
+          const screen = await visitScreen('/sessions/liste');
 
-      // then
-      assert
-        .dom(
-          screen.getByText(
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
+              ),
+            )
+            .exists();
+          assert.dom(screen.getByRole('link', { name: 'documentation pour voir les nouveautés.' })).exists();
+        });
+      });
+
+      module('when certification center is not SCO isManagingStudent', function () {
+        test('it should not display the banner', async function (assert) {
+          // given
+          const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+          await authenticateSession(certificationPointOfContact.id);
+
+          // when
+          const screen = await visitScreen('/sessions/liste');
+
+          // then
+          const certificationBannerMessage = screen.queryByText(
             'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
-          ),
-        )
-        .exists();
-      assert.dom(screen.getByRole('link', { name: 'documentation pour voir les nouveautés.' })).exists();
-    });
-
-    test('it should not display the banner when User is NOT SCO isManagingStudent', async function (assert) {
-      // given
-      const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      await authenticateSession(certificationPointOfContact.id);
-
-      // when
-      const screen = await visitScreen('/sessions/liste');
-
-      // then
-      const certificationBannerMessage = screen.queryByText(
-        'La certification Pix se déroulera du 6 novembre 2023 au 29 mars 2024 pour les lycées et du 4 mars au 14 juin 2024 pour les collèges. Pensez à consulter la',
-      );
-      assert.dom(certificationBannerMessage).doesNotExist();
+          );
+          assert.dom(certificationBannerMessage).doesNotExist();
+        });
+      });
     });
   });
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -3,7 +3,7 @@ import { click, currentURL, fillIn, find, triggerEvent } from '@ember/test-helpe
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import { setupIntl } from 'ember-intl/test-support/index';
 
 module('Acceptance | Session Details Certification Candidates', function (hooks) {
@@ -336,6 +336,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           const screen = await visit(`/sessions/${sessionWithoutCandidates.id}/candidats`);
 
           await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+          const modal = await screen.findByRole('dialog');
           await fillIn(screen.getByLabelText('* Nom de naissance'), 'BackStreet');
           await fillIn(screen.getByLabelText('* Prénom'), 'Boys');
           await click(screen.getByLabelText('Homme'));
@@ -358,8 +359,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           );
           await fillIn(screen.getByLabelText('E-mail de convocation'), 'roooooar@example.net');
 
-          const closeButton = screen.getByRole('button', { name: 'Fermer' });
-          await click(closeButton);
+          await click(within(modal).getByRole('button', { name: 'Fermer' }));
 
           // when
           await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
-import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
+import { visit as visitScreen, visit, within } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { waitForDialogClose } from '../helpers/wait-for';
@@ -203,12 +203,11 @@ module('Acceptance | Session Finalization', function (hooks) {
           // when
           const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
           await click(screen.getByRole('button', { name: 'Ajouter / Supprimer' }));
-          await screen.findByRole('dialog');
+          const modal = await screen.findByRole('dialog');
           const allDeleteIssueReportButtons = screen.getAllByRole('button', { name: 'Supprimer le signalement' });
           await click(allDeleteIssueReportButtons[0]);
 
-          const closeButton = screen.getByRole('button', { name: 'Fermer' });
-          await click(closeButton);
+          await click(within(modal).getByRole('button', { name: 'Fermer' }));
 
           // then
           assert.dom(screen.getByText('1 signalement')).exists();

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -239,4 +239,56 @@ module('Unit | Controller | authenticated', function (hooks) {
       assert.true(showLinkToSessions);
     });
   });
+
+  module('#get displayRoleManagementBanner', function () {
+    module('when certif center is SCO', function () {
+      test('should not display banner', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = run(() =>
+          store.createRecord('allowed-certification-center-access', {
+            id: 123,
+            name: 'Scoule',
+            type: 'SCO',
+          }),
+        );
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        const controller = this.owner.lookup('controller:authenticated');
+
+        // when
+        const displayBanner = controller.displayRoleManagementBanner;
+
+        // then
+        assert.false(displayBanner);
+      });
+    });
+
+    module('when certif center is SUP or PRO', function () {
+      test('should display banner', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = run(() =>
+          store.createRecord('allowed-certification-center-access', {
+            id: 345,
+            name: 'Super',
+            type: 'SUP',
+          }),
+        );
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        const controller = this.owner.lookup('controller:authenticated');
+
+        // when
+        const displayBanner = controller.displayRoleManagementBanner;
+
+        // then
+        assert.true(displayBanner);
+      });
+    });
+  });
 });

--- a/certif/tests/unit/models/allowed-certification-center-access_test.js
+++ b/certif/tests/unit/models/allowed-certification-center-access_test.js
@@ -31,6 +31,34 @@ module('Unit | Model | allowed-certification-center-access', function (hooks) {
     });
   });
 
+  module('#get isPro', function () {
+    module('when AllowedCertificationCenterAccess type is PRO', function () {
+      test('should return true', function (assert) {
+        // when
+        const model = store.createRecord('allowed-certification-center-access', {
+          type: 'PRO',
+        });
+
+        // then
+        assert.true(model.isPro);
+      });
+    });
+  });
+
+  module('#get isSup', function () {
+    module('when AllowedCertificationCenterAccess type is SUP', function () {
+      test('should return true', function (assert) {
+        // when
+        const model = store.createRecord('allowed-certification-center-access', {
+          type: 'SUP',
+        });
+
+        // then
+        assert.true(model.isSup);
+      });
+    });
+  });
+
   module('#get isScoManagingStudents', function () {
     test('should return false when AllowedCertificationCenterAccess is not managing students', function (assert) {
       // when

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -851,6 +851,12 @@
         }
       }
     },
+    "sup-and-pro": {
+      "banner": {
+        "information": "Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! '<br>' Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification. '<br>'",
+        "url-label": "Plus d’information ici"
+      }
+    },
     "team": {
       "title": "Team",
       "invite-button": "Invite a member",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -851,6 +851,12 @@
         }
       }
     },
+    "sup-and-pro": {
+      "banner": {
+        "information": "Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! '</br>' Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification. '<br>'",
+        "url-label": "Plus d’information ici"
+      }
+    },
     "team": {
       "title": "Équipe",
       "invite-button": "Inviter un membre",


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle fonctionnalité a été mise en place par la team Accès côté Pix Certif de gestion des rôles, or les utilisateurs ne sont pas forcément informés de cette évolution.

## :robot: Proposition
Afficher une bannière de gestion des rôles pour les centres de certif PRO et SUP.

## :rainbow: Remarques
On ne l'affiche pas pour le SCO car ils ont l'habitude de cette gestion coté Orga. Il n'y a donc pas nécessité à leur afficher cette bannière. De plus ils ont déjà une bannière pour les dates collèges et lycées.

Nous n'avons volontairement pas effectué la traduction en anglais, car peu d'utilisateurs sont concernés et que nous ne sommes pas en possession du fichier gestion des rôles traduit.

## :100: Pour tester
- Aller sur l'espace Pix Certif d'un centre SCO (se connecter avec certif-sco@example.net / mot de passe : pix123 ), et constater que la bannière sur la gestion des rôles ne s'affiche pas (mais la bannière sur les dates lycées et collège est toujours là)
- Aller sur l'espace Pix Certif d'un centre PRO ou SUP (se connecter avec certif-pro@example.net / mot de passe : pix123 ), et constater que la bannière s'affiche correctement. Cliquer sur le lien, et constater qu'on accède à un fichier spécifique à la gestion des rôles sur le Cloud.