### PR TITLE
[FEATURE] Expliciter la désignation d'un référent CléA Numérique dans les espaces Pix Certif des CDC habilités (PIX-9882).

### DIFF
--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -12,7 +12,7 @@
           <PixTooltip class="members-list-item__tool-tip" @isWide="true" @position="bottom">
             <:triggerElement>
               <span tabindex="0">
-                <FaIcon @icon="info-circle" />
+                <FaIcon @icon="info-circle" aria-label={{t "pages.team.pix-referer-tooltip"}} />
               </span>
             </:triggerElement>
             <:tooltip>

--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -9,7 +9,7 @@
           <PixTag class="members-list-item__tag" @color="blue-light">
             {{t "pages.team.pix-referer"}}
           </PixTag>
-          <PixTooltip class="members-list-item__tool-tip" @isWide="true" @position="bottom">
+          <PixTooltip class="members-list-item__tool-tip" @isWide="true" @position="left">
             <:triggerElement>
               <span tabindex="0">
                 <FaIcon @icon="info-circle" aria-label={{t "pages.team.pix-referer-tooltip"}} />

--- a/certif/app/controllers/authenticated/team/list.js
+++ b/certif/app/controllers/authenticated/team/list.js
@@ -59,6 +59,7 @@ export default class AuthenticatedTeamListController extends Controller {
         await member.updateReferer({ userId: member.id, isReferer: true });
         this.shouldShowRefererSelectionModal = !this.shouldShowRefererSelectionModal;
         this.send('refreshModel');
+        this.notifications.success(this.intl.t('pages.team.notifications.success'));
       } catch (responseError) {
         this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
       }

--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -61,8 +61,4 @@
       color: $pix-neutral-50;
     }
   }
-
-  &__referer-add-button {
-    width: 20%;
-  }
 }

--- a/certif/app/templates/authenticated/team/list.hbs
+++ b/certif/app/templates/authenticated/team/list.hbs
@@ -33,7 +33,7 @@
           {{t "pages.team.no-referer-section.description"}}
         </p>
 
-        <PixButton class="team__referer-add-button" @triggerAction={{this.toggleRefererModal}}>
+        <PixButton @triggerAction={{this.toggleRefererModal}}>
           {{t "pages.team.no-referer-section.select-referer-button"}}
         </PixButton>
       </div>

--- a/certif/app/templates/authenticated/team/list.hbs
+++ b/certif/app/templates/authenticated/team/list.hbs
@@ -26,9 +26,9 @@
         <FaIcon @icon="bell" />
       </div>
       <div>
-        <h1 class="team__no-referer-title">
+        <h2 class="team__no-referer-title">
           {{t "pages.team.no-referer-section.title"}}
-        </h1>
+        </h2>
         <p class="team__no-referer-description">
           {{t "pages.team.no-referer-section.description"}}
         </p>

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -8,8 +8,8 @@ import {
   createAllowedCertificationCenterAccess,
   createCertificationPointOfContactWithCustomCenters,
   createCertificationPointOfContactWithTermsOfServiceAccepted,
-} from '../helpers/test-init';
-import setupIntl from '../helpers/setup-intl';
+} from '../../../helpers/test-init';
+import setupIntl from '../../../helpers/setup-intl';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | authenticated | team', function (hooks) {

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { click, currentURL } from '@ember/test-helpers';
-import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 
 import { setupApplicationTest } from 'ember-qunit';
 import {
@@ -122,6 +122,42 @@ module('Acceptance | authenticated | team', function (hooks) {
                   }),
                 )
                 .exists();
+            });
+
+            module('when clicking on "referer selection"', function () {
+              test('displays a modal to select the referer', async function (assert) {
+                // given
+                const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                  undefined,
+                  'CCNG',
+                  false,
+                  'ADMIN',
+                );
+                server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+                server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+                await authenticateSession(certificationPointOfContact.id);
+
+                // when
+                const screen = await visitScreen('/equipe');
+
+                await click(screen.getByRole('button', { name: 'Désigner un référent' }));
+
+                await clickByName('Sélectionner le référent CléA Numérique');
+                await screen.findByRole('listbox');
+                await click(screen.getByRole('option', { name: 'Lili Dupont' }));
+
+                // then
+                assert.dom(screen.getByRole('heading', { name: 'Sélection du référent CléA Numérique' })).exists();
+                assert.dom(screen.getByText('Sélectionner le référent CléA Numérique')).exists();
+
+                assert
+                  .dom(
+                    screen.getByRole('button', {
+                      name: 'Valider la sélection de référent',
+                    }),
+                  )
+                  .exists();
+              });
             });
           });
 

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -214,6 +214,27 @@ module('Acceptance | authenticated | team', function (hooks) {
                 .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
                 .doesNotExist();
             });
+
+            test('does display a tooltip to inform of what is a Pix Referer', async function (assert) {
+              // given
+              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
+                undefined,
+                'CCNG',
+                false,
+                'ADMIN',
+              );
+              server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
+              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+              await authenticateSession(certificationPointOfContact.id);
+
+              // when
+              const screen = await visitScreen('/equipe');
+
+              // then
+              const row = within(await screen.findByRole('row', { name: 'Membres du centre de certification' }));
+              const pixRefererCell = within(row.getByRole('cell', { name: "Référent CléA Numérique" }));
+              assert.dom(pixRefererCell.getByText('Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.')).exists();
+            });
           });
         });
 

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -156,7 +156,7 @@ module('Acceptance | authenticated | team', function (hooks) {
               });
 
               module('when selecting a referer in the modal', function () {
-                test('displays a modal to select the referer', async function (assert) {
+                test('select a new referer and display a success notification', async function (assert) {
                   // given
                   const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
                     undefined,
@@ -187,7 +187,8 @@ module('Acceptance | authenticated | team', function (hooks) {
                   assert.dom(row.getByRole('cell', { name: 'Dupont' })).exists();
                   assert.dom(row.getByRole('cell', { name: 'Lili' })).exists();
                   assert.dom(row.getByRole('cell', { name: 'Administrateur' })).exists();
-                  assert.dom(row.getByRole('cell', { name: 'Référent CléA Numérique' })).exists();
+                  assert.dom(await screen.findByText('Un nouveau référent CléA Numérique a été nommé.')).exists();
+                  assert.dom(await row.findByRole('cell', { name: 'Référent CléA Numérique' })).exists();
                 });
               });
             });
@@ -232,8 +233,14 @@ module('Acceptance | authenticated | team', function (hooks) {
 
               // then
               const row = within(await screen.findByRole('row', { name: 'Membres du centre de certification' }));
-              const pixRefererCell = within(row.getByRole('cell', { name: "Référent CléA Numérique" }));
-              assert.dom(pixRefererCell.getByText('Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.')).exists();
+              const pixRefererCell = within(row.getByRole('cell', { name: 'Référent CléA Numérique' }));
+              assert
+                .dom(
+                  pixRefererCell.getByText(
+                    'Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.',
+                  ),
+                )
+                .exists();
             });
           });
         });

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -107,7 +107,14 @@ module('Acceptance | authenticated | team', function (hooks) {
               const screen = await visitScreen('/equipe');
 
               // then
-              assert.dom(screen.getByText('Aucun référent désigné pour la certification Pix-CléA Numérique')).exists();
+              assert
+                .dom(
+                  screen.getByRole('heading', {
+                    name: 'Aucun référent désigné pour la certification Pix-CléA Numérique',
+                    level: 2,
+                  }),
+                )
+                .exists();
               assert
                 .dom(
                   screen.getByText(

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -107,11 +107,18 @@ module('Acceptance | authenticated | team', function (hooks) {
               const screen = await visitScreen('/equipe');
 
               // then
-              assert.dom(screen.getByText(this.intl.t('pages.team.no-referer-section.title'))).exists();
+              assert.dom(screen.getByText('Aucun référent désigné pour la certification Pix-CléA Numérique')).exists();
+              assert
+                .dom(
+                  screen.getByText(
+                    'Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.',
+                  ),
+                )
+                .exists();
               assert
                 .dom(
                   screen.getByRole('button', {
-                    name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
+                    name: 'Désigner un référent',
                   }),
                 )
                 .exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -867,8 +867,8 @@
         }
       },
       "no-referer-section": {
-        "title": "Aucun référent Pix désigné",
-        "description": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
+        "title": "Aucun référent désigné pour la certification Pix-CléA Numérique",
+        "description": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
         "select-referer-button": "Désigner un référent"
       },
       "pix-referer": "Référent Pix",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -871,7 +871,7 @@
         "description": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
         "select-referer-button": "Désigner un référent"
       },
-      "pix-referer": "Référent Pix",
+      "pix-referer": "Référent CléA Numérique",
       "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "referer": "Référent",
       "select-referer-modal": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -871,6 +871,9 @@
         "description": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
         "select-referer-button": "Désigner un référent"
       },
+      "notifications": {
+        "success": "Un nouveau référent CléA Numérique a été nommé."
+      },
       "pix-referer": "Référent CléA Numérique",
       "pix-referer-tooltip": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
       "referer": "Référent",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -872,7 +872,7 @@
         "select-referer-button": "Désigner un référent"
       },
       "pix-referer": "Référent CléA Numérique",
-      "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
+      "pix-referer-tooltip": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
       "referer": "Référent",
       "select-referer-modal": {
         "title": "Sélection du référent CléA Numérique",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -875,7 +875,7 @@
       "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "referer": "Référent",
       "select-referer-modal": {
-        "title": "Sélection du référent Pix",
+        "title": "Sélection du référent CléA Numérique",
         "actions": {
           "cancel-extra-information": "Annuler la sélection de référent",
           "validate": "Valider",
@@ -883,7 +883,7 @@
         },
         "description": "Le Groupement d’intérêt public, sis 21-23 rue des Ardennes 75019 Paris PIX met en œuvre en tant que responsable de traitement un traitement de données à caractère personnel portant sur votre adresse email professionnel de référent Pix.<br />La finalité de ce traitement est la communication des informations nécessaires aux attributions du référent Pix au sein du centre de certification agréé. Le traitement de cette données repose sur l’exécution de la convention d’agrément de votre centre de certification.<br />Les données sont conservées pendant la durée de la convention d’agrément en vigueur entre le GIP Pix et le centre habilité auquel vous êtes rattaché.<br />Vous disposez de droits personnels, droits d'accès, de rectification et d’effacement des données, le droit de limitation ou d’opposition au traitement pour motif légitime et le droit d’introduire une réclamation auprès d’une autorité de contrôle ainsi que le droit de définir des directives relatives à la conservation, à l'effacement et à la communication de vos données à caractère personnel en cas de décès que vous pouvez exercer par courriel auprès de notre DPD en adressant votre demande à l’adresse électronique suivante : dpd@pix.fr .<br />Vous disposez de la possibilité d’introduire une réclamation auprès de Commission nationale Informatique et libertés « CNIL » à l’adresse suivante : 3 Place de Fontenoy – TSA 80715 – 75334 Paris Cedex 07.",
         "empty-option": "--Sélectionner--",
-        "label": "Sélectionner un référent Pix"
+        "label": "Sélectionner le référent CléA Numérique"
       },
       "tabs": {
         "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -867,8 +867,8 @@
         }
       },
       "no-referer-section": {
-        "title": "Aucun référent Pix désigné",
-        "description": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
+        "title": "Aucun référent désigné pour la certification Pix-CléA Numérique",
+        "description": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
         "select-referer-button": "Désigner un référent"
       },
       "pix-referer": "Référent Pix",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -875,7 +875,7 @@
       "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "referer": "Référent",
       "select-referer-modal": {
-        "title": "Sélection du référent Pix",
+        "title": "Sélection du référent CléA Numérique",
         "actions": {
           "cancel-extra-information": "Annuler la sélection de référent",
           "validate": "Valider",
@@ -883,7 +883,7 @@
         },
         "description": "Le Groupement d’intérêt public, sis 21-23 rue des Ardennes 75019 Paris PIX met en œuvre en tant que responsable de traitement un traitement de données à caractère personnel portant sur votre adresse email professionnel de référent Pix.<br />La finalité de ce traitement est la communication des informations nécessaires aux attributions du référent Pix au sein du centre de certification agréé. Le traitement de cette données repose sur l’exécution de la convention d’agrément de votre centre de certification.<br />Les données sont conservées pendant la durée de la convention d’agrément en vigueur entre le GIP Pix et le centre habilité auquel vous êtes rattaché.<br />Vous disposez de droits personnels, droits d'accès, de rectification et d’effacement des données, le droit de limitation ou d’opposition au traitement pour motif légitime et le droit d’introduire une réclamation auprès d’une autorité de contrôle ainsi que le droit de définir des directives relatives à la conservation, à l'effacement et à la communication de vos données à caractère personnel en cas de décès que vous pouvez exercer par courriel auprès de notre DPD en adressant votre demande à l’adresse électronique suivante : dpd@pix.fr .<br />Vous disposez de la possibilité d’introduire une réclamation auprès de Commission nationale Informatique et libertés « CNIL » à l’adresse suivante : 3 Place de Fontenoy – TSA 80715 – 75334 Paris Cedex 07.",
         "empty-option": "--Sélectionner--",
-        "label": "Sélectionner le référent Pix"
+        "label": "Sélectionner le référent CléA Numérique"
       },
       "tabs": {
         "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -871,7 +871,7 @@
         "description": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
         "select-referer-button": "Désigner un référent"
       },
-      "pix-referer": "Référent Pix",
+      "pix-referer": "Référent CléA Numérique",
       "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "referer": "Référent",
       "select-referer-modal": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -871,6 +871,9 @@
         "description": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
         "select-referer-button": "Désigner un référent"
       },
+      "notifications": {
+        "success": "Un nouveau référent CléA Numérique a été nommé."
+      },
       "pix-referer": "Référent CléA Numérique",
       "pix-referer-tooltip": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
       "referer": "Référent",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -872,7 +872,7 @@
         "select-referer-button": "Désigner un référent"
       },
       "pix-referer": "Référent CléA Numérique",
-      "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
+      "pix-referer-tooltip": "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.",
       "referer": "Référent",
       "select-referer-modal": {
         "title": "Sélection du référent CléA Numérique",


### PR DESCRIPTION
Co-authored-by: Syrine

## :unicorn: Problème

Le wording est confusant car il désigne un “référent Pix” sans préciser plus exactement qu’il s’agit d’un référent CléA Numérique alors que ça peut être une personne différente du référent Pix du CDC.

Lors de la désignation ou de la modification du référent, aucune indication explicite ne précise que l’action de l’utilisateur a bien été prise en compte.

## :robot: Proposition

Modifier le wording dans l’onglet “Equipe” :


→ “Aucun référent désigné pour la certification Pix-CléA Numérique

Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.”


→ “Changer de référent CléA Numérique” pour le bouton en haut à droite

→ “Référent CléA Numérique” dans le chip

→ Texte suivant dans l’info bulle : “Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numériques seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.”


→ “Sélection du référent CléA Numérique”

→ “Sélectionner le référent CléA Numérique”

Rajouter un toaster de succès avec le texte suivant : 

“Un nouveau référent CléA Numérique a été nommé.”

## :rainbow: Remarques


## :100: Pour tester

* Sur Pix Admin avec le compte : superadmin@example.net
  * Dans [https://admin-pr7541.review.pix.fr/certification-centers/7002](https://admin-pr7541.review.pix.fr/certification-centers/7002) changer le membre en administrateur 
* Dans Pix Certif avec le compte `certif-pro@example.net`
* Dans equipe/membres constater
  * que le titre est "Aucun référent Pix désigné pour la certification Pix-CléA Numérique" 
  * que la description est "Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numérique seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique."
  * Le bouton en haut à droite se nomme "Changer de référent"
* Désigner un référent (attention action irréversible)
  * la modale affiche “Sélection du référent CléA Numérique” et “Sélectionner le référent CléA Numérique” 
  * valider, **prêter attention au toaster de succès !**
* A la validation vérifier
  * Le toaster de succès affiche “Un nouveau référent CléA Numérique a été nommé.”
  * que le tableau affiche désormais dans la colonne référent
    *   “Référent CléA Numérique”
    * + infobulle :  “Le référent de cette double certification sera notifié lorsque des résultats Pix-CléA Numériques seront disponibles et devront être enregistrés sur la plateforme de CléA Numérique.”