### PR TITLE
[BUGFIX] Elargir la période de génération d'une date au hasard pour une factory de mirage dans certif (Pix-10161)

### DIFF
--- a/admin/mirage/factories/session.js
+++ b/admin/mirage/factories/session.js
@@ -35,8 +35,9 @@ export default Factory.extend({
     twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
     const tenDaysAgo = new Date();
     tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
-
-    return new Date(+twoDaysAgo + Math.random() * (tenDaysAgo - twoDaysAgo)).toISOString().slice(0, 10);
+    //generate a random session date between 2 and 10 days ago
+    const randomTimestamp = twoDaysAgo.getTime() + Math.random() * (tenDaysAgo - twoDaysAgo);
+    return new Date(randomTimestamp).toISOString().slice(0, 10);
   },
 
   time() {

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -10,12 +10,13 @@ export default Factory.extend({
   },
 
   birthdate() {
-    const twoDaysAgo = new Date();
-    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-    const tenDaysAgo = new Date();
-    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
-
-    return new Date(+twoDaysAgo + Math.random() * (tenDaysAgo - twoDaysAgo)).toISOString().slice(0, 10);
+    const twentyYearsAgo = new Date();
+    twentyYearsAgo.setFullYear(twentyYearsAgo.getFullYear() - 20);
+    const fiftyYearsAgo = new Date();
+    fiftyYearsAgo.setFullYear(fiftyYearsAgo.getFullYear() - 50);
+    //generate a random birthdate between 20 and 50 years ago
+    const randomTimestamp = twentyYearsAgo.getTime() + Math.random() * (fiftyYearsAgo - twentyYearsAgo);
+    return new Date(randomTimestamp).toISOString().slice(0, 10);
   },
 
   birthCity() {


### PR DESCRIPTION
## :unicorn: Problème

Nous avons supprimé Faker. Dans le remplacement, nous avons réduit la période dans laquelle une date été générée. Il y avait donc des dates d'anniversaire similaire pour plusieurs candidats.

## :robot: Proposition

Élargir la période dans laquelle nous générons une date.

## :rainbow: Remarques

Nous en avons profité pour essayer de restructurer la fonction (utilisé dans certif et dans admin) pour clarifier le mécanisme de génération aléatoire de date dans une période.

## :100: Pour tester

Les tests de la CI doivent passer... À chaque fois.
