### PR TITLE
[FEATURE] Annuler la certification quand il n'y a pas assez de réponse et un problème technique (PIX-9978)

### DIFF
--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -283,30 +283,60 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     });
 
     describe('when less than the minimum number of answers required by the config has been answered', function () {
-      it('should be rejected', function () {
-        const difficulty = 0;
-        const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
-        const challenges = _buildChallenges(difficulty, numberOfChallenges);
-        const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
-        algorithm.getEstimatedLevelAndErrorRate
-          .withArgs({
+      describe('when the candidate did not finish the test due to technical issues', function () {
+        it('should be cancelled', function () {
+          const difficulty = 0;
+          const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
+          const challenges = _buildChallenges(difficulty, numberOfChallenges);
+          const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
+          algorithm.getEstimatedLevelAndErrorRate
+            .withArgs({
+              challenges,
+              allAnswers,
+            })
+            .returns({
+              estimatedLevel: 0,
+            });
+
+          algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
+
+          const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
             challenges,
             allAnswers,
-          })
-          .returns({
-            estimatedLevel: 0,
+            algorithm,
+            abortReason: 'candidate',
           });
 
-        algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
-
-        const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
-          challenges,
-          allAnswers,
-          algorithm,
-          abortReason: 'candidate',
+          expect(score.status).to.equal(status.REJECTED);
         });
+      });
 
-        expect(score.status).to.equal(status.REJECTED);
+      describe('when the candidate did not finish the test due to time issues', function () {
+        it('should be rejected', function () {
+          const difficulty = 0;
+          const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
+          const challenges = _buildChallenges(difficulty, numberOfChallenges);
+          const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
+          algorithm.getEstimatedLevelAndErrorRate
+            .withArgs({
+              challenges,
+              allAnswers,
+            })
+            .returns({
+              estimatedLevel: 0,
+            });
+
+          algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
+
+          const score = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
+            challenges,
+            allAnswers,
+            algorithm,
+            abortReason: 'candidate',
+          });
+
+          expect(score.status).to.equal(status.REJECTED);
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la nouvelle certification, des nouvelles règles de scoring ont été décidées, afin de coller avec la nouvelle philosophie de la certif.

## :robot: Proposition

Implémenter la règles cas 2b - certif avec moins de V questions et AVEC problème technique

Pour une certification non terminée, avec moins de V questions, et dont la raison de l’abandon sélectionnée lors de la finalisation de la session est “Problème technique” : 

- passer la certification au statut “Annulée”
- écrire un message automatique pour le candidat (= champ commentForCandidate dans la table assessment-results) : TBD
- écrire un message automatique pour le prescripteur (= champ commentForOrganization dans la table assessment-results) : TBD

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- créer une session v3 et inscrire un candidat en renseignant un destinataire des résultats = soi-même (pour recevoir le csv des résultats après publication  )
- lancer le test avec le candidat, et ne répondre qu'à 1 question
- dans Pix certif, cliquer sur “Finaliser la session”
- sélectionner l’option “Problème technique” comme raison de l’abandon puis confirmer la finalisation
- dans Pix admin > ouvrir la page de détails de la certif 
- résultat : le statut de la certif est “Annulée”
- un message automatique est renseigné dans le champ “Pour le candidat :” dans la section “Commentaires jury”
- publier la session
- sur le compte app du candidat, ouvrir la page 'Mes certifications”
- résultat : la certif est au statut “Annulée”
- un lien “Détails” est affiché avec le message du jury
- ouvrir le mail reçu avec les résultat de la certif
- résultat : pour cette certification, il est indiqué “Annulée” dans la colonne “Statut”, et le message du jury est indiqué dans la colonne “Commentaire jury pour l’organisation”

