### PR TITLE
[TECH] Récupérer une organisation grâce au code en tant que queryparams (Pix-10133)

### DIFF
--- a/1d/app/pods/school/route.js
+++ b/1d/app/pods/school/route.js
@@ -9,8 +9,10 @@ export default class SchoolRoute extends Route {
     this.currentLearner.remove();
   }
 
-  async model(params) {
-    const school = await this.store.findRecord('school', params.code);
+  async model(_params, transition) {
+    const school = await this.store.queryRecord('school', {
+      code: transition.to.parent.params.code,
+    });
     const divisions = [...new Set(school.organizationLearners.map((learner) => learner.division))];
     return {
       code: school.code,

--- a/1d/mirage/config.js
+++ b/1d/mirage/config.js
@@ -60,8 +60,8 @@ function routes() {
     return schema.challenges.find(request.params.challenge_id);
   });
 
-  this.get('/schools/:code', (schema, request) => {
-    if (request.params.code === 'MINIPIXOU') {
+  this.get('/schools', (schema, request) => {
+    if (request.queryParams.code === 'MINIPIXOU') {
       return schema.schools.first();
     }
     return new Response(404);

--- a/api/src/school/application/school-controller.js
+++ b/api/src/school/application/school-controller.js
@@ -2,7 +2,7 @@ import { usecases } from '../shared/usecases/index.js';
 import * as schoolSerializer from '../infrastructure/serializers/school-serializer.js';
 
 const getSchool = async function (request) {
-  const { code } = request.params;
+  const { code } = request.query;
   const school = await usecases.getSchoolByCode({ code });
   return schoolSerializer.serialize(school);
 };

--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -7,12 +7,12 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/pix1d/schools/{code}',
+      path: '/api/pix1d/schools',
       config: {
         pre: [{ method: securityPreHandlers.checkPix1dActivated }],
         auth: false,
         validate: {
-          params: Joi.object({
+          query: Joi.object({
             code: identifiersType.code,
           }),
         },

--- a/api/tests/school/unit/application/school-controller_test.js
+++ b/api/tests/school/unit/application/school-controller_test.js
@@ -32,7 +32,7 @@ describe('Unit | Controller | school-controller', function () {
         // when
 
         const request = {
-          params: { code },
+          query: { code },
         };
         const response = await schoolController.getSchool(request, hFake);
         // Then

--- a/api/tests/school/unit/application/school-route_test.js
+++ b/api/tests/school/unit/application/school-route_test.js
@@ -14,7 +14,7 @@ describe('Unit | Router | school-router', function () {
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/pix1d/schools/AZERTY34');
+      const response = await httpTestServer.request('GET', '/api/pix1d/schools?code=AZERTY123');
 
       // then
       expect(response.statusCode).to.equal(200);


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on récupérait une organisation via le code, on utilisait la même mécanique que pour un id. Or le code n'est pas l'id de l'organisation.

## :robot: Proposition
Faire la requête en mettant le code comme un query params 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- aller sur pix1d et renseigner un code `MINIPIXOU` ou `MAXIPIXOU` et voir que tout se passe bien 
