### PR TITLE
[BUGFIX] Harmoniser la taille des boutons sur la création de session en masse et ajout de candidat sur Pix Certif (PIX-10142).

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -80,6 +80,10 @@
   padding-right: 0.625rem;
   margin-left: auto;
   margin-right: 1.25rem;
+
+  > label, a {
+    min-width: 164px;
+  }
 }
 
 .panel-actions__warning {

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -124,6 +124,10 @@
     display: grid;
     grid-template-columns: 1fr 10fr 2fr;
     padding: 24px 16px 24px 0;
+
+    > label, button {
+      width: 164px;
+    }
   }
 
   &__section--download__button:first-of-type {

--- a/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
@@ -61,6 +61,8 @@ module('Acceptance | Routes | Authenticated | Sessions | import', function (hook
       // then
       assert.strictEqual(currentURL(), '/sessions/import');
       assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
+      assert.dom(screen.getByText('Télécharger (.csv)')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Importer (.csv)' })).exists();
     });
   });
 });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -77,11 +77,11 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
     module('when there is no candidates yet', function () {
       test('it should display a download button and upload button', async function (assert) {
         // when
-        await visit(`/sessions/${session.id}/candidats`);
+        const screen = await visit(`/sessions/${session.id}/candidats`);
 
         // then
-        assert.contains('Télécharger (.ods)');
-        assert.contains('Importer (.ods)');
+        assert.dom(screen.getByRole('link', { name: 'Télécharger (.ods)' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Importer (.ods)' })).exists();
       });
 
       test('it should display a sentence when there is no certification candidates yet', async function (assert) {

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -118,14 +118,14 @@ module('Acceptance | Session Import', function (hooks) {
           // when
           screen = await visit('/sessions/import');
           const importButton = screen.getByRole('button', { name: 'Continuer' });
-          assert.dom(importButton).hasClass('pix-button--disabled');
+          assert.dom(importButton).hasAttribute('disabled');
           const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
-          assert.dom(importButton).doesNotHaveClass('pix-button--disabled');
+          assert.dom(importButton).doesNotHaveAttribute('disabled');
           await click(importButton);
 
           // then
-          assert.dom(importButton).hasClass('pix-button--disabled');
+          assert.dom(importButton).hasAttribute('disabled');
         });
 
         test("it should display the file's name once pre-imported", async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, la taille de certains boutons diffèrent, donnant un rendu visuel peu agréable.

<img width="1109" alt="Capture d’écran 2023-11-28 à 16 18 46" src="https://github.com/1024pix/pix/assets/58915422/ae3115fb-d988-46b3-8a81-84fe8565577a">


## :robot: Proposition
Harmoniser la tailles des boutons qui vont de pair, à savoir : 
- Les boutons de la page de création de sessions en masse : "Télécharger (.csv)" et "Importer (.csv)"
- Les boutons de la page d'ajout de candidat : "Télécharger (.ods)" et "Importer (.ods)"

## :rainbow: Remarques
Amélioration de quelques tests liés aux boutons dans le premier commit.

## :100: Pour tester

- Se connecter à Pix Certif avec certif-pro@example.net / pix123
- Cliquer sur le bouton pour Éditer/Créer plusieurs sessions
- Constater que les deux boutons ("Télécharger (.csv)" et "Importer (.csv)") font désormais la même taille
- Revenir à la liste des sessions
- Cliquer sur une session au hasard
- Cliquer sur l'onglet Candidats
- Constater que les deux boutons ("Télécharger (.ods)" et "Importer (.ods)") font désormais la même taille

