### PR TITLE
[FEATURE] Pix1D - Activation du bouton de vérification uniquement sur réponse complète (Pix-10086)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-item-qroc/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qroc/template.hbs
@@ -31,7 +31,7 @@
           name={{block.randomName}}
           autocomplete="nope"
           data-uid="qroc-proposal-uid"
-          {{on "change" this.updateUserAnswerValue}}
+          {{on "keyup" this.updateUserAnswerValue}}
         />
       {{else if (eq @challenge.format "phrase")}}
         <PixInput
@@ -42,7 +42,7 @@
           placeholder={{block.placeholder}}
           autocomplete="nope"
           data-uid="qroc-proposal-uid"
-          {{on "change" this.updateUserAnswerValue}}
+          {{on "keyup" this.updateUserAnswerValue}}
         />
       {{else if (eq @challenge.format "nombre")}}
         <PixInput
@@ -54,7 +54,7 @@
           placeholder={{block.placeholder}}
           @value={{this.userAnswer}}
           data-uid="qroc-proposal-uid"
-          {{on "change" this.updateUserAnswerValue}}
+          {{on "keyup" this.updateUserAnswerValue}}
         />
       {{else}}
         <PixInput
@@ -64,7 +64,7 @@
           type="text"
           autocomplete="nope"
           data-uid="qroc-proposal-uid"
-          {{on "change" this.updateUserAnswerValue}}
+          {{on "keyup" this.updateUserAnswerValue}}
         />
       {{/if}}
     {{/if}}

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/component.js
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/component.js
@@ -37,7 +37,7 @@ export default class ChallengeItemQrocm extends Component {
   @action
   onInputChange(key, event) {
     this.answersValue[key] = event.target.value;
-    this.args.setAnswerValue(JSON.stringify(this.answersValue));
+    this._synchronizeAnswers();
   }
 
   @action
@@ -46,6 +46,18 @@ export default class ChallengeItemQrocm extends Component {
     const newAnswersValue = this.answersValue;
     newAnswersValue[key] = value;
     this.answersValue = newAnswersValue;
-    this.args.setAnswerValue(JSON.stringify(this.answersValue));
+    this._synchronizeAnswers();
+  }
+
+  _synchronizeAnswers() {
+    if (this._allFieldsAnswered(this.answersValue)) {
+      this.args.setAnswerValue(JSON.stringify(this.answersValue));
+    } else {
+      this.args.setAnswerValue('');
+    }
+  }
+
+  _allFieldsAnswered(answers) {
+    return !Object.values(answers).includes('');
   }
 }

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -41,7 +41,7 @@
               placeholder={{block.placeholder}}
               name={{block.randomName}}
               autocomplete="nope"
-              {{on "change" (fn this.onInputChange block.input)}}
+              {{on "keyup" (fn this.onInputChange block.input)}}
             />
           {{else if (eq @challenge.format "phrase")}}
             <PixInput
@@ -52,7 +52,7 @@
               autocomplete="nope"
               placeholder={{block.placeholder}}
               @ariaLabel={{block.ariaLabel}}
-              {{on "change" (fn this.onInputChange block.input)}}
+              {{on "keyup" (fn this.onInputChange block.input)}}
             />
           {{else}}
             <PixInput
@@ -64,7 +64,7 @@
               placeholder={{block.placeholder}}
               @value={{get @answersValue block.input}}
               @ariaLabel={{block.ariaLabel}}
-              {{on "change" (fn this.onInputChange block.input)}}
+              {{on "keyup" (fn this.onInputChange block.input)}}
             />
           {{/if}}
         </div>

--- a/1d/app/pods/components/challenge/component.js
+++ b/1d/app/pods/components/challenge/component.js
@@ -13,6 +13,7 @@ export default class Challenge extends Component {
   get disableCheckButton() {
     return this.answerValue === null || this.answerValue === '';
   }
+
   @action
   setAnswerValue(value) {
     this.answerValue = value;

--- a/1d/app/pods/components/challenge/component.js
+++ b/1d/app/pods/components/challenge/component.js
@@ -13,7 +13,6 @@ export default class Challenge extends Component {
   get disableCheckButton() {
     return this.answerValue === null || this.answerValue === '';
   }
-
   @action
   setAnswerValue(value) {
     this.answerValue = value;

--- a/1d/mirage/factories/challenge.js
+++ b/1d/mirage/factories/challenge.js
@@ -17,6 +17,13 @@ export default Factory.extend({
     instruction: 'Un QROC est une question',
     proposals: 'Select: ${banana#tomatoPlaceholder§saladAriaLabel options=["good-answer","bad-answer"]}',
   }),
+  QROCWithMultipleSelect: trait({
+    type: 'QROCM-ind',
+    instruction: 'Un QROCM attend plusieurs réponses.',
+    proposals:
+      'Banana: ${banana# - Sélectionne - §banana options=["a","b"]}\nPeach: ${peach# - Sélectionne - §peach options=["c","d"]}',
+    embedUrl: '',
+  }),
   QROCM: trait({
     type: 'QROCM-dep',
     instruction: 'Trouve les bonnes réponses.',

--- a/1d/tests/acceptance/challenge-item-qcm_test.js
+++ b/1d/tests/acceptance/challenge-item-qcm_test.js
@@ -30,4 +30,16 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
     // then
     assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
   });
+
+  module('when user unselects all checkboxes', function () {
+    test('"Je vérifie" button is enabled', async function (assert) {
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      await click(screen.getByRole('checkbox', { name: 'Profil 1' }));
+      await click(screen.getByRole('checkbox', { name: 'Profil 1' }));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
+    });
+  });
 });

--- a/1d/tests/acceptance/challenge-item-qroc_test.js
+++ b/1d/tests/acceptance/challenge-item-qroc_test.js
@@ -20,6 +20,29 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       assert.dom('.challenge-item-proposals__response').exists({ count: 1 });
       assert.dom(screen.getByText('Rue de :')).exists();
     });
+
+    module('when user provides an answer', function () {
+      test('"Je vérifie" button is enabled', async function (assert) {
+        // when
+        const screen = await visit(`/assessments/${assessment.id}/challenges`);
+        await fillIn(screen.getByLabelText('Rue de :'), 'la paix');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isEnabled();
+      });
+    });
+
+    module('when user removes its answer', function () {
+      test('"Je vérifie" button is enabled', async function (assert) {
+        // when
+        const screen = await visit(`/assessments/${assessment.id}/challenges`);
+        await fillIn(screen.getByLabelText('Rue de :'), 'la paix');
+        await fillIn(screen.getByLabelText('Rue de :'), '');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
+      });
+    });
   });
 
   module('with text-area format', function (hooks) {
@@ -44,6 +67,18 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       // then
       assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+    });
+
+    module('when user removes its answer', function () {
+      test('"Je vérifie" button is disabled again', async function (assert) {
+        // when
+        const screen = await visit(`/assessments/${assessment.id}/challenges`);
+        await fillIn('textarea[data-uid="qroc-proposal-uid"]', 'good-answer');
+        await fillIn('textarea[data-uid="qroc-proposal-uid"]', '');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
+      });
     });
   });
 

--- a/1d/tests/acceptance/challenge-item-qroc_test.js
+++ b/1d/tests/acceptance/challenge-item-qroc_test.js
@@ -1,4 +1,4 @@
-import { click, fillIn } from '@ember/test-helpers';
+import { click, fillIn, triggerKeyEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from '../helpers';
@@ -26,6 +26,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         // when
         const screen = await visit(`/assessments/${assessment.id}/challenges`);
         await fillIn(screen.getByLabelText('Rue de :'), 'la paix');
+        await triggerKeyEvent(screen.getByLabelText('Rue de :'), 'keyup', 13);
 
         // then
         assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isEnabled();
@@ -63,6 +64,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       // when
       const screen = await visit(`/assessments/${assessment.id}/challenges`);
       await fillIn('textarea[data-uid="qroc-proposal-uid"]', 'good-answer');
+      await triggerKeyEvent('textarea[data-uid="qroc-proposal-uid"]', 'keyup', 13);
       await click(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') }));
 
       // then

--- a/1d/tests/acceptance/challenge-item-qrocm_test.js
+++ b/1d/tests/acceptance/challenge-item-qrocm_test.js
@@ -9,10 +9,11 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
   hooks.beforeEach(async function () {
     assessment = this.server.create('assessment');
-    this.server.create('challenge', 'QROCM');
   });
 
   test('should render challenge information and question', async function (assert) {
+    this.server.create('challenge', 'QROCM');
+
     // when
     const screen = await visit(`/assessments/${assessment.id}/challenges`);
     // then
@@ -21,6 +22,8 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
   });
 
   test('should display answer feedback bubble if user validates after writing the right answer in input and selecting the correct option', async function (assert) {
+    this.server.create('challenge', 'QROCM');
+
     // when
     const screen = await visit(`/assessments/${assessment.id}/challenges`);
     await fillIn(screen.getByLabelText('prenom'), 'good-answer');
@@ -31,5 +34,47 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
     // then
     assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+  });
+
+  module('when user has partially answered in a list box', function () {
+    test('"Je vérifie" button remains disabled', async function (assert) {
+      this.server.create('challenge', 'QROCWithMultipleSelect');
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      await clickByName('banana');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'a' }));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
+    });
+  });
+
+  module('when user has partially answered in an input', function () {
+    test('"Je vérifie" button remains disabled', async function (assert) {
+      this.server.create('challenge', 'QROCM');
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      await fillIn(screen.getByLabelText('prenom'), 'bob');
+
+      // then
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
+    });
+  });
+
+  module('when user removes an answer', function () {
+    test('"Je vérifie" button is disabled again', async function (assert) {
+      this.server.create('challenge', 'QROCM');
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      await fillIn(screen.getByLabelText('prenom'), 'bob');
+      await clickByName('livre');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'good-answer' }));
+      await fillIn(screen.getByLabelText('prenom'), '');
+
+      // then
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
+    });
   });
 });

--- a/1d/tests/acceptance/challenge-item-qrocm_test.js
+++ b/1d/tests/acceptance/challenge-item-qrocm_test.js
@@ -1,4 +1,4 @@
-import { click, fillIn } from '@ember/test-helpers';
+import { click, fillIn, triggerKeyEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from '../helpers';
@@ -27,6 +27,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
     // when
     const screen = await visit(`/assessments/${assessment.id}/challenges`);
     await fillIn(screen.getByLabelText('prenom'), 'good-answer');
+    await triggerKeyEvent(screen.getByLabelText('prenom'), 'keyup', 13);
     await clickByName('livre');
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'good-answer' }));

--- a/1d/tests/acceptance/challenge-workflow_test.js
+++ b/1d/tests/acceptance/challenge-workflow_test.js
@@ -20,7 +20,7 @@ module('Acceptance | Challenge workflow', function (hooks) {
   });
 
   module('when user has not answered yet', function () {
-    test('disable "Je vérifie" button', async function (assert) {
+    test('"Je vérifie" button is disabled', async function (assert) {
       const assessment = this.server.create('assessment');
       this.server.create('challenge');
       // when


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "Je vérifie" des épreuves est activé dès que l'élève a saisie une réponse, même s'il y a plusieurs réponses à donner. L'élève peut alors demander à vérifier une épreuve sans avoir complètement répondu et aura obligatoirement faux.

## :robot: Proposition
N'activer le bouton que quand toutes les réponses ont été données et le désactiver en cas de suppression d'une des réponses.

## :100: Pour tester
Passer sur l'ensemble des épreuves des 2 missions. Le comportement du bouton "Je vérifie" est conforme à la proposition.
