### PR TITLE
[TECH] Déplacer les routes d'affichage et de suppression d'un candidat à une session dans src (PIX-9876).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -122,9 +122,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CertificationCandidatesError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
-  if (error instanceof DomainErrors.CertificationCandidateForbiddenDeletionError) {
-    return new HttpErrors.ForbiddenError(error.message);
-  }
   if (error instanceof DomainErrors.CancelledInvitationError) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -178,30 +178,6 @@ const register = async function (server) {
       },
     },
     {
-      method: 'DELETE',
-      path: '/api/sessions/{id}/certification-candidates/{certificationCandidateId}',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: identifiersType.sessionId,
-            certificationCandidateId: identifiersType.certificationCandidateId,
-          }),
-        },
-        pre: [
-          {
-            method: authorization.verifySessionAuthorization,
-            assign: 'authorizationCheck',
-          },
-        ],
-        handler: sessionController.deleteCertificationCandidate,
-        tags: ['api', 'sessions', 'certification-candidates'],
-        notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés',
-          'Elle supprime un candidat de certification à la session.',
-        ],
-      },
-    },
-    {
       method: 'GET',
       path: '/api/admin/sessions/{id}/jury-certification-summaries',
       config: {

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -178,29 +178,6 @@ const register = async function (server) {
       },
     },
     {
-      method: 'GET',
-      path: '/api/sessions/{id}/certification-candidates',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: identifiersType.sessionId,
-          }),
-        },
-        pre: [
-          {
-            method: authorization.verifySessionAuthorization,
-            assign: 'authorizationCheck',
-          },
-        ],
-        handler: sessionController.getCertificationCandidates,
-        tags: ['api', 'sessions', 'certification-candidates'],
-        notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés',
-          'Elle retourne les candidats de certification inscrits à la session.',
-        ],
-      },
-    },
-    {
       method: 'DELETE',
       path: '/api/sessions/{id}/certification-candidates/{certificationCandidateId}',
       config: {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -81,13 +81,6 @@ const getCandidatesImportSheet = async function (
     .header('Content-Disposition', `attachment; filename=${filename + sessionId}.ods`);
 };
 
-const getCertificationCandidates = async function (request, h, dependencies = { certificationCandidateSerializer }) {
-  const sessionId = request.params.id;
-
-  const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });
-  return dependencies.certificationCandidateSerializer.serialize(certificationCandidates);
-};
-
 const deleteCertificationCandidate = async function (request) {
   const certificationCandidateId = request.params.certificationCandidateId;
 
@@ -282,7 +275,6 @@ const sessionController = {
   getJurySession,
   get,
   getCandidatesImportSheet,
-  getCertificationCandidates,
   deleteCertificationCandidate,
   getJuryCertificationSummaries,
   generateSessionResultsDownloadLink,

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,5 +1,6 @@
 import { SessionPublicationBatchError } from '../http-errors.js';
 import { usecases } from '../../domain/usecases/index.js';
+import { usecases as certificationUsecases } from '../../../src/certification/shared/domain/usecases/index.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import * as sessionResultsLinkService from '../../domain/services/session-results-link-service.js';
 import * as sessionValidator from '../../../src/certification/session/domain/validators/session-validator.js';
@@ -182,7 +183,7 @@ const enrolStudentsToSession = async function (
   const studentIds = request.deserializedPayload.organizationLearnerIds;
 
   await usecases.enrolStudentsToSession({ sessionId, referentId, studentIds });
-  const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });
+  const certificationCandidates = await certificationUsecases.getSessionCertificationCandidates({ sessionId });
   const certificationCandidatesSerialized =
     dependencies.certificationCandidateSerializer.serialize(certificationCandidates);
   return h.response(certificationCandidatesSerialized).created();

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -82,14 +82,6 @@ const getCandidatesImportSheet = async function (
     .header('Content-Disposition', `attachment; filename=${filename + sessionId}.ods`);
 };
 
-const deleteCertificationCandidate = async function (request) {
-  const certificationCandidateId = request.params.certificationCandidateId;
-
-  await usecases.deleteUnlinkedCertificationCandidate({ certificationCandidateId });
-
-  return null;
-};
-
 const getJuryCertificationSummaries = async function (
   request,
   h,
@@ -276,7 +268,6 @@ const sessionController = {
   getJurySession,
   get,
   getCandidatesImportSheet,
-  deleteCertificationCandidate,
   getJuryCertificationSummaries,
   generateSessionResultsDownloadLink,
   getSessionResultsToDownload,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -525,12 +525,6 @@ class CertificationCandidatePersonalInfoWrongFormat extends DomainError {
   }
 }
 
-class CertificationCandidateForbiddenDeletionError extends DomainError {
-  constructor(message = 'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.') {
-    super(message);
-  }
-}
-
 class CertificationCandidatesError extends DomainError {
   constructor({ message = "Quelque chose s'est mal passé. Veuillez réessayer", code = null, meta = null } = {}) {
     super(message, code, meta);
@@ -1165,7 +1159,6 @@ export {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateCreationOrUpdateError,
   CertificationCandidateDeletionError,
-  CertificationCandidateForbiddenDeletionError,
   CertificationCandidateMultipleUserLinksWithinSessionError,
   CertificationCandidateNotFoundError,
   CertificationCandidateOnFinalizedSessionError,

--- a/api/src/certification/session/application/certification-candidate-controller.js
+++ b/api/src/certification/session/application/certification-candidate-controller.js
@@ -1,6 +1,5 @@
 import * as certificationCandidateSerializer from '../../shared/infrastructure/serializers/jsonapi/certification-candidate-serializer.js';
 import { usecases } from '../../shared/domain/usecases/index.js';
-import { usecases as usecasesLib } from '../../../../lib/domain/usecases/index.js';
 
 const add = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
@@ -18,7 +17,7 @@ const add = async function (request, h, dependencies = { certificationCandidateS
 const get = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
 
-  const certificationCandidates = await usecasesLib.getSessionCertificationCandidates({ sessionId });
+  const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });
   return dependencies.certificationCandidateSerializer.serialize(certificationCandidates);
 };
 

--- a/api/src/certification/session/application/certification-candidate-controller.js
+++ b/api/src/certification/session/application/certification-candidate-controller.js
@@ -1,5 +1,6 @@
 import * as certificationCandidateSerializer from '../../shared/infrastructure/serializers/jsonapi/certification-candidate-serializer.js';
 import { usecases } from '../../shared/domain/usecases/index.js';
+import { usecases as usecasesLib } from '../../../../lib/domain/usecases/index.js';
 
 const add = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
@@ -14,7 +15,15 @@ const add = async function (request, h, dependencies = { certificationCandidateS
   return h.response(dependencies.certificationCandidateSerializer.serialize(addedCertificationCandidate)).created();
 };
 
+const getCertificationCandidates = async function (request, h, dependencies = { certificationCandidateSerializer }) {
+  const sessionId = request.params.id;
+
+  const certificationCandidates = await usecasesLib.getSessionCertificationCandidates({ sessionId });
+  return dependencies.certificationCandidateSerializer.serialize(certificationCandidates);
+};
+
 const certificationCandidateController = {
   add,
+  getCertificationCandidates,
 };
 export { certificationCandidateController };

--- a/api/src/certification/session/application/certification-candidate-controller.js
+++ b/api/src/certification/session/application/certification-candidate-controller.js
@@ -21,8 +21,17 @@ const get = async function (request, h, dependencies = { certificationCandidateS
   return dependencies.certificationCandidateSerializer.serialize(certificationCandidates);
 };
 
+const deleteCandidate = async function (request) {
+  const certificationCandidateId = request.params.certificationCandidateId;
+
+  await usecases.deleteUnlinkedCertificationCandidate({ certificationCandidateId });
+
+  return null;
+};
+
 const certificationCandidateController = {
   add,
   get,
+  deleteCandidate,
 };
 export { certificationCandidateController };

--- a/api/src/certification/session/application/certification-candidate-controller.js
+++ b/api/src/certification/session/application/certification-candidate-controller.js
@@ -1,7 +1,7 @@
 import * as certificationCandidateSerializer from '../../shared/infrastructure/serializers/jsonapi/certification-candidate-serializer.js';
 import { usecases } from '../../shared/domain/usecases/index.js';
 
-const add = async function (request, h, dependencies = { certificationCandidateSerializer }) {
+const addCandidate = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
   const certificationCandidate = await dependencies.certificationCandidateSerializer.deserialize(request.payload);
   const complementaryCertification = request.payload.data.attributes['complementary-certification'] ?? null;
@@ -14,7 +14,7 @@ const add = async function (request, h, dependencies = { certificationCandidateS
   return h.response(dependencies.certificationCandidateSerializer.serialize(addedCertificationCandidate)).created();
 };
 
-const get = async function (request, h, dependencies = { certificationCandidateSerializer }) {
+const getCandidate = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
 
   const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });
@@ -30,8 +30,8 @@ const deleteCandidate = async function (request) {
 };
 
 const certificationCandidateController = {
-  add,
-  get,
+  addCandidate,
+  getCandidate,
   deleteCandidate,
 };
 export { certificationCandidateController };

--- a/api/src/certification/session/application/certification-candidate-controller.js
+++ b/api/src/certification/session/application/certification-candidate-controller.js
@@ -15,7 +15,7 @@ const add = async function (request, h, dependencies = { certificationCandidateS
   return h.response(dependencies.certificationCandidateSerializer.serialize(addedCertificationCandidate)).created();
 };
 
-const getCertificationCandidates = async function (request, h, dependencies = { certificationCandidateSerializer }) {
+const get = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
 
   const certificationCandidates = await usecasesLib.getSessionCertificationCandidates({ sessionId });
@@ -24,6 +24,6 @@ const getCertificationCandidates = async function (request, h, dependencies = { 
 
 const certificationCandidateController = {
   add,
-  getCertificationCandidates,
+  get,
 };
 export { certificationCandidateController };

--- a/api/src/certification/session/application/certification-candidate-route.js
+++ b/api/src/certification/session/application/certification-candidate-route.js
@@ -55,7 +55,7 @@ const register = async function (server) {
             assign: 'authorizationCheck',
           },
         ],
-        handler: certificationCandidateController.add,
+        handler: certificationCandidateController.addCandidate,
         tags: ['api', 'sessions', 'certification-candidates'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',
@@ -78,7 +78,7 @@ const register = async function (server) {
             assign: 'authorizationCheck',
           },
         ],
-        handler: certificationCandidateController.get,
+        handler: certificationCandidateController.getCandidate,
         tags: ['api', 'sessions', 'certification-candidates'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',

--- a/api/src/certification/session/application/certification-candidate-route.js
+++ b/api/src/certification/session/application/certification-candidate-route.js
@@ -63,6 +63,29 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/sessions/{id}/certification-candidates',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+          }),
+        },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: certificationCandidateController.getCertificationCandidates,
+        tags: ['api', 'sessions', 'certification-candidates'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle retourne les candidats de certification inscrits à la session.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/session/application/certification-candidate-route.js
+++ b/api/src/certification/session/application/certification-candidate-route.js
@@ -86,6 +86,30 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/sessions/{id}/certification-candidates/{certificationCandidateId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+            certificationCandidateId: identifiersType.certificationCandidateId,
+          }),
+        },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: certificationCandidateController.deleteCandidate,
+        tags: ['api', 'sessions', 'certification-candidates'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle supprime un candidat de certification à la session.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/session/application/certification-candidate-route.js
+++ b/api/src/certification/session/application/certification-candidate-route.js
@@ -78,7 +78,7 @@ const register = async function (server) {
             assign: 'authorizationCheck',
           },
         ],
-        handler: certificationCandidateController.getCertificationCandidates,
+        handler: certificationCandidateController.get,
         tags: ['api', 'sessions', 'certification-candidates'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',

--- a/api/src/certification/session/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session/application/http-error-mapper-configuration.js
@@ -3,6 +3,7 @@ import {
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionAlreadyFinalizedError,
+  CertificationCandidateForbiddenDeletionError,
 } from '../domain/errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
 
@@ -18,6 +19,10 @@ const sessionDomainErrorMappingConfiguration = [
   {
     name: SessionAlreadyFinalizedError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code),
+  },
+  {
+    name: CertificationCandidateForbiddenDeletionError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
 

--- a/api/src/certification/session/domain/errors.js
+++ b/api/src/certification/session/domain/errors.js
@@ -37,10 +37,17 @@ class SessionWithMissingAbortReasonError extends DomainError {
   }
 }
 
+class CertificationCandidateForbiddenDeletionError extends DomainError {
+  constructor(message = 'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.') {
+    super(message);
+  }
+}
+
 export {
   SessionStartedDeletionError,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionAlreadyFinalizedError,
+  CertificationCandidateForbiddenDeletionError,
 };

--- a/api/src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js
@@ -1,5 +1,13 @@
-import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
+/**
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ */
 
+import { CertificationCandidateForbiddenDeletionError } from '../../../../../lib/domain/errors.js';
+
+/**
+ * @param {Object} params
+ * @param {deps['certificationCandidateRepository']} params.certificationCandidateRepository
+ */
 const deleteUnlinkedCertificationCandidate = async function ({
   certificationCandidateId,
   certificationCandidateRepository,

--- a/api/src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js
@@ -2,7 +2,7 @@
  * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 
-import { CertificationCandidateForbiddenDeletionError } from '../../../../../lib/domain/errors.js';
+import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
 
 /**
  * @param {Object} params

--- a/api/src/certification/session/domain/usecases/get-session-certification-candidates.js
+++ b/api/src/certification/session/domain/usecases/get-session-certification-candidates.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ */
+
+/**
+ * @param {Object} params
+ * @param {deps['certificationCandidateRepository']} params.certificationCandidateRepository
+ */
 const getSessionCertificationCandidates = async function ({ sessionId, certificationCandidateRepository }) {
   return certificationCandidateRepository.findBySessionId(sessionId);
 };

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -8,10 +8,7 @@ import _ from 'lodash';
 import * as translations from '../../../translations/index.js';
 import { AdminMemberError } from '../../authorization/domain/errors.js';
 import { domainErrorMapper } from './domain-error-mapper.js';
-import {
-  SessionStartedDeletionError,
-  CertificationCandidateForbiddenDeletionError,
-} from '../../certification/session/domain/errors.js';
+import { SessionStartedDeletionError } from '../../certification/session/domain/errors.js';
 
 const { Error: JSONAPIError } = jsonapiSerializer;
 const NOT_VALID_RELATIONSHIPS = ['externalId', 'participantExternalId'];
@@ -102,7 +99,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.LocaleNotSupportedError) {
     return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
   }
-
   if (error instanceof AdminMemberError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }
@@ -111,9 +107,6 @@ function _mapToHttpError(error) {
   }
   if (error instanceof SessionStartedDeletionError) {
     return new HttpErrors.ConflictError(error.message);
-  }
-  if (error instanceof CertificationCandidateForbiddenDeletionError) {
-    return new HttpErrors.ForbiddenError(error.message);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -7,8 +7,11 @@ import { extractLocaleFromRequest } from '../../../lib/infrastructure/utils/requ
 import _ from 'lodash';
 import * as translations from '../../../translations/index.js';
 import { AdminMemberError } from '../../authorization/domain/errors.js';
-import { SessionStartedDeletionError } from '../../certification/session/domain/errors.js';
 import { domainErrorMapper } from './domain-error-mapper.js';
+import {
+  SessionStartedDeletionError,
+  CertificationCandidateForbiddenDeletionError,
+} from '../../certification/session/domain/errors.js';
 
 const { Error: JSONAPIError } = jsonapiSerializer;
 const NOT_VALID_RELATIONSHIPS = ['externalId', 'participantExternalId'];
@@ -108,6 +111,9 @@ function _mapToHttpError(error) {
   }
   if (error instanceof SessionStartedDeletionError) {
     return new HttpErrors.ConflictError(error.message);
+  }
+  if (error instanceof CertificationCandidateForbiddenDeletionError) {
+    return new HttpErrors.ForbiddenError(error.message);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/tests/acceptance/application/session/session-controller-delete-certification-candidate_test.js
+++ b/api/tests/acceptance/application/session/session-controller-delete-certification-candidate_test.js
@@ -8,7 +8,7 @@ describe('Acceptance | Controller | session-controller-delete-certification-cand
     server = await createServer();
   });
 
-  describe('#deleteCertificationCandidate', function () {
+  describe('#deleteCandidate', function () {
     let sessionId;
     let userId;
     let certificationCandidateId;

--- a/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
@@ -1,6 +1,7 @@
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 import { certificationCandidateController } from '../../../../../src/certification/session/application/certification-candidate-controller.js';
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases as usecasesLib } from '../../../../../lib/domain/usecases/index.js';
 
 describe('Unit | Controller | certification-candidate-controller', function () {
   describe('#add', function () {
@@ -45,6 +46,38 @@ describe('Unit | Controller | certification-candidate-controller', function () {
       // then
       expect(response.source).to.equal(certificationCandidateJsonApi);
       expect(response.statusCode).to.equal(201);
+    });
+  });
+
+  describe('#getCertificationCandidates', function () {
+    let request;
+    const sessionId = 1;
+    const certificationCandidates = 'candidates';
+    const certificationCandidatesJsonApi = 'candidatesJSONAPI';
+
+    beforeEach(function () {
+      // given
+      request = {
+        params: { id: sessionId },
+      };
+      sinon
+        .stub(usecasesLib, 'getSessionCertificationCandidates')
+        .withArgs({ sessionId })
+        .resolves(certificationCandidates);
+    });
+
+    it('should return certification candidates', async function () {
+      // when
+      const certificationCandidateSerializer = { serialize: sinon.stub() };
+      certificationCandidateSerializer.serialize
+        .withArgs(certificationCandidates)
+        .returns(certificationCandidatesJsonApi);
+      const response = await certificationCandidateController.getCertificationCandidates(request, hFake, {
+        certificationCandidateSerializer,
+      });
+
+      // then
+      expect(response).to.deep.equal(certificationCandidatesJsonApi);
     });
   });
 });

--- a/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
@@ -49,7 +49,7 @@ describe('Unit | Controller | certification-candidate-controller', function () {
     });
   });
 
-  describe('#getCertificationCandidates', function () {
+  describe('#get', function () {
     let request;
     const sessionId = 1;
     const certificationCandidates = 'candidates';
@@ -72,7 +72,7 @@ describe('Unit | Controller | certification-candidate-controller', function () {
       certificationCandidateSerializer.serialize
         .withArgs(certificationCandidates)
         .returns(certificationCandidatesJsonApi);
-      const response = await certificationCandidateController.getCertificationCandidates(request, hFake, {
+      const response = await certificationCandidateController.get(request, hFake, {
         certificationCandidateSerializer,
       });
 

--- a/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
@@ -79,4 +79,26 @@ describe('Unit | Controller | certification-candidate-controller', function () {
       expect(response).to.deep.equal(certificationCandidatesJsonApi);
     });
   });
+
+  describe('#deleteCandidate ', function () {
+    let request;
+    const sessionId = 1;
+    const certificationCandidateId = 1;
+
+    beforeEach(function () {
+      // given
+      request = {
+        params: { id: sessionId, certificationCandidateId },
+      };
+      sinon.stub(usecases, 'deleteUnlinkedCertificationCandidate').withArgs({ certificationCandidateId }).resolves();
+    });
+
+    it('should return 204 when deleting successfully the candidate', async function () {
+      // when
+      const response = await certificationCandidateController.deleteCandidate(request, hFake);
+
+      // then
+      expect(response).to.be.null;
+    });
+  });
 });

--- a/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
@@ -38,7 +38,7 @@ describe('Unit | Controller | certification-candidate-controller', function () {
       certificationCandidateSerializer.deserialize.resolves(certificationCandidate);
 
       // when
-      const response = await certificationCandidateController.add(request, hFake, {
+      const response = await certificationCandidateController.addCandidate(request, hFake, {
         certificationCandidateSerializer,
       });
 
@@ -71,7 +71,7 @@ describe('Unit | Controller | certification-candidate-controller', function () {
       certificationCandidateSerializer.serialize
         .withArgs(certificationCandidates)
         .returns(certificationCandidatesJsonApi);
-      const response = await certificationCandidateController.get(request, hFake, {
+      const response = await certificationCandidateController.getCandidate(request, hFake, {
         certificationCandidateSerializer,
       });
 

--- a/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
@@ -1,7 +1,6 @@
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 import { certificationCandidateController } from '../../../../../src/certification/session/application/certification-candidate-controller.js';
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
-import { usecases as usecasesLib } from '../../../../../lib/domain/usecases/index.js';
 
 describe('Unit | Controller | certification-candidate-controller', function () {
   describe('#add', function () {
@@ -61,7 +60,7 @@ describe('Unit | Controller | certification-candidate-controller', function () {
         params: { id: sessionId },
       };
       sinon
-        .stub(usecasesLib, 'getSessionCertificationCandidates')
+        .stub(usecases, 'getSessionCertificationCandidates')
         .withArgs({ sessionId })
         .resolves(certificationCandidates);
     });

--- a/api/tests/certification/session/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-route_test.js
@@ -110,6 +110,64 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
+  describe('GET /api/sessions/{id}/certification-candidates', function () {
+    it('should exist', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
+      sinon.stub(certificationCandidateController, 'get').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/sessions/3/certification-candidates');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('DELETE /api/sessions/{id}/certification-candidates/{certificationCandidateId}', function () {
+    it('should return 404 if the user is not authorized on the session', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates');
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should exist', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
+      sinon.stub(certificationCandidateController, 'deleteCandidate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates/1');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return an error if certification candidate id is incorrect', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
+      sinon.stub(certificationCandidateController, 'deleteCandidate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates/ID');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
   describe('id validation', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
@@ -129,6 +187,22 @@ describe('Unit | Application | Sessions | Routes', function () {
         condition: 'session ID params is out of range for database integer (> 2147483647)',
         request: { method: 'GET', url: '/api/sessions/9999999999/certification-candidates' },
       },
+      {
+        condition: 'session ID params is not a number',
+        request: { method: 'DELETE', url: '/api/sessions/salut/certification-candidates/1' },
+      },
+      {
+        condition: 'session ID params is out of range for database integer (> 2147483647)',
+        request: { method: 'DELETE', url: '/api/sessions/9999999999/certification-candidates/1' },
+      },
+      {
+        condition: 'certification candidate ID params is not a number',
+        request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/salut' },
+      },
+      {
+        condition: 'certification candidate ID params is out of range for database integer (> 2147483647)',
+        request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/9999999999' },
+      },
     ].forEach(({ condition, request }) => {
       it(`should return 400 when ${condition}`, async function () {
         // given
@@ -141,22 +215,6 @@ describe('Unit | Application | Sessions | Routes', function () {
         // then
         expect(response.statusCode).to.equal(400);
       });
-    });
-  });
-
-  describe('GET /api/sessions/{id}/certification-candidates', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(certificationCandidateController, 'get').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/sessions/3/certification-candidates');
-
-      // then
-      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/certification/session/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-route_test.js
@@ -121,6 +121,14 @@ describe('Unit | Application | Sessions | Routes', function () {
         condition: 'session ID params is out of range for database integer (> 2147483647)',
         request: { method: 'POST', url: '/api/sessions/9999999999/certification-candidates' },
       },
+      {
+        condition: 'session ID params is not a number',
+        request: { method: 'GET', url: '/api/sessions/salut/certification-candidates' },
+      },
+      {
+        condition: 'session ID params is out of range for database integer (> 2147483647)',
+        request: { method: 'GET', url: '/api/sessions/9999999999/certification-candidates' },
+      },
     ].forEach(({ condition, request }) => {
       it(`should return 400 when ${condition}`, async function () {
         // given
@@ -133,6 +141,22 @@ describe('Unit | Application | Sessions | Routes', function () {
         // then
         expect(response.statusCode).to.equal(400);
       });
+    });
+  });
+
+  describe('GET /api/sessions/{id}/certification-candidates', function () {
+    it('should exist', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
+      sinon.stub(certificationCandidateController, 'getCertificationCandidates').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/sessions/3/certification-candidates');
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/certification/session/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-route_test.js
@@ -44,7 +44,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('should return 200', async function () {
         // given
         sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
-        sinon.stub(certificationCandidateController, 'add').returns('ok');
+        sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -66,7 +66,7 @@ describe('Unit | Application | Sessions | Routes', function () {
         it('should return 400', async function () {
           // given
           sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
-          sinon.stub(certificationCandidateController, 'add').returns('ok');
+          sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
 
@@ -89,7 +89,7 @@ describe('Unit | Application | Sessions | Routes', function () {
         it('should return 400', async function () {
           // given
           sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
-          sinon.stub(certificationCandidateController, 'add').returns('ok');
+          sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
 
@@ -114,7 +114,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     it('should exist', async function () {
       // given
       sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(certificationCandidateController, 'get').returns('ok');
+      sinon.stub(certificationCandidateController, 'getCandidate').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/certification/session/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-route_test.js
@@ -148,7 +148,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     it('should exist', async function () {
       // given
       sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(certificationCandidateController, 'getCertificationCandidates').returns('ok');
+      sinon.stub(certificationCandidateController, 'get').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/certification/session/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session/unit/application/http-error-mapper-configuration_test.js
@@ -4,6 +4,7 @@ import {
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionAlreadyFinalizedError,
+  CertificationCandidateForbiddenDeletionError,
 } from '../../../../../src/certification/session/domain/errors.js';
 import { sessionDomainErrorMappingConfiguration } from '../../../../../src/certification/session/application/http-error-mapper-configuration.js';
 import { DomainErrorMappingConfiguration } from '../../../../../src/shared/application/models/domain-error-mapping-configuration.js';
@@ -74,6 +75,24 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       expect(error).to.be.instanceOf(HttpErrors.ConflictError);
       expect(error.message).to.equal(message);
       expect(error.code).to.equal(code);
+    });
+  });
+
+  context('when mapping "CertificationCandidateForbiddenDeletionError"', function () {
+    it('returns an CertificationCandidateForbiddenDeletionError Http Error', function () {
+      //given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CertificationCandidateForbiddenDeletionError.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new CertificationCandidateForbiddenDeletionError());
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.ForbiddenError);
+      expect(error.message).to.equal(
+        'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.',
+      );
     });
   });
 });

--- a/api/tests/certification/session/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -1,6 +1,6 @@
 import { sinon, expect, catchErr } from '../../../../../test-helper.js';
 import { deleteUnlinkedCertificationCandidate } from '../../../../../../src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js';
-import { CertificationCandidateForbiddenDeletionError } from '../../../../../../lib/domain/errors.js';
+import { CertificationCandidateForbiddenDeletionError } from '../../../../../../src/certification/session/domain/errors.js';
 
 describe('Unit | UseCase | delete-unlinked-sertification-candidate', function () {
   let certificationCandidateId;

--- a/api/tests/certification/session/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/delete-unlinked-certification-candidate_test.js
@@ -1,6 +1,6 @@
-import { sinon, expect, catchErr } from '../../../test-helper.js';
-import { deleteUnlinkedCertificationCandidate } from '../../../../lib/domain/usecases/delete-unlinked-certification-candidate.js';
-import { CertificationCandidateForbiddenDeletionError } from '../../../../lib/domain/errors.js';
+import { sinon, expect, catchErr } from '../../../../../test-helper.js';
+import { deleteUnlinkedCertificationCandidate } from '../../../../../../src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js';
+import { CertificationCandidateForbiddenDeletionError } from '../../../../../../lib/domain/errors.js';
 
 describe('Unit | UseCase | delete-unlinked-sertification-candidate', function () {
   let certificationCandidateId;

--- a/api/tests/certification/session/unit/domain/usecases/get-session-certification-candidates_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/get-session-certification-candidates_test.js
@@ -1,7 +1,7 @@
-import { expect, sinon } from '../../../test-helper.js';
-import { getSessionCertificationCandidates } from '../../../../lib/domain/usecases/get-session-certification-candidates.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { getSessionCertificationCandidates } from '../../../../../../src/certification/session/domain/usecases/get-session-certification-candidates.js';
 
-describe('Unit | Domain | Use Cases | get-session-certification-candidates', function () {
+describe('Unit | UseCase | get-session-certification-candidates', function () {
   const sessionId = 'sessionId';
   const certificationCandidates = 'candidates';
   let certificationCandidateRepository;

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -367,16 +367,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseCode(response)).to.equal('SESSION_STARTED_CANDIDATE_ALREADY_LINKED_TO_USER');
     });
 
-    it('responds Forbidden when a CertificationCandidateForbiddenDeletionError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.CertificationCandidateForbiddenDeletionError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal(
-        'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.',
-      );
-    });
-
     it('responds Forbidden when a ForbiddenAccess error occurs', async function () {
       routeHandler.throws(new ForbiddenAccess('Accès non autorisé.'));
       const response = await server.requestObject(request);

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -14,10 +14,7 @@ import { HttpErrors, UnauthorizedError } from '../../../../src/shared/applicatio
 import { handle } from '../../../../src/shared/application/error-manager.js';
 import { AdminMemberError } from '../../../../src/authorization/domain/errors.js';
 
-import {
-  SessionStartedDeletionError,
-  CertificationCandidateForbiddenDeletionError,
-} from '../../../../src/certification/session/domain/errors.js';
+import { SessionStartedDeletionError } from '../../../../src/certification/session/domain/errors.js';
 import { domainErrorMapper } from '../../../../src/shared/application/domain-error-mapper.js';
 import { authenticationDomainErrorMappingConfiguration } from '../../../../src/authentication/application/http-error-mapper-configuration.js';
 
@@ -179,21 +176,6 @@ describe('Shared | Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
-    });
-
-    it('should instantiate ForbiddenError when a CertificationCandidateForbiddenDeletionError', async function () {
-      // given
-      const error = new CertificationCandidateForbiddenDeletionError();
-      sinon.stub(HttpErrors, 'ForbiddenError');
-      const params = { request: {}, h: hFake, error };
-
-      // when
-      await handle(params.request, params.h, params.error);
-
-      // then
-      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(
-        'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.',
-      );
     });
 
     context('Locale errors', function () {

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -13,7 +13,11 @@ import {
 import { HttpErrors, UnauthorizedError } from '../../../../src/shared/application/http-errors.js';
 import { handle } from '../../../../src/shared/application/error-manager.js';
 import { AdminMemberError } from '../../../../src/authorization/domain/errors.js';
-import { SessionStartedDeletionError } from '../../../../src/certification/session/domain/errors.js';
+
+import {
+  SessionStartedDeletionError,
+  CertificationCandidateForbiddenDeletionError,
+} from '../../../../src/certification/session/domain/errors.js';
 import { domainErrorMapper } from '../../../../src/shared/application/domain-error-mapper.js';
 import { authenticationDomainErrorMappingConfiguration } from '../../../../src/authentication/application/http-error-mapper-configuration.js';
 
@@ -175,6 +179,21 @@ describe('Shared | Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
+    });
+
+    it('should instantiate ForbiddenError when a CertificationCandidateForbiddenDeletionError', async function () {
+      // given
+      const error = new CertificationCandidateForbiddenDeletionError();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(
+        'Il est interdit de supprimer un candidat de certification déjà lié à un utilisateur.',
+      );
     });
 
     context('Locale errors', function () {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -106,48 +106,6 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('DELETE /api/sessions/{id}/certification-candidates/{certificationCandidateId}', function () {
-    it('should return 404 if the user is not authorized on the session', async function () {
-      // given
-      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates');
-
-      // then
-      expect(response.statusCode).to.equal(404);
-    });
-
-    it('should exist', async function () {
-      // given
-      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(sessionController, 'deleteCertificationCandidate').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates/1');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('should return an error if certification candidate id is incorrect', async function () {
-      // given
-      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(sessionController, 'deleteCertificationCandidate').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('DELETE', '/api/sessions/3/certification-candidates/ID');
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-
   describe('POST /api/sessions/{id}/candidate-participation', function () {
     it('should exist', async function () {
       // given
@@ -175,22 +133,6 @@ describe('Unit | Application | Sessions | Routes', function () {
       {
         condition: 'session ID params is out of range for database integer (> 2147483647)',
         request: { method: 'GET', url: '/api/admin/sessions/9999999999' },
-      },
-      {
-        condition: 'session ID params is not a number',
-        request: { method: 'DELETE', url: '/api/sessions/salut/certification-candidates/1' },
-      },
-      {
-        condition: 'session ID params is out of range for database integer (> 2147483647)',
-        request: { method: 'DELETE', url: '/api/sessions/9999999999/certification-candidates/1' },
-      },
-      {
-        condition: 'certification candidate ID params is not a number',
-        request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/salut' },
-      },
-      {
-        condition: 'certification candidate ID params is out of range for database integer (> 2147483647)',
-        request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/9999999999' },
       },
       {
         condition: 'session ID params is not a number',

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -106,22 +106,6 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('GET /api/sessions/{id}/certification-candidates', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
-      sinon.stub(sessionController, 'getCertificationCandidates').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/sessions/3/certification-candidates');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('DELETE /api/sessions/{id}/certification-candidates/{certificationCandidateId}', function () {
     it('should return 404 if the user is not authorized on the session', async function () {
       // given
@@ -191,14 +175,6 @@ describe('Unit | Application | Sessions | Routes', function () {
       {
         condition: 'session ID params is out of range for database integer (> 2147483647)',
         request: { method: 'GET', url: '/api/admin/sessions/9999999999' },
-      },
-      {
-        condition: 'session ID params is not a number',
-        request: { method: 'GET', url: '/api/sessions/salut/certification-candidates' },
-      },
-      {
-        condition: 'session ID params is out of range for database integer (> 2147483647)',
-        request: { method: 'GET', url: '/api/sessions/9999999999/certification-candidates' },
       },
       {
         condition: 'session ID params is not a number',

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -112,38 +112,6 @@ describe('Unit | Controller | sessionController', function () {
     });
   });
 
-  describe('#getCertificationCandidates', function () {
-    let request;
-    const sessionId = 1;
-    const certificationCandidates = 'candidates';
-    const certificationCandidatesJsonApi = 'candidatesJSONAPI';
-
-    beforeEach(function () {
-      // given
-      request = {
-        params: { id: sessionId },
-      };
-      sinon
-        .stub(usecases, 'getSessionCertificationCandidates')
-        .withArgs({ sessionId })
-        .resolves(certificationCandidates);
-    });
-
-    it('should return certification candidates', async function () {
-      // when
-      const certificationCandidateSerializer = { serialize: sinon.stub() };
-      certificationCandidateSerializer.serialize
-        .withArgs(certificationCandidates)
-        .returns(certificationCandidatesJsonApi);
-      const response = await sessionController.getCertificationCandidates(request, hFake, {
-        certificationCandidateSerializer,
-      });
-
-      // then
-      expect(response).to.deep.equal(certificationCandidatesJsonApi);
-    });
-  });
-
   describe('#deleteCertificationCandidate ', function () {
     let request;
     const sessionId = 1;

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -113,28 +113,6 @@ describe('Unit | Controller | sessionController', function () {
     });
   });
 
-  describe('#deleteCertificationCandidate ', function () {
-    let request;
-    const sessionId = 1;
-    const certificationCandidateId = 1;
-
-    beforeEach(function () {
-      // given
-      request = {
-        params: { id: sessionId, certificationCandidateId },
-      };
-      sinon.stub(usecases, 'deleteUnlinkedCertificationCandidate').withArgs({ certificationCandidateId }).resolves();
-    });
-
-    it('should return 204 when deleting successfully the candidate', async function () {
-      // when
-      const response = await sessionController.deleteCertificationCandidate(request, hFake);
-
-      // then
-      expect(response).to.be.null;
-    });
-  });
-
   describe('#getJuryCertificationSummaries ', function () {
     it('should return jury certification summaries', async function () {
       // given

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -1,6 +1,7 @@
 import { catchErr, expect, hFake, sinon } from '../../../test-helper.js';
 import { sessionController } from '../../../../lib/application/sessions/session-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { usecases as certificationUsecases } from '../../../../src/certification/shared/domain/usecases/index.js';
 import { UserAlreadyLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate.js';
 import { UserLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserLinkedToCertificationCandidate.js';
 import { SessionPublicationBatchResult } from '../../../../lib/domain/models/SessionPublicationBatchResult.js';
@@ -287,7 +288,7 @@ describe('Unit | Controller | sessionController', function () {
       };
       const requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
       sinon.stub(usecases, 'enrolStudentsToSession');
-      sinon.stub(usecases, 'getSessionCertificationCandidates');
+      sinon.stub(certificationUsecases, 'getSessionCertificationCandidates');
       const certificationCandidateSerializer = { serialize: sinon.stub() };
       dependencies = {
         requestResponseUtils,
@@ -299,7 +300,7 @@ describe('Unit | Controller | sessionController', function () {
       beforeEach(function () {
         dependencies.requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(userId);
         usecases.enrolStudentsToSession.withArgs({ sessionId, referentId: userId, studentIds }).resolves();
-        usecases.getSessionCertificationCandidates.withArgs({ sessionId }).resolves(studentList);
+        certificationUsecases.getSessionCertificationCandidates.withArgs({ sessionId }).resolves(studentList);
         dependencies.certificationCandidateSerializer.serialize
           .withArgs(studentList)
           .returns(serializedCertificationCandidate);

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -48,10 +48,6 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.CertificationCandidatePersonalInfoWrongFormat).to.exist;
   });
 
-  it('should export a CertificationCandidateForbiddenDeletionError', function () {
-    expect(errors.CertificationCandidateForbiddenDeletionError).to.exist;
-  });
-
   it('should export a NotFoundError', function () {
     expect(errors.NotFoundError).to.exist;
   });


### PR DESCRIPTION
## :unicorn: Problème

Migration de l'arborescende de l'API sous forme de bounded context

## :robot: Proposition

Migrer les routes d'ajout et de suppression des candidats

## :rainbow: Remarques
⚠️ Je voulais traiter les models, notamment CertificateCandidate + son sous-model ComplementaryCertification, pour basculer cela dans /sessions

* Mais ça risque de rentrer en conflit avec l'import de masse des sessions (PIX-9878)
* Ca nécessite aussi de refacto pour virer du bookshelf (histoire de ne pas se trainer quelque chose qui doit disparaitre)
* de déplacer du code de `/src/certification/shared` vers `/src/certification/session`
  * rappel : en DDD, la duplication de code est acceptable si elle sert à rendre les choses "mieux"

## :100: Pour tester

https://certif-pr7548.review.pix.fr/connexion

* Sur Pix Certif, avec `certif-pro@example.net`
* Dans une session, ajouter un candidat
* Supprimer un candidat
* + tests au vert dans la CICD
