### PR TITLE
[DOCS] Améliorer le style du fichier de documentation de contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,19 @@ Par ailleurs, on souhaite que le CHANGELOG puisse être compris par des interven
 
 On suit la convention que la description doit marcher comme une fin de phrase à `Une fois mergée, cette _pull request_ permettra de …`.
 
-// BAD
-// Serialise tout les badgeParnerCompetences
-// Proposition d'ADR pour séparer Domain Transactions et Domain Events
+#### Mauvais exemples
 
-// GOOD
-// Sérialiser tout les badgeParnerCompetences
-// Proposer un ADR pour séparer Domain Transactions et Domain Events
+> [!CAUTION]
+> Serialise tout les badgeParnerCompetences
+> 
+> Proposition d'ADR pour séparer Domain Transactions et Domain Events
+
+#### Bons exemples
+
+> [!TIP]
+> Sérialiser tout les badgeParnerCompetences
+>
+> Proposer un ADR pour séparer Domain Transactions et Domain Events
 
 ### `US_ID`
 


### PR DESCRIPTION
## :unicorn: Problème
Les exemples de description de PR ne rendent pas très bien visuellement

![image](https://github.com/1024pix/pix/assets/5855339/fb6390aa-3857-492e-86b3-38f0874040f7)

## :robot: Proposition
Mettre en avant ces exemples avec [la nouvelle syntaxe d'"alertes" GitHub](https://github.com/orgs/community/discussions/16925).

![image](https://github.com/1024pix/pix/assets/5855339/74a6ea0d-1670-4775-83e5-187de3f34bdb)

## :rainbow: Remarques
Malheureusement ce n'est pas possible de mettre un titre custom sur ces blocs, j'ai ajouté un titre pour clarifier que ce sont des exemples.

## :100: Pour tester
Regarder le rendu et constater que c'est plus facile à lire.

Utiliser ce rich diff ne suffit pas :
![image](https://github.com/1024pix/pix/assets/5855339/82398293-5142-49e3-b779-84a88e3acc4e)

Il faut prévisualiser le résultat dans la vue complète de GitHub.

![image](https://github.com/1024pix/pix/assets/5855339/f055dde2-dfe4-4565-88af-44a67eae010a)
