### PR TITLE
[FEATURE] Modification de la hiérarchie des boutons de création de sessions (PIX-10146).

### DIFF
--- a/certif/app/components/no-session-panel.hbs
+++ b/certif/app/components/no-session-panel.hbs
@@ -7,7 +7,11 @@
       {{t "pages.sessions.list.actions.creation.label"}}
     </PixButtonLink>
     {{#if this.shouldRenderImportTemplateButton}}
-      <PixButtonLink @route="authenticated.sessions.import">
+      <PixButtonLink
+        @route="authenticated.sessions.import"
+        @backgroundColor="transparent-light"
+        @isBorderVisible="true"
+      >
         {{t "pages.sessions.list.actions.multiple-creation.label"}}
       </PixButtonLink>
     {{/if}}

--- a/certif/app/components/no-session-panel.hbs
+++ b/certif/app/components/no-session-panel.hbs
@@ -1,5 +1,5 @@
 <div class="no-session-panel">
-  <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt="" role="none" />
+  <img class="no-session-panel__icon" src="{{this.rootURL}}/icons/empty-list-session.svg" alt="" role="none" />
   <h1 class="page-title">{{t "pages.sessions.list.empty.title"}}</h1>
 
   <div class="no-session-panel__link-to-create">

--- a/certif/app/components/no-session-panel.hbs
+++ b/certif/app/components/no-session-panel.hbs
@@ -1,17 +1,15 @@
 <div class="no-session-panel">
-  <div class="no-session-panel__explain-create-session">
-    <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt="" role="none" />
-    <h1 class="page-title">{{t "pages.sessions.list.empty.title"}}</h1>
+  <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt="" role="none" />
+  <h1 class="page-title">{{t "pages.sessions.list.empty.title"}}</h1>
 
-    <div class="no-session-panel__link-to-create">
-      <PixButtonLink @route="authenticated.sessions.new">
-        {{t "pages.sessions.list.actions.creation.label"}}
+  <div class="no-session-panel__link-to-create">
+    <PixButtonLink @route="authenticated.sessions.new">
+      {{t "pages.sessions.list.actions.creation.label"}}
+    </PixButtonLink>
+    {{#if this.shouldRenderImportTemplateButton}}
+      <PixButtonLink @route="authenticated.sessions.import">
+        {{t "pages.sessions.list.actions.multiple-creation.label"}}
       </PixButtonLink>
-      {{#if this.shouldRenderImportTemplateButton}}
-        <PixButtonLink @route="authenticated.sessions.import">
-          {{t "pages.sessions.list.actions.multiple-creation.label"}}
-        </PixButtonLink>
-      {{/if}}
-    </div>
+    {{/if}}
   </div>
 </div>

--- a/certif/app/styles/pages/authenticated/sessions/no-session-panel.scss
+++ b/certif/app/styles/pages/authenticated/sessions/no-session-panel.scss
@@ -1,17 +1,20 @@
 .no-session-panel {
   display: flex;
   flex-direction: column;
+  align-items: center;
   flex-grow: 1;
-
-  &__explain-create-session {
-    text-align: center;
-    margin: 5%;
-  }
+  padding: 5%;
+  text-align: center;
 
   &__link-to-create {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     padding-top: 20px;
     gap: 8px;
+
+    .pix-button {
+      width: 100%;
+    }
   }
 }

--- a/certif/app/styles/pages/authenticated/sessions/no-session-panel.scss
+++ b/certif/app/styles/pages/authenticated/sessions/no-session-panel.scss
@@ -1,20 +1,23 @@
 .no-session-panel {
   display: flex;
   flex-direction: column;
+  padding: 92px 0 92px 0;
   align-items: center;
-  flex-grow: 1;
-  padding: 5%;
   text-align: center;
+
+  @include device-is('mobile') {
+    padding: $pix-spacing-xxs 0 $pix-spacing-xxs 0;
+  }
+
+  &__icon {
+    width: 100%;
+    max-width: 294px;
+  }
 
   &__link-to-create {
     display: flex;
     flex-direction: column;
-    align-items: center;
     padding-top: 20px;
     gap: 8px;
-
-    .pix-button {
-      width: 100%;
-    }
   }
 }

--- a/certif/tests/integration/components/no-session-panel_test.js
+++ b/certif/tests/integration/components/no-session-panel_test.js
@@ -27,8 +27,6 @@ module('Integration | Component | no-session-panel', function (hooks) {
     // then
     const createOneSessionButton = screen.getByRole('link', { name: 'Créer une session' });
     const createMultipleSessionsButton = screen.getByRole('link', { name: 'Créer plusieurs sessions' });
-    assert.dom(createOneSessionButton).exists();
-    assert.dom(createMultipleSessionsButton).exists();
     const buttonsInTheRightOrder = createOneSessionButton.compareDocumentPosition(createMultipleSessionsButton);
     assert.strictEqual(buttonsInTheRightOrder, Node.DOCUMENT_POSITION_FOLLOWING);
   });

--- a/certif/tests/integration/components/no-session-panel_test.js
+++ b/certif/tests/integration/components/no-session-panel_test.js
@@ -7,7 +7,7 @@ import { render } from '@1024pix/ember-testing-library';
 module('Integration | Component | no-session-panel', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders a button link to the new session creation page', async function (assert) {
+  test('it renders buttons links to create sessions', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
     const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
@@ -22,55 +22,62 @@ module('Integration | Component | no-session-panel', function (hooks) {
     this.owner.register('service:current-user', CurrentUserStub);
 
     // when
-    const { getByRole } = await render(hbs`<NoSessionPanel />`);
+    const screen = await render(hbs`<NoSessionPanel />`);
 
     // then
-    assert.dom(getByRole('link', { name: 'Créer une session' })).exists();
+    const createOneSessionButton = screen.getByRole('link', { name: 'Créer une session' });
+    const createMultipleSessionsButton = screen.getByRole('link', { name: 'Créer plusieurs sessions' });
+    assert.dom(createOneSessionButton).exists();
+    assert.dom(createMultipleSessionsButton).exists();
+    const buttonsInTheRightOrder = createOneSessionButton.compareDocumentPosition(createMultipleSessionsButton);
+    assert.strictEqual(buttonsInTheRightOrder, Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  module('when certification center is not a type SCO which manages students', function () {
-    test('it renders a button link to the sessions import page', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        type: 'SUP',
-        isRelatedToManagingStudentsOrganization: false,
+  module('when certification center is a type SCO', function () {
+    module('when it manages students', function () {
+      test('it does not render a button link to the sessions import page', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SCO',
+          isRelatedToManagingStudentsOrganization: true,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // when
+        const { queryByRole } = await render(hbs`<NoSessionPanel />`);
+
+        // then
+        assert.dom(queryByRole('link', { name: 'Créer plusieurs sessions' })).doesNotExist();
       });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-
-      // when
-      const { getByRole } = await render(hbs`<NoSessionPanel />`);
-
-      // then
-      assert.dom(getByRole('link', { name: 'Créer plusieurs sessions' })).exists();
     });
-  });
 
-  module('when certification center is a type SCO which manages students', function () {
-    test('it does not render a button link to the sessions import page', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        type: 'SCO',
-        isRelatedToManagingStudentsOrganization: true,
+    module('when it does not manage students', function () {
+      test('it does render a button link to the sessions import page', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SCO',
+          isRelatedToManagingStudentsOrganization: false,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // when
+        const { getByRole } = await render(hbs`<NoSessionPanel />`);
+
+        // then
+        assert.dom(getByRole('link', { name: 'Créer plusieurs sessions' })).exists();
       });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-
-      // when
-      const { queryByRole } = await render(hbs`<NoSessionPanel />`);
-
-      // then
-      assert.dom(queryByRole('link', { name: 'Créer plusieurs sessions' })).doesNotExist();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lors de la connexion à un espace Pix Certif n’ayant aucune session créée, alors l’utilisateur arrive sur un écran qui lui propose alternativement de créer une ou plusieurs session sans guidage particulier pour ses débuts.

## :robot: Proposition

Ordonner les boutons de création de session en colonne avec le bouton de création d’une seule session (parcours plus simple d’utilisation) au dessus de la gestion massive des sessions.

Hiérarchiser les boutons :

* Primary pour le bouton de création d’une seule session
* Secondary pour le bouton de création de plusieurs sessions

## :rainbow: Remarques

⚠️ Exclusion du changement de couleur et d'arrondi, utiliser la version actuelle du design system.

## :100: Pour tester
* Sur Pix Certif avec `certifV3@example.net` https://certif-pr7553.review.pix.fr/sessions/liste
* Constater que le design (hormis la couleur et l'arrondi) correspond à la nouvelle maquette
* Cliquer sur les boutons pour vérifier qu'ils sont actionnables

Résultat PR : 

<img width="734" alt="Capture d’écran 2023-11-30 à 18 11 00" src="https://github.com/1024pix/pix/assets/58915422/d00a4884-0ac9-4217-ab03-baa0786e46a5">

Maquette : 

![image](https://github.com/1024pix/pix/assets/170271/5dc46402-cfaf-4f16-bc63-7f7461ce4bfd)

