### PR TITLE
[FEATURE][CERTIF] Permettre l'annulation d'une invitation par un administrateur (PIX-5002)

### DIFF
--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -82,6 +82,29 @@ const register = async function (server) {
         tags: ['api', 'invitations'],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/certification-center-invitations/{certificationCenterInvitationId}',
+      config: {
+        handler: certificationCenterInvitationController.cancelCertificationCenterInvitation,
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
+            assign: 'isAdminOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterInvitationId: identifiersType.certificationCenterInvitationId.required(),
+          }),
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification**\n',
+          "- Cette route permet d'annuler une invitation actuellement en attente selon un **id d'invitation**",
+        ],
+        tags: ['api', 'certification-center-invitation'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -5,7 +5,40 @@ import { identifiersType } from '../../domain/types/identifiers-type.js';
 import { securityPreHandlers } from '../security-pre-handlers.js';
 
 const register = async function (server) {
+  const adminRoutes = [
+    {
+      method: 'DELETE',
+      path: '/api/admin/certification-center-invitations/{certificationCenterInvitationId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterInvitationId: identifiersType.certificationCenterInvitationId,
+          }),
+        },
+        handler: certificationCenterInvitationController.cancelCertificationCenterInvitation,
+        tags: ['api', 'admin', 'invitations', 'cancel'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet d'annuler une invitation envoyée mais non acceptée encore.",
+        ],
+      },
+    },
+  ];
+
   server.route([
+    ...adminRoutes,
     {
       method: 'POST',
       path: '/api/certification-center-invitations/{id}/accept',
@@ -47,35 +80,6 @@ const register = async function (server) {
           "- Cette route permet de récupérer les détails d'une invitation selon un **id d'invitation** et un **code**\n",
         ],
         tags: ['api', 'invitations'],
-      },
-    },
-    {
-      method: 'DELETE',
-      path: '/api/admin/certification-center-invitations/{certificationCenterInvitationId}',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            certificationCenterInvitationId: identifiersType.certificationCenterInvitationId,
-          }),
-        },
-        handler: certificationCenterInvitationController.cancelCertificationCenterInvitation,
-        tags: ['api', 'admin', 'invitations', 'cancel'],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            "- Elle permet d'annuler une invitation envoyée mais non acceptée encore.",
-        ],
       },
     },
   ]);

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -17,6 +17,7 @@ import * as checkUserBelongsToOrganizationUseCase from './usecases/checkUserBelo
 import * as checkUserCanDisableHisOrganizationMembershipUseCase from './usecases/checkUserCanDisableHisOrganizationMembership.js';
 import * as checkUserIsAdminAndManagingStudentsForOrganization from './usecases/checkUserIsAdminAndManagingStudentsForOrganization.js';
 import * as checkUserIsAdminOfCertificationCenterUsecase from './usecases/checkUserIsAdminOfCertificationCenter.js';
+import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
 import * as checkUserIsMemberOfCertificationCenterUsecase from './usecases/checkUserIsMemberOfCertificationCenter.js';
 import * as checkUserIsMemberOfCertificationCenterSessionUsecase from './usecases/checkUserIsMemberOfCertificationCenterSession.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
@@ -207,6 +208,31 @@ function checkUserIsAdminOfCertificationCenter(
     })
     .catch(() => _replyForbiddenError(h));
 }
+
+function checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId(
+  request,
+  h,
+  dependencies = { checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase },
+) {
+  if (
+    !request.auth.credentials ||
+    !request.auth.credentials.userId ||
+    !request.params.certificationCenterInvitationId
+  ) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
+
+  return dependencies.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase
+    .execute({ certificationCenterInvitationId, userId })
+    .then((isAdminInCertificationCenter) => {
+      return isAdminInCertificationCenter ? h.response(true) : _replyForbiddenError(h);
+    })
+    .catch(() => _replyForbiddenError(h));
+}
+
 function checkUserIsMemberOfCertificationCenter(
   request,
   h,
@@ -660,6 +686,7 @@ const securityPreHandlers = {
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserIsMemberOfAnOrganization,
   checkUserIsAdminOfCertificationCenter,
+  checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
   checkUserIsMemberOfCertificationCenter,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,

--- a/api/lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js
+++ b/api/lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js
@@ -1,0 +1,21 @@
+import * as certificationCenterInvitationRepository from '../../infrastructure/repositories/certification-center-invitation-repository.js';
+import * as certificationCenterMembershipRepository from '../../infrastructure/repositories/certification-center-membership-repository.js';
+
+async function execute({
+  certificationCenterInvitationId,
+  userId,
+  dependencies = { certificationCenterInvitationRepository, certificationCenterMembershipRepository },
+}) {
+  const certificationCenterInvitation = await dependencies.certificationCenterInvitationRepository.get(
+    certificationCenterInvitationId,
+  );
+
+  if (!certificationCenterInvitation) return false;
+
+  return await dependencies.certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+    certificationCenterId: certificationCenterInvitation.certificationCenterId,
+    userId,
+  });
+}
+
+export { execute };

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -16,112 +16,116 @@ describe('Acceptance | API | Certification center invitations', function () {
     server = await createServer();
   });
 
-  describe('POST /api/certification-center-invitations/{id}/accept', function () {
-    it('it should return an HTTP code 204', async function () {
-      // given
-      databaseBuilder.factory.buildUser({ id: 293, email: 'user@example.net' });
-      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-      const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
-        id: 123,
-        code: 'AZERT123',
-        certificationCenterId: certificationCenter.id,
-        status: CertificationCenterInvitation.StatusType.PENDING,
-      });
+  context('global routes', function () {
+    describe('POST /api/certification-center-invitations/{id}/accept', function () {
+      it('it should return an HTTP code 204', async function () {
+        // given
+        databaseBuilder.factory.buildUser({ id: 293, email: 'user@example.net' });
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+          id: 123,
+          code: 'AZERT123',
+          certificationCenterId: certificationCenter.id,
+          status: CertificationCenterInvitation.StatusType.PENDING,
+        });
 
-      await databaseBuilder.commit();
+        await databaseBuilder.commit();
 
-      // when
-      const result = await server.inject({
-        headers: {
-          authorization: false,
-        },
-        method: 'POST',
-        url: `/api/certification-center-invitations/${certificationCenterInvitation.id}/accept`,
-        payload: {
-          data: {
-            id: '123_AZERT123',
-            type: 'certification-center-invitations-responses',
-            attributes: {
-              code: 'AZERT123',
-              email: 'user@example.net',
+        // when
+        const result = await server.inject({
+          headers: {
+            authorization: false,
+          },
+          method: 'POST',
+          url: `/api/certification-center-invitations/${certificationCenterInvitation.id}/accept`,
+          payload: {
+            data: {
+              id: '123_AZERT123',
+              type: 'certification-center-invitations-responses',
+              attributes: {
+                code: 'AZERT123',
+                email: 'user@example.net',
+              },
             },
           },
-        },
+        });
+
+        // then
+        expect(result.statusCode).to.equal(204);
+
+        const membership = await knex('certification-center-memberships')
+          .select('userId')
+          .where({ certificationCenterId: certificationCenter.id })
+          .first();
+        const invitation = await knex('certification-center-invitations')
+          .select('status')
+          .where({ certificationCenterId: certificationCenter.id })
+          .first();
+
+        expect(membership.userId).to.equal(293);
+        expect(invitation.status).to.equal(CertificationCenterInvitation.StatusType.ACCEPTED);
       });
-
-      // then
-      expect(result.statusCode).to.equal(204);
-
-      const membership = await knex('certification-center-memberships')
-        .select('userId')
-        .where({ certificationCenterId: certificationCenter.id })
-        .first();
-      const invitation = await knex('certification-center-invitations')
-        .select('status')
-        .where({ certificationCenterId: certificationCenter.id })
-        .first();
-
-      expect(membership.userId).to.equal(293);
-      expect(invitation.status).to.equal(CertificationCenterInvitation.StatusType.ACCEPTED);
     });
-  });
 
-  describe('GET /api/certification-center-invitations/{id}', function () {
-    it('should return the certification-center invitation and 200 status code', async function () {
-      // given
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ name: 'Centre des Pixous' }).id;
-      const certificationCenterInvitationId = databaseBuilder.factory.buildCertificationCenterInvitation({
-        certificationCenterId,
-        status: CertificationCenterInvitation.StatusType.PENDING,
-        code: 'ABCDEFGH01',
-      }).id;
+    describe('GET /api/certification-center-invitations/{id}', function () {
+      it('should return the certification-center invitation and 200 status code', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ name: 'Centre des Pixous' }).id;
+        const certificationCenterInvitationId = databaseBuilder.factory.buildCertificationCenterInvitation({
+          certificationCenterId,
+          status: CertificationCenterInvitation.StatusType.PENDING,
+          code: 'ABCDEFGH01',
+        }).id;
 
-      await databaseBuilder.commit();
+        await databaseBuilder.commit();
 
-      // when
-      const response = await server.inject({
-        method: 'GET',
-        url: `/api/certification-center-invitations/${certificationCenterInvitationId}?code=ABCDEFGH01`,
-      });
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/certification-center-invitations/${certificationCenterInvitationId}?code=ABCDEFGH01`,
+        });
 
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result).to.deep.equal({
-        data: {
-          type: 'certification-center-invitations',
-          id: certificationCenterInvitationId.toString(),
-          attributes: {
-            'certification-center-id': certificationCenterId,
-            'certification-center-name': 'Centre des Pixous',
-            status: CertificationCenterInvitation.StatusType.PENDING,
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal({
+          data: {
+            type: 'certification-center-invitations',
+            id: certificationCenterInvitationId.toString(),
+            attributes: {
+              'certification-center-id': certificationCenterId,
+              'certification-center-name': 'Centre des Pixous',
+              status: CertificationCenterInvitation.StatusType.PENDING,
+            },
           },
-        },
+        });
       });
     });
   });
 
-  describe('DELETE /api/admin/certification-centers/{id}/invitations/{certificationCenterInvitationId}', function () {
-    it('should return 204 HTTP status code', async function () {
-      // given
-      const adminMember = await insertUserWithRoleSuperAdmin();
-      const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
-        certificationCenterId: databaseBuilder.factory.buildCertificationCenter().id,
-        status: CertificationCenterInvitation.StatusType.PENDING,
+  context('admin routes', function () {
+    describe('DELETE /api/admin/certification-centers/{id}/invitations/{certificationCenterInvitationId}', function () {
+      it('should return 204 HTTP status code', async function () {
+        // given
+        const adminMember = await insertUserWithRoleSuperAdmin();
+        const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+          certificationCenterId: databaseBuilder.factory.buildCertificationCenter().id,
+          status: CertificationCenterInvitation.StatusType.PENDING,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'DELETE',
+          url: `/api/admin/certification-center-invitations/${certificationCenterInvitation.id}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(adminMember.id),
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(204);
       });
-
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject({
-        method: 'DELETE',
-        url: `/api/admin/certification-center-invitations/${certificationCenterInvitation.id}`,
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(adminMember.id),
-        },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/unit/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id_test.js
+++ b/api/tests/unit/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id_test.js
@@ -1,0 +1,87 @@
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from '../../../../lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
+
+describe('Unit | Application | UseCases | checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase', function () {
+  let certificationCenterInvitation,
+    certificationCenterInvitationRepository,
+    certificationCenterMembershipRepository,
+    dependencies,
+    user;
+
+  beforeEach(function () {
+    certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation();
+    user = domainBuilder.buildUser();
+
+    certificationCenterInvitationRepository = {
+      get: sinon.stub(),
+    };
+    certificationCenterMembershipRepository = {
+      isAdminOfCertificationCenter: sinon.stub(),
+    };
+
+    certificationCenterInvitationRepository.get.withArgs(certificationCenterInvitation.id);
+    certificationCenterMembershipRepository.isAdminOfCertificationCenter.withArgs({
+      certificationCenterId: certificationCenterInvitation.certificationCenterId,
+      userId: user.id,
+    });
+
+    dependencies = {
+      certificationCenterInvitationRepository,
+      certificationCenterMembershipRepository,
+    };
+  });
+
+  context('when user is admin of the certification center', function () {
+    it('returns true', async function () {
+      // given
+      certificationCenterInvitationRepository.get.resolves(certificationCenterInvitation);
+      certificationCenterMembershipRepository.isAdminOfCertificationCenter.resolves(true);
+
+      // when
+      const response = await checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase.execute({
+        certificationCenterInvitationId: certificationCenterInvitation.id,
+        userId: user.id,
+        dependencies,
+      });
+
+      // then
+      expect(response).to.be.true;
+    });
+  });
+
+  context('when user is not admin of the certification center', function () {
+    it('returns false', async function () {
+      // given
+      certificationCenterInvitationRepository.get.resolves(certificationCenterInvitation);
+      certificationCenterMembershipRepository.isAdminOfCertificationCenter.resolves(false);
+
+      // when
+      const response = await checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase.execute({
+        certificationCenterInvitationId: certificationCenterInvitation.id,
+        userId: user.id,
+        dependencies,
+      });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+
+  context('when there is no certification center invitation', function () {
+    it('returns false', async function () {
+      // given
+      certificationCenterInvitationRepository.get.resolves();
+
+      // when
+      const response = await checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase.execute({
+        certificationCenterInvitationId: certificationCenterInvitation.id,
+        userId: user.id,
+        dependencies,
+      });
+
+      // then
+      expect(response).to.be.false;
+      expect(certificationCenterMembershipRepository.isAdminOfCertificationCenter).to.not.have.been.called;
+    });
+  });
+});

--- a/certif/app/components/table/header.hbs
+++ b/certif/app/components/table/header.hbs
@@ -1,0 +1,3 @@
+<th class="{{if @size (concat 'table__column--' @size) 'table__column'}}" ...attributes>
+  {{yield}}
+</th>

--- a/certif/app/components/team/invitations-list-item.hbs
+++ b/certif/app/components/team/invitations-list-item.hbs
@@ -3,4 +3,21 @@
   <td>
     {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
   </td>
+  <td>
+    <div class="invitations-list-item__actions">
+      <PixTooltip @isInline={{true}}>
+        <:triggerElement>
+          <PixIconButton
+            @ariaLabel={{t "pages.team-invitations.actions.cancel-invitation"}}
+            @icon="trash-can"
+            @triggerAction={{fn @onCancelInvitationButtonClicked @invitation}}
+            @withBackground={{true}}
+          />
+        </:triggerElement>
+        <:tooltip>
+          {{t "pages.team-invitations.actions.cancel-invitation"}}
+        </:tooltip>
+      </PixTooltip>
+    </div>
+  </td>
 </tr>

--- a/certif/app/components/team/invitations-list.hbs
+++ b/certif/app/components/team/invitations-list.hbs
@@ -4,6 +4,7 @@
       <tr>
         <Table::Header>{{t "pages.team-invitations.table.labels.email-address"}}</Table::Header>
         <Table::Header>{{t "pages.team-invitations.table.labels.last-sending-date"}}</Table::Header>
+        <Table::Header @size="small">{{t "pages.team-invitations.table.labels.actions"}}</Table::Header>
       </tr>
     </thead>
     <tbody>

--- a/certif/app/components/team/invitations-list.hbs
+++ b/certif/app/components/team/invitations-list.hbs
@@ -2,10 +2,8 @@
   <table>
     <thead>
       <tr>
-        <th class="table__column table__column--medium">{{t "pages.team-invitations.table.labels.email-address"}}</th>
-        <th class="table__column table__column--medium">{{t
-            "pages.team-invitations.table.labels.last-sending-date"
-          }}</th>
+        <Table::Header>{{t "pages.team-invitations.table.labels.email-address"}}</Table::Header>
+        <Table::Header>{{t "pages.team-invitations.table.labels.last-sending-date"}}</Table::Header>
       </tr>
     </thead>
     <tbody>

--- a/certif/app/components/team/invitations-list.hbs
+++ b/certif/app/components/team/invitations-list.hbs
@@ -9,7 +9,10 @@
     </thead>
     <tbody>
       {{#each @invitations as |invitation|}}
-        <Team::InvitationsListItem @invitation={{invitation}} />
+        <Team::InvitationsListItem
+          @invitation={{invitation}}
+          @onCancelInvitationButtonClicked={{@onCancelInvitationButtonClicked}}
+        />
       {{/each}}
     </tbody>
   </table>

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class AuthenticatedTeamListInvitationsController extends Controller {
+  @action
+  async cancelInvitation(certificationCenterInvitation) {
+    await certificationCenterInvitation.destroyRecord();
+  }
+}

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -8,7 +8,13 @@ export default class AuthenticatedTeamListInvitationsController extends Controll
 
   @action
   async cancelInvitation(certificationCenterInvitation) {
-    await certificationCenterInvitation.destroyRecord();
-    this.notifications.success(this.intl.t('pages.team-invitations.notifications.success.invitation-cancelled'));
+    try {
+      await certificationCenterInvitation.destroyRecord();
+      this.notifications.success(this.intl.t('pages.team-invitations.notifications.success.invitation-cancelled'));
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+    }
   }
 }

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -1,9 +1,14 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 
 export default class AuthenticatedTeamListInvitationsController extends Controller {
+  @service intl;
+  @service notifications;
+
   @action
   async cancelInvitation(certificationCenterInvitation) {
     await certificationCenterInvitation.destroyRecord();
+    this.notifications.success(this.intl.t('pages.team-invitations.notifications.success.invitation-cancelled'));
   }
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -56,6 +56,7 @@ $navbar-height: 60px;
 @import 'components/session-supervising/handle-live-alert-modal';
 @import 'components/session-supervising/live-alert-handled-modal';
 @import 'components/session-summary-list';
+@import 'components/team/invitations-list-item';
 @import 'components/dropdown';
 @import 'components/user-logged-menu';
 

--- a/certif/app/styles/components/team/invitations-list-item.scss
+++ b/certif/app/styles/components/team/invitations-list-item.scss
@@ -1,0 +1,5 @@
+.invitations-list-item__actions {
+  display: flex;
+  gap: $pix-spacing-m;
+  width: 38px;
+}

--- a/certif/app/templates/authenticated/team/list/invitations.hbs
+++ b/certif/app/templates/authenticated/team/list/invitations.hbs
@@ -1,3 +1,3 @@
 {{page-title "Invitations"}}
 
-<Team::InvitationsList @invitations={{@model}} />
+<Team::InvitationsList @invitations={{@model}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -301,38 +301,6 @@ function routes() {
     return new Response(204);
   });
 
-  this.get('/certification-center-invitations/:id', (schema, request) => {
-    const certificationCenterInvitationId = request.params.id;
-    const code = request.queryParams?.code;
-
-    switch (code) {
-      case 'CANCELLED':
-        return new Response(403, {}, { errors: [{ status: '403' }] });
-      case 'ACCEPTED':
-        return new Response(412, {}, { errors: [{ status: '412' }] });
-      default:
-        return schema.certificationCenterInvitations.find(certificationCenterInvitationId);
-    }
-  });
-
-  this.post('/certification-center-invitations/:id/accept', (schema) => {
-    const certificationPointOfContact = schema.certificationPointOfContacts.first();
-    const allowedCertificationCenterAccess = schema.allowedCertificationCenterAccesses.create({
-      name: 'Collège Truffaut',
-      type: 'SCO',
-      externalId: 'ABC123',
-      isRelatedToManagingStudentsOrganization: false,
-      isAccessBlockedCollege: false,
-      isAccessBlockedLycee: false,
-      isAccessBlockedAEFE: false,
-      isAccessBlockedAgri: false,
-    });
-
-    certificationPointOfContact.update({ allowedCertificationCenterAccesses: [allowedCertificationCenterAccess] });
-
-    return new Response(204);
-  });
-
   this.post('/certification-centers/:id/sessions/validate-for-mass-import', async (schema, request) => {
     const { type } = request.requestBody;
     const { id: certificationCenterId } = request.params;
@@ -382,4 +350,51 @@ function routes() {
   });
 
   this.patch('/sessions/:id/candidates/:candidateId/dismiss-live-alert', () => new Response(204));
+
+  _configureCertificationCenterInvitationRoutes(this);
+}
+
+function _configureCertificationCenterInvitationRoutes(context) {
+  const basePath = '/certification-center-invitations';
+
+  context.delete(`${basePath}/:id`, (schema, request) => {
+    const certificationCenterInvitationId = request.params.id;
+    const certificationCenterInvitation = schema.certificationCenterInvitations.find(certificationCenterInvitationId);
+
+    certificationCenterInvitation.destroy();
+
+    return new Response(204);
+  });
+
+  context.get(`${basePath}/:id`, (schema, request) => {
+    const certificationCenterInvitationId = request.params.id;
+    const code = request.queryParams?.code;
+
+    switch (code) {
+      case 'CANCELLED':
+        return new Response(403, {}, { errors: [{ status: '403' }] });
+      case 'ACCEPTED':
+        return new Response(412, {}, { errors: [{ status: '412' }] });
+      default:
+        return schema.certificationCenterInvitations.find(certificationCenterInvitationId);
+    }
+  });
+
+  context.post(`${basePath}/:id/accept`, (schema) => {
+    const certificationPointOfContact = schema.certificationPointOfContacts.first();
+    const allowedCertificationCenterAccess = schema.allowedCertificationCenterAccesses.create({
+      name: 'Collège Truffaut',
+      type: 'SCO',
+      externalId: 'ABC123',
+      isRelatedToManagingStudentsOrganization: false,
+      isAccessBlockedCollege: false,
+      isAccessBlockedLycee: false,
+      isAccessBlockedAEFE: false,
+      isAccessBlockedAgri: false,
+    });
+
+    certificationPointOfContact.update({ allowedCertificationCenterAccesses: [allowedCertificationCenterAccess] });
+
+    return new Response(204);
+  });
 }

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -62,7 +62,7 @@ module('Acceptance | Team | Invitations', function (hooks) {
     });
 
     module('when user clicks on cancel invitation button', function () {
-      test('removes the invitation', async function (assert) {
+      test('removes the invitation and displays a success notification', async function (assert) {
         // given
         this.server.create('certification-center-invitation', {
           certificationCenterId: 1,
@@ -77,6 +77,7 @@ module('Acceptance | Team | Invitations', function (hooks) {
 
         // then
         assert.dom(screen.queryByText('daisy.draté@example.net')).doesNotExist();
+        assert.dom(screen.getByText('L’invitation a bien été supprimée.')).exists();
       });
     });
   });

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -79,6 +79,34 @@ module('Acceptance | Team | Invitations', function (hooks) {
         assert.dom(screen.queryByText('daisy.draté@example.net')).doesNotExist();
         assert.dom(screen.getByText('L’invitation a bien été supprimée.')).exists();
       });
+
+      module('when an error occurs', function () {
+        test('displays an error notification', async function (assert) {
+          // given
+          this.server.create('certification-center-invitation', {
+            id: 15,
+            certificationCenterId: 1,
+            email: 'anna.liz@example.net',
+            updatedAt: new Date('2023-11-30'),
+          });
+          this.server.delete(`/certification-center-invitations/15`, () => new Response(500));
+
+          const screen = await visit('/equipe/invitations');
+
+          // when
+          await clickByName(this.intl.t('pages.team-invitations.actions.cancel-invitation'));
+
+          // then
+          assert.dom(screen.queryByText('anna.liz@example.net')).exists();
+          assert
+            .dom(
+              screen.getByText(
+                'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+              ),
+            )
+            .exists();
+        });
+      });
     });
   });
 });

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -1,13 +1,14 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import setupIntl from '../../helpers/setup-intl';
+import setupIntl from '../../../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import {
   authenticateSession,
   createCertificationPointOfContactWithTermsOfServiceAccepted,
-} from '../../helpers/test-init';
+} from '../../../helpers/test-init';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Team | Invitations', function (hooks) {
   setupApplicationTest(hooks);
@@ -29,35 +30,54 @@ module('Acceptance | Team | Invitations', function (hooks) {
     });
   });
 
-  module('When user is admin', function () {
-    test('displays invitations list', async function (assert) {
-      // given
+  module('When user is admin', function (hooks) {
+    hooks.beforeEach(async function () {
       const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
         undefined,
         'Centre de certification du pix',
         false,
         'ADMIN',
       );
+      await authenticateSession(certificationPointOfContact.id);
+    });
 
-      server.create('certification-center-invitation', {
+    test('displays invitations list', async function (assert) {
+      // given
+      this.server.create('certification-center-invitation', {
         certificationCenterId: 123,
         email: 'camile.onette@example.net',
         updatedAt: new Date('2023-09-20'),
       });
-
-      server.create('certification-center-invitation', {
+      this.server.create('certification-center-invitation', {
         certificationCenterId: 123,
         email: 'camile.onette@example.net',
         updatedAt: new Date('2023-09-19'),
       });
-
-      await authenticateSession(certificationPointOfContact.id);
 
       // when
       await visit('/equipe/invitations');
 
       // then
       assert.strictEqual(currentURL(), '/equipe/invitations');
+    });
+
+    module('when user clicks on cancel invitation button', function () {
+      test('removes the invitation', async function (assert) {
+        // given
+        this.server.create('certification-center-invitation', {
+          certificationCenterId: 1,
+          email: 'daisy.draté@example.net',
+          updatedAt: new Date('2023-11-30'),
+        });
+
+        const screen = await visit('/equipe/invitations');
+
+        // when
+        await clickByName(this.intl.t('pages.team-invitations.actions.cancel-invitation'));
+
+        // then
+        assert.dom(screen.queryByText('daisy.draté@example.net')).doesNotExist();
+      });
     });
   });
 });

--- a/certif/tests/integration/components/team/invitations-list-item_test.js
+++ b/certif/tests/integration/components/team/invitations-list-item_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import dayjs from 'dayjs';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -14,6 +15,10 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
     store = this.owner.lookup('service:store');
   });
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   test('displays a pending invitation table row item', async function (assert) {
     // given
     const invitation = store.createRecord('certification-center-invitation', {
@@ -23,14 +28,41 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
     });
 
     this.set('invitation', invitation);
+    this.set('cancelInvitation', sinon.stub());
 
     //  when
-    const screen = await renderScreen(hbs`<Team::InvitationsListItem @invitation={{this.invitation}} />`);
+    const screen = await renderScreen(
+      hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+    );
 
     // then
     const expectedDate = dayjs(invitation.updatedAt).format('DD/MM/YYYY - HH:mm');
 
     assert.dom(screen.getByLabelText('Invitations en attente')).containsText(invitation.email);
     assert.dom(screen.getByLabelText('Invitations en attente')).containsText(expectedDate);
+    assert
+      .dom(screen.getByRole('button', { name: this.intl.t('pages.team-invitations.actions.cancel-invitation') }))
+      .exists();
+  });
+
+  module('when the user clicks on the cancel invitation button', function () {
+    test('calls the cancel invitation action', async function (assert) {
+      // given
+      const invitation = store.createRecord('certification-center-invitation');
+      const cancelInvitation = sinon.stub();
+
+      this.set('invitation', invitation);
+      this.set('cancelInvitation', cancelInvitation);
+
+      await renderScreen(
+        hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+      );
+
+      // when
+      await clickByName(this.intl.t('pages.team-invitations.actions.cancel-invitation'));
+
+      // then
+      assert.ok(cancelInvitation.calledWith(invitation));
+    });
   });
 });

--- a/certif/tests/integration/components/team/invitations-list_test.js
+++ b/certif/tests/integration/components/team/invitations-list_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -8,29 +9,32 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let store;
+  let cancelInvitation;
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
+    cancelInvitation = sinon.stub();
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
   });
 
   test('displays email address, last sending date and actions headers', async function (assert) {
     // given
     this.set('invitations', []);
+    this.set('cancelInvitation', cancelInvitation);
 
     // when
-    const screen = await renderScreen(hbs`<Team::InvitationsList @invitations={{this.invitations}} />`);
+    const screen = await renderScreen(
+      hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+    );
 
     // then
     assert.strictEqual(screen.getAllByRole('columnheader').length, 3);
-    assert.dom(screen.getByRole('columnheader', { name: this.intl.t('Adresse email') })).exists();
-    assert
-      .dom(
-        screen.getByRole('columnheader', {
-          name: this.intl.t('Date de dernier envoi'),
-        }),
-      )
-      .exists();
-    assert.dom(screen.getByRole('columnheader', { name: this.intl.t('Actions') })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Adresse email' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Date de dernier envoi' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Actions' })).exists();
   });
 
   test('displays pending invitations list ', async function (assert) {
@@ -48,12 +52,35 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
     });
 
     this.set('invitations', [invitation, secondInvitation]);
+    this.set('cancelInvitation', cancelInvitation);
 
     //  when
-    const screen = await renderScreen(hbs`<Team::InvitationsList @invitations={{this.invitations}} />`);
+    const screen = await renderScreen(
+      hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+    );
 
     // then
 
     assert.strictEqual(screen.getAllByLabelText('Invitations en attente').length, 2);
+  });
+
+  module('when the user clicks on the cancel invitation button', function () {
+    test('calls the cancel invitation action', async function (assert) {
+      // given
+      const invitation = store.createRecord('certification-center-invitation');
+
+      this.set('invitations', [invitation]);
+      this.set('cancelInvitation', cancelInvitation);
+
+      await renderScreen(
+        hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+      );
+
+      // when
+      await clickByName(this.intl.t('pages.team-invitations.actions.cancel-invitation'));
+
+      // then
+      assert.ok(cancelInvitation.calledWith(invitation));
+    });
   });
 });

--- a/certif/tests/integration/components/team/invitations-list_test.js
+++ b/certif/tests/integration/components/team/invitations-list_test.js
@@ -13,6 +13,26 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
+  test('displays email address, last sending date and actions headers', async function (assert) {
+    // given
+    this.set('invitations', []);
+
+    // when
+    const screen = await renderScreen(hbs`<Team::InvitationsList @invitations={{this.invitations}} />`);
+
+    // then
+    assert.strictEqual(screen.getAllByRole('columnheader').length, 3);
+    assert.dom(screen.getByRole('columnheader', { name: this.intl.t('Adresse email') })).exists();
+    assert
+      .dom(
+        screen.getByRole('columnheader', {
+          name: this.intl.t('Date de dernier envoi'),
+        }),
+      )
+      .exists();
+    assert.dom(screen.getByRole('columnheader', { name: this.intl.t('Actions') })).exists();
+  });
+
   test('displays pending invitations list ', async function (assert) {
     // given
     const invitation = store.createRecord('certification-center-invitation', {

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/team/list/invitations', function (hooks) {
+  setupTest(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/team/list/invitations');
+  });
+
+  module('#cancelInvitation', function () {
+    test('cancel invitation', async function (assert) {
+      // given
+      const certificationCenterInvitation = {
+        destroyRecord: sinon.stub(),
+      };
+
+      // when
+      await controller.cancelInvitation(certificationCenterInvitation);
+
+      // then
+      assert.ok(certificationCenterInvitation.destroyRecord.called);
+    });
+  });
+});

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
@@ -33,5 +33,25 @@ module('Unit | Controller | authenticated/team/list/invitations', function (hook
       assert.ok(certificationCenterInvitation.destroyRecord.called);
       assert.ok(controller.notifications.success.calledWithExactly('L’invitation a bien été supprimée.'));
     });
+
+    module('when an error occurs', function () {
+      test('displays an error notification', async function (assert) {
+        // given
+        const certificationCenterInvitation = {
+          destroyRecord: sinon.stub().rejects(),
+        };
+        controller.notifications = { error: sinon.stub() };
+
+        // when
+        await controller.cancelInvitation(certificationCenterInvitation);
+
+        // then
+        assert.ok(
+          controller.notifications.error.calledWithExactly(
+            'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+          ),
+        );
+      });
+    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
@@ -2,8 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Unit | Controller | authenticated/team/list/invitations', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   let controller;
 
@@ -11,18 +14,24 @@ module('Unit | Controller | authenticated/team/list/invitations', function (hook
     controller = this.owner.lookup('controller:authenticated/team/list/invitations');
   });
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('#cancelInvitation', function () {
-    test('cancel invitation', async function (assert) {
+    test('cancel invitation and displays a success notification', async function (assert) {
       // given
       const certificationCenterInvitation = {
         destroyRecord: sinon.stub(),
       };
+      controller.notifications = { success: sinon.stub() };
 
       // when
       await controller.cancelInvitation(certificationCenterInvitation);
 
       // then
       assert.ok(certificationCenterInvitation.destroyRecord.called);
+      assert.ok(controller.notifications.success.calledWithExactly('L’invitation a bien été supprimée.'));
     });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -896,6 +896,11 @@
       "actions": {
         "cancel-invitation": "Delete invitation"
       },
+      "notifications": {
+        "success": {
+          "invitation-cancelled": "The invitation has been deleted."
+        }
+      },
       "table": {
         "labels": {
           "actions": "Actions",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -893,6 +893,9 @@
       "update-referer-button": "Changer de référent"
     },
     "team-invitations": {
+      "actions": {
+        "cancel-invitation": "Delete invitation"
+      },
       "table": {
         "labels": {
           "actions": "Actions",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -895,6 +895,7 @@
     "team-invitations": {
       "table": {
         "labels": {
+          "actions": "Actions",
           "email-address": "Email address",
           "last-sending-date": "Last sending date"
         },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -896,6 +896,11 @@
       "actions": {
         "cancel-invitation": "Supprimer l'invitation"
       },
+      "notifications": {
+        "success": {
+          "invitation-cancelled": "L’invitation a bien été supprimée."
+        }
+      },
       "table": {
         "labels": {
           "actions": "Actions",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -893,6 +893,9 @@
       "update-referer-button": "Changer de référent"
     },
     "team-invitations": {
+      "actions": {
+        "cancel-invitation": "Supprimer l'invitation"
+      },
       "table": {
         "labels": {
           "actions": "Actions",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -895,6 +895,7 @@
     "team-invitations": {
       "table": {
         "labels": {
+          "actions": "Actions",
           "email-address": "Adresse email",
           "last-sending-date": "Date de dernier envoi"
         },


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, un administrateur sur l'application Pix Certif n'a pas le moyen d'annuler une invitation en attente.

## :robot: Proposition

Dans la liste des invitations, afficher une action permettant à un administrateur d'annuler une invitation en attente.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter sur Pix Certif () avec le compte `james.paledroits@example.net`
- Cliquer sur le menu `Équipe` dans la barre de gauche
- Cliquer sur l'onglet `Invitations`
- Constater l'affichage d'une nouvelle colonne nommée `Actions`
- Cliquer sur l'icône `Poubelle` pour annuler une invitation
- Constater l'affichage d'une notification de succès
- Constater le retrait de l'invitation dans la liste

Si aucune invitation n'est en attente, vous pouvez toujours envoyer de nouvelles invitations via le bouton `Inviter un membre`.
