### PR TITLE
[FEATURE] QCU - Remplacer l'alerte native `required` par une alerte comme sur l'éval (PIX-10027)

### DIFF
--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 
 export default class ModuleQcu extends Component {
   @tracked selectedAnswerId = null;
+  @tracked requiredMessage = false;
 
   qcu = this.args.qcu;
 
@@ -27,6 +28,12 @@ export default class ModuleQcu extends Component {
   @action
   async submitAnswer(event) {
     event.preventDefault();
+    if (!this.selectedAnswerId) {
+      this.requiredMessage = true;
+
+      return;
+    }
+    this.requiredMessage = false;
     const answerData = { userResponse: [this.selectedAnswerId], element: this.qcu };
     await this.args.submitAnswer(answerData);
   }

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -12,17 +12,18 @@
 
     <div class="element-qcu__proposals">
       {{#each @qcu.proposals as |proposal|}}
-        <PixRadioButton
-          name={{@qcu.id}}
-          @value={{proposal.id}}
-          {{on "click" (fn this.radioClicked proposal.id)}}
-          required
-        >
+        <PixRadioButton name={{@qcu.id}} @value={{proposal.id}} {{on "click" (fn this.radioClicked proposal.id)}}>
           {{proposal.content}}
         </PixRadioButton>
       {{/each}}
     </div>
   </fieldset>
+
+  {{#if this.requiredMessage}}
+    <PixMessage role="alert" @type="error" @withIcon={{true}}>
+      {{t "pages.modulix.verification-precondition-failed-alert.qcu"}}
+    </PixMessage>
+  {{/if}}
 
   {{#unless this.qcu.lastCorrection}}
     <PixButton @backgroundColor="green" @shape="rounded" @type="submit" class="element-qcu__verify_button">

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.strictEqual(findAll('.element-qcu-header__instruction').length, 1);
     assert.strictEqual(findAll('.element-qcu-header__direction').length, 1);
     assert.ok(screen.getByText('Instruction'));
-    assert.ok(screen.getByText(this.intl.t('pages.modulix.qcu.direction')));
+    assert.ok(screen.getByText('Choisissez une seule réponse.'));
 
     assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
     assert.ok(screen.getByLabelText('radio1'));
@@ -82,7 +82,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
 
     // then
-    assert.ok(screen.getByText('Good job!'));
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Good job!');
     assert.ok(screen.getByRole('group').disabled);
     assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
@@ -103,7 +104,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
 
     // then
-    assert.ok(screen.getByText('Too Bad!'));
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Too Bad!');
     assert.ok(screen.getByRole('group').disabled);
     assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -84,8 +84,6 @@ module('Integration | Component | Module | QCU', function (hooks) {
     // then
     assert.ok(screen.getByText('Good job!'));
     assert.ok(screen.getByRole('group').disabled);
-    assert.ok(screen.getByLabelText('radio1').required);
-    assert.ok(screen.getByLabelText('radio2').required);
     assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
 
@@ -107,9 +105,53 @@ module('Integration | Component | Module | QCU', function (hooks) {
     // then
     assert.ok(screen.getByText('Too Bad!'));
     assert.ok(screen.getByRole('group').disabled);
-    assert.ok(screen.getByLabelText('radio1').required);
-    assert.ok(screen.getByLabelText('radio2').required);
     assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  });
+
+  test('should display an error message if QCU is validated without response', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcuElement = store.createRecord('qcu', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
+        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+      ],
+      type: 'qcus',
+    });
+    this.set('qcu', qcuElement);
+    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
+
+    // when
+    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+
+    // then
+    assert.dom(screen.getByRole('alert')).exists();
+  });
+
+  test('should hide the error message when QCU is validated with response', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcuElement = store.createRecord('qcu', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
+        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+      ],
+      type: 'qcus',
+    });
+    const givenSubmitAnswerStub = function () {};
+    this.set('submitAnswer', givenSubmitAnswerStub);
+    this.set('qcu', qcuElement);
+    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
+
+    // when
+    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.getByLabelText('radio1'));
+    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+
+    // then
+    assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
   });
 });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1188,6 +1188,9 @@
       },
       "qcu": {
         "direction": "Select one answer."
+      },
+      "verification-precondition-failed-alert": {
+        "qcu": "To validate, select an answer."
       }
     },
     "not-connected": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1188,6 +1188,9 @@
       },
       "qcu": {
         "direction": "Choisissez une seule réponse."
+      },
+      "verification-precondition-failed-alert": {
+        "qcu": "Pour valider, sélectionnez une réponse."
       }
     },
     "not-connected": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'usage de la mécanique de required par défaut d'HTML échoue aux critères d'a11y suivants : contrastes, identification de l'erreur et suggestions de correction (cf. [cet article](https://adrianroselli.com/2019/02/avoid-default-field-validation.html))

## :robot: Proposition
Nous intégrons notre propre système de validation des QCU, pour cela nous intégrons `PixMessage` de _pix-ui_.

## :rainbow: Remarques
Sur les fichiers de traduction nous nous sommes posé quelques questions:
- faut-il privilégier le camelcase ou le kebabcase pour les clés du json ?
- est-ce que le nom choisi pour notre clé actuelle est pertinent ?

Pour tester l'apparition du message d'alerte nous avons privilégié le `getByRole('alert')` (en suivant les préconisations de [la doc de testing-library](https://testing-library.com/docs/queries/about/#priority)) plutôt que le getBytext ou l'usage des selecteurs CSS.
Mais, avec le `getByRole` nous ne pouvons préciser le contenu texte attendu dans l'alerte.

## :100: Pour tester

**Cas nominal:**

1. Se rendre sur [la page](https://app-pr7557.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
2. Aller jusqu'au grain d'activité avec les QCU
3. Valider un QCU sans avoir sélectionné d'option
4. Vérifier que le message d'alerte s'affiche bien avec le texte : "Pour valider, sélectionnez une réponse."

**Cas 2:**

1. Faire le cas nominal
2. Sélectionner une option sur ce même QCU
3. Valider le QCU
4. Vérifier que le message d'alerte a disparu et qu'il est remplacé par le feedback global
