### PR TITLE
[TECH] Migrer les routes et controllers d'Answer et Assessment vers la nouvelle arbo API (PIX-9591).

### DIFF
--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,9 +1,7 @@
 import * as accountRecovery from './application/account-recovery/index.js';
 import * as adminMembers from './application/admin-members/index.js';
 import * as activityAnswers from './application/activity-answers/index.js';
-import * as answers from './application/answers/index.js';
 import * as assessmentResults from './application/assessment-results/index.js';
-import * as assessments from './application/assessments/index.js';
 import * as authentication from './application/authentication/index.js';
 import * as authenticationOidc from './application/authentication/oidc/index.js';
 import * as badges from './application/badges/index.js';
@@ -55,9 +53,7 @@ const routes = [
   accountRecovery,
   adminMembers,
   activityAnswers,
-  answers,
   assessmentResults,
-  assessments,
   authentication,
   authenticationOidc,
   badges,

--- a/api/server.js
+++ b/api/server.js
@@ -12,6 +12,8 @@ import { deserializer } from './lib/infrastructure/serializers/jsonapi/deseriali
 import { knex } from './db/knex-database-connection.js';
 
 // bounded context migration
+import { sharedRoutes } from './src/shared/routes.js';
+
 import { evaluationRoutes } from './src/evaluation/routes.js';
 
 import { certificationSessionRoutes } from './src/certification/session/routes.js';
@@ -43,7 +45,7 @@ const certificationRoutes = [
   certificationCourseRoutes,
 ];
 const prescriptionRoutes = [learnerManagementRoutes, learnerListRoutes, targetProfileRoutes, campaignRoutes];
-const sharedRoutes = [prescriberManagementRoutes];
+const prescriptionSharedRoutes = [prescriberManagementRoutes];
 
 monitoringTools.installHapiHook();
 
@@ -134,13 +136,14 @@ const setupRoutesAndPlugins = async function (server) {
     plugins,
     routes,
     authenticationRoutes,
+    sharedRoutes,
     evaluationRoutes,
     scenarioSimulatorRoutes,
     devcompRoutes,
     schoolRoutes,
     ...certificationRoutes,
-    ...sharedRoutes,
     ...prescriptionRoutes,
+    ...prescriptionSharedRoutes,
   );
   await server.register(configuration);
 };

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,9 +1,9 @@
-import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
-import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/correction-serializer.js';
-import { usecases } from '../../domain/usecases/index.js';
-import { evaluationUsecases } from '../../../src/evaluation/domain/usecases/index.js';
+import * as answerSerializer from '../../../../lib/infrastructure/serializers/jsonapi/answer-serializer.js';
+import * as correctionSerializer from '../../../../lib/infrastructure/serializers/jsonapi/correction-serializer.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { evaluationUsecases } from '../../domain/usecases/index.js';
 
-import * as requestResponseUtils from '../../infrastructure/utils/request-response-utils.js';
+import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 
 const save = async function (request, h, dependencies = { answerSerializer, requestResponseUtils }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,4 +1,4 @@
-import * as answerSerializer from '../../../../lib/infrastructure/serializers/jsonapi/answer-serializer.js';
+import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
 import * as correctionSerializer from '../../../../lib/infrastructure/serializers/jsonapi/correction-serializer.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';

--- a/api/src/evaluation/application/answers/index.js
+++ b/api/src/evaluation/application/answers/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import { answerController } from './answer-controller.js';
-import { identifiersType } from '../../domain/types/identifiers-type.js';
-import { NotFoundError } from '../../domain/errors.js';
+import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -1,6 +1,6 @@
-import { Answer } from '../../../../src/evaluation/domain/models/Answer.js';
+import { Answer } from '../../../domain/models/Answer.js';
 import jsonapiSerializer from 'jsonapi-serializer';
-import { AnswerStatusJsonApiAdapter } from '../../adapters/answer-status-json-api-adapter.js';
+import { AnswerStatusJsonApiAdapter } from '../../../../../lib/infrastructure/adapters/answer-status-json-api-adapter.js';
 
 const { Serializer } = jsonapiSerializer;
 

--- a/api/src/evaluation/routes.js
+++ b/api/src/evaluation/routes.js
@@ -1,3 +1,4 @@
+import * as answersRoutes from './application/answers/index.js';
 import * as autonomousCoursesRoutes from './application/autonomous-courses/index.js';
 import * as competenceEvaluationsRoutes from './application/competence-evaluations/index.js';
 import * as feedbacksRoutes from './application/feedbacks/index.js';
@@ -7,6 +8,7 @@ import * as stagesRoutes from './application/stages/index.js';
 import * as stageCollectionRoutes from './application/stage-collections/index.js';
 
 const evaluationRoutes = [
+  answersRoutes,
   autonomousCoursesRoutes,
   competenceEvaluationsRoutes,
   stageCollectionRoutes,

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -6,7 +6,7 @@ import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/in
 import * as events from '../../../../lib/domain/events/index.js';
 import { logger } from '../../../../lib/infrastructure/logger.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
-import * as assessmentSerializer from '../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer.js';
+import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import * as activitySerializer from '../../../../lib/infrastructure/serializers/jsonapi/activity-serializer.js';
 import * as challengeSerializer from '../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
 import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -1,23 +1,23 @@
-import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import { Serializer as JSONAPISerializer } from 'jsonapi-serializer';
-import { AssessmentEndedError } from '../../domain/errors.js';
-import { usecases } from '../../domain/usecases/index.js';
-import { usecases as devcompUsecases } from '../../../src/devcomp/domain/usecases/index.js';
-import * as events from '../../domain/events/index.js';
-import { logger } from '../../infrastructure/logger.js';
-import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
-import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
-import * as activitySerializer from '../../infrastructure/serializers/jsonapi/activity-serializer.js';
-import * as challengeSerializer from '../../infrastructure/serializers/jsonapi/challenge-serializer.js';
-import * as competenceEvaluationSerializer from '../../../src/evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
+import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/index.js';
+import * as events from '../../../../lib/domain/events/index.js';
+import { logger } from '../../../../lib/infrastructure/logger.js';
+import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
+import * as assessmentSerializer from '../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer.js';
+import * as activitySerializer from '../../../../lib/infrastructure/serializers/jsonapi/activity-serializer.js';
+import * as challengeSerializer from '../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
+import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 import {
   extractLocaleFromRequest,
   extractUserIdFromRequest,
-} from '../../infrastructure/utils/request-response-utils.js';
-import * as certificationChallengeRepository from '../../infrastructure/repositories/certification-challenge-repository.js';
+} from '../../../../lib/infrastructure/utils/request-response-utils.js';
+import * as certificationChallengeRepository from '../../../../lib/infrastructure/repositories/certification-challenge-repository.js';
 
-import { Examiner } from '../../domain/models/Examiner.js';
-import { ValidatorAlwaysOK } from '../../domain/models/ValidatorAlwaysOK.js';
+import { Examiner } from '../../../../lib/domain/models/Examiner.js';
+import { ValidatorAlwaysOK } from '../../../../lib/domain/models/ValidatorAlwaysOK.js';
 
 const save = async function (request, h, dependencies = { assessmentRepository }) {
   const assessment = assessmentSerializer.deserialize(request.payload);

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -1,9 +1,9 @@
 import Joi from 'joi';
-import { config } from '../../config.js';
+import { config } from '../../../../lib/config.js';
 import { assessmentController } from './assessment-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
-import { assessmentAuthorization } from '../preHandlers/assessment-authorization.js';
-import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { assessmentAuthorization } from '../../../../lib/application/preHandlers/assessment-authorization.js';
+import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 
 const { featureToggles } = config;
 

--- a/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -1,5 +1,5 @@
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { Progression } from '../../../../src/evaluation/domain/models/Progression.js';
+import { Assessment } from '../../../domain/models/Assessment.js';
+import { Progression } from '../../../../evaluation/domain/models/Progression.js';
 import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;

--- a/api/src/shared/routes.js
+++ b/api/src/shared/routes.js
@@ -1,0 +1,5 @@
+import * as assessmentsRoutes from './application/assessments/index.js';
+
+const sharedRoutes = [assessmentsRoutes];
+
+export { sharedRoutes };

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-find_test.js
@@ -1,5 +1,5 @@
-import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
 
 describe('Acceptance | Controller | answer-controller-find', function () {
   describe('GET /api/answers?challengeId=Y&assessmentId=Z', function () {

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -3,10 +3,10 @@ import {
   generateValidRequestAuthorizationHeader,
   databaseBuilder,
   mockLearningContent,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
+import { createServer } from '../../../../../server.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-get_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-get_test.js
@@ -1,5 +1,5 @@
-import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
 
 describe('Acceptance | Controller | answer-controller-get', function () {
   describe('GET /api/answers/:id', function () {

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -4,10 +4,10 @@ import {
   databaseBuilder,
   mockLearningContent,
   generateValidRequestAuthorizationHeader,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
+import { createServer } from '../../../../../server.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 
 const { FRENCH_FRANCE, ENGLISH_SPOKEN } = LOCALE;
 

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-update_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-update_test.js
@@ -1,5 +1,5 @@
-import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
 
 describe('Acceptance | Controller | answer-controller-update', function () {
   describe('PATCH /api/answers/:id', function () {

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -1,6 +1,6 @@
-import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
-import { answerController } from '../../../../lib/application/answers/answer-controller.js';
-import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+import { answerController } from '../../../../../src/evaluation/application/answers/answer-controller.js';
+import { usecases } from '../../../../../lib/domain/usecases/index.js';
 
 describe('Unit | Controller | answer-controller', function () {
   let answerSerializerStub;

--- a/api/tests/evaluation/unit/application/answers/index_test.js
+++ b/api/tests/evaluation/unit/application/answers/index_test.js
@@ -1,7 +1,7 @@
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import * as moduleUnderTest from '../../../../lib/application/answers/index.js';
-import { answerController } from '../../../../lib/application/answers/answer-controller.js';
-import { config } from '../../../../lib/config.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import * as moduleUnderTest from '../../../../../src/evaluation/application/answers/index.js';
+import { answerController } from '../../../../../src/evaluation/application/answers/answer-controller.js';
+import { config } from '../../../../../lib/config.js';
 
 const { features } = config;
 

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -1,8 +1,8 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
-import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
-import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
-import { AnswerStatusJsonApiAdapter as answerStatusJSONAPIAdapter } from '../../../../../lib/infrastructure/adapters/answer-status-json-api-adapter.js';
-import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/answer-serializer.js';
+import { expect, domainBuilder } from '../../../../../test-helper.js';
+import { Answer } from '../../../../../../src/evaluation/domain/models/Answer.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { AnswerStatusJsonApiAdapter as answerStatusJSONAPIAdapter } from '../../../../../../lib/infrastructure/adapters/answer-status-json-api-adapter.js';
+import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/answer-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
   describe('#serialize', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -6,11 +6,11 @@ import {
   learningContentBuilder,
   insertUserWithRoleSuperAdmin,
   generateValidRequestAuthorizationHeader,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { config as settings } from '../../../../lib/config.js';
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { config as settings } from '../../../../../lib/config.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 const lastChallengeAnswer = 'last challenge answer';
 const lastChallengeId = 'lastChallengeId';

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -5,11 +5,11 @@ import {
   knex,
   mockLearningContent,
   learningContentBuilder,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { Assessment, TrainingTrigger } from '../../../../lib/domain/models/index.js';
-import * as badgeAcquisitionRepository from '../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
-import { createServer } from '../../../../server.js';
+import { Assessment, TrainingTrigger } from '../../../../../lib/domain/models/index.js';
+import * as badgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
+import { createServer } from '../../../../../server.js';
 import _ from 'lodash';
 
 describe('Acceptance | Controller | assessment-controller-complete-assessment', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
@@ -1,5 +1,5 @@
-import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
 
 describe('Acceptance | API | assessment-controller-find-competence-evaluations', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-last-challenge-id_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-last-challenge-id_test.js
@@ -3,10 +3,10 @@ import {
   databaseBuilder,
   insertUserWithRoleSuperAdmin,
   generateValidRequestAuthorizationHeader,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Acceptance | API | assessment-controller-get-last-challenge-id', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-campaign-assessment_test.js
@@ -6,10 +6,10 @@ import {
   learningContentBuilder,
   knex,
   sinon,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 const competenceId = 'recCompetence';
 const skillWeb1Id = 'recAcquisWeb1';

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -6,11 +6,11 @@ import {
   learningContentBuilder,
   knex,
   sinon,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { CertificationVersion } from '../../../../../src/shared/domain/models/CertificationVersion.js';
 
 const competenceId = 'recCompetence';
 const skillWeb1Id = 'recAcquisWeb1';

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -6,11 +6,11 @@ import {
   learningContentBuilder,
   knex,
   sinon,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { KnowledgeElement } from '../../../../../lib/domain/models/KnowledgeElement.js';
 
 const competenceId = 'recCompetence';
 const skillWeb1Id = 'recAcquisWeb1';

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-demo_test.js
@@ -1,5 +1,5 @@
-import { expect, databaseBuilder, mockLearningContent, learningContentBuilder } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
+import { expect, databaseBuilder, mockLearningContent, learningContentBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
 
 describe('Acceptance | API | assessment-controller-get-next-challenge-for-demo', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -4,11 +4,11 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -1,10 +1,10 @@
-import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 
 const { FRENCH_SPOKEN } = LOCALE;
 
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Acceptance | API | assessment-controller-get', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-pause-assessment_test.js
@@ -4,9 +4,9 @@ import {
   generateValidRequestAuthorizationHeader,
   knex,
   mockLearningContent,
-} from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Acceptance | API | assessment-controller-pause-assessment', function () {
   describe('POST /api/assessments/{id}/alert', function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-post_test.js
@@ -1,6 +1,6 @@
-import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
-import { BookshelfAssessment } from '../../../../lib/infrastructure/orm-models/Assessment.js';
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { BookshelfAssessment } from '../../../../../lib/infrastructure/orm-models/Assessment.js';
 
 describe('Acceptance | API | Assessments POST', function () {
   let server;

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-update-last-challenge-state_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-update-last-challenge-state_test.js
@@ -5,10 +5,10 @@ import {
   mockLearningContent,
   learningContentBuilder,
   knex,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 const competenceId = 'recCompetence';
 const skillWeb2Id = 'recAcquisWeb2';

--- a/api/tests/shared/integration/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/integration/application/assessments/assessment-controller_test.js
@@ -1,7 +1,7 @@
-import { expect, sinon, domainBuilder, HttpTestServer } from '../../../test-helper.js';
-import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { assessmentAuthorization } from '../../../../lib/application/preHandlers/assessment-authorization.js';
-import * as moduleUnderTest from '../../../../lib/application/assessments/index.js';
+import { expect, sinon, domainBuilder, HttpTestServer } from '../../../../test-helper.js';
+import { usecases } from '../../../../../lib/domain/usecases/index.js';
+import { assessmentAuthorization } from '../../../../../lib/application/preHandlers/assessment-authorization.js';
+import * as moduleUnderTest from '../../../../../src/shared/application/assessments/index.js';
 
 describe('Integration | Application | Assessments | assessment-controller', function () {
   let assessment;

--- a/api/tests/shared/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -1,8 +1,8 @@
-import { sinon, expect, domainBuilder, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
-import { assessmentController } from '../../../../lib/application/assessments/assessment-controller.js';
-import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
+import { sinon, expect, domainBuilder, generateValidRequestAuthorizationHeader } from '../../../../test-helper.js';
+import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
+import { AssessmentEndedError } from '../../../../../lib/domain/errors.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
 
 const { FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 

--- a/api/tests/shared/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller-save_test.js
@@ -1,6 +1,6 @@
-import { sinon, expect, hFake } from '../../../test-helper.js';
-import { assessmentController as controller } from '../../../../lib/application/assessments/assessment-controller.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { sinon, expect, hFake } from '../../../../test-helper.js';
+import { assessmentController as controller } from '../../../../../src/shared/application/assessments/assessment-controller.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Unit | Controller | assessment-controller-save', function () {
   describe('#save', function () {

--- a/api/tests/shared/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller_test.js
@@ -1,11 +1,11 @@
-import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
-import { assessmentController } from '../../../../lib/application/assessments/assessment-controller.js';
-import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { usecases as devcompUsecases } from '../../../../src/devcomp/domain/usecases/index.js';
-import * as events from '../../../../lib/domain/events/index.js';
-import { AssessmentCompleted } from '../../../../lib/domain/events/AssessmentCompleted.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
-import { Activity } from '../../../../src/school/domain/models/Activity.js';
+import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
+import { usecases } from '../../../../../lib/domain/usecases/index.js';
+import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import * as events from '../../../../../lib/domain/events/index.js';
+import { AssessmentCompleted } from '../../../../../lib/domain/events/AssessmentCompleted.js';
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { Activity } from '../../../../../src/school/domain/models/Activity.js';
 
 describe('Unit | Controller | assessment-controller', function () {
   describe('#createAssessmentPreviewForPix1d', function () {

--- a/api/tests/shared/unit/application/assessments/index_test.js
+++ b/api/tests/shared/unit/application/assessments/index_test.js
@@ -1,9 +1,9 @@
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { config as settings } from '../../../../lib/config.js';
-import { assessmentAuthorization } from '../../../../lib/application/preHandlers/assessment-authorization.js';
-import { assessmentController } from '../../../../lib/application/assessments/assessment-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
-import * as moduleUnderTest from '../../../../lib/application/assessments/index.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { config as settings } from '../../../../../lib/config.js';
+import { assessmentAuthorization } from '../../../../../lib/application/preHandlers/assessment-authorization.js';
+import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
+import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import * as moduleUnderTest from '../../../../../src/shared/application/assessments/index.js';
 
 describe('Unit | Application | Router | assessment-router', function () {
   describe('POST /api/assessments', function () {

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -1,6 +1,6 @@
-import { expect, domainBuilder } from '../../../../test-helper.js';
-import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer.js';
-import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { expect, domainBuilder } from '../../../../../test-helper.js';
+import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/assessment-serializer.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
   describe('#serialize()', function () {


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à présent, seuls les usecases d'`assessment` et `answer` ont été migrés vers la nouvelle arbo API ([voir PR](https://github.com/1024pix/pix/pull/7178)).

## :robot: Proposition

Déplacer les routes et controllers associés.

## :rainbow: Remarques

- Answer est dans le scope `evaluation`
- Assessment est dans le scope `shared`

## :100: Pour tester

✅ Tests verts
