### PR TITLE
[TECH] Ajouter le script de migration supprimant la table autonomous-courses (PIX-10104).

### DIFF
--- a/api/db/migrations/20231201142713_remove-autonomous-courses-table.js
+++ b/api/db/migrations/20231201142713_remove-autonomous-courses-table.js
@@ -1,0 +1,11 @@
+import { up as autonomousCoursesTableCreation } from './20231030144246_create_autonomous_courses.js';
+
+const TABLE_NAME = 'autonomous-courses';
+
+const up = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+const down = autonomousCoursesTableCreation;
+
+export { up, down };

--- a/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-autonomous-course_test.js
@@ -5,7 +5,6 @@ import {
   expect,
   mockLearningContent,
   learningContentBuilder,
-  knex,
   sinon,
 } from '../../../../test-helper.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
@@ -26,10 +25,6 @@ describe('Integration | Usecases | Save autonomous course', function () {
     const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
     const learningContentObjects = learningContentBuilder([learningContent]);
     mockLearningContent(learningContentObjects);
-  });
-
-  afterEach(async function () {
-    await knex('autonomous-courses').delete();
   });
 
   context('when target-profile does not exist', function () {

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-repository_test.js
@@ -1,12 +1,8 @@
-import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 import { repositories } from '../../../../../src/evaluation/infrastructure/repositories/index.js';
 import { constants } from '../../../../../lib/domain/constants.js';
 
 describe('Integration | Repository | Autonomous Course', function () {
-  afterEach(function () {
-    return knex('autonomous-courses').delete();
-  });
-
   it('#save', async function () {
     // given
     sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);


### PR DESCRIPTION
## 🎄 Problème

Dans une précédente PR, nous avions ajouté la table `autonomous-courses` à la base de données ([voir la PR](https://github.com/1024pix/pix/pull/7359)).

Or, nous n'avons en réalité plus besoin d'avoir une table spécifique car les parcours autonomes sont au final des campagnes. Elles sont donc stockées dans la table `campaigns`.

## 🎁  Proposition

Ajouter un script de migration pour supprimer la table `autonomous-courses` de la base de données.

## 🧦 Remarques

Dans le premier commit, le reset de la table `autonomous-courses` est supprimé.
Dans tous les cas, il n'est plus nécessaire de faire ces resets depuis ce travail : https://github.com/1024pix/pix/pull/7438

## 🎅  Pour tester

- Sur la branche dev, faire un `npm run db:reset`
  👀 sur votre DB, vous devriez avoir la table `autonomous-courses`
  
- Checkout cette nouvelle branche en local

- Faire un `npm run db:migrate`
  ✅ constater que la table n'existe plus dans votre DB
