### PR TITLE
[TECH] Corriger le test flaky

### DIFF
--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -179,7 +179,7 @@ describe('Acceptance | API | Autonomous Course', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.length).to.equal(3);
-      expect(response.result.data).to.deep.equal(expectedResult);
+      expect(response.result.data).to.deep.have.members(expectedResult);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Un test flaky a été detecté dans la CI.

## :gift: Proposition
Utiliser `to.have.deep.members` au lieu de `to.deep.equal` sur le tableau. Cela permet d'avoir le test qui soit bon, même si les résultats sont renvoyés dans un ordre différent. 

## :socks: Remarques
L'ordre des résultats n'est pas important, donc ce fix convient.

## :santa: Pour tester
CI 🍏 