### PR TITLE
[TECH] Simplification des definitions JSDoc (PIX-10211)

### DIFF
--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -1,5 +1,8 @@
 /**
- * @typedef {import ('../../../lib/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../lib/domain/usecases/index.js').CertificationRepository} CertificationRepository
+ * @typedef {import('../../../lib/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
+ * @typedef {import('../../../lib/domain/usecases/index.js').SessionRepository} SessionRepository
+ * @typedef {import('../../../lib/domain/usecases/index.js').MailService} MailService
  */
 import {
   SendingEmailToResultRecipientError,
@@ -15,9 +18,9 @@ import { logger } from '../../infrastructure/logger.js';
 
 /**
  * @param {Object} params
- * @param {deps['certificationRepository']} params.certificationRepository
- * @param {deps['finalizedSessionRepository']} params.finalizedSessionRepository
- * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {CertificationRepository} params.certificationRepository
+ * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+ * @param {SessionRepository} params.sessionRepository
  */
 async function publishSession({
   publishedAt = new Date(),
@@ -42,10 +45,10 @@ async function publishSession({
 
 /**
  * @param {Object} params
- * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
- * @param {deps['sessionRepository']} params.sessionRepository
+ * @param {certificationCenterRepository} params.certificationCenterRepository
+ * @param {sessionRepository} params.sessionRepository
  * @param {Object} params.dependencies
- * @param {deps['mailService']} params.dependencies.mailService
+ * @param {mailService} params.dependencies.mailService
  */
 async function manageEmails({
   i18n,
@@ -89,9 +92,9 @@ async function manageEmails({
 
 /**
  * @param {Object} params
- * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['mailService']} params.mailService
+ * @param {CertificationCenterRepository} params.certificationCenterRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {MailService} params.mailService
  */
 async function _manageCleaEmails({ session, certificationCenterRepository, sessionRepository, mailService }) {
   const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(session.id);
@@ -121,7 +124,7 @@ async function _manageCleaEmails({ session, certificationCenterRepository, sessi
 
 /**
  * @param {Object} params
- * @param {deps['mailService']} params.mailService
+ * @param {MailService} params.mailService
  */
 async function _managerPrescriberEmails({ session, mailService, i18n }) {
   const recipientEmails = _distinctCandidatesResultRecipientEmails(session.certificationCandidates);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -205,15 +205,14 @@ function requirePoleEmploiNotifier() {
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  *
- * @typedef {{
- *  certificationCenterRepository : certificationCenterRepository,
- *  certificationRepository : certificationRepository,
- *  finalizedSessionRepository : finalizedSessionRepository,
- *  mailService : mailService,
- *  sessionPublicationService : sessionPublicationService,
- *  sessionRepository : sessionRepository,
- * }} dependencies
+ * @typedef {certificationCenterRepository} CertificationCenterRepository
+ * @typedef {certificationRepository} CertificationRepository
+ * @typedef {finalizedSessionRepository} FinalizedSessionRepository
+ * @typedef {mailService} MailService
+ * @typedef {sessionPublicationService} SessionPublicationService
+ * @typedef {sessionRepository} SessionRepository
  */
+
 const dependencies = {
   accountRecoveryDemandRepository,
   activityAnswerRepository,

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -1,14 +1,17 @@
 /**
- * @typedef {import ('../../../lib/domain/usecases/index.js').dependencies} deps
+ * @typedef {import ('../../../lib/domain/usecases/index.js').CertificationRepository} CertificationRepository
+ * @typedef {import ('../../../lib/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
+ * @typedef {import ('../../../lib/domain/usecases/index.js').SessionRepository} SessionRepository
+ * @typedef {import ('../../../lib/domain/usecases/index.js').MailService} MailService
  */
 
 /**
  * @param {Object} params
- * @param {deps['certificationRepository']} params.certificationRepository
- * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
- * @param {deps['finalizedSessionRepository']} params.finalizedSessionRepository
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['sessionPublicationService']} params.sessionPublicationService
+ * @param {CertificationRepository} params.certificationRepository
+ * @param {certificationCenterRepository} params.certificationCenterRepository
+ * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {SessionPublicationService} params.sessionPublicationService
  */
 const publishSession = async function ({
   i18n,

--- a/api/src/certification/session/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/src/certification/session/domain/usecases/add-certification-candidate-to-session.js
@@ -1,5 +1,9 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import ('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').CertificationCandidateRepository} CertificationCandidateRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').CertificationCpfService} CertificationCpfService
+ * @typedef {import ('../../../shared/domain/usecases/index.js').CertificationCpfCountryRepository} CertificationCpfCountryRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').CertificationCpfCityRepository} CertificationCpfCityRepository
  */
 
 import {
@@ -12,11 +16,11 @@ import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../lib/domain/const
 
 /**
  * @param {Object} params
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['certificationCandidateRepository']} params.certificationCandidateRepository
- * @param {deps['certificationCpfService']} params.certificationCpfService
- * @param {deps['certificationCpfCountryRepository']} params.certificationCpfCountryRepository
- * @param {deps['certificationCpfCityRepository']} params.certificationCpfCityRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {CertificationCandidateRepository} params.certificationCandidateRepository
+ * @param {CertificationCpfService} params.certificationCpfService
+ * @param {CertificationCpfCountryRepository} params.certificationCpfCountryRepository
+ * @param {CertificationCpfCityRepository} params.certificationCpfCityRepository
  */
 const addCertificationCandidateToSession = async function ({
   sessionId,

--- a/api/src/certification/session/domain/usecases/assign-certification-officer-to-jury-session.js
+++ b/api/src/certification/session/domain/usecases/assign-certification-officer-to-jury-session.js
@@ -1,3 +1,15 @@
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').JurySessionRepository} JurySessionRepository
+ * @typedef {import('../../../shared/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationOfficerRepository} CertificationOfficerRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {JurySessionRepository} params.jurySessionRepository
+ * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+ * @param {CertificationOfficerRepository} params.certificationOfficerRepository
+ */
 const assignCertificationOfficerToJurySession = async function ({
   sessionId,
   certificationOfficerId,

--- a/api/src/certification/session/domain/usecases/create-session.js
+++ b/api/src/certification/session/domain/usecases/create-session.js
@@ -1,5 +1,9 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import ('../../../shared/domain/usecases/index.js').CertificationCenterRepository} CertificationCenterRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').UserRepository} UserRepository
+ * @typedef {import ('../../../shared/domain/usecases/index.js').SessionValidator} SessionValidator
+ * @typedef {import ('../../../shared/domain/usecases/index.js').SessionCodeService} SessionCodeService
  */
 
 import { Session } from '../models/Session.js';
@@ -8,11 +12,11 @@ import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
 
 /**
  * @param {Object} params
- * @param {deps['certificationCenterRepository']} params.certificationCenterRepository
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['userRepository']} params.userRepository
- * @param {deps['sessionValidator']} params.sessionValidator
- * @param {deps['sessionCodeService']} params.sessionCodeService
+ * @param {CertificationCenterRepository} params.certificationCenterRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {UserRepository} params.userRepository
+ * @param {SessionValidator} params.sessionValidator
+ * @param {SessionCodeService} params.sessionCodeService
  */
 const createSession = async function ({
   userId,

--- a/api/src/certification/session/domain/usecases/delete-session.js
+++ b/api/src/certification/session/domain/usecases/delete-session.js
@@ -1,16 +1,18 @@
 import { SessionStartedDeletionError } from '../errors.js';
 
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationCourseRepository} CertificationCourseRepository
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
  */
 
 /**
  * @param {Object} params
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['certificationCourseRepository']} params.certificationCourseRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {CertificationCourseRepository} params.certificationCourseRepository
  */
 const deleteSession = async function ({ sessionId, sessionRepository, certificationCourseRepository }) {
   if (await _isSessionStarted(certificationCourseRepository, sessionId)) {
+    certificationCourseRepository.findCertificationCoursesBySessionId;
     throw new SessionStartedDeletionError();
   }
 
@@ -19,6 +21,10 @@ const deleteSession = async function ({ sessionId, sessionRepository, certificat
 
 export { deleteSession };
 
+/**
+ * @param {CertificationCourseRepository} certificationCourseRepository
+ * @param {Number} sessionId
+ */
 async function _isSessionStarted(certificationCourseRepository, sessionId) {
   const foundCertificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({
     sessionId,

--- a/api/src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js
+++ b/api/src/certification/session/domain/usecases/delete-unlinked-certification-candidate.js
@@ -1,12 +1,12 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationCandidateRepository} CertificationCandidateRepository
  */
 
 import { CertificationCandidateForbiddenDeletionError } from '../errors.js';
 
 /**
  * @param {Object} params
- * @param {deps['certificationCandidateRepository']} params.certificationCandidateRepository
+ * @param {CertificationCandidateRepository} params.certificationCandidateRepository
  */
 const deleteUnlinkedCertificationCandidate = async function ({
   certificationCandidateId,

--- a/api/src/certification/session/domain/usecases/dismiss-live-alert.js
+++ b/api/src/certification/session/domain/usecases/dismiss-live-alert.js
@@ -1,12 +1,12 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
  */
 
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
 /**
  * @param {Object} params
- * @param {deps['certificationChallengeLiveAlertRepository']} params.certificationChallengeLiveAlertRepository
+ * @param {CertificationChallengeLiveAlertRepository} params.certificationChallengeLiveAlertRepository
  */
 export const dismissLiveAlert = async ({ userId, sessionId, certificationChallengeLiveAlertRepository }) => {
   const certificationChallengeLiveAlert =

--- a/api/src/certification/session/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/session/domain/usecases/get-attendance-sheet.js
@@ -1,14 +1,19 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionForAttendanceSheetRepository} SessionForAttendanceSheetRepository
+ *
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').AttendanceSheetPdfUtils} AttendanceSheetPdfUtils
  */
 
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
 /**
  * @param {Object} params
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['sessionForAttendanceSheetRepository']} params.sessionForAttendanceSheetRepository
- * @param {deps['attendanceSheetPdfUtils']} params.attendanceSheetPdfUtils
+ * @param {SessionRepository} params.sessionRepository
+ * @param {SessionForAttendanceSheetRepository} params.sessionForAttendanceSheetRepository
+ * @param {AttendanceSheetPdfUtils} params.attendanceSheetPdfUtils
  */
 const getAttendanceSheet = async function ({
   userId,

--- a/api/src/certification/session/domain/usecases/get-cpf-presigned-urls.js
+++ b/api/src/certification/session/domain/usecases/get-cpf-presigned-urls.js
@@ -1,10 +1,15 @@
-/** @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps */
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').CpfExportsStorage} CpfExportsStorage
+ */
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').CpfExportRepository} CpfExportRepository
+ */
 import { CpfImportStatus } from '../models/CpfImportStatus.js';
 
 /**
  * @param {Object} params
- * @param {deps['cpfExportsStorage']} params.cpfExportsStorage
- * @param {deps['cpfExportRepository']} params.cpfExportRepository
+ * @param {CpfExportsStorage} params.cpfExportsStorage
+ * @param {CpfExportRepository} params.cpfExportRepository
  */
 const getPreSignedUrls = async function ({ cpfExportRepository, cpfExportsStorage }) {
   const filenames = await cpfExportRepository.findFileNamesByStatus({ cpfImportStatus: CpfImportStatus.READY_TO_SEND });

--- a/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
+++ b/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
@@ -1,13 +1,15 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionForInvigilatorKitRepository} SessionForInvigilatorKitRepository
  */
 
 import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
 
 /**
  * @param {Object} params
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['sessionForInvigilatorKitRepository']} params.sessionForInvigilatorKitRepository
+ * @param {SessionRepository} params.sessionRepository
+ * @param {SessionForInvigilatorKitRepository} params.sessionForInvigilatorKitRepository
  */
 const getInvigilatorKitSessionInfo = async function ({
   userId,

--- a/api/src/certification/session/domain/usecases/get-session-certification-candidates.js
+++ b/api/src/certification/session/domain/usecases/get-session-certification-candidates.js
@@ -1,10 +1,10 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationCandidateRepository} CertificationCandidateRepository
  */
 
 /**
  * @param {Object} params
- * @param {deps['certificationCandidateRepository']} params.certificationCandidateRepository
+ * @param {CertificationCandidateRepository} params.certificationCandidateRepository
  */
 const getSessionCertificationCandidates = async function ({ sessionId, certificationCandidateRepository }) {
   return certificationCandidateRepository.findBySessionId(sessionId);

--- a/api/src/certification/session/domain/usecases/integrate-cpf-processing-receipts.js
+++ b/api/src/certification/session/domain/usecases/integrate-cpf-processing-receipts.js
@@ -1,12 +1,16 @@
-/** @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps */
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').CpfReceiptsStorage} CpfReceiptsStorage
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').CpfCertificationResultRepository} CpfCertificationResultRepository
+ */
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import bluebird from 'bluebird';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../../lib/infrastructure/constants.js';
 
 /**
  * @param {Object} params
- * @param {deps['cpfReceiptsStorage']} params.cpfReceiptsStorage
- * @param {deps['cpfCertificationResultRepository']} params.cpfCertificationResultRepository
+ * @param {CpfReceiptsStorage} params.cpfReceiptsStorage
+ * @param {CpfCertificationResultRepository} params.cpfCertificationResultRepository
  */
 const integrateCpfProccessingReceipts = async function ({ cpfReceiptsStorage, cpfCertificationResultRepository }) {
   logger.info('Starting CPF receipts integration from external storage');
@@ -32,8 +36,8 @@ export { integrateCpfProccessingReceipts };
 
 /**
  * @param {Object} params
- * @param {deps['cpfReceiptsStorage']} params.cpfReceiptsStorage
- * @param {deps['cpfCertificationResultRepository']} params.cpfCertificationResultRepository
+ * @param {CpfReceiptsStorage} params.cpfReceiptsStorage
+ * @param {CpfCertificationResultRepository} params.cpfCertificationResultRepository
  */
 async function _updateCertificationCourses({ cpfReceipt, cpfReceiptsStorage, cpfCertificationResultRepository }) {
   const cpfInfos = await cpfReceiptsStorage.getCpfInfosByReceipt({ cpfReceipt });

--- a/api/src/certification/session/domain/usecases/update-session.js
+++ b/api/src/certification/session/domain/usecases/update-session.js
@@ -1,11 +1,13 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionValidator} SessionValidator
  */
 
 /**
  * @param {Object} params
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['sessionValidator']} params.sessionValidator
+ * @param {SessionRepository} params.sessionRepository
+ * @param {SessionValidator} params.sessionValidator
  */
 const updateSession = async function ({ session, sessionRepository, sessionValidator }) {
   sessionValidator.validate(session);

--- a/api/src/certification/session/domain/usecases/upload-cpf-files.js
+++ b/api/src/certification/session/domain/usecases/upload-cpf-files.js
@@ -1,8 +1,10 @@
-/** @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps */
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').CpfExportsStorage} CpfExportsStorage
+ */
 
 /**
  * @param {Object} params
- * @param {deps['cpfExportsStorage']} params.cpfExportsStorage
+ * @param {cpfExportsStorage} params.cpfExportsStorage
  */
 const uploadCpfFiles = async function ({ filename, readableStream, logger, cpfExportsStorage }) {
   logger.trace('uploadCpfFiles: start upload');

--- a/api/src/certification/session/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session/domain/usecases/validate-live-alert.js
@@ -1,5 +1,13 @@
 /**
- * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
+ *
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').AssessmentRepository} AssessmentRepository
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').IssueReportCategoryRepository} IssueReportCategoryRepository
+ *
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationIssueReportRepository} CertificationIssueReportRepository
  */
 
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
@@ -7,10 +15,10 @@ import { CertificationIssueReport, CertificationIssueReportCategory } from '../.
 
 /**
  * @param {Object} params
- * @param {deps['certificationChallengeLiveAlertRepository']} params.certificationChallengeLiveAlertRepository
- * @param {deps['assessmentRepository']} params.assessmentRepository
- * @param {deps['issueReportCategoryRepository']} params.issueReportCategoryRepository
- * @param {deps['certificationIssueReportRepository']} params.certificationIssueReportRepository
+ * @param {CertificationChallengeLiveAlertRepository} params.certificationChallengeLiveAlertRepository
+ * @param {AssessmentRepository} params.assessmentRepository
+ * @param {IssueReportCategoryRepository} params.issueReportCategoryRepository
+ * @param {CertificationIssueReportRepository} params.certificationIssueReportRepository
  */
 export const validateLiveAlert = async ({
   userId,

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -1,3 +1,5 @@
+// eslint-disable import/no-restricted-paths
+
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -45,42 +47,38 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 /**
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  *
- * @typedef {{
- *  assessmentRepository : assessmentRepository,
- *  attendanceSheetPdfUtils : attendanceSheetPdfUtils,
- *  badgeRepository : badgeRepository,
- *  certificationCandidateRepository : certificationCandidateRepository,
- *  certificationCenterRepository : certificationCenterRepository,
- *  certificationChallengeLiveAlertRepository : certificationChallengeLiveAlertRepository,
- *  certificationCpfService : certificationCpfService,
- *  certificationIssueReportRepository : certificationIssueReportRepository,
- *  challengeRepository : challengeRepository,
- *  certificationCpfCityRepository : certificationCpfCityRepository,
- *  certificationCpfCountryRepository : certificationCpfCountryRepository,
- *  certificationOfficerRepository: certificationOfficerRepository,
- *  complementaryCertificationBadgesRepository : complementaryCertificationBadgesRepository,
- *  complementaryCertificationRepository : complementaryCertificationRepository,
- *  complementaryCertificationForTargetProfileAttachmentRepository : complementaryCertificationForTargetProfileAttachmentRepository,
- *  complementaryCertificationTargetProfileHistoryRepository : complementaryCertificationTargetProfileHistoryRepository,
- *  cpfExportRepository: cpfExportRepository,
- *  finalizedSessionRepository: finalizedSessionRepository,
- *  flashAlgorithmService : flashAlgorithmService,
- *  issueReportCategoryRepository : issueReportCategoryRepository,
- *  jurySessionRepository: jurySessionRepository,
- *  mailService : mailService,
- *  organizationRepository : organizationRepository,
- *  sessionCodeService : sessionCodeService,
- *  sessionsImportValidationService : sessionsImportValidationService,
- *  temporarySessionsStorageForMassImportService : temporarySessionsStorageForMassImportService,
- *  sessionForAttendanceSheetRepository : sessionForAttendanceSheetRepository,
- *  sessionForInvigilatorKitRepository : sessionForInvigilatorKitRepository,
- *  cpfCertificationResultRepository : cpfCertificationResultRepository,
- *  sessionRepository : sessionRepository,
- *  sessionValidator : sessionValidator,
- *  userRepository : userRepository,
- *  cpfReceiptsStorage : cpfReceiptsStorage,
- *  cpfExportsStorage : cpfExportsStorage,
- * }} dependencies
+ * @typedef {assessmentRepository} AssessmentRepository
+ * @typedef {attendanceSheetPdfUtils} AttendanceSheetPdfUtils
+ * @typedef {badgeRepository} BadgeRepository
+ * @typedef {certificationCandidateRepository} CertificationCandidateRepository
+ * @typedef {certificationCenterRepository} CertificationCenterRepository
+ * @typedef {certificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
+ * @typedef {certificationCpfService} CertificationCpfService
+ * @typedef {certificationIssueReportRepository} CertificationIssueReportRepository
+ * @typedef {challengeRepository} ChallengeRepository
+ * @typedef {certificationCpfCityRepository} CertificationCpfCityRepository
+ * @typedef {certificationCpfCountryRepository} CertificationCpfCountryRepository
+ * @typedef {certificationOfficerRepository} CertificationOfficerRepository
+ * @typedef {complementaryCertificationBadgesRepository} ComplementaryCertificationBadgesRepository
+ * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
+ * @typedef {complementaryCertificationForTargetProfileAttachmentRepository} ComplementaryCertificationForTargetProfileAttachmentRepository
+ * @typedef {complementaryCertificationTargetProfileHistoryRepository} ComplementaryCertificationTargetProfileHistoryRepository
+ * @typedef {cpfExportRepository} CpfExportRepository
+ * @typedef {finalizedSessionRepository} FinalizedSessionRepository
+ * @typedef {flashAlgorithmService} FlashAlgorithmService
+ * @typedef {issueReportCategoryRepository} IssueReportCategoryRepository
+ * @typedef {jurySessionRepository} JurySessionRepository
+ * @typedef {mailService} MailService
+ * @typedef {organizationRepository} OrganizationRepository
+ * @typedef {sessionCodeService} SessionCodeService
+ * @typedef {sessionForAttendanceSheetRepository} SessionForAttendanceSheetRepository
+ * @typedef {sessionForInvigilatorKitRepository} SessionForInvigilatorKitRepository
+ * @typedef {cpfCertificationResultRepository} CpfCertificationResultRepository
+ * @typedef {sessionRepository} SessionRepository
+ * @typedef {sessionValidator} SessionValidator
+ * @typedef {userRepository} UserRepository
+ * @typedef {cpfReceiptsStorage} CpfReceiptsStorage
+ * @typedef {cpfExportsStorage} CpfExportsStorage
  */
 const dependencies = {
   assessmentRepository,

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -53,6 +53,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
  * @typedef {certificationCandidateRepository} CertificationCandidateRepository
  * @typedef {certificationCenterRepository} CertificationCenterRepository
  * @typedef {certificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
+ * @typedef {certificationCourseRepository} CertificationCourseRepository
  * @typedef {certificationCpfService} CertificationCpfService
  * @typedef {certificationIssueReportRepository} CertificationIssueReportRepository
  * @typedef {challengeRepository} ChallengeRepository


### PR DESCRIPTION
## :christmas_tree: Problème
La maniere de gerer les "typedef", n'est pas evidente

## :gift: Proposition
Remplacer 
`@param {deps['certificationRepository']} params.certificationRepository`
par 
`@param {CertificationRepository} params.certificationRepository`

## :socks: Remarques
On peut linter/prettier:
`"prettier-plugin-jsdoc": "^1.1.1",`
et dans .prettierrc.json `"plugins": ["./node_modules/prettier-plugin-jsdoc/dist/index.js"]`
Mais le plugin force un saut de ligne entre chaque typedef, c'est un peu lourd

## :santa: Pour tester
S'assurer que le ctrl+click se fait bien dans les IDE
