### PR TITLE
[FEATURE] Ajouter un tracking sur le click "alternative textuelle" d'un élément Image (PIX-10122).

### DIFF
--- a/mon-pix/app/pods/components/module/image/component.js
+++ b/mon-pix/app/pods/components/module/image/component.js
@@ -1,13 +1,21 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class ModuleImage extends Component {
   @tracked modalIsOpen = false;
+  @service metrics;
 
   @action
   showModal() {
     this.modalIsOpen = true;
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Afficher l’alternative textuelle : ${this.args.image.id}`,
+      'pix-event-name': `Click sur le bouton alternative textuelle : ${this.args.image.id}`,
+    });
   }
 
   @action

--- a/mon-pix/tests/unit/components/module/image_test.js
+++ b/mon-pix/tests/unit/components/module/image_test.js
@@ -1,15 +1,64 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createPodsComponent from '../../../helpers/create-pods-component';
+import sinon from 'sinon';
 
 module('Unit | Component | Module | Image', function (hooks) {
   setupTest(hooks);
+
+  module('#showModal', function () {
+    test('should switch the #modalIsOpen boolean', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const image = store.createRecord('image', { id: 'image-id' });
+
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = () => {};
+
+      const component = createPodsComponent('module/image', { image });
+      assert.false(component.modalIsOpen);
+
+      // when
+      component.showModal();
+
+      // then
+      assert.true(component.modalIsOpen);
+    });
+
+    test('should call metrics service', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const image = store.createRecord('image', { id: 'image-id' });
+
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      const component = createPodsComponent('module/image', { image });
+      assert.false(component.modalIsOpen);
+
+      // when
+      component.showModal();
+
+      // then
+      assert.true(
+        metrics.add.calledWithExactly({
+          event: 'custom-event',
+          'pix-event-category': 'Modulix',
+          'pix-event-action': `Afficher l’alternative textuelle : ${image.id}`,
+          'pix-event-name': `Click sur le bouton alternative textuelle : ${image.id}`,
+        }),
+      );
+    });
+  });
 
   module('#closeModal', function () {
     module('When we want to close the modal', function () {
       test('should switch the #modalIsOpen boolean', async function (assert) {
         // given
-        const component = createPodsComponent('module/image');
+        const store = this.owner.lookup('service:store');
+        const image = store.createRecord('image', { id: 'image-id' });
+
+        const component = createPodsComponent('module/image', { image });
         assert.false(component.modalIsOpen);
 
         component.showModal();


### PR DESCRIPTION
## :christmas_tree: Problème
Nous souhaitons savoir si cette fonctionnalité est utilisée, mais nous n'avons rien actuellement qui nous permet de le savoir.

## :gift: Proposition
Ajouter un événement au click sur le bouton en question

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Aller sur un module sur Pix App
- Arriver sur un élément 
- Cliquer sur le bouton "Alternative textuelle"
- Constater qu'une requête est faite à Matomo