### PR TITLE
[FEATURE] Pouvoir configurer le nombre max de challenges capés sur la variation de capacité (PIX-10187).

### DIFF
--- a/api/db/database-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/db/database-builder/factory/build-flash-algorithm-configuration.js
@@ -8,8 +8,9 @@ const buildFlashAlgorithmConfiguration = function ({
   minimumEstimatedSuccessRateRanges = [],
   limitToOneQuestionPerTube = null,
   enablePassageByAllCompetences = false,
-  variationPercent = null,
   doubleMeasuresUntil = null,
+  variationPercent = null,
+  variationPercentUntil = null,
 } = {}) {
   const values = {
     warmUpLength,
@@ -19,8 +20,9 @@ const buildFlashAlgorithmConfiguration = function ({
     minimumEstimatedSuccessRateRanges: JSON.stringify(minimumEstimatedSuccessRateRanges),
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
-    variationPercent,
     doubleMeasuresUntil,
+    variationPercent,
+    variationPercentUntil,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20231204132912_add-variation-percent-until-for-flash-simulator.js
+++ b/api/db/migrations/20231204132912_add-variation-percent-until-for-flash-simulator.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'flash-algorithm-configurations';
+const COLUMN_NAME = 'variationPercentUntil';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -35,6 +35,7 @@ async function simulateFlashAssessmentScenario(
     enablePassageByAllCompetences,
     doubleMeasuresUntil,
     variationPercent,
+    variationPercentUntil,
   } = request.payload;
 
   const pickAnswerStatus = _getPickAnswerStatusMethod(dependencies.pickAnswerStatusService, request.payload);
@@ -67,6 +68,7 @@ async function simulateFlashAssessmentScenario(
           enablePassageByAllCompetences,
           doubleMeasuresUntil,
           variationPercent,
+          variationPercentUntil,
         },
         _.isUndefined,
       );

--- a/api/src/certification/flash-certification/application/scenario-simulator-route.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-route.js
@@ -30,8 +30,9 @@ const _baseScenarioParametersValidator = Joi.object().keys({
   limitToOneQuestionPerTube: Joi.boolean(),
   minimumEstimatedSuccessRateRanges: Joi.array().items(_successRatesConfigurationValidator),
   enablePassageByAllCompetences: Joi.boolean(),
-  variationPercent: Joi.number().min(0).max(1),
   doubleMeasuresUntil: Joi.number().min(0),
+  variationPercent: Joi.number().min(0).max(1),
+  variationPercentUntil: Joi.number().min(0),
 });
 
 const register = async (server) => {

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js
@@ -48,7 +48,6 @@ class FlashAssessmentAlgorithm {
       allAnswers: answersForComputingEstimatedLevel ?? assessmentAnswers,
       challenges,
       initialCapacity,
-      variationPercent: this._configuration.variationPercent,
     });
 
     const challengesAfterRulesApplication = this._applyChallengeSelectionRules(assessmentAnswers, challenges);
@@ -102,6 +101,7 @@ class FlashAssessmentAlgorithm {
       challenges,
       estimatedLevel: initialCapacity,
       variationPercent: this._configuration.variationPercent,
+      variationPercentUntil: this._configuration.variationPercentUntil,
       doubleMeasuresUntil: this._configuration.doubleMeasuresUntil,
     });
   }

--- a/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/flash-certification/domain/model/FlashAssessmentAlgorithmConfiguration.js
@@ -9,8 +9,9 @@ import { FlashAssessmentSuccessRateHandler } from './FlashAssessmentSuccessRateH
  * @param limitToOneQuestionPerTube - limits questions to one per tube
  * @param flashImplementation - the flash algorithm implementation
  * @param enablePassageByAllCompetences - enable or disable the passage through all competences
- * @param variationPercent - maximum variation of estimated level between two answers
  * @param doubleMeasuresUntil - use the double measure strategy for specified number of challenges
+ * @param variationPercent - maximum variation of estimated level between two answers
+ * @param variationPercentUntil - maximum variation of estimated level between two answers for a specified number of challenges
  */
 export class FlashAssessmentAlgorithmConfiguration {
   constructor({
@@ -21,8 +22,9 @@ export class FlashAssessmentAlgorithmConfiguration {
     minimumEstimatedSuccessRateRanges = [],
     limitToOneQuestionPerTube = false,
     enablePassageByAllCompetences = false,
-    variationPercent,
     doubleMeasuresUntil,
+    variationPercent,
+    variationPercentUntil,
   } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
@@ -31,8 +33,9 @@ export class FlashAssessmentAlgorithmConfiguration {
     this.minimumEstimatedSuccessRateRanges = minimumEstimatedSuccessRateRanges;
     this.limitToOneQuestionPerTube = limitToOneQuestionPerTube;
     this.enablePassageByAllCompetences = enablePassageByAllCompetences;
-    this.variationPercent = variationPercent;
     this.doubleMeasuresUntil = doubleMeasuresUntil;
+    this.variationPercent = variationPercent;
+    this.variationPercentUntil = variationPercentUntil;
   }
 
   toDTO() {
@@ -46,8 +49,9 @@ export class FlashAssessmentAlgorithmConfiguration {
       ),
       limitToOneQuestionPerTube: this.limitToOneQuestionPerTube,
       enablePassageByAllCompetences: this.enablePassageByAllCompetences,
-      variationPercent: this.variationPercent,
       doubleMeasuresUntil: this.doubleMeasuresUntil,
+      variationPercent: this.variationPercent,
+      variationPercentUntil: this.variationPercentUntil,
     };
   }
 
@@ -59,8 +63,9 @@ export class FlashAssessmentAlgorithmConfiguration {
     minimumEstimatedSuccessRateRanges,
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
-    variationPercent,
     doubleMeasuresUntil,
+    variationPercent,
+    variationPercentUntil,
   }) {
     return new FlashAssessmentAlgorithmConfiguration({
       warmUpLength,
@@ -72,8 +77,9 @@ export class FlashAssessmentAlgorithmConfiguration {
         : minimumEstimatedSuccessRateRanges,
       limitToOneQuestionPerTube,
       enablePassageByAllCompetences,
-      variationPercent,
       doubleMeasuresUntil,
+      variationPercent,
+      variationPercentUntil,
     });
   }
 }

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -40,8 +40,9 @@ function getEstimatedLevelAndErrorRate({
   allAnswers,
   challenges,
   estimatedLevel = DEFAULT_ESTIMATED_LEVEL,
-  variationPercent,
   doubleMeasuresUntil = 0,
+  variationPercent,
+  variationPercentUntil,
 }) {
   if (allAnswers.length === 0) {
     return { estimatedLevel, errorRate: DEFAULT_ERROR_RATE };
@@ -54,6 +55,8 @@ function getEstimatedLevelAndErrorRate({
   let answerIndex = 0;
 
   while (answerIndex < allAnswers.length) {
+    const variationPercentForCurrentAnswer = variationPercentUntil >= answerIndex ? variationPercent : undefined;
+
     if (!_shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex, answersLength: allAnswers.length })) {
       const answer = allAnswers[answerIndex];
       ({ latestEstimatedLevel, likelihood, normalizedPosteriori } = _singleMeasure({
@@ -62,7 +65,7 @@ function getEstimatedLevelAndErrorRate({
         latestEstimatedLevel,
         likelihood,
         normalizedPosteriori,
-        variationPercent,
+        variationPercent: variationPercentForCurrentAnswer,
       }));
 
       answerIndex++;
@@ -75,7 +78,7 @@ function getEstimatedLevelAndErrorRate({
         latestEstimatedLevel,
         likelihood,
         normalizedPosteriori,
-        variationPercent,
+        variationPercent: variationPercentForCurrentAnswer,
       }));
 
       answerIndex += 2;

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -21,7 +21,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
   enablePassageByAllCompetences = false,
   doubleMeasuresUntil = 0,
   variationPercent,
-  variationPercentUntil = 0,
+  variationPercentUntil,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -19,8 +19,9 @@ export async function simulateFlashDeterministicAssessmentScenario({
   limitToOneQuestionPerTube = true,
   minimumEstimatedSuccessRateRanges = [],
   enablePassageByAllCompetences = false,
-  variationPercent,
   doubleMeasuresUntil = 0,
+  variationPercent,
+  variationPercentUntil = 0,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 
@@ -33,6 +34,7 @@ export async function simulateFlashDeterministicAssessmentScenario({
       minimumEstimatedSuccessRateRanges,
       enablePassageByAllCompetences,
       variationPercent,
+      variationPercentUntil,
       doubleMeasuresUntil,
       challengesBetweenSameCompetence,
       maximumAssessmentLength: stopAtChallenge,

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -11,6 +11,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         maximumAssessmentLength: 2,
         challengesBetweenSameCompetence: 3,
         variationPercent: 4,
+        variationPercentUntil: 3,
         doubleMeasuresUntil: 5,
         forcedCompetences: ['comp1', 'comp2'],
         minimumEstimatedSuccessRateRanges: [
@@ -36,6 +37,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         limitToOneQuestionPerTube: true,
         enablePassageByAllCompetences: false,
         variationPercent: 4,
+        variationPercentUntil: 3,
         doubleMeasuresUntil: 5,
       });
     });
@@ -47,6 +49,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         maximumAssessmentLength: 2,
         challengesBetweenSameCompetence: 3,
         variationPercent: 4,
+        variationPercentUntil: 3,
         doubleMeasuresUntil: 5,
         minimumEstimatedSuccessRateRanges: [
           { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
@@ -71,6 +74,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         limitToOneQuestionPerTube: true,
         enablePassageByAllCompetences: false,
         variationPercent: 4,
+        variationPercentUntil: 3,
         doubleMeasuresUntil: 5,
       });
     });
@@ -82,6 +86,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         maximumAssessmentLength: 2,
         challengesBetweenSameCompetence: 3,
         variationPercent: 4,
+        variationPercentUntil: 3,
         doubleMeasuresUntil: 5,
         forcedCompetences: ['comp1', 'comp2'],
         limitToOneQuestionPerTube: true,
@@ -102,6 +107,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         limitToOneQuestionPerTube: true,
         enablePassageByAllCompetences: false,
         variationPercent: 4,
+        variationPercentUntil: 3,
         doubleMeasuresUntil: 5,
       });
     });
@@ -116,6 +122,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
           maximumAssessmentLength: 2,
           challengesBetweenSameCompetence: 3,
           variationPercent: 4,
+          variationPercentUntil: 3,
           doubleMeasuresUntil: 5,
           forcedCompetences: ['comp1', 'comp2'],
           minimumEstimatedSuccessRateRanges: [

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -455,6 +455,7 @@ const _getAlgorithmConfig = (options) => {
 
 const _getEstimatedLevelAndErrorRateParams = (params) => ({
   variationPercent: undefined,
+  variationPercentUntil: undefined,
   doubleMeasuresUntil: undefined,
   ...params,
 });

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -357,9 +357,9 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         });
       });
 
-      context('when limiting the estimated level variation', function () {
+      context('when limiting the estimated level variation to a given number of challenges', function () {
         context('when giving a right answer', function () {
-          it('should return the limited estimatedLevel', function () {
+          it('should return the limited estimatedLevel for the correct number of challenges', function () {
             // given
             const challenges = [
               domainBuilder.buildChallenge({
@@ -371,12 +371,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
             const variationPercent = 0.5;
+            const variationPercentUntil = 1;
 
             // when
             const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
               allAnswers,
               challenges,
               variationPercent,
+              variationPercentUntil,
             });
 
             // then
@@ -397,12 +399,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[0].id })];
 
             const variationPercent = 0.5;
+            const variationPercentUntil = 1;
 
             // when
             const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
               allAnswers,
               challenges,
               variationPercent,
+              variationPercentUntil,
             });
 
             // then

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -9,8 +9,9 @@ export const buildFlashAlgorithmConfiguration = ({
   minimumEstimatedSuccessRateRanges = [],
   limitToOneQuestionPerTube,
   enablePassageByAllCompetences,
-  variationPercent,
   doubleMeasuresUntil,
+  variationPercent,
+  variationPercentUntil,
 } = {}) => {
   return new FlashAssessmentAlgorithmConfiguration({
     warmUpLength,
@@ -22,7 +23,8 @@ export const buildFlashAlgorithmConfiguration = ({
     ),
     limitToOneQuestionPerTube,
     enablePassageByAllCompetences,
-    variationPercent,
     doubleMeasuresUntil,
+    variationPercent,
+    variationPercentUntil,
   });
 };

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -114,6 +114,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
@@ -191,6 +192,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
@@ -282,6 +284,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
@@ -361,6 +364,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
@@ -441,6 +445,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
             variationPercent: undefined,
+            variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns({

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -348,6 +348,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 allAnswers: answers,
                 estimatedLevel: sinon.match.number,
                 variationPercent: undefined,
+                variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns({
@@ -425,6 +426,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 allAnswers: answers,
                 estimatedLevel: sinon.match.number,
                 variationPercent: undefined,
+                variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns({
@@ -504,6 +506,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 allAnswers: answers,
                 estimatedLevel: sinon.match.number,
                 variationPercent: undefined,
+                variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns({
@@ -577,6 +580,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                   allAnswers: answers,
                   estimatedLevel: sinon.match.number,
                   variationPercent: undefined,
+                  variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns({
@@ -650,6 +654,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                   allAnswers: answers,
                   estimatedLevel: sinon.match.number,
                   variationPercent: undefined,
+                  variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns({
@@ -717,6 +722,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
             variationPercent: undefined,
+            variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns({

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -152,6 +152,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
@@ -219,6 +220,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               allAnswers,
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -154,6 +154,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               challenges: [nextChallengeToAnswer],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({ estimatedLevel: 0 });
@@ -289,6 +290,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               challenges: [nextChallenge],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({ estimatedLevel: 0 });
@@ -388,6 +390,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               challenges: [answeredChallenge],
               estimatedLevel: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
+              variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
@@ -494,6 +497,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
                   challenges: [nextChallengeToAnswer],
                   estimatedLevel: config.v3Certification.defaultCandidateCapacity,
                   variationPercent: configuration.variationPercent,
+                  variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns({ estimatedLevel: 0 });

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -347,6 +347,7 @@ function prepareStubs({
       challenges: sinon.match.any,
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 0, errorRate: 0.1 })
@@ -355,6 +356,7 @@ function prepareStubs({
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 1, errorRate: 1.1 })
@@ -363,6 +365,7 @@ function prepareStubs({
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 2, errorRate: 2.1 })
@@ -371,6 +374,7 @@ function prepareStubs({
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
       estimatedLevel: initialCapacity,
       variationPercent: undefined,
+      variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
     .returns({ estimatedLevel: 3, errorRate: 3.1 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, la limite de la variation de capacité (variationPercent) s’applique sur l’ensemble des questions. 
Il faut pouvoir l’appliquer à une portion spécifique seulement.

## :gift: Proposition
Paramètre déjà existant en entrée de la route de génération d'un scénario:
- variationPercent - variation maximum du niveau estimé entre deux réponses

Ajout de paramètre en entrée de la route de génération d'un scénario:
- variationPercentUntil - variation maximum du niveau estimé entre deux réponses pour un nombre défini de challenges

## :santa: Pour tester

```
TOKEN=$(curl 'https://api-pr7579.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7579.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "capacity", "capacity": 1.5, "variationPercent": 0.2, "variationPercentUntil": 5 }' | jq '.'
```
