### PR TITLE
[TECH] Simplifier l'injection de dépendances au niveau des controllers dans le contexte de DevComp (PIX-10238). 

### DIFF
--- a/api/src/devcomp/application/modules/controller.js
+++ b/api/src/devcomp/application/modules/controller.js
@@ -1,20 +1,16 @@
-import * as moduleSerializer from '../../infrastructure/serializers/jsonapi/module-serializer.js';
-import * as elementAnswerSerializer from '../../infrastructure/serializers/jsonapi/element-answer-serializer.js';
-import { usecases } from '../../domain/usecases/index.js';
-
-const getBySlug = async function (request, h, dependencies = { moduleSerializer, usecases }) {
+const getBySlug = async function (request, h, { moduleSerializer, usecases }) {
   const { slug } = request.params;
-  const module = await dependencies.usecases.getModule({ slug });
+  const module = await usecases.getModule({ slug });
 
-  return dependencies.moduleSerializer.serialize(module);
+  return moduleSerializer.serialize(module);
 };
 
-const verifyAnswer = async function (request, h, dependencies = { elementAnswerSerializer, usecases }) {
+const verifyAnswer = async function (request, h, { elementAnswerSerializer, usecases }) {
   const { moduleSlug, elementId } = request.params;
   const { 'user-response': userResponse } = request.payload.data.attributes;
-  const answer = await dependencies.usecases.verifyAnswer({ moduleSlug, userResponse, elementId });
+  const answer = await usecases.verifyAnswer({ moduleSlug, userResponse, elementId });
 
-  return dependencies.elementAnswerSerializer.serialize(answer);
+  return elementAnswerSerializer.serialize(answer);
 };
 
 const modulesController = { getBySlug, verifyAnswer };

--- a/api/src/devcomp/application/modules/index.js
+++ b/api/src/devcomp/application/modules/index.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import { modulesController } from './controller.js';
+import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
 
 const register = async function (server) {
   server.route([
@@ -8,7 +9,7 @@ const register = async function (server) {
       path: '/api/modules/{slug}',
       config: {
         auth: false,
-        handler: modulesController.getBySlug,
+        handler: handlerWithDependencies(modulesController.getBySlug),
         validate: {
           params: Joi.object({ slug: Joi.string().required() }),
         },
@@ -21,7 +22,7 @@ const register = async function (server) {
       path: '/api/modules/{moduleSlug}/elements/{elementId}/answers',
       config: {
         auth: false,
-        handler: modulesController.verifyAnswer,
+        handler: handlerWithDependencies(modulesController.verifyAnswer),
         validate: {
           params: Joi.object({
             moduleSlug: Joi.string().required(),

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -1,0 +1,17 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
+import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
+
+const dependencies = {
+  usecases,
+  elementAnswerSerializer,
+  moduleSerializer,
+};
+
+const handlerWithDependencies = (handler) => {
+  return (request, h) => {
+    return handler(request, h, dependencies);
+  };
+};
+
+export { handlerWithDependencies };


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, l'injection de dépendances dans les controllers se fait à l'aide d'imports par défauts. Cela implique que le fichier importe finalement les dépendances dont il a besoin, mais ça a l'avantage de pouvoir être remplacé pour tester unitairement. 

## :gift: Proposition
Wrapper nos handlers avec une fonction qui elle a toutes les dépendances liées au contexte de devcomp : 
- nos serializers 
- nos usecases 

Cette proposition a l'avantage d'être explicite : si on veut ce wrapper, on le dit explicitement et on bénéficie des dépendances. 

Exemple: 
```javascript
handler: handlerWithDependencies(modulesController.getBySlug),
```

## :socks: Remarques
[Une autre solution à base de plugin Hapi avait été envisagée](https://github.com/1024pix/pix/compare/dev...poc-inject-dependencies-in-controller), mais je la trouvais trop lié à hapi.js et moins explicite. 

Une évolution future serait d'importer dans `dependencies` directement tous les serializers. 

## :santa: Pour tester
- CI OK
- Aller sur Pix App et afficher un module `/modules/bien-ecrire-son-adresse-mail`.