### PR TITLE
[BUGFIX] Cacher le bouton détacher le profil cible pour les organisations qui sont référentes (PIX-10205)

### DIFF
--- a/admin/app/components/organizations/target-profiles-section.hbs
+++ b/admin/app/components/organizations/target-profiles-section.hbs
@@ -44,11 +44,13 @@
                     {{summary.name}}
                   </LinkTo>
                 </td>
-                {{#if (this.canDetachTargetProfile summary)}}
+                {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
                   <td>
-                    <PixButton @backgroundColor="red" @size="small" @triggerAction={{(fn this.openModal summary)}}>
-                      Détacher
-                    </PixButton>
+                    {{#if (this.canDetachTargetProfile summary)}}
+                      <PixButton @backgroundColor="red" @size="small" @triggerAction={{(fn this.openModal summary)}}>
+                        Détacher
+                      </PixButton>
+                    {{/if}}
                   </td>
                 {{/if}}
               </tr>

--- a/admin/app/components/organizations/target-profiles-section.js
+++ b/admin/app/components/organizations/target-profiles-section.js
@@ -19,9 +19,8 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
   }
 
   @action
-  canDetachTargetProfile({ isPublic }) {
-    console.log(this.accessControl);
-    return this.accessControl.hasAccessToOrganizationActionsScope && !isPublic;
+  canDetachTargetProfile({ canDetach }) {
+    return canDetach;
   }
 
   @action

--- a/admin/app/models/target-profile-summary.js
+++ b/admin/app/models/target-profile-summary.js
@@ -2,7 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TargetProfileSummary extends Model {
   @attr() name;
-  @attr() isPublic;
   @attr() outdated;
   @attr() createdAt;
+  @attr() canDetach;
 }

--- a/admin/tests/integration/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/integration/components/organizations/target-profiles-section_test.js
@@ -86,12 +86,12 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const publicTargetProfileSummary = store.createRecord('target-profile-summary', {
           id: 666,
           name: 'Number of The Beast',
-          isPublic: true,
+          canDetach: false,
         });
         const privateTargetProfileSummary = store.createRecord('target-profile-summary', {
           id: 777,
           name: 'Super Lucky',
-          isPublic: false,
+          canDetach: true,
         });
         const organization = store.createRecord('organization', {
           id: 1,
@@ -115,6 +115,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const targetProfileSummary = store.createRecord('target-profile-summary', {
           id: 666,
           name: 'Number of The Beast',
+          canDetach: true,
         });
         const organization = store.createRecord('organization', {
           id: 1,
@@ -143,6 +144,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const targetProfileSummary = store.createRecord('target-profile-summary', {
           id: 666,
           name: 'Number of The Beast',
+          canDetach: true,
         });
         const organization = store.createRecord('organization', {
           id: 1,
@@ -178,6 +180,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
             store.createRecord('target-profile-summary', {
               id: 666,
               name: 'Number of The Beast',
+              canDetach: true,
             }),
           ],
           get: sinon.stub().returns({ reload: sinon.stub() }),

--- a/admin/tests/unit/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/unit/components/organizations/target-profiles-section_test.js
@@ -165,7 +165,7 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
   });
 
   module('#canDetachTargetProfile', () => {
-    test('should return false if target profile is public and user can has access to organization action', function (assert) {
+    test('should return true if target profile is detachable and user can has access to organization action', function (assert) {
       //given
       class AccessControlStub extends Service {
         hasAccessToOrganizationActionsScope = true;
@@ -175,9 +175,9 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
       const component = createComponent('component:organizations/target-profiles-section');
 
       // then
-      assert.notOk(component.canDetachTargetProfile({ isPublic: true }));
+      assert.ok(component.canDetachTargetProfile({ canDetach: true }));
     });
-    test("should return false if target profile is public and user don't has access to organization action", function (assert) {
+    test("should return false if target profile is not detachable and user don't has access to organization action", function (assert) {
       //given
       class AccessControlStub extends Service {
         hasAccessToOrganizationActionsScope = false;
@@ -187,31 +187,7 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
       const component = createComponent('component:organizations/target-profiles-section');
 
       // then
-      assert.notOk(component.canDetachTargetProfile({ isPublic: true }));
-    });
-    test("should return false if target profile is private and user don't has access to organization action", function (assert) {
-      //given
-      class AccessControlStub extends Service {
-        hasAccessToOrganizationActionsScope = false;
-      }
-      this.owner.register('service:access-control', AccessControlStub);
-
-      const component = createComponent('component:organizations/target-profiles-section');
-
-      // then
-      assert.notOk(component.canDetachTargetProfile({ isPublic: false }));
-    });
-    test('should return true if target profile is private and user  has access to organization action', function (assert) {
-      //given
-      class AccessControlStub extends Service {
-        hasAccessToOrganizationActionsScope = true;
-      }
-      this.owner.register('service:access-control', AccessControlStub);
-
-      const component = createComponent('component:organizations/target-profiles-section');
-
-      // then
-      assert.ok(component.canDetachTargetProfile({ isPublic: false }));
+      assert.notOk(component.canDetachTargetProfile({ canDetach: false }));
     });
   });
 });

--- a/api/lib/domain/models/TargetProfileSummaryForAdmin.js
+++ b/api/lib/domain/models/TargetProfileSummaryForAdmin.js
@@ -1,10 +1,21 @@
 class TargetProfileSummaryForAdmin {
-  constructor({ id, name, isPublic, outdated, createdAt } = {}) {
-    this.id = id;
-    this.name = name;
-    this.outdated = outdated;
-    this.isPublic = isPublic;
-    this.createdAt = createdAt;
+  #isPublic;
+  #sharedOrganizationId;
+  #ownerOrganizationId;
+
+  constructor(params = {}) {
+    this.id = params.id;
+    this.name = params.name;
+    this.outdated = params.outdated;
+    this.createdAt = params.createdAt;
+    this.#isPublic = params.isPublic;
+    this.#sharedOrganizationId = params.sharedOrganizationId;
+    this.#ownerOrganizationId = params.ownerOrganizationId;
+  }
+  get canDetach() {
+    return (
+      !this.#isPublic && Boolean(this.#sharedOrganizationId) && this.#sharedOrganizationId !== this.#ownerOrganizationId
+    );
   }
 }
 

--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -23,6 +23,8 @@ const findByOrganization = async function ({ organizationId }) {
       name: 'target-profiles.name',
       outdated: 'target-profiles.outdated',
       isPublic: 'target-profiles.isPublic',
+      ownerOrganizationId: 'target-profiles.ownerOrganizationId',
+      sharedOrganizationId: 'target-profile-shares.organizationId',
     })
     .leftJoin('target-profile-shares', function () {
       this.on('target-profile-shares.targetProfileId', 'target-profiles.id').on(
@@ -47,7 +49,12 @@ const findByTraining = async function ({ trainingId, domainTransaction = DomainT
   const knexConn = domainTransaction?.knexTransaction || knex;
 
   const results = await knexConn('target-profiles')
-    .select({ id: 'target-profiles.id', name: 'target-profiles.name', outdated: 'target-profiles.outdated' })
+    .select({
+      id: 'target-profiles.id',
+      name: 'target-profiles.name',
+      outdated: 'target-profiles.outdated',
+      ownerOrganizationId: 'target-profiles.ownerOrganizationId',
+    })
     .innerJoin('target-profile-trainings', 'target-profiles.id', 'target-profile-trainings.targetProfileId')
     .where({ trainingId })
     .orderBy('id', 'ASC');

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (targetProfileSummaries, meta) {
   return new Serializer('target-profile-summary', {
-    attributes: ['name', 'isPublic', 'outdated', 'createdAt'],
+    attributes: ['name', 'outdated', 'createdAt', 'canDetach'],
     meta,
   }).serialize(targetProfileSummaries);
 };

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1202,8 +1202,8 @@ describe('Acceptance | Application | organization-controller', function () {
             attributes: {
               name: 'Super profil cible',
               outdated: false,
-              'is-public': true,
               'created-at': undefined,
+              'can-detach': false,
             },
           },
         ],

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -438,7 +438,6 @@ describe('Acceptance | Controller | training-controller', function () {
         id: 1,
         name: 'Super profil cible',
         outdated: false,
-        'is-public': undefined,
         'created-at': undefined,
       });
       databaseBuilder.factory.buildTargetProfileTraining({
@@ -453,8 +452,8 @@ describe('Acceptance | Controller | training-controller', function () {
         attributes: {
           name: targetProfile.name,
           outdated: false,
-          'is-public': undefined,
           'created-at': undefined,
+          'can-detach': false,
         },
       };
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -21,7 +21,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
       });
 
       // then
-      expect(actualTargetProfileSummary).to.deep.equal({ ...targetProfile, isPublic: undefined });
+      expect(actualTargetProfileSummary).to.deep.equal(targetProfile);
     });
 
     context('ordered target profile list', function () {
@@ -148,7 +148,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
             { id: 1, name: 'paTtErN', outdated: false, createdAt: new Date('2021-01-01') },
             { id: 2, name: 'AApatterNOo', outdated: true, createdAt: new Date('2021-01-01') },
             { id: 3, name: 'NotUnderTheRadar', outdated: false, createdAt: new Date('2021-01-01') },
-            { id: 4, name: 'PaTternXXXX', outdated: true, isPublic: true, createdAt: new Date('2021-01-01') },
+            { id: 4, name: 'PaTternXXXX', outdated: true, createdAt: new Date('2021-01-01') },
           ];
           targetProfileData.map(databaseBuilder.factory.buildTargetProfile);
           return databaseBuilder.commit();
@@ -339,8 +339,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', isPublic: false, outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -368,7 +368,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -407,8 +407,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', isPublic: false, outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -442,8 +442,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', isPublic: true, outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: true, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -471,7 +471,7 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', isPublic: true, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -513,9 +513,9 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
           // then
           const expectedTargetProfileSummaries = [
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'A_tp', isPublic: true, outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'B_tp', isPublic: false, outdated: false }),
-            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 12, name: 'C_tp', isPublic: false, outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 10, name: 'A_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'B_tp', outdated: false }),
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 12, name: 'C_tp', outdated: false }),
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
@@ -553,16 +553,8 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
 
       // then
       const expectedTargetProfileSummaries = [
-        domainBuilder.buildTargetProfileSummaryForAdmin({
-          ...targetProfile1,
-          isPublic: undefined,
-          createdAt: undefined,
-        }),
-        domainBuilder.buildTargetProfileSummaryForAdmin({
-          ...targetProfile2,
-          isPublic: undefined,
-          createdAt: undefined,
-        }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile1, createdAt: undefined }),
+        domainBuilder.buildTargetProfileSummaryForAdmin({ ...targetProfile2, createdAt: undefined }),
       ];
       expect(targetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
     });

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
@@ -6,6 +6,8 @@ const buildTargetProfileSummaryForAdmin = function ({
   outdated = false,
   isPublic,
   createdAt,
+  ownerOrganizationId,
+  sharedOrganizationId,
 } = {}) {
   return new TargetProfileSummaryForAdmin({
     id,
@@ -13,6 +15,8 @@ const buildTargetProfileSummaryForAdmin = function ({
     outdated,
     isPublic,
     createdAt,
+    ownerOrganizationId,
+    sharedOrganizationId,
   });
 };
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -531,7 +531,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
             attributes: {
               name: 'Super profil cible',
               outdated: false,
-              'is-public': undefined,
+              'can-detach': false,
               'created-at': undefined,
             },
           },

--- a/api/tests/unit/domain/models/TargetProfileSummaryForAdmin_test.js
+++ b/api/tests/unit/domain/models/TargetProfileSummaryForAdmin_test.js
@@ -1,0 +1,41 @@
+import { expect, domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Domain | Models | TargetProfileSummaryForAdmin', function () {
+  describe('#canDetach', function () {
+    describe('should returns true', function () {
+      it('when target profile is not public and organizationOwnerId is different from sharedOrganizationId', function () {
+        // given
+        const targetProfileSummary = domainBuilder.buildTargetProfileSummaryForAdmin({
+          isPublic: false,
+          ownerOrganisationId: 1,
+          sharedOrganizationId: 2,
+        });
+
+        // then
+        expect(targetProfileSummary.canDetach).to.be.true;
+      });
+    });
+    describe('should returns false', function () {
+      it('when target profile is public', function () {
+        // given
+        const targetProfileSummary = domainBuilder.buildTargetProfileSummaryForAdmin({
+          isPublic: false,
+        });
+
+        // then
+        expect(targetProfileSummary.canDetach).to.be.false;
+      });
+      it('when target profile is not public and is ownerOrganizationId equals sharedOrgnizationId ', function () {
+        // given
+        const targetProfileSummary = domainBuilder.buildTargetProfileSummaryForAdmin({
+          isPublic: false,
+          sharedOrganizationId: 1,
+          ownerOrganizationId: 1,
+        });
+
+        // then
+        expect(targetProfileSummary.canDetach).to.be.false;
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -9,14 +9,12 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 1,
           name: 'TPA',
-          isPublic: false,
           outdated: false,
           createdAt: new Date('2021-01-01'),
         }),
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 2,
           name: 'TPB',
-          isPublic: true,
           outdated: true,
           createdAt: new Date('2021-01-01'),
         }),
@@ -35,8 +33,8 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPA',
               outdated: false,
-              'is-public': false,
               'created-at': new Date('2021-01-01'),
+              'can-detach': false,
             },
           },
           {
@@ -45,8 +43,8 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
             attributes: {
               name: 'TPB',
               outdated: true,
-              'is-public': true,
               'created-at': new Date('2021-01-01'),
+              'can-detach': false,
             },
           },
         ],


### PR DESCRIPTION
## :christmas_tree: Problème
On a permis de détacher les PC depuis les orgas sans exclure l’orga de référence. 
On a donc un bouton “détacher” pour détacher l’orga de référence du PC, qui n’a pas d’effet car on ne peut pas détacher l’orga de référence de son PC. 

## :gift: Proposition
On ne veut pas voir le bouton “détacher” pour l’orga de référence du PC.

## :socks: Remarques
On utilise les propriétés privées des classes pour stocker les infos nécessaire au calcul de l'info de détachement d'un pc.
on `revert` une partie des changement introduit dans la PR #7528 (l'ajout de `isPublic` un peu partout suite à son ajout dans le modèle sous forme de propriété publique)

## :santa: Pour tester
Pour le fix
- se rendre sur l'Admin
- afficher l'orga 1000 (orga de référence sur le profil cible 6001)
- afficher l'onglet "Profil cible"
- ne pas voir le bouton détacher pour le profil cible 6001
Pour le non régression
- afficher l'orga 1003
- afficher l'onglet "Profil cible" 
- rattacher le profil cible 6001
- voir le bouton détacher pour le profil cible 6001
- cliquer sur détacher puis confirmer
- ne plus voir le bouton détacher.
