### PR TITLE
[TECH] Supprimer la clef de traduction current-lang de mon-pix

### DIFF
--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -12,7 +12,7 @@ export default BaseAuthenticator.extend({
   serverTokenEndpoint: `${ENV.APP.API_HOST}/api/token/anonymous`,
 
   async authenticate({ campaignCode }) {
-    const bodyObject = { campaign_code: campaignCode, lang: this.intl.t('current-lang') };
+    const bodyObject = { campaign_code: campaignCode, lang: this.intl.primaryLocale };
 
     const body = Object.keys(bodyObject)
       .map((k) => `${k}=${encodeURIComponent(bodyObject[k])}`)

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -45,7 +45,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
   }
 
   get currentLanguage() {
-    return this.intl.t('current-lang');
+    return this.intl.primaryLocale;
   }
 
   get cguUrl() {

--- a/mon-pix/app/components/data-protection-policy-information-banner.js
+++ b/mon-pix/app/components/data-protection-policy-information-banner.js
@@ -27,7 +27,7 @@ export default class DataProtectionPolicyInformationBanner extends Component {
   }
 
   get dataProtectionPolicyUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.prumaryLocale;
     if (currentLanguage === 'en') {
       return 'https://pix.org/en-gb/personal-data-protection-policy';
     }

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -126,7 +126,7 @@ export default class SignupForm extends Component {
     this.isLoading = true;
 
     this._trimNamesAndEmailOfUser();
-    this.args.user.lang = this.intl.t('current-lang');
+    this.args.user.lang = this.intl.primaryLocale;
 
     const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
 

--- a/mon-pix/app/controllers/authenticated/user-trainings.js
+++ b/mon-pix/app/controllers/authenticated/user-trainings.js
@@ -1,6 +1,9 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default class UserTrainingsController extends Controller {
+  @service intl;
+
   pageOptions = [
     { label: '8', value: 8 },
     { label: '16', value: 16 },

--- a/mon-pix/app/controllers/authenticated/user-tutorials/recommended.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/recommended.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 
 export default class RecommendedController extends Controller {
   @service router;
+  @service intl;
 
   @tracked isSidebarVisible = false;
 

--- a/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 
 export default class SavedController extends Controller {
   @service router;
+  @service intl;
 
   pageOptions = [
     { label: '10', value: 10 },

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -10,7 +10,7 @@ export default class textWithMultipleLang extends Helper {
     if (isHTMLSafe(text)) {
       text = text.toString();
     }
-    const lang = this.intl.t('current-lang');
+    const lang = this.intl.primaryLocale;
     const listOfLocales = this.intl.locales;
     let outputText = _clean(text, listOfLocales);
     if (text && listOfLocales.includes(lang)) {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -15,12 +15,12 @@ export default class Url extends Service {
   }
 
   get homeUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }
 
   get cguUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/conditions-generales-d-utilisation`;
     }
@@ -30,7 +30,7 @@ export default class Url extends Service {
   }
 
   get dataProtectionPolicyUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/politique-protection-donnees-personnelles-app`;
     }
@@ -41,7 +41,7 @@ export default class Url extends Service {
   }
 
   get _showcaseWebsiteUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
 
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
@@ -54,7 +54,7 @@ export default class Url extends Service {
   }
 
   get accessibilityUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/accessibilite`;
     }
@@ -64,7 +64,7 @@ export default class Url extends Service {
   }
 
   get accessibilityHelpUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return `https://pix.${this.currentDomain.getExtension()}/en-gb/help-accessibility`;
     }
@@ -72,7 +72,7 @@ export default class Url extends Service {
   }
 
   get supportHomeUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
 
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return 'https://support.pix.org/en/support/home';
@@ -81,7 +81,7 @@ export default class Url extends Service {
   }
 
   get levelSevenNewsUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
 
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return 'https://pix.org/en/news/discover-level-7-on-pix';

--- a/mon-pix/app/templates/authenticated/user-trainings.hbs
+++ b/mon-pix/app/templates/authenticated/user-trainings.hbs
@@ -18,7 +18,7 @@
         <PixPagination
           @pagination={{@model.trainings.meta.pagination}}
           @pageOptions={{this.pageOptions}}
-          @locale={{t "current-lang"}}
+          @locale={{this.intl.primaryLocale}}
           @isCondensed="true"
         />
       </div>

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -16,7 +16,7 @@
       <PixPagination
         @pagination={{@model.recommendedTutorials.meta.pagination}}
         @pageOptions={{this.pageOptions}}
-        @locale="{{t 'current-lang'}}"
+        @locale={{this.intl.primaryLocale}}
         @isCondensed="true"
       />
     {{else}}

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -10,7 +10,7 @@
       <PixPagination
         @pagination={{@model.savedTutorials.meta.pagination}}
         @pageOptions={{this.pageOptions}}
-        @locale="{{t 'current-lang'}}"
+        @locale={{this.intl.primaryLocale}}
         @isCondensed="true"
       />
     {{else}}

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -33,7 +33,7 @@ module('Unit | Component | signup-form', function (hooks) {
     }
 
     class IntlStub extends Service {
-      t = sinon.stub().returns('fr');
+      primaryLocale = 'fr';
       get = sinon.stub().returns(['fr']);
     }
 

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
@@ -25,7 +25,7 @@ module('Unit | Helper | text with multiple lang', function (hooks) {
     },
   ].forEach((expected) => {
     test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
-      textWithMultipleLangHelper.intl.t = () => expected.lang;
+      textWithMultipleLangHelper.intl.primaryLocale = expected.lang;
 
       assert.strictEqual(
         textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString(),

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -10,7 +10,7 @@ const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
-module('Unit | Service | locale', function (hooks) {
+module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
@@ -24,7 +24,7 @@ module('Unit | Service | locale', function (hooks) {
       const homeUrl = service.homeUrl;
 
       // then
-      const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${this.intl.t('current-lang')}`;
+      const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${this.intl.primaryLocale}`;
       assert.strictEqual(homeUrl, expectedDefinedHomeUrl);
     });
   });
@@ -33,7 +33,7 @@ module('Unit | Service | locale', function (hooks) {
     let defaultLocale;
 
     hooks.beforeEach(function () {
-      defaultLocale = this.intl.t('current-lang');
+      defaultLocale = this.intl.primaryLocale;
     });
 
     hooks.afterEach(function () {
@@ -103,7 +103,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
-          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
 
           // when
@@ -121,7 +121,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
-          service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
           const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
 
           // when
@@ -139,7 +139,7 @@ module('Unit | Service | locale', function (hooks) {
           service.currentDomain = { isFranceDomain: false };
           const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
           service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
-          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
 
           // when
           const cguUrl = service.cguUrl;
@@ -171,7 +171,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
-          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
 
           // when
@@ -189,7 +189,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
-          service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
           const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
 
           // when
@@ -205,7 +205,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
-          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
 
           // when
@@ -224,7 +224,7 @@ module('Unit | Service | locale', function (hooks) {
         // given
         const service = this.owner.lookup('service:url');
         service.currentDomain = { isFranceDomain: true };
-        service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+        service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
         const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
 
         // when
@@ -239,7 +239,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
-          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
 
           // when
@@ -257,7 +257,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
-          service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
           const expectedAccessibilityUrl = 'https://pix.org/fr/accessibilite';
 
           // when
@@ -273,7 +273,7 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
-          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
 
           // when
@@ -291,7 +291,7 @@ module('Unit | Service | locale', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       service.currentDomain = { isFranceDomain: true };
-      service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+      service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
       const expectedLevelSevenNewsUrl = 'https://pix.fr/actualites/decouvrez-le-niveau-7-des-maintenant-sur-pix';
 
       // when
@@ -306,7 +306,7 @@ module('Unit | Service | locale', function (hooks) {
         // given
         const service = this.owner.lookup('service:url');
         service.currentDomain = { isFranceDomain: false };
-        service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+        service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
         const expectedLevelSevenNewsUrl = 'https://pix.org/en/news/discover-level-7-on-pix';
 
         // when

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "en",
   "api-error-messages": {
     "join-error": {
       "r11": "{ value }",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "fr",
   "api-error-messages": {
     "join-error": {
       "r11": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R11)",


### PR DESCRIPTION
## :christmas_tree: Problème
Pour connaitre la langue actuelle de l'application, on utilise une clef de traduction `current-lang` avec la langue courante. 
Cela nécessite de bien mettre la langue que l'on traduit dans cette propriété, cela ne semble pas hyper intuitif.


## :gift: Proposition
Cela est inutile car on a la propriété `primaryLocale` sur l'objet `intl`: https://ember-intl.github.io/ember-intl/docs/guide/service-api#primarylocale-readonly

## :santa: Pour tester
Faire le tour de l'application pour vérifier que la locale est bien passé. Quelques endroits intéressant:
- les liens vers CGU et autre dans le formulaire de création de compte
- dans tutorials et trainings
