### PR TITLE
[TECH] Nettoyer le fichier .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,17 +8,13 @@
 
 # dependencies
 **/node_modules
-**/bower_components
 
 # misc
 **/.eslintcache
 **/.sass-cache
-**/connect.lock
-**/libpeerconnection.log
 **/npm-debug.log
 **/testem.log
 **/out.log
-**/api/.env
 **/*.log
 **/*.log.*
 
@@ -28,9 +24,6 @@
 !.idea/runConfigurations/*.xml
 *.iml
 *.code-workspace
-
-# SQLite3 local dev file
-*.sqlite3
 
 # system
 .DS_Store
@@ -78,16 +71,8 @@ api/scripts/extractions
 # Visual regression snapshots
 high-level-tests/e2e/cypress/snapshots/actual/**
 
-# Jupyter Notebook
-**/.cache
-**/.config
-**/.ipython
-**/.ipynb_checkpoints
-**/.local
-
 # Pipe viewer
 **/pv*.out
-
 
 # Docker-compose config
 docker/data/


### PR DESCRIPTION
## :christmas_tree: Problème
Le fichier .gitignore contient pas mal de choses qui ne devrait pas y être (genre tout ce qui est exclusion de fichier d'éditeur, ou système de type DS_STORE). Mais comme les dévelopeurs n'utilisent pas de gitignore global on les garde.
En revanche il y a vraiment des vieilleries ou des doublons (genre le .env).

## :gift: Proposition
Le supprimer.

## :santa: Pour tester
`git status` et voir qu'il n'y a pas plus de fichiers non tracker localement.
