### PR TITLE
[TECH] Permet de désactiver le logger en développement

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -22,6 +22,10 @@ function isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';
 }
 
+function isFeatureNotDisabled(environmentVariable) {
+  return environmentVariable !== 'false';
+}
+
 function _getNumber(numberAsString, defaultValue) {
   const number = parseInt(numberAsString, 10);
   return isNaN(number) ? defaultValue : number;
@@ -353,7 +357,7 @@ const configuration = (function () {
   };
 
   if (config.environment === 'development') {
-    config.logging.enabled = true;
+    config.logging.enabled = isFeatureNotDisabled(process.env.LOG_ENABLED);
   } else if (process.env.NODE_ENV === 'test') {
     config.auditLogger.baseUrl = 'http://audit-logger.local';
     config.auditLogger.clientSecret = 'client-super-secret';

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -22,10 +22,6 @@ function isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';
 }
 
-function isBooleanFeatureEnabledElseDefault(environmentVariable, defaultValue) {
-  return environmentVariable === 'true' ? true : defaultValue;
-}
-
 function _getNumber(numberAsString, defaultValue) {
   const number = parseInt(numberAsString, 10);
   return isNaN(number) ? defaultValue : number;
@@ -79,7 +75,7 @@ const configuration = (function () {
       },
     ],
     auditLogger: {
-      isEnabled: isBooleanFeatureEnabledElseDefault(process.env.PIX_AUDIT_LOGGER_ENABLED, false),
+      isEnabled: isFeatureEnabled(process.env.PIX_AUDIT_LOGGER_ENABLED),
       baseUrl: process.env.PIX_AUDIT_LOGGER_BASE_URL,
       clientSecret: process.env.PIX_AUDIT_LOGGER_CLIENT_SECRET,
     },
@@ -481,7 +477,7 @@ const configuration = (function () {
     config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };
     config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
-    config.logging.enabled = isBooleanFeatureEnabledElseDefault(process.env.TEST_LOG_ENABLED, false);
+    config.logging.enabled = isFeatureEnabled(process.env.TEST_LOG_ENABLED);
     config.logging.enableLogKnexQueries = false;
     config.logging.enableLogStartingEventDispatch = false;
     config.logging.enableLogEndingEventDispatch = false;


### PR DESCRIPTION
## :christmas_tree: Problème
Voir #4033

## :gift: Proposition
Ne pas suivre la recommandation de l'issue, mais regarder explicitement si le logging est désactivé.

## :santa: Pour tester

1. `NODE_ENV=development` et pas de `LOG_ENABLED`: on me voit
2. `NODE_ENV=development` et `LOG_ENABLED=false`: on me voit plus
1. `NODE_ENV=development` et `LOG_ENABLED=true`: on me voit
2. `NODE_ENV=production` et `LOG_ENABLED=false`: on me voit plus
3. `NODE_ENV=production` et `LOG_ENABLED=true`: on me voit
4. `NODE_ENV=production` et pas de  `LOG_ENABLED`: on me voit plus

Surprenant non ? Et encore l'API n'est pas en forme.