### PR TITLE
[FEATURE] Dependency injection in ES6 classes (TECH TIMES).

### DIFF
--- a/api/src/certification/session/application/session-controller.js
+++ b/api/src/certification/session/application/session-controller.js
@@ -25,7 +25,7 @@ const update = async function (request, h, dependencies = { sessionSerializer })
 const remove = async function (request, h) {
   const sessionId = request.params.id;
 
-  await usecases.deleteSession({ sessionId });
+  await usecases.deleteSession.execute({ sessionId });
 
   return h.response().code(204);
 };

--- a/api/src/certification/session/domain/usecases/delete-session.js
+++ b/api/src/certification/session/domain/usecases/delete-session.js
@@ -2,8 +2,9 @@
  * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
 import { SessionStartedDeletionError } from '../errors.js';
+import { UseCase } from '../../../../shared/domain/usecases/usecase.js';
 
-class DeleteSession {
+class DeleteSession extends UseCase {
   /** @type {deps['sessionRepository']} */
   #sessionRepository;
 
@@ -16,6 +17,7 @@ class DeleteSession {
    * @param {deps['certificationCourseRepository']} params.certificationCourseRepository
    */
   constructor({ sessionRepository, certificationCourseRepository }) {
+    super();
     this.#sessionRepository = sessionRepository;
     this.#certificationCourseRepository = certificationCourseRepository;
   }
@@ -40,7 +42,4 @@ class DeleteSession {
   }
 }
 
-const deleteSession = async ({ sessionId, sessionRepository, certificationCourseRepository }) => {
-  return new DeleteSession({ sessionRepository, certificationCourseRepository }).execute({ sessionId });
-};
-export { deleteSession };
+export { DeleteSession as deleteSession };

--- a/api/src/certification/session/domain/usecases/delete-session.js
+++ b/api/src/certification/session/domain/usecases/delete-session.js
@@ -1,27 +1,46 @@
-import { SessionStartedDeletionError } from '../errors.js';
-
 /**
  * @typedef {import ('../../../shared/domain/usecases/index.js').dependencies} deps
  */
+import { SessionStartedDeletionError } from '../errors.js';
 
-/**
- * @param {Object} params
- * @param {deps['sessionRepository']} params.sessionRepository
- * @param {deps['certificationCourseRepository']} params.certificationCourseRepository
- */
-const deleteSession = async function ({ sessionId, sessionRepository, certificationCourseRepository }) {
-  if (await _isSessionStarted(certificationCourseRepository, sessionId)) {
-    throw new SessionStartedDeletionError();
+class DeleteSession {
+  /** @type {deps['sessionRepository']} */
+  #sessionRepository;
+
+  /** @type {deps['certificationCourseRepository']} */
+  #certificationCourseRepository;
+
+  /**
+   * @param {Object} params
+   * @param {deps['sessionRepository']} params.sessionRepository
+   * @param {deps['certificationCourseRepository']} params.certificationCourseRepository
+   */
+  constructor({ sessionRepository, certificationCourseRepository }) {
+    this.#sessionRepository = sessionRepository;
+    this.#certificationCourseRepository = certificationCourseRepository;
   }
 
-  await sessionRepository.remove(sessionId);
-};
+  /**
+   * @param {Object} params
+   * @param {integer} params.sessionId - session identifier
+   */
+  async execute({ sessionId }) {
+    if (await this.#isSessionStarted(sessionId)) {
+      throw new SessionStartedDeletionError();
+    }
 
-export { deleteSession };
+    await this.#sessionRepository.remove(sessionId);
+  }
 
-async function _isSessionStarted(certificationCourseRepository, sessionId) {
-  const foundCertificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({
-    sessionId,
-  });
-  return foundCertificationCourses.length > 0;
+  async #isSessionStarted(sessionId) {
+    const foundCertificationCourses = await this.#certificationCourseRepository.findCertificationCoursesBySessionId({
+      sessionId,
+    });
+    return foundCertificationCourses.length > 0;
+  }
 }
+
+const deleteSession = async ({ sessionId, sessionRepository, certificationCourseRepository }) => {
+  return new DeleteSession({ sessionRepository, certificationCourseRepository }).execute({ sessionId });
+};
+export { deleteSession };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -54,6 +54,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
  *  certificationCpfService : certificationCpfService,
  *  certificationIssueReportRepository : certificationIssueReportRepository,
  *  challengeRepository : challengeRepository,
+ *  certificationCourseRepository : certificationCourseRepository,
  *  certificationCpfCityRepository : certificationCpfCityRepository,
  *  certificationCpfCountryRepository : certificationCpfCountryRepository,
  *  certificationOfficerRepository: certificationOfficerRepository,

--- a/api/src/shared/domain/usecases/usecase.js
+++ b/api/src/shared/domain/usecases/usecase.js
@@ -1,0 +1,3 @@
+class UseCase {}
+
+export { UseCase };

--- a/api/src/shared/infrastructure/utils/dependency-injection.js
+++ b/api/src/shared/infrastructure/utils/dependency-injection.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { UseCase } from '../../domain/usecases/usecase.js';
 
 function injectDefaults(defaults, targetFn) {
   return (args) => targetFn(Object.assign(Object.create(defaults), args));
@@ -6,6 +7,9 @@ function injectDefaults(defaults, targetFn) {
 
 function injectDependencies(toBeInjected, dependencies) {
   return _.mapValues(toBeInjected, (value) => {
+    if (Object.prototype.isPrototypeOf.call(UseCase, value)) {
+      return new value(dependencies);
+    }
     if (_.isFunction(value)) {
       return _.partial(injectDefaults, dependencies, value)();
     } else {

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/delete-session_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/delete-session_test.js
@@ -11,11 +11,10 @@ describe('Unit | UseCase | delete-session', function () {
       certificationCourseRepository.findCertificationCoursesBySessionId.resolves([]);
 
       // when
-      await deleteSession({
-        sessionId: 123,
+      await new deleteSession({
         sessionRepository,
         certificationCourseRepository,
-      });
+      }).execute({ sessionId: 123 });
 
       // then
       expect(sessionRepository.remove).to.have.been.calledWithExactly(123);
@@ -32,11 +31,11 @@ describe('Unit | UseCase | delete-session', function () {
       ]);
 
       // when
-      const error = await catchErr(deleteSession)({
-        sessionId: 123,
+      const service = new deleteSession({
         sessionRepository,
         certificationCourseRepository,
       });
+      const error = await catchErr(service.execute, service)({ sessionId: 123 });
 
       // then
       expect(error).to.be.instanceOf(SessionStartedDeletionError);

--- a/api/tests/certification/session/unit/application/session-controller_test.js
+++ b/api/tests/certification/session/unit/application/session-controller_test.js
@@ -131,7 +131,7 @@ describe('Unit | Controller | session-controller', function () {
       // given
       const sessionId = 1;
       const userId = 1;
-      sinon.stub(usecases, 'deleteSession');
+      sinon.stub(usecases.deleteSession, 'execute');
       const request = {
         params: { id: sessionId },
         auth: {
@@ -145,7 +145,7 @@ describe('Unit | Controller | session-controller', function () {
       await sessionController.remove(request, hFake);
 
       // then
-      expect(usecases.deleteSession).to.have.been.calledWithExactly({
+      expect(usecases.deleteSession.execute).to.have.been.calledWithExactly({
         sessionId,
       });
     });

--- a/api/tests/shared/unit/infrastructure/utils/dependency-injection_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/dependency-injection_test.js
@@ -1,5 +1,6 @@
 import { expect } from '../../../../test-helper.js';
 import { injectDependencies } from '../../../../../src/shared/infrastructure/utils/dependency-injection.js';
+import { UseCase } from '../../../../../src/shared/domain/usecases/usecase.js';
 
 describe('Unit | Utils | #injectDependencies', function () {
   context('when the object value to be injected is a function', function () {
@@ -18,6 +19,32 @@ describe('Unit | Utils | #injectDependencies', function () {
 
       // then
       expect(injected.functionToBeInjected({})).to.equal(dependency);
+    });
+  });
+
+  context('when the object value to be injected is a prototype of UseCase class', function () {
+    it('should inject dependencies by name', function () {
+      // given
+      const dependency = Symbol('a dependency');
+      const dependencies = { dependency };
+      class TestUseCase extends UseCase {
+        constructor({ dependency }) {
+          super();
+          this.dependency = dependency;
+        }
+        execute() {
+          return this.dependency;
+        }
+      }
+      const toBeInjected = {
+        myClass: TestUseCase,
+      };
+
+      // when
+      const injected = injectDependencies(toBeInjected, dependencies);
+
+      // then
+      expect(injected.myClass.execute()).to.equal(dependency);
     });
   });
 


### PR DESCRIPTION
⚠️ Conclusion en vue de clotûre : https://github.com/1024pix/pix/pull/7593#issuecomment-1976195231

## :christmas_tree: Problème

Dans le modèle actuel les usecases sont un ensemble de fonctions publiques + privées dans lesquelles se baladent les dependances injectées.

Cela 
* Ajoute beaucoup de verbosité à notre code notament au niveau signature des fonctions
* Fait notamment perdre les apports de la JSDoc ou en ajouter un peu inutilement (doit être dupliquée sur les fonctions privées)

## :gift: Proposition

* Utiliser des classes ES6 pour encapsuler notre code et
  * partager les dépendances injectées et bénéficier partout de la JSDoc automatiquement
  * amincir les signature de fonctions privées (`@type` sur attributs de classe)
* Ajouter à l'injection de dépendance la capacité à instancier des classes avec ses dépendances

## :socks: Remarques

Améliroation à apporter pour un prochain commit 

* On 'triche' un peu car la `class` porte une notion pour l'injection de dépendances, à savoir l'aliasing `... as ...` pour garder la cohérence de démarrer l'appel des usecases par une minuscule (`usecases.deleteSession`. Voir plus bas.
* Next steps
  * Faire porter l'aliasing par le mécanisme d'injection de dépendances pour que la class reste "pure"

Le TODO :

```
// TODO :
// Etape 1 Créer un Proxy autour de 'value', c'est à dire différentier la création
//    de l'empreinte injectée et de l'instanciation
//
// Etape 2 nom = nom de la class en camelCase (virer le 'as')
//
// A discuter :
//     Etape 3 => forward to execute direct ?
//     ~ a voir parce que ça peut empêcher d'être "libre" du nom de la fonction `execute`
//     par exemple avoir plusieurs `execute` pour un même usecase.
``` 

## :santa: Pour tester

* La CICD se lance et passe au vert ✅ 
* L'API se lance
