### PR TITLE
[TECH] Auto rebuild libxmljs2 on ARM64 macs

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -148,6 +148,7 @@
     "lint:translations:fix": "npm run lint:translations -- --fix",
     "postdeploy": "DEBUG=knex:* npm run db:migrate",
     "preinstall": "npx check-engine",
+    "postinstall": "node scripts/install-libxmljs2/check-if-build-is-compatible.js",
     "scalingo-postbuild": "node scripts/generate-cron > cron.json",
     "start": "node index.js",
     "start:watch": "nodemon index.js",

--- a/api/scripts/install-libxmljs2/check-if-build-is-compatible.js
+++ b/api/scripts/install-libxmljs2/check-if-build-is-compatible.js
@@ -1,0 +1,16 @@
+import cp from 'child_process';
+import { stdout, stderr } from 'node:process';
+import os from 'os';
+
+// Currently built binary of libxmljs2 is node compatible with node20 on
+// arm64 macs. We rebuild the binary if its import fails.
+try {
+  if (os.platform() === 'darwin' && os.arch() === 'arm64') {
+    // eslint-disable-next-line n/no-unpublished-import
+    await import('libxmljs2');
+  }
+} catch (err) {
+  const process = cp.exec('npm run build', { cwd: './node_modules/libxmljs2' });
+  process.stdout.pipe(stdout);
+  process.stderr.pipe(stderr);
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le binaire installé par libxmljs2 pour node20 n'est pas compatible avec node20 sur les mac ARM64.

## :gift: Proposition
Si la version de la lib ne peut être chargée, nous la rebuildons en post-install.

## :santa: Pour tester

Sur mac M1/M2
```
npm ci
// le rebuild doit se produire

npm i
// le rebuild ne se produit pas
```