### PR TITLE
[TECH] Supprimer la clef de traduction current-lang de orga

### DIFF
--- a/orga/app/helpers/text-with-multiple-lang.js
+++ b/orga/app/helpers/text-with-multiple-lang.js
@@ -10,7 +10,7 @@ export default class textWithMultipleLang extends Helper {
     if (isHTMLSafe(text)) {
       text = text.toString();
     }
-    const lang = this.intl.t('current-lang');
+    const lang = this.intl.primaryLocale;
     const listOfLocales = this.intl.locales;
     let outputText = _clean(text, listOfLocales);
 

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -42,7 +42,7 @@ export default class Url extends Service {
   }
 
   get homeUrl() {
-    const currentLanguage = this.intl.get('primaryLocale');
+    const currentLanguage = this.intl.primaryLocale;
     return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }
 
@@ -67,7 +67,7 @@ export default class Url extends Service {
   }
 
   get forgottenPasswordUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
     if (currentLanguage === 'en') {
       url += '?lang=en';
@@ -76,7 +76,7 @@ export default class Url extends Service {
   }
 
   _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath }) {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
 
     if (this.currentDomain.isFranceDomain) {
       return `${PIX_FR_DOMAIN}${frenchPath}`;

--- a/orga/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/orga/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -25,7 +25,7 @@ module('Unit | Helper | TextWithMultipleLang', function (hooks) {
   ].forEach((expected) => {
     test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
       // given
-      helper.intl.t = () => expected.lang;
+      helper.intl.primaryLocale = expected.lang;
 
       // when
       const computedText = helper.compute([expected.text]).toString();

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -36,18 +36,6 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#homeUrl', function () {
-    test('calls intl to get first locale configured', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      sinon.spy(this.intl, 'get');
-
-      // when
-      service.homeUrl;
-
-      // then
-      assert.ok(this.intl.get.calledWith('primaryLocale'));
-    });
-
     test('returns home url with current locale', function (assert) {
       // given
       const currentLocale = 'en';
@@ -70,6 +58,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.fr/mentions-legales';
       service.currentDomain = { isFranceDomain: true };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const url = service.legalNoticeUrl;
@@ -83,7 +72,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/en-gb/legal-notice';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const url = service.legalNoticeUrl;
@@ -97,7 +86,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/mentions-legales';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const url = service.legalNoticeUrl;
@@ -113,6 +102,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
       service.currentDomain = { isFranceDomain: true };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const cguUrl = service.dataProtectionPolicyUrl;
@@ -126,7 +116,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const cguUrl = service.dataProtectionPolicyUrl;
@@ -140,7 +130,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const cguUrl = service.dataProtectionPolicyUrl;
@@ -156,6 +146,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
       service.currentDomain = { isFranceDomain: true };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const cguUrl = service.cguUrl;
@@ -169,7 +160,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const cguUrl = service.cguUrl;
@@ -183,7 +174,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const cguUrl = service.cguUrl;
@@ -199,6 +190,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
       service.currentDomain = { isFranceDomain: true };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const url = service.accessibilityUrl;
@@ -212,7 +204,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/en-gb/accessibility-pix-orga';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const url = service.accessibilityUrl;
@@ -226,7 +218,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/accessibilite-pix-orga';
       service.currentDomain = { isFranceDomain: false };
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const url = service.accessibilityUrl;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "en",
   "api-error-messages": {
     "campaign-creation": {
       "custom-landing-page_too_long": "Please choose a shorter text to display on the starting page.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "fr",
   "api-error-messages": {
     "campaign-creation": {
       "custom-landing-page_too_long": "Le texte de présentation de la campagne est trop long.",


### PR DESCRIPTION
## :christmas_tree: Problème

Pour connaitre la langue actuelle de l'application, on utilise une clef de traduction current-lang avec la langue courante.
Cela nécessite de bien mettre la langue que l'on traduit dans cette propriété, cela ne semble pas hyper intuitif.

Suite de #7585 sur orga

## :gift: Proposition
Cela est inutile car on a la propriété primaryLocale sur l'objet intl: https://ember-intl.github.io/ember-intl/docs/guide/service-api#primarylocale-readonly

## :santa: Pour tester
Regarder les urls en org et fr pour:
- le reset de mot de passe
- le site vitrine
