### PR TITLE
[TECH] Supprimer la clef de traduction current-lang de certif

### DIFF
--- a/certif/app/components/no-session-panel.js
+++ b/certif/app/components/no-session-panel.js
@@ -12,7 +12,7 @@ export default class PanelHeader extends Component {
 
   get shouldRenderImportTemplateButton() {
     const topLevelDomain = this.currentDomain.getExtension();
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
 
     return !this.isScoManagingStudents && !isOrgTldAndEnglishCurrentLanguage;

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -8,7 +8,7 @@ export default class PanelHeader extends Component {
 
   get shouldRenderImportTemplateButton() {
     const topLevelDomain = this.currentDomain.getExtension();
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
 
     return (

--- a/certif/app/controllers/terms-of-service.js
+++ b/certif/app/controllers/terms-of-service.js
@@ -9,7 +9,7 @@ export default class TermsOfServiceController extends Controller {
   @service router;
   @service intl;
 
-  @tracked isEnglishLocale = this.intl.t('current-lang') === 'en';
+  @tracked isEnglishLocale = this.intl.primaryLocale === 'en';
 
   @action
   async submit() {

--- a/certif/app/helpers/text-with-multiple-lang.js
+++ b/certif/app/helpers/text-with-multiple-lang.js
@@ -10,7 +10,7 @@ export default class textWithMultipleLang extends Helper {
     if (isHTMLSafe(text)) {
       text = text.toString();
     }
-    const lang = this.intl.t('current-lang');
+    const lang = this.intl.primaryLocale;
     const listOfLocales = this.intl.locales;
     let outputText = _clean(text, listOfLocales);
 

--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -9,7 +9,7 @@ export default class ImportRoute extends Route {
 
   beforeModel() {
     const topLevelDomain = this.currentDomain.getExtension();
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
 
     if (

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -76,10 +76,10 @@ export default class Url extends Service {
   }
 
   #isFrenchSpoken() {
-    return this.intl.t('current-lang') === 'fr';
+    return this.intl.primaryLocale === 'fr';
   }
 
   #isEnglishSpoken() {
-    return this.intl.t('current-lang') === 'en';
+    return this.intl.primaryLocale === 'en';
   }
 }

--- a/certif/tests/unit/components/no-session-panel_test.js
+++ b/certif/tests/unit/components/no-session-panel_test.js
@@ -31,7 +31,7 @@ module('Unit | Component | no-session-panel', function (hooks) {
             getExtension = sinon.stub().returns('org');
           }
           class IntlStub extends Service {
-            t = sinon.stub().returns('fr');
+            primaryLocale = 'fr';
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
@@ -61,7 +61,7 @@ module('Unit | Component | no-session-panel', function (hooks) {
             getExtension = sinon.stub().returns('org');
           }
           class IntlStub extends Service {
-            t = sinon.stub().returns('en');
+            primaryLocale = 'en';
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
@@ -93,7 +93,7 @@ module('Unit | Component | no-session-panel', function (hooks) {
           getExtension = sinon.stub().returns('fr');
         }
         class IntlStub extends Service {
-          t = sinon.stub().returns('fr');
+          primaryLocale = 'fr';
         }
 
         this.owner.register('service:current-domain', CurrentDomainStub);

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -31,7 +31,7 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
             getExtension = sinon.stub().returns('org');
           }
           class IntlStub extends Service {
-            t = sinon.stub().returns('fr');
+            primaryLocale = 'fr';
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
@@ -61,7 +61,7 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
             getExtension = sinon.stub().returns('org');
           }
           class IntlStub extends Service {
-            t = sinon.stub().returns('en');
+            primaryLocale = 'en';
           }
 
           this.owner.register('service:current-domain', CurrentDomainStub);
@@ -93,7 +93,7 @@ module('Unit | Component | sessions | panel-header', function (hooks) {
           getExtension = sinon.stub().returns('fr');
         }
         class IntlStub extends Service {
-          t = sinon.stub().returns('fr');
+          primaryLocale = 'fr';
         }
 
         this.owner.register('service:current-domain', CurrentDomainStub);

--- a/certif/tests/unit/helpers/text-with-multiple-lang_test.js
+++ b/certif/tests/unit/helpers/text-with-multiple-lang_test.js
@@ -24,7 +24,7 @@ module('Unit | Helper | text with multiple lang', function (hooks) {
     },
   ].forEach((expected) => {
     test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
-      textWithMultipleLangHelper.intl.t = () => expected.lang;
+      textWithMultipleLangHelper.intl.primaryLocale = expected.lang;
 
       assert.strictEqual(
         textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString(),

--- a/certif/tests/unit/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/import_test.js
@@ -23,7 +23,7 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
           getExtension = sinon.stub().returns('org');
         }
         class IntlStub extends Service {
-          t = sinon.stub().returns('fr');
+          primaryLocale = 'fr';
         }
         class RouterStub extends Service {
           replaceWith = sinon.stub().resolves();
@@ -59,7 +59,7 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
           getExtension = sinon.stub().returns('org');
         }
         class IntlStub extends Service {
-          t = sinon.stub().returns('en');
+          primaryLocale = 'en';
         }
         class RouterStub extends Service {
           replaceWith = sinon.stub().resolves();
@@ -96,7 +96,7 @@ module('Unit | Route | authenticated/sessions/import', function (hooks) {
         getExtension = sinon.stub().returns('fr');
       }
       class IntlStub extends Service {
-        t = sinon.stub().returns('fr');
+        primaryLocale = 'fr';
       }
       class RouterStub extends Service {
         replaceWith = sinon.stub().resolves();

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -29,7 +29,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
@@ -43,7 +43,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedDataProtectionPolicyUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
@@ -72,7 +72,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const cguUrl = service.cguUrl;
@@ -86,7 +86,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const cguUrl = service.cguUrl;
@@ -115,7 +115,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie?lang=en';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      service.intl = { t: sinon.stub().returns('en') };
+      service.intl = { primaryLocale: 'en' };
 
       // when
       const forgottenPasswordUrl = service.forgottenPasswordUrl;
@@ -129,7 +129,7 @@ module('Unit | Service | url', function (hooks) {
       const service = this.owner.lookup('service:url');
       const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-      service.intl = { t: sinon.stub().returns('fr') };
+      service.intl = { primaryLocale: 'fr' };
 
       // when
       const forgottenPasswordUrl = service.forgottenPasswordUrl;
@@ -160,7 +160,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { t: sinon.stub().returns('en') };
+          service.intl = { primaryLocale: 'en' };
 
           // when
           const legalNoticeUrl = service.legalNoticeUrl;
@@ -175,7 +175,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { t: sinon.stub().returns('fr') };
+          service.intl = { primaryLocale: 'fr' };
 
           // when
           const legalNoticeUrl = service.legalNoticeUrl;
@@ -208,7 +208,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { t: sinon.stub().returns('en') };
+          service.intl = { primaryLocale: 'en' };
 
           // when
           const accessibilityUrl = service.accessibilityUrl;
@@ -223,7 +223,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { t: sinon.stub().returns('fr') };
+          service.intl = { primaryLocale: 'fr' };
 
           // when
           const accessibilityUrl = service.accessibilityUrl;
@@ -256,7 +256,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { t: sinon.stub().returns('en') };
+          service.intl = { primaryLocale: 'en' };
 
           // when
           const supportUrl = service.supportUrl;
@@ -271,7 +271,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
-          service.intl = { t: sinon.stub().returns('fr') };
+          service.intl = { primaryLocale: 'fr' };
 
           // when
           const supportUrl = service.supportUrl;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "en",
   "common": {
     "actions": {
       "add": "Add",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "fr",
   "common": {
     "actions": {
       "add": "Ajouter",


### PR DESCRIPTION
## :christmas_tree: Problème

Pour connaitre la langue actuelle de l'application, on utilise une clef de traduction current-lang avec la langue courante.
Cela nécessite de bien mettre la langue que l'on traduit dans cette propriété, cela ne semble pas hyper intuitif.

Suite de #7585 sur certif

## :gift: Proposition
Cela est inutile car on a la propriété primaryLocale sur l'objet intl: https://ember-intl.github.io/ember-intl/docs/guide/service-api#primarylocale-readonly

## :santa: Pour tester
Regarder les urls en org et fr pour:
- le site vitrine
