### PR TITLE
[TECH] Passer le versionning de `@fortawesome/fontawesome-svg-core` en `^`

### DIFF
--- a/1d/package-lock.json
+++ b/1d/package-lock.json
@@ -23,7 +23,7 @@
         "@embroider/core": "^3.0.0",
         "@embroider/webpack": "^3.0.0",
         "@fortawesome/ember-fontawesome": "^2.0.0",
-        "@fortawesome/fontawesome-svg-core": "6.5.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.1",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@glimmer/component": "^1.1.2",

--- a/1d/package.json
+++ b/1d/package.json
@@ -47,7 +47,7 @@
     "@embroider/core": "^3.0.0",
     "@embroider/webpack": "^3.0.0",
     "@fortawesome/ember-fontawesome": "^2.0.0",
-    "@fortawesome/fontawesome-svg-core": "6.5.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@glimmer/component": "^1.1.2",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -23,7 +23,7 @@
         "@embroider/webpack": "^3.1.4",
         "@formatjs/intl": "^2.5.1",
         "@fortawesome/ember-fontawesome": "^2.0.0",
-        "@fortawesome/fontawesome-svg-core": "6.5.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.0",
         "@fortawesome/free-brands-svg-icons": "^6.2.1",
         "@fortawesome/free-regular-svg-icons": "^6.2.1",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -54,7 +54,7 @@
     "@embroider/webpack": "^3.1.4",
     "@formatjs/intl": "^2.5.1",
     "@fortawesome/ember-fontawesome": "^2.0.0",
-    "@fortawesome/fontawesome-svg-core": "6.5.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-regular-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -24,7 +24,7 @@
         "@embroider/webpack": "^3.0.0",
         "@formatjs/intl": "^2.9.1",
         "@fortawesome/ember-fontawesome": "^2.0.0",
-        "@fortawesome/fontawesome-svg-core": "6.5.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.0",
         "@fortawesome/free-brands-svg-icons": "^6.2.1",
         "@fortawesome/free-regular-svg-icons": "^6.2.1",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -55,7 +55,7 @@
     "@embroider/webpack": "^3.0.0",
     "@formatjs/intl": "^2.9.1",
     "@fortawesome/ember-fontawesome": "^2.0.0",
-    "@fortawesome/fontawesome-svg-core": "6.5.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-regular-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -29,7 +29,7 @@
         "@formatjs/intl-locale": "^3.0.7",
         "@formatjs/intl-pluralrules": "^5.1.4",
         "@fortawesome/ember-fontawesome": "^2.0.0",
-        "@fortawesome/fontawesome-svg-core": "6.5.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.0",
         "@fortawesome/free-brands-svg-icons": "^6.2.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -60,7 +60,7 @@
     "@formatjs/intl-locale": "^3.0.7",
     "@formatjs/intl-pluralrules": "^5.1.4",
     "@fortawesome/ember-fontawesome": "^2.0.0",
-    "@fortawesome/fontawesome-svg-core": "6.5.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -28,7 +28,7 @@
         "@formatjs/intl-locale": "^3.0.11",
         "@formatjs/intl-pluralrules": "^5.1.8",
         "@fortawesome/ember-fontawesome": "^2.0.0",
-        "@fortawesome/fontawesome-svg-core": "6.5.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.1",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@glimmer/component": "^1.1.2",

--- a/orga/package.json
+++ b/orga/package.json
@@ -59,7 +59,7 @@
     "@formatjs/intl-locale": "^3.0.11",
     "@formatjs/intl-pluralrules": "^5.1.8",
     "@fortawesome/ember-fontawesome": "^2.0.0",
-    "@fortawesome/fontawesome-svg-core": "6.5.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@glimmer/component": "^1.1.2",


### PR DESCRIPTION
## :christmas_tree: Problème
On pin la version de `@fortawesome/fontawesome-svg-core` alors qu'elle ne porte pas de risque de mise à jour.

## :gift: Proposition
Utiliser la stratégie permettant de monter les mineurs et patchs comme la majorité des dépendances, via `^`.

## :socks: Remarques
RAS

## :santa: Pour tester
Vérifier que la CI passe.
