### PR TITLE
[FEATURE][CERTIF] Permettre à un administrateur de renvoyer une invitation en attente (PIX-9786)

### DIFF
--- a/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
+++ b/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
@@ -1,5 +1,6 @@
 import { usecases } from '../../domain/usecases/index.js';
-import * as certificationCenterInvitationSerializer from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
+import { certificationCenterInvitationSerializer } from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
+import { requestResponseUtils } from '../../infrastructure/utils/request-response-utils.js';
 
 const acceptCertificationCenterInvitation = async function (request, h) {
   const certificationCenterInvitationId = request.params.id;
@@ -33,10 +34,23 @@ const cancelCertificationCenterInvitation = async function (request, h) {
   return h.response().code(204);
 };
 
+const resendCertificationCenterInvitation = async function (request, h) {
+  const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
+  const locale = requestResponseUtils.extractLocaleFromRequest(request);
+
+  const certificationCenterInvitation = await usecases.resendCertificationCenterInvitation({
+    certificationCenterInvitationId,
+    locale,
+  });
+
+  return h.response(certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitation)).code(200);
+};
+
 const certificationCenterInvitationController = {
   acceptCertificationCenterInvitation,
   getCertificationCenterInvitation,
   cancelCertificationCenterInvitation,
+  resendCertificationCenterInvitation,
 };
 
 export { certificationCenterInvitationController };

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -105,6 +105,29 @@ const register = async function (server) {
         tags: ['api', 'certification-center-invitation'],
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/certification-center-invitations/{certificationCenterInvitationId}',
+      config: {
+        handler: certificationCenterInvitationController.resendCertificationCenterInvitation,
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
+            assign: 'isAdminOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterInvitationId: identifiersType.certificationCenterInvitationId.required(),
+          }),
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification**\n',
+          "- Cette route permet de renvoyer une invitation en attente selon un **id d'invitation**",
+        ],
+        tags: ['api', 'certification-center-invitation'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/services/certification-center-invitation-service.js
+++ b/api/lib/domain/services/certification-center-invitation-service.js
@@ -28,28 +28,46 @@ const createOrUpdateCertificationCenterInvitation = function ({
       );
     }
 
-    const mailerResponse = await mailService.sendCertificationCenterInvitationEmail({
-      certificationCenterInvitationId: certificationCenterInvitation.id,
-      certificationCenterName: certificationCenter.name,
-      code: certificationCenterInvitation.code,
+    await _sendInvitationEmail(
+      mailService,
+      certificationCenterInvitation,
+      certificationCenter,
       email,
       locale,
-    });
-
-    if (mailerResponse.status !== 'SUCCESS') {
-      if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
-        throw new SendingEmailToInvalidDomainError(email);
-      }
-
-      if (mailerResponse.hasFailedBecauseEmailWasInvalid()) {
-        throw new SendingEmailToInvalidEmailAddressError(email, mailerResponse.errorMessage);
-      }
-
-      throw new SendingEmailError();
-    }
-
-    await certificationCenterInvitationRepository.updateModificationDate(certificationCenterInvitation.id);
+      certificationCenterInvitationRepository,
+    );
   };
 };
 
 export { createOrUpdateCertificationCenterInvitation };
+
+async function _sendInvitationEmail(
+  mailService,
+  certificationCenterInvitation,
+  certificationCenter,
+  email,
+  locale,
+  certificationCenterInvitationRepository,
+) {
+  const mailerResponse = await mailService.sendCertificationCenterInvitationEmail({
+    certificationCenterInvitationId: certificationCenterInvitation.id,
+    certificationCenterName: certificationCenter.name,
+    code: certificationCenterInvitation.code,
+    email,
+    locale,
+  });
+
+  if (mailerResponse.status !== 'SUCCESS') {
+    if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+      throw new SendingEmailToInvalidDomainError(email);
+    }
+
+    if (mailerResponse.hasFailedBecauseEmailWasInvalid()) {
+      throw new SendingEmailToInvalidEmailAddressError(email, mailerResponse.errorMessage);
+    }
+
+    throw new SendingEmailError();
+  }
+
+  await certificationCenterInvitationRepository.updateModificationDate(certificationCenterInvitation.id);
+}

--- a/api/lib/domain/services/certification-center-invitation-service.js
+++ b/api/lib/domain/services/certification-center-invitation-service.js
@@ -39,7 +39,23 @@ const createOrUpdateCertificationCenterInvitation = function ({
   };
 };
 
-export { createOrUpdateCertificationCenterInvitation };
+const resendCertificationCenterInvitation = function ({
+  certificationCenterInvitationRepository,
+  mailService = maillingService,
+}) {
+  return async function ({ certificationCenter, certificationCenterInvitation, locale }) {
+    await _sendInvitationEmail(
+      mailService,
+      certificationCenterInvitation,
+      certificationCenter,
+      certificationCenterInvitation.email,
+      locale,
+      certificationCenterInvitationRepository,
+    );
+  };
+};
+
+export { createOrUpdateCertificationCenterInvitation, resendCertificationCenterInvitation };
 
 async function _sendInvitationEmail(
   mailService,

--- a/api/lib/domain/usecases/resend-certification-center-invitation.js
+++ b/api/lib/domain/usecases/resend-certification-center-invitation.js
@@ -1,0 +1,25 @@
+const resendCertificationCenterInvitation = async function ({
+  certificationCenterInvitationId,
+  locale,
+  certificationCenterRepository,
+  certificationCenterInvitationRepository,
+  certificationCenterInvitationService,
+}) {
+  const certificationCenterInvitation = await certificationCenterInvitationRepository.get(
+    certificationCenterInvitationId,
+  );
+  const certificationCenter = await certificationCenterRepository.get(
+    certificationCenterInvitation.certificationCenterId,
+  );
+  await certificationCenterInvitationService.resendCertificationCenterInvitation({
+    certificationCenterInvitationRepository,
+  })({
+    certificationCenter,
+    certificationCenterInvitation,
+    locale,
+  });
+
+  return certificationCenterInvitationRepository.get(certificationCenterInvitationId);
+};
+
+export { resendCertificationCenterInvitation };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
@@ -24,4 +24,6 @@ const deserializeForAdmin = function (payload) {
   });
 };
 
-export { serialize, serializeForAdmin, deserializeForAdmin };
+const certificationCenterInvitationSerializer = { serialize, serializeForAdmin, deserializeForAdmin };
+
+export { certificationCenterInvitationSerializer, serialize, serializeForAdmin, deserializeForAdmin };

--- a/api/lib/infrastructure/utils/request-response-utils.js
+++ b/api/lib/infrastructure/utils/request-response-utils.js
@@ -3,8 +3,9 @@ import { tokenService } from '../../../src/shared/domain/services/token-service.
 import { LOCALE } from '../../../src/shared/domain/constants.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
+const requestResponseUtils = { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
 
-export { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
+export { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest, requestResponseUtils };
 
 function escapeFileName(fileName) {
   return fileName.replace(/[^_. A-Za-z0-9-]/g, '_');

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -148,6 +148,99 @@ describe('Acceptance | API | Certification center invitations', function () {
         });
       });
     });
+
+    describe(`PATCH /api/certification-center-invitations/{id}`, function () {
+      context('when user is admin of the certification center', function () {
+        let adminUser;
+        let certificationCenter;
+
+        beforeEach(async function () {
+          adminUser = databaseBuilder.factory.buildUser();
+          certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId: adminUser.id,
+            certificationCenterId: certificationCenter.id,
+            role: 'ADMIN',
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('returns a 200 HTTP status code with updated certification center invitation', async function () {
+          // given
+          const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+            certificationCenterId: certificationCenter.id,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject({
+            method: 'PATCH',
+            url: `/api/certification-center-invitations/${certificationCenterInvitation.id}`,
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+            },
+          });
+
+          // then
+          const updatedCertificationCenterInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME)
+            .where({ id: certificationCenterInvitation.id })
+            .first();
+
+          expect(response.statusCode).to.equal(200);
+          expect(response.result).to.deep.equal({
+            data: {
+              type: 'certification-center-invitations',
+              id: `${updatedCertificationCenterInvitation.id}`,
+              attributes: {
+                email: updatedCertificationCenterInvitation.email,
+                role: updatedCertificationCenterInvitation.role,
+                'updated-at': updatedCertificationCenterInvitation.updatedAt,
+              },
+            },
+          });
+        });
+      });
+
+      context('when user is not admin of the certification center', function () {
+        let user;
+        let certificationCenter;
+
+        beforeEach(async function () {
+          user = databaseBuilder.factory.buildUser();
+          certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId: user.id,
+            certificationCenterId: certificationCenter.id,
+            role: 'MEMBER',
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('returns a 403 HTTP status code', async function () {
+          // given
+          const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+            certificationCenterId: certificationCenter.id,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject({
+            method: 'PATCH',
+            url: `/api/certification-center-invitations/${certificationCenterInvitation.id}`,
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(user.id),
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+    });
   });
 
   context('admin routes', function () {

--- a/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
+++ b/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
@@ -2,6 +2,8 @@ import { expect, sinon, hFake, domainBuilder } from '../../../test-helper.js';
 import { certificationCenterInvitationController } from '../../../../lib/application/certification-center-invitations/certification-center-invitation-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { CertificationCenterInvitation } from '../../../../lib/domain/models/CertificationCenterInvitation.js';
+import { certificationCenterInvitationSerializer } from '../../../../lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
+import { requestResponseUtils } from '../../../../lib/infrastructure/utils/request-response-utils.js';
 
 describe('Unit | Application | Certification-center-Invitations | Certification-center-invitation-controller', function () {
   describe('#acceptCertificationCenterInvitation', function () {
@@ -65,6 +67,56 @@ describe('Unit | Application | Certification-center-Invitations | Certification-
 
       // then
       expect(response.statusCode).to.equal(204);
+    });
+  });
+
+  describe('#resendCertificationCenterInvitation', function () {
+    it('calls the resend certification center invitation usecase and returns an certification center invitation', async function () {
+      // given
+      const certificationCenterInvitationId = 123;
+      const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
+        id: certificationCenterInvitationId,
+      });
+      const locale = 'nl-BE';
+      const serializerResult = {
+        type: 'certification-center-invitation',
+        id: certificationCenterInvitation.id,
+        attributes: {
+          email: certificationCenterInvitation.email,
+          role: certificationCenterInvitation.role,
+          'updated-at': certificationCenterInvitation.updatedAt,
+        },
+      };
+
+      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest').returns(locale);
+
+      sinon.stub(usecases, 'resendCertificationCenterInvitation');
+      usecases.resendCertificationCenterInvitation
+        .withArgs({
+          certificationCenterInvitationId,
+          locale,
+        })
+        .resolves(certificationCenterInvitation);
+
+      sinon.stub(certificationCenterInvitationSerializer, 'serializeForAdmin');
+      certificationCenterInvitationSerializer.serializeForAdmin
+        .withArgs(certificationCenterInvitation)
+        .returns(serializerResult);
+
+      // when
+      const response = await certificationCenterInvitationController.resendCertificationCenterInvitation(
+        {
+          auth: { credentials: { userId: 1 } },
+          params: { certificationCenterInvitationId },
+        },
+        hFake,
+      );
+
+      // then
+      expect(requestResponseUtils.extractLocaleFromRequest).to.have.been.called;
+      expect(usecases.resendCertificationCenterInvitation).to.have.been.called;
+      expect(response.statusCode).to.equal(200);
+      expect(response.source).to.deep.equal(serializerResult);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/resend-certification-center-invitation_test.js
+++ b/api/tests/unit/domain/usecases/resend-certification-center-invitation_test.js
@@ -1,0 +1,47 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { resendCertificationCenterInvitation } from '../../../../lib/domain/usecases/resend-certification-center-invitation.js';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Domain | UseCases | resendCertificationCenterInvitation', function () {
+  it('resends the certification center invitation and returns it', async function () {
+    // given
+    const locale = 'nl-BE';
+    const certificationCenter = domainBuilder.buildCertificationCenter();
+    const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
+      certificationCenterId: certificationCenter.id,
+    });
+    const resendCertificationCenterInvitationInjector = sinon.stub();
+    const resendCertificationCenterInvitationFn = sinon.stub();
+    const certificationCenterInvitationService = {
+      resendCertificationCenterInvitation: resendCertificationCenterInvitationInjector.returns(
+        resendCertificationCenterInvitationFn,
+      ),
+    };
+    const certificationCenterRepository = {
+      get: sinon.stub(),
+    };
+    const certificationCenterInvitationRepository = {
+      get: sinon.stub(),
+    };
+
+    resendCertificationCenterInvitationInjector.withArgs({ certificationCenterInvitationRepository });
+    resendCertificationCenterInvitationFn.withArgs({ certificationCenter, certificationCenterInvitation, locale });
+    certificationCenterInvitationRepository.get.resolves(certificationCenterInvitation);
+    certificationCenterRepository.get.resolves(certificationCenter);
+
+    // when
+    const result = await resendCertificationCenterInvitation({
+      certificationCenterInvitationId: certificationCenterInvitation.id,
+      locale,
+      certificationCenterInvitationRepository,
+      certificationCenterRepository,
+      certificationCenterInvitationService,
+    });
+
+    // then
+    expect(certificationCenterInvitationRepository.get).to.have.been.calledTwice;
+    expect(certificationCenterRepository.get).to.have.been.called;
+    expect(certificationCenterInvitationService.resendCertificationCenterInvitation).to.have.been.called;
+    expect(result).to.equals(certificationCenterInvitation);
+  });
+});

--- a/certif/app/components/team/invitations-list-item.hbs
+++ b/certif/app/components/team/invitations-list-item.hbs
@@ -12,6 +12,8 @@
             @icon="redo"
             @triggerAction={{fn @onResendInvitationButtonClicked @invitation}}
             @withBackground={{true}}
+            disabled={{@invitation.isResendingInvitation}}
+            aria-disabled={{@invitation.isResendingInvitation}}
           />
         </:triggerElement>
         <:tooltip>

--- a/certif/app/components/team/invitations-list-item.hbs
+++ b/certif/app/components/team/invitations-list-item.hbs
@@ -8,6 +8,20 @@
       <PixTooltip @isInline={{true}}>
         <:triggerElement>
           <PixIconButton
+            @ariaLabel={{t "pages.team-invitations.actions.resend-invitation"}}
+            @icon="redo"
+            @triggerAction={{fn @onResendInvitationButtonClicked @invitation}}
+            @withBackground={{true}}
+          />
+        </:triggerElement>
+        <:tooltip>
+          {{t "pages.team-invitations.actions.resend-invitation"}}
+        </:tooltip>
+      </PixTooltip>
+
+      <PixTooltip @isInline={{true}}>
+        <:triggerElement>
+          <PixIconButton
             @ariaLabel={{t "pages.team-invitations.actions.cancel-invitation"}}
             @icon="trash-can"
             @triggerAction={{fn @onCancelInvitationButtonClicked @invitation}}

--- a/certif/app/components/team/invitations-list.hbs
+++ b/certif/app/components/team/invitations-list.hbs
@@ -12,6 +12,7 @@
         <Team::InvitationsListItem
           @invitation={{invitation}}
           @onCancelInvitationButtonClicked={{@onCancelInvitationButtonClicked}}
+          @onResendInvitationButtonClicked={{@onResendInvitationButtonClicked}}
         />
       {{/each}}
     </tbody>

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -20,6 +20,11 @@ export default class AuthenticatedTeamListInvitationsController extends Controll
 
   @action
   async resendInvitation(certificationCenterInvitation) {
-    await certificationCenterInvitation.save();
+    try {
+      await certificationCenterInvitation.save();
+      this.notifications.success(this.intl.t('pages.team-invitations.notifications.success.invitation-resent'));
+    } catch (_) {
+      //
+    }
   }
 }

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -17,4 +17,9 @@ export default class AuthenticatedTeamListInvitationsController extends Controll
       this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
     }
   }
+
+  @action
+  async resendInvitation(certificationCenterInvitation) {
+    await certificationCenterInvitation.save();
+  }
 }

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -23,8 +23,10 @@ export default class AuthenticatedTeamListInvitationsController extends Controll
     try {
       await certificationCenterInvitation.save();
       this.notifications.success(this.intl.t('pages.team-invitations.notifications.success.invitation-resent'));
-    } catch (_) {
-      //
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
     }
   }
 }

--- a/certif/app/controllers/authenticated/team/list/invitations.js
+++ b/certif/app/controllers/authenticated/team/list/invitations.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import ENV from 'pix-certif/config/environment';
 
 export default class AuthenticatedTeamListInvitationsController extends Controller {
   @service intl;
@@ -20,6 +21,10 @@ export default class AuthenticatedTeamListInvitationsController extends Controll
 
   @action
   async resendInvitation(certificationCenterInvitation) {
+    if (certificationCenterInvitation.isResendingInvitation) return;
+
+    certificationCenterInvitation.isResendingInvitation = true;
+
     try {
       await certificationCenterInvitation.save();
       this.notifications.success(this.intl.t('pages.team-invitations.notifications.success.invitation-resent'));
@@ -27,6 +32,11 @@ export default class AuthenticatedTeamListInvitationsController extends Controll
       // eslint-disable-next-line no-console
       console.error(error);
       this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+    } finally {
+      setTimeout(
+        () => (certificationCenterInvitation.isResendingInvitation = false),
+        ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND,
+      );
     }
   }
 }

--- a/certif/app/models/certification-center-invitation.js
+++ b/certif/app/models/certification-center-invitation.js
@@ -1,7 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
+import { tracked } from '@glimmer/tracking';
 
 export default class CertificationCenterInvitation extends Model {
+  @tracked
+  isResendingInvitation = false;
+
   @attr('string') email;
   @attr('string') status;
   @attr('date') updatedAt;

--- a/certif/app/templates/authenticated/team/list/invitations.hbs
+++ b/certif/app/templates/authenticated/team/list/invitations.hbs
@@ -1,3 +1,7 @@
 {{page-title "Invitations"}}
 
-<Team::InvitationsList @invitations={{@model}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />
+<Team::InvitationsList
+  @invitations={{@model}}
+  @onCancelInvitationButtonClicked={{this.cancelInvitation}}
+  @onResendInvitationButtonClicked={{this.resendInvitation}}
+/>

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -84,6 +84,11 @@ module.exports = function (environment) {
         defaultValue: 8,
         minValue: 1,
       }),
+      MILLISECONDS_BEFORE_MAIL_RESEND: _getEnvironmentVariableAsNumber({
+        environmentVariableName: 'MILLISECONDS_BEFORE_MAIL_RESEND',
+        defaultValue: 5000,
+        minValue: 0,
+      }),
       sessionSupervisingPollingRate: process.env.SESSION_SUPERVISING_POLLING_RATE ?? 5000,
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
     },

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -380,6 +380,15 @@ function _configureCertificationCenterInvitationRoutes(context) {
     }
   });
 
+  context.patch(`${basePath}/:id`, (schema, request) => {
+    const certificationCenterInvitationId = request.params.id;
+    const certificationCenterInvitation = schema.certificationCenterInvitations.find(certificationCenterInvitationId);
+
+    certificationCenterInvitation.updatedAt = new Date('2023-12-05T11:35:00Z');
+
+    return certificationCenterInvitation;
+  });
+
   context.post(`${basePath}/:id/accept`, (schema) => {
     const certificationPointOfContact = schema.certificationPointOfContacts.first();
     const allowedCertificationCenterAccess = schema.allowedCertificationCenterAccesses.create({

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -110,7 +110,7 @@ module('Acceptance | Team | Invitations', function (hooks) {
     });
 
     module('when user clicks on resend invitation button', function () {
-      test('resends the invitation', async function (assert) {
+      test('resends the invitation and displays a success notification', async function (assert) {
         // given
         this.server.create('certification-center-invitation', {
           certificationCenterId: 1,
@@ -125,7 +125,8 @@ module('Acceptance | Team | Invitations', function (hooks) {
 
         // then
         assert.dom(screen.getByRole('cell', { name: 'medhi.khaman@example.net' })).exists();
-        assert.dom(screen.getByRole('cell', { name: '05/12/2023 - 12:35' })).exists();
+        assert.dom(screen.getByRole('cell', { name: '05/12/2023 - 11:35' })).exists();
+        assert.dom(screen.getByText("L'invitation a bien été renvoyée.")).exists();
       });
     });
   });

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -128,6 +128,34 @@ module('Acceptance | Team | Invitations', function (hooks) {
         assert.dom(screen.getByRole('cell', { name: '05/12/2023 - 11:35' })).exists();
         assert.dom(screen.getByText("L'invitation a bien été renvoyée.")).exists();
       });
+
+      module('when an error occurs', function () {
+        test('displays an error notification', async function (assert) {
+          // given
+          this.server.create('certification-center-invitation', {
+            id: 15,
+            certificationCenterId: 1,
+            email: 'anna.liz@example.net',
+            updatedAt: new Date('2023-11-30'),
+          });
+          this.server.patch('/certification-center-invitations/15', () => new Response(500));
+
+          const screen = await visit('/equipe/invitations');
+
+          // when
+          await clickByName(this.intl.t('pages.team-invitations.actions.resend-invitation'));
+
+          // then
+          assert.dom(screen.queryByText('anna.liz@example.net')).exists();
+          assert
+            .dom(
+              screen.getByText(
+                'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+              ),
+            )
+            .exists();
+        });
+      });
     });
   });
 });

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -108,5 +108,25 @@ module('Acceptance | Team | Invitations', function (hooks) {
         });
       });
     });
+
+    module('when user clicks on resend invitation button', function () {
+      test('resends the invitation', async function (assert) {
+        // given
+        this.server.create('certification-center-invitation', {
+          certificationCenterId: 1,
+          email: 'medhi.khaman@example.net',
+          updatedAt: new Date('2023-12-05T11:30:00Z'),
+        });
+
+        const screen = await visit('/equipe/invitations');
+
+        // when
+        await clickByName(this.intl.t('pages.team-invitations.actions.resend-invitation'));
+
+        // then
+        assert.dom(screen.getByRole('cell', { name: 'medhi.khaman@example.net' })).exists();
+        assert.dom(screen.getByRole('cell', { name: '05/12/2023 - 12:35' })).exists();
+      });
+    });
   });
 });

--- a/certif/tests/integration/components/team/invitations-list-item_test.js
+++ b/certif/tests/integration/components/team/invitations-list-item_test.js
@@ -88,4 +88,25 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
       assert.ok(resendInvitation.calledWith(invitation));
     });
   });
+
+  module('when certification center invitation has already been resent', function () {
+    test('disables the resend invitation button', async function (assert) {
+      // given
+      const invitation = store.createRecord('certification-center-invitation');
+
+      invitation.isResendingInvitation = true;
+
+      this.set('invitation', invitation);
+      this.set('cancelInvitation', sinon.stub());
+      this.set('resendInvitation', sinon.stub());
+
+      // when
+      const screen = await renderScreen(
+        hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button', { name: "Renvoyer l'invitation" })).isDisabled();
+    });
+  });
 });

--- a/certif/tests/integration/components/team/invitations-list-item_test.js
+++ b/certif/tests/integration/components/team/invitations-list-item_test.js
@@ -29,10 +29,11 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
 
     this.set('invitation', invitation);
     this.set('cancelInvitation', sinon.stub());
+    this.set('resendInvitation', sinon.stub());
 
     //  when
     const screen = await renderScreen(
-      hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+      hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
     );
 
     // then
@@ -40,9 +41,8 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
 
     assert.dom(screen.getByLabelText('Invitations en attente')).containsText(invitation.email);
     assert.dom(screen.getByLabelText('Invitations en attente')).containsText(expectedDate);
-    assert
-      .dom(screen.getByRole('button', { name: this.intl.t('pages.team-invitations.actions.cancel-invitation') }))
-      .exists();
+    assert.dom(screen.getByRole('button', { name: "Renvoyer l'invitation" })).exists();
+    assert.dom(screen.getByRole('button', { name: "Supprimer l'invitation" })).exists();
   });
 
   module('when the user clicks on the cancel invitation button', function () {
@@ -53,9 +53,10 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
 
       this.set('invitation', invitation);
       this.set('cancelInvitation', cancelInvitation);
+      this.set('resendInvitation', sinon.stub());
 
       await renderScreen(
-        hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+        hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
       );
 
       // when
@@ -63,6 +64,28 @@ module('Integration | Component |  team/invitation-list-item', function (hooks) 
 
       // then
       assert.ok(cancelInvitation.calledWith(invitation));
+    });
+  });
+
+  module('when the user clicks on the resend invitation button', function () {
+    test('calls the resend invitation action', async function (assert) {
+      // given
+      const invitation = store.createRecord('certification-center-invitation');
+      const resendInvitation = sinon.stub();
+
+      this.set('invitation', invitation);
+      this.set('cancelInvitation', sinon.stub());
+      this.set('resendInvitation', resendInvitation);
+
+      await renderScreen(
+        hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
+      );
+
+      // when
+      await clickByName(this.intl.t('pages.team-invitations.actions.resend-invitation'));
+
+      // then
+      assert.ok(resendInvitation.calledWith(invitation));
     });
   });
 });

--- a/certif/tests/integration/components/team/invitations-list_test.js
+++ b/certif/tests/integration/components/team/invitations-list_test.js
@@ -9,11 +9,16 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let store;
-  let cancelInvitation;
+  let cancelInvitation, resendInvitation;
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
+
     cancelInvitation = sinon.stub();
+    resendInvitation = sinon.stub();
+
+    this.set('cancelInvitation', cancelInvitation);
+    this.set('resendInvitation', resendInvitation);
   });
 
   hooks.afterEach(function () {
@@ -23,11 +28,10 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
   test('displays email address, last sending date and actions headers', async function (assert) {
     // given
     this.set('invitations', []);
-    this.set('cancelInvitation', cancelInvitation);
 
     // when
     const screen = await renderScreen(
-      hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+      hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
     );
 
     // then
@@ -52,11 +56,10 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
     });
 
     this.set('invitations', [invitation, secondInvitation]);
-    this.set('cancelInvitation', cancelInvitation);
 
     //  when
     const screen = await renderScreen(
-      hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+      hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
     );
 
     // then
@@ -70,10 +73,9 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
       const invitation = store.createRecord('certification-center-invitation');
 
       this.set('invitations', [invitation]);
-      this.set('cancelInvitation', cancelInvitation);
 
       await renderScreen(
-        hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} />`,
+        hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
       );
 
       // when
@@ -81,6 +83,25 @@ module('Integration | Component |  team/invitation-list', function (hooks) {
 
       // then
       assert.ok(cancelInvitation.calledWith(invitation));
+    });
+  });
+
+  module('when the user clicks on the resend invitation button', function () {
+    test('calls the resend invitation action', async function (assert) {
+      // given
+      const invitation = store.createRecord('certification-center-invitation');
+
+      this.set('invitations', [invitation]);
+
+      await renderScreen(
+        hbs`<Team::InvitationsList @invitations={{this.invitations}} @onCancelInvitationButtonClicked={{this.cancelInvitation}} @onResendInvitationButtonClicked={{this.resendInvitation}} />`,
+      );
+
+      // when
+      await clickByName(this.intl.t('pages.team-invitations.actions.resend-invitation'));
+
+      // then
+      assert.ok(resendInvitation.calledWith(invitation));
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
@@ -54,4 +54,19 @@ module('Unit | Controller | authenticated/team/list/invitations', function (hook
       });
     });
   });
+
+  module('#resendInvitation', function () {
+    test('resends invitation', async function (assert) {
+      // given
+      const certificationCenterInvitation = {
+        save: sinon.stub(),
+      };
+
+      // when
+      await controller.resendInvitation(certificationCenterInvitation);
+
+      // then
+      assert.ok(certificationCenterInvitation.save.called);
+    });
+  });
 });

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
@@ -71,5 +71,26 @@ module('Unit | Controller | authenticated/team/list/invitations', function (hook
       assert.ok(certificationCenterInvitation.save.called);
       assert.ok(controller.notifications.success.calledWithExactly("L'invitation a bien été renvoyée."));
     });
+
+    module('when an error occurs', function () {
+      test('displays an error notification', async function (assert) {
+        // given
+        const certificationCenterInvitation = {
+          save: sinon.stub().rejects(),
+        };
+
+        controller.notifications = { error: sinon.stub() };
+
+        // when
+        await controller.resendInvitation(certificationCenterInvitation);
+
+        // then
+        assert.ok(
+          controller.notifications.error.calledWithExactly(
+            'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+          ),
+        );
+      });
+    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/invitations_test.js
@@ -56,17 +56,20 @@ module('Unit | Controller | authenticated/team/list/invitations', function (hook
   });
 
   module('#resendInvitation', function () {
-    test('resends invitation', async function (assert) {
+    test('resends invitation and displays a success notification', async function (assert) {
       // given
       const certificationCenterInvitation = {
         save: sinon.stub(),
       };
+
+      controller.notifications = { success: sinon.stub() };
 
       // when
       await controller.resendInvitation(certificationCenterInvitation);
 
       // then
       assert.ok(certificationCenterInvitation.save.called);
+      assert.ok(controller.notifications.success.calledWithExactly("L'invitation a bien été renvoyée."));
     });
   });
 });

--- a/certif/tests/unit/models/certification-center-invitation_test.js
+++ b/certif/tests/unit/models/certification-center-invitation_test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Models | certification-center-invitation', function (hooks) {
+  setupTest(hooks);
+
+  let store;
+  let certificationCenterInvitation;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    certificationCenterInvitation = store.createRecord('certification-center-invitation');
+  });
+
+  test('returns the default value of "isResendingInvitation" attribute', function (assert) {
+    // given
+    // when
+    // then
+    assert.false(certificationCenterInvitation.isResendingInvitation);
+  });
+
+  module('when updating the value of "isResendingInvitation" attribute', function () {
+    test('returns the updated value', function (assert) {
+      // given
+      // when
+      certificationCenterInvitation.isResendingInvitation = true;
+
+      // then
+      assert.true(certificationCenterInvitation.isResendingInvitation);
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -896,7 +896,8 @@
     },
     "team-invitations": {
       "actions": {
-        "cancel-invitation": "Delete invitation"
+        "cancel-invitation": "Delete invitation",
+        "resend-invitation": "Resend invitation"
       },
       "notifications": {
         "success": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -901,7 +901,8 @@
       },
       "notifications": {
         "success": {
-          "invitation-cancelled": "The invitation has been deleted."
+          "invitation-cancelled": "The invitation has been deleted.",
+          "invitation-resent": "The invitation has been resent."
         }
       },
       "table": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -901,7 +901,8 @@
       },
       "notifications": {
         "success": {
-          "invitation-cancelled": "L’invitation a bien été supprimée."
+          "invitation-cancelled": "L’invitation a bien été supprimée.",
+          "invitation-resent": "L'invitation a bien été renvoyée."
         }
       },
       "table": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -896,7 +896,8 @@
     },
     "team-invitations": {
       "actions": {
-        "cancel-invitation": "Supprimer l'invitation"
+        "cancel-invitation": "Supprimer l'invitation",
+        "resend-invitation": "Renvoyer l'invitation"
       },
       "notifications": {
         "success": {


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement il n'est pas possible, pour un administrateur d'un centre de certification, de renvoyer une invitation d'une invitation en attente.

## :gift: Proposition

Ajouter un bouton d'action pour permettre à un administrateur de renvoyer une invitation en attente.

## :socks: Remarques

Pour éviter que l'administrateur ne clique plusieurs fois rapidement sur le bouton de renvoie d'invitation, ce dernier est désactivé après un clic pour une durée de _5 secondes_.

## :santa: Pour tester

1. Se connecter sur Pix Certif avec le compte `james-paledroits@example.net`
2. Cliquer sur le menu `Équipe`
3. Cliquer sur l'onglet `Invitations (x)` (_x_ étant le nombre d'invitations en attente)
4. Cliquer sur le bouton `Renvoyer l'invitation` d'une invitation
5. Constater l'affichage d'une notification de succès
6. Vérifier que la date présente dans la colonne `Date de dernier envoie` a bien été mise à jour
7. Constater que le bouton `Renvoyer l'invitation` de l'invitation est désactivé
8. Attendre 5 secondes
9. Constater que le bouton `Renvoyer l'invitation` de l'invitation est de nouveau actif
10. Vérifier en BDD dans la table `certification-center-invitations` que la colonne `updatedAt` a bien été mise à jour

