### PR TITLE
[TECH] Fix la version de  libxmljs2 à 0.32.0 pour rester compatible avec les proc ARM (PIX-10260).

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -99,7 +99,7 @@
         "eslint-plugin-unicorn": "^49.0.0",
         "form-data": "^4.0.0",
         "inquirer": "^9.0.0",
-        "libxmljs2": "^0.33.0",
+        "libxmljs2": "0.32.0",
         "mocha": "^10.0.0",
         "mocha-junit-reporter": "^2.0.2",
         "mockdate": "^3.0.5",
@@ -7862,18 +7862,18 @@
       }
     },
     "node_modules/libxmljs2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
-      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
+        "@mapbox/node-pre-gyp": "^1.0.10",
         "bindings": "~1.5.0",
-        "nan": "~2.18.0"
+        "nan": "~2.17.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/lie": {
@@ -8645,9 +8645,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "dev": true
     },
     "node_modules/nanoid": {

--- a/api/package.json
+++ b/api/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-unicorn": "^49.0.0",
     "form-data": "^4.0.0",
     "inquirer": "^9.0.0",
-    "libxmljs2": "^0.33.0",
+    "libxmljs2": "0.32.0",
     "mocha": "^10.0.0",
     "mocha-junit-reporter": "^2.0.2",
     "mockdate": "^3.0.5",


### PR DESCRIPTION
## :christmas_tree: Problème
Il y a un bug avec la lib en version 0.33.0 
https://github.com/marudor/libxmljs2/issues/203


## :gift: Proposition
Rester en version 0.32.0

## :socks: Remarques
On pourra la mettre à jour quand le bug sera resolu

## :santa: Pour tester
Lancer les tests de `cpf-certification-xml-export-service_test.js`
`