### PR TITLE
[FEATURE][CERTIF] Permettre aux administrateurs d'un centre de certification de changer le rôle de ses membres (PIX-5001)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -368,6 +368,7 @@ buildUser.withCertificationCenterMembership = function buildUserWithCertificatio
   createdAt = new Date(),
   updatedAt = new Date(),
   certificationCenterId = null,
+  role = 'MEMBER',
 } = {}) {
   email = _generateAnEmailIfNecessary(email, id, lastName, firstName);
 
@@ -396,6 +397,7 @@ buildUser.withCertificationCenterMembership = function buildUserWithCertificatio
   buildCertificationCenterMembership({
     userId: user.id,
     certificationCenterId,
+    role,
   });
 
   return user;

--- a/api/db/seeds/data/team-acces/build-certification-centers.js
+++ b/api/db/seeds/data/team-acces/build-certification-centers.js
@@ -80,6 +80,14 @@ export async function buildCertificationCenters(databaseBuilder) {
     externalId: 'TEAM_ACCES_456',
   });
 
+  await createCertificationCenter({
+    name: 'Accèstral',
+    certificationCenterId: CERTIFICATION_CENTER_OFFSET_ID + 2,
+    databaseBuilder,
+    members: [{ id: userWithAdminRole1.id, role: 'ADMIN' }],
+    externalId: 'TEAM_ACCES_789',
+  });
+
   _buildCertificationCenterInvitations({
     databaseBuilder,
     users: [userWithInvitation, secondUserWithInvitation],

--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -14,7 +14,7 @@ const disable = async function (request, h, dependencies = { requestResponseUtil
   return h.response().code(204);
 };
 
-const update = async function (
+const updateFromPixAdmin = async function (
   request,
   h,
   dependencies = { requestResponseUtils, certificationCenterMembershipSerializer },
@@ -40,6 +40,6 @@ const update = async function (
   );
 };
 
-const certificationCenterMembershipController = { disable, update };
+const certificationCenterMembershipController = { disable, updateFromPixAdmin };
 
 export { certificationCenterMembershipController };

--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -1,7 +1,8 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as requestResponseUtils from '../../infrastructure/utils/request-response-utils.js';
 import * as certificationCenterMembershipSerializer from '../../infrastructure/serializers/jsonapi/certification-center-membership-serializer.js';
-import { BadRequestError } from '../http-errors.js';
+import { BadRequestError, ForbiddenError } from '../http-errors.js';
+import { getCertificationCenterId } from '../../infrastructure/repositories/certification-center-membership-repository.js';
 
 const disable = async function (request, h, dependencies = { requestResponseUtils }) {
   const certificationCenterMembershipId = request.params.id;
@@ -40,6 +41,34 @@ const updateFromPixAdmin = async function (
   );
 };
 
-const certificationCenterMembershipController = { disable, updateFromPixAdmin };
+const updateFromPixCertif = async function (
+  request,
+  h,
+  dependencies = { requestResponseUtils, certificationCenterMembershipSerializer },
+) {
+  const certificationCenterId = request.params.certificationCenterId;
+  const certificationCenterMembershipId = request.params.id;
+  const certificationCenterMembership = dependencies.certificationCenterMembershipSerializer.deserialize(
+    request.payload,
+  );
+  const currentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+
+  const foundCertificationCenterId = await getCertificationCenterId(certificationCenterMembershipId);
+  if (foundCertificationCenterId != certificationCenterId) {
+    throw new ForbiddenError('Wrong certification center');
+  }
+
+  const updatedCertificationCenterMembership = await usecases.updateCertificationCenterMembership({
+    certificationCenterMembershipId,
+    role: certificationCenterMembership.role,
+    updatedByUserId: currentUserId,
+  });
+
+  return h.response(
+    dependencies.certificationCenterMembershipSerializer.serializeMembers(updatedCertificationCenterMembership),
+  );
+};
+
+const certificationCenterMembershipController = { disable, updateFromPixAdmin, updateFromPixCertif };
 
 export { certificationCenterMembershipController };

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -1,7 +1,36 @@
+import Joi from 'joi';
+
 import { certificationCenterMembershipController } from './certification-center-membership-controller.js';
 import { securityPreHandlers } from '../security-pre-handlers.js';
+import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {
+  const globalRoutes = [
+    {
+      method: 'PATCH',
+      path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships/{id}',
+      config: {
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+            id: identifiersType.certificationCenterMembershipId,
+          }),
+        },
+        handler: certificationCenterMembershipController.updateFromPixCertif,
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenter,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            "- Modification du rôle d'un membre d'un centre de certification\n",
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
+  ];
   const adminRoutes = [
     {
       method: 'DELETE',
@@ -54,7 +83,7 @@ const register = async function (server) {
     },
   ];
 
-  server.route([...adminRoutes]);
+  server.route([...globalRoutes, ...adminRoutes]);
 };
 
 const name = 'certification-center-memberships-api';

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -32,7 +32,7 @@ const register = async function (server) {
       method: 'PATCH',
       path: '/api/admin/certification-center-memberships/{id}',
       config: {
-        handler: certificationCenterMembershipController.update,
+        handler: certificationCenterMembershipController.updateFromPixAdmin,
         pre: [
           {
             method: (request, h) =>

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -207,6 +207,21 @@ const updateRefererStatusByUserIdAndCertificationCenterId = async function ({
   await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME).where({ userId, certificationCenterId }).update({ isReferer });
 };
 
+const getCertificationCenterId = async function (certificationCenterMembershipId) {
+  const result = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
+    .select('certification-center-memberships.certificationCenterId')
+    .where({ 'certification-center-memberships.id': certificationCenterMembershipId })
+    .first();
+
+  if (!result) {
+    throw new NotFoundError(
+      `Cannot find a certificationCenterId for membership with id ${certificationCenterMembershipId}`,
+    );
+  }
+
+  return result.certificationCenterId;
+};
+
 const getRefererByCertificationCenterId = async function ({ certificationCenterId }) {
   const refererCertificationCenterMembership = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
     .select('certification-center-memberships.*', 'users.lastName', 'users.firstName', 'users.email')
@@ -289,6 +304,7 @@ export {
   findOneWithCertificationCenterIdAndUserId,
   findById,
   findByUserId,
+  getCertificationCenterId,
   getRefererByCertificationCenterId,
   isAdminOfCertificationCenter,
   isMemberOfCertificationCenter,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -36,10 +36,17 @@ const serializeMembers = function (certificationCenterMemberships) {
   return new Serializer('members', {
     transform: function (record) {
       const { id, firstName, lastName } = record.user;
-      return { id, firstName, lastName, isReferer: record.isReferer, role: record.role };
+      return {
+        id,
+        firstName,
+        lastName,
+        isReferer: record.isReferer,
+        role: record.role,
+        certificationCenterMembershipId: record.id,
+      };
     },
     ref: 'id',
-    attributes: ['firstName', 'lastName', 'isReferer', 'role'],
+    attributes: ['firstName', 'lastName', 'isReferer', 'role', 'certificationCenterMembershipId'],
   }).serialize(certificationCenterMemberships);
 };
 

--- a/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
@@ -298,4 +298,183 @@ describe('Acceptance | API | Certification Center Membership', function () {
       });
     });
   });
+
+  context('Pix Certif routes', function () {
+    describe('PATCH /api/certification-centers/{certificationCenterId}/certification-center-memberships/{id}', function () {
+      let certificationCenter;
+      let certificationCenterMembership;
+      let user;
+
+      beforeEach(async function () {
+        certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        user = databaseBuilder.factory.buildUser();
+        certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId: user.id,
+        });
+        await databaseBuilder.commit();
+      });
+
+      context('Success cases', function () {
+        it('returns a 200 HTTP status code with the updated certification center membership', async function () {
+          // given
+          const certifCenterAdminUser = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+            certificationCenterId: certificationCenter.id,
+            role: 'ADMIN',
+          });
+          const request = {
+            method: 'PATCH',
+            url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships/${certificationCenterMembership.id}`,
+            payload: {
+              id: user.id,
+              data: {
+                'certification-center-membership-id': certificationCenterMembership.id.toString(),
+                type: 'certification-center-memberships',
+                attributes: {
+                  role: 'ADMIN',
+                },
+              },
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(certifCenterAdminUser.id),
+            },
+          };
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject(request);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          const expectedUpdatedCertificationCenterMembership = {
+            data: {
+              type: 'members',
+              id: user.id.toString(),
+              attributes: {
+                'certification-center-membership-id': certificationCenterMembership.id,
+                'first-name': certifCenterAdminUser.firstName,
+                'is-referer': false,
+                'last-name': certifCenterAdminUser.lastName,
+                role: 'ADMIN',
+              },
+            },
+          };
+          expect(_.omit(response.result, 'included')).to.deep.equal(expectedUpdatedCertificationCenterMembership);
+        });
+      });
+
+      context('Error cases', function () {
+        context('when current user has a member role', function () {
+          it('returns a 403 HTTP status code', async function () {
+            // given
+            const certifCenterMemberUser = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+              certificationCenterId: certificationCenter.id,
+              role: 'MEMBER',
+            });
+            const request = {
+              method: 'PATCH',
+              url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships/${certificationCenterMembership.id}`,
+              payload: {
+                id: user.id,
+                data: {
+                  type: 'certification-center-memberships',
+                  'certification-center-membership-id': certificationCenterMembership.id.toString(),
+                  attributes: {
+                    role: 'ADMIN',
+                  },
+                },
+              },
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(certifCenterMemberUser.id),
+              },
+            };
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(403);
+          });
+        });
+
+        context('when certification center membership does not belong to the certification center', function () {
+          it('returns a 403 HTTP status code', async function () {
+            // given
+            const certifCenterAdminUser = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+              certificationCenterId: certificationCenter.id,
+              role: 'ADMIN',
+            });
+
+            const anotherCertificationCenter = databaseBuilder.factory.buildCertificationCenter();
+            const anotherCertificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+              certificationCenterId: anotherCertificationCenter.id,
+            });
+            const anotherCertificationCenterMembershipId = anotherCertificationCenterMembership.id;
+
+            const request = {
+              method: 'PATCH',
+              url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships/${anotherCertificationCenterMembershipId}`,
+              payload: {
+                data: {
+                  id: user.id,
+                  type: 'certification-center-memberships',
+                  attributes: {
+                    role: 'ADMIN',
+                    'certification-center-membership-id': anotherCertificationCenterMembershipId,
+                  },
+                },
+              },
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(certifCenterAdminUser.id),
+              },
+            };
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(403);
+          });
+        });
+
+        context('when certification center membership ID in url is not valid', function () {
+          it('returns a 400 HTTP status code', async function () {
+            // given
+            const certifCenterAdminUser = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+              certificationCenterId: certificationCenter.id,
+              role: 'ADMIN',
+            });
+            const wrongCertificationCenterMembershipId = certificationCenterMembership.id + 1;
+            const notValidMembershipId = `toto`;
+            const request = {
+              method: 'PATCH',
+              url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships/${notValidMembershipId}`,
+              payload: {
+                data: {
+                  id: user.id,
+                  type: 'certification-center-memberships',
+                  attributes: {
+                    role: 'ADMIN',
+                    'certification-center-membership-id': wrongCertificationCenterMembershipId,
+                  },
+                },
+              },
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(certifCenterAdminUser.id),
+              },
+            };
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(400);
+          });
+        });
+      });
+    });
+  });
 });

--- a/api/tests/integration/application/certification-center-memberships/certification-center-membership-controller_test.js
+++ b/api/tests/integration/application/certification-center-memberships/certification-center-membership-controller_test.js
@@ -1,0 +1,29 @@
+import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { certificationCenterMembershipController } from '../../../../lib/application/certification-center-memberships/certification-center-membership-controller.js';
+import * as moduleUnderTest from '../../../../lib/application/certification-center-memberships/index.js';
+
+describe('Integration | Application | certification-center-memberships | certification-center-membership-controller', function () {
+  let httpTestServer;
+
+  beforeEach(async function () {
+    sinon
+      .stub(certificationCenterMembershipController, 'updateFromPixCertif')
+      .callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminOfCertificationCenter').returns(() => true);
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('PATCH  /api/certification-centers/{certificationCenterId}/certification-center-memberships/{id}', function () {
+    context('Success cases', function () {
+      it('calls updateFromPixCertif method', async function () {
+        // when
+        await httpTestServer.request('PATCH', '/api/certification-centers/123/certification-center-memberships/456');
+
+        // then
+        expect(certificationCenterMembershipController.updateFromPixCertif).to.be.called;
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -981,4 +981,35 @@ describe('Integration | Repository | Certification Center Membership', function 
       });
     });
   });
+
+  describe('#getCertificationCenterId', function () {
+    it('returns certification center id', async function () {
+      // given
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+      });
+      const certificationCenterMembershipId = certificationCenterMembership.id;
+      await databaseBuilder.commit();
+
+      // when
+      const certificationCenterId = await certificationCenterMembershipRepository.getCertificationCenterId(
+        certificationCenterMembershipId,
+      );
+
+      // then
+      expect(certificationCenterId).to.equal(certificationCenter.id);
+    });
+
+    context('when certification center membership does not exist', function () {
+      it('throws an error', async function () {
+        // when
+        const error = await catchErr(certificationCenterMembershipRepository.getCertificationCenterId)(15);
+
+        // then
+        expect(error).to.be.instanceof(NotFoundError);
+        expect(error.message).to.equal('Cannot find a certificationCenterId for membership with id 15');
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -117,6 +117,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
               'last-name': user.lastName,
               'is-referer': certificationCenterMembership.isReferer,
               role: certificationCenterMembership.role,
+              'certification-center-membership-id': certificationCenterMembership.id,
             },
           },
         ],

--- a/certif/app/adapters/member.js
+++ b/certif/app/adapters/member.js
@@ -8,6 +8,18 @@ export default class MemberAdapter extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/certification-centers/${query.certificationCenterId}/members`;
   }
 
+  urlForUpdateRecord(id) {
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/certification-center-memberships/${id}`;
+  }
+
+  updateRecord(store, type, snapshot) {
+    const payload = this.serialize(snapshot);
+    const certificationCenterMembershipId = payload.data.attributes['certification-center-membership-id'];
+    const url = this.buildURL(type.modelName, certificationCenterMembershipId, snapshot, 'updateRecord');
+    return this.ajax(url, 'PATCH', { data: payload });
+  }
+
   buildURL(modelName, id, snapshot, requestType, query) {
     if (requestType === 'update-referer') {
       const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;

--- a/certif/app/components/dropdown/icon-trigger.hbs
+++ b/certif/app/components/dropdown/icon-trigger.hbs
@@ -1,0 +1,13 @@
+<div id="icon-trigger" class="dropdown" ...attributes>
+  <PixIconButton
+    @icon={{@icon}}
+    aria-label="{{@ariaLabel}}"
+    class="{{@dropdownButtonClass}}"
+    @triggerAction={{this.toggle}}
+    @size="small"
+    @color="dark-grey"
+  />
+  <Dropdown::Content @display={{this.display}} @close={{this.close}} class="{{@dropdownContentClass}}">
+    {{yield}}
+  </Dropdown::Content>
+</div>

--- a/certif/app/components/dropdown/icon-trigger.js
+++ b/certif/app/components/dropdown/icon-trigger.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class IconTrigger extends Component {
+  @tracked display = false;
+
+  @action
+  toggle(event) {
+    event.stopPropagation();
+    this.display = !this.display;
+  }
+
+  @action
+  close() {
+    this.display = false;
+  }
+}

--- a/certif/app/components/dropdown/item.js
+++ b/certif/app/components/dropdown/item.js
@@ -1,0 +1,11 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class DropdownItem extends Component {
+  @action
+  handleKeyUp(event) {
+    if (event.key === 'Enter') {
+      this.args.onClick();
+    }
+  }
+}

--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -1,7 +1,60 @@
 <tr aria-label="Membres du centre de certification">
   <td>{{@member.lastName}}</td>
   <td>{{@member.firstName}}</td>
-  <td>{{@member.roleLabel}}</td>
+  <td>
+    {{#if this.isEditionMode}}
+      <div id="selectCertificationCenterRole">
+        <PixSelect
+          class="table__input"
+          @label="{{t 'pages.team.members.actions.select-role.label'}}"
+          @screenReaderOnly={{true}}
+          @hideDefaultOption={{true}}
+          @placeholder="{{t 'pages.team.members.actions.select-role.label'}}"
+          @onChange={{this.setRoleSelection}}
+          @options={{this.roleOptions}}
+          @value={{@member.role}}
+        />
+      </div>
+    {{else}}
+      {{@member.roleLabel}}
+    {{/if}}
+  </td>
+  {{#if this.shouldDisplayManagingColumn}}
+    <td>
+      {{#if this.shouldDisplayManageMemberRoleButton}}
+        <Dropdown::IconTrigger
+          @icon="ellipsis-vertical"
+          @dropdownButtonClass="zone-edit-role__dropdown-button"
+          @dropdownContentClass="managing-member__dropdown-content"
+          @ariaLabel={{t "pages.team.members.actions.manage"}}
+        >
+          <Dropdown::Item @onClick={{this.toggleEditionMode}}>
+            {{t "pages.team.members.actions.edit-role"}}
+          </Dropdown::Item>
+        </Dropdown::IconTrigger>
+      {{/if}}
+      {{#if this.isEditionMode}}
+        <div class="members-list-item__managing-role">
+          <PixButton
+            id="save-certification-center-role"
+            @triggerAction={{fn this.updateMember @member}}
+            @size="small"
+            aria-label={{t "pages.team.members.actions.save"}}
+          >
+            {{t "pages.team.members.actions.save"}}
+          </PixButton>
+          <PixIconButton
+            @icon="xmark"
+            id="cancel-update-certification-center-role"
+            aria-label="{{t 'common.actions.cancel'}}"
+            @triggerAction={{this.cancelUpdateRoleOfMember}}
+            @withBackground={{false}}
+            @color="dark-grey"
+          />
+        </div>
+      {{/if}}
+    </td>
+  {{/if}}
   {{#if @shouldDisplayRefererColumn}}
     <td>
       {{#if @member.isReferer}}

--- a/certif/app/components/members-list-item.js
+++ b/certif/app/components/members-list-item.js
@@ -1,0 +1,79 @@
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+const ARIA_LABEL_MEMBER_TRANSLATION = 'pages.team.members.actions.select-role.options.member';
+const ARIA_LABEL_ADMIN_TRANSLATION = 'pages.team.members.actions.select-role.options.admin';
+
+export default class MembersListItem extends Component {
+  @service currentUser;
+  @service notifications;
+  @service intl;
+  @service session;
+  @tracked isEditionMode = false;
+
+  roleOptions = [
+    {
+      value: 'ADMIN',
+      label: this.intl.t(ARIA_LABEL_ADMIN_TRANSLATION),
+      disabled: false,
+    },
+    {
+      value: 'MEMBER',
+      label: this.intl.t(ARIA_LABEL_MEMBER_TRANSLATION),
+      disabled: false,
+    },
+  ];
+
+  displayRoleByOrganizationRole = {
+    ADMIN: this.intl.t(ARIA_LABEL_ADMIN_TRANSLATION),
+    MEMBER: this.intl.t(ARIA_LABEL_MEMBER_TRANSLATION),
+  };
+
+  get shouldDisplayManagingColumn() {
+    return this.currentUser.isAdminOfCurrentCertificationCenter;
+  }
+
+  get shouldDisplayManageMemberRoleButton() {
+    if (this.isCurrentUserMembership) {
+      return false;
+    }
+    if (!this.currentUser.isAdminOfCurrentCertificationCenter) {
+      return false;
+    }
+    return !this.isEditionMode;
+  }
+
+  get isCurrentUserMembership() {
+    return this.currentUser.certificationPointOfContact.id === this.args.member.id;
+  }
+
+  @action
+  setRoleSelection(value) {
+    this.args.member.role = value;
+  }
+
+  @action
+  toggleEditionMode() {
+    this.isEditionMode = true;
+  }
+
+  @action
+  async updateMember(member) {
+    this.isEditionMode = false;
+    try {
+      await member.save();
+      this.notifications.success(this.intl.t('pages.team.members.notifications.change-member-role.success'));
+    } catch (e) {
+      member.rollbackAttributes();
+      this.notifications.error(this.intl.t('pages.team.members.notifications.change-member-role.error'));
+    }
+  }
+
+  @action
+  cancelUpdateRoleOfMember() {
+    this.isEditionMode = false;
+    this.args.member.rollbackAttributes();
+  }
+}

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -7,12 +7,14 @@
             <th class="table__column table__column--medium">{{t "common.labels.candidate.lastname"}}</th>
             <th class="table__column table__column--medium">{{t "common.labels.candidate.firstname"}}</th>
             <th class="table__column table__column--medium">{{t "common.labels.candidate.role"}}</th>
+            {{#if this.shouldDisplayManagingColumn}}
+              <th class="table__column table__column--medium">{{t "pages.team.table-headers.actions"}}</th>
+            {{/if}}
             {{#if this.shouldDisplayRefererColumn}}
               <th class="table__column table__column--medium">{{t "pages.team.referer"}}</th>
             {{/if}}
           </tr>
         </thead>
-
         <tbody>
           {{#each @members as |member|}}
             <MembersListItem @member={{member}} @shouldDisplayRefererColumn={{this.shouldDisplayRefererColumn}} />

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -3,8 +3,13 @@ import { service } from '@ember/service';
 
 export default class MembersList extends Component {
   @service featureToggles;
+  @service currentUser;
 
   get shouldDisplayRefererColumn() {
     return this.args.hasCleaHabilitation;
+  }
+
+  get shouldDisplayManagingColumn() {
+    return this.currentUser.isAdminOfCurrentCertificationCenter;
   }
 }

--- a/certif/app/models/member.js
+++ b/certif/app/models/member.js
@@ -9,6 +9,7 @@ export default class Member extends Model {
   @attr('string') lastName;
   @attr('boolean') isReferer;
   @attr('string') role;
+  @attr('number') certificationCenterMembershipId;
 
   certificationCenterMembersRole = {
     ADMIN: this.intl.t('pages.team.members.role.admin'),

--- a/certif/app/styles/components/members-list-item.scss
+++ b/certif/app/styles/components/members-list-item.scss
@@ -14,4 +14,16 @@
     font-weight: 900;
     font-size: 18px;
   }
+
+  &__managing-role {
+    display:flex;
+    gap: $pix-spacing-s;
+  }
+
+}
+
+.managing-member{
+  &__dropdown-content {
+    width: 150px;
+  }
 }

--- a/certif/tests/acceptance/routes/authenticated/team/members-list-item_test.js
+++ b/certif/tests/acceptance/routes/authenticated/team/members-list-item_test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit } from '@1024pix/ember-testing-library';
+import { clickByName } from '@1024pix/ember-testing-library';
+
+import setupIntl from '../../../../helpers/setup-intl';
+import {
+  authenticateSession,
+  createCertificationPointOfContactWithTermsOfServiceAccepted,
+} from '../../../../helpers/test-init';
+
+module('Acceptance | Routes | Team | membersListItem', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('when user is an admin', function (hooks) {
+    let userWithAdminRole;
+
+    hooks.beforeEach(async function () {
+      userWithAdminRole = createCertificationPointOfContactWithTermsOfServiceAccepted(
+        undefined,
+        'PIX Certification Center',
+        false,
+        'ADMIN',
+      );
+      server.create('member', { id: 1234, firstName: 'Lee', lastName: 'Tige', isReferer: false });
+
+      await authenticateSession(userWithAdminRole.id);
+    });
+
+    test('change member’s role', async function (assert) {
+      // given
+      const manageButtonName = this.intl.t('pages.team.members.actions.manage');
+
+      // when
+      const screen = await visit(`/equipe/membres`);
+      await clickByName(manageButtonName);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.team.members.actions.edit-role'),
+          }),
+        )
+        .exists();
+    });
+  });
+});

--- a/certif/tests/integration/components/dropdown/icon-trigger_test.js
+++ b/certif/tests/integration/components/dropdown/icon-trigger_test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Dropdown | icon-trigger', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display actions menu', async function (assert) {
+    // when
+    await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions' />`);
+
+    // then
+    assert.dom('[aria-label="Afficher les actions"]').exists();
+  });
+
+  test('should display actions on click', async function (assert) {
+    // when
+    await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions'>Something</Dropdown::IconTrigger>`);
+    await clickByName('Afficher les actions');
+
+    // then
+    assert.contains('Something');
+  });
+
+  test('should hide actions on click again', async function (assert) {
+    // when
+    await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions'>Something</Dropdown::IconTrigger>`);
+    await clickByName('Afficher les actions');
+    await clickByName('Afficher les actions');
+
+    // then
+    assert.notContains('Something');
+  });
+});

--- a/certif/tests/integration/components/members-list-item_test.js
+++ b/certif/tests/integration/components/members-list-item_test.js
@@ -6,7 +6,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 module('Integration | Component | MembersListItem', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when user is a member', function () {
+  module('when member is a member', function () {
     test('it shows member firstName, lastName and role', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -27,7 +27,7 @@ module('Integration | Component | MembersListItem', function (hooks) {
     });
   });
 
-  module('when user is an administrator', function () {
+  module('when member is an administrator', function () {
     test('it shows admin firstName, lastName and role', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/certif/tests/integration/components/members-list-item_test.js
+++ b/certif/tests/integration/components/members-list-item_test.js
@@ -1,46 +1,193 @@
 import { module, test } from 'qunit';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | MembersListItem', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when member is a member', function () {
-    test('it shows member firstName, lastName and role', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const memberMembership = store.createRecord('member', {
-        firstName: 'John',
-        lastName: 'Williams',
-        role: 'MEMBER',
+  let store;
+  let currentUser;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    currentUser = this.owner.lookup('service:current-user');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when current user has a member role', function (hooks) {
+    hooks.beforeEach(function () {
+      sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(false);
+    });
+
+    module('when member has a member role', function () {
+      test('it shows member firstName, lastName and role', async function (assert) {
+        // given
+        const memberWithMemberRole = store.createRecord('member', {
+          firstName: 'John',
+          lastName: 'Williams',
+          role: 'MEMBER',
+        });
+
+        sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithMemberRole.id });
+        this.set('member', memberWithMemberRole);
+
+        // when
+        const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+
+        // then
+        assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+        assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
+        assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.member') })).exists();
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.members.role.member') }))
+          .doesNotExist();
       });
-      this.set('member', memberMembership);
+    });
 
-      // when
-      const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+    module('when member has an admin role', function () {
+      test('it shows admin firstName, lastName and role', async function (assert) {
+        // given
+        const memberWithAdminRole = store.createRecord('member', {
+          firstName: 'Maria',
+          lastName: 'Carré',
+          role: 'ADMIN',
+        });
 
-      // then
-      assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
-      assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.member') })).exists();
+        sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithAdminRole.id });
+        this.set('member', memberWithAdminRole);
+
+        // when
+        const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+
+        // then
+        assert.dom(screen.getByRole('cell', { name: 'Maria' })).exists();
+        assert.dom(screen.getByRole('cell', { name: 'Carré' })).exists();
+        assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.admin') })).exists();
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.members.role.member') }))
+          .doesNotExist();
+      });
     });
   });
 
-  module('when member is an administrator', function () {
-    test('it shows admin firstName, lastName and role', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const adminMembership = store.createRecord('member', { firstName: 'Maria', lastName: 'Carré', role: 'ADMIN' });
-      this.set('member', adminMembership);
+  module('when current user has an admin role', function (hooks) {
+    hooks.beforeEach(function () {
+      sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(true);
+    });
 
-      // when
-      const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+    module('when not in edit mode', function () {
+      module('when member is not the connected user', function () {
+        test('it shows member firstName, lastName, role and manage button', async function (assert) {
+          // given
+          const memberWithMemberRole = store.createRecord('member', {
+            id: 123,
+            firstName: 'John',
+            lastName: 'Williams',
+            role: 'MEMBER',
+          });
 
-      // then
-      assert.dom(screen.getByRole('cell', { name: 'Maria' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Carré' })).exists();
-      assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.admin') })).exists();
+          sinon.stub(currentUser, 'certificationPointOfContact').value({ id: 1 });
+          this.set('member', memberWithMemberRole);
+
+          // when
+          const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+
+          // then
+          assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+          assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
+          assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.member') })).exists();
+          assert.dom(screen.getByRole('button', { name: this.intl.t('pages.team.members.actions.manage') })).exists();
+        });
+      });
+
+      module('when member is the connected user', function () {
+        test('it shows member firstName, lastName, role but does not show manage button', async function (assert) {
+          // given
+          const memberWithMemberRole = store.createRecord('member', {
+            id: 123,
+            firstName: 'John',
+            lastName: 'Williams',
+            role: 'MEMBER',
+          });
+          this.set('member', memberWithMemberRole);
+          sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithMemberRole.id });
+
+          // when
+          const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+
+          // then
+          assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+          assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
+          assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.member') })).exists();
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.members.actions.manage') }))
+            .doesNotExist();
+        });
+      });
+    });
+
+    module('when mode edition is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        const memberWithMemberRole = store.createRecord('member', {
+          id: 123,
+          firstName: 'John',
+          lastName: 'Williams',
+          role: 'MEMBER',
+        });
+
+        sinon.stub(currentUser, 'certificationPointOfContact').value({ id: 1 });
+        this.set('member', memberWithMemberRole);
+      });
+
+      test('it shows role selection menu, save button and cancel button', async function (assert) {
+        // given
+        // when
+        const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+        await clickByName(this.intl.t('pages.team.members.actions.manage'));
+        await clickByName(this.intl.t('pages.team.members.actions.edit-role'));
+
+        // then
+        assert.dom(screen.getByLabelText(this.intl.t('pages.team.members.actions.select-role.label'))).exists();
+        assert.dom(screen.getByRole('button', { name: this.intl.t('pages.team.members.actions.save') })).exists();
+        assert.dom(screen.getByRole('button', { name: this.intl.t('common.actions.cancel') })).exists();
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.members.actions.manage') }))
+          .doesNotExist();
+        assert
+          .dom(
+            screen.queryByRole('button', {
+              name: this.intl.t('pages.team.members.actions.edit-role'),
+            }),
+          )
+          .doesNotExist();
+      });
+
+      module('when selecting a new role', function () {
+        test('it displays the selected role', async function (assert) {
+          // given
+          const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
+          await clickByName(this.intl.t('pages.team.members.actions.manage'));
+          await clickByName(this.intl.t('pages.team.members.actions.edit-role'));
+
+          // when
+          await clickByName(this.intl.t('pages.team.members.actions.select-role.label'));
+          await screen.findByRole('listbox');
+          await click(
+            screen.getByRole('option', { name: this.intl.t('pages.team.members.actions.select-role.options.admin') }),
+          );
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: this.intl.t('pages.team.members.actions.select-role.label') }))
+            .containsText(this.intl.t('pages.team.members.actions.select-role.options.admin'));
+        });
+      });
     });
   });
 });

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -1,28 +1,51 @@
 import { module, test } from 'qunit';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import EmberObject from '@ember/object';
+import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | MembersList', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  let store;
+  let currentUser;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    currentUser = this.owner.lookup('service:current-user');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('when there are members in certification center', function () {
-    test('it displays column headers and lists the team members', async function (assert) {
+    test('it displays column headers for last name, first name, role, actions and lists the team members', async function (assert) {
       // given
-      const adminMembership = EmberObject.create({ firstName: 'Satoru', lastName: 'Gojô', role: 'ADMIN' });
-      const memberMembership = EmberObject.create({ firstName: 'Itadori', lastName: 'Yuji', role: 'MEMBER' });
-      const members = [adminMembership, memberMembership];
+      const memberWithAdminRole = store.createRecord('member', {
+        firstName: 'Satoru',
+        lastName: 'Gojô',
+        role: 'ADMIN',
+      });
+      const memberWithMemberRole = store.createRecord('member', {
+        firstName: 'Itadori',
+        lastName: 'Yuji',
+        role: 'MEMBER',
+      });
+      const members = [memberWithAdminRole, memberWithMemberRole];
+
+      sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithAdminRole.id });
+      sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').get(() => true);
       this.set('members', members);
 
       // when
-      const screen = await renderScreen(
-        hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`,
-      );
+      const screen = await renderScreen(hbs`<MembersList @members={{this.members}}/>`);
 
       // then
-      assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();
-      assert.dom(screen.getByRole('columnheader', { name: 'Prénom' })).exists();
+      assert.dom(screen.getByRole('columnheader', { name: this.intl.t('common.labels.candidate.lastname') })).exists();
+      assert.dom(screen.getByRole('columnheader', { name: this.intl.t('common.labels.candidate.firstname') })).exists();
+      assert.dom(screen.getByRole('columnheader', { name: this.intl.t('common.labels.candidate.role') })).exists();
+      assert.dom(screen.getByRole('columnheader', { name: this.intl.t('pages.team.table-headers.actions') })).exists();
       assert.strictEqual(members.length, 2);
       assert.contains('Gojô');
       assert.contains('Itadori');
@@ -32,9 +55,11 @@ module('Integration | Component | MembersList', function (hooks) {
   module('when certification center is habilitated CléA', function () {
     test('it shows the referer column', async function (assert) {
       // given
-      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
-      const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
+      const certifMember1 = store.createRecord('member', { firstName: 'Maria', lastName: 'Carré', isReferer: false });
+      const certifMember2 = store.createRecord('member', { firstName: 'John', lastName: 'Williams', isReferer: true });
       const members = [certifMember1, certifMember2];
+
+      sinon.stub(currentUser, 'certificationPointOfContact').value({ id: certifMember1.id });
       this.set('members', members);
       this.set('hasCleaHabilitation', true);
 
@@ -42,7 +67,6 @@ module('Integration | Component | MembersList', function (hooks) {
       const screen = await renderScreen(
         hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`,
       );
-
       // then
       assert.dom(screen.getByRole('columnheader', { name: this.intl.t('pages.team.referer') })).exists();
     });
@@ -51,9 +75,11 @@ module('Integration | Component | MembersList', function (hooks) {
   module('when a member is referer', function () {
     test('it shows the referer tag', async function (assert) {
       // given
-      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
-      const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
+      const certifMember1 = store.createRecord('member', { firstName: 'Maria', lastName: 'Carré', isReferer: false });
+      const certifMember2 = store.createRecord('member', { firstName: 'John', lastName: 'Williams', isReferer: true });
       const members = [certifMember1, certifMember2];
+
+      sinon.stub(currentUser, 'certificationPointOfContact').value({ id: certifMember1.id });
       this.set('members', members);
       this.set('hasCleaHabilitation', true);
 
@@ -63,6 +89,7 @@ module('Integration | Component | MembersList', function (hooks) {
       );
 
       // then
+
       assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).exists();
     });
   });
@@ -70,8 +97,10 @@ module('Integration | Component | MembersList', function (hooks) {
   module('when there is no referer', function () {
     test('it does not show the referer tag', async function (assert) {
       // given
-      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+      const certifMember1 = store.createRecord('member', { firstName: 'Maria', lastName: 'Carré', isReferer: false });
       const members = [certifMember1];
+
+      sinon.stub(currentUser, 'certificationPointOfContact').value({ id: certifMember1.id });
       this.set('members', members);
       this.set('hasCleaHabilitation', true);
 
@@ -88,8 +117,10 @@ module('Integration | Component | MembersList', function (hooks) {
   module('when certification center is not habilitated CléA', function () {
     test('it does not show the referer column', async function (assert) {
       // given
-      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+      const certifMember1 = store.createRecord('member', { firstName: 'Maria', lastName: 'Carré', isReferer: false });
       const members = [certifMember1];
+
+      sinon.stub(currentUser, 'certificationPointOfContact').value({ id: certifMember1.id });
       this.set('members', members);
       this.set('hasCleaHabilitation', false);
 

--- a/certif/tests/unit/adapters/member_test.js
+++ b/certif/tests/unit/adapters/member_test.js
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 import Service from '@ember/service';
+import ENV from 'pix-certif/config/environment';
 
 module('Unit | Adapter | member', function (hooks) {
   setupTest(hooks);
@@ -16,6 +18,71 @@ module('Unit | Adapter | member', function (hooks) {
 
       // then
       assert.true(url.endsWith(`certification-centers/${certificationCenterId}/members`));
+    });
+  });
+
+  module('#urlForUpdateRecord', function () {
+    test('calls the right url', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:member');
+      const store = this.owner.lookup('service:store');
+
+      const certificationCenterId = 123;
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: certificationCenterId,
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const certificationCenterMembershipId = 456;
+
+      // when
+      const url = await adapter.urlForUpdateRecord(certificationCenterMembershipId, 'member', {});
+
+      // then
+      assert.true(url.endsWith('/certification-centers/123/certification-center-memberships/456'));
+    });
+  });
+
+  module('#updateRecord', () => {
+    test('triggers an ajax call with the url, data and method', async function (assert) {
+      // given
+      const certificationCenterId = 123;
+      const certificationCenterMembershipId = 456;
+      const url = `${ENV.APP.API_HOST}/api/certification-centers/${certificationCenterId}/certification-center-memberships/456`;
+      const userId = 888;
+      const role = 'MEMBER';
+      const adapter = this.owner.lookup('adapter:member');
+      sinon.stub(adapter, 'ajax').resolves();
+      sinon.stub(adapter, 'buildURL').returns(url);
+      sinon.stub(adapter, 'serialize').returns({
+        id: userId,
+        data: { attributes: { 'certification-center-membership-id': certificationCenterMembershipId, role } },
+      }); //
+      const snapshot = { id: userId };
+
+      const store = this.owner.lookup('service:store');
+
+      // when
+      await adapter.updateRecord(store, { modelName: 'certificationCenterMembership' }, snapshot);
+
+      // then
+      const expectedModelName = 'certificationCenterMembership';
+      const expectedId = 456;
+      const expectedSnapshot = { id: userId };
+      sinon.assert.calledWith(adapter.buildURL, expectedModelName, expectedId, expectedSnapshot);
+
+      const expectedMethod = 'PATCH';
+      const expectedData = {
+        data: {
+          id: userId,
+          data: { attributes: { 'certification-center-membership-id': certificationCenterMembershipId, role } },
+        },
+      };
+      sinon.assert.calledWith(adapter.ajax, url, expectedMethod, expectedData);
+      assert.ok(adapter);
     });
   });
 

--- a/certif/tests/unit/components/members-list-item_test.js
+++ b/certif/tests/unit/components/members-list-item_test.js
@@ -1,0 +1,79 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Component | MembersListItem', (hooks) => {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('#updateCertificationCenterMembership', () => {
+    test('disables edition mode, saves membership and displays success notification', async function (assert) {
+      // given
+      const component = createGlimmerComponent('component:members-list-item');
+      component.isEditionMode = true;
+      component.notifications = {
+        success: sinon.stub(),
+      };
+      const member = {
+        save: sinon.stub().resolves(),
+      };
+
+      // when
+      await component.updateMember(member);
+
+      // then
+      assert.false(component.isEditionMode);
+      assert.ok(member.save.called);
+      assert.ok(component.notifications.success.called);
+    });
+
+    module('when an error occurs', function () {
+      test('rollbacks membership role modification and display error notification', async function (assert) {
+        // given
+        const component = createGlimmerComponent('component:members-list-item');
+        component.isEditionMode = true;
+        component.notifications = {
+          error: sinon.stub(),
+        };
+        const member = {
+          save: sinon.stub().rejects(),
+          rollbackAttributes: sinon.stub(),
+        };
+
+        // when
+        await component.updateMember(member);
+
+        // then
+        assert.false(component.isEditionMode);
+        assert.ok(member.save.called);
+        assert.ok(member.rollbackAttributes.called);
+        assert.ok(component.notifications.error.called);
+      });
+    });
+
+    module('when the cancel button is clicked', function () {
+      test('rollbacks member role modification', async function (assert) {
+        // given
+        const component = createGlimmerComponent('component:members-list-item');
+        component.isEditionMode = true;
+        component.notifications = {
+          error: sinon.stub(),
+        };
+        const member = {
+          rollbackAttributes: sinon.stub(),
+        };
+        component.args.member = member;
+
+        // when
+        await component.cancelUpdateRoleOfMember();
+
+        // then
+        assert.false(component.isEditionMode);
+        assert.ok(member.rollbackAttributes.called);
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -888,6 +888,9 @@
         "empty-option": "--Sélectionner--",
         "label": "Sélectionner le référent CléA Numérique"
       },
+      "table-headers": {
+        "actions": "Actions"
+      },
       "tabs": {
         "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",
         "member": "Members ({count, plural, =0 {-} other {{count}}})"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -861,6 +861,24 @@
       "invite-button": "Invite a member",
       "invite-member-button": "Invite a member",
       "members": {
+        "actions": {
+          "edit-role": "Change role",
+          "manage": "Manage",
+          "save": "Save",
+          "select-role": {
+            "label": "Select a role",
+            "options": {
+              "admin": "Administrator",
+              "member": "Member"
+            }
+          }
+        },
+        "notifications": {
+          "change-member-role": {
+            "error": "An error occurred while changing this member's role.",
+            "success": "The role has been changed."
+          }
+        },
         "role": {
           "admin": "Administrator",
           "member": "Member"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -861,6 +861,24 @@
       "invite-button": "Inviter un membre",
       "invite-member-button": "Inviter un membre",
       "members": {
+        "actions": {
+          "edit-role": "Modifier le rôle",
+          "manage": "Gérer",
+          "save": "Enregistrer",
+          "select-role": {
+            "label": "Sélectionner un rôle",
+            "options": {
+              "admin": "Administrateur",
+              "member": "Membre"
+            }
+          }
+        },
+        "notifications": {
+          "change-member-role": {
+            "error": "Une erreur est survenue lors de la modification du rôle du membre.",
+            "success": "Le rôle a bien été changé."
+          }
+        },
         "role": {
           "admin": "Administrateur",
           "member": "Membre"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -888,6 +888,9 @@
         "empty-option": "--Sélectionner--",
         "label": "Sélectionner le référent CléA Numérique"
       },
+      "table-headers": {
+        "actions": "Actions"
+      },
       "tabs": {
         "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",
         "member": "Membres ({count, plural, =0 {-} other {{count}}})"


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement un administrateur de centre de certification ne peut pas changer le rôle de ses membres.

## :gift: Proposition
 Pour permettre la modification du rôle : 
- rajouter une colonne "Actions" à droite de “Rôle” 
- ajouter pour chaque membre du centre de certification un bouton "Modifier le rôle", accessible uniquement aux administrateurs.
- L'administrateur connecté ne peut pas modifier son propre rôle.

## :socks: Remarques
RAS

## :santa: Pour tester

1. Se connecter à Pix Certif avec le compte d'un utilisateur qui est administrateur d'un centre de certification (par exemple : `James Palédroits`)
2. Choisir le centre sur lequel l'utilisateur est administrateur avec d'autres membres (par exemple : `Accessorium`)
3. Se rendre dans l'onglet `Equipe`
4. Constater la présence d'une colonne `Actions`
5. Constater que dans la liste des membres, aucun bouton de modification ne figure dans la ligne de l'utilisateur connecté. 
6. Constater la présence d'un bouton `Modifier le rôle` dans cette colonne, pour chacun des autres membres.
7. Cliquer sur ce bouton, un selecteur apparait et deux choix s'offrent à vous : `Membre` et `Administrateur`
8. Cliquer sur le bouton `Annuler`, le rôle du membre reste inchangé
9. Cliquer à nouveau sur modifier le rôle et cette fois-ci lui donner un autre rôle
10. Cliquer sur `Enregistrer`, le rôle du membre est mis à jour et une notification de succès apparaît
11. Vérifier en BDD que le rôle du membre a bien été mis à jour dans la table `certification-center-memberships`
12. Changer de centre de certification pour un centre de certification où l'utilisateur connecté est à la fois administrateur et le seul membre (par exemple : Accèstral).
13. Constater la présence d'une colonne `Actions`
14. Constater que dans la liste des membres, aucun bouton de modification ne figure dans la ligne de l'utilisateur connecté. 
15. Changer de centre de certification pour un centre de certification où l'utilisateur connecté est un simple membre (par exemple : `Accessovolt`)
16. Constater l'absence de la colonne `Actions`

**🛑 Pour tester la notification d'erreur :** 

1. Changer le signal en `offline` dans l'onglet network de la console du navigateur 
2. Modifier le rôle de l'utilisateur et enregistrer ce changement
3. Une notification d'erreur apparaît et le role du membre reste inchangé

