### PR TITLE
[TECH] Afficher directement les informations pour l'import de sessions en masse sur Pix Certif (PIX-10148)

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,4 +1,3 @@
-<p>{{t "pages.sessions.import.step-one.instructions.title"}}</p>
 <section class="import-page__section--download panel">
   <div class="import-page__section--download__instruction">
     {{t "pages.sessions.import.step-one.instructions.creation.list"}}

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,12 +1,5 @@
 <p>{{t "pages.sessions.import.step-one.instructions.title"}}</p>
 <div class="import-page_section--instructions">
-  <PixCollapsible @title={{t "pages.sessions.import.step-one.instructions.creation.title"}} @iconTitle="plus">
-    {{t "pages.sessions.import.step-one.instructions.creation.list"}}
-    <ul>
-      <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
-      <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
-    </ul>
-  </PixCollapsible>
   <PixCollapsible @title={{t "pages.sessions.import.step-one.instructions.edition.title"}} @iconTitle="plus">
     <ul>
       <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
@@ -19,6 +12,13 @@
 </div>
 
 <section class="import-page__section--download panel">
+  <div class="import-page__section--download__instruction">
+    {{t "pages.sessions.import.step-one.instructions.creation.list"}}
+    <ul>
+      <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
+      <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
+    </ul>
+  </div>
   <div class="import-page__section--download__button">
     <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
     <span>{{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}</span>

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,16 +1,4 @@
 <p>{{t "pages.sessions.import.step-one.instructions.title"}}</p>
-<div class="import-page_section--instructions">
-  <PixCollapsible @title={{t "pages.sessions.import.step-one.instructions.edition.title"}} @iconTitle="plus">
-    <ul>
-      <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
-      <li>{{t "pages.sessions.import.step-one.instructions.edition.subscription" htmlSafe=true}}</li>
-    </ul>
-    <PixMessage @type="warning" @withIcon={{true}}>
-      {{t "pages.sessions.import.step-one.instructions.edition.warning"}}
-    </PixMessage>
-  </PixCollapsible>
-</div>
-
 <section class="import-page__section--download panel">
   <div class="import-page__section--download__instruction">
     {{t "pages.sessions.import.step-one.instructions.creation.list"}}
@@ -18,6 +6,16 @@
       <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
       <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
     </ul>
+  </div>
+  <div class="import-page__section--download__instruction">
+    {{t "pages.sessions.import.step-one.instructions.edition.title"}}
+    <ul>
+      <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
+      <li>{{t "pages.sessions.import.step-one.instructions.edition.subscription" htmlSafe=true}}</li>
+    </ul>
+    <PixMessage @type="warning" @withIcon={{true}}>
+      {{t "pages.sessions.import.step-one.instructions.edition.warning"}}
+    </PixMessage>
   </div>
   <div class="import-page__section--download__button">
     <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,12 +1,12 @@
 <section class="import-page__section--download panel">
-  <div class="import-page__section--download__instruction">
+  <div class="import-page__section--download-instruction">
     {{t "pages.sessions.import.step-one.instructions.creation.list"}}
     <ul>
       <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
       <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
     </ul>
   </div>
-  <div class="import-page__section--download__instruction">
+  <div class="import-page__section--download-instruction">
     {{t "pages.sessions.import.step-one.instructions.edition.title"}}
     <ul>
       <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
@@ -16,7 +16,7 @@
       {{t "pages.sessions.import.step-one.instructions.edition.warning"}}
     </PixMessage>
   </div>
-  <div class="import-page__section--download__button">
+  <div class="import-page__section--download-button">
     <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
     <span>{{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}</span>
     <PixButton
@@ -29,7 +29,7 @@
     </PixButton>
   </div>
 
-  <div tabindex="0" class="import-page__section--download__button">
+  <div tabindex="0" class="import-page__section--download-button">
     <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
     <span>{{t "pages.sessions.import.step-one.actions.session-import-upload.extra-information"}}</span>
     <PixButtonUpload

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -31,7 +31,7 @@
         @iconTitle="plus"
         class="import-page-section__collapsible-header--non-blocking"
       >
-        <ul>
+        <ul class="import-page-section__collapsible-header--non-blocking-list">
           {{#each this.translatedNonBlockingErrorReport as |report|}}
             <li>
               <PixMessage @type="warning">
@@ -60,7 +60,7 @@
         @iconTitle="plus"
         class="import-page-section__collapsible-header--blocking"
       >
-        <ul>
+        <ul class="import-page-section__collapsible-header--blocking-list">
           {{#each this.translatedBlockingErrorReport as |report|}}
             <li>
               <PixMessage @type="error">

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -8,10 +8,12 @@
           "pages.sessions.import.step-two.sessions-and-empty-sessions-count"
           sessionsCount=@sessionsCount
           sessionsWithoutCandidatesCount=@sessionsWithoutCandidatesCount
-        }}</li>
+        }}
+      </li>
       <li>
         <FaIcon @icon="user" />
-        {{t "pages.sessions.import.step-two.candidates-count" candidatesCount=@candidatesCount}}</li>
+        {{t "pages.sessions.import.step-two.candidates-count" candidatesCount=@candidatesCount}}
+      </li>
     </ul>
   </PixMessage>
   {{#if (gt this.nonBlockingErrorReportsCount 0)}}
@@ -29,9 +31,9 @@
           nonBlockingErrorReportsCount=this.nonBlockingErrorReportsCount
         }}
         @iconTitle="plus"
-        class="import-page-section__collapsible-header--non-blocking"
+        class="collapsible-header collapsible-header--non-blocking"
       >
-        <ul class="import-page-section__collapsible-header--non-blocking-list">
+        <ul class="collapsible-header__list">
           {{#each this.translatedNonBlockingErrorReport as |report|}}
             <li>
               <PixMessage @type="warning">
@@ -58,9 +60,9 @@
           blockingErrorReportsCount=this.blockingErrorReportsCount
         }}
         @iconTitle="plus"
-        class="import-page-section__collapsible-header--blocking"
+        class="collapsible-header collapsible-header--blocking"
       >
-        <ul class="import-page-section__collapsible-header--blocking-list">
+        <ul class="collapsible-header__list">
           {{#each this.translatedBlockingErrorReport as |report|}}
             <li>
               <PixMessage @type="error">

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -69,7 +69,7 @@
       margin-left: 24px;
     }
 
-    > p {
+    .pix-message--warning {
         margin-top: $pix-spacing-s;
       }
   }

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -96,6 +96,17 @@
     }
   }
 
+  &__section--download__instruction {
+    color: $pix-neutral_50;
+    padding-top: 24px;
+    font-size: 14px;
+    ul {
+      list-style: disc;
+      margin-top: 6px;
+      margin-left: 24px;
+    }
+  }
+
   &__section--download {
     display: flex;
     flex-direction: column;

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -8,43 +8,6 @@
     margin-bottom: 8px;
   }
 
-  &_section--instructions {
-    .pix-collapsible {
-      margin-bottom: 8px;
-    }
-
-    .pix-collapsible,
-    .pix-collapsible__title {
-      border-radius: 8px;
-      color: $pix-neutral-70;
-    }
-
-    .pix-collapsible__title[aria-expanded='true'] {
-      background-color: inherit;
-      border-radius: 8px 8px 0 0;
-    }
-
-    .pix-collapsible__title--uncollapsed {
-      border-radius: 8px 8px 0 0;
-    }
-
-    .pix-collapsible__content {
-      line-height: 20px;
-      padding: 14px 16px;
-    }
-
-    .pix-collapsible ul {
-      list-style: disc;
-      margin-top: 6px;
-      margin-left: 24px;
-    }
-  }
-
-  .pix-collapsible .pix-message {
-    border-radius: 4px;
-    margin-top: 8px;
-  }
-
   &__section--breadcrumb {
     background-color: $pix-neutral-5;
     border: 1px solid $pix-neutral-15;
@@ -97,20 +60,25 @@
   }
 
   &__section--download__instruction {
-    color: $pix-neutral_50;
-    padding-top: 24px;
+    color: $pix-neutral-50;
     font-size: 14px;
+
     ul {
       list-style: disc;
       margin-top: 6px;
       margin-left: 24px;
     }
+
+    > p {
+        margin-top: $pix-spacing-s;
+      }
   }
 
   &__section--download {
     display: flex;
     flex-direction: column;
-    padding: 24px;
+    padding: $pix-spacing-m;
+    gap: $pix-spacing-m;
 
     .pix-message__content {
       color: $pix-neutral-70;
@@ -128,8 +96,8 @@
 
   &__section--download__button {
     align-items: center;
-    background-color: $pix-neutral-5;
-    border: 1px solid $pix-neutral-10;
+    background-color: $pix-neutral-10;
+    border: 1px solid $pix-neutral-15;
     border-radius: 8px;
     color: $pix-neutral-90;
     display: grid;
@@ -141,10 +109,6 @@
     }
   }
 
-  &__section--download__button:first-of-type {
-    margin-bottom: 16px;
-  }
-
   &__section--download__button .download-icon {
     color: $pix-neutral-25;
     margin: auto;
@@ -153,7 +117,6 @@
   &__section--link-buttons {
     display: flex;
     gap: $pix-spacing-s;
-    margin-top: 24px;
   }
 
   &__file-name {
@@ -161,7 +124,6 @@
     justify-content: center;
     align-items: center;
     padding: 16px 24px;
-    margin-top: 24px;
     width: fit-content;
     border: 1px solid $pix-neutral-15;
     border-radius: 8px;
@@ -218,4 +180,11 @@
       color: $pix-warning-40;
     }
   }
+
+  &__collapsible-header--non-blocking-list, &__collapsible-header--blocking-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
 }

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -59,7 +59,7 @@
     }
   }
 
-  &__section--download__instruction {
+  &__section--download-instruction {
     color: $pix-neutral-50;
     font-size: 14px;
 
@@ -70,8 +70,8 @@
     }
 
     .pix-message--warning {
-        margin-top: $pix-spacing-s;
-      }
+      margin-top: $pix-spacing-s;
+    }
   }
 
   &__section--download {
@@ -94,7 +94,7 @@
     }
   }
 
-  &__section--download__button {
+  &__section--download-button {
     align-items: center;
     background-color: $pix-neutral-10;
     border: 1px solid $pix-neutral-15;
@@ -104,12 +104,13 @@
     grid-template-columns: 1fr 10fr 2fr;
     padding: 24px 16px 24px 0;
 
-    > label, button {
+    > label,
+    button {
       width: 164px;
     }
   }
 
-  &__section--download__button .download-icon {
+  &__section--download-button .download-icon {
     color: $pix-neutral-25;
     margin: auto;
   }
@@ -160,31 +161,29 @@
     color: $pix-neutral-70;
     font-weight: $font-medium;
   }
+}
 
-  &__collapsible-header--blocking,
-  &__collapsible-header--non-blocking {
-    .pix-collapsible-title__label {
-      font-size: 1rem;
-      font-weight: 400;
-    }
+.collapsible-header {
+  .pix-collapsible-title__label {
+    font-size: 1rem;
+    font-weight: 400;
   }
 
-  &__collapsible-header--blocking {
-    .pix-collapsible-title__icon {
-      color: $pix-error-70;
-    }
-  }
-
-  &__collapsible-header--non-blocking {
-    .pix-collapsible-title__icon {
-      color: $pix-warning-40;
-    }
-  }
-
-  &__collapsible-header--non-blocking-list, &__collapsible-header--blocking-list {
+  &__list {
     display: flex;
     flex-direction: column;
     gap: 8px;
   }
+}
 
+.collapsible-header--blocking {
+  .pix-collapsible-title__icon {
+    color: $pix-error-70;
+  }
+}
+
+.collapsible-header--non-blocking {
+  .pix-collapsible-title__icon {
+    color: $pix-warning-40;
+  }
 }

--- a/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
@@ -61,7 +61,13 @@ module('Acceptance | Routes | Authenticated | Sessions | import', function (hook
       // then
       assert.strictEqual(currentURL(), '/sessions/import');
       assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
-      assert.dom(screen.getByText('Télécharger (.csv)')).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: 'Télécharger le modèle vierge',
+          }),
+        )
+        .exists();
       assert.dom(screen.getByRole('button', { name: 'Importer (.csv)' })).exists();
     });
   });

--- a/certif/tests/integration/components/sessions-import/step-one-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-one-section_test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { hbs } from 'ember-cli-htmlbars';
+import { render, getByTextWithHtml } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | Import::StepOneSection', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders the step one section', async function (assert) {
+    // given
+    this.set('downloadSessionImportTemplate', () => {});
+    this.set('preImportSessions', () => {});
+    this.set('file', null);
+    this.set('fileName', () => null);
+    this.set('removeImport', () => {});
+    this.set('validateSessions', () => {});
+    this.set('isImportDisabled', true);
+
+    // when
+    const { getByText, getByRole } = await render(
+      hbs`<Import::StepOneSection
+        @downloadSessionImportTemplate={{this.downloadSessionImportTemplate}}
+        @preImportSessions={{this.preImportSessions}}
+        @file={{this.file}}
+        @fileName={{this.fileName}}
+        @removeImport={{this.removeImport}}
+        @validateSessions={{this.validateSessions}}
+        @isImportDisabled={{this.isImportDisabled}}
+      />`,
+    );
+
+    // then
+    assert.dom(getByText('Vous pouvez créer des sessions :')).exists();
+    assert.ok(getByTextWithHtml('<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,'));
+    assert.ok(getByTextWithHtml('<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.'));
+    assert.ok(getByTextWithHtml('<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,'));
+    assert.ok(getByTextWithHtml('<strong>Pour inscrire</strong> des candidats dans une session vide.'));
+    assert
+      .dom(
+        getByText(
+          'Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création.',
+        ),
+      )
+      .exists();
+    assert.dom(getByText('Télécharger le modèle vierge')).exists();
+    assert
+      .dom(
+        getByRole('button', {
+          name: 'Télécharger le modèle vierge',
+        }),
+      )
+      .exists();
+    assert.dom(getByText('Importer le modèle complété')).exists();
+    assert.dom(getByText('Importer (.csv)')).exists();
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -673,7 +673,6 @@
             "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
           },
           "instructions": {
-            "title": "Comment ça marche ?",
             "creation": {
               "title": "Pour créer des sessions ?",
               "list": "Vous pouvez créer des sessions :",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -673,7 +673,6 @@
             "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
           },
           "instructions": {
-            "title": "Comment ça marche ?",
             "creation": {
               "title": "Pour créer des sessions ?",
               "list": "Vous pouvez créer des sessions :",


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion massive des sessions est une nouvelle fonctionnalité qui a été mise à disposition de nos utilisateurs en juillet 2023.

La fonctionnalité de gestion massive des sessions correspond à un usage limité aux utilisateurs qui doivent créer de nombreuses sessions à la fois ou encore de modifier la liste de candidats de plusieurs sessions.

Lorsque l’utilisateur clique sur “Créer/éditer plusieurs sessions”, il arrive sur une page avec explications pour aider à la prise en main de cette fonctionnalité complexe.

Les explications sont contenues dans des collapsibles qui sont bien souvent ignorées par les utilisateurs. Elles ne sont pas assez visibles.

## :gift: Proposition
Préciser le texte de l’explication en dehors du collapsible en gardant le bandeau d’alerte (maquette incomplète, manque le texte sur l'édition de liste de candidats) 

## :santa: Pour tester
- Se connecter sur pix-certif (certif-pro@example.net)
- Aller sur la page d'import en masse de session
- Constater l'affichage suivant

<img width="1460" alt="Capture d’écran 2023-12-08 à 17 14 40" src="https://github.com/1024pix/pix/assets/58915422/889e7e5c-0550-4682-9291-352badd50833">

-Tester le parcours complet pour vérifier la non régression du design dans son ensemble
