### PR TITLE
[FEATURE] Modification de la hiérarchie des boutons de création de sessions (PIX-10147).

### DIFF
--- a/certif/app/components/no-session-panel.hbs
+++ b/certif/app/components/no-session-panel.hbs
@@ -2,18 +2,22 @@
   <img class="no-session-panel__icon" src="{{this.rootURL}}/icons/empty-list-session.svg" alt="" role="none" />
   <h1 class="page-title">{{t "pages.sessions.list.empty.title"}}</h1>
 
-  <div class="no-session-panel__link-to-create">
-    <PixButtonLink @route="authenticated.sessions.new">
-      {{t "pages.sessions.list.actions.creation.label"}}
-    </PixButtonLink>
-    {{#if this.shouldRenderImportTemplateButton}}
-      <PixButtonLink
-        @route="authenticated.sessions.import"
-        @backgroundColor="transparent-light"
-        @isBorderVisible="true"
-      >
-        {{t "pages.sessions.list.actions.multiple-creation.label"}}
+  <ul class="no-session-panel__link-to-create">
+    <li>
+      <PixButtonLink @route="authenticated.sessions.new">
+        {{t "pages.sessions.list.actions.creation.label"}}
       </PixButtonLink>
+    </li>
+    {{#if this.shouldRenderImportTemplateButton}}
+      <li>
+        <PixButtonLink
+          @route="authenticated.sessions.import"
+          @backgroundColor="transparent-light"
+          @isBorderVisible="true"
+        >
+          {{t "pages.sessions.list.actions.multiple-creation.label"}}
+        </PixButtonLink>
+      </li>
     {{/if}}
-  </div>
+  </ul>
 </div>

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,13 +1,17 @@
 <div class="session-list__header">
   <h1 class="page-title">{{t "pages.sessions.list.title"}}</h1>
-  <div class="session-list-header__actions">
-    <PixButtonLink @route="authenticated.sessions.new">
+  <ul class="session-list-header__actions">
+    {{#if this.shouldRenderImportTemplateButton}}
+      <li>
+        <PixButtonLink @route="authenticated.sessions.import">
+          {{t "pages.sessions.list.actions.multiple-creation-edition.label"}}
+        </PixButtonLink>
+      </li>
+    {{/if}}
+    <li>
+      <PixButtonLink @route="authenticated.sessions.new">
       {{t "pages.sessions.list.actions.creation.label"}}
     </PixButtonLink>
-    {{#if this.shouldRenderImportTemplateButton}}
-      <PixButtonLink @route="authenticated.sessions.import">
-        {{t "pages.sessions.list.actions.multiple-creation-edition.label"}}
-      </PixButtonLink>
-    {{/if}}
-  </div>
+    </li>
+  </ul>
 </div>

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -3,15 +3,19 @@
   <ul class="session-list-header__actions">
     {{#if this.shouldRenderImportTemplateButton}}
       <li>
-        <PixButtonLink @route="authenticated.sessions.import">
+        <PixButtonLink
+          @backgroundColor="transparent-light"
+          @isBorderVisible="true"
+          @route="authenticated.sessions.import"
+        >
           {{t "pages.sessions.list.actions.multiple-creation-edition.label"}}
         </PixButtonLink>
       </li>
     {{/if}}
     <li>
       <PixButtonLink @route="authenticated.sessions.new">
-      {{t "pages.sessions.list.actions.creation.label"}}
-    </PixButtonLink>
+        {{t "pages.sessions.list.actions.creation.label"}}
+      </PixButtonLink>
     </li>
   </ul>
 </div>

--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -29,10 +29,7 @@
 
 .session-list-header__actions {
   display: flex;
-
-  & .pix-button:not(:last-child) {
-    margin-right: 12px;
-  }
+  gap: $pix-spacing-xs;
 }
 
 .new-session-icon {

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -67,10 +67,13 @@ module('Integration | Component | panel-header', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
 
       // when
-      const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
+      const screen = await render(hbs`<Sessions::PanelHeader />`);
 
       // then
-      assert.dom(getByRole('link', { name: 'Créer/éditer plusieurs sessions' })).exists();
+      const createOneSessionButton = screen.getByRole('link', { name: 'Créer une session' });
+      const createOrEditMultipleSessionsButton = screen.getByRole('link', { name: 'Créer/éditer plusieurs sessions' });
+      const buttonsInTheRightOrder = createOrEditMultipleSessionsButton.compareDocumentPosition(createOneSessionButton);
+      assert.strictEqual(buttonsInTheRightOrder, Node.DOCUMENT_POSITION_FOLLOWING);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Une nouvelle version du système de design de Pix introduit un changement sur la hiérarchie des boutons.
Sur Pix Certif, sur la liste des sessions, le bouton de création d'une session est le bouton principal. Il doit donc se trouver à droite du second bouton.

## :robot: Proposition

Ordonner les boutons de création de session et création/édition de plusieurs sessions

Hiérarchiser les boutons :

* Primary pour le bouton de création d’une seule session
* Secondary pour le bouton de création de plusieurs sessions

## :rainbow: Remarques

Pour un besoin d'a11y, lorsqu'il y a plusieurs boutons d'actions, il est nécessaire de les réunir en une liste de boutons.

Cette liste a été effectué dans la page lorsqu'il n'y a aucune session existant (3eme commit)

## :100: Pour tester

Non régression des boutons sur la page sans session : 
* Se connecter sur Pix Certif avec `certifV3@example.net`
https://certif-pr7639.review.pix.fr

* Constater que les boutons n'ont pas bougé

<img width="534" alt="Capture d’écran 2023-11-30 à 18 11 00" src="https://github.com/1024pix/pix/assets/58915422/d00a4884-0ac9-4217-ab03-baa0786e46a5">

* Créer une session puis sortir de la page de détails de cette session pour retourner dans la liste
* Constater que les boutons "Créer une session" et "Créer/éditer plusieurs sessions" ont été intervertis (primary pour celui à droite et secondary pour celui à gauche)

<img width="1518" alt="Capture d’écran 2023-12-07 à 16 19 36" src="https://github.com/1024pix/pix/assets/58915422/70bede1b-9a35-48ff-90e8-7b59e9605f63">
