### PR TITLE
[TECH] Activer le logger par défaut dans les nouveaux environnements (PIX-10289).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -335,11 +335,11 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # LOGGING
 # =======
 
-# Enable or disable the logging of the API. Always true in development.
+# Enable or disable the logging of the API.
 #
 # presence: optional
 # type: Boolean
-# default: `false`
+# default: `true`
 # LOG_ENABLED=true
 LOG_STARTING_EVENT_DISPATCH=true
 LOG_ENDING_EVENT_DISPATCH=true

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -244,7 +244,7 @@ const configuration = (function () {
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
     },
     logging: {
-      enabled: isFeatureEnabled(process.env.LOG_ENABLED),
+      enabled: isFeatureNotDisabled(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
       logForHumans: _getLogForHumans(),
       enableKnexPerformanceMonitoring: isFeatureEnabled(process.env.ENABLE_KNEX_PERFORMANCE_MONITORING),
@@ -371,9 +371,7 @@ const configuration = (function () {
     },
   };
 
-  if (config.environment === 'development') {
-    config.logging.enabled = isFeatureNotDisabled(process.env.LOG_ENABLED);
-  } else if (process.env.NODE_ENV === 'test') {
+  if (process.env.NODE_ENV === 'test') {
     config.auditLogger.baseUrl = 'http://audit-logger.local';
     config.auditLogger.clientSecret = 'client-super-secret';
 


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement par défaut le logger, si non renseigné explicitement, est désactivé par défaut.
Cela ne respecte pas les préconisations de sécurité.

Source OWASP : https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
> often custom application event logging is missing, disabled or poorly configured.

Source Common Weakness (CWE-778: Insufficient Logging) : https://cwe.mitre.org/data/definitions/778.html
> When security-critical events are not logged properly, such as a failed login attempt, this can make malicious behavior more difficult to detect and may hinder forensic analysis after an attack succeeds.

Par ailleurs, cela a engendré le besoin de code spécifique en developpement pour surcharger ce problème de comportement par défaut.

## :gift: Proposition

* Modifier la configuration par défaut concernant le logger
* Corriger la documentation du `sample.env` qui est erronée pour l'environnement de développement
* Retirer le code spécifique pour l'environnement de développement, car non nécessaire désormais
* Conserver la capacité de désactiver les logs apporté dans la [PR #7589](https://github.com/1024pix/pix/pull/7589)
  
## :socks: Remarques

Avait été soulevé un point sur la désactivation des logs par défaut dans la [PR #7589](https://github.com/1024pix/pix/pull/7589#issuecomment-1840966753). 
> on peut imaginer des cas où des infos sensibles sont envoyées dans les requêtes, dans les headers

L'activation du logger n'influe pas sur l'envoi d'informations dans les requêtes et les headers. Ceci concernent d'autres éléments de configuration de l'API.

## :santa: Pour tester

* Vérifier que votre `.env` à la valeur préconisée par défaut : `LOG_ENABLED=true` (comme le `sample.env` )
  * Lancer `NODE_ENV='production' npm start` les logs de l'API doivent s'afficher
* Supprimer dans votre `.env` la ligne `LOG_ENABLED`, et assurer que votre console est à jour (par exemple en faisant un `unset LOG_ENABLED`)
  * Lancer `NODE_ENV='production' npm start` les logs de l'API doivent s'afficher
* Dans votre fichier `.env` mettre LOG_ENABLED=false
  * Lancer `NODE_ENV='production' npm start` les logs de l'API ne doivent pas s'afficher

* Refaire ces mêmes tests, mais avec `NODE_ENV='development', et vérifier que les comportements de toutes les étapes précèdentes sont les mêmes.