### PR TITLE
[FEATURE] MAJ des commentaires auto-jury en certif V3 (PIX-10212).

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -133,9 +133,12 @@ async function _handleV3Certification({
   });
 
   if (_shouldCancelV3Certification({ allAnswers, certificationCourse })) {
-    const cancelMessage = 'Cancelled due to lack of answers and technical issues';
-    assessmentResult.commentForCandidate = cancelMessage;
-    assessmentResult.commentForOrganization = cancelMessage;
+    const organizationCancelMessage =
+      "Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidat(e) au surveillant de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans l'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).";
+    const candidateCancelMessage =
+      "Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification, a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous n'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification (le cas échéant), en est informé.";
+    assessmentResult.commentForCandidate = candidateCancelMessage;
+    assessmentResult.commentForOrganization = organizationCancelMessage;
     certificationCourse.cancel();
     certificationCourseRepository.update(certificationCourse);
   }

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -221,8 +221,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               status: 'validated',
               competenceMarks: [],
               assessmentId: 123,
-              commentForCandidate: 'Cancelled due to lack of answers and technical issues',
-              commentForOrganization: 'Cancelled due to lack of answers and technical issues',
+              commentForCandidate:
+                "Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification, a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous n'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification (le cas échéant), en est informé.",
+              commentForOrganization:
+                "Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidat(e) au surveillant de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans l'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).",
             }),
           };
 


### PR DESCRIPTION
## :christmas_tree: Problème

Une certif v3 avec moins de V questions répondues, et ayant pour raison de l’abandon “Problème technique”, déclenche l’ajout automatique d’un commentaire jury à destination du candidat et du prescripteur.

-> C’est actuellement un message temporaire qui est affiché : “Cancelled due to lack of answers and technical issues”

## :gift: Proposition

Mettre à jour le wording des commentaires jury générés automatiquement en cas d’annulation automatique d’une certif pour cause de problèmes technique : 

Pour le candidat :
Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification, a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous n'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification (le cas échéant), en est informé.

Pour l'organisation :
Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidate au surveillant de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans l'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- créer une session v3 et inscrire un candidat en renseignant un destinataire des résultats = soi-même (pour recevoir le csv des résultats après publication  )
- lancer le test avec le candidat, et ne répondre qu'à 1 question
- dans Pix certif, cliquer sur “Finaliser la session”
- sélectionner l’option “Problème technique” comme raison de l’abandon puis confirmer la finalisation
- dans Pix admin > ouvrir la page de détails de la certif 
- résultat : le statut de la certif est “Annulée”
- un message automatique est renseigné dans le champ “Pour le candidat :” dans la section “Commentaires jury”
- publier la session
- sur le compte app du candidat, ouvrir la page 'Mes certifications”
- résultat : la certif est au statut “Annulée”
- un lien “Détails” est affiché avec le message du jury
- ouvrir le mail reçu avec les résultat de la certif
- résultat : pour cette certification, il est indiqué “Annulée” dans la colonne “Statut”, et le message du jury est indiqué dans la colonne “Commentaire jury pour l’organisation”
