### PR TITLE
[FEATURE] Fixer le score maximum d'une certification à 896 Pix (PIX-10132).

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -112,6 +112,7 @@ async function _handleV3Certification({
     challenges,
     allAnswers,
     abortReason,
+    maxReachableLevelOnCertificationDate: certificationCourse.getMaxReachableLevelOnCertificationDate(),
   });
 
   const emitter =

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -134,6 +134,7 @@ async function _handleV3CertificationScoring({
     challenges,
     allAnswers,
     abortReason,
+    maxReachableLevelOnCertificationDate: certificationCourse.getMaxReachableLevelOnCertificationDate(),
   });
 
   if (_shouldCancelV3Certification({ allAnswers, certificationCourse })) {

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -236,6 +236,10 @@ class CertificationCourse {
     return this._version;
   }
 
+  getMaxReachableLevelOnCertificationDate() {
+    return this._maxReachableLevelOnCertificationDate;
+  }
+
   toDTO() {
     return {
       id: this._id,

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -30,6 +30,7 @@ function buildCertificationCourse({
   isRejectedForFraud = false,
   abortReason = null,
   complementaryCertificationCourses = [],
+  maxReachableLevelOnCertificationDate = 7,
 } = {}) {
   const certificationIssueReports = [];
   if (examinerComment && examinerComment !== '') {
@@ -70,6 +71,7 @@ function buildCertificationCourse({
     isCancelled,
     abortReason,
     complementaryCertificationCourses,
+    maxReachableLevelOnCertificationDate,
   });
 }
 
@@ -98,6 +100,7 @@ buildCertificationCourse.unpersisted = function ({
   isRejectedForFraud = false,
   abortReason = null,
   complementaryCertificationCourses = [],
+  maxReachableLevelOnCertificationDate = 7,
 } = {}) {
   return new CertificationCourse({
     firstName,
@@ -125,6 +128,7 @@ buildCertificationCourse.unpersisted = function ({
     isRejectedForFraud,
     abortReason,
     complementaryCertificationCourses,
+    maxReachableLevelOnCertificationDate,
   });
 };
 

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -9,6 +9,7 @@ import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse
 
 describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function () {
   const assessmentId = 1234;
+  const maxReachableLevelOnCertificationDate = 7;
 
   let answerRepository;
   let challengeRepository;
@@ -103,6 +104,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         challenges,
         allAnswers,
         algorithm,
+        maxReachableLevelOnCertificationDate,
       });
 
       expect(score.nbPix).to.equal(expectedScoreForEstimatedLevel);
@@ -144,6 +146,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
           algorithm,
           abortReason,
+          maxReachableLevelOnCertificationDate,
         });
 
         expect(score.nbPix).to.equal(expectedScoreForEstimatedLevel);
@@ -184,6 +187,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
           algorithm,
           abortReason,
+          maxReachableLevelOnCertificationDate,
         });
 
         expect(score.nbPix).to.equal(expectedScoreForEstimatedLevel);
@@ -215,6 +219,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         challenges,
         allAnswers,
         algorithm,
+        maxReachableLevelOnCertificationDate,
       });
 
       // then
@@ -223,7 +228,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   });
 
   describe('when we reach an estimated level above the MAXIMUM', function () {
-    it('the score should be 1024', function () {
+    it('the score should be 896', function () {
       // given
       const veryHighEstimatedLevel = 1200;
       const veryHardDifficulty = 8;
@@ -246,10 +251,11 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         challenges,
         allAnswers,
         algorithm,
+        maxReachableLevelOnCertificationDate,
       });
 
       // then
-      expect(score.nbPix).to.equal(1024);
+      expect(score.nbPix).to.equal(896);
     });
   });
 
@@ -276,6 +282,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           challenges,
           allAnswers,
           algorithm,
+          maxReachableLevelOnCertificationDate,
         });
 
         expect(score.status).to.equal(status.VALIDATED);
@@ -305,6 +312,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
             algorithm,
             abortReason: 'candidate',
+            maxReachableLevelOnCertificationDate,
           });
 
           expect(score.status).to.equal(status.REJECTED);
@@ -333,6 +341,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
             algorithm,
             abortReason: 'candidate',
+            maxReachableLevelOnCertificationDate,
           });
 
           expect(score.status).to.equal(status.REJECTED);
@@ -363,6 +372,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
           algorithm,
           certificationCourseAbortReason,
+          maxReachableLevelOnCertificationDate,
         });
 
         expect(score.status).to.equal(status.VALIDATED);


### PR DESCRIPTION
## :christmas_tree: Problème

Le score enregistré lors de la certif doit être capé au score maximum (actuellement 896 = 128 * maxLevel).
Lors du déblocage du niveau 8, le score des certifs déjà terminées ne devra PAS changer.

## :gift: Proposition

Se baser sur la propriété `maxReachableLevelOnCertificationDate` disponible dans la table `certification-courses` pour fixer le score.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- créer une session v3 et inscrire un candidat en renseignant un destinataire des résultats = soi-même (pour recevoir le csv des résultats après publication )
- lancer le test avec le candidat, et répondre bon à l'ensemble des questions
- dans Pix certif, cliquer sur “Finaliser la session”
- dans Pix admin > ouvrir la page de détails de la certif 
- résultat : le score ne doit pas dépasser 896 pix.
- Passer le niveau maximum atteignable à 8 sur la RA
- Rejeter la session précédemment jouée
- Le score ne doit pas avoir changé
