### PR TITLE
[TECH] Migrer AssessmentResult vers la nouvelle arbo API (PIX-9927).

### DIFF
--- a/api/db/database-builder/factory/build-assessment-result.js
+++ b/api/db/database-builder/factory/build-assessment-result.js
@@ -2,7 +2,7 @@ import { buildAssessment } from './build-assessment.js';
 import { buildCertificationCourseLastAssessmentResult } from './build-certification-course-last-assessment-result.js';
 import { buildUser } from './build-user.js';
 import { databaseBuffer } from '../database-buffer.js';
-import { AssessmentResult } from '../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import _ from 'lodash';
 
 function buildAssessmentResult({

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -1,6 +1,6 @@
 import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
-import * as assessmentResultService from '../../domain/services/assessment-result-service.js';
+import * as assessmentResultService from '../../../src/shared/domain/services/assessment-result-service.js';
 
 // TODO: Should be removed and replaced by a real serializer
 function _deserializeResultsAdd(json) {

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -1,4 +1,4 @@
-import { AssessmentResult } from '../../domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
 import * as assessmentResultService from '../../domain/services/assessment-result-service.js';
 

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -6,7 +6,7 @@ import * as certifiedProfileRepository from '../../infrastructure/repositories/c
 import * as certifiedProfileSerializer from '../../infrastructure/serializers/jsonapi/certified-profile-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
-import { AssessmentResult } from '../../domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
 import * as assessmentResultService from '../../domain/services/assessment-result-service.js';
 

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -8,7 +8,7 @@ import { usecases } from '../../domain/usecases/index.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
-import * as assessmentResultService from '../../domain/services/assessment-result-service.js';
+import * as assessmentResultService from '../../../src/shared/domain/services/assessment-result-service.js';
 
 import { extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -117,12 +117,6 @@ class AlreadyRatedAssessmentError extends DomainError {
   }
 }
 
-class AssessmentResultNotCreatedError extends DomainError {
-  constructor(message = "L'assessment result n'a pas pu être généré.") {
-    super(message);
-  }
-}
-
 class AlreadyRegisteredEmailAndUsernameError extends DomainError {
   constructor(message = 'Cette adresse e-mail et cet identifiant sont déjà utilisés.') {
     super(message);
@@ -623,12 +617,6 @@ class MembershipUpdateError extends DomainError {
 
 class MissingAttributesError extends DomainError {
   constructor(message = 'Attributs manquants.') {
-    super(message);
-  }
-}
-
-class MissingAssessmentId extends DomainError {
-  constructor(message = 'AssessmentId manquant ou incorrect') {
     super(message);
   }
 }
@@ -1140,7 +1128,6 @@ export {
   ArchivedCampaignError,
   AssessmentEndedError,
   AssessmentNotCompletedError,
-  AssessmentResultNotCreatedError,
   AuditLoggerApiError,
   AuthenticationKeyExpired,
   AuthenticationMethodAlreadyExistsError,
@@ -1200,7 +1187,6 @@ export {
   MatchingReconciledStudentNotFoundError,
   MembershipCreationError,
   MembershipUpdateError,
-  MissingAssessmentId,
   MissingAttributesError,
   MissingBadgeCriterionError,
   MissingUserAccountError,

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -1,4 +1,4 @@
-import { AssessmentResult } from '../models/AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CertificationResult } from '../models/CertificationResult.js';
 import { CompetenceMark } from '../models/CompetenceMark.js';
 import { CertificationRescoringCompleted } from './CertificationRescoringCompleted.js';

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -1,4 +1,4 @@
-import { AssessmentResult } from '../models/AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CertificationScoringCompleted } from './CertificationScoringCompleted.js';
 import { CompetenceMark } from '../models/CompetenceMark.js';
 import bluebird from 'bluebird';

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -10,7 +10,7 @@ import * as eventBusBuilder from '../../infrastructure/events/EventBusBuilder.js
 import * as answerRepository from '../../../src/evaluation/infrastructure/repositories/answer-repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
-import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
+import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeRepository from '../../infrastructure/repositories/badge-repository.js';
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';

--- a/api/lib/domain/models/CertificationAssessmentScore.js
+++ b/api/lib/domain/models/CertificationAssessmentScore.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { status } from './AssessmentResult.js';
+import { status } from '../../../src/shared/domain/models/AssessmentResult.js';
 
 class CertificationAssessmentScore {
   constructor({

--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -1,4 +1,4 @@
-import { status as CertificationStatus } from './AssessmentResult.js';
+import { status as CertificationStatus } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { config } from '../../../src/shared/config.js';
 import { ABORT_REASONS } from './CertificationCourse.js';
 

--- a/api/lib/domain/models/PrivateCertificate.js
+++ b/api/lib/domain/models/PrivateCertificate.js
@@ -1,4 +1,4 @@
-import { status as assessmentResultStatuses } from './AssessmentResult.js';
+import { status as assessmentResultStatuses } from '../../../src/shared/domain/models/AssessmentResult.js';
 
 const status = {
   REJECTED: 'rejected',

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -7,7 +7,7 @@ import { AnswerStatus } from '../../../src/shared/domain/models/AnswerStatus.js'
 import { Area } from './Area.js';
 import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/model/FlashAssessmentAlgorithm.js';
-import { AssessmentResult } from './AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { AssessmentSimulator } from '../../../src/certification/flash-certification/domain/model/AssessmentSimulator.js';
 import { Authentication } from './Authentication.js';
 import { AuthenticationMethod } from './AuthenticationMethod.js';

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -1,4 +1,4 @@
-import { status as assessmentResultStatuses } from '../models/AssessmentResult.js';
+import { status as assessmentResultStatuses } from '../../../src/shared/domain/models/AssessmentResult.js';
 const STARTED = 'started';
 const ENDED_BY_SUPERVISOR = 'endedBySupervisor';
 

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -5,7 +5,7 @@ import { UserCompetence } from '../models/UserCompetence.js';
 import { PlacementProfile } from '../models/PlacementProfile.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as skillRepository from '../../infrastructure/repositories/skill-repository.js';
-import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
+import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
 import * as knowledgeElementRepository from '../../infrastructure/repositories/knowledge-element-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as scoringService from './scoring/scoring-service.js';

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -16,7 +16,7 @@ import * as algorithmDataFetcherService from '../../domain/services/algorithm-me
 import * as answerRepository from '../../../src/evaluation/infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
-import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
+import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method-repository.js';
 import * as authenticationServiceRegistry from '../services/authentication/authentication-service-registry.js';

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { knex } from '../../../db/knex-database-connection.js';
 import { MissingAssessmentId, AssessmentResultNotCreatedError } from '../../domain/errors.js';
 import { DomainTransaction } from '../DomainTransaction.js';
-import { AssessmentResult } from '../../domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
 
 function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { CertificationCourseNotPublishableError } from '../../../lib/domain/errors.js';
-import { status } from '../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../src/shared/domain/models/AssessmentResult.js';
 
 const publishCertificationCoursesBySessionId = async function (sessionId) {
   const certificationDTOs = await knex('certification-courses')

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,7 +1,6 @@
 import * as accountRecovery from './application/account-recovery/index.js';
 import * as adminMembers from './application/admin-members/index.js';
 import * as activityAnswers from './application/activity-answers/index.js';
-import * as assessmentResults from './application/assessment-results/index.js';
 import * as authentication from './application/authentication/index.js';
 import * as authenticationOidc from './application/authentication/oidc/index.js';
 import * as badges from './application/badges/index.js';
@@ -52,7 +51,6 @@ const routes = [
   accountRecovery,
   adminMembers,
   activityAnswers,
-  assessmentResults,
   authentication,
   authenticationOidc,
   badges,

--- a/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
+++ b/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
@@ -10,7 +10,7 @@ import { learningContentCache as cache } from '../../lib/infrastructure/caches/l
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import yargs from 'yargs';
 import bluebird from 'bluebird';
-import { status } from '../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../src/shared/domain/models/AssessmentResult.js';
 import readline from 'readline';
 import * as url from 'url';
 

--- a/api/src/certification/session/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/cpf-certification-result-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CpfCertificationResult } from '../../../../../lib/domain/read-models/CpfCertificationResult.js';
-import { AssessmentResult } from '../../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 import { CpfImportStatus } from '../../domain/models/CpfImportStatus.js';
 
 const findByBatchId = async function (batchId) {

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
-import * as assessmentResultRepository from '../../../../../lib/infrastructure/repositories/assessment-result-repository.js';
+import * as assessmentResultRepository from '../../../../shared/infrastructure/repositories/assessment-result-repository.js';
 import * as attendanceSheetPdfUtils from '../../../session/infrastructure/utils/pdf/attendance-sheet-pdf.js';
 import * as badgeRepository from '../../../../../lib/infrastructure/repositories/badge-repository.js';
 import * as certificationCenterRepository from '../../../shared/infrastructure/repositories/certification-center-repository.js';

--- a/api/src/shared/application/assessment-results/assessment-result-controller.js
+++ b/api/src/shared/application/assessment-results/assessment-result-controller.js
@@ -1,6 +1,6 @@
-import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
-import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
-import * as assessmentResultService from '../../../src/shared/domain/services/assessment-result-service.js';
+import { AssessmentResult } from '../../domain/models/AssessmentResult.js';
+import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
+import * as assessmentResultService from '../../domain/services/assessment-result-service.js';
 
 // TODO: Should be removed and replaced by a real serializer
 function _deserializeResultsAdd(json) {

--- a/api/src/shared/application/assessment-results/index.js
+++ b/api/src/shared/application/assessment-results/index.js
@@ -1,5 +1,5 @@
 import { assessmentResultController } from './assessment-result-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -93,6 +93,18 @@ class AssessmentEndedError extends DomainError {
   }
 }
 
+class AssessmentResultNotCreatedError extends DomainError {
+  constructor(message = "L'assessment result n'a pas pu être généré.") {
+    super(message);
+  }
+}
+
+class MissingAssessmentId extends DomainError {
+  constructor(message = 'AssessmentId manquant ou incorrect') {
+    super(message);
+  }
+}
+
 class LocaleFormatError extends DomainError {
   constructor(locale) {
     super(`Given locale is in invalid format: "${locale}"`);
@@ -143,6 +155,7 @@ class TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization extends Doma
 export {
   DomainError,
   AssessmentEndedError,
+  AssessmentResultNotCreatedError,
   ForbiddenAccess,
   EntityValidationError,
   CertificationAttestationGenerationError,
@@ -151,6 +164,7 @@ export {
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,
   InvalidTemporaryKeyError,
+  MissingAssessmentId,
   NotFoundError,
   UserNotAuthorizedToAccessEntityError,
   NoCertificationAttestationForDivisionError,

--- a/api/src/shared/domain/models/AssessmentResult.js
+++ b/api/src/shared/domain/models/AssessmentResult.js
@@ -1,4 +1,4 @@
-import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
+import { Assessment } from './Assessment.js';
 
 const status = {
   REJECTED: 'rejected',

--- a/api/src/shared/domain/services/assessment-result-service.js
+++ b/api/src/shared/domain/services/assessment-result-service.js
@@ -1,4 +1,4 @@
-import * as assessmentResultRepository from '../../../../lib/infrastructure/repositories/assessment-result-repository.js';
+import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
 import * as competenceMarkRepository from '../../../../lib/infrastructure/repositories/competence-mark-repository.js';
 import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 import bluebird from 'bluebird';

--- a/api/src/shared/domain/services/assessment-result-service.js
+++ b/api/src/shared/domain/services/assessment-result-service.js
@@ -1,6 +1,6 @@
-import * as assessmentResultRepository from '../../infrastructure/repositories/assessment-result-repository.js';
-import * as competenceMarkRepository from '../../infrastructure/repositories/competence-mark-repository.js';
-import { CompetenceMark } from '../models/CompetenceMark.js';
+import * as assessmentResultRepository from '../../../../lib/infrastructure/repositories/assessment-result-repository.js';
+import * as competenceMarkRepository from '../../../../lib/infrastructure/repositories/competence-mark-repository.js';
+import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 import bluebird from 'bluebird';
 
 async function _validatedDataForAllCompetenceMark(competenceMarks) {

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { knex } from '../../../db/knex-database-connection.js';
-import { MissingAssessmentId, AssessmentResultNotCreatedError } from '../../domain/errors.js';
-import { DomainTransaction } from '../DomainTransaction.js';
-import { AssessmentResult } from '../../../src/shared/domain/models/AssessmentResult.js';
-import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { AssessmentResultNotCreatedError, MissingAssessmentId } from '../../domain/errors.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { AssessmentResult } from '../../domain/models/AssessmentResult.js';
+import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 
 function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
   const competenceMarks = competencesMarksDTO.map((competenceMark) => new CompetenceMark(competenceMark));

--- a/api/src/shared/routes.js
+++ b/api/src/shared/routes.js
@@ -1,5 +1,6 @@
 import * as assessmentsRoutes from './application/assessments/index.js';
+import * as assessmentResultsRoutes from './application/assessment-results/index.js';
 
-const sharedRoutes = [assessmentsRoutes];
+const sharedRoutes = [assessmentsRoutes, assessmentResultsRoutes];
 
 export { sharedRoutes };

--- a/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
@@ -1,6 +1,6 @@
 import { expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
-import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('PATCH /api/admin/sessions/:id/publish', function () {
   let server;

--- a/api/tests/acceptance/application/session/session-controller-patch-unpublish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-unpublish-session_test.js
@@ -1,6 +1,6 @@
 import { expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
-import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('PATCH /api/admin/sessions/:id/unpublish', function () {
   let server;

--- a/api/tests/certification/course/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/certificate-repository_test.js
@@ -7,7 +7,7 @@ import {
   catchErr,
 } from '../../../../../test-helper.js';
 import * as certificationRepository from '../../../../../../src/certification/course/infrastructure/repositories/certificate-repository.js';
-import { status } from '../../../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Integration | Infrastructure | Repository | Certification', function () {

--- a/api/tests/certification/session/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -1,6 +1,6 @@
 import { databaseBuilder, expect, knex, domainBuilder } from '../../../../../test-helper.js';
 import * as cpfCertificationResultRepository from '../../../../../../src/certification/session/infrastructure/repositories/cpf-certification-result-repository.js';
-import { AssessmentResult } from '../../../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { CpfImportStatus } from '../../../../../../src/certification/session/domain/models/CpfImportStatus.js';
 
 describe('Integration | Repository | CpfCertificationResult', function () {

--- a/api/tests/integration/domain/event/handle-complementary-certifications-scoring_test.js
+++ b/api/tests/integration/domain/event/handle-complementary-certifications-scoring_test.js
@@ -2,7 +2,7 @@ import { expect, databaseBuilder, knex } from '../../../test-helper.js';
 import _ from 'lodash';
 
 import { handleComplementaryCertificationsScoring } from '../../../../lib/domain/events/handle-complementary-certifications-scoring.js';
-import * as assessmentResultRepository from '../../../../lib/infrastructure/repositories/assessment-result-repository.js';
+import * as assessmentResultRepository from '../../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
 import * as certificationAssessmentRepository from '../../../../lib/infrastructure/repositories/certification-assessment-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../../../lib/infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as complementaryCertificationScoringCriteriaRepository from '../../../../lib/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';

--- a/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -1,6 +1,6 @@
 import { expect, knex, databaseBuilder, domainBuilder, catchErr } from '../../../test-helper.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import * as assessmentResultRepository from '../../../../lib/infrastructure/repositories/assessment-result-repository.js';
 import { MissingAssessmentId } from '../../../../lib/domain/errors.js';
 

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -1,7 +1,7 @@
 import { expect, databaseBuilder, catchErr, knex } from '../../../test-helper.js';
 import * as certificationRepository from '../../../../lib/infrastructure/repositories/certification-repository.js';
 import { CertificationCourseNotPublishableError } from '../../../../lib/domain/errors.js';
-import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('Integration | Repository | Certification', function () {
   describe('#publishCertificationCoursesBySessionId', function () {

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -8,7 +8,7 @@ import {
   ImpactfulSubcategories,
 } from '../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 
-import { status as assessmentResultStatuses } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status as assessmentResultStatuses } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import * as juryCertificationSummaryRepository from '../../../../lib/infrastructure/repositories/jury-certification-summary-repository.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 

--- a/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
@@ -1,6 +1,6 @@
 import { expect, databaseBuilder, knex, sinon } from '../../../test-helper.js';
 import { updatePixCertificationStatus } from '../../../../scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js';
-import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 const OLD_UPDATED_AT = new Date('2020-01-01');
 const NEW_UPDATED_AT = new Date('2022-02-02');

--- a/api/tests/shared/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/shared/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -4,10 +4,10 @@ import {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-} from '../../../test-helper.js';
+} from '../../../../test-helper.js';
 
-import { createServer } from '../../../../server.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { createServer } from '../../../../../server.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Acceptance | Controller | assessment-results-controller', function () {
   let server;

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -5,7 +5,7 @@ import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import * as assessmentRepository from '../../../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import { Answer } from '../../../../../src/evaluation/domain/models/Answer.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
-import { AssessmentResult } from '../../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('Integration | Infrastructure | Repositories | assessment-repository', function () {
   describe('#getWithAnswers', function () {

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -1,8 +1,8 @@
-import { expect, knex, databaseBuilder, domainBuilder, catchErr } from '../../../test-helper.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
-import * as assessmentResultRepository from '../../../../lib/infrastructure/repositories/assessment-result-repository.js';
-import { MissingAssessmentId } from '../../../../lib/domain/errors.js';
+import { expect, knex, databaseBuilder, domainBuilder, catchErr } from '../../../../test-helper.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
+import * as assessmentResultRepository from '../../../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
+import { MissingAssessmentId } from '../../../../../src/shared/domain/errors.js';
 
 describe('Integration | Repository | AssessmentResult', function () {
   describe('#save', function () {

--- a/api/tests/shared/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/shared/unit/application/assessment-results/assessment-result-controller_test.js
@@ -1,7 +1,7 @@
-import { sinon, expect, hFake } from '../../../test-helper.js';
-import { assessmentResultController } from '../../../../lib/application/assessment-results/assessment-result-controller.js';
-import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
-import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
+import { sinon, expect, hFake } from '../../../../test-helper.js';
+import { assessmentResultController } from '../../../../../src/shared/application/assessment-results/assessment-result-controller.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
+import { CompetenceMark } from '../../../../../lib/domain/models/CompetenceMark.js';
 
 describe('Unit | Controller | assessment-results', function () {
   describe('#save', function () {

--- a/api/tests/shared/unit/application/assessment-results/index_test.js
+++ b/api/tests/shared/unit/application/assessment-results/index_test.js
@@ -1,6 +1,6 @@
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
-import * as moduleUnderTest from '../../../../lib/application/assessment-results/index.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import * as moduleUnderTest from '../../../../../src/shared/application/assessment-results/index.js';
 
 describe('Unit | Application | Assessmnet results | Route', function () {
   describe('POST /api/admin/assessment-results', function () {

--- a/api/tests/shared/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/shared/unit/domain/models/AssessmentResult_test.js
@@ -1,6 +1,6 @@
-import { expect, domainBuilder } from '../../../test-helper.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { expect, domainBuilder } from '../../../../test-helper.js';
+import { AssessmentResult } from '../../../../../src/shared/domain/models/AssessmentResult.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 
 describe('Unit | Domain | Models | AssessmentResult', function () {
   describe('#buildAlgoErrorResult', function () {

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -1,7 +1,7 @@
 import {
   status as assessmentResultStatuses,
   AssessmentResult,
-} from '../../../../lib/domain/models/AssessmentResult.js';
+} from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 
 const buildAssessmentResult = function ({

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment-score-v3.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment-score-v3.js
@@ -1,5 +1,5 @@
 import { CertificationAssessmentScoreV3 } from '../../../../lib/domain/models/CertificationAssessmentScoreV3.js';
-import { status as CertificationStatus } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status as CertificationStatus } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 const buildCertificationAssessmentScoreV3 = function ({ nbPix = 100, status = CertificationStatus.VALIDATED } = {}) {
   return new CertificationAssessmentScoreV3({

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
@@ -1,5 +1,5 @@
 import { databaseBuilder, learningContentBuilder, mockLearningContent } from '../../../test-helper.js';
-import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 
 const assessmentCreatedDate = new Date('2020-04-19');

--- a/api/tests/tooling/domain-builder/factory/build-jury-certification-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-certification-summary.js
@@ -1,5 +1,5 @@
 import { JuryCertificationSummary } from '../../../../lib/domain/read-models/JuryCertificationSummary.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 const buildJuryCertificationSummary = function ({
   id = 123,

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -1,6 +1,6 @@
 import { sinon, expect, hFake } from '../../../test-helper.js';
 import { assessmentResultController } from '../../../../lib/application/assessment-results/assessment-result-controller.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 
 describe('Unit | Controller | assessment-results', function () {

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -1,6 +1,6 @@
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { _forTestOnly } from '../../../../lib/domain/events/index.js';
-import { AssessmentResult, status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult, status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { CertificationComputeError } from '../../../../lib/domain/errors.js';
 import { AssessmentCompleted } from '../../../../lib/domain/events/AssessmentCompleted.js';
 import { ABORT_REASONS, CertificationCourse } from '../../../../lib/domain/models/CertificationCourse.js';

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -1,7 +1,7 @@
 import { catchErr, expect, domainBuilder, sinon } from '../../../test-helper.js';
 import { handleSessionFinalized as handleFinalizedSession } from '../../../../lib/domain/events/handle-session-finalized.js';
 import { JuryCertificationSummary } from '../../../../lib/domain/read-models/JuryCertificationSummary.js';
-import { status as assessmentResultStatuses } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status as assessmentResultStatuses } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { AutoJuryDone } from '../../../../lib/domain/events/AutoJuryDone.js';
 import { FinalizedSession } from '../../../../lib/domain/models/FinalizedSession.js';
 

--- a/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 import { AnswerStatus } from '../../../../lib/domain/models/index.js';
 import { CertificationAssessmentScoreV3 } from '../../../../lib/domain/models/CertificationAssessmentScoreV3.js';
-import { status } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { config } from '../../../../src/shared/config.js';
 import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse.js';
 

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -1,7 +1,7 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
 import { FinalizedSession } from '../../../../lib/domain/models/FinalizedSession.js';
 import { JuryCertificationSummary } from '../../../../lib/domain/read-models/JuryCertificationSummary.js';
-import { status as assessmentResultStatuses } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status as assessmentResultStatuses } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { CertificationIssueReportCategory } from '../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 
 describe('Unit | Domain | Models | FinalizedSession', function () {

--- a/api/tests/unit/domain/models/PrivateCertificate_test.js
+++ b/api/tests/unit/domain/models/PrivateCertificate_test.js
@@ -1,6 +1,6 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
 import { PrivateCertificate } from '../../../../lib/domain/models/PrivateCertificate.js';
-import { status as assessmentResultStatuses } from '../../../../lib/domain/models/AssessmentResult.js';
+import { status as assessmentResultStatuses } from '../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('Unit | Domain | Models | PrivateCertificate', function () {
   context('#static buildFrom', function () {

--- a/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -1,6 +1,6 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
 import { JuryCertificationSummary } from '../../../../lib/domain/read-models/JuryCertificationSummary.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import lodash from 'lodash';
 const { forIn } = lodash;
 

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon } from '../../../test-helper.js';
 
-import * as service from '../../../../lib/domain/services/assessment-result-service.js';
+import * as service from '../../../../src/shared/domain/services/assessment-result-service.js';
 import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../test-helper.js';
 
 import * as service from '../../../../lib/domain/services/assessment-result-service.js';
-import { AssessmentResult } from '../../../../lib/domain/models/AssessmentResult.js';
+import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 
 describe('Unit | Domain | Services | assessment-results', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

La migration vers une nouvelle arborescence de l'api a été entreprise, mais encore trop de usecases et services sont présents dans le répertoire lib de l'api.

## :gift: Proposition

Nous migrons dans le dossier `api/src/shared` les fichiers qui se trouvent actuellement dans le dossier `api/lib` et qui concernent l'entité `assessment-result`, en partant du model jusqu'aux routes concernées.

## :santa: Pour tester

✅ Test verts
