### PR TITLE
[FEATURE] Ajouter une icône sur la liste des campagnes (PIX-10310)

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -35,7 +35,7 @@ When(
 );
 
 Then(`je vois {int} campagne\(s\)`, (campaignsCount) => {
-  cy.get('[aria-label="Campagne"]').should("have.lengthOf", campaignsCount);
+  cy.get('table tbody tr').should("have.lengthOf", campaignsCount);
 });
 
 Then(`je vois {int} tutoriel\(s\)`, (tutorialsCount) => {

--- a/orga/app/components/campaign/detail/type.hbs
+++ b/orga/app/components/campaign/detail/type.hbs
@@ -1,0 +1,12 @@
+<span class="campaign-type">
+  <FaIcon
+    class="{{this.pictoCssClass}}"
+    @icon="{{this.picto}}"
+    @prefix="fapix"
+    aria-hidden={{this.picotAriaHidden}}
+    @title={{this.pictoTitle}}
+  />
+  {{#unless @hideLabel}}
+    <span class="campaign-type__label">{{this.label}}</span>
+  {{/unless}}
+</span>

--- a/orga/app/components/campaign/detail/type.js
+++ b/orga/app/components/campaign/detail/type.js
@@ -14,8 +14,17 @@ export default class CampaignType extends Component {
     return campaignType === 'ASSESSMENT' ? 'campaign-type__icon-assessment' : 'campaign-type__icon-profile-collection';
   }
 
+  get pictoAriaHidden() {
+    return !this.args.hideLabel;
+  }
+
+  get pictoTitle() {
+    return this.args.hideLabel ? this.label : null;
+  }
+
   get label() {
-    const { campaignType } = this.args;
-    return this.intl.t(`pages.organization-learner.activity.participation-list.type.${campaignType}`);
+    const { campaignType, labels } = this.args;
+
+    return this.intl.t(labels[campaignType]);
   }
 }

--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -37,15 +37,14 @@
 
       <tbody>
         {{#each @campaigns as |campaign|}}
-          <tr
-            aria-label={{t "pages.campaigns-list.table.row-title"}}
-            {{on "click" (fn @onClickCampaign campaign.id)}}
-            class="tr--clickable"
-          >
+          <tr {{on "click" (fn @onClickCampaign campaign.id)}} class="tr--clickable">
             <td class="table__column">
-              <LinkTo @route="authenticated.campaigns.campaign" @model={{campaign.id}}>
-                {{campaign.name}}
-              </LinkTo>
+              <span class="campaign-list__campaign-link">
+                <Campaign::Detail::Type @labels={{this.labels}} @campaignType={{campaign.type}} @hideLabel={{true}} />
+                <LinkTo @route="authenticated.campaigns.campaign" @model={{campaign.id}}>
+                  {{campaign.name}}
+                </LinkTo>
+              </span>
             </td>
             <td class="table__column--small" {{on "click" this.stopPropagation}}>{{campaign.code}}</td>
             {{#unless @listOnlyCampaignsOfCurrentUser}}

--- a/orga/app/components/campaign/list.js
+++ b/orga/app/components/campaign/list.js
@@ -13,6 +13,13 @@ export default class List extends Component {
     }
   }
 
+  get labels() {
+    return {
+      ASSESSMENT: 'components.campaign.type.explanation.ASSESSMENT',
+      PROFILES_COLLECTION: 'components.campaign.type.explanation.PROFILES_COLLECTION',
+    };
+  }
+
   @action
   stopPropagation(event) {
     event.stopPropagation();

--- a/orga/app/components/organization-learner/activity/campaign-type.hbs
+++ b/orga/app/components/organization-learner/activity/campaign-type.hbs
@@ -1,4 +1,0 @@
-<div class="campaign-type">
-  <FaIcon class="{{this.pictoCssClass}}" @icon="{{this.picto}}" @prefix="fapix" />
-  <span class="campaign-type__label">{{this.label}}</span>
-</div>

--- a/orga/app/components/organization-learner/activity/participation-row.hbs
+++ b/orga/app/components/organization-learner/activity/participation-row.hbs
@@ -9,7 +9,7 @@
     </LinkTo>
   </td>
   <td class="ellipsis">
-    <OrganizationLearner::Activity::CampaignType @campaignType={{@participation.campaignType}} />
+    <Campaign::Detail::Type @labels={{this.labels}} @campaignType={{@participation.campaignType}} />
   </td>
   <td class="table__column--left">
     <Ui::Date @date={{@participation.createdAt}} />

--- a/orga/app/components/organization-learner/activity/participation-row.js
+++ b/orga/app/components/organization-learner/activity/participation-row.js
@@ -11,6 +11,13 @@ export default class ParticipationRow extends Component {
       : 'authenticated.campaigns.participant-profile';
   }
 
+  get labels() {
+    return {
+      ASSESSMENT: 'components.campaign.type.information.ASSESSMENT',
+      PROFILES_COLLECTION: 'components.campaign.type.information.PROFILES_COLLECTION',
+    };
+  }
+
   @action
   goToParticipationDetail(event) {
     event.preventDefault();

--- a/orga/app/styles/components/campaign/detail/index.scss
+++ b/orga/app/styles/components/campaign/detail/index.scss
@@ -1,0 +1,1 @@
+@import 'type';

--- a/orga/app/styles/components/campaign/detail/type.scss
+++ b/orga/app/styles/components/campaign/detail/type.scss
@@ -1,5 +1,5 @@
 .campaign-type {
-  display: flex;
+  display: inline-flex;
   align-items: center;
 
   &__label {
@@ -7,12 +7,14 @@
   }
 
   &__icon-assessment {
+    width: 1.5rem;
+    height: 1.5rem;
     color: $pix-tertiary-50;
-    font-size: 1.5rem;
   }
 
   &__icon-profile-collection {
+    width: 1.5rem;
+    height: 1.5rem;
     color: $pix-primary;
-    font-size: 1.5rem;
   }
 }

--- a/orga/app/styles/components/campaign/index.scss
+++ b/orga/app/styles/components/campaign/index.scss
@@ -20,3 +20,4 @@
 @import 'settings/campaign-settings';
 @import 'stage-average';
 @import 'target-profile-details';
+@import 'detail';

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -1,11 +1,10 @@
 .campaign-list {
   padding: 0;
 
-  &__link {
-    display: block;
-    padding: 20px 24px;
-    color: $pix-neutral-80;
-    text-decoration: none;
+  &__campaign-link {
+    display: flex;
+    gap: $pix-spacing-xs;
+    align-items: center;
   }
 
   &__item {

--- a/orga/app/styles/components/organization-learner/index.scss
+++ b/orga/app/styles/components/organization-learner/index.scss
@@ -1,3 +1,2 @@
-@import 'activity/campaign-type';
 @import 'activity/participation-list';
 @import 'activity/cards';

--- a/orga/mirage/factories/campaign.js
+++ b/orga/mirage/factories/campaign.js
@@ -21,6 +21,10 @@ export default Factory.extend({
     return 'Jack';
   },
 
+  type() {
+    return 'PROFILES_COLLECTION';
+  },
+
   ofTypeAssessment: trait({
     afterCreate(campaign) {
       campaign.update({

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -50,7 +50,7 @@ module('Acceptance | campaigns/all-campaigns', function (hooks) {
         const screen = await visit('/campagnes/toutes');
 
         // then
-        assert.strictEqual(screen.getAllByLabelText('Campagne').length, 12, 'the number of campaigns');
+        assert.strictEqual(screen.getAllByRole('row').length, 13, 'Table length header included');
       });
 
       test('it should redirect to campaign details on click', async function (assert) {

--- a/orga/tests/acceptance/campaign-list-my-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-my-campaigns_test.js
@@ -64,7 +64,7 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
         const screen = await visitScreen('/campagnes/les-miennes');
 
         // then
-        assert.strictEqual(screen.getAllByLabelText('Campagne').length, 2, 'the number of campaigns');
+        assert.strictEqual(screen.getAllByRole('row').length, 3, 'Table length included header');
       });
 
       test('it should redirect to campaign details on click', async function (assert) {

--- a/orga/tests/integration/components/campaign/list_test.js
+++ b/orga/tests/integration/components/campaign/list_test.js
@@ -47,10 +47,21 @@ module('Integration | Component | Campaign::List', function (hooks) {
   module('When there are campaigns to display', function () {
     test('it should display a list of campaigns', async function (assert) {
       // given
-      const campaigns = [
-        { name: 'campagne 1', code: 'AAAAAA111' },
-        { name: 'campagne 2', code: 'BBBBBB222' },
-      ];
+      const store = this.owner.lookup('service:store');
+
+      const campaign1 = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
+      });
+      const campaign2 = store.createRecord('campaign', {
+        id: 2,
+        name: 'campagne 2',
+        code: 'BBBBBB222',
+        type: 'ASSESSMENT',
+      });
+      const campaigns = [campaign1, campaign2];
       campaigns.meta = {
         rowCount: 2,
       };
@@ -62,8 +73,9 @@ module('Integration | Component | Campaign::List', function (hooks) {
       );
 
       // then
-      assert.dom(screen.queryByLabelText('Aucune campagne')).doesNotExist();
-      assert.dom('[aria-label="Campagne"]').exists({ count: 2 });
+      assert.notOk(screen.queryByLabelText('Aucune campagne'));
+      assert.ok(screen.queryByText('campagne 1'));
+      assert.ok(screen.queryByText('campagne 2'));
     });
 
     test('it should display a link to access campaign detail', async function (assert) {
@@ -71,15 +83,16 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.owner.setupRouter();
 
       const store = this.owner.lookup('service:store');
+
       const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
       });
-
       const campaigns = [campaign1];
       campaigns.meta = {
-        rowCount: 2,
+        rowCount: 1,
       };
       this.set('campaigns', campaigns);
 
@@ -93,18 +106,19 @@ module('Integration | Component | Campaign::List', function (hooks) {
     });
 
     test('it should display the name of the campaigns', async function (assert) {
-      // given
       const store = this.owner.lookup('service:store');
 
       const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
       });
       const campaign2 = store.createRecord('campaign', {
         id: 2,
         name: 'campagne 2',
         code: 'BBBBBB222',
+        type: 'ASSESSMENT',
       });
       const campaigns = [campaign1, campaign2];
       campaigns.meta = {
@@ -123,21 +137,24 @@ module('Integration | Component | Campaign::List', function (hooks) {
     });
 
     test('it should display the code of the campaigns', async function (assert) {
-      // given
       const store = this.owner.lookup('service:store');
 
       const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
       });
       const campaign2 = store.createRecord('campaign', {
         id: 2,
         name: 'campagne 2',
         code: 'BBBBBB222',
+        type: 'ASSESSMENT',
       });
       const campaigns = [campaign1, campaign2];
-
+      campaigns.meta = {
+        rowCount: 2,
+      };
       this.set('campaigns', campaigns);
 
       // when
@@ -151,13 +168,21 @@ module('Integration | Component | Campaign::List', function (hooks) {
     });
 
     test('it should display the owner of the campaigns', async function (assert) {
-      // given
       const store = this.owner.lookup('service:store');
+
       const campaign1 = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
         ownerFirstName: 'Jean-Michel',
         ownerLastName: 'Jarre',
       });
       const campaign2 = store.createRecord('campaign', {
+        id: 2,
+        name: 'campagne 2',
+        code: 'BBBBBB222',
+        type: 'ASSESSMENT',
         ownerFirstName: 'Mathilde',
         ownerLastName: 'Bonnin de La Bonninière de Beaumont',
       });
@@ -168,13 +193,13 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`,
       );
 
       // then
-      assert.dom('[aria-label="Campagne"]:first-child').containsText('Jean-Michel Jarre');
-      assert.dom('[aria-label="Campagne"]:last-child').containsText('Mathilde Bonnin de La Bonninière de Beaumont');
+      assert.ok(screen.getByText('Jean-Michel Jarre'));
+      assert.ok(screen.getByText('Mathilde Bonnin de La Bonninière de Beaumont'));
     });
 
     test('it must display the creation date of the campaigns', async function (assert) {
@@ -183,12 +208,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
+        type: 'ASSESSMENT',
         code: 'AAAAAA111',
         createdAt: '03/02/2020',
       });
       const campaign2 = store.createRecord('campaign', {
         id: 2,
         name: 'campagne 2',
+        type: 'ASSESSMENT',
         code: 'BBBBBB222',
         createdAt: '02/02/2020',
       });
@@ -212,6 +239,7 @@ module('Integration | Component | Campaign::List', function (hooks) {
       const store = this.owner.lookup('service:store');
       const campaign1 = store.createRecord('campaign', {
         participationsCount: 10,
+        type: 'ASSESSMENT',
       });
 
       const campaigns = [campaign1];
@@ -221,12 +249,12 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`,
       );
 
       // then
-      assert.dom('[aria-label="Campagne"]').containsText('10');
+      assert.ok(screen.getByRole('cell', { name: '10' }));
     });
 
     test('it should display the shared participations count', async function (assert) {
@@ -234,6 +262,7 @@ module('Integration | Component | Campaign::List', function (hooks) {
       const store = this.owner.lookup('service:store');
       const campaign1 = store.createRecord('campaign', {
         sharedParticipationsCount: 4,
+        type: 'ASSESSMENT',
       });
 
       const campaigns = [campaign1];
@@ -243,20 +272,20 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`,
       );
 
       // then
-      assert.dom('[aria-label="Campagne"]').containsText('4');
+      assert.ok(screen.getByText('4'));
     });
 
     module('when showing current user campaign list', function () {
       test('it should not show created by column and value', async function (assert) {
         // given
         const campaigns = [
-          { name: 'campagne 1', code: 'AAAAAA111', ownerFullName: 'Dupont Alice' },
-          { name: 'campagne 2', code: 'BBBBBB222', ownerFullName: 'Dupont Alice' },
+          { name: 'campagne 1', code: 'AAAAAA111', type: 'ASSESSMENT', ownerFullName: 'Dupont Alice' },
+          { name: 'campagne 2', code: 'BBBBBB222', type: 'ASSESSMENT', ownerFullName: 'Dupont Alice' },
         ];
         campaigns.meta = {
           rowCount: 2,

--- a/orga/tests/integration/components/organization-learner/activity/participation-list_test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-list_test.js
@@ -6,7 +6,7 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | OrganizationLearner::Activity::ParticipationList', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display participations details', async function (assert) {
+  test('it should display participations details of Assessment', async function (assert) {
     this.set('participations', [
       {
         campaignType: 'ASSESSMENT',
@@ -17,12 +17,36 @@ module('Integration | Component | OrganizationLearner::Activity::ParticipationLi
       },
     ]);
 
-    await render(hbs`<OrganizationLearner::Activity::ParticipationList @participations={{this.participations}} />`);
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity::ParticipationList @participations={{this.participations}} />`,
+    );
 
-    assert.contains('Ma 1ère campagne');
-    assert.contains('Evaluation');
-    assert.contains('12/12/2022');
-    assert.contains('25/12/2022');
-    assert.contains('Résultats reçus');
+    assert.ok(screen.getByText('Ma 1ère campagne'));
+    assert.ok(screen.getByText('Évaluation'));
+    assert.ok(screen.getByText('12/12/2022'));
+    assert.ok(screen.getByText('25/12/2022'));
+    assert.ok(screen.getByText('Résultats reçus'));
+  });
+
+  test('it should display participations details of Profiles collection', async function (assert) {
+    this.set('participations', [
+      {
+        campaignType: 'PROFILES_COLLECTION',
+        campaignName: 'Ma 1ère campagne',
+        createdAt: '2022-12-12',
+        sharedAt: '2022-12-25',
+        status: 'SHARED',
+      },
+    ]);
+
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity::ParticipationList @participations={{this.participations}} />`,
+    );
+
+    assert.ok(screen.getByText('Ma 1ère campagne'));
+    assert.ok(screen.getByText('Collecte de profil'));
+    assert.ok(screen.getByText('12/12/2022'));
+    assert.ok(screen.getByText('25/12/2022'));
+    assert.ok(screen.getByText('Profil reçu'));
   });
 });

--- a/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
@@ -36,7 +36,7 @@ module('Integration | Component | OrganizationLearner | Activity::ParticipationR
     assert
       .dom(
         screen.getByRole('cell', {
-          name: this.intl.t('pages.organization-learner.activity.participation-list.type.ASSESSMENT'),
+          name: this.intl.t('components.campaign.type.information.ASSESSMENT'),
         }),
       )
       .exists();
@@ -76,7 +76,7 @@ module('Integration | Component | OrganizationLearner | Activity::ParticipationR
     this.participation = {
       id: '125',
       campaignId: '789',
-      campaignType: 'PROFILE_COLLECTION',
+      campaignType: 'PROFILES_COLLECTION',
       campaignName: 'Ma campagne',
       createdAt: new Date('2023-02-01'),
       sharedAt: new Date('2023-03-01'),

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -200,6 +200,18 @@
     }
   },
   "components": {
+    "campaign": {
+      "type": {
+        "explanation" : {
+          "ASSESSMENT":"Campaign of type assessment",
+          "PROFILES_COLLECTION":"Campaign of type profiles collection"
+        },
+        "information" : {
+          "ASSESSMENT": "Assessment",
+          "PROFILES_COLLECTION": "Profiles collection"
+        }
+      }
+    },
     "certificability": {
       "placeholder-select": "Eligible / Non-eligible"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -203,6 +203,18 @@
     }
   },
   "components": {
+    "campaign": {
+      "type": {
+        "explanation" : {
+          "ASSESSMENT":"Campagne d'évaluation",
+          "PROFILES_COLLECTION":"Campagne de collecte de profil"
+        },
+        "information" : {
+          "ASSESSMENT":"Évaluation",
+          "PROFILES_COLLECTION":"Collecte de profil"
+        }
+      }
+    },
     "certificability": {
       "placeholder-select": "Certifiable / Non certifiable"
     },
@@ -754,10 +766,6 @@
               "status": "Statut"
             },
             "row-title": "Participation"
-          },
-          "type": {
-            "ASSESSMENT": "Evaluation",
-            "PROFILES_COLLECTION": "Collecte de profil"
           }
         },
         "participations-title": "Liste de toutes les participations",


### PR DESCRIPTION
## :christmas_tree: Problème
Il est difficile de distinguer les deux typologie de campagne disponible sur la page

## :gift: Proposition
Ajouter une icone au niveau du nom de la campagne afin de mieux distinguer leur typologie.

## :socks: Remarques
Factorisation du composant Campagne Type

## :santa: Pour tester
Se connecter sur Pix Orga et vérifier que l'on distingue mieux les typologies de campagne