### PR TITLE
[FEATURE] Pouvoir activer l'affichage des places à une orga depuis PixAdmin (PIX-9725)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -205,6 +205,15 @@
         Activer l'envoi multiple pour les campagnes de type évaluation
       </PixCheckbox>
     </div>
+    <div class="form-field organization-edit-form__checkbox">
+      <PixCheckbox
+        @id="enablePlacesManagement"
+        {{on "change" this.onChangePlacesManagement}}
+        @checked={{this.form.enablePlacesManagement}}
+      >
+        Activer la page de Places sur PixOrga
+      </PixCheckbox>
+    </div>
     <div class="form-actions">
       <PixButton
         @size="small"

--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -140,18 +140,18 @@
     </div>
 
     <div class="form-field organization-edit-form__checkbox">
-      <label for="showSkills" class="form-field__label">Affichage des acquis dans l'export de résultats</label>
-      {{#if (v-get this.form "showSkills" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "showSkills" "message"}}
-        </div>
-      {{/if}}
       <Input
         id="showSkills"
         @type="checkbox"
         class={{if (v-get this.form "showSkills" "isInvalid") "form-control is-invalid" "form-control"}}
         @checked={{this.form.showSkills}}
       />
+      <label for="showSkills" class="form-field__label">Affichage des acquis dans l'export de résultats</label>
+      {{#if (v-get this.form "showSkills" "isInvalid")}}
+        <div class="form-field__error">
+          {{v-get this.form "showSkills" "message"}}
+        </div>
+      {{/if}}
     </div>
 
     <div class="form-field">
@@ -181,18 +181,18 @@
 
     {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
       <div class="form-field organization-edit-form__checkbox">
-        <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
-        {{#if (v-get this.form "isManagingStudents" "isInvalid")}}
-          <div class="form-field__error">
-            {{v-get this.form "isManagingStudents" "message"}}
-          </div>
-        {{/if}}
         <Input
           id="isManagingStudents"
           @type="checkbox"
           class={{if (v-get this.form "isManagingStudents" "isInvalid") "form-control is-invalid" "form-control"}}
           @checked={{this.form.isManagingStudents}}
         />
+        <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
+        {{#if (v-get this.form "isManagingStudents" "isInvalid")}}
+          <div class="form-field__error">
+            {{v-get this.form "isManagingStudents" "message"}}
+          </div>
+        {{/if}}
       </div>
     {{/if}}
 
@@ -201,6 +201,7 @@
         @id="enableMultipleSendingAssessement"
         {{on "change" this.onChangeMultipleSendingAssessment}}
         @checked={{this.form.enableMultipleSendingAssessment}}
+        @class="form-field__label"
       >
         Activer l'envoi multiple pour les campagnes de type évaluation
       </PixCheckbox>
@@ -210,6 +211,7 @@
         @id="enablePlacesManagement"
         {{on "change" this.onChangePlacesManagement}}
         @checked={{this.form.enablePlacesManagement}}
+        @class="form-field__label"
       >
         Activer la page de Places sur PixOrga
       </PixCheckbox>

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -44,6 +44,11 @@ export default class OrganizationInformationSectionEditionMode extends Component
   }
 
   @action
+  onChangePlacesManagement() {
+    this.form.enablePlacesManagement = !this.form.enablePlacesManagement;
+  }
+
+  @action
   async updateOrganization(event) {
     event.preventDefault();
 
@@ -69,6 +74,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('showSkills', this.form.showSkills);
     this.args.organization.set('identityProviderForCampaigns', this.form.identityProviderForCampaigns);
     this.args.organization.set('enableMultipleSendingAssessment', this.form.enableMultipleSendingAssessment);
+    this.args.organization.set('enablePlacesManagement', this.form.enablePlacesManagement);
 
     this.closeAndResetForm();
     return this.args.onSubmit();
@@ -87,6 +93,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.form.documentationUrl = this.args.organization.documentationUrl;
     this.form.showSkills = this.args.organization.showSkills;
     this.form.enableMultipleSendingAssessment = this.args.organization.enableMultipleSendingAssessment;
+    this.form.enablePlacesManagement = this.args.organization.enablePlacesManagement;
     this.form.identityProviderForCampaigns =
       this.args.organization.identityProviderForCampaigns ?? this.noIdentityProviderOption.value;
   }

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -82,6 +82,8 @@
         <li>Affichage du Net Promoter Score : {{if @organization.showNPS "Oui" "Non"}}</li>
         <li>Activer l'envoi multiple sur les campagnes d'évaluation :
           {{if @organization.enableMultipleSendingAssessment "Oui" "Non"}}</li>
+        <li>Activer la page de Places sur PixOrga :
+          {{if @organization.enablePlacesManagement "Oui" "Non"}}</li>
         {{#if @organization.code}}
           <br />
           <li>Code : {{@organization.code}}</li>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -39,6 +39,7 @@ export default class Organization extends Model {
   static get featureList() {
     return {
       MULTIPLE_SENDING_ASSESSMENT: 'MULTIPLE_SENDING_ASSESSMENT',
+      PLACES_MANAGEMENT: 'PLACES_MANAGEMENT',
     };
   }
 
@@ -52,6 +53,18 @@ export default class Organization extends Model {
       this.features = {};
     }
     this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT] = value;
+  }
+
+  get enablePlacesManagement() {
+    if (!this.features) return false;
+    return this.features[Organization.featureList.PLACES_MANAGEMENT];
+  }
+
+  set enablePlacesManagement(value) {
+    if (!this.features) {
+      this.features = {};
+    }
+    this.features[Organization.featureList.PLACES_MANAGEMENT] = value;
   }
 
   async hasMember(userId) {

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -69,7 +69,7 @@
         & > input[type='checkbox'] {
           width: 16px;
           height: 16px;
-          margin: 0 8px;
+          margin-right: var(--pix-spacing-3x);
         }
       }
     }

--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -33,7 +33,7 @@
       font-size: 0.8em;
     }
 
-    &__label {
+    &__label, &__label label {
       margin: 0;
       font-weight: 600;
     }

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -125,6 +125,7 @@ module('Integration | Component | organizations/information-section', function (
       await click(screen.getByRole('option', { name: 'organization 2' }));
       await clickByName("Affichage des acquis dans l'export de résultats");
       await clickByName("Activer l'envoi multiple pour les campagnes de type évaluation");
+      await clickByName('Activer la page de Places sur PixOrga');
 
       // when
       await clickByName('Enregistrer');
@@ -138,6 +139,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom(screen.getByRole('link', { name: 'https://pix.fr/' })).exists();
       assert.dom(screen.getByText('SSO : organization 2')).exists();
       assert.dom(screen.getByText("Activer l'envoi multiple sur les campagnes d'évaluation : Oui")).exists();
+      assert.dom(screen.getByText('Activer la page de Places sur PixOrga : Oui')).exists();
     });
   });
 });

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -4,6 +4,90 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Model | organization', function (hooks) {
   setupTest(hooks);
 
+  module('#enablePlacesManagement', function () {
+    module('#get', function () {
+      test('it returns true when feature is enabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['PLACES_MANAGEMENT']: true },
+        });
+
+        // when
+        const enablePlacesManagement = model.enablePlacesManagement;
+
+        // then
+        assert.true(enablePlacesManagement);
+      });
+      test('it returns false when feature is disabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['PLACES_MANAGEMENT']: false },
+        });
+
+        // when
+        const enablePlacesManagement = model.enablePlacesManagement;
+
+        // then
+        assert.false(enablePlacesManagement);
+      });
+      test('it returns false when no features are provided', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {});
+
+        // when
+        const enablePlacesManagement = model.enablePlacesManagement;
+
+        // then
+        assert.false(enablePlacesManagement);
+      });
+    });
+
+    module('#set', function () {
+      test('it enables feature', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['PLACES_MANAGEMENT']: false },
+        });
+
+        // when
+        model.enablePlacesManagement = true;
+
+        // then
+        const enablePlacesManagement = model.enablePlacesManagement;
+        assert.true(enablePlacesManagement);
+      });
+      test('it disable feature', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['PLACES_MANAGEMENT']: true },
+        });
+        // when
+        model.enablePlacesManagement = false;
+
+        // then
+        const enablePlacesManagement = model.enablePlacesManagement;
+        assert.false(enablePlacesManagement);
+      });
+      test('it handles having no features yet', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {});
+
+        // when
+        model.enablePlacesManagement = true;
+
+        // then
+        const enablePlacesManagement = model.enablePlacesManagement;
+        assert.true(enablePlacesManagement);
+      });
+    });
+  });
+
   module('#enableMultipleSendingAssessment', function () {
     module('#get', function () {
       test('it returns true when feature is enabled', function (assert) {


### PR DESCRIPTION
## :christmas_tree: Problème
Nous ne pouvons pas activer la feature de gestion des places à toutes les orgas car cela demande de l’accompagnement. 

## :gift: Proposition
On a ajouté une fonctionnalité activable par organisation. Dans cette PR, on fait évoluer la page d'édition d'une organisation pour permettre aux utilisateurs de PixAdmin d'activer cette fonctionnalité.

## :socks: Remarques
BSR : Aligne les checkboxes sur le formulaire d'édition d'une organisation.

## :santa: Pour tester
- Se connecter à PixAdmin
- Aller sur la page d'une organisation
- Passer en mode édition 
- Cocher la case "Activer la page Places dans PixOrga"
- Valider le formulaire et constater que la ligne "Activer la page Places dans PixOrga" est passé à "Oui"
