### PR TITLE
[FEATURE] Supprimer le fil d’Ariane de l'import en masse des sessions sur Pix Certif (PIX-10149).

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,4 +1,8 @@
 <section class="import-page__section--download panel">
+  <div class="import-page__section--download__title">
+    <FaIcon @icon="cloud-arrow-up" class="fa-lg" />
+    <h2>{{t "pages.sessions.import.step-one.title"}}</h2>
+  </div>
   <div class="import-page__section--download__instruction">
     {{t "pages.sessions.import.step-one.instructions.creation.list"}}
     <ul>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -1,4 +1,9 @@
 <section class="import-page__section--download panel import-page__resume-section">
+  <div class="import-page__section--download__title">
+    <FaIcon @icon="clipboard-list" class="fa-lg" />
+    <h2>{{t "pages.sessions.import.step-two.title"}}</h2>
+  </div>
+
   <PixMessage @type="info">
     <ul>
       <li>

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -8,6 +8,21 @@
     margin-bottom: 8px;
   }
 
+  &__section--download__title {
+    display: flex;
+    align-items: center;
+    gap: $pix-spacing-xs;
+
+    > svg {
+      color: $pix-neutral-50;
+    }
+
+    > h2 {
+      @extend %pix-title-s;
+      color: $pix-neutral-90;
+    }
+  }
+
   &__section--download__instruction {
     color: $pix-neutral-50;
     font-size: 14px;

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -8,57 +8,6 @@
     margin-bottom: 8px;
   }
 
-  &__section--breadcrumb {
-    background-color: $pix-neutral-5;
-    border: 1px solid $pix-neutral-15;
-    box-shadow: none;
-    margin: 24px 0 16px;
-    padding: 16px;
-
-    .breadcrumb-icon {
-      color: $pix-neutral-40;
-      margin: 0 24px;
-    }
-
-    ol {
-      align-items: center;
-      counter-reset: import-breadcrumb;
-      display: flex;
-      justify-content: center;
-      list-style: none;
-    }
-
-    ol li {
-      align-items: center;
-      color: $pix-neutral_50;
-      counter-increment: import-breadcrumb;
-      display: flex;
-    }
-
-    ol li::before {
-      align-items: center;
-      background-color: $pix-neutral-25;
-      border-radius: 50%;
-      color: $pix-neutral-0;
-      content: '' counter(import-breadcrumb);
-      font-size: 1.1rem;
-      font-weight: $font-medium;
-      display: flex;
-      height: 30px;
-      justify-content: center;
-      margin-right: 16px;
-      width: 30px;
-    }
-
-    ol li.active {
-      color: $pix-neutral_90;
-    }
-
-    ol li.active::before {
-      background-color: $pix-success-60;
-    }
-  }
-
   &__section--download__instruction {
     color: $pix-neutral-50;
     font-size: 14px;
@@ -132,12 +81,6 @@
     color: $pix-neutral-70;
     font-size: 1rem;
     line-height: 1.5rem;
-  }
-}
-
-.import-page-section-breadcrumb {
-  &__summary-link {
-    cursor: default;
   }
 }
 

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -6,18 +6,6 @@
   </PixReturnTo>
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
 
-  <div class="import-page__section--breadcrumb panel">
-    <ol aria-label={{t "pages.sessions.import.breadcrumb.extra-information"}}>
-      <li class={{if this.isImportStepOne "active" ""}} aria-current={{if this.isImportStepOne "step" ""}}>
-        {{t "pages.sessions.import.breadcrumb.import"}}
-      </li>
-      <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
-      <li class={{if this.isImportStepOne "" "active"}} aria-current={{if this.isImportStepOne "" "step"}}>
-        {{t "pages.sessions.import.breadcrumb.summary"}}
-      </li>
-    </ol>
-  </div>
-
   {{#if this.isImportStepOne}}
     <Import::StepOneSection
       @downloadSessionImportTemplate={{this.downloadSessionImportTemplate}}

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -147,7 +147,7 @@ module('Acceptance | Session Import', function (hooks) {
             // given
             const blob = new Blob(['foo']);
             const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
-            const { getAllByRole, getByLabelText, getByRole, queryByLabelText } = await visit('/sessions/import');
+            const { getByLabelText, getByRole, queryByLabelText } = await visit('/sessions/import');
             const importButton = getByLabelText('Importer le modèle complété');
             await triggerEvent(importButton, 'change', { files: [file] });
             const importConfirmationButton = getByRole('button', { name: 'Continuer' });
@@ -161,12 +161,6 @@ module('Acceptance | Session Import', function (hooks) {
             // then
             assert.dom(importButton).exists();
             assert.dom(queryByLabelText('fichier.csv')).doesNotExist();
-            assert
-              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Import du modèle'))
-              .hasAttribute('aria-current', 'step');
-            assert
-              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Récapitulatif'))
-              .hasAttribute('aria-current', '');
           });
         });
 
@@ -209,8 +203,7 @@ module('Acceptance | Session Import', function (hooks) {
             });
 
             // when
-            const { getAllByRole, getByLabelText, getByRole, getByText, queryByLabelText } =
-              await visit('/sessions/import');
+            const { getByLabelText, getByRole, getByText, queryByLabelText } = await visit('/sessions/import');
             const input = getByLabelText('Importer le modèle complété');
             await triggerEvent(input, 'change', { files: [file] });
             const importButton = getByRole('button', { name: 'Continuer' });
@@ -220,12 +213,6 @@ module('Acceptance | Session Import', function (hooks) {
             // then
             assert.dom(getByText('2 sessions dont 1 session sans candidat')).exists();
             assert.dom(getByText('3 candidats')).exists();
-            assert
-              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Récapitulatif'))
-              .hasAttribute('aria-current', 'step');
-            assert
-              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Import du modèle'))
-              .hasAttribute('aria-current', '');
             assert.dom(queryByLabelText('fichier.csv')).doesNotExist();
           });
 

--- a/certif/tests/integration/components/sessions-import/step-one-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-one-section_test.js
@@ -30,6 +30,7 @@ module('Integration | Component | Import::StepOneSection', function (hooks) {
     );
 
     // then
+    assert.dom(getByRole('heading', { name: 'Import du modèle', level: 2 })).exists();
     assert.dom(getByText('Vous pouvez créer des sessions :')).exists();
     assert.ok(getByTextWithHtml('<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,'));
     assert.ok(getByTextWithHtml('<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.'));

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -24,6 +24,22 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     assert.dom(getByText('12 candidats')).exists();
   });
 
+  test('it renders a title', async function (assert) {
+    // given
+    this.set('sessionsCount', 2);
+    this.set('sessionsWithoutCandidatesCount', 0);
+    this.set('candidatesCount', 12);
+    this.set('errorReports', []);
+
+    // when
+    const { getByRole } = await render(
+      hbs`<Import::StepTwoSection @sessionsCount={{this.sessionsCount}} @sessionsWithoutCandidatesCount={{this.sessionsWithoutCandidatesCount}}  @candidatesCount={{this.candidatesCount}} @errorReports={{this.errorReports}}/>`,
+    );
+
+    // then
+    assert.dom(getByRole('heading', { name: 'Récapitulatif', level: 2 })).exists();
+  });
+
   module('when the imported file contains errors', function () {
     [
       { error: 'CANDIDATE_FIRST_NAME_REQUIRED', expectedMessage: 'Champ obligatoire "Prénom" manquant' },

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -641,11 +641,6 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
-        "breadcrumb": {
-          "extra-information": "Fil d'Arianne",
-          "import": "Import du modèle",
-          "summary": "Récapitulatif"
-        },
         "candidates-list": {
           "import-fail-prefix": "No candidate has been uploaded.<br/>",
           "import-success": "The candidate list has been successfully uploaded.",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -684,6 +684,7 @@
           }
         },
         "step-two": {
+          "title": "Récapitulatif",
           "actions": {
             "confirm": {
               "label": "Finaliser la création/édition"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -648,6 +648,7 @@
           "unknown-document-version": "This version of the document is unknown."
         },
         "step-one": {
+          "title": "Import du modèle",
           "actions": {
             "cancel": {
               "label": "Annuler l'import"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -684,6 +684,7 @@
           }
         },
         "step-two": {
+          "title": "Récapitulatif",
           "actions": {
             "confirm": {
               "label": "Finaliser la création/édition"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -641,11 +641,6 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
-        "breadcrumb": {
-          "extra-information": "Fil d'Arianne",
-          "import": "Import du modèle",
-          "summary": "Récapitulatif"
-        },
         "candidates-list": {
           "import-fail-prefix": "Aucun candidat n’a été importé. <br/>",
           "import-success": "La liste des candidats a été importée avec succès.",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -648,6 +648,7 @@
           "unknown-document-version": "La version du document est inconnue."
         },
         "step-one": {
+          "title": "Import du modèle",
           "actions": {
             "cancel": {
               "label": "Annuler l'import"


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion massive des sessions est une nouvelle fonctionnalité qui a été mise à disposition de nos utilisateurs en juillet 2023.

Le fil d’Ariane introduit plus de complexité que nécessaire selon nos retours utilisateurs.

## :gift: Proposition
Supprimer le fil d’Ariane et inclure les titres dans les deux étapes de la fonctionnalité

## :santa: Pour tester

- Se connecter sur pix Certif avec certif-pro@example.net
- Cliquer sur le bouton de création/édition de plusieurs sessions
- Constater que le fil d'Ariane n'existe plus
- Constater que le titre "Import du modèle" apparaît dans la première étape

(maquette)
<img width="500" alt="Capture d’écran 2023-12-08 à 16 41 06" src="https://github.com/1024pix/pix/assets/58915422/51eac559-90c3-4afc-b5fa-91f253f4e00c">

- Importer un fichier csv
- Constater que le titre "Récapitulatif" apparaît dans la deuxième étape

(maquette)
<img width="510" alt="Capture d’écran 2023-12-08 à 16 40 56" src="https://github.com/1024pix/pix/assets/58915422/2631f9c2-9d42-4efe-a739-a531daeb64c0">
