### PR TITLE
[BUGFIX] Corriger un problème d'affichage du Language Switcher (PIX-9761)

### DIFF
--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -64,10 +64,8 @@
     </div>
   </div>
   {{#if this.isInternationalDomain}}
-    <LanguageSwitcher
-      class="login-or-register__language-switcher"
-      @selectedLanguage={{this.selectedLanguage}}
-      @onLanguageChange={{this.onLanguageChange}}
-    />
+    <div class="login-or-register__language-switcher">
+      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+    </div>
   {{/if}}
 </div>

--- a/mon-pix/app/styles/pages/_language.scss
+++ b/mon-pix/app/styles/pages/_language.scss
@@ -1,11 +1,7 @@
 .language {
-  display: flex;
-  flex-direction: column;
-  gap: $pix-spacing-s;
   padding: $pix-spacing-xs 0;
 
-  &__label {
-    min-width: 200px;
-    margin: 0;
+  &__notification {
+    margin-top: $pix-spacing-s;
   }
 }

--- a/mon-pix/app/templates/authenticated/user-account/language.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/language.hbs
@@ -6,7 +6,7 @@
   />
 
   {{#if this.shouldDisplayLanguageUpdatedMessage}}
-    <PixMessage @type="success" @withIcon={{true}}>
+    <PixMessage class="language__notification" @type="success" @withIcon={{true}}>
       {{t "pages.user-account.language.update-successful"}}
     </PixMessage>
   {{/if}}

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -65,7 +65,9 @@
     {{/if}}
 
     {{#if this.shouldDisplayLanguageSwitcher}}
-      <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+      <div>
+        <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+      </div>
     {{/if}}
   </main>
 </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à une modification du `<PixSelect>` sur PixUI, le design de certains des sélecteurs de langues présents sur les applications front ont été cassés.

## :gift: Proposition
Corriger le design des sélecteurs de langues au niveau du css et html dans les applications front.

## :socks: Remarques
Le calcul qui est fait dans Pix UI pour simuler le comportement d'une balise `<select>` ne semble pas bon parce qu’il ne prend pas en compte la tailles des deux icônes (🌐 + 🔽 ), dans le cadre du sélecteur de langues, quand un élément est sélectionné. Du coup, lorsqu'une des options du Pix Select a un texte très long, celui-ci est rogné lorsqu'il est sélectionné. Mais cela sera à voir dans une autre PR, sur le repo Pix UI.

## :santa: Pour tester
#### 🟣 Pix App (.org)
Faire des tests de non regression sur toutes les pages où il y a un sélecteur de langues : 

- `/connexion`
- `/inscription`
- `/mon-compte/langue`
- `/campagnes/SCOBADGE1/presentation`


#### 🟢 Pix Certif (.org)
Faire des tests de non regression sur toutes les pages où il y a un sélecteur de langues : 

- https://certif-pr7656.review.pix.org/connexion
- https://certif-pr7656.review.pix.org/rejoindre?invitationId=107066&code=AM8PZ4B7LM

_Si vous n'avez pas d'invitation en BDD, créez là directement depuis la BDD en ajoutant une ligne dans la table `certification-center-invitations` ou envoyez une invitation depuis Pix Admin._

#### 🔵 Pix Orga (.org)
Faire des tests de non regression sur toutes les pages où il y a un sélecteur de langues : 

- https://orga-pr7656.review.pix.org/connexion
- https://orga-pr7656.review.pix.org/rejoindre?invitationId=1&code=Q9ICXLZU37

_Si vous n'avez pas d'invitation en BDD, créez là directement depuis la BDD en ajoutant une ligne dans la table `organization-invitations` ou envoyez une invitation depuis Pix Admin._
