### PR TITLE
[FEATURE] Renommer le bouton permettant de modifier les infos candidats d'une certification sur Pix Admin (PIX-10164).

### DIFF
--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -95,7 +95,7 @@
           aria-label="Modifier les informations du candidat"
           @isDisabled={{this.isModifyButtonDisabled}}
         >
-          Modifier
+          Modifier infos candidat
         </PixButton>
       </div>
     </div>

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -666,7 +666,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
     module('Certification results edition', function () {
       module('when candidate results edit button is clicked', function () {
-        test('it disables candidate informations edit button', async function (assert) {
+        test('it disables candidate information edit button', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -675,12 +675,12 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           await clickByName('Modifier les résultats du candidat');
 
           // then
-          assert.dom(screen.getByLabelText('Modifier les informations du candidat')).isDisabled();
+          assert.dom(screen.getByRole('button', { name: 'Modifier les informations du candidat' })).isDisabled();
         });
       });
 
       module('when candidate results form cancel button is clicked', function () {
-        test('it re-enables candidate informations edit button', async function (assert) {
+        test('it re-enables candidate information edit button', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -690,12 +690,15 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           await clickByName('Annuler la modification des résultats du candidat');
 
           // then
-          assert.dom(screen.getByLabelText('Modifier les informations du candidat')).exists().isEnabled();
+          assert
+            .dom(screen.getByRole('button', { name: 'Modifier les informations du candidat' }))
+            .exists()
+            .isEnabled();
         });
       });
 
       module('when candidate results form is submitted', function () {
-        test('it also re-enables candidate informations edit button', async function (assert) {
+        test('it also re-enables candidate information edit button', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
@@ -709,7 +712,10 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           await clickByName('Confirmer');
 
           // then
-          assert.dom(screen.getByLabelText('Modifier les informations du candidat')).exists().isEnabled();
+          assert
+            .dom(screen.getByRole('button', { name: 'Modifier les informations du candidat' }))
+            .exists()
+            .isEnabled();
         });
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement le bouton se nomme "Modifier". Or, d’autres boutons de modification vont être ajoutés sur cette page, il y a donc un risque de confusion avec le nom actuel du bouton de modification de la section “Candidat”.

## :gift: Proposition
Renommer le bouton en "Modifier infos candidat"

## :socks: Remarques
Le bouton ayant un aria-label, il n'a pas été nécessaire de modifier les tests car testing prend l'aria-label en nom accessible pour le bouton. Une amélioration a été faite en appelant la méthode byRole plutôt que LabelText.

## :santa: Pour tester

- Se connecter sur Admin (superadmin@example.net)
- Aller dans l'onglet Sessions
- Trouver une session finalisée et cliquer sur son id pour accéder aux détails
- Aller dans l'onglet Certification
- Cliquer sur un candidat
- Constater le nouveau wording "Modifier infos candidat"
