### PR TITLE
[TECH] Supprimer le paramètre disableEntropyCache des appels a randomUUID

### DIFF
--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -45,9 +45,7 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   async saveIdToken({ idToken, userId }) {
-    // The session ID must be unpredictable, thus we disable the entropy cache
-    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
-    const uuid = randomUUID({ disableEntropyCache: true });
+    const uuid = randomUUID();
     const { idTokenLifespanMs } = this.temporaryStorageConfig;
 
     await logoutUrlTemporaryStorage.save({

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -126,9 +126,7 @@ class OidcAuthenticationService {
       return null;
     }
 
-    // The session ID must be unpredictable, thus we disable the entropy cache
-    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
-    const uuid = randomUUID({ disableEntropyCache: true });
+    const uuid = randomUUID();
 
     const { idTokenLifespanMs } = this.temporaryStorageConfig;
 
@@ -179,10 +177,8 @@ class OidcAuthenticationService {
 
   getAuthenticationUrl({ redirectUri }) {
     const redirectTarget = new URL(this.authenticationUrl);
-    // The session ID must be unpredictable, thus we disable the entropy cache
-    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
-    const state = randomUUID({ disableEntropyCache: true });
-    const nonce = randomUUID({ disableEntropyCache: true });
+    const state = randomUUID();
+    const nonce = randomUUID();
 
     const params = [
       { key: 'state', value: state },

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -87,9 +87,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   }
 
   async saveIdToken({ idToken, userId }) {
-    // The session ID must be unpredictable, thus we disable the entropy cache
-    // See https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy
-    const uuid = randomUUID({ disableEntropyCache: true });
+    const uuid = randomUUID();
     const { idTokenLifespanMs } = this.temporaryStorageConfig;
 
     await logoutUrlTemporaryStorage.save({


### PR DESCRIPTION
## :christmas_tree: Problème
Le commentaire associé a l'ajout du paramètre `disableEntropyCache` sous entend que le cache d'entropie serait prédictible et ainsi non sécurisé. Ce paramètre avait été rajouté dans https://github.com/1024pix/pix/pull/6935#discussion_r1304559045.

## :gift: Proposition
En reprenant l'argumentaire développé dans le message cité précédement.

> A aucun moment la documentation avertit de risque de collision, le cache est la pour aller plus vite quand c'est possible. On aurait un doute sur l'implémentation de ce cache ?

Je n'ai trouvé aucune documentation sur le fait que l'implémentation du cache d'entropie de node serait prédictible (le cache n'est pas public) ou qu'il créerait des risques de collisions (les entrées de cache utilisés sont supprimé a chaque utilisation). Il accélère les appels a `randomUUID` lorsque le cache est au moins un peu rempli. Dans le cas contraire, il va bloquer pour récupérer suffisament d'entropie.

## :santa: Pour tester
- :green_circle: tests
- Voir la doc de node.js https://nodejs.org/docs/latest-v20.x/api/crypto.html#cryptorandomuuidoptions
- tester l'authentification via un SSO
