### PR TITLE
[TECH] Installer toutes les dépendances dans circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
       - restore_cache:
           keys:
             - v7-api-npm-{{ checksum "cachekey" }}
-      - run: npm ci --no-optional
+      - run: npm ci
       - save_cache:
           key: v7-api-npm-{{ checksum "cachekey" }}
           paths:
@@ -323,7 +323,7 @@ jobs:
       - restore_cache:
           keys:
             - v7-audit-logger-npm-{{ checksum "cachekey" }}
-      - run: npm ci --no-optional
+      - run: npm ci
       - save_cache:
           key: v7-audit-logger-npm-{{ checksum "cachekey" }}
           paths:
@@ -499,7 +499,7 @@ jobs:
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
-          command: npm ci --no-optional
+          command: npm ci
 
       - run:
           working_directory: ~/pix/mon-pix
@@ -570,7 +570,7 @@ jobs:
       - run:
           name: Install Pix API
           working_directory: ~/pix/api
-          command: npm ci --no-optional
+          command: npm ci
 
       - run:
           working_directory: ~/pix/orga


### PR DESCRIPTION
## :christmas_tree: Problème
L'ajout du flag `--no-optional` a été introduit dans https://github.com/1024pix/pix/commit/31d8be72ededca0420bc5be1b2d1190068f629b1 via https://github.com/1024pix/pix/pull/3803
L'ajout du package `nyc` a depuis été supprimé. 


## :gift: Proposition
Supprimer ce flag.
Ce flag n'est plus utile d'autant que lors de la génération du package-lock on inclut tout.

## :socks: Remarques
Permettra de débloquer https://github.com/1024pix/pix/pull/7662

## :santa: Pour tester
Aucune idée. Faire un npm ci et lancer les tests.
