### PR TITLE
[TECH] améliore le temps d'exécution de la requête qui affiche les participants d'une orga sans import (PIX-10108)

### DIFF
--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -164,8 +164,20 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           organizationId,
         });
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const { id: otherOrganizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+          otherOrganizationId,
+          userId,
+        });
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
         databaseBuilder.factory.buildCampaignParticipation({ organizationLearnerId, userId, campaignId });
-        databaseBuilder.factory.buildCampaignParticipation({ organizationLearnerId, userId });
+        databaseBuilder.factory.buildCampaignParticipation({
+          organizationLearnerId: otherOrganizationLearnerId,
+          userId,
+          campaignId: otherCampaignId,
+        });
         await databaseBuilder.commit();
         // when
         const {
@@ -1293,10 +1305,15 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           organizationId: otherOrganizationId,
           type: CampaignTypes.PROFILES_COLLECTION,
         }).id;
-        const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        const userId = databaseBuilder.factory.buildUser().id;
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
+          userId,
         });
-
+        const { id: otherOrganizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: otherOrganizationId,
+          userId,
+        });
         const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           organizationLearnerId,
@@ -1308,7 +1325,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,
-          organizationLearnerId,
+          organizationLearnerId: otherOrganizationLearnerId,
           userId,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt: new Date('2022-01-01'),


### PR DESCRIPTION
## :christmas_tree: Problème
Pour certaines orga, l'affichage de la page participants timeout.

## :gift: Proposition
## :gift: Proposition
L'utilisation du `explain` sur la commande actuelle met en évidence une complexité / coût de la requete important
<details>
<summary>  explain de la requète actuelle </summary>
```
Limit  (cost=17616.09..17616.12 rows=1 width=152)
  ->  Unique  (cost=17616.09..17616.12 rows=1 width=152)
        ->  Sort  (cost=17616.09..17616.10 rows=1 width=152)
              Sort Key: \"organization-learners\".\"lastName\", \"organization-learners\".\"firstName\", \"organization-learners\".id, (first_value(\"campaign-participations_1\".\"isCertifiable\") OVER (?)), (first_value(\"campaign-participations_1\".\"sharedAt\") OVER (?)), (count(*) FILTER (WHERE (\"campaign-participations\".id IS NOT NULL)) OVER (?)), (max(\"campaign-participations\".\"createdAt\") OVER (?)), (first_value(campaigns.name) OVER (?)), (first_value(campaigns.type) OVER (?)), (first_value(\"campaign-participations\".status) OVER (?))
              ->  WindowAgg  (cost=17616.04..17616.08 rows=1 width=152)
                    ->  WindowAgg  (cost=17616.04..17616.07 rows=1 width=181)
                          ->  Sort  (cost=17616.04..17616.04 rows=1 width=85)
                                Sort Key: \"organization-learners\".id, \"campaign-participations\".\"createdAt\" DESC
                                ->  Nested Loop Left Join  (cost=2126.23..17616.03 rows=1 width=85)
                                      Join Filter: (\"organization-learners_1\".id = \"organization-learners\".id)
                                      ->  Nested Loop  (cost=1085.02..16574.79 rows=1 width=76)
                                            ->  Gather  (cost=1084.60..16574.34 rows=1 width=42)
                                                  Workers Planned: 2
                                                  ->  Nested Loop  (cost=84.60..15574.24 rows=1 width=42)
                                                        Join Filter: ((\"organization-learners\".id = \"campaign-participations\".\"organizationLearnerId\") AND (\"organization-learners\".\"userId\" = \"campaign-participations\".\"userId\"))
                                                        ->  Nested Loop  (cost=84.16..14055.52 rows=2231 width=27)
                                                              ->  Parallel Bitmap Heap Scan on \"organization-learners\"  (cost=83.73..7151.80 rows=2957 width=23)
                                                                    Recheck Cond: (\"organizationId\" = 13404)
                                                                    Filter: (\"deletedAt\" IS NULL)
                                                                    ->  Bitmap Index Scan on organization_learners_organizationid_nationalstudentid_unique  (cost=0.00..81.95 rows=7119 width=0)
                                                                          Index Cond: (\"organizationId\" = 13404)
                                                              ->  Index Scan using users_pkey on users  (cost=0.43..2.33 rows=1 width=4)
                                                                    Index Cond: (id = \"organization-learners\".\"userId\")
                                                                    Filter: (NOT \"isAnonymous\")
                                                        ->  Index Scan using campaign_participations_userid_index on \"campaign-participations\"  (cost=0.44..0.59 rows=6 width=31)
                                                              Index Cond: (\"userId\" = users.id)
                                                              Filter: ((NOT \"isImproved\") AND (\"deletedAt\" IS NULL))
                                            ->  Index Scan using campaigns_pkey on campaigns  (cost=0.42..0.45 rows=1 width=42)
                                                  Index Cond: (id = \"campaign-participations\".\"campaignId\")
                                                  Filter: (\"organizationId\" = 13404)
                                      ->  Unique  (cost=1041.20..1041.22 rows=1 width=25)
                                            ->  Sort  (cost=1041.20..1041.21 rows=1 width=25)
                                                  Sort Key: \"organization-learners_1\".id, (first_value(\"campaign-participations_1\".\"isCertifiable\") OVER (?)), (first_value(\"campaign-participations_1\".\"sharedAt\") OVER (?))
                                                  ->  WindowAgg  (cost=1041.17..1041.19 rows=1 width=25)
                                                        ->  Sort  (cost=1041.17..1041.17 rows=1 width=13)
                                                              Sort Key: \"organization-learners_1\".id, \"campaign-participations_1\".\"sharedAt\" DESC
                                                              ->  Nested Loop  (cost=1.30..1041.16 rows=1 width=13)
                                                                    ->  Nested Loop  (cost=0.86..1030.83 rows=22 width=13)
                                                                          ->  Index Scan using campaigns_organizationid_index on campaigns campaigns_1  (cost=0.42..941.10 rows=1 width=4)
                                                                                Index Cond: (\"organizationId\" = 13404)
                                                                                Filter: ((type)::text = '$PROFILES_COLLECTION'::text)
                                                                          ->  Index Scan using campaign_participations_campaignid_index on \"campaign-participations\" \"campaign-participations_1\"  (cost=0.44..88.23 rows=150 width=17)
                                                                                Index Cond: (\"campaignId\" = campaigns_1.id)
                                                                                Filter: ((\"deletedAt\" IS NULL) AND ((status)::text = 'SHARED'::text))
                                                                    ->  Index Scan using organization_learners_pkey on \"organization-learners\" \"organization-learners_1\"  (cost=0.43..0.47 rows=1 width=4)
                                                                          Index Cond: (id = \"campaign-participations_1\".\"organizationLearnerId\")
                                                                          Filter: ((\"deletedAt\" IS NULL) AND (\"organizationId\" = 13404)
```
</details>
on décide de reprendre la requete pour supprimer l'utilisation du disctinct et de la sous requete
et d'utiliser des sous requetes ciblées tirant parti des index existant.
 
<details>
<summary>  explain du poc de solution </summary>
```
Limit  (cost=73953.62..80492.28 rows=50 width=1592)
  ->  Result  (cost=73953.62..307383.82 rows=1785 width=1592)
        ->  Sort  (cost=73953.62..73958.09 rows=1785 width=27)
              Sort Key: "organization-learners"."lastName", ((SubPlan 3)) DESC, "organization-learners"."firstName", "organization-learners".id
              ->  Nested Loop  (cost=1.00..73894.33 rows=1785 width=27)
                    ->  Index Scan using organization_learners_organizationid_nationalstudentid_unique on "organization-learners"  (cost=0.56..55961.29 rows=2366 width=23)
                          Index Cond: ("organizationId" = 13404)
                          Filter: (("deletedAt" IS NULL) AND ((SubPlan 8) > 0))
                          SubPlan 8
                            ->  GroupAggregate  (cost=0.44..6.85 rows=5 width=12)
                                  Group Key: "campaign-participations_7"."organizationLearnerId"
                                  ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_7"  (cost=0.44..6.78 rows=5 width=4)
                                        Index Cond: ("organizationLearnerId" = "organization-learners".id)
                                        Filter: (("isImproved" IS FALSE) AND ("deletedAt" IS NULL))
                    ->  Index Scan using users_pkey on users  (cost=0.43..2.41 rows=1 width=4)
                          Index Cond: (id = "organization-learners"."userId")
                          Filter: (NOT "isAnonymous")
                    SubPlan 3
                      ->  GroupAggregate  (cost=0.44..6.85 rows=5 width=12)
                            Group Key: "campaign-participations_2"."organizationLearnerId"
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_2"  (cost=0.44..6.78 rows=5 width=4)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                                  Filter: (("isImproved" IS FALSE) AND ("deletedAt" IS NULL))
        SubPlan 1
          ->  Limit  (cost=19.03..19.03 rows=1 width=9)
                ->  Sort  (cost=19.03..19.03 rows=1 width=9)
                      Sort Key: "campaign-participations"."sharedAt" DESC
                      ->  Nested Loop  (cost=0.86..19.02 rows=1 width=9)
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations"  (cost=0.44..6.79 rows=5 width=13)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                                  Filter: (("deletedAt" IS NULL) AND ((status)::text = 'SHARED'::text))
                            ->  Index Scan using campaigns_pkey on campaigns  (cost=0.42..2.45 rows=1 width=4)
                                  Index Cond: (id = "campaign-participations"."campaignId")
                                  Filter: ((type)::text = 'PROFILES_COLLECTION'::text)
        SubPlan 2
          ->  Limit  (cost=19.03..19.03 rows=1 width=8)
                ->  Sort  (cost=19.03..19.03 rows=1 width=8)
                      Sort Key: "campaign-participations_1"."sharedAt" DESC
                      ->  Nested Loop  (cost=0.86..19.02 rows=1 width=8)
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_1"  (cost=0.44..6.79 rows=5 width=12)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                                  Filter: (("deletedAt" IS NULL) AND ((status)::text = 'SHARED'::text))
                            ->  Index Scan using campaigns_pkey on campaigns campaigns_1  (cost=0.42..2.45 rows=1 width=4)
                                  Index Cond: (id = "campaign-participations_1"."campaignId")
                                  Filter: ((type)::text = 'PROFILES_COLLECTION'::text)
        SubPlan 4
          ->  Limit  (cost=21.46..21.46 rows=1 width=8)
                ->  Sort  (cost=21.46..21.48 rows=6 width=8)
                      Sort Key: "campaign-participations_3"."createdAt" DESC NULLS LAST
                      ->  Nested Loop  (cost=0.86..21.43 rows=6 width=8)
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_3"  (cost=0.44..6.78 rows=6 width=12)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                            ->  Index Only Scan using campaigns_pkey on campaigns campaigns_2  (cost=0.42..2.44 rows=1 width=4)
                                  Index Cond: (id = "campaign-participations_3"."campaignId")
        SubPlan 5
          ->  Limit  (cost=21.46..21.46 rows=1 width=34)
                ->  Sort  (cost=21.46..21.48 rows=6 width=34)
                      Sort Key: "campaign-participations_4"."createdAt" DESC NULLS LAST
                      ->  Nested Loop  (cost=0.86..21.43 rows=6 width=34)
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_4"  (cost=0.44..6.78 rows=6 width=12)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                            ->  Index Scan using campaigns_pkey on campaigns campaigns_3  (cost=0.42..2.44 rows=1 width=30)
                                  Index Cond: (id = "campaign-participations_4"."campaignId")
        SubPlan 6
          ->  Limit  (cost=21.46..21.46 rows=1 width=20)
                ->  Sort  (cost=21.46..21.48 rows=6 width=20)
                      Sort Key: "campaign-participations_5"."createdAt" DESC NULLS LAST
                      ->  Nested Loop  (cost=0.86..21.43 rows=6 width=20)
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_5"  (cost=0.44..6.78 rows=6 width=12)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                            ->  Index Scan using campaigns_pkey on campaigns campaigns_4  (cost=0.42..2.44 rows=1 width=16)
                                  Index Cond: (id = "campaign-participations_5"."campaignId")
        SubPlan 7
          ->  Limit  (cost=21.46..21.46 rows=1 width=15)
                ->  Sort  (cost=21.46..21.48 rows=6 width=15)
                      Sort Key: "campaign-participations_6"."createdAt" DESC NULLS LAST
                      ->  Nested Loop  (cost=0.86..21.43 rows=6 width=15)
                            ->  Index Scan using campaign_participations_organizationlearnerid_index on "campaign-participations" "campaign-participations_6"  (cost=0.44..6.78 rows=6 width=19)
                                  Index Cond: ("organizationLearnerId" = "organization-learners".id)
                            ->  Index Only Scan using campaigns_pkey on campaigns campaigns_5  (cost=0.42..2.44 rows=1 width=4)
                                  Index Cond: (id = "campaign-participations_6"."campaignId")
```
</details> 

Pour en savoir plus , voici une page qui reprend l'inverstigation / solution technique » https://1024pix.atlassian.net/wiki/spaces/prescription/pages/3929276430/Optimisation+de+la+page+participants.

travail similaire fait dans #7587

## :socks: Remarques
On utilise des sous requêtes plutôt que des knex.raw().
On a ré-écrit certains tests pour qu'il reflètent mieux les contraintes du domaine.

## :santa: Pour tester

-  se rendre sur orga
-  se connecter avec un compte pro
-  afficher la liste des participants
-  jouer avec les filtres

