### PR TITLE
[TECH] Impacts suite mise à  jour Pix UI v41.2.0. (PIX-10344)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -90,6 +90,8 @@
   {{#if this.optionsMenuShouldBeDisplayed}}
     <div class="session-supervising-candidate-in-list__menu">
       <PixIconButton
+        @withBackground="{{true}}"
+        @size="small"
         @icon="ellipsis-v"
         aria-label={{t "pages.session-supervising.candidate-in-list.display-candidate-options"}}
         @triggerAction={{this.toggleMenu}}

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -215,11 +215,6 @@
     }
   }
 
-  &__controls-download-button {
-    border: 1px solid $pix-neutral-50;
-    color: $pix-neutral-90;
-  }
-
   &__controls-download-button:not(:last-of-type) {
     margin-right: 8px;
   }

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -44,7 +44,8 @@
       <PixButtonLink
         class="session-details__controls-download-button"
         @href="{{this.urlToDownloadSessionIssueReportSheet}}"
-        @backgroundColor="transparent"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
         @size="small"
         target="_blank"
         aria-label={{t "pages.sessions.detail.downloads.incident-report.extra-information"}}
@@ -57,7 +58,8 @@
       <PixButtonLink
         class="session-details__controls-download-button"
         @href="{{this.session.urlToDownloadSupervisorKitPdf}}"
-        @backgroundColor="transparent"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
         @size="small"
         target="_blank"
         aria-label={{t "pages.sessions.detail.downloads.invigilator-kit.extra-information"}}
@@ -71,7 +73,8 @@
         <PixButtonLink
           class="session-details__controls-download-button"
           @href="{{this.session.urlToDownloadAttendanceSheet}}"
-          @backgroundColor="transparent"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
           @size="small"
           target="_blank"
           aria-label={{t "pages.sessions.detail.downloads.attendance-sheet.extra-information"}}


### PR DESCRIPTION
## :christmas_tree: Problème
Suite passage Renovate et mise à jour de Pix UI on constate certains changements sur Pix Certif

Pix Certif : Petite dette pour l'expérience utilisateur avec 2 points bloquants

écran de détails d'une certif pour l'état hover de 3 boutons
![image](https://github.com/1024pix/pix/assets/103997660/32403c05-0bcf-4057-9126-7ac0ee8b5650)

écran surveillant, l'icon button pour pouvoir terminer la session ou autoriser à reprendre n'est pas visible car identique à la couleur du fond.
![image](https://github.com/1024pix/pix/assets/103997660/c0987f23-2453-4850-b1d4-f73a4200e414)

## :gift: Proposition
Utiliser les bons paramètres sur les composants et supprimer les styles qui écrasent le comportement par défaut.

## :santa: Pour tester
- Se connecter sur Pix Certif avec `certif-pro@example.net`
- Aller sur une session avec des candidats qui ont commencé leur certification
- Voir que les 3 boutons de Téléchargements sont uniformes
![Capture d’écran 2023-12-12 à 11 10 57](https://github.com/1024pix/pix/assets/103997660/be7c0e94-db52-4ab6-818b-36bba7bd96fb)

- Se rendre sur l'espace surveillant et voir les boutons "3 petits points" correctement afficher
![Capture d’écran 2023-12-12 à 11 11 21](https://github.com/1024pix/pix/assets/103997660/39105d47-a929-4c4e-b16c-a1b1238b4d60)
