### PR TITLE
[FEATURE] Ajoute l'organizationId sur le model Campaign de PixApp (PIX-10345).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
@@ -16,6 +16,7 @@ const serialize = function (campaignsToJoin) {
       'isForAbsoluteNovice',
       'isRestricted',
       'isSimplifiedAccess',
+      'organizationId',
       'organizationName',
       'organizationType',
       'organizationLogoUrl',

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -270,6 +270,7 @@ describe('Unit | Application | Controller | Campaign', function () {
           'is-simplified-access': campaignToJoin.isSimplifiedAccess,
           'is-for-absolute-novice': campaignToJoin.isForAbsoluteNovice,
           'identity-provider': campaignToJoin.identityProvider,
+          'organization-id': campaignToJoin.organizationId,
           'organization-name': campaignToJoin.organizationName,
           'organization-type': campaignToJoin.organizationType,
           'organization-logo-url': campaignToJoin.organizationLogoUrl,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | campaign-to-join-serializer', function (
             'is-simplified-access': campaignToJoin.isSimplifiedAccess,
             'is-for-absolute-novice': campaignToJoin.isForAbsoluteNovice,
             'identity-provider': campaignToJoin.identityProvider,
+            'organization-id': campaignToJoin.organizationId,
             'organization-name': campaignToJoin.organizationName,
             'organization-type': campaignToJoin.organizationType,
             'organization-logo-url': campaignToJoin.organizationLogoUrl,

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -12,6 +12,7 @@ export default class Campaign extends Model {
   @attr('boolean') isSimplifiedAccess;
   @attr('boolean') isForAbsoluteNovice;
   @attr('boolean') isArchived;
+  @attr() organizationId;
   @attr('string') organizationName;
   @attr('string') organizationType;
   @attr('string') organizationLogoUrl;


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l'Epix sur les Parcours Autonome, la team ExpEval a besoin de pouvoir identifier facilement l'organisation d'une campagne pour pouvoir personnaliser l'affichage de la page de début et de fin de parcours.

## :gift: Proposition
On ajoute l'organizationId sur le model Campaign de PixApp.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
