### PR TITLE
[BUGFIX] Finaliser un parcours lorsqu'un tube de déclencheur de CF n'est plus disponible dans le référentiel (PIX-10347).

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -82,7 +82,8 @@ const findByTrainingId = async function ({ trainingId, domainTransaction = Domai
   const trainingTriggerIds = trainingTriggers.map(({ id }) => id);
   const trainingTriggerTubes = await knexConn('training-trigger-tubes')
     .whereIn('trainingTriggerId', trainingTriggerIds)
-    .select('*');
+    .select('*')
+    .orderBy('tubeId', 'asc');
 
   return Promise.all(
     trainingTriggers.map(async (trainingTrigger) => {

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -118,12 +118,16 @@ async function _toDomain({ trainingTrigger, triggerTubes }) {
     });
   }
 
+  const availableTriggerTubes = triggerTubes.filter(({ tubeId }) => {
+    return tubeIds.includes(tubeId);
+  });
+
   return new TrainingTrigger({
     id: trainingTrigger.id,
     trainingId: trainingTrigger.trainingId,
     type: trainingTrigger.type,
     threshold: trainingTrigger.threshold,
-    triggerTubes: triggerTubes.map(
+    triggerTubes: availableTriggerTubes.map(
       ({ id, tubeId, level }) => new TrainingTriggerTube({ id, tube: tubes.find(({ id }) => id === tubeId), level }),
     ),
   });

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -480,6 +480,32 @@ describe('Integration | Repository | training-trigger-repository', function () {
           trainingTriggerId: trainingTrigger.id,
         });
       });
+
+      it('should return training triggers with empty tube', async function () {
+        // given
+        const trainingId = databaseBuilder.factory.buildTraining().id;
+        const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
+        databaseBuilder.factory.buildTrainingTriggerTube({
+          trainingTriggerId: trainingTrigger.id,
+          tubeId: 'notExistTubeId',
+        });
+        databaseBuilder.factory.buildTrainingTriggerTube({
+          trainingTriggerId: trainingTrigger.id,
+          tubeId: 'recTube0',
+        });
+        await databaseBuilder.commit();
+
+        sinon.stub(logger, 'warn').returns();
+
+        // when
+        const trainingTriggers = await trainingTriggerRepository.findByTrainingId({ trainingId });
+
+        // then
+        expect(trainingTriggers).to.have.lengthOf(1);
+        expect(trainingTriggers[0].triggerTubes).to.have.lengthOf(2);
+        expect(trainingTriggers[0].triggerTubes[0].tube).to.be.undefined;
+        expect(trainingTriggers[0].triggerTubes[1].tube.id).to.be.equal('recTube0');
+      });
     });
 
     it('should return empty array when no training trigger found', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -481,7 +481,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
         });
       });
 
-      it('should return training triggers with empty tube', async function () {
+      it('should return only available training triggers', async function () {
         // given
         const trainingId = databaseBuilder.factory.buildTraining().id;
         const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
@@ -502,9 +502,8 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
         // then
         expect(trainingTriggers).to.have.lengthOf(1);
-        expect(trainingTriggers[0].triggerTubes).to.have.lengthOf(2);
-        expect(trainingTriggers[0].triggerTubes[0].tube).to.be.undefined;
-        expect(trainingTriggers[0].triggerTubes[1].tube.id).to.be.equal('recTube0');
+        expect(trainingTriggers[0].triggerTubes).to.have.lengthOf(1);
+        expect(trainingTriggers[0].triggerTubes[0].tube.id).to.be.equal('recTube0');
       });
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, si un déclencheur de CF référence un tube qui n’est plus présent dans la release, alors l’utilisateur ne peut pas finir son parcours. Il obtient une erreur 500. 

![Screenshot 2023-12-12 at 12 19 41](https://github.com/1024pix/pix/assets/26384707/cb6d9c25-d6f4-4d4f-ba70-77d8dbef12f7)


## :gift: Proposition

Plusieurs solutions peuvent être envisagées : 
 -  Ne plus proposer le training => Le CF n’est plus proposé donc personne d’autres passant une campagne avec le PC ne l’obtiendra
- Ne plus utiliser ce déclencheur => Le CF se base sur l’autre déclencheur s’il en a un, sinon il ne pourra plus être obtenu
- Ne plus utiliser ce tube dans le déclencheur => Le déclencheur sera “plus simple” ou “plus dur”  et donc les critères seront changés par rapport à ce qui avait voulu mais il sera toujours proposé

Cette PR met en oeuvre la dernière solution : de ne plus utiliser le tube dans le déclencheur.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

## A la main
Sur Pix Admin: 
- Se rendre sur Pix Admin 
- Créer un CF et un déclencheur
- Modifier un tube d'un déclencheur pour un tube foireux : `notExistingId`

Sur Pix Orga :
- Créer une campagne avec le Profil Cible lié au CF 

Sur Pix App :
- Passer la campagne 
- Et constater à la fin que la page de fin de campagne apparait

## Utiliser la campagne EDUMULTIP
Sur Pix App : 
- Passer la campagne `EDUMULTIP`
- Et constater à la fin que la page de fin de campagne apparait