### PR TITLE
[FEATURE] Mise en place du feature toggle pour la certification au niveau n-1 (PIX-10317)

### DIFF
--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -29,6 +29,7 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
+  FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -951,6 +951,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_PIX_1D_ENABLED=false
 
+# Enable the Pix+ lower level granting when a candidate fails a certification by a slim margin
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ENABLE_PIX_PLUS_LOWER_LEVEL=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -189,6 +189,7 @@ const configuration = (function () {
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
       isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
+      isPixPlusLowerLeverEnabled: isFeatureEnabled(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
     },
     fwb: {
       isEnabled: isFeatureEnabled(process.env.FWB_ENABLED),

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -23,6 +23,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-pix1d-enabled': true,
+            'is-pix-plus-lower-lever-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## :christmas_tree: Problème

Le développement de cette feature et des moyens d’information du candidat, du destinataire des résultats et du jury Pix ne sera pas fait exactement en même temps.

## :gift: Proposition
Mettre en place le FT : ENABLE_PIX_PLUS_LOWER_LEVEL pour terminer les devs sereinement avant de communiquer et d’ouvrir la nouvelle fonctionnalité

## :socks: Remarques
Nope
## :santa: Pour tester
taper l'url: https://api-pr7672.review.pix.fr/api/feature-toggles 
S'assurer que le FT a la valeur requise