### PR TITLE
[TECH] Migre les usages de `momentjs`.

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -15,9 +15,6 @@ import {
   extractUserIdFromRequest,
   extractLocaleFromRequest,
 } from '../../infrastructure/utils/request-response-utils.js';
-import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat.js';
-dayjs.extend(customParseFormat);
 import { getDivisionCertificationResultsCsv } from '../../infrastructure/utils/csv/certification-results/get-division-certification-results-csv.js';
 import * as organizationForAdminSerializer from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin-serializer.js';
 

--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -1,6 +1,6 @@
+import dayjs from 'dayjs';
 import { Skill } from '../models/Skill.js';
 import _ from 'lodash';
-import moment from 'moment';
 
 const statuses = {
   VALIDATED: 'validated',
@@ -93,7 +93,7 @@ class KnowledgeElement {
   static computeDaysSinceLastKnowledgeElement(knowledgeElements) {
     const lastCreatedAt = _(knowledgeElements).map('createdAt').max();
     const precise = true;
-    return moment().diff(lastCreatedAt, 'days', precise);
+    return dayjs().diff(lastCreatedAt, 'days', precise);
   }
 
   static findDirectlyValidatedFromGroups(knowledgeElementsByCompetence) {

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -5,7 +5,7 @@ import {
   MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING,
   MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING,
 } from '../../constants.js';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { getNewAcquiredStages } from '../../../../src/evaluation/domain/services/stages/get-new-acquired-stages-service.js';
 
 class AssessmentResult {
@@ -109,7 +109,7 @@ class AssessmentResult {
     const isImprovementPossible =
       knowledgeElements.filter((knowledgeElement) => {
         const isOldEnoughToBeImproved =
-          moment(assessmentCreatedAt).diff(knowledgeElement.createdAt, 'days', true) >=
+          dayjs(assessmentCreatedAt).diff(knowledgeElement.createdAt, 'days', true) >=
           MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
         return knowledgeElement.isInvalidated && isOldEnoughToBeImproved;
       }).length > 0;
@@ -149,7 +149,7 @@ class AssessmentResult {
   _timeBeforeRetryingPassed(sharedAt) {
     const isShared = Boolean(sharedAt);
     if (!isShared) return false;
-    return sharedAt && moment().diff(sharedAt, 'days', true) >= MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+    return sharedAt && dayjs().diff(sharedAt, 'days', true) >= MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }
 

--- a/api/lib/domain/services/improvement-service.js
+++ b/api/lib/domain/services/improvement-service.js
@@ -1,12 +1,12 @@
+import dayjs from 'dayjs';
 import { constants } from '../constants.js';
-import moment from 'moment';
 
 function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements, assessment, minimumDelayInDays }) {
   const startedDateOfAssessment = assessment.createdAt;
 
   return currentUserKnowledgeElements.filter((knowledgeElement) => {
     const isNotOldEnoughToBeImproved =
-      moment(startedDateOfAssessment).diff(knowledgeElement.createdAt, 'days', true) < minimumDelayInDays;
+      dayjs(startedDateOfAssessment).diff(knowledgeElement.createdAt, 'days', true) < minimumDelayInDays;
     return knowledgeElement.isValidated || isNotOldEnoughToBeImproved;
   });
 }

--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -1,5 +1,7 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+dayjs.extend(utc);
 import * as csvSerializer from '../../serializers/csv/csv-serializer.js';
-import moment from 'moment';
 
 const EMPTY_ARRAY = [];
 
@@ -72,7 +74,7 @@ class CampaignProfilesCollectionResultLine {
 
   _getSharedAtColumn() {
     return this.campaignParticipationResult.isShared
-      ? moment.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD')
+      ? dayjs.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD')
       : this.notShared;
   }
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 
 const { get } = lodash;
 
-import moment from 'moment';
+import dayjs from 'dayjs';
 import querystring from 'querystring';
 import { AuthenticationMethod } from '../../../domain/models/AuthenticationMethod.js';
 import * as OidcIdentityProviders from '../../../domain/constants/oidc-identity-providers.js';
@@ -66,10 +66,11 @@ const notify = async (userId, payload, dependencies) => {
     }
 
     accessToken = tokenResponse.data['access_token'];
+    const tokenExpiredDate = tokenResponse.data['expires_in'];
     const authenticationComplement = new AuthenticationMethod.PoleEmploiOidcAuthenticationComplement({
       accessToken,
       refreshToken: tokenResponse.data['refresh_token'],
-      expiredDate: moment().add(tokenResponse.data['expires_in'], 's').toDate(),
+      expiredDate: tokenExpiredDate ? dayjs().add(tokenExpiredDate, 's').toDate() : new Date(),
     });
     await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
       authenticationComplement,

--- a/api/lib/infrastructure/files/candidates-import/CandidateData.js
+++ b/api/lib/infrastructure/files/candidates-import/CandidateData.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 import _ from 'lodash';
 const FRANCE_COUNTRY_CODE = '99100';
 import { CertificationCandidate } from '../../../domain/models/CertificationCandidate.js';
@@ -48,7 +48,7 @@ class CandidateData {
     this.email = this._emptyStringIfNull(email);
     this.resultRecipientEmail = this._emptyStringIfNull(resultRecipientEmail);
     this.externalId = this._emptyStringIfNull(externalId);
-    this.birthdate = birthdate === null ? '' : moment(birthdate, 'YYYY-MM-DD').format('YYYY-MM-DD');
+    this.birthdate = birthdate === null ? '' : dayjs(birthdate, 'YYYY-MM-DD').format('YYYY-MM-DD');
     if (!_.isFinite(extraTimePercentage) || extraTimePercentage <= 0) {
       this.extraTimePercentage = '';
     } else {

--- a/api/lib/infrastructure/files/candidates-import/SessionData.js
+++ b/api/lib/infrastructure/files/candidates-import/SessionData.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 class SessionData {
   constructor({
@@ -33,8 +33,8 @@ class SessionData {
     this.publishedAt = publishedAt;
     this.certificationCenterId = certificationCenterId;
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
-    this.startTime = moment(time, 'HH:mm').format('HH:mm');
-    this.date = moment(date, 'YYYY-MM-DD').format('DD/MM/YYYY');
+    this.startTime = dayjs(time, 'HH:mm').format('HH:mm');
+    this.date = dayjs(date, 'YYYY-MM-DD').format('DD/MM/YYYY');
   }
 
   static fromSession(session) {

--- a/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
+++ b/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
@@ -1,6 +1,8 @@
-import moment from 'moment';
-import lodash from 'lodash';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
+dayjs.extend(customParseFormat);
 
+import lodash from 'lodash';
 const { isEmpty, isNil, each } = lodash;
 
 import { SiecleXmlImportError, SIECLE_ERRORS } from '../../../domain/errors.js';
@@ -72,7 +74,7 @@ function _mapStudentInformationToOrganizationLearner(studentNode) {
     middleName: _getValueFromParsedElement(studentNode.PRENOM2),
     thirdName: _getValueFromParsedElement(studentNode.PRENOM3),
     sex: _convertSexCode(studentNode.CODE_SEXE),
-    birthdate: moment(studentNode.DATE_NAISS, 'DD/MM/YYYY').format('YYYY-MM-DD') || null,
+    birthdate: dayjs(studentNode.DATE_NAISS?.[0], 'DD/MM/YYYY').format('YYYY-MM-DD') || null,
     birthCountryCode: _getValueFromParsedElement(studentNode.CODE_PAYS),
     birthProvinceCode: _getValueFromParsedElement(studentNode.CODE_DEPARTEMENT_NAISS),
     birthCityCode: _getValueFromParsedElement(studentNode.CODE_COMMUNE_INSEE_NAISS),

--- a/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
+++ b/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
@@ -67,6 +67,8 @@ class XMLOrganizationLearnersSet {
 }
 
 function _mapStudentInformationToOrganizationLearner(studentNode) {
+  const parsedBirthdate = studentNode.DATE_NAISS?.[0];
+
   return {
     lastName: _getValueFromParsedElement(studentNode.NOM_DE_FAMILLE),
     preferredLastName: _getValueFromParsedElement(studentNode.NOM_USAGE),
@@ -74,7 +76,7 @@ function _mapStudentInformationToOrganizationLearner(studentNode) {
     middleName: _getValueFromParsedElement(studentNode.PRENOM2),
     thirdName: _getValueFromParsedElement(studentNode.PRENOM3),
     sex: _convertSexCode(studentNode.CODE_SEXE),
-    birthdate: dayjs(studentNode.DATE_NAISS?.[0], 'DD/MM/YYYY').format('YYYY-MM-DD') || null,
+    birthdate: dayjs(parsedBirthdate, 'DD/MM/YYYY').format('YYYY-MM-DD') || null,
     birthCountryCode: _getValueFromParsedElement(studentNode.CODE_PAYS),
     birthProvinceCode: _getValueFromParsedElement(studentNode.CODE_DEPARTEMENT_NAISS),
     birthCityCode: _getValueFromParsedElement(studentNode.CODE_COMMUNE_INSEE_NAISS),

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -1,4 +1,6 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+dayjs.extend(utc);
 import _ from 'lodash';
 
 const STATS_COLUMNS_COUNT = 3;
@@ -106,10 +108,10 @@ class CampaignAssessmentCsvLine {
         this.targetedKnowledgeElementsCount,
         this.learningContent.skills.length,
       ),
-      moment.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
+      dayjs.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
       this._makeYesNoColumns(this.campaignParticipationInfo.isShared),
       this.campaignParticipationInfo.isShared
-        ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD')
+        ? dayjs.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD')
         : this.emptyContent,
       ...(this.stageCollection.hasStage ? [this._getReachedStage()] : []),
       ...(this.campaignParticipationInfo.isShared

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -49,7 +49,6 @@
         "jszip": "^3.10.0",
         "knex": "^3.0.0",
         "lodash": "^4.17.21",
-        "moment": "^2.29.3",
         "moment-timezone": "^0.5.34",
         "ms": "^2.1.3",
         "node-cache": "^5.1.2",

--- a/api/package.json
+++ b/api/package.json
@@ -55,7 +55,6 @@
     "jszip": "^3.10.0",
     "knex": "^3.0.0",
     "lodash": "^4.17.21",
-    "moment": "^2.29.3",
     "moment-timezone": "^0.5.34",
     "ms": "^2.1.3",
     "node-cache": "^5.1.2",

--- a/api/scripts/certification/get-results-certifications.js
+++ b/api/scripts/certification/get-results-certifications.js
@@ -1,8 +1,12 @@
 import fileSystem from 'fs';
 import axios from 'axios';
 import { Parser } from '@json2csv/plainjs';
-import moment from 'moment-timezone';
 import * as url from 'url';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const HEADERS = [
   'ID de certification',
@@ -93,7 +97,7 @@ function toCSVRow(rowJSON) {
   res[lastname] = certificationData['last-name'];
 
   if (certificationData['birthdate']) {
-    res[birthdate] = moment.utc(certificationData['birthdate'], 'YYYY-MM-DD').tz('Europe/Paris').format('DD/MM/YYYY');
+    res[birthdate] = dayjs.utc(certificationData['birthdate'], 'YYYY-MM-DD').tz('Europe/Paris').format('DD/MM/YYYY');
   } else {
     res[birthdate] = '';
   }
@@ -104,9 +108,9 @@ function toCSVRow(rowJSON) {
 
   res[sessionNumber] = certificationData['session-id'];
 
-  res[dateStart] = moment.utc(certificationData['created-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
+  res[dateStart] = dayjs.utc(certificationData['created-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
   if (certificationData['completed-at']) {
-    res[dateEnd] = moment(certificationData['completed-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
+    res[dateEnd] = dayjs(certificationData['completed-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
   } else {
     res[dateEnd] = '';
   }
@@ -125,7 +129,7 @@ function toCSVRow(rowJSON) {
 }
 
 function saveInFile(csv, sessionId) {
-  const filepath = `session_${sessionId}_export_${moment.utc().format('DD-MM-YYYY_HH-mm')}.csv`;
+  const filepath = `session_${sessionId}_export_${dayjs.utc().format('DD-MM-YYYY_HH-mm')}.csv`;
   fileSystem.writeFile(filepath, csv, (err) => {
     if (err) throw err;
     console.log('Les données de certifications sont dans le fichier :' + filepath);

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -8,7 +8,6 @@ dotenv.config({ path: `${__dirname}/../../.env` });
 import _ from 'lodash';
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
-import moment from 'moment';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as skillRepository from '../../lib/infrastructure/repositories/skill-repository.js';
 import * as campaignRepository from '../../lib/infrastructure/repositories/campaign-repository.js';
@@ -20,6 +19,7 @@ import {
   generateKnowledgeElementSnapshots,
 } from '../prod/generate-knowledge-element-snapshots-for-campaigns.js';
 import { generate } from '../../lib/domain/services/code-generator.js';
+import dayjs from 'dayjs';
 
 const { SHARED, TO_SHARE } = CampaignParticipationStatuses;
 
@@ -360,9 +360,9 @@ async function _createAssessments({ userAndCampaignParticipationIds, trx }) {
 async function _createCampaignParticipations({ campaignId, trx, organizationLearnerAndUserIds }) {
   const participationData = [];
   for (const organizationLearnerAndUserId of organizationLearnerAndUserIds) {
-    const createdAt = moment(baseDate).add(_.random(0, 100), 'days').toDate();
+    const createdAt = dayjs(baseDate).add(_.random(0, 100), 'days').toDate();
     const isShared = Boolean(_.random(0, 1));
-    const sharedAt = isShared ? moment(createdAt).add(_.random(1, 10), 'days').toDate() : null;
+    const sharedAt = isShared ? dayjs(createdAt).add(_.random(1, 10), 'days').toDate() : null;
     const userId = organizationLearnerAndUserId.userId;
     const organizationLearnerId = organizationLearnerAndUserId.id;
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -1,11 +1,11 @@
 import * as dotenv from 'dotenv';
 import path from 'path';
-import moment from 'moment';
 import ms from 'ms';
 
 import { getArrayOfStrings, getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
 
 import * as url from 'url';
+import dayjs from 'dayjs';
 
 dotenv.config();
 
@@ -35,7 +35,7 @@ function _getDate(dateAsString) {
   if (!dateAsString) {
     return null;
   }
-  const dateAsMoment = moment(dateAsString);
+  const dateAsMoment = dayjs(dateAsString);
   if (!dateAsMoment.isValid()) {
     return null;
   }

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import { BookshelfUser } from '../../../../lib/infrastructure/orm-models/User.js';
@@ -316,7 +315,7 @@ const acceptPixLastTermsOfService = async function (id) {
   const user = await BookshelfUser.where({ id }).fetch({ require: false });
   await user.save(
     {
-      lastTermsOfServiceValidatedAt: moment().toDate(),
+      lastTermsOfServiceValidatedAt: new Date(),
       mustValidateTermsOfService: false,
     },
     { patch: true, method: 'update' },

--- a/api/tests/integration/domain/services/organization-learners-xml-service_test.js
+++ b/api/tests/integration/domain/services/organization-learners-xml-service_test.js
@@ -5,7 +5,7 @@ import * as organizationLearnersXmlService from '../../../../lib/domain/services
 
 const fixturesDirPath = `${url.fileURLToPath(new URL('../../../', import.meta.url))}tooling/fixtures/`;
 
-describe('Integration | Services | organization-learnerz-xml-service', function () {
+describe('Integration | Services | organization-learners-xml-service', function () {
   describe('extractOrganizationLearnersInformationFromSIECLE', function () {
     it('should parse two organizationLearners information', async function () {
       // given


### PR DESCRIPTION
## :christmas_tree: Problème

Cela fait un moment (lol) que la décision de remplacer `momentjs` a été prise (voir l'[ADR n°30](https://github.com/1024pix/pix/blob/dev/docs/adr/0030-revoir-le-choix-d-une-librairie-de-gestion-des-dates.md)). Pourtant, il reste des usages dans le code.

## :gift: Proposition

Supprimer les usages de `momentjs`.

## :socks: Remarques

RAS

## :santa: Pour tester

Une CI verte.
