### PR TITLE
[TECH] Remettre le delete-record suite à un fix coté ember-data (PIX-9766)

### DIFF
--- a/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
+++ b/admin/app/controllers/authenticated/complementary-certifications/complementary-certification/attach-target-profile.js
@@ -72,6 +72,7 @@ export default class AttachTargetProfileController extends Controller {
 
       complementaryCertificationBadges.forEach((complementaryCertificationBadge) => {
         complementaryCertification.complementaryCertificationBadges.removeObject(complementaryCertificationBadge);
+        complementaryCertificationBadge.deleteRecord();
       });
 
       this.#targetProfileBadges.forEach((badge, badgeId) => {


### PR DESCRIPTION
## :christmas_tree: Problème
La montée de version d'ember data avait posé probleme sur un deleteRecord d'ember-data

## :gift: Proposition
Le remettre suite au passage à ember en 4.12

## :socks: Remarques


## :santa: Pour tester
Ouvrir admin avec le debugger ouvert
Attacher un nouveau profil cible à une certification complementaire
S'assurer qu'il n'y a pas d'erreur dans la console
