### PR TITLE
[BUGFIX] ajoute le parametre d'url threshold dans le lien personalisé de fin de parcours (PIX-10357)

### DIFF
--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -45,9 +45,16 @@ const getByUserIdAndCampaignId = async function ({ userId, campaignId, badges, r
     const skillIds = competences.flatMap(({ targetedSkillIds }) => targetedSkillIds);
     const skills = await skillRepository.findOperativeByIds(skillIds);
     convertLevelStagesIntoThresholds(stages, skills);
+    if (reachedStage) {
+      const stage = stages.find((stage) => stage.id == reachedStage.id);
+      // if the stage is a stage level, we need to add the converted threshold
+      reachedStage = {
+        ...reachedStage,
+        threshold: stage.threshold,
+      };
+    }
   }
   const isTargetProfileResetAllowed = await _getTargetProfileResetAllowed(campaignId);
-
   return new AssessmentResult({
     participationResults,
     competences,

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -56,7 +56,7 @@ const serialize = function (results) {
     },
     reachedStage: {
       ref: 'id',
-      attributes: ['title', 'message', 'totalStage', 'reachedStage'],
+      attributes: ['title', 'message', 'totalStage', 'reachedStage', 'threshold'],
     },
     typeForAttribute(attribute) {
       return attribute === 'reachedStage' ? 'reached-stages' : attribute;

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -353,6 +353,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
             attributes: {
               message: 'Tu as le palier 1',
               title: 'palier 1',
+              threshold: 20,
               'reached-stage': 1,
               'total-stage': 2,
             },

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -693,6 +693,12 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
             userId,
             campaignId,
             targetProfile,
+            reachedStage: {
+              id: stage3.id,
+              totalStage: 4,
+              reachedStageNumber: 3,
+              reachedStage: stage3,
+            },
             badges: [],
             stages: stagesFromDomain,
             locale: 'FR',
@@ -701,6 +707,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           const competenceResult2 = participantResult.competenceResults.find(({ id }) => id === 'rec2');
 
           // then
+          expect(participantResult.reachedStage.threshold).to.equal(50);
           expect(competenceResult1).to.deep.equal({
             id: 'rec1',
             name: 'comp1Fr',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -177,6 +177,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               message: 'Message2',
               'total-stage': 3,
               'reached-stage': 2,
+              threshold: 50,
             },
             id: '3',
             type: 'reached-stages',

--- a/mon-pix/app/models/reached-stage.js
+++ b/mon-pix/app/models/reached-stage.js
@@ -5,6 +5,7 @@ export default class ReachedStage extends Model {
   @attr('string') message;
   @attr('number') totalStage;
   @attr('number') reachedStage;
+  @attr('number') threshold;
 
   @belongsTo('campaign-participation-result') campaignParticipationResult;
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à l'insertion des paliers en base, nous n'envoyons plus les "thresholds" des paliers par niveau car nous n'avons plus besoin de les convertir. Hors ce threshold était utilisé pour générer une url  fournie aux prescripteurs.

## :gift: Proposition
Retourner le threshold du palier dans la route de fin de parcours. 

## :santa: Pour tester
Tests au vert
