### PR TITLE
[BUGFIX] Rétablir la possibilité d'annuler la création d'un contenu formatif (PIX-10367).

### DIFF
--- a/admin/app/controllers/authenticated/trainings/new.js
+++ b/admin/app/controllers/authenticated/trainings/new.js
@@ -13,6 +13,11 @@ export default class NewController extends Controller {
   }
 
   @action
+  goBackToTrainingList() {
+    this.router.transitionTo('authenticated.trainings.list');
+  }
+
+  @action
   async createOrUpdateTraining(trainingFormData) {
     try {
       const { id } = await this.store.createRecord('training', trainingFormData).save();

--- a/admin/tests/acceptance/authenticated/trainings/training_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training_test.js
@@ -71,6 +71,27 @@ module('Acceptance | Trainings | Training', function (hooks) {
         // then
         assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).hasClass('active');
       });
+
+      test('should be redirected to training detail page after training creation', async function (assert) {
+        // when
+        await visit(`/trainings/list`);
+        await clickByName('Nouveau contenu formatif');
+
+        await fillByLabel('Titre', 'Nouveau contenu formatif');
+        await fillByLabel('Lien', 'http://www.example.net');
+        await click(screen.getByText('Webinaire'));
+
+        await fillByLabel('Jours (JJ)', 1);
+        await fillByLabel('Heures (HH)', 0);
+        await fillByLabel('Minutes (MM)', 0);
+        await click(screen.getByText('Francophone (fr)'));
+        await fillByLabel('Nom du fichier du logo éditeur', 'Logo.svg', { exact: false });
+        await fillByLabel("Nom de l'éditeur", 'Editeur', { exact: false });
+        await click(screen.getByRole('button', { name: 'Créer le contenu formatif' }));
+
+        // then
+        assert.strictEqual(currentURL(), `/trainings/3/triggers`);
+      });
     });
 
     module('triggers details page', function () {
@@ -91,27 +112,6 @@ module('Acceptance | Trainings | Training', function (hooks) {
         // then
         assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).hasClass('active');
       });
-    });
-
-    test('should be redirected to training detail page after training creation', async function (assert) {
-      // when
-      await visit(`/trainings/list`);
-      await clickByName('Nouveau contenu formatif');
-
-      await fillByLabel('Titre', 'Nouveau contenu formatif');
-      await fillByLabel('Lien', 'http://www.example.net');
-      await click(screen.getByText('Webinaire'));
-
-      await fillByLabel('Jours (JJ)', 1);
-      await fillByLabel('Heures (HH)', 0);
-      await fillByLabel('Minutes (MM)', 0);
-      await click(screen.getByText('Francophone (fr)'));
-      await fillByLabel('Nom du fichier du logo éditeur', 'Logo.svg', { exact: false });
-      await fillByLabel("Nom de l'éditeur", 'Editeur', { exact: false });
-      await click(screen.getByRole('button', { name: 'Créer le contenu formatif' }));
-
-      // then
-      assert.strictEqual(currentURL(), `/trainings/3/triggers`);
     });
 
     test('triggers should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/acceptance/authenticated/trainings/training_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training_test.js
@@ -92,6 +92,18 @@ module('Acceptance | Trainings | Training', function (hooks) {
         // then
         assert.strictEqual(currentURL(), `/trainings/3/triggers`);
       });
+
+      test('should be redirected to training list when user click on cancel button', async function (assert) {
+        // when
+        await visit(`/trainings/list`);
+        await clickByName('Nouveau contenu formatif');
+
+        // given
+        await clickByName('Annuler');
+
+        // then
+        assert.strictEqual(currentURL(), `/trainings/list`);
+      });
     });
 
     module('triggers details page', function () {

--- a/admin/tests/unit/controllers/authenticated/trainings/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/new_test.js
@@ -21,6 +21,16 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
     });
   });
 
+  module('#goBackToTrainingList', function () {
+    test('should go to training list page', async function (assert) {
+      controller.router.transitionTo = sinon.stub();
+
+      controller.goBackToTrainingList();
+
+      assert.ok(controller.router.transitionTo.calledWith('authenticated.trainings.list'));
+    });
+  });
+
   module('#createOrUpdateTraining', function () {
     test('it should save training', async function (assert) {
       const trainingData = {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, sur Pix Admin, lorsqu'on essaie d'annuler la création d'un CF cela ne fonctionne pas. (Cf: https://github.com/1024pix/pix/pull/7655#issuecomment-1853915951) 

## :gift: Proposition
Le code permettant d'annuler la création a été supprimé malencontreusement dans [ce commit ](https://github.com/1024pix/pix/commit/66a7ce85ae5867d2c005bda53fcfab4ca756b1a6). Remettre en place le code


## :socks: Remarques
Ce genre d'erreur est du au fait : 
- la couverture de tests était insufissante 
- surtour nous n'avons pas de linter sur les templates pour nous dire qu'on référence quelque chose qui n'est pas présente : [Glint](https://typed-ember.gitbook.io/glint/) deviendra notre ami 

## :santa: Pour tester
- Se connecter sur Pix Admin
- Se rendre sur `/trainings/new`
- Cliquer sur "Annuler"
- Constater qu'on revient sur la liste des CF
