### PR TITLE
[REFACTOR] Amélioration du style des détails de la page d'atterrissage des campagnes (PIX-10376)

### DIFF
--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -113,77 +113,73 @@
 
 /* ------------------------ DETAILS ------------------------ */
 
-.campaign-landing-page__container__details {
-  padding-top: 60px;
-  padding-bottom: 70px;
+.campaign-landing-page__details {
+  padding: 3rem 6rem 0;
+
+  @include device-is('mobile') {
+    padding-inline: 2rem;
+  }
 }
 
-.campaign-landing-page__details__text {
+.campaign-landing-page-details__title {
+  @extend %pix-title-s;
+
+  text-align: center;
+
+  &::after {
+    display: block;
+    width: 18rem;
+    max-width: 100%;
+    height: 2px;
+    margin: 1em auto 0;
+    background-color: var(--pix-primary-500);
+    content: '';
+  }
+}
+
+.campaign-landing-page-details__article {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  font-family: $font-open-sans;
+  padding-block: 3rem;
 
-  .title {
-    font-size: 1.375rem;
-    text-align: center;
+  @include device-is('mobile') {
+    flex-direction: column;
+  }
 
-    &::after {
-      position: relative;
-      width: 100px;
-      height: 15px;
-      margin: 35px auto;
-      border-bottom: 2px solid $pix-primary;
-      content: '';
+  & + .campaign-landing-page-details__article {
+    border-top: 2px dashed var(--pix-neutral-20);
+  }
+
+  &-image {
+    display: block;
+    flex-shrink: 0;
+    min-width: 8.75rem;
+    margin-bottom: 1rem;
+
+    @include device-is('tablet') {
+      margin: 0 2rem;
     }
   }
 
-  .article-title {
-    color: $pix-neutral-100;
-    font-weight: $font-medium;
-    font-size: 1.5rem;
-    line-height: 30px;
+  &-text {
+    flex-grow: 1;
+
+    @include device-is('tablet') {
+      padding-inline: 2rem;
+    }
+
+    & > :not(:first-child) {
+      margin-top: 0.5rem;
+    }
+
+    h3 {
+      @extend %pix-title-xs;
+    }
+
+    p {
+      @extend %pix-body-m;
+    }
   }
-
-  .article-list {
-    display: block;
-    color: $pix-neutral-100;
-    font-size: 0.875rem;
-    line-height: 22px;
-  }
-
-  .article-text {
-    margin: auto;
-    color: $pix-neutral-100;
-    font-size: 1rem;
-    line-height: 24px;
-  }
-}
-
-.campaign-landing-page__details__measure__container {
-  display: flex;
-  flex-direction: column;
-  width: 80%;
-  margin: auto;
-  padding: 10px;
-
-  @include device-is('tablet') {
-    flex-direction: row;
-  }
-
-  &--dashline {
-    margin-top: 50px;
-    padding: 50px 10px 10px;
-    border-top: 1px dashed $pix-neutral-22;
-  }
-}
-
-.campaign-landing-page__details__article-side {
-  padding: 0 $pix-spacing-xl;
-}
-
-.campaign-landing-page__details__article-image {
-  padding-bottom: 100px;
 }
 
 /* ------------------------ ERROR ------------------------ */

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -6,55 +6,53 @@
     <CampaignStartBlock @campaign={{@model}} @startCampaignParticipation={{this.startCampaignParticipation}} />
 
     {{#if @model.isAssessment}}
-      <div class="rounded-panel campaign-landing-page__container__details">
-        <div class="campaign-landing-page__details__text">
-          <h2 class="campaign-landing-page__details__text title">
-            {{t "pages.campaign-landing.assessment.details"}}
-          </h2>
+      <div class="campaign-landing-page__details rounded-panel">
+        <h2 class="campaign-landing-page-details__title">
+          {{t "pages.campaign-landing.assessment.details"}}
+        </h2>
 
-          <div class="campaign-landing-page__details__measure__container">
-            <img
-              class="campaign-landing-page__details__article-image measure"
-              src="/images/illustrations/landing-page/icon-mesurer.svg"
-              alt=""
-            />
-            <div class="campaign-landing-page__details__article-side">
-              <p class="campaign-landing-page__details__text article-title">
-                {{t "pages.campaign-landing.assessment.evaluate.title"}}
-              </p>
-              {{t "pages.campaign-landing.assessment.evaluate.description"}}
-            </div>
+        <div class="campaign-landing-page-details__article">
+          <img
+            class="campaign-landing-page-details__article-image"
+            src="/images/illustrations/landing-page/icon-mesurer.svg"
+            alt=""
+          />
+          <div class="campaign-landing-page-details__article-text">
+            <h3 class="campaign-landing-page-details__article-title">
+              {{t "pages.campaign-landing.assessment.evaluate.title"}}
+            </h3>
+            <p>{{t "pages.campaign-landing.assessment.evaluate.description"}}</p>
+          </div>
+        </div>
+
+        <div class="campaign-landing-page-details__article">
+          <img
+            class="campaign-landing-page-details__article-image"
+            src="/images/illustrations/landing-page/icon-conseil.svg"
+            alt=""
+          />
+          <div class="campaign-landing-page-details__article-text">
+            <h3 class="campaign-landing-page-details__article-title">
+              {{t "pages.campaign-landing.assessment.develop.title"}}
+            </h3>
+            <p>{{t "pages.campaign-landing.assessment.develop.description"}}</p>
           </div>
 
-          <div
-            class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline"
-          >
-            <img src="/images/illustrations/landing-page/icon-conseil.svg" alt="" />
-            <div class="campaign-landing-page__details__article-side">
-              <p class="campaign-landing-page__details__text article-title">
-                {{t "pages.campaign-landing.assessment.develop.title"}}
-              </p>
-              <p class="campaign-landing-page__details__text article-text">
-                {{t "pages.campaign-landing.assessment.develop.description"}}
-              </p>
-            </div>
+        </div>
 
+        <div class="campaign-landing-page-details__article">
+          <img
+            class="campaign-landing-page-details__article-image"
+            src="/images/illustrations/landing-page/icon-certif.svg"
+            alt=""
+          />
+          <div class="campaign-landing-page-details__article-text">
+            <h3 class="campaign-landing-page-details__article-title">
+              {{t "pages.campaign-landing.assessment.certify.title"}}
+            </h3>
+            <p>{{t "pages.campaign-landing.assessment.certify.description"}}</p>
           </div>
 
-          <div
-            class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline"
-          >
-            <img src="/images/illustrations/landing-page/icon-certif.svg" alt="" />
-            <div class="campaign-landing-page__details__article-side">
-              <p class="campaign-landing-page__details__text article-title">
-                {{t "pages.campaign-landing.assessment.certify.title"}}
-              </p>
-              <p class="campaign-landing-page__details__text article-text">
-                {{t "pages.campaign-landing.assessment.certify.description"}}
-              </p>
-            </div>
-
-          </div>
         </div>
       </div>
     {{/if}}


### PR DESCRIPTION
## :christmas_tree: Problème

L'intégration visuelle de cette partie de la page d'atterrissage des campagnes n'était pas tout à fait clean.

Par exemple, certains espaces variaient sans raison.

## :gift: Proposition

Revoir l'intégration de la partie basse de la page en essayant de la rendre la plus proche possible de la maquette.

## :socks: Remarques

Les variables CSS de Pix-UI sont utilisées.

## :santa: Pour tester

- Visiter la page d'atterrissage de la [campagne EVAL12345 en intégration](https://app.integration.pix.fr/campagnes/EVAL12345/presentation) (si vous aviez déjà lancé la campagne, passez en navigation privée) et la comparer avec la [nouvelle version en RA](https://app-pr7680.review.pix.fr/campagnes/EVAL12345/presentation).
( 💻 +📱)
- Comparer aussi avec le design sur Figma.
- ✅ Attester de l'amélioration visuelle.

