### PR TITLE
[TECH] Ajout d'un script pour mettre à jour la colonne Authentication Complement (PIX-10101)

### DIFF
--- a/api/lib/domain/usecases/update-authentication-complement.js
+++ b/api/lib/domain/usecases/update-authentication-complement.js
@@ -1,0 +1,24 @@
+import { NotFoundError } from '../errors.js';
+
+const updateAuthenticationComplement = async function ({
+  authenticationMethodRepository,
+  externalIdentifier,
+  identityProvider,
+  authenticationComplement,
+}) {
+  const authenticationMethod = await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
+    externalIdentifier,
+    identityProvider,
+  });
+
+  if (!authenticationMethod) {
+    throw new NotFoundError(
+      `No authentication method found with externalIdentifier: ${externalIdentifier} and identityProvider: ${identityProvider}`,
+    );
+  }
+
+  const id = authenticationMethod.id;
+  await authenticationMethodRepository.update({ id, authenticationComplement });
+};
+
+export { updateAuthenticationComplement };

--- a/api/scripts/team-acces/update-fwb-authentication-complements.js
+++ b/api/scripts/team-acces/update-fwb-authentication-complements.js
@@ -1,0 +1,89 @@
+import url from 'url';
+
+import _ from 'lodash';
+import bluebird from 'bluebird';
+
+import { disconnect } from '../../db/knex-database-connection.js';
+import { checkCsvHeader, parseCsvWithHeader } from '../helpers/csvHelpers.js';
+import { usecases } from '../../lib/domain/usecases/index.js';
+import { FWB } from '../../lib/domain/constants/oidc-identity-providers.js';
+
+const MODULE_PATH = url.fileURLToPath(import.meta.url);
+const IS_LAUNCHED_FROM_CLI = process.argv[1] === MODULE_PATH;
+const TIMER_NAME = '';
+const REQUIRED_FIELD_NAMES = ['SUB', 'FirstName', 'LastName', 'EmployeeNumber', 'Population'];
+
+async function main() {
+  const filePath = process.argv[2];
+  const parsingOptions = {
+    skipEmptyLines: true,
+    header: true,
+    transform: (value) => {
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+      if (_.isEmpty(value)) {
+        value = null;
+      }
+
+      return value;
+    },
+  };
+
+  await checkCsvHeader({
+    filePath,
+    requiredFieldNames: REQUIRED_FIELD_NAMES,
+  });
+
+  console.log('Reading and parsing csv data file... ');
+
+  const fwbAuthenticationComplementsData = await parseCsvWithHeader(filePath, parsingOptions);
+  const errors = [];
+
+  await bluebird.mapSeries(fwbAuthenticationComplementsData, async (fwbAuthenticationComplementData) => {
+    const {
+      SUB: externalIdentifier,
+      FirstName: given_name,
+      LastName: family_name,
+      Population: population,
+      EmployeeNumber: employeeNumber,
+    } = fwbAuthenticationComplementData;
+    const authenticationComplement = { given_name, family_name, employeeNumber, population };
+
+    try {
+      await usecases.updateAuthenticationComplement({
+        externalIdentifier,
+        identityProvider: FWB.code,
+        authenticationComplement,
+      });
+    } catch (error) {
+      errors.push({ fwbAuthenticationComplementData, error });
+    }
+  });
+
+  if (errors.length === 0) return;
+
+  console.log(`Errors occurs on ${errors.length} element(s)!`);
+  errors.forEach((error) => {
+    console.log(JSON.stringify(error.fwbAuthenticationComplementData));
+    console.error(error.error?.message);
+  });
+
+  throw new Error('Process done with errors');
+}
+
+(async function () {
+  if (IS_LAUNCHED_FROM_CLI) {
+    try {
+      console.time(TIMER_NAME);
+      await main();
+      console.log('\n fwb authentication complements updated with success');
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      console.timeEnd(TIMER_NAME);
+    }
+  }
+})();

--- a/api/tests/unit/domain/usecases/update-authentication-complement_test.js
+++ b/api/tests/unit/domain/usecases/update-authentication-complement_test.js
@@ -1,0 +1,62 @@
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { updateAuthenticationComplement } from '../../../../lib/domain/usecases/update-authentication-complement.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('unit | domain | usecases | update-authentication-complement', function () {
+  it('updates authentication complement', async function () {
+    //given
+    const authenticationMethodRepository = {
+      findOneByExternalIdentifierAndIdentityProvider: sinon.stub(),
+      update: sinon.stub().resolves(),
+    };
+    const externalIdentifier = 'externalIdentifier';
+    const identityProvider = 'FWB';
+    const authenticationComplement = {};
+    const id = 1;
+    const authenticationMethod = domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+      id,
+      identityProvider,
+      externalIdentifier,
+    });
+    authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider.resolves(authenticationMethod);
+
+    //when
+    await updateAuthenticationComplement({
+      authenticationMethodRepository,
+      externalIdentifier,
+      identityProvider,
+      authenticationComplement,
+    });
+
+    //then
+    expect(
+      authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider,
+    ).to.have.been.calledWithExactly({ externalIdentifier, identityProvider });
+    expect(authenticationMethodRepository.update).to.have.been.calledWithExactly({ id, authenticationComplement });
+  });
+
+  context('when there is no authentication method', function () {
+    it('throws a NotFound error', async function () {
+      // given
+      const authenticationMethodRepository = {
+        findOneByExternalIdentifierAndIdentityProvider: sinon.stub(),
+      };
+      const externalIdentifier = 'externalIdentifier';
+      const identityProvider = 'FWB';
+      const authenticationComplement = {};
+
+      authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider.resolves(null);
+
+      // when
+      const error = await catchErr(updateAuthenticationComplement)({
+        authenticationMethodRepository,
+        externalIdentifier,
+        identityProvider,
+        authenticationComplement,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Dorénavant, on peut stocker une nouvelle donnée identifiante via SSO et cette possibilité va être exploitée par la FWB pour stocker l’employee number. 

Compte tenu de la période fin d’année, beaucoup d’utilisateurs ne se connecteront pas pour qu’on puisse récupérer les employees numbers avant la fin de l’année. 

## :gift: Proposition

On doit réaliser un script d’update de l’employee number à partir d’un fichier CSV qui sera retourné par la FWB.

## :socks: Remarques

RAS

## :santa: Pour tester

- Télécharger le fichier csv suivant [data.csv](https://github.com/1024pix/pix/files/13672187/data.csv)
- Récupérer, dans la table` authentication-methods` la valeur du champ externalIdentifier en faisant la requête : 
`Select "externalIdentifier" FROM "authentication-methods" where "identityProvider"='FWB';`
- Ecraser la valeur `externalIdentifier-101605` par celle que vous avez récupéré dans le fichier `data.csv`.
- Aller dans le dossier `api/scripts/team-acces`.
- Exécuter la commande suivante `node update-fwb-authentication-complements.js  <chemin vers fichier csv>`.
- Vérifier en DB que l'`Authentication Complement` de la table `Authentication Method` contient bien les informations du fichier csv.


