### PR TITLE
[FEATURE] affiches les statistiques de places d'une organisation (PIX-(9723).

### DIFF
--- a/orga/app/adapters/organization-place-statistic.js
+++ b/orga/app/adapters/organization-place-statistic.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class PlaceStatisticsAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    const { organizationId } = query;
+    delete query.organizationId;
+
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/place-statistics`;
+  }
+}

--- a/orga/app/components/places/statistics.hbs
+++ b/orga/app/components/places/statistics.hbs
@@ -1,0 +1,10 @@
+<section class="statistics">
+  <PixIndicatorCard @title={{t "cards.available-seats-count.title"}} @color="success" @icon="users">
+    {{@available}}
+    <span class="statistics__total">{{t "cards.available-seats-count.value" total=@total}}</span>
+  </PixIndicatorCard>
+  <PixIndicatorCard @title={{t "cards.occupied-seats-count.title"}} @color="warning" @icon="users">
+    {{@occupied}}
+    <span class="statistics__total">{{t "cards.occupied-seats-count.value" total=@total}}</span>
+  </PixIndicatorCard>
+</section>

--- a/orga/app/models/organization-place-statistic.js
+++ b/orga/app/models/organization-place-statistic.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class PlaceStatistics extends Model {
+  @attr('number') available;
+  @attr('number') total;
+  @attr('number') occupied;
+}

--- a/orga/app/routes/authenticated/places.js
+++ b/orga/app/routes/authenticated/places.js
@@ -4,10 +4,17 @@ import { service } from '@ember/service';
 export default class AuthenticatedPlacesRoute extends Route {
   @service currentUser;
   @service router;
+  @service store;
 
   beforeModel() {
     if (!this.currentUser.isAdminInOrganization || !this.currentUser.prescriber.placesManagement) {
       this.router.replaceWith('application');
     }
+  }
+
+  model() {
+    return this.store
+      .queryRecord('organization-place-statistic', { organizationId: this.currentUser.organization.id })
+      .catch(() => this.route.replaceWith('application'));
   }
 }

--- a/orga/app/styles/components/places/index.scss
+++ b/orga/app/styles/components/places/index.scss
@@ -1,1 +1,2 @@
 @import 'title';
+@import 'statistics';

--- a/orga/app/styles/components/places/statistics.scss
+++ b/orga/app/styles/components/places/statistics.scss
@@ -1,0 +1,9 @@
+.statistics {
+  display: flex;
+  gap: var(--pix-spacing-8x);
+  margin-top: var(--pix-spacing-8x);
+
+  &__total {
+    @extend %pix-body-m;
+  }
+}

--- a/orga/app/templates/authenticated/places.hbs
+++ b/orga/app/templates/authenticated/places.hbs
@@ -1,3 +1,4 @@
 {{page-title (t "pages.places.title")}}
 
 <Places::Title />
+<Places::Statistics @available={{@model.available}} @occupied={{@model.occupied}} @total={{@model.total}} />

--- a/orga/tests/integration/components/places/statistics_test.js
+++ b/orga/tests/integration/components/places/statistics_test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | Places::Statistics', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display occupied and available places', async function (assert) {
+    // given
+    this.total = 30;
+    this.occupied = 20;
+    this.available = 10;
+    // when
+    const screen = await render(
+      hbs`<Places::Statistics @total={{this.total}} @occupied={{this.occupied}} @available={{this.available}} />`,
+    );
+
+    // then
+    assert.ok(screen.getByText(this.available));
+    assert.ok(screen.getAllByText(this.intl.t('cards.available-seats-count.value', { total: this.total }))[0]);
+    assert.ok(screen.getByText(this.occupied));
+    assert.ok(screen.getAllByText(this.intl.t('cards.occupied-seats-count.value', { total: this.total }))[1]);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -57,6 +57,14 @@
     }
   },
   "cards": {
+    "available-seats-count": {
+      "title": "Seats available",
+      "value": "/{total} seats"
+    },
+    "occupied-seats-count": {
+      "title": "Seats occupied",
+      "value": "/{total} seats"
+    },
     "participants-average-results": {
       "title": "Average result",
       "information": "Find here the average results of your campaign. This includes all the participants who have completed their customised test and sent their results."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -60,6 +60,14 @@
     }
   },
   "cards": {
+    "available-seats-count": {
+      "title": "Places disponibles",
+      "value": "/{total} places"
+    },
+    "occupied-seats-count": {
+      "title": "Places occupées",
+      "value": "/{total} places"
+    },
     "participants-average-results": {
       "title": "Résultat moyen",
       "information": "Retrouvez ici la moyenne des résultats de votre campagne. Ce nombre comprend l'ensemble des participants ayant fini leur parcours et envoyé leur résultat."


### PR DESCRIPTION
## :christmas_tree: Problème
Afin de pouvoir mieux connaitre l'état des places disponibles (et commander un nouveau lot de places)
un prescripteur veut consulter : 
-     le nombre de places actives
-     le nombre de places occupées 
-     le nombre de places disponibles

## :gift: Proposition
afficher les statistiques de places (nb de places occupées / nb de places libres / nombre de place totales)

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter en tant qu'organisation possédant la feature de gestion de places
- Se rendre sur la page /places
- Observer la présence des PixIndicatorCards
- Vérifier les icônes, les couleurs et les traductions
- 🎉 