### PR TITLE
[FEATURE] Ajouter un bouton de modification pour les commentaires jury d'une certification sur Pix Admin (PIX-10165).

### DIFF
--- a/admin/app/components/certifications/certification/comments.hbs
+++ b/admin/app/components/certifications/certification/comments.hbs
@@ -1,0 +1,56 @@
+<div class="certification-informations__row">
+  <div class="certification-informations__card">
+    <h2 class="certification-informations__card__title">Commentaires jury</h2>
+    <Certifications::InfoField
+      @value={{@certification.commentForCandidate}}
+      @edition={{this.editingComments}}
+      @label="Pour le candidat :"
+      @fieldId="certification-commentForCandidate"
+      @isTextarea={{true}}
+    />
+    <Certifications::InfoField
+      @value={{@certification.commentForOrganization}}
+      @edition={{this.editingComments}}
+      @label="Pour l'organisation :"
+      @fieldId="certification-commentForOrganization"
+      @isTextarea={{true}}
+    />
+    <Certifications::InfoField
+      @value={{@certification.commentForJury}}
+      @edition={{this.editingComments}}
+      @label="Pour le jury :"
+      @fieldId="certification-commentForJury"
+      @isTextarea={{true}}
+    />
+    <Certifications::InfoField
+      @value={{@certification.juryId}}
+      @edition={{false}}
+      @label="Identifiant jury :"
+      @isTextarea={{true}}
+    />
+
+    {{#if this.editingComments}}
+      <ul class="certification-information-comments">
+        <li>
+          <PixButton
+            @size="small"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @triggerAction={{this.cancelCommentsEdit}}
+          >
+            Annuler
+          </PixButton>
+        </li>
+        <li>
+          <PixButton @size="small" @triggerAction={{this.saveComments}}>
+            Enregistrer
+          </PixButton>
+        </li>
+      </ul>
+    {{else}}
+      <PixButton @size="small" @triggerAction={{this.editComments}}>
+        Modifier commentaires jury
+      </PixButton>
+    {{/if}}
+  </div>
+</div>

--- a/admin/app/components/certifications/certification/comments.js
+++ b/admin/app/components/certifications/certification/comments.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class Comments extends Component {
+  @tracked editingComments = false;
+
+  @action
+  editComments() {
+    this.editingComments = true;
+  }
+
+  @action
+  async saveComments() {
+    const hasBeenSaved = await this.args.onCommentsSave();
+    if (hasBeenSaved) {
+      this.cancelCommentsEdit();
+    }
+  }
+
+  @action
+  cancelCommentsEdit() {
+    this.editingComments = false;
+  }
+}

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -290,6 +290,18 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
+  async onCommentsSave() {
+    try {
+      await this.saveAssessmentResult();
+      this.notifications.success('Les commentaires du jury ont bien été enregistrés.');
+      return true;
+    } catch (e) {
+      this.notifications.error("Les commentaires du jury n'ont pas pu être enregistrés.");
+      return false;
+    }
+  }
+
+  @action
   openCandidateEditModal() {
     this.isCandidateEditModalOpen = true;
   }

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -175,3 +175,8 @@
     }
   }
 }
+
+.certification-information-comments {
+  display: flex;
+  gap: $pix-spacing-xs;
+}

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -212,39 +212,11 @@
     </section>
   {{/if}}
 
-  <div class="certification-informations__row">
-    <div class="certification-informations__card {{if this.editingCandidateResults 'border-primary'}}">
-      <h2 class="certification-informations__card__title">Commentaires jury</h2>
-      <Certifications::InfoField
-        @value={{this.certification.commentForCandidate}}
-        @edition={{this.editingCandidateResults}}
-        @label="Pour le candidat :"
-        @fieldId="certification-commentForCandidate"
-        @isTextarea={{true}}
-      />
-      <Certifications::InfoField
-        @value={{this.certification.commentForOrganization}}
-        @edition={{this.editingCandidateResults}}
-        @label="Pour l'organisation :"
-        @fieldId="certification-commentForOrganization"
-        @isTextarea={{true}}
-      />
-      <Certifications::InfoField
-        @value={{this.certification.commentForJury}}
-        @edition={{this.editingCandidateResults}}
-        @label="Pour le jury :"
-        @fieldId="certification-commentForJury"
-        @isTextarea={{true}}
-      />
-      <Certifications::InfoField
-        @value={{this.certification.juryId}}
-        @edition={{false}}
-        @label="Identifiant jury :"
-        @isTextarea={{true}}
-      />
-    </div>
+  <Certifications::Certification::Comments
+    @onCommentsSave={{this.onCommentsSave}}
+    @certification={{this.certification}}
+  />
 
-  </div>
   <div class="certification-informations__row">
     <div class="certification-informations__card {{if this.editingCandidateResults 'border-primary'}}">
       <h2 class="certification-informations__card__title">Résultats</h2>

--- a/admin/tests/unit/components/certifications/certification/comments_test.js
+++ b/admin/tests/unit/components/certifications/certification/comments_test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+
+module('Unit | Component | certifications/certification/comments', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:certifications/certification/comments');
+  });
+
+  test('it does not close the edition panel when comments cannot be saved', async function (assert) {
+    // given
+    component.editingComments = true;
+    component.args = {
+      onCommentsSave: sinon.stub(),
+    };
+
+    // when
+    await component.saveComments();
+
+    // then
+    assert.true(component.editingComments);
+  });
+
+  test('it closes the edition panel when comments are saved', async function (assert) {
+    // given
+    component.editingComments = true;
+    component.args = {
+      onCommentsSave: sinon.stub(),
+    };
+
+    component.args.onCommentsSave.resolves(true);
+
+    // when
+    await component.saveComments();
+
+    // then
+    assert.false(component.editingComments);
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -4,6 +4,7 @@ import { setupTest } from 'ember-qunit';
 
 import EmberObject from '@ember/object';
 import setupIntl from '../../../../../helpers/setup-intl';
+import Service from '@ember/service';
 
 module('Unit | Controller | authenticated/certifications/certification/informations', function (hooks) {
   setupTest(hooks);
@@ -675,6 +676,48 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         assert.ok(shouldDisplayRejectCertificationButton);
       });
+    });
+  });
+
+  module('#onCommentsSave', function () {
+    test('it displays a success notification if comments are saved', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications/certification/informations');
+      controller.saveAssessmentResult = sinon.stub();
+      controller.saveAssessmentResult.resolves();
+
+      const notificationSuccessStub = sinon.stub();
+      class NotificationsStub extends Service {
+        success = notificationSuccessStub;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      await controller.onCommentsSave();
+
+      // then
+      sinon.assert.calledOnce(notificationSuccessStub);
+      assert.ok(controller);
+    });
+
+    test('it displays an error notification if comments cannot be saved', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications/certification/informations');
+      controller.saveAssessmentResult = sinon.stub();
+      controller.saveAssessmentResult.throws();
+
+      const notificationErrorStub = sinon.stub();
+      class NotificationsStub extends Service {
+        error = notificationErrorStub;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      await controller.onCommentsSave();
+
+      // then
+      sinon.assert.calledOnce(notificationErrorStub);
+      assert.ok(controller);
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de l’implémentation des nouvelles règles de scoring pour la certif v3, il a été décidé de simplifier le rejet d’une certification pour cause de fraude. Ainsi, il ne sera plus nécessaire pour le pôle certif d’ouvrir une page permettant de modifier des infos non pertinentes pour rejeter une certif pour fraude.

Certaines informations modifiables sur cette page doivent pouvoir être modifiées, notamment les commentaires jury.

## :gift: Proposition

Sur la page de détails d’une certif v3 ET v2 > onglet “Informations”, ajouter un bouton “Modifier commentaires jury" en bas de la section “Commentaires jury”

![image](https://github.com/1024pix/pix/assets/36371437/bf947263-3579-4b54-a1ed-848a490c1683)

Cliquer sur ce bouton rend éditable tous les champs de cette section, avec 2 boutons : 

    “Annuler”
    “Enregistrer”

![image](https://github.com/1024pix/pix/assets/36371437/9a862d21-fecd-4d32-9f9e-272d5ee5c5eb)

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Ouvrir la page de détails d’une certif v3 > onglet “Informations”
- Résultat : un bouton “Modifier commentaires jury" est affiché dans la section “Commentaires jury”
- Cliquer sur le bouton 
- Résultat : les champs de cette section devienne éditables
- Ajouter un commentaire pour l’un des champs et cliquer sur “Enregistrer”
- Résultat : le commentaire ajouté est maintenant affiché dans le champ correspondant
- Vérifier qu’il est également bien sur le certificat du candidat pour le champ “Pour le candidat :” ET dans le fichier csv des résultats pour le champ “Pour l'organisation :”

- Répéter ces étapes pour une certif v2 (https://admin-pr7683.review.pix.fr/certifications/137240)