### PR TITLE
[BUGFIX] Ne plus remonter une 500 lors du double appel à la création d'une participation (PIX-10374)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -197,6 +197,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.OrganizationLearnersCouldNotBeSavedError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.OrganizationLearnersConstraintError) {
+    return new HttpErrors.ConflictError(error.message);
+  }
   if (error instanceof DomainErrors.AssessmentNotCompletedError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -216,6 +216,12 @@ class OrganizationLearnersCouldNotBeSavedError extends DomainError {
   }
 }
 
+class OrganizationLearnersConstraintError extends DomainError {
+  constructor(message = 'Constraint during inserting organization learners') {
+    super(message);
+  }
+}
+
 class MultipleOrganizationLearnersWithDifferentNationalStudentIdError extends DomainError {
   constructor(message = 'Multiple organization learners with different INE') {
     super(message);
@@ -1213,6 +1219,7 @@ export {
   OrganizationLearnerDisabledError,
   OrganizationLearnerNotFound,
   OrganizationLearnersCouldNotBeSavedError,
+  OrganizationLearnersConstraintError,
   OrganizationNotAuthorizedMultipleSendingAssessmentToCreateCampaignError,
   OrganizationNotFoundError,
   OrganizationTagNotFound,


### PR DESCRIPTION
## :christmas_tree: Problème
Une 500 est remonté lors du Bug sur le double appel côté FRONT qui pollue légèrement

## :gift: Proposition
Ajouter une error ConflictError

## :socks: Remarques
RAS

## :santa: Pour tester
CI verte