### PR TITLE
[BUGFIX] Améliorer les différents états des boutons (PIX-10388)

### DIFF
--- a/1d/app/pods/identified/missions/list/missions.scss
+++ b/1d/app/pods/identified/missions/list/missions.scss
@@ -17,6 +17,8 @@
   }
 }
 
-.pix-button--background-blue.card:hover {
-  background-color: transparent;
+.pix-button.card {
+  &:hover, &:focus, &:active, &:focus-visible {
+    background-color: transparent;
+  }
 }

--- a/1d/app/pods/school/school.scss
+++ b/1d/app/pods/school/school.scss
@@ -27,8 +27,8 @@
   }
 }
 
-.pix-button--background-blue.learners__item {
-  &:hover {
+.pix-button.learners__item {
+  &:hover, &:focus, &:active, &:focus-visible {
     background-color: #EBEFFF;
   }
 }

--- a/1d/app/styles/globals/_buttons.scss
+++ b/1d/app/styles/globals/_buttons.scss
@@ -14,7 +14,7 @@
     color: $pix-primary;
     background-color: var(--pix-color-neutral-0);
 
-    &:hover, &:focus {
+    &:hover, &:focus, &:active, &:focus-visible {
       color: var(--pix-color-neutral-0);
     }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à la montée de version de Pix UI, la couleur par défaut des différents états des PixButton ne correspondait plus au design de Pix 1D.

## :gift: Proposition
Surcharger le style des PixButton, en changeant la couleur sur les différents états.

## :socks: Remarques
RAS.

## :santa: Pour tester
Faire des tests de non régression sur l'application Pix 1D en vérifiant que les boutons correspondent au design selon les états.
