### PR TITLE
[TECH] Mettre à jour ember-data en 4.7 sur Pix App (PIX-10420).

### DIFF
--- a/mon-pix/app/components/authentication/oidc-reconciliation.js
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.js
@@ -25,7 +25,7 @@ export default class OidcReconciliationComponent extends Component {
   }
 
   get shouldShowGarAuthenticationMethod() {
-    return this.args.authenticationMethods.any(
+    return this.args.authenticationMethods.some(
       (authenticationMethod) => authenticationMethod.identityProvider === 'GAR',
     );
   }

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -184,7 +184,7 @@ export default class SkillReview extends Component {
   }
 
   get competenceResultsGroupedByAreas() {
-    const competenceResults = this.args.model.campaignParticipationResult.get('competenceResults').toArray();
+    const competenceResults = this.args.model.campaignParticipationResult.get('competenceResults');
     return competenceResults.reduce((acc, competenceResult) => {
       const currentArea = competenceResult.areaTitle;
       const competence = {

--- a/mon-pix/app/controllers/authenticated/user-account/connection-methods.js
+++ b/mon-pix/app/controllers/authenticated/user-account/connection-methods.js
@@ -23,13 +23,13 @@ export default class ConnectionMethodsController extends Controller {
   }
 
   get shouldShowPixAuthenticationMethod() {
-    return this.model.authenticationMethods.any(
+    return this.model.authenticationMethods.some(
       (authenticationMethod) => authenticationMethod.identityProvider === 'PIX',
     );
   }
 
   get shouldShowGarAuthenticationMethod() {
-    return this.model.authenticationMethods.any(
+    return this.model.authenticationMethods.some(
       (authenticationMethod) => authenticationMethod.identityProvider === 'GAR',
     );
   }

--- a/mon-pix/app/models/answer.js
+++ b/mon-pix/app/models/answer.js
@@ -1,6 +1,6 @@
 /* eslint ember/no-classic-classes: 0 */
 
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 import { equal, not } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
@@ -22,10 +22,10 @@ export default Model.extend(ValueAsArrayOfString, {
   resultDetails: attr('string'),
   timeout: attr('number'),
   focusedOut: attr('boolean'),
-  assessment: belongsTo('assessment'),
-  challenge: belongsTo('challenge'),
-  correction: belongsTo('correction'),
-  levelup: belongsTo('levelup'),
+  assessment: belongsTo('assessment', { async: true, inverse: 'answers' }),
+  challenge: belongsTo('challenge', { async: true, inverse: 'answer' }),
+  correction: belongsTo('correction', { async: true, inverse: null }),
+  levelup: belongsTo('levelup', { async: false, inverse: null }),
 
   isResultOk: equal('result', 'ok'),
   isResultNotOk: not('isResultOk'),

--- a/mon-pix/app/models/area.js
+++ b/mon-pix/app/models/area.js
@@ -8,8 +8,8 @@ export default class Area extends Model {
   @attr('string') color;
 
   // includes
-  @hasMany('resultCompetence') resultCompetences;
-  @hasMany('competence') competences;
+  @hasMany('resultCompetence', { async: true, inverse: 'area' }) resultCompetences;
+  @hasMany('competence', { async: true, inverse: 'area' }) competences;
 
   get sortedCompetences() {
     return this.competences.sortBy('code');

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -54,13 +54,13 @@ export default class Assessment extends Model {
   @or('isCompetenceEvaluation', 'isForNotFlashCampaign', 'isDemo') showProgressBar;
 
   get answersSinceLastCheckpoints() {
-    const answers = this.answers.toArray();
-    const howManyAnswersSinceTheLastCheckpoint = answers.length % ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
+    const howManyAnswersSinceTheLastCheckpoint =
+      this.currentChallengeNumber % ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
     const sliceAnswersFrom =
       howManyAnswersSinceTheLastCheckpoint === 0
         ? -ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS
         : -howManyAnswersSinceTheLastCheckpoint;
-    return answers.slice(sliceAnswersFrom);
+    return this.answers.slice(sliceAnswersFrom);
   }
 
   get currentChallengeNumber() {

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -1,7 +1,7 @@
 /* eslint ember/no-computed-properties-in-native-classes: 0 */
 
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import { equal, or, not, and } from '@ember/object/computed';
+import { and, equal, not, or } from '@ember/object/computed';
 import ENV from 'mon-pix/config/environment';
 
 export const assessmentStates = {
@@ -26,10 +26,10 @@ export default class Assessment extends Model {
   @attr('string') competenceId;
 
   // includes
-  @hasMany('answer') answers;
-  @belongsTo('certification-course') certificationCourse;
-  @belongsTo('course', { inverse: null }) course;
-  @belongsTo('progression', { inverse: null }) progression;
+  @hasMany('answer', { async: true, inverse: 'assessment' }) answers;
+  @belongsTo('certification-course', { async: true, inverse: 'assessment' }) certificationCourse;
+  @belongsTo('course', { async: true, inverse: null }) course;
+  @belongsTo('progression', { async: true, inverse: null }) progression;
 
   // methods
   @equal('type', 'CERTIFICATION') isCertification;

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -17,5 +17,5 @@ export default class CampaignParticipation extends Model {
   @belongsTo('campaignParticipationResult') campaignParticipationResult;
   @belongsTo('user') user;
 
-  @hasMany('training') trainings;
+  @hasMany('training', { async: true, inverse: 'campaignParticipation' }) trainings;
 }

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -12,5 +12,5 @@ export default class CertificationCourse extends Model {
   @attr('number') sessionId;
 
   // includes
-  @belongsTo('assessment') assessment;
+  @belongsTo('assessment', { async: true, inverse: 'certificationCourse' }) assessment;
 }

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -28,7 +28,7 @@ export default class Challenge extends Model {
   @attr('boolean') shuffled;
 
   // includes
-  @belongsTo('answer') answer;
+  @belongsTo('answer', { async: false, inverse: 'challenge' }) answer;
 
   // methods
   @computed('embedUrl', 'embedTitle', 'embedHeight')

--- a/mon-pix/app/models/competence-evaluation.js
+++ b/mon-pix/app/models/competence-evaluation.js
@@ -1,4 +1,4 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class CompetenceEvaluation extends Model {
   // attributes
@@ -10,7 +10,7 @@ export default class CompetenceEvaluation extends Model {
   @attr('string') competenceId;
 
   // includes
-  @belongsTo('assessment') assessment;
-  @belongsTo('scorecard', { async: false }) scorecard;
-  @belongsTo('user') user;
+  @belongsTo('assessment', { async: true, inverse: null }) assessment;
+  @belongsTo('scorecard', { async: true, inverse: null }) scorecard;
+  @belongsTo('user', { async: true, inverse: null }) user;
 }

--- a/mon-pix/app/models/competence.js
+++ b/mon-pix/app/models/competence.js
@@ -4,5 +4,5 @@ export default class Competence extends Model {
   // attributes
   @attr('string') name;
 
-  @belongsTo('area') area;
+  @belongsTo('area', { async: true, inverse: 'competences' }) area;
 }

--- a/mon-pix/app/models/correction.js
+++ b/mon-pix/app/models/correction.js
@@ -12,8 +12,8 @@ export default class Correction extends Model {
   @attr('array') solutionsWithoutGoodAnswers;
 
   // includes
-  @hasMany('tutorial', { inverse: null }) tutorials;
-  @hasMany('tutorial', { inverse: null }) learningMoreTutorials; // Traduction: TutoSavoirPlus
+  @hasMany('tutorial', { async: false, inverse: null }) tutorials;
+  @hasMany('tutorial', { async: false, inverse: null }) learningMoreTutorials; // Traduction: TutoSavoirPlus
 
   // methods
   @empty('hint') hasNoHints;

--- a/mon-pix/app/models/profile.js
+++ b/mon-pix/app/models/profile.js
@@ -5,7 +5,7 @@ export default class Profile extends Model {
   @attr('number') maxReachablePixScore;
   @attr('number') maxReachableLevel;
 
-  @hasMany('scorecard') scorecards;
+  @hasMany('scorecard', { async: false, inverse: null }) scorecards;
 
   get areas() {
     return this.scorecards.mapBy('area').uniqBy('code');

--- a/mon-pix/app/models/profile.js
+++ b/mon-pix/app/models/profile.js
@@ -8,6 +8,6 @@ export default class Profile extends Model {
   @hasMany('scorecard', { async: false, inverse: null }) scorecards;
 
   get areas() {
-    return this.scorecards.mapBy('area').uniqBy('code');
+    return this.scorecards.map((s) => s.area).uniqBy('code');
   }
 }

--- a/mon-pix/app/models/result-competence.js
+++ b/mon-pix/app/models/result-competence.js
@@ -7,5 +7,5 @@ export default class ResultCompetence extends Model {
   @attr('number') level;
 
   // includes
-  @belongsTo('area') area;
+  @belongsTo('area', { inverse: 'resultCompetences' }) area;
 }

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -31,8 +31,8 @@ export default class Scorecard extends Model {
   @attr('string') competenceId;
 
   // includes
-  @belongsTo('area') area;
-  @hasMany('tutorial') tutorials;
+  @belongsTo('area', { async: false, inverse: null }) area;
+  @hasMany('tutorial', { async: true, inverse: 'scorecard' }) tutorials;
 
   // methods
   get capedPercentageAheadOfNextLevel() {

--- a/mon-pix/app/models/shared-profile-for-campaign.js
+++ b/mon-pix/app/models/shared-profile-for-campaign.js
@@ -13,6 +13,6 @@ export default class SharedProfileForCampaign extends Model {
 
   @computed('scorecards.@each.area')
   get areas() {
-    return this.scorecards.mapBy('area').uniqBy('code');
+    return this.scorecards.map((s) => s.area).uniqBy('code');
   }
 }

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -10,7 +10,7 @@ export default class Training extends Model {
   @attr('string') editorLogoUrl;
   @attr() duration;
 
-  @belongsTo('campaign-participation') campaignParticpation;
+  @belongsTo('campaign-participation', { async: true, inverse: 'trainings' }) campaignParticipation;
 
   get isAutoformation() {
     return this.type === 'autoformation';

--- a/mon-pix/app/models/tutorial-evaluation.js
+++ b/mon-pix/app/models/tutorial-evaluation.js
@@ -4,8 +4,8 @@ export default class TutorialEvaluation extends Model {
   @attr('string') status;
 
   // includes
-  @belongsTo('user') user;
-  @belongsTo('tutorial', { async: false }) tutorial;
+  @belongsTo('user', { async: true, inverse: null }) user;
+  @belongsTo('tutorial', { async: false, inverse: 'tutorialEvaluation' }) tutorial;
 
   get isLiked() {
     return this.status === 'LIKED';

--- a/mon-pix/app/models/tutorial.js
+++ b/mon-pix/app/models/tutorial.js
@@ -16,7 +16,7 @@ export default class Tutorial extends Model {
   @attr('string') skillId;
 
   // includes
-  @belongsTo('scorecard') scorecard;
+  @belongsTo('scorecard', { async: true, inverse: 'tutorials' }) scorecard;
   @belongsTo('userSavedTutorial', { inverse: 'tutorial', async: false }) userSavedTutorial;
   @belongsTo('tutorialEvaluation', { inverse: 'tutorial', async: false }) tutorialEvaluation;
 

--- a/mon-pix/app/models/user-saved-tutorial.js
+++ b/mon-pix/app/models/user-saved-tutorial.js
@@ -4,6 +4,6 @@ export default class UserSavedTutorial extends Model {
   // attributes
   @attr('date') updatedAt;
   // includes
-  @belongsTo('user') user;
-  @belongsTo('tutorial', { async: false }) tutorial;
+  @belongsTo('user', { async: true, inverse: null }) user;
+  @belongsTo('tutorial', { async: false, inverse: 'userSavedTutorial' }) tutorial;
 }

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -24,11 +24,11 @@ export default class User extends Model {
   @attr() lastDataProtectionPolicySeenAt;
 
   // includes
-  @belongsTo('is-certifiable') isCertifiable;
-  @belongsTo('profile') profile;
-  @hasMany('certification') certifications;
-  @hasMany('scorecard') scorecards;
-  @hasMany('trainings') trainings;
+  @belongsTo('is-certifiable', { async: true, inverse: null }) isCertifiable;
+  @belongsTo('profile', { async: true, inverse: null }) profile;
+  @hasMany('certification', { async: true, inverse: 'user' }) certifications;
+  @hasMany('scorecard', { async: true, inverse: null }) scorecards;
+  @hasMany('trainings', { async: true, inverse: null }) trainings;
 
   // methods
   get fullName() {

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -18,8 +18,8 @@ export default class ChallengeRoute extends Route {
     const currentChallengeNumber = parseInt(params.challenge_number);
     const isBackToPreviousChallenge = currentChallengeNumber < assessment.answers.length;
     if (isBackToPreviousChallenge) {
-      const challengeId = assessment.answers[currentChallengeNumber].challenge.get('id');
-      challenge = await this.store.findRecord('challenge', challengeId);
+      const answers = await assessment.answers;
+      challenge = await answers[currentChallengeNumber].challenge;
     } else {
       if (assessment.isPreview && params.challengeId) {
         challenge = await this.store.findRecord('challenge', params.challengeId);

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -18,8 +18,7 @@ export default class ChallengeRoute extends Route {
     const currentChallengeNumber = parseInt(params.challenge_number);
     const isBackToPreviousChallenge = currentChallengeNumber < assessment.answers.length;
     if (isBackToPreviousChallenge) {
-      const answers = assessment.answers.toArray();
-      const challengeId = answers[currentChallengeNumber].challenge.get('id');
+      const challengeId = assessment.answers[currentChallengeNumber].challenge.get('id');
       challenge = await this.store.findRecord('challenge', challengeId);
     } else {
       if (assessment.isPreview && params.challengeId) {

--- a/mon-pix/app/routes/authenticated/competences/resume.js
+++ b/mon-pix/app/routes/authenticated/competences/resume.js
@@ -12,7 +12,8 @@ export default class ResumeRoute extends Route {
     return this.store.queryRecord('competenceEvaluation', { competenceId, startOrResume: true });
   }
 
-  afterModel(competenceEvaluation) {
-    return this.router.replaceWith('assessments.resume', competenceEvaluation.get('assessment.id'));
+  async afterModel(competenceEvaluation) {
+    const assessment = await competenceEvaluation.assessment;
+    return this.router.replaceWith('assessments.resume', assessment.id);
   }
 }

--- a/mon-pix/app/serializers/application.js
+++ b/mon-pix/app/serializers/application.js
@@ -1,3 +1,7 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
-export default class ApplicationSerializer extends JSONAPISerializer {}
+export default class ApplicationSerializer extends JSONAPISerializer {
+  // This bypasses extractErrors emberData behavior which relies on the property being a function.
+  // This should not be needed after upgrading to ember-data v5
+  extractErrors = false;
+}

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -5,7 +5,7 @@ export default class OidcIdentityProviders extends Service {
   @service store;
 
   get list() {
-    return this.store.peekAll('oidc-identity-provider').toArray();
+    return this.store.peekAll('oidc-identity-provider');
   }
 
   getIdentityProviderNamesByAuthenticationMethods(methods) {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -54,7 +54,7 @@
         "ember-cli-sass": "^11.0.1",
         "ember-component-css": "^0.8.1",
         "ember-cookies": "^1.0.0",
-        "ember-data": "~4.0.2",
+        "ember-data": "~4.5.0",
         "ember-dayjs": "^0.12.0",
         "ember-exam": "^8.0.0",
         "ember-fetch": "^8.1.2",
@@ -2136,22 +2136,23 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.0.2.tgz",
-      "integrity": "sha512-tOqlpaJSlgsA0xv+kXcLYFlhsgIJ/pJc/ldUPkJAyq47LP0l/u7zqY+u+ek6TA+qRGU1YLT5eUVQ9GwdEbRcQA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.5.0.tgz",
+      "integrity": "sha512-1cOOamZVK6pvkJ8DstDUI9ixVWaK26h5ktVLRHkSc2m3NKKblTmI89F4viEnvAmK8uzfLLQMqTRQfXuFUofwVA==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.0.2",
-        "@ember-data/store": "4.0.2",
+        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/store": "4.5.0",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.6",
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/adapter/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -2495,9 +2496,9 @@
       }
     },
     "node_modules/@ember-data/adapter/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -2512,7 +2513,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/adapter/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -2909,16 +2910,17 @@
       "dev": true
     },
     "node_modules/@ember-data/canary-features": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.0.2.tgz",
-      "integrity": "sha512-apTSVB+ayY9rMXg8N8mGREFHd5Ymfi7tM30815L5Yb96VlYDk5u8vGImCXqdXKPIgFVn+WGao0uHWCXRB2KNWg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.5.0.tgz",
+      "integrity": "sha512-qw/Glr2cimq+KBq23ZSvmHJa9z54eLXi134YrfjwQ7zcUaDmWJ043KvtOsc3KTqHXHfkrAFX4Kz2hKusB6ImrQ==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/canary-features/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -3262,9 +3264,9 @@
       }
     },
     "node_modules/@ember-data/canary-features/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -3279,7 +3281,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/canary-features/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -3676,21 +3678,22 @@
       "dev": true
     },
     "node_modules/@ember-data/debug": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.0.2.tgz",
-      "integrity": "sha512-MhyPF90LsksihSn8GvqslG/H8ASGLiaNJ2YfdcI+lOGgoCsuNtxbcfcfFxQE5WNbnjkNxohZznAQ/tcwch4TjA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.5.0.tgz",
+      "integrity": "sha512-uXFnkGIjG9iXk8h684F7+Ee6fbtJc8akx92XfMrgjczqa6YiAAzQZnxE617tgI6uWOWLYBNOIu1sJY8XMxLFJQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.0.2",
+        "@ember-data/private-build-infra": "4.5.0",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.6",
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/debug/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -4034,9 +4037,9 @@
       }
     },
     "node_modules/@ember-data/debug/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -4051,7 +4054,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/debug/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -4448,27 +4451,29 @@
       "dev": true
     },
     "node_modules/@ember-data/model": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.0.2.tgz",
-      "integrity": "sha512-dkwz3iKNp03ACqbD6oTp4ouqSz/ja41Q17jjb/KKK65ym6J0Y6OvtMVBlzHb+UpnHfKVkKAdpslk8svUm3T8vg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.5.0.tgz",
+      "integrity": "sha512-wlkh7x0MgZgp+548oLm0Aol+wNjmQNMmpY/oLft6UmFfV8r2PouowQj1dXPEFmcyoQR5jbndfX2PqJ5Ti+oDuA==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.0.2",
-        "@ember-data/private-build-infra": "4.0.2",
-        "@ember-data/store": "4.0.2",
+        "@ember-data/canary-features": "4.5.0",
+        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/store": "4.5.0",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
+        "@embroider/macros": "^1.8.3",
+        "ember-auto-import": "^2.4.2",
         "ember-cached-decorator-polyfill": "^0.1.4",
-        "ember-cli-babel": "^7.26.6",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0",
-        "ember-compatibility-helpers": "^1.2.0",
-        "inflection": "~1.13.1"
+        "ember-cli-typescript": "^5.1.0",
+        "ember-compatibility-helpers": "^1.2.6",
+        "inflection": "~1.13.2"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/model/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -4812,9 +4817,9 @@
       }
     },
     "node_modules/@ember-data/model/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -4829,7 +4834,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/model/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -5235,40 +5240,40 @@
       "dev": true
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.0.2.tgz",
-      "integrity": "sha512-bFPTSVvcGkvpCRn5dkvZLEZgjPxzWAakpqsKpC6UCmWkVHj1eDeuPBPpGkBZD9MVK95Y8VFmD0vIABwDlBFTmw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.5.0.tgz",
+      "integrity": "sha512-ZO6iKCcDkj5eAngWCAr3e82NT6DDrPcwbKjWeUNW4vl9gKjf6f8YRH+xKLykyCpqCo0gvpjS8Y5SI3jJ4wxScw==",
       "dev": true,
       "dependencies": {
-        "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@ember-data/canary-features": "4.0.2",
+        "@babel/plugin-transform-block-scoping": "^7.18.9",
+        "@ember-data/canary-features": "4.5.0",
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-debug-macros": "^0.3.3",
+        "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^3.0.3",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-rollup": "^5.0.0",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "chalk": "^4.0.0",
-        "ember-cli-babel": "^7.26.6",
+        "chalk": "^4.1.2",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^4.1.0",
-        "ember-cli-version-checker": "^5.1.1",
-        "esm": "^3.2.25",
+        "ember-cli-typescript": "^5.1.0",
+        "ember-cli-version-checker": "^5.1.2",
         "git-repo-info": "^2.1.1",
-        "glob": "^7.1.6",
+        "glob": "^8.0.3",
         "npm-git-info": "^1.0.3",
         "rimraf": "^3.0.2",
         "rsvp": "^4.8.5",
-        "semver": "^7.1.3",
+        "semver": "^7.3.7",
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -5347,6 +5352,26 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/@ember-data/private-build-infra/node_modules/async-disk-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@ember-data/private-build-infra/node_modules/async-disk-cache/node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -5382,6 +5407,35 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/babel-plugin-module-resolver/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/broccoli-babel-transpiler": {
@@ -5465,6 +5519,26 @@
         "symlink-or-copy": "^1.1.8"
       }
     },
+    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-babel-transpiler/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@ember-data/private-build-infra/node_modules/broccoli-babel-transpiler/node_modules/matcher-collection": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
@@ -5521,6 +5595,26 @@
         "node": "6.* || >= 8.*"
       }
     },
+    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-persistent-filter/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@ember-data/private-build-infra/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -5543,6 +5637,26 @@
         "quick-temp": "^0.1.3",
         "rimraf": "^2.3.4",
         "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-plugin/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/broccoli-plugin/node_modules/rimraf": {
@@ -5743,6 +5857,26 @@
         "symlink-or-copy": "^1.1.8"
       }
     },
+    "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-babel/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-babel/node_modules/matcher-collection": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
@@ -5772,9 +5906,9 @@
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -5789,7 +5923,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-typescript/node_modules/walk-sync": {
@@ -5908,6 +6042,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/human-signals": {
@@ -6113,6 +6278,26 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/@ember-data/private-build-infra/node_modules/sync-disk-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@ember-data/private-build-infra/node_modules/sync-disk-cache/node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -6172,22 +6357,23 @@
       "dev": true
     },
     "node_modules/@ember-data/record-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.0.2.tgz",
-      "integrity": "sha512-F1oiMcmeGQkaVp50j6MTeE7sAPSBLUhMnfNRDO70jhVIcMmj0W1W6qvRbk3tVOq+TZ7+Jc8TFWh+43gC6EBfsQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.5.0.tgz",
+      "integrity": "sha512-FxG2eOHcw1UV7jQVRWbnHPJVNVCHYNOzmonvK7w8AuVrGAS4uH0WstkxlftroiNxS49jnbgMa0/nZ+U8KTPeLw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.0.2",
-        "@ember-data/private-build-infra": "4.0.2",
-        "@ember-data/store": "4.0.2",
+        "@ember-data/canary-features": "4.5.0",
+        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/store": "4.5.0",
         "@ember/edition-utils": "^1.2.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.6",
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/record-data/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -6531,9 +6717,9 @@
       }
     },
     "node_modules/@ember-data/record-data/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -6548,7 +6734,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/record-data/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -6951,20 +7137,21 @@
       "dev": true
     },
     "node_modules/@ember-data/serializer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.0.2.tgz",
-      "integrity": "sha512-He8olHmgARXrHx+Gi1F2z4BSN2YmLm3GnIjPuTXjrRpgRV1u7EFrt1H84yo3voYA9c7PIIHoxhLyitm2sfWyBQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.5.0.tgz",
+      "integrity": "sha512-iAvIVkjdplmzabdQOJPLqvCBhbLJlMUkkfDRXhqUD2KLGcvWMLGC6btOed8FLHoAkrb7oEvF4r2FnchpfVGwRg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.0.2",
-        "@ember-data/store": "4.0.2",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.6",
+        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/store": "4.5.0",
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/serializer/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -7308,9 +7495,9 @@
       }
     },
     "node_modules/@ember-data/serializer/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -7325,7 +7512,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/serializer/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -7722,23 +7909,25 @@
       "dev": true
     },
     "node_modules/@ember-data/store": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.0.2.tgz",
-      "integrity": "sha512-+WJUAP1Xz+N+UAssEqipuBsQ38HoHCmQL470Hr6aZ5jK2rs3yZ4X3GGa+Mj2aRNTTDbNEP3w7tnTQyXElzZkJA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.5.0.tgz",
+      "integrity": "sha512-XQ1jIfaOa+O6nojW5ZQCbF9oYHbyHLDbCfL3kIcRcbFA4xmmRzbGDkyM2hjZYHaOuhhDb4mC7JRW6dHOX5qDRg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.0.2",
-        "@ember-data/private-build-infra": "4.0.2",
+        "@ember-data/canary-features": "4.5.0",
+        "@ember-data/private-build-infra": "4.5.0",
         "@ember/string": "^3.0.0",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-auto-import": "^2.2.4",
+        "@embroider/macros": "^1.8.3",
+        "@glimmer/tracking": "^1.1.2",
+        "ember-auto-import": "^2.4.2",
         "ember-cached-decorator-polyfill": "^0.1.4",
-        "ember-cli-babel": "^7.26.6",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/@ember-data/store/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -8082,9 +8271,9 @@
       }
     },
     "node_modules/@ember-data/store/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -8099,7 +8288,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/@ember-data/store/node_modules/ember-cli-typescript/node_modules/semver": {
@@ -31342,29 +31531,31 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.0.2.tgz",
-      "integrity": "sha512-vpz44QuQS1QRRV18idb7N2UH8PIvfwtBXyxrAetB9W/9rZP7aU00y38flJN6ioeZRI3iVhdpNoqhkpUsm/xztQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.5.0.tgz",
+      "integrity": "sha512-pjqsV2IB1/mG5Lh92VOBF9EM/5zijblJw6vVTyinNBiALWLZNKq3CGsk8kKiuGHfExa0DB9zXhwmHN90+Z+lFg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "4.0.2",
-        "@ember-data/debug": "4.0.2",
-        "@ember-data/model": "4.0.2",
-        "@ember-data/private-build-infra": "4.0.2",
-        "@ember-data/record-data": "4.0.2",
-        "@ember-data/serializer": "4.0.2",
-        "@ember-data/store": "4.0.2",
+        "@ember-data/adapter": "4.5.0",
+        "@ember-data/debug": "4.5.0",
+        "@ember-data/model": "4.5.0",
+        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/record-data": "4.5.0",
+        "@ember-data/serializer": "4.5.0",
+        "@ember-data/store": "4.5.0",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
+        "@embroider/macros": "^1.8.3",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-typescript": "^4.1.0",
-        "ember-inflector": "^4.0.1"
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.1.0",
+        "ember-inflector": "^4.0.2"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*",
+        "yarn": "1.22.19"
       }
     },
     "node_modules/ember-data/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -31708,9 +31899,9 @@
       }
     },
     "node_modules/ember-data/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -31725,7 +31916,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/ember-data/node_modules/ember-cli-typescript/node_modules/semver": {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -54,7 +54,7 @@
         "ember-cli-sass": "^11.0.1",
         "ember-component-css": "^0.8.1",
         "ember-cookies": "^1.0.0",
-        "ember-data": "~4.5.0",
+        "ember-data": "~4.7.3",
         "ember-dayjs": "^0.12.0",
         "ember-exam": "^8.0.0",
         "ember-fetch": "^8.1.2",
@@ -2136,13 +2136,13 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.5.0.tgz",
-      "integrity": "sha512-1cOOamZVK6pvkJ8DstDUI9ixVWaK26h5ktVLRHkSc2m3NKKblTmI89F4viEnvAmK8uzfLLQMqTRQfXuFUofwVA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.7.3.tgz",
+      "integrity": "sha512-eww8FovgJZvJVLvaTmZhYnYLca6M5Br5LluVF6bLH66VvBXsLaWSykRL5Lz+UHTme18AQxKQYX3vNseV/abWIg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.5.0",
-        "@ember-data/store": "4.5.0",
+        "@ember-data/private-build-infra": "4.7.3",
+        "@ember-data/store": "4.7.3",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-auto-import": "^2.4.2",
@@ -2151,8 +2151,7 @@
         "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/adapter/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -2910,17 +2909,16 @@
       "dev": true
     },
     "node_modules/@ember-data/canary-features": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.5.0.tgz",
-      "integrity": "sha512-qw/Glr2cimq+KBq23ZSvmHJa9z54eLXi134YrfjwQ7zcUaDmWJ043KvtOsc3KTqHXHfkrAFX4Kz2hKusB6ImrQ==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.7.3.tgz",
+      "integrity": "sha512-/MSaH49NJ1VFu1aEgNHCxZTLCoGk3dna+TcdCpEd86i47CfMhQP5vV/MvkZqjBIinqAuyeFivsGy6pv86F3xCA==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.11",
         "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/canary-features/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -3678,12 +3676,12 @@
       "dev": true
     },
     "node_modules/@ember-data/debug": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.5.0.tgz",
-      "integrity": "sha512-uXFnkGIjG9iXk8h684F7+Ee6fbtJc8akx92XfMrgjczqa6YiAAzQZnxE617tgI6uWOWLYBNOIu1sJY8XMxLFJQ==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.7.3.tgz",
+      "integrity": "sha512-vL0AO4IsTtRsvGp5VGPl1AqeMse12P8RA63xkIM5PXs2hia3hIHvU0qe/8KCgnfLbo7DDcaaGsbnGQ0jWfHmfA==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/private-build-infra": "4.7.3",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-auto-import": "^2.4.2",
@@ -3692,8 +3690,7 @@
         "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/debug/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -4451,14 +4448,14 @@
       "dev": true
     },
     "node_modules/@ember-data/model": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.5.0.tgz",
-      "integrity": "sha512-wlkh7x0MgZgp+548oLm0Aol+wNjmQNMmpY/oLft6UmFfV8r2PouowQj1dXPEFmcyoQR5jbndfX2PqJ5Ti+oDuA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.7.3.tgz",
+      "integrity": "sha512-gtE+JE+2XsU1IqSy8hAxuHTGC6COfMnJYlxfmTXDPKw4bwaBfPPsGLKzEXRR94KoYVoCNr0rX+t852h+R2wApA==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.5.0",
-        "@ember-data/private-build-infra": "4.5.0",
-        "@ember-data/store": "4.5.0",
+        "@ember-data/canary-features": "4.7.3",
+        "@ember-data/private-build-infra": "4.7.3",
+        "@ember-data/store": "4.7.3",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "@embroider/macros": "^1.8.3",
@@ -4472,8 +4469,7 @@
         "inflection": "~1.13.2"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/model/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -5240,13 +5236,13 @@
       "dev": true
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.5.0.tgz",
-      "integrity": "sha512-ZO6iKCcDkj5eAngWCAr3e82NT6DDrPcwbKjWeUNW4vl9gKjf6f8YRH+xKLykyCpqCo0gvpjS8Y5SI3jJ4wxScw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.7.3.tgz",
+      "integrity": "sha512-hqROBtrumsqXk+yiLYawmMkQHe2HcJSsOE584EiwqOItFZZWg4DQCdGGvnJxY5Kt1UibSvR2n1OMX//RhhIENA==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-block-scoping": "^7.18.9",
-        "@ember-data/canary-features": "4.5.0",
+        "@ember-data/canary-features": "4.7.3",
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
@@ -5272,8 +5268,7 @@
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -6357,14 +6352,14 @@
       "dev": true
     },
     "node_modules/@ember-data/record-data": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.5.0.tgz",
-      "integrity": "sha512-FxG2eOHcw1UV7jQVRWbnHPJVNVCHYNOzmonvK7w8AuVrGAS4uH0WstkxlftroiNxS49jnbgMa0/nZ+U8KTPeLw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.7.3.tgz",
+      "integrity": "sha512-QSeK+tJrNHvhPPxN1nrARuOQrz9a1rEnIHIvQHqZNPRsuTEUmvp6LDGdULJikzKoyCOBFPotDZcS6PtIwCLuLQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.5.0",
-        "@ember-data/private-build-infra": "4.5.0",
-        "@ember-data/store": "4.5.0",
+        "@ember-data/canary-features": "4.7.3",
+        "@ember-data/private-build-infra": "4.7.3",
+        "@ember-data/store": "4.7.3",
         "@ember/edition-utils": "^1.2.0",
         "ember-auto-import": "^2.4.2",
         "ember-cli-babel": "^7.26.11",
@@ -6372,8 +6367,7 @@
         "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/record-data/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -7137,21 +7131,20 @@
       "dev": true
     },
     "node_modules/@ember-data/serializer": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.5.0.tgz",
-      "integrity": "sha512-iAvIVkjdplmzabdQOJPLqvCBhbLJlMUkkfDRXhqUD2KLGcvWMLGC6btOed8FLHoAkrb7oEvF4r2FnchpfVGwRg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.7.3.tgz",
+      "integrity": "sha512-TgBm1Ar2wijaXgN3KVO6TuU57Y89thzAxJl4rWHg3HrzcRK2Pqlzvy7FY1jL6JlYcYAreVNJ5TBIKSLjXUeIOQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.5.0",
-        "@ember-data/store": "4.5.0",
+        "@ember-data/private-build-infra": "4.7.3",
+        "@ember-data/store": "4.7.3",
         "ember-auto-import": "^2.4.2",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0",
         "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/serializer/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -7909,13 +7902,13 @@
       "dev": true
     },
     "node_modules/@ember-data/store": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.5.0.tgz",
-      "integrity": "sha512-XQ1jIfaOa+O6nojW5ZQCbF9oYHbyHLDbCfL3kIcRcbFA4xmmRzbGDkyM2hjZYHaOuhhDb4mC7JRW6dHOX5qDRg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.7.3.tgz",
+      "integrity": "sha512-pgO7ooyJzG0MHQ2BRqxjyGfsr3+g1N7C/0qjbNXhaF6RoQDeEyHzZLQHR8sCqznqdZaydP4b62KoouZMX6l3Dg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.5.0",
-        "@ember-data/private-build-infra": "4.5.0",
+        "@ember-data/canary-features": "4.7.3",
+        "@ember-data/private-build-infra": "4.7.3",
         "@ember/string": "^3.0.0",
         "@embroider/macros": "^1.8.3",
         "@glimmer/tracking": "^1.1.2",
@@ -7926,8 +7919,7 @@
         "ember-cli-typescript": "^5.1.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/store/node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -31531,18 +31523,18 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.5.0.tgz",
-      "integrity": "sha512-pjqsV2IB1/mG5Lh92VOBF9EM/5zijblJw6vVTyinNBiALWLZNKq3CGsk8kKiuGHfExa0DB9zXhwmHN90+Z+lFg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.7.3.tgz",
+      "integrity": "sha512-0tRyDE8HWKszrHAcES0QUcozetCl6+6/FHl79x9WRNGtkYPOlDlZ2Rxq4Bkn+mbRGm7S586d6HHOddd6LVd3cA==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "4.5.0",
-        "@ember-data/debug": "4.5.0",
-        "@ember-data/model": "4.5.0",
-        "@ember-data/private-build-infra": "4.5.0",
-        "@ember-data/record-data": "4.5.0",
-        "@ember-data/serializer": "4.5.0",
-        "@ember-data/store": "4.5.0",
+        "@ember-data/adapter": "4.7.3",
+        "@ember-data/debug": "4.7.3",
+        "@ember-data/model": "4.7.3",
+        "@ember-data/private-build-infra": "4.7.3",
+        "@ember-data/record-data": "4.7.3",
+        "@ember-data/serializer": "4.7.3",
+        "@ember-data/store": "4.7.3",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "@embroider/macros": "^1.8.3",
@@ -31554,8 +31546,7 @@
         "ember-inflector": "^4.0.2"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*",
-        "yarn": "1.22.19"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/ember-data/node_modules/@babel/plugin-proposal-private-property-in-object": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -85,7 +85,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-component-css": "^0.8.1",
     "ember-cookies": "^1.0.0",
-    "ember-data": "~4.0.2",
+    "ember-data": "~4.5.0",
     "ember-dayjs": "^0.12.0",
     "ember-exam": "^8.0.0",
     "ember-fetch": "^8.1.2",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -85,7 +85,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-component-css": "^0.8.1",
     "ember-cookies": "^1.0.0",
-    "ember-data": "~4.5.0",
+    "ember-data": "~4.7.3",
     "ember-dayjs": "^0.12.0",
     "ember-exam": "^8.0.0",
     "ember-fetch": "^8.1.2",

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -118,24 +118,24 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
     });
 
     module('when the asked challenges is already answered', function (hooks) {
+      let answer;
+
       hooks.beforeEach(function () {
+        answer = {
+          id: 3,
+          challenge: {
+            id: 'oldRecId',
+            get: () => 'oldRecId',
+          },
+        };
         const assessmentWithAnswers = {
-          answers: [
-            {
-              id: 3,
-              challenge: {
-                id: 'oldRecId',
-                get: () => 'oldRecId',
-              },
-            },
-          ],
+          answers: [answer],
           type: 'COMPETENCE',
         };
         route.modelFor.returns(assessmentWithAnswers);
-        storeStub.findRecord.resolves({ id: 'recId' });
       });
 
-      test('should call findRecord to find the asked challenge', async function (assert) {
+      test('should use challenge from answer', async function (assert) {
         // given
         const params = {
           challengeId: 'recId',
@@ -143,11 +143,10 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
         };
 
         // when
-        await route.model(params);
+        const model = await route.model(params);
 
         // then
-        sinon.assert.calledWith(findRecordStub, 'challenge', 'oldRecId');
-        assert.ok(true);
+        assert.strictEqual(model.challenge, answer.challenge);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/authenticated/competences/resume_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/competences/resume_test.js
@@ -44,13 +44,13 @@ module('Unit | Route | Competence | Resume', function (hooks) {
   });
 
   module('#afterModel', function () {
-    test('should transition to assessments.resume', function (assert) {
+    test('should transition to assessments.resume', async function (assert) {
       // given
       route.router.replaceWith.returns();
       const competenceEvaluation = EmberObject.create({ competenceId, assessment: { id: 'assessmentId' } });
 
       // when
-      route.afterModel(competenceEvaluation);
+      await route.afterModel(competenceEvaluation);
 
       // then
       sinon.assert.calledOnce(route.router.replaceWith);


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous sommes bloqués à la version 4.0 d'ember-data.

## :gift: Proposition
Passer en 4.7

## :socks: Remarques
Il reste surement des dépracations dans les modèles de pods, mais je propose qu'on suive un peu mieux le deprecations workflows d'ember : https://guides.emberjs.com/v3.22.0/configuring-ember/handling-deprecations/#toc_deprecation-workflow


## :santa: Pour tester
CI OK 

Sur Pix App 
- Tester les reprises d'une compétence
- Tester le précédent après avoir répondu à une épreuve