### PR TITLE
[TECH] Correction de l'affichage des heures des invitations (PIX-10414).

### DIFF
--- a/admin/app/components/certification-centers/invitations.hbs
+++ b/admin/app/components/certification-centers/invitations.hbs
@@ -19,7 +19,7 @@
               <tr aria-label="Invitation en attente de {{invitation.email}}">
                 <td>{{invitation.email}}</td>
                 <td>{{invitation.roleLabel}}</td>
-                <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>
+                <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}</td>
                 <td>
                   <PixButton
                     @size="small"

--- a/admin/app/components/organizations/invitations.hbs
+++ b/admin/app/components/organizations/invitations.hbs
@@ -21,7 +21,7 @@
               <tr aria-label="Invitation en attente de {{invitation.email}}">
                 <td>{{invitation.email}}</td>
                 <td>{{invitation.roleInFrench}}</td>
-                <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>
+                <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}</td>
                 {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
                   <td>
                     <PixButton

--- a/admin/app/components/users/user-organization-memberships.hbs
+++ b/admin/app/components/users/user-organization-memberships.hbs
@@ -32,7 +32,7 @@
               <td>{{organizationMembership.organizationName}}</td>
               <td>{{organizationMembership.organizationType}}</td>
               <td>{{organizationMembership.organizationExternalId}}</td>
-              <td>{{dayjs-format organizationMembership.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>
+              <td>{{dayjs-format organizationMembership.updatedAt "DD/MM/YYYY [-] HH:mm"}}</td>
               <ActionsOnUsersRoleInOrganization @organizationMembership={{organizationMembership}} />
             </tr>
           {{/each}}

--- a/admin/tests/acceptance/authenticated/organizations/invitations-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/invitations-management_test.js
@@ -4,9 +4,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import setupIntl from '../../../helpers/setup-intl';
 
 module('Acceptance | Organizations | Invitations management', function (hooks) {
   setupApplicationTest(hooks);
+  setupIntl(hooks);
   setupMirage(hooks);
 
   test('should allow to invite a member when user has access', async function (assert) {
@@ -65,7 +67,10 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
     module('and an error occurs', function () {
       test('it should display an error notification and the invitation should remain in the list', async function (assert) {
         // given
+        const dayjsService = this.owner.lookup('service:dayjs');
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const updatedAt = new Date('2023-12-05T09:00:00Z');
+
         const organization = this.server.create('organization', {
           id: 5,
           name: 'Kabuki',
@@ -74,6 +79,7 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
           id: 10,
           email: 'kabuki@example.net',
           lang: 'fr',
+          updatedAt,
           organization,
         });
         this.server.delete(
@@ -87,8 +93,12 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
         await click(screen.getByRole('button', { name: 'Annuler l’invitation de kabuki@example.net' }));
 
         // then
+        const formattedDate = dayjsService.self(updatedAt).format('DD/MM/YYYY [-] HH:mm');
+
         assert.dom(screen.getByText('Une erreur s’est produite, veuillez réessayer.')).exists();
         assert.dom(screen.getByRole('row', { name: 'Invitation en attente de kabuki@example.net' })).exists();
+        assert.dom(screen.getByRole('cell', { name: 'kabuki@example.net' })).exists();
+        assert.dom(screen.getByRole('cell', { name: formattedDate })).exists();
       });
     });
   });

--- a/admin/tests/integration/components/certification-centers/invitations_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations_test.js
@@ -26,13 +26,17 @@ module('Integration | Component | Certification Centers | Invitations', function
     test('should show invitations list', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const dayjsService = this.owner.lookup('service:dayjs');
+
+      const invitationUpdatedAt1 = new Date('2020-02-02T09:00:00Z');
+      const invitationUpdatedAt2 = new Date('2022-02-02T15:12:00Z');
       const certificationCenterInvitation1 = store.createRecord('certification-center-invitation', {
         email: 'elo.dela@example.net',
-        updatedAt: new Date('2020-02-02'),
+        updatedAt: invitationUpdatedAt1,
       });
       const certificationCenterInvitation2 = store.createRecord('certification-center-invitation', {
         email: 'alain.finis@example.net',
-        updatedAt: new Date('2022-02-02'),
+        updatedAt: invitationUpdatedAt2,
       });
       this.certificationCenterInvitations = [certificationCenterInvitation1, certificationCenterInvitation2];
       this.cancelCertificationCenterInvitation = sinon.stub();
@@ -46,11 +50,16 @@ module('Integration | Component | Certification Centers | Invitations', function
       );
 
       // then
+      const formattedInvitationUpdatedAt1 = dayjsService.self(invitationUpdatedAt1).format('DD/MM/YYYY [-] HH:mm');
+      const formattedInvitationUpdatedAt2 = dayjsService.self(invitationUpdatedAt2).format('DD/MM/YYYY [-] HH:mm');
+
       assert.dom(screen.getByRole('heading', { name: 'Invitations' })).exists();
       assert.dom(screen.getByRole('columnheader', { name: 'Adresse e-mail' })).exists();
       assert.dom(screen.getByRole('columnheader', { name: 'Date de dernier envoi' })).exists();
       assert.dom(screen.getByRole('cell', { name: 'elo.dela@example.net' })).exists();
+      assert.dom(screen.getByRole('cell', { name: formattedInvitationUpdatedAt1 })).exists();
       assert.dom(screen.getByRole('cell', { name: 'alain.finis@example.net' })).exists();
+      assert.dom(screen.getByRole('cell', { name: formattedInvitationUpdatedAt2 })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/users/user-organization-memberships_test.js
+++ b/admin/tests/integration/components/users/user-organization-memberships_test.js
@@ -36,20 +36,27 @@ module('Integration | Component | users | organization-memberships', function (h
         hasAccessToOrganizationActionsScope = false;
       }
       this.owner.register('service:accessControl', SessionStub);
+      const dayjsService = this.owner.lookup('service:dayjs');
 
+      const membershipUpdatedAt1 = new Date('2023-12-05T08:00:00Z');
+      const membershipUpdatedAt2 = new Date('2023-12-05T09:00:00Z');
       const organizationMembership1 = EmberObject.create({
+        id: 111,
         role: 'MEMBER',
         organizationId: 100025,
         organizationName: 'Dragon & Co',
         organizationType: 'PRO',
+        updatedAt: membershipUpdatedAt1,
       });
 
       const organizationMembership2 = EmberObject.create({
+        id: 222,
         role: 'MEMBER',
         organizationId: 100095,
         organizationName: 'Collège The Night Watch',
         organizationType: 'SCO',
         organizationExternalId: '1237457A',
+        updatedAt: membershipUpdatedAt2,
       });
 
       const organizationMemberships = [organizationMembership1, organizationMembership2];
@@ -61,8 +68,21 @@ module('Integration | Component | users | organization-memberships', function (h
       );
 
       // then
-      assert.dom(screen.getByText('Collège The Night Watch')).exists();
-      assert.dom(screen.getByText('Dragon & Co')).exists();
+      const formattedUpdatedAt1 = dayjsService.self(membershipUpdatedAt1).format('DD/MM/YYYY [-] HH:mm');
+      const formattedUpdatedAt2 = dayjsService.self(membershipUpdatedAt1).format('DD/MM/YYYY [-] HH:mm');
+
+      assert.dom(screen.getByRole('cell', { name: '111' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '100025' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Dragon & Co' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'PRO' })).exists();
+      assert.dom(screen.getByRole('cell', { name: formattedUpdatedAt1 })).exists();
+
+      assert.dom(screen.getByRole('cell', { name: '222' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '100095' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Collège The Night Watch' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'SCO' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '1237457A' })).exists();
+      assert.dom(screen.getByRole('cell', { name: formattedUpdatedAt2 })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/users/user-organization-memberships_test.js
+++ b/admin/tests/integration/components/users/user-organization-memberships_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -69,20 +69,23 @@ module('Integration | Component | users | organization-memberships', function (h
 
       // then
       const formattedUpdatedAt1 = dayjsService.self(membershipUpdatedAt1).format('DD/MM/YYYY [-] HH:mm');
-      const formattedUpdatedAt2 = dayjsService.self(membershipUpdatedAt1).format('DD/MM/YYYY [-] HH:mm');
+      const formattedUpdatedAt2 = dayjsService.self(membershipUpdatedAt2).format('DD/MM/YYYY [-] HH:mm');
 
-      assert.dom(screen.getByRole('cell', { name: '111' })).exists();
-      assert.dom(screen.getByRole('cell', { name: '100025' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Dragon & Co' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'PRO' })).exists();
-      assert.dom(screen.getByRole('cell', { name: formattedUpdatedAt1 })).exists();
+      const rows = await screen.findAllByRole('row');
+      assert.dom(within(rows[1]).getByRole('cell', { name: '222' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: '100095' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: 'Collège The Night Watch' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: 'SCO' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: '1237457A' })).exists();
+      assert.dom(within(rows[1]).getByRole('cell', { name: formattedUpdatedAt2 })).exists();
 
-      assert.dom(screen.getByRole('cell', { name: '222' })).exists();
-      assert.dom(screen.getByRole('cell', { name: '100095' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Collège The Night Watch' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'SCO' })).exists();
-      assert.dom(screen.getByRole('cell', { name: '1237457A' })).exists();
-      assert.dom(screen.getByRole('cell', { name: formattedUpdatedAt2 })).exists();
+      assert.dom(within(rows[2]).getByRole('cell', { name: '111' })).exists();
+
+      assert.dom(within(rows[2]).getByRole('cell', { name: '111' })).exists();
+      assert.dom(within(rows[2]).getByRole('cell', { name: '100025' })).exists();
+      assert.dom(within(rows[2]).getByRole('cell', { name: 'Dragon & Co' })).exists();
+      assert.dom(within(rows[2]).getByRole('cell', { name: 'PRO' })).exists();
+      assert.dom(within(rows[2]).getByRole('cell', { name: formattedUpdatedAt1 })).exists();
     });
   });
 });

--- a/certif/app/components/team/invitations-list-item.hbs
+++ b/certif/app/components/team/invitations-list-item.hbs
@@ -1,7 +1,7 @@
 <tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
   <td>{{@invitation.email}}</td>
   <td>
-    {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
+    {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}
   </td>
   <td>
     <div class="invitations-list-item__actions">

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -1,14 +1,13 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { clickByName, visit } from '@1024pix/ember-testing-library';
-
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import {
   authenticateSession,
   createCertificationPointOfContactWithTermsOfServiceAccepted,
 } from '../../../helpers/test-init';
 import setupIntl from '../../../helpers/setup-intl';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Team | Invitations', function (hooks) {
   setupApplicationTest(hooks);
@@ -112,10 +111,13 @@ module('Acceptance | Team | Invitations', function (hooks) {
     module('when user clicks on resend invitation button', function () {
       test('resends the invitation and displays a success notification', async function (assert) {
         // given
+        const dayjsService = this.owner.lookup('service:dayjs');
+        const previousUpdatedAt = new Date('2023-12-05T09:00:00Z');
+
         this.server.create('certification-center-invitation', {
           certificationCenterId: 1,
           email: 'medhi.khaman@example.net',
-          updatedAt: new Date('2023-12-05T11:30:00Z'),
+          updatedAt: previousUpdatedAt,
         });
 
         const screen = await visit('/equipe/invitations');
@@ -124,6 +126,10 @@ module('Acceptance | Team | Invitations', function (hooks) {
         await clickByName(this.intl.t('pages.team-invitations.actions.resend-invitation'));
 
         // then
+        const formattedDate = dayjsService.self(new Date('2023-12-05T11:35:00Z')).format('DD/MM/YYYY [-] HH:mm');
+
+        assert.dom(screen.getByRole('cell', { name: 'medhi.khaman@example.net' })).exists();
+        assert.dom(screen.getByRole('cell', { name: formattedDate })).exists();
         assert.dom(screen.getByText("L'invitation a bien été renvoyée.")).exists();
       });
 

--- a/orga/app/components/team/invitations-list-item.hbs
+++ b/orga/app/components/team/invitations-list-item.hbs
@@ -1,7 +1,7 @@
 <tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
   <td>{{@invitation.email}}</td>
   <td class="hide-on-mobile">
-    {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
+    {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm"}}
   </td>
   <td>
     <div class="invitations-list__action">

--- a/orga/tests/integration/components/team/invitations-list_test.js
+++ b/orga/tests/integration/components/team/invitations-list_test.js
@@ -36,16 +36,19 @@ module('Integration | Component | Team::InvitationsList', function (hooks) {
 
   test('it should display email and creation date of invitation', async function (assert) {
     // given
-    const pendingInvitationDate = '2019-10-08T10:50:00Z';
+    const dayjsService = this.owner.lookup('service:dayjs');
+    const pendingInvitationDate = '2023-12-05T09:00:00Z';
 
     this.set('invitations', [{ email: 'gigi@example.net', isPending: true, updatedAt: pendingInvitationDate }]);
 
     // when
-    await render(hbs`<Team::InvitationsList @invitations={{this.invitations}} />`);
+    const component = await render(hbs`<Team::InvitationsList @invitations={{this.invitations}} />`);
 
     // then
-    assert.contains('gigi@example.net');
-    assert.contains(this.dayjs.self(pendingInvitationDate).format('DD/MM/YYYY - HH:mm'));
+    const formattedPendingInvitationDate = dayjsService.self(pendingInvitationDate).format('DD/MM/YYYY [-] HH:mm');
+
+    assert.dom(component.getByRole('cell', { name: 'gigi@example.net' })).exists();
+    assert.dom(component.getByRole('cell', { name: formattedPendingInvitationDate })).exists();
   });
 
   test('it should show success notification when cancelling an invitation succeeds', async function (assert) {


### PR DESCRIPTION
## :christmas_tree: Problème

Le test d’Acceptance _resends the invitation and displays a success notification_ tombe KO sur les postes locaux car, contrairement à la CICD, le test s’execute selon la locale de l’ordinateur.

L’erreur est détectée sur `certif/app/components/team/invitations-list-item.hbs` où le paramètre locale de dayjs-format ne semble pas avoir l’impact escompté.

On retrouve le même code problématique dans Pix Admin et Pix Orga, à savoir `{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}`

## :gift: Proposition

- Supprimer l'utilisation du champ `locale` sur les appels au helper `dayjs-format` car pas utile vu que le format est déjà setté.
- Corriger le test _resends the invitation and displays a success notification_ en utilisant `dayjs.self(date).format('DD/MM/YYYY [-] HH:mm')` afin que cela passe sur tous les postes.


## :socks: Remarques
- Les dates affichées sont dans la timezone de l'utilisateur.

## :santa: Pour tester
### Non régression Pix Admin
- Se connecter sur la RA de Pix Admin https://admin-pr7689.review.pix.fr/ avec le compte superadmin@example.net

#### Page de détail d'une organisation -> onglet Invitations
- Aller sur l'onglet invitation la page de détail de l'organisation Collège House of the dragon : https://admin-pr7689.review.pix.fr/organizations/2023/invitations
- Vérifier que la date de l'invitation est bien affichée. 

#### Page de détail d'un centre de certif -> onglet Invitations
- Aller sur la page de détail du centre de certif Accèssorium : https://admin-pr7689.review.pix.fr/certification-centers/8000/invitations
-  Vérifier que la date des invitations sont bien affichées. 

#### Page de détail d'un utilisateur -> onglet Pix Orga
- Aller sur la page de détail de Admin Leaving puis sur l'onglet Pix Orga : https://admin-pr7689.review.pix.fr/users/10002/organizations
-  Vérifier que la date de dernière modification est bien affichée.

### Non régression Pix Orga 
- Se connecter sur la RA de Pix Orga https://orga-pr7689.review.pix.fr avec le compte allorga@example.net
- Aller sur l'onglet Equipe puis sur Invitations
- Vérifier que la date de dernier envoi de l'invitation est bien affichée. 

### Non régression Pix Certif
- Se connecter sur la RA de Pix Certif https://certif-pr7689.review.pix.fr avec le compte james-paledroits@example.net
- Aller sur l'onglet Equipe puis sur Invitations
- Vérifier que les dates de dernier envoi des invitations sont bien affichées. 

### Test en local
- Changer le fuseau horaire de votre machine en se mettant par exemple sur celui de San Francisco, CA - États-Unis
- Lancer les tests de Pix Admin, Orga et Certif en local
- Vérifier que les tests fonctionnent bien 😄 
