### PR TITLE
[BUGFIX] Problème de hover sur le bouton de retour sur Certif. (PIX-10369)

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -1,8 +1,5 @@
 .add-student {
   margin-bottom: 68px;
-  &__return-to span {
-    color: $pix-neutral-60;
-  }
 
   &__title {
     color: $pix-neutral-70;

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -5,8 +5,7 @@
   width: 100%;
 
   &__return-to {
-    font-weight: 400;
-    font-size: 0.875rem;
+    width: fit-content;
   }
 }
 

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^1.0.0",
         "@1024pix/eslint-config": "^1.1.1",
-        "@1024pix/pix-ui": "^41.2.0",
+        "@1024pix/pix-ui": "^42.0.4",
         "@1024pix/stylelint-config": "^5.0.2",
         "@babel/eslint-parser": "^7.22.15",
         "@babel/plugin-proposal-decorators": "^7.22.15",
@@ -126,9 +126,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-41.2.0.tgz",
-      "integrity": "sha512-1bIPJ4UtL5DMYe8M4ehPXSFjfmgguJ1lN9Meq+V2+5kBsFSwBWmbf9hjKdFcSizMuyFVM/iygiZohjDk6Li9gg==",
+      "version": "42.0.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-42.0.4.tgz",
+      "integrity": "sha512-Qjz0ahnlqGS6My/+uk0b+OnOT2cAPnF2HTTnuVbLcxPA97+K+7NEaySGgPlFPUfZxU3YqlFT4VrlN7mkD/vrNA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^1.0.0",
     "@1024pix/eslint-config": "^1.1.1",
-    "@1024pix/pix-ui": "^41.2.0",
+    "@1024pix/pix-ui": "^42.0.4",
     "@1024pix/stylelint-config": "^5.0.2",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/plugin-proposal-decorators": "^7.22.15",


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l'on passe en hover sur tous les buttons de retour de l'app Certif, l'icone flèche devient blanche mais le cercle bleu en background ne s'affiche pas.

## :gift: Proposition
La correction a été faite coté Pix Ui mais il reste encore quelques modifications à faire sur le bouton

## :socks: Remarques
Upgrade de la version de PIx-ui sur Certif

Les review app avaient galéré à se lacener, voici l'url puisque le bot ne les a pas mises 
* https://certif-pr7691.review.pix.org/connexion

## :santa: Pour tester
- Se connecter à Pix Certif avec `certif-pro@example.net`
- Aller sur la page détail d'une session et passer en hover sur le bouton de retour "Revenir à la liste des sessions"
- Bien avoir le visuel de la flèche avec le rond bleu foncé <img width="36" alt="Capture d’écran 2023-12-19 à 17 33 32" src="https://github.com/1024pix/pix/assets/103997660/b410c46f-ecad-40b6-b540-2682bdf2f769">
- Aller sur une session à finaliser et passer en hover sur le bouton de retour "Retour à la session"
- Bien avoir le visuel
- Aller sur "Créer/éditer plusieurs sessions" et passer en hover sur le bouton retour "Revenir à la liste des sessions"
- Bien avoir le visuel