### PR TITLE
[FEATURE] Retourner une erreur 404 lors de l'enregistrement d'un signalement si la catégorie liée n'existe pas en base de données (PIX-10210)

### DIFF
--- a/api/src/certification/issue-reports/domain/read-models/CertificationIssueReportCategory.js
+++ b/api/src/certification/issue-reports/domain/read-models/CertificationIssueReportCategory.js
@@ -1,0 +1,11 @@
+/**
+ * Class representing a certification issue report category read model
+ * @typedef {Object} CertificationIssueReportCategory
+ * @property {number} id
+ */
+
+export class CertificationIssueReportCategory {
+  constructor({ id }) {
+    this.id = id;
+  }
+}

--- a/api/src/certification/shared/infrastructure/repositories/issue-report-category-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/issue-report-category-repository.js
@@ -1,7 +1,18 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { CertificationIssueReportCategory } from '../../../issue-reports/domain/read-models/CertificationIssueReportCategory.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
+function _toDomain(issueReportCategoryModel) {
+  return new CertificationIssueReportCategory({ id: issueReportCategoryModel.id });
+}
 
 const get = async function ({ name }) {
-  return knex('issue-report-categories').where({ name }).first();
+  const issueReportCategory = await knex('issue-report-categories').where({ name }).first();
+
+  if (!issueReportCategory) {
+    throw new NotFoundError('The issue report category name does not exist');
+  }
+  return _toDomain(issueReportCategory);
 };
 
 export { get };

--- a/api/tests/certification/shared/integration/infrastructure/repositories/issue-report-categories-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/issue-report-categories-repository_test.js
@@ -1,18 +1,43 @@
-import { expect, databaseBuilder } from '../../../../../test-helper.js';
+import { expect, databaseBuilder, catchErr } from '../../../../../test-helper.js';
 import * as issueReportCategoryRepository from '../../../../../../src/certification/shared/infrastructure/repositories/issue-report-category-repository.js';
+import { CertificationIssueReportCategory } from '../../../../../../src/certification/issue-reports/domain/read-models/CertificationIssueReportCategory.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Integration | Repository | Issue Report Categories', function () {
   describe('#get', function () {
-    it('should return a certification issue report', async function () {
-      // given
-      const issueReportCategory = databaseBuilder.factory.buildIssueReportCategory({ category: 'OTHER' });
-      await databaseBuilder.commit();
+    describe('when the issue report category name exists', function () {
+      it('should return a CertificationIssueReportCategory domain read model', async function () {
+        // given
+        const categoryId = 1;
+        const issueReportCategory = databaseBuilder.factory.buildIssueReportCategory({
+          id: categoryId,
+          category: 'OTHER',
+        });
+        await databaseBuilder.commit();
 
-      // when
-      const result = await issueReportCategoryRepository.get({ name: issueReportCategory.name });
+        // when
+        const result = await issueReportCategoryRepository.get({ name: issueReportCategory.name });
 
-      // then
-      expect(result).to.deep.equal({ ...issueReportCategory });
+        // then
+        expect(result).to.be.instanceof(CertificationIssueReportCategory);
+        expect(result.id).to.equal(categoryId);
+      });
+    });
+
+    describe('when the issue report category name does not exist', function () {
+      it('should throw a Not Found domain error', async function () {
+        // given
+        databaseBuilder.factory.buildIssueReportCategory({ category: 'OTHER', name: 'Some problem' });
+        await databaseBuilder.commit();
+
+        // when
+        const nonExistingCategoryName = 'NON_EXISTING_CATEGORY_NAME';
+        const result = await catchErr(issueReportCategoryRepository.get)({ name: nonExistingCategoryName });
+
+        // then
+        expect(result).to.be.instanceOf(NotFoundError);
+        expect(result.message).to.equal(`The issue report category name does not exist`);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/save-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/save-certification-issue-report_test.js
@@ -1,68 +1,101 @@
-import { expect, sinon, domainBuilder } from '../../../test-helper.js';
+import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import { saveCertificationIssueReport } from '../../../../lib/domain/usecases/save-certification-issue-report.js';
 import { CertificationIssueReport } from '../../../../src/certification/shared/domain/models/CertificationIssueReport.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | UseCase | save-certification-issue-report', function () {
   describe('#saveCertificationIssueReport', function () {
     describe('when there is a category of issue report', function () {
-      it('should save the certification issue report', async function () {
-        // given
-        const certificationIssueReportRepository = { save: sinon.stub() };
-        const issueReportCategoryRepository = { get: sinon.stub() };
-        const sessionId = 1;
-        const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
-        const certificationIssueReportDTO = {
-          certificationCourseId: aCertificationCourse.getId(),
-          category: 'FRAUD',
-          description: 'une description',
-        };
-        const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
-        issueReportCategoryRepository.get
-          .withArgs({ name: certificationIssueReportDTO.category })
-          .resolves({ id: 1234, name: certificationIssueReportDTO.category });
-        certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
+      describe('when the category of issue report exists', function () {
+        it('should save the certification issue report', async function () {
+          // given
+          const certificationIssueReportRepository = { save: sinon.stub() };
+          const issueReportCategoryRepository = { get: sinon.stub() };
+          const sessionId = 1;
+          const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
+          const certificationIssueReportDTO = {
+            certificationCourseId: aCertificationCourse.getId(),
+            category: 'FRAUD',
+            description: 'une description',
+          };
+          const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
+          issueReportCategoryRepository.get
+            .withArgs({ name: certificationIssueReportDTO.category })
+            .resolves({ id: 1234, name: certificationIssueReportDTO.category });
+          certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
 
-        // when
-        const certifIssueReportResult = await saveCertificationIssueReport({
-          certificationIssueReportDTO,
-          certificationIssueReportRepository,
-          issueReportCategoryRepository,
+          // when
+          const certifIssueReportResult = await saveCertificationIssueReport({
+            certificationIssueReportDTO,
+            certificationIssueReportRepository,
+            issueReportCategoryRepository,
+          });
+
+          // then
+          expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
         });
+      });
 
-        // then
-        expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
+      describe('when the category of issue report does not exist', function () {
+        it('should throw a Not Found domain error', async function () {
+          // given
+          const issueReportCategoryRepository = { get: sinon.stub() };
+          const sessionId = 1;
+          const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
+          const issueReportCategoryName = 'NON_EXISTING_CATEGORY_NAME';
+          const certificationIssueReportDTO = {
+            certificationCourseId: aCertificationCourse.getId(),
+            category: issueReportCategoryName,
+            description: 'une description',
+          };
+          issueReportCategoryRepository.get.throws(
+            new NotFoundError(`The category issue report name ${issueReportCategoryName} does not exist`),
+          );
+
+          // when
+          const error = await catchErr(saveCertificationIssueReport)({
+            certificationIssueReportDTO,
+            issueReportCategoryRepository,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(NotFoundError);
+          expect(error.message).to.equal(`The category issue report name ${issueReportCategoryName} does not exist`);
+        });
       });
     });
 
     describe('when there is a subcategory of issue report', function () {
-      it('should save the certification issue report', async function () {
-        // given
-        const certificationIssueReportRepository = { save: sinon.stub() };
-        const issueReportCategoryRepository = { get: sinon.stub() };
-        const sessionId = 1;
-        const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
-        const certificationIssueReportDTO = {
-          certificationCourseId: aCertificationCourse.getId(),
-          category: 'IN_CHALLENGE',
-          subcategory: 'EMBED_NOT_WORKING',
-          description: 'une description',
-          questionNumber: 1,
-        };
-        const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
-        issueReportCategoryRepository.get
-          .withArgs({ name: certificationIssueReportDTO.subcategory })
-          .resolves({ id: 1234, name: certificationIssueReportDTO.subcategory });
-        certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
+      describe('when the subcategory of issue report exists', function () {
+        it('should save the certification issue report', async function () {
+          // given
+          const certificationIssueReportRepository = { save: sinon.stub() };
+          const issueReportCategoryRepository = { get: sinon.stub() };
+          const sessionId = 1;
+          const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
+          const certificationIssueReportDTO = {
+            certificationCourseId: aCertificationCourse.getId(),
+            category: 'IN_CHALLENGE',
+            subcategory: 'EMBED_NOT_WORKING',
+            description: 'une description',
+            questionNumber: 1,
+          };
+          const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
+          issueReportCategoryRepository.get
+            .withArgs({ name: certificationIssueReportDTO.subcategory })
+            .resolves({ id: 1234, name: certificationIssueReportDTO.subcategory });
+          certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
 
-        // when
-        const certifIssueReportResult = await saveCertificationIssueReport({
-          certificationIssueReportDTO,
-          certificationIssueReportRepository,
-          issueReportCategoryRepository,
+          // when
+          const certifIssueReportResult = await saveCertificationIssueReport({
+            certificationIssueReportDTO,
+            certificationIssueReportRepository,
+            issueReportCategoryRepository,
+          });
+
+          // then
+          expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
         });
-
-        // then
-        expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
La méthode `get` du repository `issue-report-categories` qui récupère la catégorie liée au signalement ne retourne pas d’erreur si elle ne retrouve rien lors de l'appel sur le `/api/certification-reports/{id}/certification-issue-reports (POST)`.

## :gift: Proposition
Retourner une erreur `404 NOT FOUND` au consommateur de l'API si la catégorie liée au signalement n'existe pas en base de données.

## :socks: Remarques
Les cas d'erreur est uniquement tester dans les tests du `repository` et de ceux du `usecase` impacté, et non pas dans les tests de `controller` (unit | acceptance) où y sont tester les cas passants.

## :santa: Pour tester

```
curl --location 'http://localhost:3000/api/certification-reports/105023/certification-issue-reports' \
--header 'accept-language: fr' \
--header 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo3MDAyLCJzb3VyY2UiOiJwaXgiLCJpYXQiOjE3MDI5MTgwMjQsImV4cCI6MTcwMjkxOTIyNH0.F30kCphyzPlS8z_LxUfAueiAlqFQFbvn2KvroYjSx1Q' \
--header 'content-type: application/json' \
--data '{
    "data": {
        "attributes": {
            "category": "TATA",
            "subcategory": null,
            "description": null,
            "question-number": null
        },
        "relationships": {
            "certification-report": {
                "data": {
                    "type": "certification-reports",
                    "id": "CertificationReport-141473"
                }
            }
        },
        "type": "certification-issue-reports"
    }
}'
```

## 🤶 Pour tester le cas nominale (cas passant)

1. Se connecter à pix-certif avec les identifiants `certi-pro@example.net / pix123`
2. Se rendre sur la page des sessions
3. Cliquer sur une session "finalisable" (exemple: session numéro 7005)
4. Cliquer sur le bouton `[Finaliser la session]`
5. Cliquer sur ajouter le bouton `[+ Ajouter]` dans la colonne signalement
6. Choisir une catégorie de signalement (exemple: C6 Suspicion pour fraude)
7. Cliquer le bouton `[valider]`