### PR TITLE
[FEATURE] Ajouter un endpoint interne pour mettre à jour une campagne (Pix-10138)

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -91,15 +91,6 @@ const getCsvProfilesCollectionResults = async function (request, h, dependencies
   return writableStream;
 };
 
-const update = function (request, h, dependencies = { campaignReportSerializer }) {
-  const { userId } = request.auth.credentials;
-  const campaignId = request.params.id;
-
-  return usecases
-    .updateCampaign({ userId, campaignId, ...request.deserializedPayload })
-    .then(dependencies.campaignReportSerializer.serialize);
-};
-
 const archiveCampaign = function (request, h, dependencies = { campaignReportSerializer }) {
   const { userId } = request.auth.credentials;
   const campaignId = request.params.id;
@@ -200,7 +191,6 @@ const campaignController = {
   getByCode,
   getCsvAssessmentResults,
   getCsvProfilesCollectionResults,
-  update,
   archiveCampaign,
   unarchiveCampaign,
   getCollectiveResult,

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -166,39 +166,6 @@ const register = async function (server) {
       },
     },
     {
-      method: 'PATCH',
-      path: '/api/campaigns/{id}',
-      config: {
-        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.campaignId,
-          }),
-          payload: Joi.object({
-            data: {
-              type: 'campaigns',
-              attributes: {
-                'owner-id': identifiersType.ownerId,
-                name: Joi.string().required(),
-                title: Joi.string().allow(null).required(),
-                'custom-landing-page-text': Joi.string().allow(null).required(),
-              },
-            },
-          }),
-          options: {
-            allowUnknown: true,
-          },
-        },
-        handler: campaignController.update,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            "- Modification d'une campagne\n" +
-            '- L‘utilisateur doit avoir les droits d‘accès à l‘organisation liée à la campagne à modifier',
-        ],
-        tags: ['api', 'campaign'],
-      },
-    },
-    {
       method: 'GET',
       path: '/api/campaigns/{id}/collective-results',
       config: {

--- a/api/lib/domain/usecases/update-campaign.js
+++ b/api/lib/domain/usecases/update-campaign.js
@@ -1,40 +1,31 @@
 import _ from 'lodash';
-import { UserNotAuthorizedToUpdateResourceError } from '../errors.js';
 import { EntityValidationError } from '../../../src/shared/domain/errors.js';
 import * as campaignValidator from '../validators/campaign-validator.js';
 
 const updateCampaign = async function ({
-  userId,
   campaignId,
   name,
   title,
   customLandingPageText,
   ownerId,
-  userRepository,
   campaignRepository,
   membershipRepository,
 }) {
-  const [user, campaign] = await Promise.all([
-    userRepository.getWithMemberships(userId),
-    campaignRepository.get(campaignId),
-  ]);
+  const [campaign] = await campaignRepository.get(campaignId);
 
   const organizationId = campaign.organizationId;
-  if (!user.hasAccessToOrganization(organizationId)) {
-    throw new UserNotAuthorizedToUpdateResourceError(
-      `User does not have an access to the organization ${organizationId}`,
-    );
-  }
 
-  const ownerMembership = await membershipRepository.findByUserIdAndOrganizationId({
-    userId: ownerId,
-    organizationId,
-  });
-
-  if (_.isEmpty(ownerMembership)) {
-    throw new EntityValidationError({
-      invalidAttributes: [{ attribute: 'ownerId', message: 'OWNER_NOT_IN_ORGANIZATION' }],
+  if (ownerId) {
+    const ownerMembership = await membershipRepository.findByUserIdAndOrganizationId({
+      userId: ownerId,
+      organizationId,
     });
+
+    if (_.isEmpty(ownerMembership)) {
+      throw new EntityValidationError({
+        invalidAttributes: [{ attribute: 'ownerId', message: 'OWNER_NOT_IN_ORGANIZATION' }],
+      });
+    }
   }
 
   if (name !== undefined) campaign.name = name;

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { NotFoundError } from '../../domain/errors.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import { Campaign } from '../../domain/models/Campaign.js';
@@ -40,24 +39,6 @@ const get = async function (id) {
     targetProfile: { id: campaign.targetProfileId },
     creator: { id: campaign.creatorId },
   });
-};
-
-const update = async function (campaign) {
-  const editedAttributes = _.pick(campaign, [
-    'name',
-    'title',
-    'customLandingPageText',
-    'archivedAt',
-    'archivedBy',
-    'ownerId',
-    'customResultPageText',
-    'customResultPageButtonText',
-    'customResultPageButtonUrl',
-  ]);
-
-  const [editedCampaign] = await knex('campaigns').update(editedAttributes).where({ id: campaign.id }).returning('*');
-
-  return new Campaign(editedCampaign);
 };
 
 const checkIfUserOrganizationHasAccessToCampaign = async function (campaignId, userId) {
@@ -146,7 +127,6 @@ const findAllSkills = async function ({ campaignId, domainTransaction }) {
 export {
   getByCode,
   get,
-  update,
   checkIfUserOrganizationHasAccessToCampaign,
   getCampaignTitleByCampaignParticipationId,
   getCampaignCodeByCampaignParticipationId,

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -61,6 +61,30 @@ export const get = async (campaignId) => {
 };
 
 /**
+ * @typedef UpdateCampaignPayload
+ * @type {object}
+ * @property {number} campaignId
+ * @property {string} name
+ */
+
+/**
+ * @function
+ * @name update
+ *
+ * @param {UpdateCampaignPayload} payload
+ * @returns {Promise<Campaign>}
+ */
+export const update = async (payload) => {
+  const campaignToUpdate = {
+    campaignId: payload.campaignId,
+    name: payload.name,
+  };
+
+  const updatedCampaign = await usecases.updateCampaign(campaignToUpdate);
+  return new Campaign(updatedCampaign);
+};
+
+/**
  * @typedef PageDefinition
  * @type {object}
  * @property {number} size

--- a/api/src/prescription/campaign/application/campaign-adminstration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-adminstration-controller.js
@@ -43,8 +43,17 @@ const save = async function (request, h, dependencies = { requestResponseUtils, 
   return h.response(dependencies.campaignReportSerializer.serialize(createdCampaign)).created();
 };
 
+const update = async function (request, _, dependencies = { campaignReportSerializer }) {
+  const campaignId = request.params.id;
+
+  const result = await usecases.updateCampaign({ campaignId, ...request.deserializedPayload });
+
+  return dependencies.campaignReportSerializer.serialize(result);
+};
+
 const campaignAdministrationController = {
   save,
+  update,
   createCampaigns,
 };
 

--- a/api/src/prescription/campaign/domain/usecases/update-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { EntityValidationError } from '../../../src/shared/domain/errors.js';
-import * as campaignValidator from '../validators/campaign-validator.js';
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import * as campaignValidator from '../../../../../lib/domain/validators/campaign-validator.js';
 
 const updateCampaign = async function ({
   campaignId,
@@ -8,10 +8,10 @@ const updateCampaign = async function ({
   title,
   customLandingPageText,
   ownerId,
-  campaignRepository,
+  campaignAdministrationRepository,
   membershipRepository,
 }) {
-  const [campaign] = await campaignRepository.get(campaignId);
+  const campaign = await campaignAdministrationRepository.get(campaignId);
 
   const organizationId = campaign.organizationId;
 
@@ -39,10 +39,10 @@ const updateCampaign = async function ({
     organizationId,
     targetProfileId: _.get(campaign, 'targetProfile.id'),
   };
-  campaignValidator.validate(rawCampaign);
-  await campaignRepository.update(campaign);
 
-  return campaign;
+  campaignValidator.validate(rawCampaign);
+
+  return campaignAdministrationRepository.update(campaign);
 };
 
 export { updateCampaign };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -3,6 +3,27 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import * as skillRepository from '../../../../../lib/infrastructure/repositories/skill-repository.js';
 import { Campaign } from '../../domain/read-models/Campaign.js';
 
+const get = async function (id) {
+  const campaign = await knex('campaigns').where({ id }).first();
+
+  if (!campaign) return null;
+
+  return new Campaign({
+    ...campaign,
+    organization: { id: campaign.organizationId },
+    targetProfile: { id: campaign.targetProfileId },
+    creator: { id: campaign.creatorId },
+  });
+};
+
+const update = async function (campaign) {
+  const editedAttributes = _.pick(campaign, ['name', 'title', 'customLandingPageText', 'ownerId']);
+
+  const [editedCampaign] = await knex('campaigns').update(editedAttributes).where({ id: campaign.id }).returning('*');
+
+  return new Campaign(editedCampaign);
+};
+
 const save = async function (campaigns, dependencies = { skillRepository }) {
   const trx = await knex.transaction();
   const campaignsToCreate = _.isArray(campaigns) ? campaigns : [campaigns];
@@ -56,4 +77,4 @@ const isCodeAvailable = async function (code) {
   return !(await knex('campaigns').first('id').where({ code }));
 };
 
-export { save, isCodeAvailable };
+export { save, update, get, isCodeAvailable };

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -1,4 +1,4 @@
-import { databaseBuilder, domainBuilder, expect, knex, mockLearningContent } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect, mockLearningContent } from '../../../test-helper.js';
 
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import { Campaign } from '../../../../lib/domain/models/Campaign.js';
@@ -216,75 +216,6 @@ describe('Integration | Repository | Campaign', function () {
       const promise = campaignRepository.get(nonExistentId);
       // then
       return expect(promise).to.have.been.rejectedWith(NotFoundError);
-    });
-  });
-
-  describe('#update', function () {
-    let campaign;
-
-    beforeEach(function () {
-      campaign = databaseBuilder.factory.buildCampaign();
-
-      return databaseBuilder.commit();
-    });
-
-    it('should return a Campaign domain object', async function () {
-      // when
-      const campaignSaved = await campaignRepository.update({ id: campaign.id, title: 'Title' });
-
-      // then
-      expect(campaignSaved).to.be.an.instanceof(Campaign);
-    });
-
-    it('should update the correct campaign', async function () {
-      // given
-      const campaignId = databaseBuilder.factory.buildCampaign({ title: 'MASH' }).id;
-      await databaseBuilder.commit();
-
-      // when
-      await campaignRepository.update({ id: campaign.id, title: 'Title' });
-      const row = await knex.from('campaigns').where({ id: campaignId }).first();
-
-      // then
-      expect(row.title).to.equal('MASH');
-    });
-
-    it('should not add row in table "campaigns"', async function () {
-      // given
-      const rowsCountBeforeUpdate = await knex.select('id').from('campaigns');
-      // when
-      await campaignRepository.update({ id: campaign.id, title: 'Title' });
-
-      // then
-      const rowCountAfterUpdate = await knex.select('id').from('campaigns');
-      expect(rowCountAfterUpdate.length).to.equal(rowsCountBeforeUpdate.length);
-    });
-
-    it('should update model in database', async function () {
-      // given
-      const archivedBy = databaseBuilder.factory.buildUser().id;
-      const ownerId = databaseBuilder.factory.buildUser().id;
-      await databaseBuilder.commit();
-
-      // when
-      const campaignSaved = await campaignRepository.update({
-        id: campaign.id,
-        title: 'New title',
-        name: 'New name',
-        customLandingPageText: 'New text',
-        archivedAt: new Date('2020-12-12T06:07:08Z'),
-        archivedBy,
-        ownerId,
-      });
-
-      // then
-      expect(campaignSaved.id).to.equal(campaign.id);
-      expect(campaignSaved.name).to.equal('New name');
-      expect(campaignSaved.title).to.equal('New title');
-      expect(campaignSaved.customLandingPageText).to.equal('New text');
-      expect(campaignSaved.archivedAt).to.deep.equal(new Date('2020-12-12T06:07:08Z'));
-      expect(campaignSaved.archivedBy).to.equal(archivedBy);
-      expect(campaignSaved.ownerId).to.equal(ownerId);
     });
   });
 

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -109,6 +109,36 @@ describe('Unit | API | Campaigns', function () {
     });
   });
 
+  describe('#update', function () {
+    it('should return campaign informations', async function () {
+      const campaignInformation = domainBuilder.buildCampaign({
+        id: '777',
+        code: 'SOMETHING',
+        name: 'Godzilla',
+        title: 'is Biohazard',
+        customLandingPageText: 'Pika pika pikaCHUUUUUUUUUUUUUUUUUU',
+        createdAt: new Date('2020-01-01'),
+        archivedAt: new Date('2023-01-01'),
+      });
+
+      const updateCampaignStub = sinon.stub(usecases, 'updateCampaign');
+      updateCampaignStub
+        .withArgs({ campaignId: campaignInformation.id, name: campaignInformation.name })
+        .resolves(campaignInformation);
+
+      // when
+      const result = await campaignApi.update({
+        campaignId: campaignInformation.id,
+        name: campaignInformation.name,
+        customLandingPageText: 'custom page text',
+      });
+
+      // then
+      expect(result).not.to.be.instanceOf(Campaign);
+      expect(result.customLandingPageText).to.equal(campaignInformation.customLandingPageText);
+    });
+  });
+
   describe('#findAllForOrganization', function () {
     it('should return paginated campaign list from organizationId', async function () {
       const organizationId = Symbol('organizationId');

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-controller_test.js
@@ -148,4 +148,39 @@ describe('Unit | Application | Controller | Campaign administration', function (
       expect(csvSerializerStub.deserializeForCampaignsImport).to.have.been.called;
     });
   });
+
+  describe('#update', function () {
+    it('should return the updated campaign', async function () {
+      // given
+      const request = {
+        auth: { credentials: { userId: 1 } },
+        params: { id: 1 },
+        deserializedPayload: {
+          name: 'New name',
+          title: 'New title',
+          customLandingPageText: 'New text',
+          ownerId: 5,
+        },
+      };
+
+      const updatedCampaign = Symbol('campaign');
+      const updatedCampaignSerialized = Symbol('campaign serialized');
+
+      sinon
+        .stub(usecases, 'updateCampaign')
+        .withArgs({ campaignId: 1, ...request.deserializedPayload })
+        .resolves(updatedCampaign);
+      const campaignReportSerializerStub = {
+        serialize: sinon.stub(),
+      };
+      campaignReportSerializerStub.serialize.withArgs(updatedCampaign).returns(updatedCampaignSerialized);
+      // when
+      const response = await campaignAdministrationController.update(request, hFake, {
+        campaignReportSerializer: campaignReportSerializerStub,
+      });
+
+      // then
+      expect(response).to.deep.equal(updatedCampaignSerialized);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
@@ -17,4 +17,18 @@ describe('Unit | Application | Router | campaign-administration-router ', functi
       expect(response.statusCode).to.equal(201);
     });
   });
+
+  describe('PATCH /api/campaigns/{id}', function () {
+    it('should return 400 with an invalid campaign id', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/campaigns/invalid');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign_test.js
@@ -1,21 +1,19 @@
-import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
-import { updateCampaign } from '../../../../lib/domain/usecases/update-campaign.js';
-import { UserNotAuthorizedToUpdateResourceError } from '../../../../lib/domain/errors.js';
-import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
+import { expect, sinon, catchErr, domainBuilder } from '../../../../../test-helper.js';
+import { updateCampaign } from '../../../../../../src/prescription/campaign/domain/usecases/update-campaign.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Unit | UseCase | update-campaign', function () {
   let originalCampaign;
   let userWithMembership;
   let ownerwithMembership;
-  let campaignRepository, userRepository, membershipRepository;
+  let campaignAdministrationRepository, membershipRepository;
 
   const organizationId = 1;
   const creatorId = 1;
   const ownerId = 2;
 
   beforeEach(function () {
-    userRepository = { getWithMemberships: sinon.stub() };
-    campaignRepository = {
+    campaignAdministrationRepository = {
       get: sinon.stub(),
       update: sinon.stub(),
     };
@@ -44,9 +42,8 @@ describe('Unit | UseCase | update-campaign', function () {
         user: domainBuilder.buildUser({ id: ownerId }),
         organization: { id: organizationId },
       });
-      campaignRepository.get.withArgs(originalCampaign.id).resolves(originalCampaign);
-      campaignRepository.update.callsFake((updatedCampaign) => updatedCampaign);
-      userRepository.getWithMemberships.withArgs(userWithMembership.id).resolves(userWithMembership);
+      campaignAdministrationRepository.get.withArgs(originalCampaign.id).resolves(originalCampaign);
+      campaignAdministrationRepository.update.callsFake((updatedCampaign) => updatedCampaign);
       userWithMembership.hasAccessToOrganization.withArgs(organizationId).returns(true);
       membershipRepository.findByUserIdAndOrganizationId
         .withArgs({ userId: ownerId, organizationId })
@@ -66,13 +63,12 @@ describe('Unit | UseCase | update-campaign', function () {
         campaignId: updatedCampaign.id,
         title: updatedCampaign.title,
         ownerId,
-        userRepository,
-        campaignRepository,
         membershipRepository,
+        campaignAdministrationRepository,
       });
 
       // then
-      expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly(updatedCampaign);
       expect(resultCampaign.title).to.equal(updatedCampaign.title);
       expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
     });
@@ -90,13 +86,12 @@ describe('Unit | UseCase | update-campaign', function () {
         campaignId: updatedCampaign.id,
         ownerId,
         customLandingPageText: updatedCampaign.customLandingPageText,
-        userRepository,
-        campaignRepository,
+        campaignAdministrationRepository,
         membershipRepository,
       });
 
       // then
-      expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly(updatedCampaign);
       expect(resultCampaign.title).to.equal(originalCampaign.title);
       expect(resultCampaign.customLandingPageText).to.equal(updatedCampaign.customLandingPageText);
     });
@@ -110,13 +105,12 @@ describe('Unit | UseCase | update-campaign', function () {
         userId: userWithMembership.id,
         campaignId: updatedCampaign.id,
         ownerId,
-        userRepository,
-        campaignRepository,
+        campaignAdministrationRepository,
         membershipRepository,
       });
 
       // then
-      expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly(updatedCampaign);
       expect(resultCampaign.title).to.equal(originalCampaign.title);
       expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
     });
@@ -135,13 +129,12 @@ describe('Unit | UseCase | update-campaign', function () {
         name: updatedCampaign.name,
         title: originalCampaign.title,
         ownerId,
-        userRepository,
-        campaignRepository,
+        campaignAdministrationRepository,
         membershipRepository,
       });
 
       // then
-      expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly(updatedCampaign);
       expect(resultCampaign.name).to.equal(updatedCampaign.name);
       expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
     });
@@ -167,8 +160,8 @@ describe('Unit | UseCase | update-campaign', function () {
         name: originalCampaign.name,
         title: originalCampaign.title,
         ownerId: updatedCampaign.ownerId,
-        userRepository,
-        campaignRepository,
+
+        campaignAdministrationRepository,
         membershipRepository,
       });
 
@@ -187,13 +180,12 @@ describe('Unit | UseCase | update-campaign', function () {
         name: undefined,
         title: originalCampaign.title,
         ownerId,
-        userRepository,
-        campaignRepository,
+        campaignAdministrationRepository,
         membershipRepository,
       });
 
       // then
-      expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly(updatedCampaign);
       expect(resultCampaign.name).to.equal(originalCampaign.name);
       expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
     });
@@ -210,8 +202,7 @@ describe('Unit | UseCase | update-campaign', function () {
       };
       originalCampaign = domainBuilder.buildCampaign({ organization: { id: organizationId } });
 
-      campaignRepository.get.withArgs(originalCampaign.id).resolves(originalCampaign);
-      userRepository.getWithMemberships.withArgs(userWithMembership.id).resolves(userWithMembership);
+      campaignAdministrationRepository.get.withArgs(originalCampaign.id).resolves(originalCampaign);
       userWithMembership.hasAccessToOrganization.withArgs(organizationId).returns(true);
       membershipRepository.findByUserIdAndOrganizationId
         .withArgs({ userId: ownerWithoutMembership.id, organizationId })
@@ -222,8 +213,7 @@ describe('Unit | UseCase | update-campaign', function () {
         userId: userWithMembership.id,
         campaignId: originalCampaign.id,
         ownerId: ownerWithoutMembership.id,
-        userRepository,
-        campaignRepository,
+        campaignAdministrationRepository,
         membershipRepository,
       });
 

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -288,41 +288,6 @@ describe('Unit | Application | Controller | Campaign', function () {
     });
   });
 
-  describe('#update', function () {
-    it('should return the updated campaign', async function () {
-      // given
-      const request = {
-        auth: { credentials: { userId: 1 } },
-        params: { id: 1 },
-        deserializedPayload: {
-          name: 'New name',
-          title: 'New title',
-          customLandingPageText: 'New text',
-          ownerId: 5,
-        },
-      };
-
-      const updatedCampaign = Symbol('campaign');
-      const updatedCampaignSerialized = Symbol('campaign serialized');
-
-      sinon
-        .stub(usecases, 'updateCampaign')
-        .withArgs({ userId: 1, campaignId: 1, ...request.deserializedPayload })
-        .resolves(updatedCampaign);
-      const campaignReportSerializerStub = {
-        serialize: sinon.stub(),
-      };
-      campaignReportSerializerStub.serialize.withArgs(updatedCampaign).returns(updatedCampaignSerialized);
-      // when
-      const response = await campaignController.update(request, hFake, {
-        campaignReportSerializer: campaignReportSerializerStub,
-      });
-
-      // then
-      expect(response).to.deep.equal(updatedCampaignSerialized);
-    });
-  });
-
   describe('#getCollectiveResult', function () {
     const campaignId = 1;
     const userId = 1;

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -94,20 +94,6 @@ describe('Unit | Application | Router | campaign-router ', function () {
     });
   });
 
-  describe('PATCH /api/campaigns/{id}', function () {
-    it('should return 400 with an invalid campaign id', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/campaigns/invalid');
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-
   describe('PATCH /api/admin/campaigns/{id}', function () {
     it('should return 204', async function () {
       // given

--- a/api/tests/unit/domain/usecases/update-campaign_test.js
+++ b/api/tests/unit/domain/usecases/update-campaign_test.js
@@ -200,30 +200,6 @@ describe('Unit | UseCase | update-campaign', function () {
   });
 
   context('when an error occurred', function () {
-    it('should throw an error when the user does not have an access to the campaign organization', async function () {
-      // given
-      const userWithoutMembership = {
-        id: 1,
-        hasAccessToOrganization: sinon.stub(),
-      };
-      originalCampaign = domainBuilder.buildCampaign({ organization: { id: organizationId } });
-
-      campaignRepository.get.withArgs(originalCampaign.id).resolves(originalCampaign);
-      userRepository.getWithMemberships.withArgs(userWithoutMembership.id).resolves(userWithoutMembership);
-      userWithoutMembership.hasAccessToOrganization.withArgs(organizationId).returns(false);
-
-      // when
-      const error = await catchErr(updateCampaign)({
-        userId: userWithoutMembership.id,
-        campaignId: originalCampaign.id,
-        userRepository,
-        campaignRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToUpdateResourceError);
-    });
-
     it('should throw an error when the owner is not a member of organization', async function () {
       // given
       const ownerWithoutMembership = domainBuilder.buildUser();


### PR DESCRIPTION
## :christmas_tree: Problème
XP Eval a besoin de mettre à jour un nom de campagne mais ce context ne leur appartient pas 

## :gift: Proposition
Ajouter un endpoint update afin de ne pas faire fuiter tout les context métier de la campagne

## :socks: Remarques
Migration d'update dans son BC

## :santa: Pour tester
Vérifier que la mise à jour d'une campagne fonctionne toujours sur PixOrga / PixAdmin