### PR TITLE
[TECH] Ajout de seeds d'une session de certification v3 complétée (PIX-10415)

### DIFF
--- a/api/db/seeds/data/common/tooling/learning-content.js
+++ b/api/db/seeds/data/common/tooling/learning-content.js
@@ -78,6 +78,17 @@ async function _getValidatedChallengesBySkill() {
   return VALIDATED_CHALLENGES_BY_SKILL;
 }
 
+async function getV3CertificationChallenges(count) {
+  const challenges = await getAllChallenges();
+
+  return challenges
+    .filter(
+      ({ status, difficulty, discriminant }) =>
+        status === 'validé' && difficulty !== undefined && discriminant !== undefined,
+    )
+    .slice(0, count);
+}
+
 async function findActiveSkillsByFrameworkName(frameworkName) {
   const allCompetences = await getAllCompetences();
   const competenceIds = _.filter(allCompetences, { origin: frameworkName }).map(({ id }) => id);
@@ -93,4 +104,5 @@ export {
   findFirstValidatedChallengeBySkillId,
   findCompetence,
   findActiveSkillsByFrameworkName,
+  getV3CertificationChallenges,
 };

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -163,7 +163,7 @@ async function createDraftSession({
     version,
   });
 
-  await _registerCandidatesToSession({
+  const certificationCandidates = await _registerCandidatesToSession({
     databaseBuilder,
     sessionId,
     hasJoinSession: false,
@@ -172,7 +172,7 @@ async function createDraftSession({
   });
 
   await databaseBuilder.commit();
-  return { sessionId };
+  return { sessionId, certificationCandidates };
 }
 
 /**
@@ -442,8 +442,10 @@ async function createPublishedScoSession({
  * @param {string} juryComment
  * @param {number} juryCommentAuthorId
  * @param {Date} juryCommentedAt
+ * @param {boolean} makeCandidatesPassCertification
  * @param {string} supervisorPassword
  * @param {candidatesToRegisterCount: number, hasComplementaryCertificationsToRegister : boolean, maxLevel: number, sessionDate: Date } configSession
+ * @param {number} version
  * @returns {sessionId: number} sessionId
  */
 async function createPublishedSession({
@@ -469,8 +471,10 @@ async function createPublishedSession({
   juryComment,
   juryCommentAuthorId,
   juryCommentedAt,
+  makeCandidatesPassCertification = true,
   supervisorPassword,
   configSession,
+  version,
 }) {
   _buildSession({
     databaseBuilder,
@@ -496,6 +500,7 @@ async function createPublishedSession({
     juryCommentAuthorId,
     juryCommentedAt,
     supervisorPassword,
+    version,
   });
   databaseBuilder.factory.buildFinalizedSession({
     sessionId,
@@ -523,17 +528,19 @@ async function createPublishedSession({
     certificationCandidates,
     maxLevel: configSession.maxLevel,
   });
-  await _makeCandidatesPassCertification({
-    databaseBuilder,
-    sessionId,
-    certificationCandidates,
-    coreProfileData,
-    complementaryCertificationsProfileData,
-    configSession,
-  });
+  if (makeCandidatesPassCertification) {
+    await _makeCandidatesPassCertification({
+      databaseBuilder,
+      sessionId,
+      certificationCandidates,
+      coreProfileData,
+      complementaryCertificationsProfileData,
+      configSession,
+    });
+  }
 
   await databaseBuilder.commit();
-  return { sessionId };
+  return { sessionId, certificationCandidates };
 }
 
 async function _registerOrganizationLearnersToSession({


### PR DESCRIPTION
## :christmas_tree: Problème
Lors du développement sur la certification v3, il faut des seeds propres afin d'éviter de devoir passer manuellement une certification.

## :santa: Pour tester
- Ouvrir pix admin
- Aller sur la session de certification 7007
- Aller sur une certification
- Tenter de rejeter puis de valider une certification
- Le scoring fonctionne bien