### PR TITLE
[FEATURE] Créer la page d'atterrissage d'un parcours autonome (PIX-9184).

### DIFF
--- a/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
+++ b/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
@@ -55,9 +55,13 @@ export default async function initUser(databaseBuilder) {
       targetProfileId: AUTONOMOUS_COURSES_ID + i,
       organizationId: specificOrganizationId,
       ownerId: REAL_PIX_SUPER_ADMIN_ID,
-      name: `Parcours autonome n°${i}`,
       code: `AUTOCOURS${i}`,
+      name: `Parcours autonome n°${i}`,
+      title: `Titre principal du parcours autonome n°${i}`,
+      customLandingPageText:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eget tortor ut diam dictum viverra quis at purus. Morbi id quam a massa blandit gravida.',
       createdAt: dayjs().subtract(30, 'days').toDate(),
+      idPixLabel: null,
       configCampaign: {
         participantCount: 0,
       },

--- a/mon-pix/app/components/autonomous-course/landing-page-start-block.hbs
+++ b/mon-pix/app/components/autonomous-course/landing-page-start-block.hbs
@@ -1,0 +1,44 @@
+<section class="autonomous-course-landing-page-start-block rounded-panel">
+  <div class="autonomous-course-landing-page-start-block__logos">
+    <img src="/images/pix-logo.svg" alt="Pix" />
+  </div>
+  <h1 id="autonomous-course-main-title" class="autonomous-course-landing-page-start-block__title">
+    {{t "pages.autonomous-course.landing-page.texts.title"}}<br />
+    {{@campaign.title}}
+  </h1>
+  <p class="autonomous-course-landing-page-start-block__description">
+    {{@campaign.customLandingPageText}}
+  </p>
+  {{#if this.isUserConnected}}
+    <PixButton
+      id="autonomous-course-connected-start-button"
+      class="autonomous-course-landing-page-start-block__connected-start-button"
+      @triggerAction={{@startCampaignParticipation}}
+    >
+      {{t "pages.autonomous-course.landing-page.actions.start-connected"}}
+    </PixButton>
+  {{else}}
+    <div class="autonomous-course-landing-page-start-block__launcher">
+      <p>{{t "pages.autonomous-course.landing-page.texts.first-course"}}</p>
+      <PixButton
+        id="autonomous-course-start-anonymously-button"
+        class="start-anonymously-button"
+        @triggerAction={{@startCampaignParticipation}}
+      >
+        {{t "pages.autonomous-course.landing-page.actions.start-anonymously"}}
+      </PixButton>
+      <p>{{t "common.or"}}</p>
+      <button
+        id="autonomous-course-sign-in-button"
+        class="sign-in-button"
+        type="button"
+        {{on "click" this.redirectToSigninIfUserIsAnonymous}}
+      >
+        {{t "pages.autonomous-course.landing-page.actions.sign-in"}}
+      </button>
+    </div>
+  {{/if}}
+  <p class="autonomous-course-landing-page-start-block__informations">
+    {{t "pages.autonomous-course.landing-page.texts.legal-informations" htmlSafe=true}}
+  </p>
+</section>

--- a/mon-pix/app/components/autonomous-course/landing-page-start-block.js
+++ b/mon-pix/app/components/autonomous-course/landing-page-start-block.js
@@ -1,0 +1,24 @@
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class LandingPageStartBlock extends Component {
+  @service session;
+  @service router;
+
+  get isUserConnected() {
+    return this.session.isAuthenticated;
+  }
+
+  @action
+  async redirectToSigninIfUserIsAnonymous(event) {
+    event.preventDefault();
+
+    if (this.isUserConnected) {
+      this.router.transitionTo('authenticated');
+    } else {
+      const transition = this.args.startCampaignParticipation();
+      this.session.requireAuthenticationAndApprovedTermsOfService(transition);
+    }
+  }
+}

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import ENV from 'mon-pix/config/environment';
 
 export default class CampaignLandingPageController extends Controller {
   @service currentDomain;
@@ -14,6 +15,10 @@ export default class CampaignLandingPageController extends Controller {
 
   get shouldDisplayLanguageSwitcher() {
     return this.isInternationalDomain && this.isUserNotAuthenticated;
+  }
+
+  get isAutonomousCourse() {
+    return this.model.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
   }
 
   get isInternationalDomain() {
@@ -41,6 +46,6 @@ export default class CampaignLandingPageController extends Controller {
 
   @action
   startCampaignParticipation() {
-    this.router.transitionTo('campaigns.access', this.model.code);
+    return this.router.transitionTo('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
 
 export default class EntryPoint extends Route {
   @service currentUser;
@@ -56,9 +57,11 @@ export default class EntryPoint extends Route {
       this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
     }
 
+    const isAutonomousCourse = campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
+
     if (campaign.isArchived && !hasParticipated) {
       this.router.replaceWith('campaigns.archived-error', campaign.code);
-    } else if (hasParticipated) {
+    } else if (hasParticipated && !isAutonomousCourse) {
       this.router.replaceWith('campaigns.entrance', campaign.code);
     } else {
       this.router.replaceWith('campaigns.campaign-landing-page', campaign.code);

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -20,6 +20,7 @@
 /* components */
 @import 'components/authentication/login-or-register-oidc';
 @import 'components/authentication/oidc-reconciliation';
+@import 'components/autonomous-course/landing-page-start-block';
 @import 'components/assessment-banner';
 @import 'components/background-banner';
 @import 'components/badge-card';

--- a/mon-pix/app/styles/components/autonomous-course/_landing-page-start-block.scss
+++ b/mon-pix/app/styles/components/autonomous-course/_landing-page-start-block.scss
@@ -1,0 +1,58 @@
+.autonomous-course-landing-page-start-block {
+  padding: 1.5rem 3rem 2.5rem;
+  text-align: center;
+}
+
+.autonomous-course-landing-page-start-block__logos {
+  display: flex;
+  justify-content: space-between;
+
+  img {
+    height: 5rem;
+  }
+}
+
+.autonomous-course-landing-page-start-block__title {
+  @extend %pix-title-m;
+
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.autonomous-course-landing-page-start-block__description {
+  @extend %pix-body-l;
+
+  margin-top: 1rem;
+  color: $pix-neutral-50;
+}
+
+.autonomous-course-landing-page-start-block__launcher {
+  display: inline-block;
+  margin: 1.5rem 0 2rem;
+  padding: 1.5rem 2rem;
+  background-color: $pix-neutral-10;
+  border-radius: 0.5rem;
+
+  p {
+    @extend %pix-title-xs;
+  }
+
+  .start-anonymously-button {
+    margin: 0.75rem auto 1.25rem;
+  }
+
+  .sign-in-button {
+    margin-top: 0.5rem;
+    color: $pix-primary;
+    font-size: 0.875rem;
+    text-decoration: underline;
+  }
+}
+
+.autonomous-course-landing-page-start-block__connected-start-button {
+  margin: 1.5rem auto 2rem;
+}
+
+.autonomous-course-landing-page-start-block__informations {
+  @extend %pix-body-xs;
+}

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -3,7 +3,14 @@
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <main class="campaign-landing-page__container rounded-panel--over-background-banner" role="main">
-    <CampaignStartBlock @campaign={{@model}} @startCampaignParticipation={{this.startCampaignParticipation}} />
+    {{#if this.isAutonomousCourse}}
+      <AutonomousCourse::LandingPageStartBlock
+        @campaign={{@model}}
+        @startCampaignParticipation={{this.startCampaignParticipation}}
+      />
+    {{else}}
+      <CampaignStartBlock @campaign={{@model}} @startCampaignParticipation={{this.startCampaignParticipation}} />
+    {{/if}}
 
     {{#if @model.isAssessment}}
       <div class="campaign-landing-page__details rounded-panel">

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -168,6 +168,7 @@ module.exports = function (environment) {
     ENV.APP.isTimerCountdownEnabled = false;
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
+    ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
     ENV.metrics.enabled = false;
   }
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -100,6 +100,7 @@ module.exports = function (environment) {
         minValue: 1,
       }),
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
+      AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
     },
 
     fontawesome: {

--- a/mon-pix/mirage/factories/campaign.js
+++ b/mon-pix/mirage/factories/campaign.js
@@ -1,4 +1,5 @@
 import { Factory, trait } from 'miragejs';
+import ENV from 'mon-pix/config/environment';
 
 export default Factory.extend({
   title() {
@@ -67,6 +68,17 @@ export default Factory.extend({
     afterCreate(campaign) {
       campaign.update({
         isRestricted: true,
+      });
+    },
+  }),
+
+  forAutonomousCourse: trait({
+    afterCreate(campaign) {
+      campaign.update({
+        code: 'AUTOCOUR1',
+        organizationId: ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+        title: 'Dummy title',
+        customLandingPageText: 'Dummy landing page text',
       });
     },
   }),

--- a/mon-pix/tests/acceptance/campaigns/campaign-landing-page_test.js
+++ b/mon-pix/tests/acceptance/campaigns/campaign-landing-page_test.js
@@ -11,81 +11,104 @@ module('Acceptance | Campaigns | campaign-landing-page', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks, 'fr');
 
-  let campaign;
+  module('for campaign', function (hooks) {
+    let campaign;
 
-  hooks.beforeEach(function () {
-    campaign = server.create('campaign');
-  });
-
-  module('on international domain (.org)', function () {
-    module('when connected', function () {
-      module('when accessing the campaign landing page with "Français" as default language', function () {
-        test('does not display the language switcher', async function (assert) {
-          // given
-          const user = server.create('user', 'withEmail');
-
-          // when
-          await authenticate(user);
-          const screen = await visit(`/campagnes/${campaign.code}`);
-
-          // then
-          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
-          assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
-          assert.dom(screen.queryByRole('button', { name: 'Français' })).doesNotExist();
-        });
-      });
+    hooks.beforeEach(function () {
+      campaign = server.create('campaign');
     });
 
-    module('when not connected', function () {
-      module('when accessing the fill in campaign code page with "Français" as default language', function () {
-        test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
-          // given & when
-          const screen = await visit(`/campagnes/${campaign.code}`);
+    module('on international domain (.org)', function () {
+      module('when connected', function () {
+        module('when accessing the campaign landing page with "Français" as default language', function () {
+          test('does not display the language switcher', async function (assert) {
+            // given
+            const user = server.create('user', 'withEmail');
 
-          // then
-          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
-          assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
-        });
-
-        module('when the user select "English" language', function () {
-          test('displays the fill in campaign code page with "English" as selected language', async function (assert) {
-            // given & when
+            // when
+            await authenticate(user);
             const screen = await visit(`/campagnes/${campaign.code}`);
-            await click(screen.getByRole('button', { name: 'Français' }));
-            await screen.findByRole('listbox');
-            await click(screen.getByRole('option', { name: 'English' }));
 
             // then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
-            assert.dom(screen.getByRole('button', { name: 'Begin' })).exists();
+            assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
+            assert.dom(screen.queryByRole('button', { name: 'Français' })).doesNotExist();
           });
         });
       });
 
-      module('when accessing the fill in campaign code page with "English" as selected language', function () {
-        test('displays the fill in campaign code page with "English"', async function (assert) {
-          // given && when
-          const screen = await visit(`/campagnes/${campaign.code}?lang=en`);
-
-          // then
-          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
-          assert.dom(screen.getByRole('button', { name: 'Begin' })).exists();
-        });
-
-        module('when the user select "Français" language', function () {
+      module('when not connected', function () {
+        module('when accessing the fill in campaign code page with "Français" as default language', function () {
           test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
             // given & when
-            const screen = await visit(`/campagnes/${campaign.code}?lang=en`);
-            await click(screen.getByRole('button', { name: 'English' }));
-            await screen.findByRole('listbox');
-            await click(screen.getByRole('option', { name: 'Français' }));
+            const screen = await visit(`/campagnes/${campaign.code}`);
 
             // then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
             assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
           });
+
+          module('when the user select "English" language', function () {
+            test('displays the fill in campaign code page with "English" as selected language', async function (assert) {
+              // given & when
+              const screen = await visit(`/campagnes/${campaign.code}`);
+              await click(screen.getByRole('button', { name: 'Français' }));
+              await screen.findByRole('listbox');
+              await click(screen.getByRole('option', { name: 'English' }));
+
+              // then
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+              assert.dom(screen.getByRole('button', { name: 'Begin' })).exists();
+            });
+          });
+        });
+
+        module('when accessing the fill in campaign code page with "English" as selected language', function () {
+          test('displays the fill in campaign code page with "English"', async function (assert) {
+            // given && when
+            const screen = await visit(`/campagnes/${campaign.code}?lang=en`);
+
+            // then
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.dom(screen.getByRole('button', { name: 'Begin' })).exists();
+          });
+
+          module('when the user select "Français" language', function () {
+            test('displays the fill in campaign code page with "Français" as selected language', async function (assert) {
+              // given & when
+              const screen = await visit(`/campagnes/${campaign.code}?lang=en`);
+              await click(screen.getByRole('button', { name: 'English' }));
+              await screen.findByRole('listbox');
+              await click(screen.getByRole('option', { name: 'Français' }));
+
+              // then
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+              assert.dom(screen.getByRole('button', { name: 'Je commence' })).exists();
+            });
+          });
         });
       });
+    });
+  });
+
+  module('for autonomous course', function () {
+    test('should display the autonomous course start block component', async function (assert) {
+      // given
+      const autonomousCourse = server.create('campaign', 'forAutonomousCourse');
+
+      // when
+      const screen = await visit(`/campagnes/${autonomousCourse.code}`);
+
+      // then
+      assert.strictEqual(currentURL(), `/campagnes/${autonomousCourse.code}/presentation`);
+      assert
+        .dom(
+          screen.getByText(
+            `${this.intl.t('pages.autonomous-course.landing-page.texts.title')} ${autonomousCourse.title}`,
+          ),
+        )
+        .exists();
+      assert.dom(screen.getByText('Dummy landing page text')).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/autonomous-course/landing-page-start-block_test.js
+++ b/mon-pix/tests/integration/components/autonomous-course/landing-page-start-block_test.js
@@ -1,0 +1,113 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@1024pix/ember-testing-library';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Autonomous Course | Landing page start block', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display title and custom landing page text', async function (assert) {
+    // given
+    this.set('model', {
+      title: 'dummy landing page title',
+      customLandingPageText: 'dummy landing page text',
+    });
+
+    // when
+    const screen = await render(hbs`<AutonomousCourse::LandingPageStartBlock @campaign={{this.model}} />`);
+
+    // then
+    assert
+      .dom(
+        screen.getByText(`${this.intl.t('pages.autonomous-course.landing-page.texts.title')} dummy landing page title`),
+      )
+      .exists();
+    assert.dom(screen.getByText('dummy landing page text')).exists();
+  });
+
+  module('when user is anonymous', function () {
+    test('should display the launcher block', async function (assert) {
+      // when
+      const screen = await render(hbs`<AutonomousCourse::LandingPageStartBlock />`);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.autonomous-course.landing-page.actions.start-anonymously'),
+          }),
+        )
+        .exists();
+    });
+
+    test('should start campaign participation on main button click', async function (assert) {
+      // given
+      this.set('startCampaignParticipation', sinon.stub());
+
+      // when
+      const screen = await render(
+        hbs`<AutonomousCourse::LandingPageStartBlock @startCampaignParticipation={{this.startCampaignParticipation}} />`,
+      );
+
+      // then
+      await click(
+        screen.getByRole('button', {
+          name: this.intl.t('pages.autonomous-course.landing-page.actions.start-anonymously'),
+        }),
+      );
+      sinon.assert.calledOnce(this.startCampaignParticipation);
+      assert.ok(true);
+    });
+
+    test('should redirect to log-in form on specific button click', async function (assert) {
+      const sessionService = this.owner.lookup('service:session');
+      sessionService.requireAuthenticationAndApprovedTermsOfService = sinon.stub().resolves();
+
+      this.set('startCampaignParticipation', sinon.stub());
+      this.set('redirectToSigninIfUserIsAnonymous', sinon.stub());
+
+      // when
+      const screen = await render(
+        hbs`<AutonomousCourse::LandingPageStartBlock @startCampaignParticipation={{this.startCampaignParticipation}} />`,
+      );
+
+      // then
+      await click(
+        screen.getByRole('button', {
+          name: this.intl.t('pages.autonomous-course.landing-page.actions.sign-in'),
+        }),
+      );
+      sinon.assert.calledOnce(sessionService.requireAuthenticationAndApprovedTermsOfService);
+      assert.ok(true);
+    });
+  });
+
+  module('when user is logged', function () {
+    test('should start campaign participation on main button click', async function (assert) {
+      // given
+      class SessionStub extends Service {
+        isAuthenticated = true;
+      }
+
+      this.owner.register('service:session', SessionStub);
+      this.set('startCampaignParticipation', sinon.stub());
+
+      // when
+      const screen = await render(
+        hbs`<AutonomousCourse::LandingPageStartBlock @startCampaignParticipation={{this.startCampaignParticipation}} />`,
+      );
+
+      // then
+      await click(
+        screen.getByRole('button', {
+          name: this.intl.t('pages.autonomous-course.landing-page.actions.start-connected'),
+        }),
+      );
+      sinon.assert.calledOnce(this.startCampaignParticipation);
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/autonomous-courses/landing-page-start-block_test.js
+++ b/mon-pix/tests/unit/components/autonomous-courses/landing-page-start-block_test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import Service from '@ember/service';
+
+module('Unit | Component | Autonomous Course | Landing page start block', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('autonomous-course/landing-page-start-block');
+    component.args.startCampaignParticipation = sinon.stub().returns('stubbed-transition');
+
+    component.router.transitionTo = sinon.stub();
+  });
+
+  module('#redirectToSigninIfUserIsAnonymous', function () {
+    module('when user is anonymous', function () {
+      test('should redirect to sign-in page on click', async function (assert) {
+        // given
+        const event = {
+          preventDefault: () => {},
+        };
+
+        class SessionStub extends Service {
+          isAuthenticated = false;
+          requireAuthenticationAndApprovedTermsOfService = sinon.stub();
+        }
+        this.owner.register('service:session', SessionStub);
+        const session = this.owner.lookup('service:session');
+
+        // when
+        await component.actions.redirectToSigninIfUserIsAnonymous.call(component, event);
+
+        // then
+        sinon.assert.calledWith(session.requireAuthenticationAndApprovedTermsOfService, 'stubbed-transition');
+        assert.ok(true);
+      });
+    });
+
+    module('when user is authenticated', function () {
+      test('should redirect to next page', async function (assert) {
+        // given
+        const event = {
+          preventDefault: () => {},
+        };
+
+        class SessionStub extends Service {
+          isAuthenticated = true;
+        }
+        this.owner.register('service:session', SessionStub);
+        this.owner.lookup('service:session');
+
+        // when
+        await component.actions.redirectToSigninIfUserIsAnonymous.call(component, event);
+
+        // then
+        sinon.assert.calledWith(component.router.transitionTo, 'authenticated');
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -2,6 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import ENV from 'mon-pix/config/environment';
 
 module('Unit | Route | Entry Point', function (hooks) {
   setupTest(hooks);
@@ -143,6 +144,24 @@ module('Unit | Route | Entry Point', function (hooks) {
             userId: 12,
           })
           .resolves(null);
+
+        //when
+        await route.afterModel(campaign, transition);
+
+        //then
+        sinon.assert.calledWith(route.router.replaceWith, 'campaigns.campaign-landing-page');
+        assert.ok(true);
+      });
+
+      test('should redirect to landing page when campaign is linked to autonomous course organization', async function (assert) {
+        //given
+        route.store.queryRecord
+          .withArgs('campaignParticipation', {
+            campaignId: 3,
+            userId: 12,
+            organizationId: ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+          })
+          .resolves('Existing campaign participation');
 
         //when
         await route.afterModel(campaign, transition);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -293,6 +293,20 @@
         "header": "Your answers"
       }
     },
+    "autonomous-course": {
+      "landing-page": {
+        "actions": {
+          "sign-in": "I have an account, log in to the Pix platform",
+          "start-anonymously": "Begin without a Pix account",
+          "start-connected": "Begin the course"
+        },
+        "texts": {
+          "title": "Start the course:",
+          "first-course": "Is this your first course?",
+          "legal-informations": "With or without a Pix account, information relating to your progress in the customized test will be transmitted to us.'<br>'This information is used by Pix to improve our service. "
+        }
+      }
+    },
     "campaign": {
       "errors": {
         "existing-participation": "You cannot take this customised test.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -293,6 +293,20 @@
         "header": "Vos réponses"
       }
     },
+    "autonomous-course": {
+      "landing-page": {
+        "actions": {
+          "sign-in": "J'ai déjà un compte, je me connecte",
+          "start-anonymously": "Je commence sans compte Pix",
+          "start-connected": "Je commence"
+        },
+        "texts": {
+          "title": "Commencez le parcours :",
+          "first-course": "C'est votre premier parcours Pix ?",
+          "legal-informations": "Avec ou sans compte Pix, les informations relatives à votre avancée dans le parcours nous seront transmises.'<br>'Ces informations sont à l'usage de Pix pour l'amélioration du service."
+        }
+      }
+    },
     "campaign": {
       "errors": {
         "existing-participation": "Le parcours n'est pas accessible pour vous.",


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsque nous cliquons sur un lien de parcours autonome, nous n'avons pas encore de page d'atterrissage spécifique.

## :gift: Proposition

Adapter la page d'atterrissage d'une campagne pour y intégrer notre bloc d'en-tête spécifique.

## :socks: Remarques

- Des ids ont été ajoutées à certains éléments de la page (titre principal, boutons) pour le tracking.

## :santa: Pour tester

- Visiter la page [de la campagne AUTOCOURS1](https://app-pr7699.review.pix.fr/campagnes/AUTOCOURS1/presentation) **en étant connecté** à PixApp **et non-connecté**.
- Possibilité de comparer avec [une campagne "normale"](https://app-pr7699.review.pix.fr/campagnes/EVAL12345/presentation)
- ✅ Vérifier que la landing est bien comme attendue et que les actions présentes fonctionnent bien.