### PR TITLE
[FEATURE] Modification de la traduction "places" en anglais (PIX-10419)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -878,8 +878,8 @@
       }
     },
     "places": {
-      "title":"Places",
-      "before-date":"at"
+      "title":"Seats",
+      "before-date":"on"
     },
     "preselect-target-profile": {
       "title": "Topic selection",


### PR DESCRIPTION
## :christmas_tree: Problème
le texte était `seats on` et non `places at`

## :gift: Proposition
Bah changer la trad quoi

## :socks: Remarques
J'ai bien mangé

## :santa: Pour tester
- Se connecter en tant qu'administrateur d'organisation ayant la feature de gestion de places
- Être sur la version anglaise de l'app
- Aller sur la page `/places`
- Remarquer que la traduction est bien modifiée
- 🎉 