### PR TITLE
[FEATURE] Modification du texte sur l'activation de la feature places d'une organisation (PIX-10413)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -213,7 +213,7 @@
         @checked={{this.form.enablePlacesManagement}}
         @class="form-field__label"
       >
-        Activer la page de Places sur PixOrga
+        Activer la page Places sur PixOrga
       </PixCheckbox>
     </div>
     <div class="form-actions">

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -82,7 +82,7 @@
         <li>Affichage du Net Promoter Score : {{if @organization.showNPS "Oui" "Non"}}</li>
         <li>Activer l'envoi multiple sur les campagnes d'évaluation :
           {{if @organization.enableMultipleSendingAssessment "Oui" "Non"}}</li>
-        <li>Activer la page de Places sur PixOrga :
+        <li>Activer la page Places sur PixOrga :
           {{if @organization.enablePlacesManagement "Oui" "Non"}}</li>
         {{#if @organization.code}}
           <br />

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -125,7 +125,7 @@ module('Integration | Component | organizations/information-section', function (
       await click(screen.getByRole('option', { name: 'organization 2' }));
       await clickByName("Affichage des acquis dans l'export de résultats");
       await clickByName("Activer l'envoi multiple pour les campagnes de type évaluation");
-      await clickByName('Activer la page de Places sur PixOrga');
+      await clickByName('Activer la page Places sur PixOrga');
 
       // when
       await clickByName('Enregistrer');
@@ -139,7 +139,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom(screen.getByRole('link', { name: 'https://pix.fr/' })).exists();
       assert.dom(screen.getByText('SSO : organization 2')).exists();
       assert.dom(screen.getByText("Activer l'envoi multiple sur les campagnes d'évaluation : Oui")).exists();
-      assert.dom(screen.getByText('Activer la page de Places sur PixOrga : Oui')).exists();
+      assert.dom(screen.getByText('Activer la page Places sur PixOrga : Oui')).exists();
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Le texte était : `Activer la page de Place sur PixOrga`

## :gift: Proposition
Le remplacer par : `Activer la page Places sur PixOrga`

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Admin
- Aller sur la page de détail d'une Organisation
- Vérifier le nouveau wording sur le détail
- Vérifier le nouveau wording sur l'édition
- 🐈‍⬛ 
