### PR TITLE
[FEATURE] Utiliser la bonne couleur de fond dans les tag du Pix Score d'une collecte de profil (PIX-10432)

### DIFF
--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -75,7 +75,7 @@
               </td>
               <td class="table__column--center">
                 {{#if profile.sharedAt}}
-                  <PixTag @color="purple" class="pix-score-tag">
+                  <PixTag @color="tertiary" class="pix-score-tag">
                     {{t "pages.profiles-list.table.column.pix-score.value" score=profile.pixScore}}
                   </PixTag>
                 {{/if}}


### PR DESCRIPTION
## :christmas_tree: Problème
Le tag du Pix Score n'est pas lisible actuellement sur le résultat d'une collecte de profil

![image](https://github.com/1024pix/pix/assets/101280231/25d3bdef-f08a-4c3d-9537-9e0d9ca78385)


## :gift: Proposition
Utiliser la couleur de fond : pix-tertiary-100
Utiliser la couleur de fond : pix-tertiary-900

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Orga
- Aller sur la page de résultat d'une campagne de collecte de profil
- Vérifier les couleurs de tag du pix score
- 🐈‍⬛ 
