### PR TITLE
[FEATURE][CERTIF] Permettre à un administrateur de quitter un centre de certification (PIX-8639)

### DIFF
--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -21,16 +21,18 @@
   </td>
   {{#if this.shouldDisplayManagingColumn}}
     <td>
-      {{#if this.shouldDisplayManageMemberRoleButton}}
+      {{#if this.shouldDisplayMemberManageButton}}
         <Dropdown::IconTrigger
           @icon="ellipsis-vertical"
           @dropdownButtonClass="zone-edit-role__dropdown-button"
           @dropdownContentClass="managing-member__dropdown-content"
           @ariaLabel={{t "pages.team.members.actions.manage"}}
         >
-          <Dropdown::Item @onClick={{this.toggleEditionMode}}>
-            {{t "pages.team.members.actions.edit-role"}}
-          </Dropdown::Item>
+          {{#if this.shouldDisplayChangeRoleOption}}
+            <Dropdown::Item @onClick={{this.toggleEditionMode}}>
+              {{t "pages.team.members.actions.edit-role"}}
+            </Dropdown::Item>
+          {{/if}}
         </Dropdown::IconTrigger>
       {{/if}}
       {{#if this.isEditionMode}}

--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -33,6 +33,11 @@
               {{t "pages.team.members.actions.edit-role"}}
             </Dropdown::Item>
           {{/if}}
+          {{#if this.shouldDisplayLeaveCertificationCenterOption}}
+            <Dropdown::Item @onClick={{@onLeaveCertificationCenterButtonClicked}}>
+              {{t "pages.team.members.actions.leave-certification-center"}}
+            </Dropdown::Item>
+          {{/if}}
         </Dropdown::IconTrigger>
       {{/if}}
       {{#if this.isEditionMode}}

--- a/certif/app/components/members-list-item.js
+++ b/certif/app/components/members-list-item.js
@@ -36,7 +36,7 @@ export default class MembersListItem extends Component {
   }
 
   get shouldDisplayMemberManageButton() {
-    return this.shouldDisplayChangeRoleOption;
+    return this.shouldDisplayChangeRoleOption || this.shouldDisplayLeaveCertificationCenterOption;
   }
 
   get shouldDisplayChangeRoleOption() {
@@ -49,6 +49,10 @@ export default class MembersListItem extends Component {
     }
 
     return !this.isEditionMode;
+  }
+
+  get shouldDisplayLeaveCertificationCenterOption() {
+    return this.args.isMultipleAdminsAvailable && this.isCurrentUserMembership;
   }
 
   get isCurrentUserMembership() {

--- a/certif/app/components/members-list-item.js
+++ b/certif/app/components/members-list-item.js
@@ -35,13 +35,19 @@ export default class MembersListItem extends Component {
     return this.currentUser.isAdminOfCurrentCertificationCenter;
   }
 
-  get shouldDisplayManageMemberRoleButton() {
+  get shouldDisplayMemberManageButton() {
+    return this.shouldDisplayChangeRoleOption;
+  }
+
+  get shouldDisplayChangeRoleOption() {
     if (this.isCurrentUserMembership) {
       return false;
     }
+
     if (!this.currentUser.isAdminOfCurrentCertificationCenter) {
       return false;
     }
+
     return !this.isEditionMode;
   }
 

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -17,10 +17,22 @@
         </thead>
         <tbody>
           {{#each @members as |member|}}
-            <MembersListItem @member={{member}} @shouldDisplayRefererColumn={{this.shouldDisplayRefererColumn}} />
+            <MembersListItem
+              @member={{member}}
+              @shouldDisplayRefererColumn={{this.shouldDisplayRefererColumn}}
+              @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}}
+              @onLeaveCertificationCenterButtonClicked={{this.openLeaveCertificationCenterModal}}
+            />
           {{/each}}
         </tbody>
       </table>
     </div>
   </div>
 </div>
+
+<Team::Modal::LeaveCertificationCenter
+  @certificationCenterName={{this.currentUser.currentAllowedCertificationCenterAccess.name}}
+  @isOpen={{this.isLeaveCertificationCenterModalOpen}}
+  @onClose={{this.closeLeaveCertificationCenterModal}}
+  @onSubmit={{this.leaveCertificationCenter}}
+/>

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -4,14 +4,14 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--medium">{{t "common.labels.candidate.lastname"}}</th>
-            <th class="table__column table__column--medium">{{t "common.labels.candidate.firstname"}}</th>
-            <th class="table__column table__column--medium">{{t "common.labels.candidate.role"}}</th>
+            <Table::Header>{{t "common.labels.candidate.lastname"}}</Table::Header>
+            <Table::Header>{{t "common.labels.candidate.firstname"}}</Table::Header>
+            <Table::Header>{{t "common.labels.candidate.role"}}</Table::Header>
             {{#if this.shouldDisplayManagingColumn}}
-              <th class="table__column table__column--medium">{{t "pages.team.table-headers.actions"}}</th>
+              <Table::Header>{{t "pages.team.table-headers.actions"}}</Table::Header>
             {{/if}}
             {{#if this.shouldDisplayRefererColumn}}
-              <th class="table__column table__column--medium">{{t "pages.team.referer"}}</th>
+              <Table::Header>{{t "pages.team.referer"}}</Table::Header>
             {{/if}}
           </tr>
         </thead>

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -1,9 +1,14 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class MembersList extends Component {
   @service featureToggles;
   @service currentUser;
+
+  @tracked
+  isLeaveCertificationCenterModalOpen = false;
 
   get shouldDisplayRefererColumn() {
     return this.args.hasCleaHabilitation;
@@ -16,5 +21,10 @@ export default class MembersList extends Component {
   get isMultipleAdminsAvailable() {
     const adminMembers = this.args.members?.filter((member) => member.isAdmin);
     return adminMembers.length > 1;
+  }
+
+  @action
+  closeLeaveCertificationCenterModal() {
+    this.isLeaveCertificationCenterModalOpen = false;
   }
 }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -24,6 +24,11 @@ export default class MembersList extends Component {
   }
 
   @action
+  openLeaveCertificationCenterModal() {
+    this.isLeaveCertificationCenterModalOpen = true;
+  }
+
+  @action
   closeLeaveCertificationCenterModal() {
     this.isLeaveCertificationCenterModalOpen = false;
   }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -45,6 +45,7 @@ export default class MembersList extends Component {
           certificationCenterName: this.currentUser.currentAllowedCertificationCenterAccess.name,
         }),
       );
+      await this.session.waitBeforeInvalidation(5000);
       this.session.invalidate();
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -4,8 +4,9 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class MembersList extends Component {
-  @service featureToggles;
   @service currentUser;
+  @service featureToggles;
+  @service session;
 
   @tracked
   isLeaveCertificationCenterModalOpen = false;
@@ -37,5 +38,6 @@ export default class MembersList extends Component {
   async leaveCertificationCenter() {
     await this.args.onLeaveCertificationCenter();
     this.closeLeaveCertificationCenterModal();
+    this.session.invalidate();
   }
 }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -12,4 +12,9 @@ export default class MembersList extends Component {
   get shouldDisplayManagingColumn() {
     return this.currentUser.isAdminOfCurrentCertificationCenter;
   }
+
+  get isMultipleAdminsAvailable() {
+    const adminMembers = this.args.members?.filter((member) => member.isAdmin);
+    return adminMembers.length > 1;
+  }
 }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -27,4 +27,9 @@ export default class MembersList extends Component {
   closeLeaveCertificationCenterModal() {
     this.isLeaveCertificationCenterModalOpen = false;
   }
+
+  @action
+  async leaveCertificationCenter() {
+    await this.args.onLeaveCertificationCenter();
+  }
 }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -36,5 +36,6 @@ export default class MembersList extends Component {
   @action
   async leaveCertificationCenter() {
     await this.args.onLeaveCertificationCenter();
+    this.closeLeaveCertificationCenterModal();
   }
 }

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -6,6 +6,8 @@ import { tracked } from '@glimmer/tracking';
 export default class MembersList extends Component {
   @service currentUser;
   @service featureToggles;
+  @service intl;
+  @service notifications;
   @service session;
 
   @tracked
@@ -36,8 +38,20 @@ export default class MembersList extends Component {
 
   @action
   async leaveCertificationCenter() {
-    await this.args.onLeaveCertificationCenter();
-    this.closeLeaveCertificationCenterModal();
-    this.session.invalidate();
+    try {
+      await this.args.onLeaveCertificationCenter();
+      this.notifications.success(
+        this.intl.t('pages.team.members.notifications.leave-certification-center.success', {
+          certificationCenterName: this.currentUser.currentAllowedCertificationCenterAccess.name,
+        }),
+      );
+      this.session.invalidate();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      this.notifications.error(this.intl.t('pages.team.members.notifications.leave-certification-center.error'));
+    } finally {
+      this.closeLeaveCertificationCenterModal();
+    }
   }
 }

--- a/certif/app/components/team/modal/leave-certification-center.hbs
+++ b/certif/app/components/team/modal/leave-certification-center.hbs
@@ -1,0 +1,21 @@
+<PixModal
+  @title={{t "pages.team.members.modals.leave-certification-center.title"}}
+  @showModal={{@isOpen}}
+  @onCloseButtonClick={{@onClose}}
+>
+  <:content>
+    <p class="leave-certification-center-modal">
+      {{t
+        "pages.team.members.modals.leave-certification-center.message"
+        certificationCenterName=@certificationCenterName
+        htmlSafe=true
+      }}
+    </p>
+  </:content>
+  <:footer>
+    <PixButton @triggerAction={{@onClose}} @backgroundColor="transparent-light" @isBorderVisible={{true}}>{{t
+        "common.actions.cancel"
+      }}</PixButton>
+    <PixButton @triggerAction={{@onSubmit}} @backgroundColor="error">{{t "common.actions.confirm"}}</PixButton>
+  </:footer>
+</PixModal>

--- a/certif/app/controllers/authenticated/team/list/members.js
+++ b/certif/app/controllers/authenticated/team/list/members.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class AuthenticatedTeamListMembersController extends Controller {
+  @service currentUser;
+  @service store;
+
+  @action
+  async leaveCertificationCenter() {
+    await this.currentUser.currentCertificationCenterMembership.destroyRecord();
+  }
+}

--- a/certif/app/models/member.js
+++ b/certif/app/models/member.js
@@ -20,6 +20,10 @@ export default class Member extends Model {
     return this.certificationCenterMembersRole[this.role];
   }
 
+  get isAdmin() {
+    return this.role === 'ADMIN';
+  }
+
   updateReferer = memberAction({
     type: 'post',
     urlType: 'update-referer',

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import { FRENCH_INTERNATIONAL_LOCALE, FRENCH_FRANCE_LOCALE } from 'pix-certif/services/locale';
+import { later } from '@ember/runloop';
 
 export default class CurrentSessionService extends SessionService {
   @service currentDomain;
@@ -49,5 +50,11 @@ export default class CurrentSessionService extends SessionService {
 
     const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
     this.locale.setLocale(locale);
+  }
+
+  waitBeforeInvalidation(millisecondsToWait) {
+    return new Promise((resolve) => {
+      later(() => resolve(), millisecondsToWait);
+    });
   }
 }

--- a/certif/app/templates/authenticated/team/list/members.hbs
+++ b/certif/app/templates/authenticated/team/list/members.hbs
@@ -1,1 +1,5 @@
-<MembersList @members={{@model.members}} @hasCleaHabilitation={{@model.hasCleaHabilitation}} />
+<MembersList
+  @members={{@model.members}}
+  @hasCleaHabilitation={{@model.hasCleaHabilitation}}
+  @onLeaveCertificationCenter={{this.leaveCertificationCenter}}
+/>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -352,6 +352,7 @@ function routes() {
   this.patch('/sessions/:id/candidates/:candidateId/dismiss-live-alert', () => new Response(204));
 
   _configureCertificationCenterInvitationRoutes(this);
+  _configureCertificationCenterMemberRoutes(this);
 }
 
 function _configureCertificationCenterInvitationRoutes(context) {
@@ -404,6 +405,14 @@ function _configureCertificationCenterInvitationRoutes(context) {
 
     certificationPointOfContact.update({ allowedCertificationCenterAccesses: [allowedCertificationCenterAccess] });
 
+    return new Response(204);
+  });
+}
+
+function _configureCertificationCenterMemberRoutes(context) {
+  context.post('/certification-centers/:certificationCenterId/members/me/disable', (schema, request) => {
+    const member = schema.members.first();
+    member.destroy();
     return new Response(204);
   });
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -410,7 +410,7 @@ function _configureCertificationCenterInvitationRoutes(context) {
 }
 
 function _configureCertificationCenterMemberRoutes(context) {
-  context.post('/certification-centers/:certificationCenterId/members/me/disable', (schema, request) => {
+  context.delete('/certification-center-memberships/:id', (schema) => {
     const member = schema.members.first();
     member.destroy();
     return new Response(204);

--- a/certif/tests/acceptance/team/list/invitations_test.js
+++ b/certif/tests/acceptance/team/list/invitations_test.js
@@ -1,14 +1,14 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import setupIntl from '../../../helpers/setup-intl';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import {
   authenticateSession,
   createCertificationPointOfContactWithTermsOfServiceAccepted,
 } from '../../../helpers/test-init';
-import { clickByName, visit } from '@1024pix/ember-testing-library';
+import setupIntl from '../../../helpers/setup-intl';
 
 module('Acceptance | Team | Invitations', function (hooks) {
   setupApplicationTest(hooks);
@@ -124,8 +124,6 @@ module('Acceptance | Team | Invitations', function (hooks) {
         await clickByName(this.intl.t('pages.team-invitations.actions.resend-invitation'));
 
         // then
-        assert.dom(screen.getByRole('cell', { name: 'medhi.khaman@example.net' })).exists();
-        assert.dom(screen.getByRole('cell', { name: '05/12/2023 - 11:35' })).exists();
         assert.dom(screen.getByText("L'invitation a bien été renvoyée.")).exists();
       });
 
@@ -136,7 +134,7 @@ module('Acceptance | Team | Invitations', function (hooks) {
             id: 15,
             certificationCenterId: 1,
             email: 'anna.liz@example.net',
-            updatedAt: new Date('2023-11-30'),
+            updatedAt: new Date(),
           });
           this.server.patch('/certification-center-invitations/15', () => new Response(500));
 

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -40,7 +40,7 @@ module('Acceptance | authenticated | team', function (hooks) {
       assert.dom(screen.getByRole('cell', { name: 'Lee' })).exists();
       assert.dom(screen.getByRole('cell', { name: 'Tige' })).exists();
 
-      assert.dom(screen.getByRole('link', { name: 'Membres (2)' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Membres (3)' })).exists();
       assert.dom(screen.getByRole('link', { name: 'Invitations (-)' })).exists();
 
       assert.dom(screen.getByText(this.intl.t('pages.team.invite-button'))).exists();
@@ -171,7 +171,7 @@ module('Acceptance | authenticated | team', function (hooks) {
                     false,
                     'ADMIN',
                   );
-                  server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false, role: 'ADMIN' });
+                  server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false, role: 'MEMBER' });
                   server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
                   await authenticateSession(certificationPointOfContact.id);
 
@@ -190,12 +190,11 @@ module('Acceptance | authenticated | team', function (hooks) {
                   );
 
                   // then
-                  const row = within(await screen.findByRole('row', { name: 'Membres du centre de certification' }));
-                  assert.dom(row.getByRole('cell', { name: 'Dupont' })).exists();
-                  assert.dom(row.getByRole('cell', { name: 'Lili' })).exists();
-                  assert.dom(row.getByRole('cell', { name: 'Administrateur' })).exists();
+                  assert.dom(screen.getByRole('cell', { name: 'Dupont' })).exists();
+                  assert.dom(screen.getByRole('cell', { name: 'Lili' })).exists();
+                  assert.dom(screen.getByRole('cell', { name: 'Membre' })).exists();
                   assert.dom(await screen.findByText('Un nouveau référent CléA Numérique a été nommé.')).exists();
-                  assert.dom(await row.findByRole('cell', { name: 'Référent CléA Numérique' })).exists();
+                  assert.dom(await screen.findByRole('cell', { name: 'Référent CléA Numérique' })).exists();
                 });
               });
             });
@@ -209,8 +208,8 @@ module('Acceptance | authenticated | team', function (hooks) {
                 'CCNG',
                 false,
                 'ADMIN',
+                true,
               );
-              server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
               server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
               await authenticateSession(certificationPointOfContact.id);
 
@@ -228,8 +227,8 @@ module('Acceptance | authenticated | team', function (hooks) {
                 'CCNG',
                 false,
                 'ADMIN',
+                true,
               );
-              server.create('member', { firstName: 'Jamal', lastName: 'Opié', isReferer: true });
               server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
               await authenticateSession(certificationPointOfContact.id);
 

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -14,6 +14,7 @@ import {
 } from '../../../helpers/test-init';
 import setupIntl from '../../../helpers/setup-intl';
 import { waitForDialog, waitForDialogClose } from '../../../helpers/wait-for';
+import sinon from 'sinon';
 
 module('Acceptance | authenticated | team', function (hooks) {
   setupApplicationTest(hooks);
@@ -333,6 +334,9 @@ module('Acceptance | authenticated | team', function (hooks) {
       module('when user wants to leave the certification center', function () {
         test('leaves the certification center, displays a success notification and disconnects the user', async function (assert) {
           // given
+          const session = this.owner.lookup('service:session');
+          sinon.stub(session, 'waitBeforeInvalidation');
+
           const leavingAdminUser = createCertificationPointOfContactWithTermsOfServiceAccepted(
             undefined,
             'Shelltif',

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -13,6 +13,7 @@ export function createCertificationPointOfContact(
   isRelatedOrganizationManagingStudents = false,
   certificationCenterCount = 1,
   certificationCenterRole = 'MEMBER',
+  isCertificationPointOfContactReferer = false,
 ) {
   const allowedCertificationCenterAccesses = _createCertificationCenters(certificationCenterCount, {
     certificationCenterName,
@@ -30,12 +31,22 @@ export function createCertificationPointOfContact(
     role: certificationCenterRole,
   });
 
-  return createCertificationPointOfContactWithCustomCenters({
+  const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
     certificationCenterRole,
     certificationCenterMemberships,
   });
+
+  _createCertificationCenterMember({
+    id: certificationPointOfContact.id,
+    firstName: certificationPointOfContact.firstName,
+    lastName: certificationPointOfContact.lastName,
+    role: certificationCenterRole,
+    isReferer: isCertificationPointOfContactReferer,
+  });
+
+  return certificationPointOfContact;
 }
 
 export function createCertificationPointOfContactWithCustomCenters({
@@ -51,6 +62,16 @@ export function createCertificationPointOfContactWithCustomCenters({
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
     certificationCenterMemberships,
+  });
+}
+
+function _createCertificationCenterMember({ role, firstName, lastName, id, isReferer }) {
+  return server.create('member', {
+    id,
+    role,
+    firstName,
+    lastName,
+    isReferer,
   });
 }
 
@@ -107,6 +128,7 @@ export function createCertificationPointOfContactWithTermsOfServiceAccepted(
   certificationCenterName = 'Centre de certification du pix',
   isRelatedOrganizationManagingStudents = false,
   certificationCenterRole = 'MEMBER',
+  isCertificationPointOfContactReferer = false,
 ) {
   return createCertificationPointOfContact(
     true,
@@ -115,6 +137,7 @@ export function createCertificationPointOfContactWithTermsOfServiceAccepted(
     isRelatedOrganizationManagingStudents,
     1,
     certificationCenterRole,
+    isCertificationPointOfContactReferer,
   );
 }
 

--- a/certif/tests/helpers/wait-for.js
+++ b/certif/tests/helpers/wait-for.js
@@ -13,3 +13,16 @@ export async function waitForDialogClose() {
     }
   });
 }
+
+export async function waitForDialog() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/certif/tests/integration/components/members-list-item_test.js
+++ b/certif/tests/integration/components/members-list-item_test.js
@@ -156,6 +156,62 @@ module('Integration | Component | MembersListItem', function (hooks) {
             // then
             assert.dom(screen.getByRole('button', { name: this.intl.t('pages.team.members.actions.manage') })).exists();
           });
+
+          module('when clicking on manage button', function () {
+            test('displays a dropdown with one option to leave the current certification center', async function (assert) {
+              // given
+              const memberWithAdminRole = store.createRecord('member', {
+                id: 123,
+                firstName: 'John',
+                lastName: 'Williams',
+                role: 'ADMIN',
+              });
+              this.set('member', memberWithAdminRole);
+              this.set('isMultipleAdminsAvailable', true);
+              this.set('leaveCertificationCenter', sinon.stub());
+              sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithAdminRole.id });
+
+              const screen = await renderScreen(
+                hbs`<MembersListItem @member={{this.member}} @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}} @onLeaveCertificationCenterButtonClicked={{this.leaveCertificationCenter}} />`,
+              );
+
+              // when
+              await clickByName('Gérer');
+
+              // then
+              assert.dom(screen.getByRole('list')).exists();
+              assert.strictEqual(screen.getAllByRole('listitem').length, 1);
+              assert.dom(screen.getByText('Quitter cet espace Pix Certif')).exists();
+            });
+
+            module('when clicking on "Quitter cet espace Pix Certif"', function () {
+              test('calls the onLeaveCertificationCenterButtonClicked event handler', async function (assert) {
+                // given
+                const memberWithAdminRole = store.createRecord('member', {
+                  id: 123,
+                  firstName: 'John',
+                  lastName: 'Williams',
+                  role: 'ADMIN',
+                });
+                const leaveCertificationCenter = sinon.stub();
+                this.set('member', memberWithAdminRole);
+                this.set('isMultipleAdminsAvailable', true);
+                this.set('leaveCertificationCenter', leaveCertificationCenter);
+                sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithAdminRole.id });
+
+                await renderScreen(
+                  hbs`<MembersListItem @member={{this.member}} @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}} @onLeaveCertificationCenterButtonClicked={{this.leaveCertificationCenter}} />`,
+                );
+
+                // when
+                await clickByName('Gérer');
+                await clickByName('Quitter cet espace Pix Certif');
+
+                // then
+                assert.true(leaveCertificationCenter.calledOnce);
+              });
+            });
+          });
         });
       });
     });

--- a/certif/tests/integration/components/members-list-item_test.js
+++ b/certif/tests/integration/components/members-list-item_test.js
@@ -134,6 +134,29 @@ module('Integration | Component | MembersListItem', function (hooks) {
               .doesNotExist();
           });
         });
+
+        module('and is not the only admin in the certification center', function () {
+          test('shows manage button', async function (assert) {
+            // given
+            const memberWithAdminRole = store.createRecord('member', {
+              id: 123,
+              firstName: 'John',
+              lastName: 'Williams',
+              role: 'ADMIN',
+            });
+            this.set('member', memberWithAdminRole);
+            this.set('isMultipleAdminsAvailable', true);
+            sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithAdminRole.id });
+
+            // when
+            const screen = await renderScreen(
+              hbs`<MembersListItem @member={{this.member}} @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}} />`,
+            );
+
+            // then
+            assert.dom(screen.getByRole('button', { name: this.intl.t('pages.team.members.actions.manage') })).exists();
+          });
+        });
       });
     });
 

--- a/certif/tests/integration/components/members-list-item_test.js
+++ b/certif/tests/integration/components/members-list-item_test.js
@@ -107,27 +107,32 @@ module('Integration | Component | MembersListItem', function (hooks) {
       });
 
       module('when member is the connected user', function () {
-        test('it shows member firstName, lastName, role but does not show manage button', async function (assert) {
-          // given
-          const memberWithMemberRole = store.createRecord('member', {
-            id: 123,
-            firstName: 'John',
-            lastName: 'Williams',
-            role: 'MEMBER',
+        module('and is the only admin in the certification center', function () {
+          test('it shows member firstName, lastName, role but does not show manage button', async function (assert) {
+            // given
+            const memberWithMemberRole = store.createRecord('member', {
+              id: 123,
+              firstName: 'John',
+              lastName: 'Williams',
+              role: 'MEMBER',
+            });
+            this.set('member', memberWithMemberRole);
+            this.set('isMultipleAdminsAvailable', false);
+            sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithMemberRole.id });
+
+            // when
+            const screen = await renderScreen(
+              hbs`<MembersListItem @member={{this.member}} @isMultipleAdminsAvailable={{this.isMultipleAdminsAvailable}} />`,
+            );
+
+            // then
+            assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+            assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
+            assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.member') })).exists();
+            assert
+              .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.members.actions.manage') }))
+              .doesNotExist();
           });
-          this.set('member', memberWithMemberRole);
-          sinon.stub(currentUser, 'certificationPointOfContact').value({ id: memberWithMemberRole.id });
-
-          // when
-          const screen = await renderScreen(hbs`<MembersListItem @member={{this.member}} />`);
-
-          // then
-          assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
-          assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
-          assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.members.role.member') })).exists();
-          assert
-            .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.members.actions.manage') }))
-            .doesNotExist();
         });
       });
     });

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -1,8 +1,11 @@
 import { module, test } from 'qunit';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { click } from '@ember/test-helpers';
+
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { waitForDialog, waitForDialogClose } from '../../helpers/wait-for';
 
 module('Integration | Component | MembersList', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -131,6 +134,101 @@ module('Integration | Component | MembersList', function (hooks) {
 
       // then
       assert.dom(screen.queryByRole('columnheader', { name: this.intl.t('pages.team.referer') })).doesNotExist();
+    });
+  });
+
+  module('when the connected user is not the only admin of the certification center', function () {
+    module('when clicking on "Quitter cet espace Pix Certif"', function (hooks) {
+      hooks.beforeEach(function () {
+        const connectedUserWithAdminRole = store.createRecord('member', {
+          id: 1,
+          firstName: 'Jacques',
+          lastName: 'Ouzi',
+          role: 'ADMIN',
+        });
+        const memberWithAdminRole = store.createRecord('member', {
+          id: 2,
+          firstName: 'Annie',
+          lastName: 'Versaire',
+          role: 'ADMIN',
+        });
+        const memberWithMemberRole = store.createRecord('member', {
+          id: 3,
+          firstName: 'Franck',
+          lastName: 'Ofone',
+          role: 'MEMBER',
+        });
+        const members = [connectedUserWithAdminRole, memberWithAdminRole, memberWithMemberRole];
+
+        sinon.stub(currentUser, 'certificationPointOfContact').value({ id: connectedUserWithAdminRole.id });
+        sinon.stub(currentUser, 'isAdminOfCurrentCertificationCenter').value(true);
+        sinon.stub(currentUser, 'currentAllowedCertificationCenterAccess').value({ name: 'Certif NextGen' });
+
+        this.set('members', members);
+      });
+
+      test('displays a modal', async function (assert) {
+        // given
+        const screen = await renderScreen(hbs`<MembersList @members={{this.members}}/>`);
+
+        await click(screen.getAllByRole('button', { name: 'Gérer' })[0]);
+
+        // when
+        await clickByName('Quitter cet espace Pix Certif');
+        await waitForDialog();
+
+        // then
+        assert.dom(screen.getByRole('heading', { level: 1, name: 'Quitter cet espace Pix Certif' })).exists();
+        assert.dom(screen.getByText('Certif NextGen')).exists();
+      });
+
+      module('when leave certification center modal is displayed', function () {
+        module('when clicking on "Annuler" button', function () {
+          test('closes the modal', async function (assert) {
+            // given
+            const screen = await renderScreen(hbs`<MembersList @members={{this.members}}/>`);
+
+            await click(screen.getAllByRole('button', { name: 'Gérer' })[0]);
+            await clickByName('Quitter cet espace Pix Certif');
+            await waitForDialog();
+
+            // when
+            await clickByName('Annuler');
+            await waitForDialogClose();
+
+            // then
+            assert
+              .dom(screen.queryByRole('heading', { level: 1, name: 'Quitter cet espace Pix Certif' }))
+              .doesNotExist();
+          });
+        });
+
+        module('when clicking on "Confirmer" button', function () {
+          test('calls "onLeaveCertificationCenter" event handler and closes the modal', async function (assert) {
+            // given
+            const onLeaveCertificationCenter = sinon.stub();
+            this.set('onLeaveCertificationCenter', onLeaveCertificationCenter);
+
+            const screen = await renderScreen(
+              hbs`<MembersList @members={{this.members}} @onLeaveCertificationCenter={{this.onLeaveCertificationCenter}}/>`,
+            );
+
+            await click(screen.getAllByRole('button', { name: 'Gérer' })[0]);
+            await clickByName('Quitter cet espace Pix Certif');
+            await waitForDialog();
+
+            // when
+            await clickByName('Confirmer');
+            await waitForDialogClose();
+
+            // then
+            assert
+              .dom(screen.queryByRole('heading', { level: 1, name: 'Quitter cet espace Pix Certif' }))
+              .doesNotExist();
+            assert.true(onLeaveCertificationCenter.calledOnce);
+          });
+        });
+      });
     });
   });
 });

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -208,6 +208,8 @@ module('Integration | Component | MembersList', function (hooks) {
             // given
             const onLeaveCertificationCenter = sinon.stub();
             this.set('onLeaveCertificationCenter', onLeaveCertificationCenter);
+            const session = this.owner.lookup('service:session');
+            sinon.stub(session, 'waitBeforeInvalidation');
 
             const screen = await renderScreen(
               hbs`<MembersList @members={{this.members}} @onLeaveCertificationCenter={{this.onLeaveCertificationCenter}}/>`,
@@ -222,6 +224,7 @@ module('Integration | Component | MembersList', function (hooks) {
             await waitForDialogClose();
 
             // then
+            sinon.assert.called(session.waitBeforeInvalidation);
             assert
               .dom(screen.queryByRole('heading', { level: 1, name: 'Quitter cet espace Pix Certif' }))
               .doesNotExist();

--- a/certif/tests/integration/components/team/modal/leave-certification-center_test.js
+++ b/certif/tests/integration/components/team/modal/leave-certification-center_test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Components | Team::Modal::LeaveCertificationCenter', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when the modal is open', function (hooks) {
+    let screen;
+    let closeModal, leaveCertificationCenter;
+
+    hooks.beforeEach(async function () {
+      closeModal = sinon.stub();
+      leaveCertificationCenter = sinon.stub();
+
+      this.set('certificationCenterName', 'Havana Certification');
+      this.set('isOpen', true);
+      this.set('leaveCertificationCenter', leaveCertificationCenter);
+      this.set('closeModal', closeModal);
+
+      screen = await render(
+        hbs`<Team::Modal::LeaveCertificationCenter @certificationCenterName={{this.certificationCenterName}} @isOpen={{this.isOpen}} @onSubmit={{this.leaveCertificationCenter}} @onClose={{this.closeModal}} />`,
+      );
+    });
+
+    test('displays modal content', function (assert) {
+      // then
+      assert.dom(screen.getByRole('heading', { level: 1, name: 'Quitter cet espace Pix Certif' })).exists();
+      assert.dom(screen.getByText('Havana Certification')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Confirmer' })).exists();
+    });
+
+    module('when clicking on "Confirm" button', function () {
+      test('calls "onSubmit" function', async function (assert) {
+        // when
+        await clickByName('Confirmer');
+
+        // then
+        assert.true(leaveCertificationCenter.calledOnce);
+      });
+    });
+
+    module('when clicking on "Cancel" button', function () {
+      test('calls "onClose" button', async function (assert) {
+        // when
+        await clickByName('Annuler');
+
+        // then
+        assert.true(closeModal.calledOnce);
+      });
+    });
+  });
+});

--- a/certif/tests/unit/components/members-list_test.js
+++ b/certif/tests/unit/components/members-list_test.js
@@ -72,4 +72,19 @@ module('Unit | Component | MembersList', (hooks) => {
       });
     });
   });
+
+  module.only('Methods', function () {
+    module('#closeLeaveCertificationCenterModal', function () {
+      test('sets "isLeaveCertificationCenterModalOpen" value to "false"', function (assert) {
+        // given
+        component.isLeaveCertificationCenterModalOpen = true;
+
+        // when
+        component.closeLeaveCertificationCenterModal();
+
+        // then
+        assert.false(component.isLeaveCertificationCenterModalOpen);
+      });
+    });
+  });
 });

--- a/certif/tests/unit/components/members-list_test.js
+++ b/certif/tests/unit/components/members-list_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import setupIntl from '../../helpers/setup-intl';
@@ -73,7 +74,7 @@ module('Unit | Component | MembersList', (hooks) => {
     });
   });
 
-  module.only('Methods', function () {
+  module('Methods', function () {
     module('#closeLeaveCertificationCenterModal', function () {
       test('sets "isLeaveCertificationCenterModalOpen" value to "false"', function (assert) {
         // given
@@ -84,6 +85,20 @@ module('Unit | Component | MembersList', (hooks) => {
 
         // then
         assert.false(component.isLeaveCertificationCenterModalOpen);
+      });
+    });
+
+    module('#leaveCertificationCenter', function () {
+      test('calls parent component onLeaveCertificationCenter event handler', async function (assert) {
+        // given
+        const onLeaveCertificationCenter = sinon.stub().resolves();
+        component.args.onLeaveCertificationCenter = onLeaveCertificationCenter;
+
+        // when
+        await component.leaveCertificationCenter();
+
+        // then
+        assert.true(onLeaveCertificationCenter.calledOnce);
       });
     });
   });

--- a/certif/tests/unit/components/members-list_test.js
+++ b/certif/tests/unit/components/members-list_test.js
@@ -101,5 +101,18 @@ module('Unit | Component | MembersList', (hooks) => {
         assert.true(onLeaveCertificationCenter.calledOnce);
       });
     });
+
+    module('#openLeaveCertificationCenterModal', function () {
+      test('sets "isLeaveCertificationCenterModalOpen" value to "true"', function (assert) {
+        // given
+        component.isLeaveCertificationCenterModalOpen = false;
+
+        // when
+        component.openLeaveCertificationCenterModal();
+
+        // then
+        assert.true(component.isLeaveCertificationCenterModalOpen);
+      });
+    });
   });
 });

--- a/certif/tests/unit/components/members-list_test.js
+++ b/certif/tests/unit/components/members-list_test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Component | MembersList', (hooks) => {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  let component, store;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:members-list');
+    store = this.owner.lookup('service:store');
+  });
+
+  module('Getters', function () {
+    module('#isMultipleAdminsAvailable', () => {
+      module('when there is multiple members with the role "ADMIN"', function () {
+        test('returns true', function (assert) {
+          // given
+          component.args.members = [
+            store.createRecord('member', {
+              id: 1,
+              firstName: 'Éva',
+              lastName: 'Kué',
+              role: 'ADMIN',
+            }),
+            store.createRecord('member', {
+              id: 2,
+              firstName: 'Matt',
+              lastName: 'Ematic',
+              role: 'ADMIN',
+            }),
+            store.createRecord('member', {
+              id: 3,
+              firstName: 'Harry',
+              lastName: 'Coe',
+              role: 'MEMBER',
+            }),
+          ];
+
+          // when
+          // then
+          assert.true(component.isMultipleAdminsAvailable);
+        });
+      });
+
+      module('when there is one member with the role "ADMIN"', function () {
+        test('returns false', function (assert) {
+          // given
+          component.args.members = [
+            store.createRecord('member', {
+              id: 1,
+              firstName: 'Jean',
+              lastName: 'Tourloupe',
+              role: 'ADMIN',
+            }),
+            store.createRecord('member', {
+              id: 2,
+              firstName: 'Éva',
+              lastName: 'Noui',
+              role: 'MEMBER',
+            }),
+          ];
+
+          // when
+          // then
+          assert.false(component.isMultipleAdminsAvailable);
+        });
+      });
+    });
+  });
+});

--- a/certif/tests/unit/components/members-list_test.js
+++ b/certif/tests/unit/components/members-list_test.js
@@ -100,6 +100,44 @@ module('Unit | Component | MembersList', (hooks) => {
         // then
         assert.true(onLeaveCertificationCenter.calledOnce);
       });
+
+      module('when connected user leaves the certification center ', function () {
+        test('calls notifications service to display a success message', async function (assert) {
+          // given
+          const notifications = this.owner.lookup('service:notifications');
+          sinon.stub(notifications, 'success');
+          const currentUser = this.owner.lookup('service:current-user');
+          sinon.stub(currentUser, 'currentAllowedCertificationCenterAccess').value({ name: 'Shertif' });
+          const onLeaveCertificationCenter = sinon.stub().resolves();
+          component.args.onLeaveCertificationCenter = onLeaveCertificationCenter;
+
+          // when
+          await component.leaveCertificationCenter();
+
+          // then
+          assert.true(
+            notifications.success.calledOnceWith(
+              'Votre accès a été supprimé avec succès du centre de certification Shertif. Vous allez être déconnecté de Pix Certif...',
+            ),
+          );
+        });
+      });
+
+      module('when an error occurs', function () {
+        test('calls notifications service to display an error message', async function (assert) {
+          // given
+          const notifications = this.owner.lookup('service:notifications');
+          sinon.stub(notifications, 'error');
+          const onLeaveCertificationCenter = sinon.stub().rejects(new Error());
+          component.args.onLeaveCertificationCenter = onLeaveCertificationCenter;
+
+          // when
+          await component.leaveCertificationCenter();
+
+          // then
+          assert.true(notifications.error.calledOnceWith('Une erreur est survenue lors de la suppression du membre.'));
+        });
+      });
     });
 
     module('#openLeaveCertificationCenterModal', function () {

--- a/certif/tests/unit/controllers/authenticated/team/list/members_test.js
+++ b/certif/tests/unit/controllers/authenticated/team/list/members_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+import setupIntl from '../../../../../helpers/setup-intl';
+
+module('Unit | Controller | authenticated/team/list/members', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/team/list/members');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('#leaveCertificationCenter', function () {
+    test('deletes the current user membership', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      sinon.stub(currentUser, 'currentCertificationCenterMembership').value({
+        destroyRecord: sinon.stub(),
+      });
+
+      // when
+      await controller.leaveCertificationCenter();
+
+      // then
+      assert.true(currentUser.currentCertificationCenterMembership.destroyRecord.calledWith());
+    });
+  });
+});

--- a/certif/tests/unit/models/member_test.js
+++ b/certif/tests/unit/models/member_test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Model | Member', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#isAdmin', function () {
+    module('when member has role "ADMIN"', function () {
+      test('returns true', function (assert) {
+        // given
+        const member = store.createRecord('member', { role: 'ADMIN' });
+
+        // when
+        // then
+        assert.true(member.isAdmin);
+      });
+    });
+
+    module('when member does not have the role "ADMIN"', function () {
+      test('returns false', function (assert) {
+        // given
+        const member = store.createRecord('member', { role: 'MEMBER' });
+
+        // when
+        // then
+        assert.false(member.isAdmin);
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -871,6 +871,12 @@
             }
           }
         },
+        "modals": {
+          "leave-certification-center": {
+            "title": "Leave this Pix Certif space",
+            "message": "Are you sure you want to leave this Pix Certif space? You will no longer have access to <strong>{certificationCenterName}</strong>.<br/><br/>Your sessions remain accessible to the rest of the team.<br/><br/>Your access to other Pix Certif spaces will not be affected.<br/><br/>You'll be disconnected."
+          }
+        },
         "notifications": {
           "change-member-role": {
             "error": "An error occurred while changing this member's role.",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -861,6 +861,7 @@
       "members": {
         "actions": {
           "edit-role": "Change role",
+          "leave-certification-center": "Leave this Pix Certif space",
           "manage": "Manage",
           "save": "Save",
           "select-role": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -882,6 +882,10 @@
           "change-member-role": {
             "error": "An error occurred while changing this member's role.",
             "success": "The role has been changed."
+          },
+          "leave-certification-center": {
+            "error": "An error occurred while deleting the member.",
+            "success": "You have been successfully removed from the {certificationCenterName} certification centre. You are about to be disconnected from Pix Certif..."
           }
         },
         "role": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -882,6 +882,10 @@
           "change-member-role": {
             "error": "Une erreur est survenue lors de la modification du rôle du membre.",
             "success": "Le rôle a bien été changé."
+          },
+          "leave-certification-center": {
+            "error": "Une erreur est survenue lors de la suppression du membre.",
+            "success": "Votre accès a été supprimé avec succès du centre de certification {certificationCenterName}. Vous allez être déconnecté de Pix Certif..."
           }
         },
         "role": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -861,6 +861,7 @@
       "members": {
         "actions": {
           "edit-role": "Modifier le rôle",
+          "leave-certification-center": "Quitter cet espace Pix Certif",
           "manage": "Gérer",
           "save": "Enregistrer",
           "select-role": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -871,6 +871,12 @@
             }
           }
         },
+        "modals": {
+          "leave-certification-center": {
+            "title": "Quitter cet espace Pix Certif",
+            "message": "Êtes-vous sûr de vouloir quitter cet espace Pix Certif ? Vous n’aurez plus accès à <strong>{certificationCenterName}</strong>.<br/><br/>Vos sessions restent accessibles au reste de l'équipe.<br/><br/>Vos accès à d’autres espaces Pix Certif ne seront pas impactés.<br/><br/>Vous allez être déconnecté."
+          }
+        },
         "notifications": {
           "change-member-role": {
             "error": "Une erreur est survenue lors de la modification du rôle du membre.",


### PR DESCRIPTION
## TODO
- [x] Surprimer les méthodes `adapter.leaveCertificationCenter` et `adapter.urlForDeleteRecord` qui ne sont plus utiles
- [x] Côté controller, appeler la méthode `deleteRecord` sur `currentUser.currentCertificationCenterMembership`
- [x] Corriger les tests associés, notamment la partie Mirage pour pointer vers la nouvelle API
- [x] Traiter les retours 👿 
- [x] Une fois #7767 mergée, faire un rebase en supprimant de la présente PR tous les commits avec le scope API
- [x] Faire de nouvelles revues techniques et fonctionnelles car les coches actuelles ont été mises avant de gros changement


## :christmas_tree: Problème
Actuellement, dans Pix Certif, un administrateur peut supprimer des membres de son centre de certification, mais il ne peut pas quitter lui-même l'espace si il y a plusieurs administrateurs.

## :gift: Proposition
Permettre à un administrateur d'un centre de certification de quitter l’espace : 

- seulement si il a le rôle ADMIN
- seulement si ce n'est PAS LE DERNIER ADMIN

L'utilisateur est déconnecté une fois qu’il a  choisi de quitter l’espace, peu importe s’il est rattaché à un ou plusieurs espaces Pix Certif. 

Un utilisateur avec le rôle MEMBRE ne pourra pas quitter son espace Pix Certif.

Cette règle s'applique pour tous les types de centres de certification.

## :socks: Remarques
RAS.

## :santa: Pour tester

1. Se connecter à Pix Certif avec un utilisateur ayant le rôle `Administrateur` (ex: james-paledroits@example.net)
2. Se rendre dans l'onglet `Equipe`
3. Dans la liste des membres du centre de certification, vous devriez voir plusieurs membres avec le rôle `Administrateur`
4. Au niveau du nom de votre utilisateur, dans la colonne `Actions`, vous devriez voir des petits points, qui au clic vous proposent de `Quitter cet espace Pix Certif`
5. Cliquez dessus, vous devriez voir une modal apparaitre avec deux boutons d'action `Annuler` et `Confirmer`
6. Cliquez sur le bouton `Annuler`, la modale doit se refermer et aucun changement n'est effectué
7. Cliquer à nouveau sur le bouton permettant de quitter l'espace Pix Certif, et cette fois-ci cliquez sur le bouton `Confirmer` à l'ouverture de la modale
8. Une notification de succès apparaît et vous êtes déconnecté de Pix Certif.

#### **🔴 Cas d'erreur** 

1. Dans la modale, avant de cliquer sur le bouton `Confirmer`, activer le mode `offline` situé dans la partie network dans la console de votre navigateur
2. Une notification doit apparaitre avec le message `Une erreur est survenue lors de la suppression du membre.` et aucun changement n'est effectué
