### PR TITLE
[TECH] Éviter que le test de la modal remplacer des étudiants soit Flaky sur Pix Orga (PIX-10421)

### DIFF
--- a/orga/tests/integration/components/sup-organization-participant/import_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/import_test.js
@@ -113,9 +113,7 @@ module('Integration | Component | SupOrganizationParticipant::Import', function 
 
       const cancelButton = await screen.findByRole('button', { name: this.intl.t('common.actions.cancel') });
 
-      await click(cancelButton);
-
-      await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+      await Promise.all([waitForElementToBeRemoved(() => screen.queryByRole('dialog')), click(cancelButton)]);
 
       // then
       assert


### PR DESCRIPTION
## :christmas_tree: Problème
Le `waitElementToBeRemoved` throw une erreur dans le cas ou l'element qu'on essaie de trouver a déjà disparu

https://app.circleci.com/pipelines/github/1024pix/pix/69084/workflows/850cb54d-cc73-47d7-b75e-574896000dab/jobs/588553

## :gift: Proposition
Retirer le await du click en amont afin d'être sûr que l'on selectionne bien la modal pour attendre qu'elle disparaisse

## :socks: Remarques
Ce test est très rarement flaky. mais flaky quand même

## :santa: Pour tester
CI verte