### PR TITLE
[TECH] Fixer le style sur l'un des sous-titre de la page d'import de masse de sessions (PIX-10434)

### DIFF
--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -1,5 +1,5 @@
 <section class="import-page__section--download panel import-page__resume-section">
-  <div class="import-page__section--download__title">
+  <div class="import-page__title">
     <FaIcon @icon="clipboard-list" class="fa-lg" />
     <h2>{{t "pages.sessions.import.step-two.title"}}</h2>
   </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Suite au merge d’une PR contenant un refacto sur les noms des classes des titres, le style sur le titre en question n’apparaît plus. Il convient de les remettre en place (voir screenshots pour plus de détails).
![Capture d’écran 2023-12-14 à 16 25 26](https://github.com/1024pix/pix/assets/152303583/d12f45be-2246-4185-bb2c-8a4f249a7b0d)
![Capture d’écran 2023-12-14 à 16 26 27](https://github.com/1024pix/pix/assets/152303583/cee98403-3718-480f-b48d-9f96b9ca3b05)

## :gift: Proposition
Il suffit de ré-appliquer le bon nom de classe sur le titre.

## :socks: Remarques
RAS

## :santa: Pour tester

1. Se connecter à l'app Certif via le compte certif-pro@example.net (mdp: pix123).
2. Cliquer ensuite sur le bouton `[créer/éditer plusieurs sessions]`
3. Cliquer sur `[importer (.csv)]` et importer le fichier csv partagé ci-dessous (`import-sessions (5).csv`)
4. Aller à l'étape suivante en cliquant sur `[continuer]`
5. Constater que le sous-titre `"Récapitulatif"` à bien le bon style (le même que sur la page précédente)

[import-sessions (5).csv](https://github.com/1024pix/pix/files/13702292/import-sessions.5.csv)