### PR TITLE
[FEATURE] Ajout de la colonne minimumReproducibilityRateLowerLevel dans complementaryCertification (PIX-10318)

### DIFF
--- a/api/db/migrations/20231218090719_add_minimumReproducibilityRateLowerLevel_to_complementaryCertifications.js
+++ b/api/db/migrations/20231218090719_add_minimumReproducibilityRateLowerLevel_to_complementaryCertifications.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = 'complementary-certifications';
+const COLUMN_NAME = 'minimumReproducibilityRateLowerLevel';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.decimal(COLUMN_NAME, 5, 2).default(null);
+  });
+
+  await knex(TABLE_NAME)
+    .update({
+      minimumReproducibilityRateLowerLevel: knex.ref('minimumReproducibilityRate'),
+    })
+    .where({ key: 'CLEA' });
+
+  await knex(TABLE_NAME)
+    .update({ [COLUMN_NAME]: 60 })
+    .whereNull('minimumReproducibilityRateLowerLevel');
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## :christmas_tree: Problème
Les certifications complémentaires Pix+ Droit et Pix+ Edu 1er et 2nd degré respectent actuellement des conditions d’obtention strictes. Si le candidat se positionne sur un niveau donné, il doit réussir à certifier ce niveau précis, sinon sa certification est rejetée.

Pour les candidats qui ratent de peu le niveau positionné, cela peut-être une grande source de frustration.

Actuellement, les candidats Pix+ Droit doivent respecter un taux de réussite d’au moins 75% sur la partie Pix+ (70% pour les candidats Pix+ Edu) pour valider leur niveau n.

 On souhaite accorder le niveau n-1 aux candidats qui obtiendraient :

pour Pix+ Edu (1er et 2nd degré) entre 60% et 70% de réussite sur la partie Pix+

pour Pix+ Droit entre 60% et 75% de réussite sur la partie Pix+.

## :gift: Proposition
Ajouter une colonne minimumReproducibilityRateLowerLevel dans la table complementaryCertification pour pouvoir enregistrer le 60% de réussite minimum pour obtenir le niveau n-1 (permettra de changer ce pourcentage si jamais une demande métier nous est faite en ce sens)

pour CléA, dans cette colonne : minimumReproducibilityRateLowerLevel = minimumReproducibilityRate car pas de niveaux multiples, donc pas de n-1 possible.

## :santa: Pour tester
Interroger la BDD pour vérifier que:

 - les complementaryCertifications CLEA ont bien une colonne minimumReproducibilityRateLowerLevel === minimumReproducibilityRate 
 
 - les complementaryCertifications NON CLEA ont bien une colonne minimumReproducibilityRateLowerLevel === 60
 
 
 
![image](https://github.com/1024pix/pix/assets/37305474/6ba3dd45-64df-49bc-bb09-67e90dcdd6f7)

