### PR TITLE
[FEATURE] Voir les informations complémentaires d'une certification sur la page de détails (PIX-10290).

### DIFF
--- a/admin/app/adapters/v3-certification-course-details-for-administration.js
+++ b/admin/app/adapters/v3-certification-course-details-for-administration.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class V3CertificationCourseDetailsForAdministration extends ApplicationAdapter {
+  urlForFindRecord(id) {
+    return `${this.host}/${this.namespace}/admin/certification-courses-v3/${id}/details`;
+  }
+}

--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -1,5 +1,20 @@
 <div class="certification-details-v3__container">
   <section class="page-section"></section>
-  <section class="page-section"></section>
+  <section class="page-section">
+    <h2 class="certification-details-v3__title">Informations complémentaires</h2>
+
+    <dl class="certification-details-v3__list">
+      <dt>Nombre de question répondues <br /> / Nombre total de questions</dt>
+      <dd>10/10</dd>
+      <dt>Nombre de question OK :</dt>
+      <dd>4</dd>
+      <dt>Nombre de question KO :</dt>
+      <dd>1</dd>
+      <dt>Nombre de question abandonnées :</dt>
+      <dd>2</dd>
+      <dt>Nombre de problèmes techniques validés :</dt>
+      <dd>3</dd>
+    </dl>
+  </section>
 </div>
 <section class="page-section"></section>

--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -5,15 +5,15 @@
 
     <dl class="certification-details-v3__list">
       <dt>Nombre de question répondues <br /> / Nombre total de questions</dt>
-      <dd>10/10</dd>
+      <dd>{{@details.numberOfAnsweredQuestions}}/{{@details.totalNumberOfQuestions}}</dd>
       <dt>Nombre de question OK :</dt>
-      <dd>4</dd>
+      <dd>{{@details.numberOfOkAnswers}}</dd>
       <dt>Nombre de question KO :</dt>
-      <dd>1</dd>
+      <dd>{{@details.numberOfKoAnswers}}</dd>
       <dt>Nombre de question abandonnées :</dt>
-      <dd>2</dd>
+      <dd>{{@details.numberOfAbandAnswers}}</dd>
       <dt>Nombre de problèmes techniques validés :</dt>
-      <dd>3</dd>
+      <dd>{{@details.numberOfValidatedLiveAlerts}}</dd>
     </dl>
   </section>
 </div>

--- a/admin/app/models/certification-challenges-for-administration.js
+++ b/admin/app/models/certification-challenges-for-administration.js
@@ -1,0 +1,22 @@
+import Model, { attr } from '@ember-data/model';
+export default class CertificationChallengesForAdministration extends Model {
+  @attr() answerStatus;
+  @attr() validatedLiveAlert;
+  version = 3;
+
+  isOk() {
+    return this.answerStatus === 'ok';
+  }
+
+  isKo() {
+    return this.answerStatus === 'ko';
+  }
+
+  isAband() {
+    return this.answerStatus === 'aband';
+  }
+
+  hasLiveAlert() {
+    return !!this.validatedLiveAlert;
+  }
+}

--- a/admin/app/models/certification-details-v3.js
+++ b/admin/app/models/certification-details-v3.js
@@ -1,3 +1,0 @@
-import Model from '@ember-data/model';
-
-export default class CertificationDetailsV3 extends Model {}

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -1,6 +1,33 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 export default class V3CertificationCourseDetailsForAdministration extends Model {
   @attr() certificationCourseId;
-  @attr() certificationChallengesForAdministration;
+  @hasMany('certification-challenges-for-administration') certificationChallengesForAdministration;
   version = 3;
+
+  get numberOfAnsweredQuestions() {
+    return this.certificationChallengesForAdministration.filter((challenge) => {
+      return challenge.answerStatus;
+    }).length;
+  }
+
+  get totalNumberOfQuestions() {
+    // TODO: save the number of questions at the start of a certification to get it here
+    return 32;
+  }
+
+  get numberOfOkAnswers() {
+    return this.certificationChallengesForAdministration.filter((challenge) => challenge.isOk()).length;
+  }
+
+  get numberOfKoAnswers() {
+    return this.certificationChallengesForAdministration.filter((challenge) => challenge.isKo()).length;
+  }
+
+  get numberOfAbandAnswers() {
+    return this.certificationChallengesForAdministration.filter((challenge) => challenge.isAband()).length;
+  }
+
+  get numberOfValidatedLiveAlerts() {
+    return this.certificationChallengesForAdministration.filter((challenge) => challenge.hasLiveAlert()).length;
+  }
 }

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+export default class V3CertificationCourseDetailsForAdministration extends Model {
+  @attr() certificationCourseId;
+  @attr() certificationChallengesForAdministration;
+  version = 3;
+}

--- a/admin/app/routes/authenticated/certifications/certification/details.js
+++ b/admin/app/routes/authenticated/certifications/certification/details.js
@@ -8,7 +8,7 @@ export default class CertificationDetailsRoute extends Route {
     const certificationVersion = this.modelFor('authenticated.certifications.certification').version;
     const { certification_id } = this.paramsFor('authenticated.certifications.certification');
     if (certificationVersion === 3) {
-      return { version: 3 };
+      return this.store.findRecord('v3-certification-course-details-for-administration', certification_id);
     }
     return this.store.findRecord('certification-details', certification_id);
   }

--- a/admin/app/styles/authenticated/certifications/certification/details-v3.scss
+++ b/admin/app/styles/authenticated/certifications/certification/details-v3.scss
@@ -4,4 +4,31 @@
      grid-template-columns: 1fr 1fr;
      gap: $pix-spacing-s;
    }
+
+  &__title {
+    @extend %pix-title-xs;
+
+    padding-bottom: var(--pix-spacing-6x);
+    color : var(--pix-neutral-800);
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+
+    dd, dt {
+      padding: var(--pix-spacing-2x) 0;
+      border-bottom: var(--pix-neutral-100) 1px solid;
+    }
+
+    dt {
+      color: var(--pix-neutral-500);
+    }
+
+    dd {
+      display: flex;
+      align-items: center;
+      color: var(--pix-neutral-900);
+    }
+  }
 }

--- a/admin/app/templates/authenticated/certifications/certification/details.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/details.hbs
@@ -1,6 +1,6 @@
 {{page-title "Certif " @model.id " Détails | Pix Admin" replace=true}}
 {{#if (eq @model.version 3)}}
-  <Certifications::Certification::DetailsV3 />
+  <Certifications::Certification::DetailsV3 @details={{@model}} />
 {{else}}
   <Certifications::Certification::DetailsV2 @details={{@model}} />
 {{/if}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -359,6 +359,10 @@ function routes() {
     const id = request.params.id;
     return schema.certificationDetails.find(id);
   });
+  this.get('/admin/certification-courses-v3/:id/details', (schema, request) => {
+    const id = request.params.id;
+    return schema.v3CertificationCourseDetailsForAdministrations.find(id);
+  });
   this.post('/admin/certification/neutralize-challenge', () => {
     return new Response(204);
   });

--- a/admin/tests/acceptance/authenticated/certifications/certification/details_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/details_test.js
@@ -23,7 +23,7 @@ module('Acceptance | authenticated/certifications/certification/details', functi
           isNeutralized: false,
         },
       ];
-      const certificationId = this.server.create('certification').id;
+      const certificationId = this.server.create('certification', { id: 1 }).id;
       this.server.create('certification-detail', {
         id: certificationId,
         competencesWithMark: [],
@@ -37,6 +37,28 @@ module('Acceptance | authenticated/certifications/certification/details', functi
 
       // then
       assert.dom(screen.getByText('Statut :')).exists();
+      assert.dom(screen.getByText('Créé le :')).exists();
+      assert.dom(screen.getByText('Terminée le :')).exists();
+      assert.dom(screen.getByText('Score :')).exists();
+      assert.dom(screen.getByText('Taux de reproductibilité :')).exists();
+    });
+  });
+
+  module('when certification is V3', function () {
+    test('renders the V3 details page', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const certificationId = this.server.create('certification', { id: 2, version: 3 }).id;
+      this.server.create('v3-certification-course-details-for-administration', {
+        id: certificationId,
+        certificationChallengesForAdministration: [],
+      });
+
+      // when
+      const screen = await visit(`/certifications/${certificationId}/details`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Informations complémentaires', level: 2 })).exists();
     });
   });
 

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | certifications/candidate-edit-modal', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('#display', function () {
+    test('it should display the certification complementary info section with the right info', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.model = store.createRecord('v3-certification-course-details-for-administration', {
+        certificationChallengesForAdministration: createChallengesForAdministration(
+          ['ok', 'ok', 'ko', 'aband', null],
+          store,
+        ),
+      });
+
+      // when
+      const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+      const expected = [
+        {
+          term: 'Nombre de question répondues  / Nombre total de questions',
+          definition: '4/32',
+        },
+        {
+          term: 'Nombre de question OK :',
+          definition: '2',
+        },
+        {
+          term: 'Nombre de question KO :',
+          definition: '1',
+        },
+        {
+          term: 'Nombre de question abandonnées :',
+          definition: '1',
+        },
+        {
+          term: 'Nombre de problèmes techniques validés :',
+          definition: '1',
+        },
+      ];
+
+      const terms = screen.getAllByRole('term');
+      const definitions = screen.getAllByRole('definition');
+      const result = terms.map((term, i) => ({ term: term.textContent, definition: definitions[i].textContent }));
+
+      // then
+      assert.deepEqual(expected, result);
+    });
+  });
+});
+
+function createChallengesForAdministration(answerStatuses, store) {
+  return answerStatuses.map((answerStatus, index) =>
+    store.createRecord('certification-challenges-for-administration', {
+      id: index,
+      answerStatus,
+      validatedLiveAlert: !answerStatus,
+    }),
+  );
+}

--- a/admin/tests/unit/adapters/v3-certification-course-details-for-administration_test.js
+++ b/admin/tests/unit/adapters/v3-certification-course-details-for-administration_test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | v3-certification-course-details-for-administration', function (hooks) {
+  setupTest(hooks);
+
+  module('#urlForFindRecord', function () {
+    test('should build get url from certification details id', function (assert) {
+      // when
+      const adapter = this.owner.lookup('adapter:v3-certification-course-details-for-administration');
+      const url = adapter.urlForFindRecord(123, 'v3-certification-course-details-for-administration');
+
+      // then
+      assert.ok(url.endsWith('/admin/certification-courses-v3/123/details'));
+    });
+  });
+});

--- a/admin/tests/unit/models/v3-certification-course-details-for-administration_test.js
+++ b/admin/tests/unit/models/v3-certification-course-details-for-administration_test.js
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | v3-certification-course-details-for-administration', function (hooks) {
+  setupTest(hooks);
+
+  module('#numberOfOkAnswers', function () {
+    test('it should return the number of OK answers', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationChallengeDetails = store.createRecord('v3-certification-course-details-for-administration', {
+        certificationChallengesForAdministration: createChallengesForAdministration(
+          ['ok', 'ok', 'ko', 'aband', null],
+          store,
+        ),
+      });
+
+      // when
+      const result = certificationChallengeDetails.numberOfOkAnswers;
+
+      // then
+      assert.strictEqual(result, 2);
+    });
+  });
+
+  module('#numberOfKoAnswers', function () {
+    test('it should return the number of KO answers', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationChallengeDetails = store.createRecord('v3-certification-course-details-for-administration', {
+        certificationChallengesForAdministration: createChallengesForAdministration(
+          ['ko', 'ok', 'ko', 'aband', null],
+          store,
+        ),
+      });
+
+      // when
+      const result = certificationChallengeDetails.numberOfKoAnswers;
+
+      // then
+      assert.strictEqual(result, 2);
+    });
+  });
+
+  module('#numberOfAbandAnswers', function () {
+    test('it should return the number of abandonned answers', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationChallengeDetails = store.createRecord('v3-certification-course-details-for-administration', {
+        certificationChallengesForAdministration: createChallengesForAdministration(
+          ['aband', 'ok', 'ko', 'aband', null],
+          store,
+        ),
+      });
+
+      // when
+      const result = certificationChallengeDetails.numberOfAbandAnswers;
+
+      // then
+      assert.strictEqual(result, 2);
+    });
+  });
+
+  module('#numberOfValidatedLiveAlerts', function () {
+    test('it should return the number of challenges with validated live alerts', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certificationChallengeDetails = store.createRecord('v3-certification-course-details-for-administration', {
+        certificationChallengesForAdministration: createChallengesForAdministration(
+          [null, 'ok', null, 'ok', null],
+          store,
+        ),
+      });
+
+      // when
+      const result = certificationChallengeDetails.numberOfValidatedLiveAlerts;
+
+      // then
+      assert.strictEqual(result, 3);
+    });
+  });
+});
+
+function createChallengesForAdministration(answerStatuses, store) {
+  return answerStatuses.map((answerStatus, index) =>
+    store.createRecord('certification-challenges-for-administration', {
+      id: index,
+      answerStatus,
+      validatedLiveAlert: !answerStatus,
+    }),
+  );
+}

--- a/api/src/certification/course/application/certification-course-controller.js
+++ b/api/src/certification/course/application/certification-course-controller.js
@@ -1,6 +1,7 @@
 import { usecases } from '../../shared/domain/usecases/index.js';
 import * as events from '../../../../lib/domain/events/index.js';
 import * as assessmentResultSerializer from '../infrastructure/serializers/jsonapi/assessment-result-serializer.js';
+import * as v3CertificationDetailsForAdministrationSerializer from '../infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js';
 
 const reject = async function (request, h, dependencies = { events }) {
   const certificationCourseId = request.params.id;
@@ -39,8 +40,19 @@ const updateJuryComments = async function (request, h, dependencies = { assessme
   return null;
 };
 
-const getCertificationV3Details = async function (request, h) {
-  return h.response().code(200);
+const getCertificationV3Details = async function (
+  request,
+  h,
+  dependencies = { v3CertificationDetailsForAdministrationSerializer },
+) {
+  const certificationCourseId = request.params.id;
+  const certificationDetails = await usecases.getV3CertificationCourseDetailsForAdministration({
+    certificationCourseId,
+  });
+
+  return h
+    .response(dependencies.v3CertificationDetailsForAdministrationSerializer.serialize({ certificationDetails }))
+    .code(200);
 };
 
 export const certificationCourseController = {

--- a/api/src/certification/course/application/certification-course-controller.js
+++ b/api/src/certification/course/application/certification-course-controller.js
@@ -39,8 +39,13 @@ const updateJuryComments = async function (request, h, dependencies = { assessme
   return null;
 };
 
+const getCertificationV3Details = async function (request, h) {
+  return h.response().code(200);
+};
+
 export const certificationCourseController = {
   reject,
   unreject,
+  getCertificationV3Details,
   updateJuryComments,
 };

--- a/api/src/certification/course/application/certification-course-route.js
+++ b/api/src/certification/course/application/certification-course-route.js
@@ -77,6 +77,32 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/certification-courses-v3/{id}/details',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
+        handler: certificationCourseController.getCertificationV3Details,
+        tags: ['api'],
+        notes: ['Cette route est utilisé par Pix Admin', "Elle renvoie le détail d'une certification"],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/course/domain/models/V3CertificationChallengeForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationChallengeForAdministration.js
@@ -1,6 +1,7 @@
 export class V3CertificationChallengeForAdministration {
-  constructor({ challengeId, answerStatus }) {
+  constructor({ challengeId, answerStatus, validatedLiveAlert }) {
     this.challengeId = challengeId;
     this.answerStatus = answerStatus;
+    this.validatedLiveAlert = validatedLiveAlert;
   }
 }

--- a/api/src/certification/course/domain/models/V3CertificationChallengeForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationChallengeForAdministration.js
@@ -1,0 +1,6 @@
+export class V3CertificationChallengeForAdministration {
+  constructor({ challengeId, answerStatus }) {
+    this.challengeId = challengeId;
+    this.answerStatus = answerStatus;
+  }
+}

--- a/api/src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js
@@ -1,0 +1,5 @@
+export class V3CertificationChallengeLiveAlertForAdministration {
+  constructor({ id }) {
+    this.id = id;
+  }
+}

--- a/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
@@ -1,0 +1,5 @@
+export class V3CertificationCourseDetailsForAdministration {
+  constructor({ certificationCourseId }) {
+    this.certificationCourseId = certificationCourseId;
+  }
+}

--- a/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
@@ -1,5 +1,6 @@
 export class V3CertificationCourseDetailsForAdministration {
-  constructor({ certificationCourseId }) {
+  constructor({ certificationCourseId, certificationChallengesForAdministration = [] }) {
     this.certificationCourseId = certificationCourseId;
+    this.certificationChallengesForAdministration = certificationChallengesForAdministration;
   }
 }

--- a/api/src/certification/course/domain/usecases/get-v3-certification-course-details-for-administration.js
+++ b/api/src/certification/course/domain/usecases/get-v3-certification-course-details-for-administration.js
@@ -1,0 +1,7 @@
+import { V3CertificationCourseDetailsForAdministration } from '../models/V3CertificationCourseDetailsForAdministration.js';
+
+export const getV3CertificationCourseDetailsForAdministration = ({ certificationCourseId }) => {
+  return new V3CertificationCourseDetailsForAdministration({
+    certificationCourseId,
+  });
+};

--- a/api/src/certification/course/domain/usecases/get-v3-certification-course-details-for-administration.js
+++ b/api/src/certification/course/domain/usecases/get-v3-certification-course-details-for-administration.js
@@ -1,7 +1,8 @@
-import { V3CertificationCourseDetailsForAdministration } from '../models/V3CertificationCourseDetailsForAdministration.js';
-
-export const getV3CertificationCourseDetailsForAdministration = ({ certificationCourseId }) => {
-  return new V3CertificationCourseDetailsForAdministration({
+export const getV3CertificationCourseDetailsForAdministration = ({
+  certificationCourseId,
+  v3CertificationCourseDetailsForAdministrationRepository,
+}) => {
+  return v3CertificationCourseDetailsForAdministrationRepository.getV3DetailsByCertificationCourseId({
     certificationCourseId,
   });
 };

--- a/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -1,0 +1,36 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { V3CertificationChallengeForAdministration } from '../../domain/models/V3CertificationChallengeForAdministration.js';
+import { V3CertificationCourseDetailsForAdministration } from '../../domain/models/V3CertificationCourseDetailsForAdministration.js';
+import { AnswerStatus } from '../../../../shared/domain/models/AnswerStatus.js';
+
+const getV3DetailsByCertificationCourseId = async function ({ certificationCourseId }) {
+  const certificationChallengesDetailsDTO = await knex('assessments')
+    .select({ challengeId: 'certification-challenges.challengeId', answerStatus: 'answers.result' })
+    .leftJoin('certification-challenges', 'certification-challenges.courseId', 'assessments.certificationCourseId')
+    .leftJoin('answers', function () {
+      this.on({ 'answers.assessmentId': 'assessments.id' }).andOn({
+        'answers.challengeId': 'certification-challenges.challengeId',
+      });
+    })
+    .where({
+      certificationCourseId,
+    });
+  return _toDomain({ certificationChallengesDetailsDTO, certificationCourseId });
+};
+
+function _toDomain({ certificationChallengesDetailsDTO, certificationCourseId }) {
+  const certificationChallengesForAdministration = certificationChallengesDetailsDTO.map(
+    (certificationChallengeDetailsDTO) =>
+      new V3CertificationChallengeForAdministration({
+        ...certificationChallengeDetailsDTO,
+        answerStatus: new AnswerStatus({ status: certificationChallengeDetailsDTO.answerStatus }),
+      }),
+  );
+
+  return new V3CertificationCourseDetailsForAdministration({
+    certificationCourseId,
+    certificationChallengesForAdministration,
+  });
+}
+
+export { getV3DetailsByCertificationCourseId };

--- a/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -2,14 +2,32 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { V3CertificationChallengeForAdministration } from '../../domain/models/V3CertificationChallengeForAdministration.js';
 import { V3CertificationCourseDetailsForAdministration } from '../../domain/models/V3CertificationCourseDetailsForAdministration.js';
 import { AnswerStatus } from '../../../../shared/domain/models/AnswerStatus.js';
+import { V3CertificationChallengeLiveAlertForAdministration } from '../../domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
+import { CertificationChallengeLiveAlertStatus } from '../../../session/domain/models/CertificationChallengeLiveAlert.js';
 
 const getV3DetailsByCertificationCourseId = async function ({ certificationCourseId }) {
-  const certificationChallengesDetailsDTO = await knex('assessments')
-    .select({ challengeId: 'certification-challenges.challengeId', answerStatus: 'answers.result' })
+  const certificationChallengesDetailsDTO = await knex
+    .with('validated-live-alerts', (queryBuilder) => {
+      queryBuilder
+        .select('*')
+        .from('certification-challenge-live-alerts')
+        .where({ status: CertificationChallengeLiveAlertStatus.VALIDATED });
+    })
+    .select({
+      challengeId: 'certification-challenges.challengeId',
+      answerStatus: 'answers.result',
+      liveAlertId: 'validated-live-alerts.id',
+    })
+    .from('assessments')
     .leftJoin('certification-challenges', 'certification-challenges.courseId', 'assessments.certificationCourseId')
     .leftJoin('answers', function () {
       this.on({ 'answers.assessmentId': 'assessments.id' }).andOn({
         'answers.challengeId': 'certification-challenges.challengeId',
+      });
+    })
+    .leftJoin('validated-live-alerts', function () {
+      this.on({ 'validated-live-alerts.assessmentId': 'assessments.id' }).andOn({
+        'validated-live-alerts.challengeId': 'certification-challenges.challengeId',
       });
     })
     .where({
@@ -24,6 +42,11 @@ function _toDomain({ certificationChallengesDetailsDTO, certificationCourseId })
       new V3CertificationChallengeForAdministration({
         ...certificationChallengeDetailsDTO,
         answerStatus: new AnswerStatus({ status: certificationChallengeDetailsDTO.answerStatus }),
+        validatedLiveAlert: certificationChallengeDetailsDTO.liveAlertId
+          ? new V3CertificationChallengeLiveAlertForAdministration({
+              id: certificationChallengeDetailsDTO.liveAlertId,
+            })
+          : undefined,
       }),
   );
 

--- a/api/src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js
+++ b/api/src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js
@@ -1,0 +1,38 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function ({ certificationDetails }) {
+  const attributes = ['certificationCourseId', 'certificationChallengesForAdministration'];
+
+  return new Serializer('v3-certification-course-details-for-administration', {
+    id: 'certificationCourseId',
+    transform: (record) => {
+      return {
+        ...record,
+        certificationChallengesForAdministration: record.certificationChallengesForAdministration.map(
+          (certificationChallenge) => ({
+            ...certificationChallenge,
+            answerStatus: certificationChallenge.answerStatus.status,
+          }),
+        ),
+      };
+    },
+    attributes,
+    typeForAttribute: (attribute) => {
+      if (attribute === 'certificationChallengesForAdministration')
+        return 'certification-challenges-for-administration';
+    },
+    certificationChallengesForAdministration: {
+      transform: (record, columnName) => {
+        if (columnName === 'answer-status') {
+          return record.answerStatus.status;
+        }
+      },
+      ref: 'challengeId',
+      attributes: ['answerStatus', 'validatedLiveAlert'],
+    },
+  }).serialize(certificationDetails);
+};
+
+export { serialize };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -39,6 +39,7 @@ import * as cpfExportRepository from '../../../session/infrastructure/repositori
 import * as sessionRepository from '../../../session/infrastructure/repositories/session-repository.js';
 import * as sessionValidator from '../../../session/domain/validators/session-validator.js';
 import * as userRepository from '../../../../../src/shared/infrastructure/repositories/user-repository.js';
+import * as v3CertificationCourseDetailsForAdministrationRepository from '../../../course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js';
 import { cpfReceiptsStorage } from '../../../session/infrastructure/storage/cpf-receipts-storage.js';
 import { cpfExportsStorage } from '../../../session/infrastructure/storage/cpf-exports-storage.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
@@ -76,6 +77,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
  * @typedef {sessionForAttendanceSheetRepository} SessionForAttendanceSheetRepository
  * @typedef {sessionForInvigilatorKitRepository} SessionForInvigilatorKitRepository
  * @typedef {cpfCertificationResultRepository} CpfCertificationResultRepository
+ * @typedef {v3CertificationCourseDetailsForAdministrationRepository} V3CertificationCourseDetailsForAdministrationRepository
  * @typedef {sessionRepository} SessionRepository
  * @typedef {sessionValidator} SessionValidator
  * @typedef {userRepository} UserRepository
@@ -119,6 +121,7 @@ const dependencies = {
   sessionRepository,
   sessionValidator,
   userRepository,
+  v3CertificationCourseDetailsForAdministrationRepository,
   cpfReceiptsStorage,
   cpfExportsStorage,
 };

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -1,0 +1,48 @@
+import { expect, databaseBuilder, domainBuilder } from '../../../../../test-helper.js';
+import * as v3CertificationCourseDetailsForAdministrationRepository from '../../../../../../src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+
+describe('Integration | Infrastructure | Repository | v3-certification-course-details-for-administration', function () {
+  describe('#getV3DetailsByCertificationCourseId', function () {
+    it('should return all challenges by certification course id', async function () {
+      // given
+      const certificationCourseId = 123;
+      const challengeId = 'recCHAL456';
+      const assessmentId = 78;
+
+      databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+      databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certificationCourseId,
+        challengeId,
+      });
+      databaseBuilder.factory.buildAssessment({
+        id: assessmentId,
+        certificationCourseId,
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId,
+        challengeId,
+        result: 'ok',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationChallenges =
+        await v3CertificationCourseDetailsForAdministrationRepository.getV3DetailsByCertificationCourseId({
+          certificationCourseId,
+        });
+
+      // then
+      const certificationChallengeForAdministration = domainBuilder.buildV3CertificationChallengeForAdministration({
+        challengeId,
+        answerStatus: AnswerStatus.OK,
+      });
+      const expectedCertificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+        certificationCourseId,
+        certificationChallengesForAdministration: [certificationChallengeForAdministration],
+      });
+      expect(certificationChallenges).to.deep.equal(expectedCertificationCourseDetails);
+    });
+  });
+});

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -25,6 +25,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         challengeId,
         result: 'ok',
       });
+
       await databaseBuilder.commit();
 
       // when
@@ -38,6 +39,66 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         challengeId,
         answerStatus: AnswerStatus.OK,
       });
+
+      const expectedCertificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+        certificationCourseId,
+        certificationChallengesForAdministration: [certificationChallengeForAdministration],
+      });
+      expect(certificationChallenges).to.deep.equal(expectedCertificationCourseDetails);
+    });
+
+    it('should return only validated live alerts', async function () {
+      // given
+      const certificationCourseId = 123;
+      const challengeId = 'recCHAL456';
+      const assessmentId = 78;
+
+      databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+      databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certificationCourseId,
+        challengeId,
+      });
+      databaseBuilder.factory.buildAssessment({
+        id: assessmentId,
+        certificationCourseId,
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId,
+        challengeId,
+        result: 'ok',
+      });
+
+      const validatedLiveAlertId = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+        assessmentId,
+        challengeId,
+        status: 'validated',
+      }).id;
+
+      databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+        assessmentId,
+        challengeId,
+        status: 'rejected',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationChallenges =
+        await v3CertificationCourseDetailsForAdministrationRepository.getV3DetailsByCertificationCourseId({
+          certificationCourseId,
+        });
+
+      // then
+      const validatedLiveAlert = domainBuilder.buildV3CertificationChallengeLiveAlertForAdministration({
+        id: validatedLiveAlertId,
+      });
+
+      const certificationChallengeForAdministration = domainBuilder.buildV3CertificationChallengeForAdministration({
+        challengeId,
+        answerStatus: AnswerStatus.OK,
+        validatedLiveAlert,
+      });
+
       const expectedCertificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
         certificationCourseId,
         certificationChallengesForAdministration: [certificationChallengeForAdministration],

--- a/api/tests/certification/course/unit/application/certification-course-route_test.js
+++ b/api/tests/certification/course/unit/application/certification-course-route_test.js
@@ -29,6 +29,7 @@ describe('Unit | Route | certification-course-route', function () {
       expect(response.statusCode).to.equal(403);
     });
   });
+
   describe('POST /api/admin/certification-courses/{id}/unreject', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
@@ -54,6 +55,29 @@ describe('Unit | Route | certification-course-route', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('GET /api/admin/certification-courses-v3/{id}/details', function () {
+    it('returns a 200', async function () {
+      // given
+      sinon
+        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+        ])
+        .callsFake(() => (request, h) => h.response().code(200).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/certification-courses-v3/1/details');
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/certification/course/unit/domain/usecases/get-certification-course-details-for-administration_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-certification-course-details-for-administration_test.js
@@ -1,16 +1,29 @@
 import { getV3CertificationCourseDetailsForAdministration } from '../../../../../../src/certification/course/domain/usecases/get-v3-certification-course-details-for-administration.js';
-import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | get-certification-course-details-for-administration', function () {
   it('should return the details', function () {
     // given
     const certificationCourseId = '1234';
+    const v3CertificationCourseDetailsForAdministrationRepository = {
+      getV3DetailsByCertificationCourseId: sinon.stub(),
+    };
+
+    const expectedDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
+      certificationCourseId,
+    });
+
+    v3CertificationCourseDetailsForAdministrationRepository.getV3DetailsByCertificationCourseId
+      .withArgs({ certificationCourseId })
+      .returns(expectedDetails);
 
     // when
-    const details = getV3CertificationCourseDetailsForAdministration({ certificationCourseId });
+    const details = getV3CertificationCourseDetailsForAdministration({
+      certificationCourseId,
+      v3CertificationCourseDetailsForAdministrationRepository,
+    });
 
     // then
-    const expectedDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({ certificationCourseId });
     expect(details).to.deep.equal(expectedDetails);
   });
 });

--- a/api/tests/certification/course/unit/domain/usecases/get-certification-course-details-for-administration_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-certification-course-details-for-administration_test.js
@@ -1,0 +1,16 @@
+import { getV3CertificationCourseDetailsForAdministration } from '../../../../../../src/certification/course/domain/usecases/get-v3-certification-course-details-for-administration.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | get-certification-course-details-for-administration', function () {
+  it('should return the details', function () {
+    // given
+    const certificationCourseId = '1234';
+
+    // when
+    const details = getV3CertificationCourseDetailsForAdministration({ certificationCourseId });
+
+    // then
+    const expectedDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({ certificationCourseId });
+    expect(details).to.deep.equal(expectedDetails);
+  });
+});

--- a/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
+++ b/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
@@ -1,0 +1,61 @@
+import * as serializer from '../../../../../../../src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js';
+
+import { V3CertificationChallengeForAdministration } from '../../../../../../../src/certification/course/domain/models/V3CertificationChallengeForAdministration.js';
+import { AnswerStatus } from '../../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { expect } from '../../../../../../test-helper.js';
+import { V3CertificationCourseDetailsForAdministration } from '../../../../../../../src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js';
+import { V3CertificationChallengeLiveAlertForAdministration } from '../../../../../../../src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
+
+describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administration-serializer', function () {
+  describe('#serialize()', function () {
+    it('should convert a Session model object into JSON API data including supervisor password', function () {
+      // given
+      const certificationCourseId = 123;
+      const liveAlertId = 789;
+      const challengeId = 'rec123';
+      const answerStatus = AnswerStatus.OK;
+
+      const certificationChallenge = new V3CertificationChallengeForAdministration({
+        challengeId,
+        answerStatus,
+        validatedLiveAlert: new V3CertificationChallengeLiveAlertForAdministration({ id: liveAlertId }),
+      });
+
+      const expectedJsonApi = {
+        data: {
+          id: `${certificationCourseId}`,
+          type: 'v3-certification-course-details-for-administrations',
+          relationships: {
+            'certification-challenges-for-administration': {
+              data: [{ type: 'certification-challenges-for-administration', id: challengeId }],
+            },
+          },
+          attributes: {
+            'certification-course-id': certificationCourseId,
+          },
+        },
+        included: [
+          {
+            type: 'certification-challenges-for-administration',
+            id: challengeId,
+            attributes: {
+              'answer-status': 'ok',
+              'validated-live-alert': { id: 789 },
+            },
+          },
+        ],
+      };
+
+      const certificationDetails = new V3CertificationCourseDetailsForAdministration({
+        certificationCourseId,
+        certificationChallengesForAdministration: [certificationChallenge],
+      });
+
+      // when
+      const json = serializer.serialize({ certificationDetails });
+
+      // then
+      expect(json).to.deep.equal(expectedJsonApi);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-for-administration.js
@@ -1,5 +1,5 @@
 import { V3CertificationChallengeForAdministration } from '../../../../src/certification/course/domain/models/V3CertificationChallengeForAdministration.js';
 
-export const buildV3CertificationChallengeForAdministration = ({ challengeId, answerStatus }) => {
-  return new V3CertificationChallengeForAdministration({ challengeId, answerStatus });
+export const buildV3CertificationChallengeForAdministration = ({ challengeId, answerStatus, validatedLiveAlert }) => {
+  return new V3CertificationChallengeForAdministration({ challengeId, answerStatus, validatedLiveAlert });
 };

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-for-administration.js
@@ -1,0 +1,5 @@
+import { V3CertificationChallengeForAdministration } from '../../../../src/certification/course/domain/models/V3CertificationChallengeForAdministration.js';
+
+export const buildV3CertificationChallengeForAdministration = ({ challengeId, answerStatus }) => {
+  return new V3CertificationChallengeForAdministration({ challengeId, answerStatus });
+};

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-live-alert-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-live-alert-for-administration.js
@@ -1,0 +1,9 @@
+import { V3CertificationChallengeLiveAlertForAdministration } from '../../../../src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
+
+const buildV3CertificationChallengeLiveAlertForAdministration = function ({ id = 456 } = {}) {
+  return new V3CertificationChallengeLiveAlertForAdministration({
+    id,
+  });
+};
+
+export { buildV3CertificationChallengeLiveAlertForAdministration };

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
@@ -1,5 +1,11 @@
 import { V3CertificationCourseDetailsForAdministration } from '../../../../src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js';
 
-export const buildV3CertificationCourseDetailsForAdministration = ({ certificationCourseId }) => {
-  return new V3CertificationCourseDetailsForAdministration({ certificationCourseId });
+export const buildV3CertificationCourseDetailsForAdministration = ({
+  certificationCourseId,
+  certificationChallengesForAdministration = [],
+}) => {
+  return new V3CertificationCourseDetailsForAdministration({
+    certificationCourseId,
+    certificationChallengesForAdministration,
+  });
 };

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
@@ -1,0 +1,5 @@
+import { V3CertificationCourseDetailsForAdministration } from '../../../../src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js';
+
+export const buildV3CertificationCourseDetailsForAdministration = ({ certificationCourseId }) => {
+  return new V3CertificationCourseDetailsForAdministration({ certificationCourseId });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -159,6 +159,7 @@ import { buildUserScorecard } from './build-user-scorecard.js';
 import { buildUserSavedTutorial } from './build-user-saved-tutorial.js';
 import { buildUserSavedTutorialWithTutorial } from './build-user-saved-tutorial-with-tutorial.js';
 import { buildV3CertificationChallengeForAdministration } from './build-v3-certification-challenge-for-administration.js';
+import { buildV3CertificationChallengeLiveAlertForAdministration } from './build-v3-certification-challenge-live-alert-for-administration.js';
 import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-certification-course-details-for-administration.js';
 import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
@@ -325,6 +326,7 @@ export {
   buildUserSavedTutorial,
   buildUserSavedTutorialWithTutorial,
   buildV3CertificationChallengeForAdministration,
+  buildV3CertificationChallengeLiveAlertForAdministration,
   buildV3CertificationCourseDetailsForAdministration,
   buildValidation,
   buildValidator,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -158,9 +158,10 @@ import { buildUserOrgaSettings } from './build-user-orga-settings.js';
 import { buildUserScorecard } from './build-user-scorecard.js';
 import { buildUserSavedTutorial } from './build-user-saved-tutorial.js';
 import { buildUserSavedTutorialWithTutorial } from './build-user-saved-tutorial-with-tutorial.js';
+import { buildV3CertificationChallengeForAdministration } from './build-v3-certification-challenge-for-administration.js';
+import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-certification-course-details-for-administration.js';
 import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
-import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-certification-course-details-for-administration.js';
 import { buildFeedback } from './build-feedback.js';
 
 export {
@@ -323,7 +324,8 @@ export {
   buildUserScorecard,
   buildUserSavedTutorial,
   buildUserSavedTutorialWithTutorial,
+  buildV3CertificationChallengeForAdministration,
+  buildV3CertificationCourseDetailsForAdministration,
   buildValidation,
   buildValidator,
-  buildV3CertificationCourseDetailsForAdministration,
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -160,6 +160,7 @@ import { buildUserSavedTutorial } from './build-user-saved-tutorial.js';
 import { buildUserSavedTutorialWithTutorial } from './build-user-saved-tutorial-with-tutorial.js';
 import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
+import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-certification-course-details-for-administration.js';
 import { buildFeedback } from './build-feedback.js';
 
 export {
@@ -324,4 +325,5 @@ export {
   buildUserSavedTutorialWithTutorial,
   buildValidation,
   buildValidator,
+  buildV3CertificationCourseDetailsForAdministration,
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix Admin, une page de détails spécifique à la certification v3 est nécessaire. Elle va nous permettre d’ajouter de nouvelles informations nécessaires pour le pôle certif en cas de questions par un candidat/prescripteur, notamment le nombre de questions du test, un résumé du nombre de réponses par statut (KO, OK, abandon), et le nombre de problèmes techniques.

## :gift: Proposition
Afficher les informations du bloc “Informations complémentaires”  

- Nb de questions répondues / nb total de questions
- Nb questions OK
- Nb questions KO
- Nb questions abandonnées
- Nb problèmes techniques validés

## :socks: Remarques
Ajout du nombre max de question en dur sur le front pour le moment.

## :santa: Pour tester
- Passer une certification V3 
- Se connecter sur Pix Certif avec certifv3@example.net
- Créer une session et ajouter un candidat
- Se connecter sur Pix App avec certifiable-contenu-user@example.net
- Entrer les infos candidat, le code candidat
- Coté espace surveillant, autoriser le candidat à passer la certif
- Passer la certification avec au minimum : une question OK, une question KO, une question passée et une question dont le signalement a été validé par le surveillant.
- Finaliser la session sur Pix Certif
- Sur Pix Admin, aller sur  Sessions de certification, puis sur Session à publier V3
- Cliquer sur l'id du candidat, puis sur l'onglet détails
- Constater que le bloc "Informations complémentaires" contient les bonne informations


<img width="1706" alt="Capture d’écran 2023-12-21 à 11 40 21" src="https://github.com/1024pix/pix/assets/58915422/b0e18c3f-42c9-4e43-ad1b-eccf879e5a28">
