### PR TITLE
[BUGFIX] Protege la route de liste des résultats d'une campagne (PIX-10438)

### DIFF
--- a/api/lib/domain/usecases/find-assessment-participation-result-list.js
+++ b/api/lib/domain/usecases/find-assessment-participation-result-list.js
@@ -1,9 +1,16 @@
-function findAssessmentParticipationResultList({
+import { UserNotAuthorizedToAccessEntityError } from '../errors.js';
+
+async function findAssessmentParticipationResultList({
+  userId,
   campaignId,
   filters,
   page,
   campaignAssessmentParticipationResultListRepository,
+  campaignRepository,
 }) {
+  if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
+  }
   return campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({ campaignId, filters, page });
 }
 

--- a/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
@@ -4,12 +4,18 @@ import { usecases } from '../../../../lib/domain/usecases/index.js';
 describe('Integration | UseCase | find-assessment-participation-result-list', function () {
   let organizationId;
   let campaignId;
+  let userId;
   const page = { number: 1 };
 
   beforeEach(async function () {
     const skill = { id: 'recSkill', status: 'actif' };
 
+    userId = databaseBuilder.factory.buildUser().id;
     organizationId = databaseBuilder.factory.buildOrganization().id;
+    databaseBuilder.factory.buildMembership({
+      organizationId,
+      userId,
+    });
     campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
     databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: skill.id });
 
@@ -29,6 +35,7 @@ describe('Integration | UseCase | find-assessment-participation-result-list', fu
   context('when there are filters', function () {
     it('returns the assessmentParticipationResultMinimal list filtered by the search', async function () {
       const { participations } = await usecases.findAssessmentParticipationResultList({
+        userId,
         campaignId,
         filters: { search: 'Tonari N' },
         page,

--- a/api/tests/unit/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/unit/domain/usecases/find-assessment-participation-result-list_test.js
@@ -4,17 +4,20 @@ import { findAssessmentParticipationResultList } from '../../../../lib/domain/us
 describe('Unit | UseCase | find-assessment-participation-result-list', function () {
   it('return the assessmentParticipationResultMinimal list', async function () {
     const findPaginatedByCampaignId = sinon.stub();
+    const checkIfUserOrganizationHasAccessToCampaign = sinon.stub();
     const campaignId = 1;
     const filters = Symbol('filters');
     const page = Symbol('page');
     const participations = Symbol('participations');
     findPaginatedByCampaignId.resolves(participations);
+    checkIfUserOrganizationHasAccessToCampaign.resolves(true);
 
     const results = await findAssessmentParticipationResultList({
       campaignId,
       filters,
       page,
       campaignAssessmentParticipationResultListRepository: { findPaginatedByCampaignId },
+      campaignRepository: { checkIfUserOrganizationHasAccessToCampaign },
     });
 
     expect(findPaginatedByCampaignId).to.have.been.calledWithExactly({ page, campaignId, filters });


### PR DESCRIPTION
## :christmas_tree: Problème
La route `/api/campaigns/{id}/assessment-results` n'était pas protegée 

## :gift: Proposition
Ajouter le check sur le usecase

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Faire un curl sur la route écrite plus haut avec une user n'appartenant par à l'orga
- Vérifier qu'on à bien un 403
