### PR TITLE
[FEATURE] Rejet d'une certification complémentaire en cas de fraude lors de la certification (PIX-10371)

### DIFF
--- a/api/lib/domain/events/handle-complementary-certifications-scoring.js
+++ b/api/lib/domain/events/handle-complementary-certifications-scoring.js
@@ -66,6 +66,7 @@ async function handleComplementaryCertificationsScoring({
           complementaryCertificationBadgeKey,
           reproducibilityRate: assessmentResult.reproducibilityRate,
           pixScore: assessmentResult.pixScore,
+          hasAcquiredPixCertification: assessmentResult.isValidated(),
           minimumEarnedPix,
           minimumReproducibilityRate,
           isRejectedForFraud: certificationCourse.isRejectedForFraud(),

--- a/api/lib/domain/events/handle-complementary-certifications-scoring.js
+++ b/api/lib/domain/events/handle-complementary-certifications-scoring.js
@@ -15,6 +15,7 @@ async function handleComplementaryCertificationsScoring({
   certificationAssessmentRepository,
   complementaryCertificationCourseResultRepository,
   complementaryCertificationScoringCriteriaRepository,
+  certificationCourseRepository,
 }) {
   checkEventTypes(event, eventTypes);
   const certificationCourseId = event.certificationCourseId;
@@ -26,6 +27,9 @@ async function handleComplementaryCertificationsScoring({
     return;
   }
 
+  const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+  const assessmentResult = await assessmentResultRepository.getByCertificationCourseId({ certificationCourseId });
+
   for (const complementaryCertificationScoringCriterion of complementaryCertificationScoringCriteria) {
     const {
       minimumReproducibilityRate,
@@ -35,9 +39,6 @@ async function handleComplementaryCertificationsScoring({
       hasComplementaryReferential,
       minimumEarnedPix,
     } = complementaryCertificationScoringCriterion;
-
-    const assessmentResult = await assessmentResultRepository.getByCertificationCourseId({ certificationCourseId });
-
     let complementaryCertificationScoringWithComplementaryReferential;
 
     if (hasComplementaryReferential) {
@@ -55,6 +56,7 @@ async function handleComplementaryCertificationsScoring({
           pixPlusAnswers,
           complementaryCertificationBadgeKey,
           assessmentResult,
+          certificationCourse,
         );
     } else {
       complementaryCertificationScoringWithComplementaryReferential =
@@ -66,6 +68,7 @@ async function handleComplementaryCertificationsScoring({
           pixScore: assessmentResult.pixScore,
           minimumEarnedPix,
           minimumReproducibilityRate,
+          isRejectedForFraud: certificationCourse.isRejectedForFraud(),
         });
     }
 
@@ -87,6 +90,7 @@ function _buildComplementaryCertificationScoringWithReferential(
   answers,
   complementaryCertificationBadgeKey,
   assessmentResult,
+  certificationCourse,
 ) {
   const answerCollection = AnswerCollectionForScoring.from({ answers, challenges });
   const reproducibilityRate = ReproducibilityRate.from({
@@ -101,6 +105,7 @@ function _buildComplementaryCertificationScoringWithReferential(
     reproducibilityRate,
     complementaryCertificationBadgeKey,
     hasAcquiredPixCertification: assessmentResult.isValidated(),
+    isRejectedForFraud: certificationCourse.isRejectedForFraud(),
   });
 }
 

--- a/api/lib/domain/models/ComplementaryCertificationScoringWithComplementaryReferential.js
+++ b/api/lib/domain/models/ComplementaryCertificationScoringWithComplementaryReferential.js
@@ -15,10 +15,10 @@ class ComplementaryCertificationScoringWithComplementaryReferential extends Part
       complementaryCertificationBadgeId,
       source: ComplementaryCertificationCourseResult.sources.PIX,
       isRejectedForFraud,
+      hasAcquiredPixCertification,
     });
 
     this.reproducibilityRate = reproducibilityRate;
-    this.hasAcquiredPixCertification = hasAcquiredPixCertification;
     this.minimumReproducibilityRate = minimumReproducibilityRate;
   }
 

--- a/api/lib/domain/models/ComplementaryCertificationScoringWithComplementaryReferential.js
+++ b/api/lib/domain/models/ComplementaryCertificationScoringWithComplementaryReferential.js
@@ -8,11 +8,13 @@ class ComplementaryCertificationScoringWithComplementaryReferential extends Part
     reproducibilityRate,
     hasAcquiredPixCertification,
     minimumReproducibilityRate,
+    isRejectedForFraud,
   } = {}) {
     super({
       complementaryCertificationCourseId,
       complementaryCertificationBadgeId,
       source: ComplementaryCertificationCourseResult.sources.PIX,
+      isRejectedForFraud,
     });
 
     this.reproducibilityRate = reproducibilityRate;
@@ -21,7 +23,11 @@ class ComplementaryCertificationScoringWithComplementaryReferential extends Part
   }
 
   isAcquired() {
-    return this.hasAcquiredPixCertification && this.reproducibilityRate.isEqualOrAbove(this.minimumReproducibilityRate);
+    return (
+      !this.isRejectedForFraud &&
+      this.hasAcquiredPixCertification &&
+      this.reproducibilityRate.isEqualOrAbove(this.minimumReproducibilityRate)
+    );
   }
 }
 

--- a/api/lib/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential.js
+++ b/api/lib/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential.js
@@ -7,6 +7,7 @@ class ComplementaryCertificationScoringWithoutComplementaryReferential extends P
     reproducibilityRate,
     pixScore,
     minimumEarnedPix,
+    hasAcquiredPixCertification,
     minimumReproducibilityRate,
     isRejectedForFraud,
   } = {}) {
@@ -14,6 +15,7 @@ class ComplementaryCertificationScoringWithoutComplementaryReferential extends P
       complementaryCertificationCourseId,
       complementaryCertificationBadgeId,
       isRejectedForFraud,
+      hasAcquiredPixCertification,
     });
 
     this.reproducibilityRate = reproducibilityRate;
@@ -23,7 +25,12 @@ class ComplementaryCertificationScoringWithoutComplementaryReferential extends P
   }
 
   isAcquired() {
-    return !this.isRejectedForFraud && this._isAboveMinimumReproducibilityRate() && this._isAboveMinimumScore();
+    return (
+      !this.isRejectedForFraud &&
+      this.hasAcquiredPixCertification &&
+      this._isAboveMinimumReproducibilityRate() &&
+      this._isAboveMinimumScore()
+    );
   }
 
   _isAboveMinimumScore() {

--- a/api/lib/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential.js
+++ b/api/lib/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential.js
@@ -8,10 +8,12 @@ class ComplementaryCertificationScoringWithoutComplementaryReferential extends P
     pixScore,
     minimumEarnedPix,
     minimumReproducibilityRate,
+    isRejectedForFraud,
   } = {}) {
     super({
       complementaryCertificationCourseId,
       complementaryCertificationBadgeId,
+      isRejectedForFraud,
     });
 
     this.reproducibilityRate = reproducibilityRate;
@@ -21,7 +23,7 @@ class ComplementaryCertificationScoringWithoutComplementaryReferential extends P
   }
 
   isAcquired() {
-    return this._isAboveMinimumReproducibilityRate() && this._isAboveMinimumScore();
+    return !this.isRejectedForFraud && this._isAboveMinimumReproducibilityRate() && this._isAboveMinimumScore();
   }
 
   _isAboveMinimumScore() {

--- a/api/lib/domain/models/PartnerCertificationScoring.js
+++ b/api/lib/domain/models/PartnerCertificationScoring.js
@@ -10,13 +10,20 @@ const SOURCES = {
 };
 
 class PartnerCertificationScoring {
-  constructor({ complementaryCertificationCourseId, complementaryCertificationBadgeId, source = SOURCES.PIX } = {}) {
+  constructor({
+    complementaryCertificationCourseId,
+    complementaryCertificationBadgeId,
+    source = SOURCES.PIX,
+    isRejectedForFraud = false,
+  } = {}) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
     this.complementaryCertificationBadgeId = complementaryCertificationBadgeId;
     this.source = source;
+    this.isRejectedForFraud = isRejectedForFraud;
     const schema = Joi.object({
       complementaryCertificationCourseId: Joi.number().integer().required(),
       complementaryCertificationBadgeId: Joi.number().integer().required(),
+      isRejectedForFraud: Joi.boolean().required(),
       source: Joi.string()
         .required()
         .valid(...Object.values(SOURCES)),

--- a/api/lib/domain/models/PartnerCertificationScoring.js
+++ b/api/lib/domain/models/PartnerCertificationScoring.js
@@ -15,15 +15,18 @@ class PartnerCertificationScoring {
     complementaryCertificationBadgeId,
     source = SOURCES.PIX,
     isRejectedForFraud = false,
+    hasAcquiredPixCertification,
   } = {}) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
     this.complementaryCertificationBadgeId = complementaryCertificationBadgeId;
     this.source = source;
     this.isRejectedForFraud = isRejectedForFraud;
+    this.hasAcquiredPixCertification = hasAcquiredPixCertification;
     const schema = Joi.object({
       complementaryCertificationCourseId: Joi.number().integer().required(),
       complementaryCertificationBadgeId: Joi.number().integer().required(),
       isRejectedForFraud: Joi.boolean().required(),
+      hasAcquiredPixCertification: Joi.boolean().required(),
       source: Joi.string()
         .required()
         .valid(...Object.values(SOURCES)),

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-scoring-without-complementary-referential.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-scoring-without-complementary-referential.js
@@ -8,6 +8,7 @@ const buildComplementaryCertificationScoringWithoutComplementaryReferential = fu
   pixScore,
   minimumEarnedPix,
   minimumReproducibilityRate,
+  hasAcquiredPixCertification = true,
 } = {}) {
   return new ComplementaryCertificationScoringWithoutComplementaryReferential({
     complementaryCertificationCourseId,
@@ -17,6 +18,7 @@ const buildComplementaryCertificationScoringWithoutComplementaryReferential = fu
     pixScore,
     minimumEarnedPix,
     minimumReproducibilityRate,
+    hasAcquiredPixCertification,
   });
 };
 

--- a/api/tests/unit/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationScoringWithoutComplementaryReferential_test.js
@@ -91,6 +91,25 @@ describe('Unit | Domain | Models | ComplementaryCertificationScoringWithoutCompl
             expect(hasAcquiredCertif).to.be.false;
           });
         });
+
+        context('pix core certification is not acquired', function () {
+          it('should return false', async function () {
+            // given
+            const cleaCertificationScoring =
+              await _buildComplementaryCertificationScoringWithoutComplementaryReferential({
+                reproducibilityRate,
+                minimumReproducibilityRate,
+                minimumEarnedPix: 120,
+                hasAcquiredPixCertification: false,
+              });
+
+            // when
+            const hasAcquiredCertification = cleaCertificationScoring.isAcquired();
+
+            // then
+            expect(hasAcquiredCertification).to.be.false;
+          });
+        });
       });
     });
   });
@@ -101,6 +120,7 @@ function _buildComplementaryCertificationScoringWithoutComplementaryReferential(
   pixScore = 0,
   minimumEarnedPix,
   minimumReproducibilityRate,
+  hasAcquiredPixCertification,
 }) {
   const certificationCourseId = 42;
   const complementaryCertificationCourseId = 999;
@@ -114,5 +134,6 @@ function _buildComplementaryCertificationScoringWithoutComplementaryReferential(
     pixScore,
     minimumEarnedPix,
     minimumReproducibilityRate,
+    hasAcquiredPixCertification,
   });
 }

--- a/api/tests/unit/domain/models/PartnerCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/PartnerCertificationScoring_test.js
@@ -10,6 +10,7 @@ describe('Unit | Domain | Models | PartnerCertificationScoring', function () {
         complementaryCertificationCourseId: 999,
         complementaryCertificationBadgeId: 60,
         certificationCourseId: 123,
+        hasAcquiredPixCertification: true,
       };
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le rejet manuel d'une certif Pix/CléA Numérique n'entraine pas le rejet de la certif CléA Numérique.


En conséquence, l'encart sur la page de détail de la session concernée qui permet au CDC de télécharger la liste des candidats ayant validé leur CléA Numérique depuis Pix Certif reste visible.

Il y a donc là la possibilité pour l’utilisateur Pix Certif de récupérer les infos et donc d'importer sur la plateforme CléA le document permettant de générer le parchemin CléA, alors que la certification CléA Numérique aurait dû être rejetée.

Il est d’autant plus important que cela ne puisse pas se produire que la certification rejetée manuellement l'est normalement pour fraude.

## :gift: Proposition
Lors du scoring d'une certification complémentaire, utiliser le flag de fraude de la du certification course pour déterminer si la certification complémentaire est acquise

## :socks: Remarques
Nope

## :santa: Pour tester
- [Aller sur admin (superadmin@example.net/pix123)](https://admin-pr7718.review.pix.fr/certifications/145039)
- Cliquer sur le bouton rejeter la certification (rouge en haut à droite)
- Constater que la complémentaire clé est aussi rejetée
- Annuler le rejet de la certification
- Constater que la certification complémentaire est à nouveau validée