### PR TITLE
[FEATURE] Ajouter un test d'acceptance pour la route assessment-results (PIX-10444)

### DIFF
--- a/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -477,4 +477,35 @@ describe('Acceptance | API | Campaign Participations', function () {
       });
     });
   });
+
+  describe('GET /api/campaigns/{id}/assessment-results', function () {
+    it('should return 403 if user is not member of organization which own campaign', async function () {
+      // given
+      const campaignOwnerId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId: campaignOwnerId,
+      });
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        organizationId,
+        ownerId: campaignOwnerId,
+      }).id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaignId}/assessment-results`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(otherUserId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Suite de la PR : https://github.com/1024pix/pix/pull/7716
Etant un HotFix, nous n'avons pas pris le temps de tester le throw si le user n'appartient pas à l'organisation

## :gift: Proposition
Ajouter un test d'acceptance pour vérifier si l'utilisateur appelant cette route est bien membre de l'organisation

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- La CI est verte 
- 🐈‍⬛ 
