### PR TITLE
[FEATURE] Ajoute l'icône de la typologie de campagne sur les pages de détails d'une campagne (PIX-10349)

### DIFF
--- a/orga/app/components/campaign/detail/type.hbs
+++ b/orga/app/components/campaign/detail/type.hbs
@@ -5,6 +5,7 @@
     @prefix="fapix"
     aria-hidden={{this.picotAriaHidden}}
     @title={{this.pictoTitle}}
+    ...attributes
   />
   {{#unless @hideLabel}}
     <span class="campaign-type__label">{{this.label}}</span>

--- a/orga/app/components/campaign/detail/type.js
+++ b/orga/app/components/campaign/detail/type.js
@@ -10,8 +10,15 @@ export default class CampaignType extends Component {
   }
 
   get pictoCssClass() {
+    const classes = [];
     const { campaignType } = this.args;
-    return campaignType === 'ASSESSMENT' ? 'campaign-type__icon-assessment' : 'campaign-type__icon-profile-collection';
+    classes.push(
+      campaignType === 'ASSESSMENT' ? 'campaign-type__icon-assessment' : 'campaign-type__icon-profile-collection',
+    );
+    if (this.args.big) {
+      classes.push(classes[0] + '--big');
+    }
+    return classes.join(' ');
   }
 
   get pictoAriaHidden() {

--- a/orga/app/components/campaign/header/title.hbs
+++ b/orga/app/components/campaign/header/title.hbs
@@ -1,11 +1,16 @@
 <header class="campaign-header-title">
   <Ui::Breadcrumb @links={{this.breadcrumbLinks}} class="campaign-header-title__breadcrumb" />
   <div class="campaign-header-title__informations">
-    <h1
-      aria-label={{t "pages.campaign.name"}}
-      class="campaign-header-title__name"
-      title={{@campaign.name}}
-    >{{@campaign.name}}</h1>
+    <h1 aria-label={{t "pages.campaign.name"}} class="campaign-header-title" title={{@campaign.name}}>
+      <Campaign::Detail::Type
+        @big={{true}}
+        @labels={{this.labels}}
+        @campaignType={{@campaign.type}}
+        @hideLabel={{true}}
+        class="campaign-header-title__type-icon"
+      />
+      <span class="campaign-header-title__name">{{@campaign.name}}</span>
+    </h1>
     <dl class="campaign-header-title__details">
       <div class="campaign-header-title__detail-item hide-on-mobile">
         <dt class="label-text">

--- a/orga/app/components/campaign/header/title.js
+++ b/orga/app/components/campaign/header/title.js
@@ -17,4 +17,11 @@ export default class Header extends Component {
       },
     ];
   }
+
+  get labels() {
+    return {
+      ASSESSMENT: 'components.campaign.type.explanation.ASSESSMENT',
+      PROFILES_COLLECTION: 'components.campaign.type.explanation.PROFILES_COLLECTION',
+    };
+  }
 }

--- a/orga/app/styles/components/campaign/detail/type.scss
+++ b/orga/app/styles/components/campaign/detail/type.scss
@@ -6,15 +6,28 @@
     margin-left: $pix-spacing-xs;
   }
 
-  &__icon-assessment {
+  &__icon-assessment, &__icon-profile-collection {
     width: 1.5rem;
     height: 1.5rem;
+
+    &--big {
+      width: 3rem;
+      height: 3rem;
+    }
+
+    @include device-is('mobile') {
+      &--big {
+        width: 2rem;
+        height: 2rem;
+      }
+    }
+  }
+
+  &__icon-assessment {
     color: $pix-tertiary-50;
   }
 
   &__icon-profile-collection {
-    width: 1.5rem;
-    height: 1.5rem;
     color: $pix-primary;
   }
 }

--- a/orga/app/styles/components/campaign/header/title.scss
+++ b/orga/app/styles/components/campaign/header/title.scss
@@ -6,19 +6,34 @@
     align-items: center;
     justify-content: space-between;
   }
-  
+
   &__breadcrumb {
     margin-bottom: $pix-spacing-s;
   }
 
-  &__name {
+  &__type-icon {
+    @extend %pix-title-l;
+
+    width: 3rem;
+    height: 3rem;
+  }
+
+  h1 {
     @extend %pix-title-m;
 
+    display: flex;
     flex: 0 1 auto;
+    flex-direction: row;
+    gap: $pix-spacing-s;
     padding-right: $pix-spacing-s;
     overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis; 
+
+    .campaign-header-title__name {
+      max-width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
   }
 
   &__details {

--- a/orga/tests/integration/components/campaign/header/title_test.js
+++ b/orga/tests/integration/components/campaign/header/title_test.js
@@ -13,15 +13,18 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
       code: '1234PixTest',
       createdAt: new Date('2021-04-14'),
       ownerFullName: 'Mulan Fa',
+      type: 'ASSESSMENT',
     };
 
     // when
-    await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+    const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
 
     // then
-    assert.contains('campagne 1');
-    assert.contains('1234PixTest');
-    assert.contains('Mulan Fa');
-    assert.contains('14/04/2021');
+    const title = screen.getByRole('heading');
+    assert.true(title.textContent.includes(this.intl.t('components.campaign.type.explanation.ASSESSMENT')));
+    assert.true(title.textContent.includes('campagne 1'));
+    assert.ok(screen.getByText('1234PixTest'));
+    assert.ok(screen.getByText('Mulan Fa'));
+    assert.ok(screen.getByText('14/04/2021'));
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Une fois les pages de détail d'une campagne, il est difficile d'identifier leur typologie au premier coup d'oeil.

## :gift: Proposition
On a ajoute l'icône de la typologie de campagne à gauche du titre de celle-ci.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter sur PixOrga
- Aller sur chaque type de campagne et vérifier la présence de l'icône
- Vérifier en mode mobile
