### PR TITLE
[FEATURE] Mise à jour des variables css d'Orga et vérifications suite à la maj de pixUI (PIX-10307)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-mastery-percentage.js
+++ b/orga/app/components/campaign/charts/participants-by-mastery-percentage.js
@@ -28,8 +28,8 @@ export default class ParticipantsByMasteryPercentage extends Component {
         datasets: [
           {
             data: steps,
-            border: '#3D68FF',
-            backgroundColor: '#3D68FF',
+            border: getComputedStyle(document.body).getPropertyValue('--pix-primary-300'),
+            backgroundColor: getComputedStyle(document.body).getPropertyValue('--pix-primary-300'),
           },
         ],
       };

--- a/orga/app/components/campaign/settings/target-profile-tooltip.hbs
+++ b/orga/app/components/campaign/settings/target-profile-tooltip.hbs
@@ -1,4 +1,4 @@
-<PixTooltip @id="target-profile-info-tooltip" @position="top-right" @isWide={{true}} @isLight={{true}}>
+<PixTooltip @id="target-profile-info-tooltip" @position="top-right" @isWide={{true}}>
   <:triggerElement>
     <FaIcon
       ...attributes

--- a/orga/app/components/campaign/settings/view.hbs
+++ b/orga/app/components/campaign/settings/view.hbs
@@ -118,7 +118,7 @@
       <PixButtonLink @route="authenticated.campaigns.new" @query={{this.queryForDuplicate}} @backgroundColor="grey">
         {{t "pages.campaign-settings.actions.duplicate"}}
       </PixButtonLink>
-      <PixButton @triggerAction={{fn this.archiveCampaign @campaign.id}} @backgroundColor="grey">
+      <PixButton @triggerAction={{fn this.archiveCampaign @campaign.id}} @backgroundColor="red">
         {{t "pages.campaign-settings.actions.archive"}}
       </PixButton>
     </div>

--- a/orga/app/components/team/invite-form.hbs
+++ b/orga/app/components/team/invite-form.hbs
@@ -15,7 +15,7 @@
   </div>
 
   <div class="form__validation">
-    <PixButton @triggerAction={{@onCancel}} @backgroundColor="transparent-light">
+    <PixButton @triggerAction={{@onCancel}} @backgroundColor="transparent-light" @isBorderVisible={{true}}>
       {{t "common.actions.cancel"}}
     </PixButton>
     <PixButton @type="submit" @isLoading={{@isLoading}}>

--- a/orga/app/components/ui/participation-status.js
+++ b/orga/app/components/ui/participation-status.js
@@ -16,7 +16,7 @@ export default class ParticipationStatus extends Component {
 }
 
 const COLORS = {
-  STARTED: 'orange-light',
+  STARTED: 'yellow-light',
   TO_SHARE: 'purple-light',
   SHARED: 'green-light',
 };

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -90,8 +90,8 @@ html {
 }
 
 body {
-  color: $pix-neutral-110;
-  background-color: $pix-neutral-10;
+  color: var(--pix-neutral-900);
+  background-color: var(--pix-neutral-20);
 }
 
 input:invalid {

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -11,7 +11,6 @@
 @import 'globals/forms';
 @import 'globals/icons';
 @import 'globals/pages';
-@import 'globals/shadows';
 @import 'globals/panels';
 @import 'globals/pix-loader';
 @import 'globals/tables';

--- a/orga/app/styles/components/campaign/analysis/recommendation-indicator.scss
+++ b/orga/app/styles/components/campaign/analysis/recommendation-indicator.scss
@@ -4,6 +4,7 @@
 
   &__bubble {
     padding: 2px;
-    fill: lighten($pix-primary, 10%);
+    fill: var(--pix-primary-300);
+
   }
 }

--- a/orga/app/styles/components/campaign/analysis/recommendations.scss
+++ b/orga/app/styles/components/campaign/analysis/recommendations.scss
@@ -1,5 +1,5 @@
 .campaign-details-analysis {
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-weight: normal;
   letter-spacing: 0;
 

--- a/orga/app/styles/components/campaign/analysis/tube-recommendation-row.scss
+++ b/orga/app/styles/components/campaign/analysis/tube-recommendation-row.scss
@@ -1,7 +1,7 @@
 .tube-recommendation-title {
   @extend %pix-title-xs;
 
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size:0.875rem;
 
   &--open {
@@ -12,11 +12,11 @@
 .tube-recommendation-subtitle {
   @extend %pix-body-s;
 
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-20)0;
   font-weight: 400;
 
   &--open {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }
 
@@ -34,7 +34,7 @@
     @extend %pix-title-s;
 
     margin-bottom: $pix-spacing-s;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size:0.875rem;
   }
 
@@ -78,7 +78,7 @@
   }
 
   &__details {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-weight: normal;
     font-size: 0.75rem;
     font-family: $font-roboto;

--- a/orga/app/styles/components/campaign/analysis/tube-recommendation-row.scss
+++ b/orga/app/styles/components/campaign/analysis/tube-recommendation-row.scss
@@ -5,7 +5,7 @@
   font-size:0.875rem;
 
   &--open {
-    margin-left: $pix-spacing-s;
+    margin-left: var(--pix-spacing-4x);
   }
 }
 
@@ -33,22 +33,22 @@
   &__description {
     @extend %pix-title-s;
 
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-500);
     font-size:0.875rem;
   }
 
   &__column {
     position: relative;
-    padding-right: $pix-spacing-xl;
-    padding-left: $pix-spacing-l;
+    padding-right: var(--pix-spacing-10x);
+    padding-left: var(--pix-spacing-8x);
   }
 
   &__title {
     @extend %pix-title-xs;
 
-    margin-bottom: $pix-spacing-s;
-    padding-left: $pix-spacing-m;
+    margin-bottom: var(--pix-spacing-4x);
+    padding-left: var(--pix-spacing-6x);
     font-weight: 500;
   }
 }
@@ -66,8 +66,8 @@
 }
 
 .tube-recommendation-tutorial-table {
-  margin-bottom: $pix-spacing-xs;
-  margin-left: $pix-spacing-m;
+  margin-bottom: var(--pix-spacing-2x);
+  margin-left: var(--pix-spacing-6x);
 
   &__row {
     padding-left: 0;

--- a/orga/app/styles/components/campaign/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-stage.scss
@@ -55,13 +55,13 @@
 
   &__bar {
     height: 16px;
-    background-color: var(--pix-primary-300);
+    background-color: var(--pix-primary-500);
     border: 1px solid var(--pix-primary-500);
     border-radius: 3px;
   }
 
   &__graph:hover &__bar {
-    background-color: var(--pix-primary-500);
+    background-color: var(--pix-primary-300);
   }
 
   &__percentage {

--- a/orga/app/styles/components/campaign/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-stage.scss
@@ -22,7 +22,7 @@
   &__values {
     min-width: 140px;
     margin-left: 32px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
     font-size: 0.75rem;
 
     &--loader {
@@ -66,7 +66,7 @@
 
   &__percentage {
     margin-left: 8px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
     font-size: 0.75rem;
     white-space: nowrap;
   }

--- a/orga/app/styles/components/campaign/charts/participants-by-stage.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-stage.scss
@@ -12,7 +12,7 @@
 
   &__stars {
     height: 1.5rem;
-    
+
     &--loader {
       min-width: 100px;
       height: 20px;
@@ -55,13 +55,13 @@
 
   &__bar {
     height: 16px;
-    background-color: lighten($pix-primary, 20%);
-    border: 1px solid $pix-primary;
+    background-color: var(--pix-primary-300);
+    border: 1px solid var(--pix-primary-500);
     border-radius: 3px;
   }
 
   &__graph:hover &__bar {
-    background-color: lighten($pix-primary, 10%);
+    background-color: var(--pix-primary-500);
   }
 
   &__percentage {

--- a/orga/app/styles/components/campaign/charts/participants-by-status.scss
+++ b/orga/app/styles/components/campaign/charts/participants-by-status.scss
@@ -14,7 +14,7 @@
       align-items: center;
       padding-bottom: 8px;
       padding-left: 24px;
-      color: $pix-neutral-70;
+      color: var(--pix-neutral-800);
 
       &:last-child {
         padding-bottom: 0px;
@@ -24,7 +24,7 @@
 
   &__legend-tooltip {
     margin-left: 8px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 
   &__legend-view {

--- a/orga/app/styles/components/campaign/detail/type.scss
+++ b/orga/app/styles/components/campaign/detail/type.scss
@@ -24,10 +24,10 @@
   }
 
   &__icon-assessment {
-    color: $pix-tertiary-50;
+    color: var(--pix-tertiary-500);
   }
 
   &__icon-profile-collection {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
   }
 }

--- a/orga/app/styles/components/campaign/detail/type.scss
+++ b/orga/app/styles/components/campaign/detail/type.scss
@@ -3,7 +3,7 @@
   align-items: center;
 
   &__label {
-    margin-left: $pix-spacing-xs;
+    margin-left: var(--pix-spacing-2x);
   }
 
   &__icon-assessment, &__icon-profile-collection {

--- a/orga/app/styles/components/campaign/empty-state.scss
+++ b/orga/app/styles/components/campaign/empty-state.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   padding: 40px 0;
-  color: $pix-neutral-30;
+  color: var(--pix-neutral-100);
 
   &__text {
     display: flex;

--- a/orga/app/styles/components/campaign/filters.scss
+++ b/orga/app/styles/components/campaign/filters.scss
@@ -4,7 +4,7 @@
   gap: $pix-spacing-s;
   margin: 8px 5px;
   padding: 10px 14px;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border-radius: 4px;
 
   @include device-is('tablet') {
@@ -17,7 +17,7 @@
   }
 
   &__title {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875em;
   }
 
@@ -58,7 +58,7 @@
   &__action {
     display: flex;
     gap: $pix-spacing-m;
-    border-top: 1.2px solid $pix-neutral-15;
+    border-top: 1.2px solid var(--pix-neutral-20);
 
     @include device-is('tablet') {
       border: none;
@@ -73,13 +73,13 @@
   &__results {
     display: flex;
     align-items: center;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 0.875em;
   }
 
   &__action-separator {
-    border-left: 1px solid $pix-neutral-20;
+    border-left: 1px solid var(--pix-neutral-20);
 
     @include device-is('mobile') {
       border-left: none;
@@ -96,7 +96,7 @@
 
     &:focus-visible + .campaign-filters__tab {
       z-index: 1;
-      box-shadow: $pix-neutral-0 0 0 0 2px, $pix-primary 0 0 0 4px;
+      box-shadow: var(--pix-neutral-0) 0 0 0 2px, var(--pix-primary-500) 0 0 0 4px;
     }
   }
 
@@ -105,23 +105,23 @@
     align-items: center;
     height: 36px;
     padding: 6px 8px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 0.8125rem;
     font-family: $font-roboto;
     background: transparent;
-    border: 1.2px solid $pix-neutral-45;
+    border: 1.2px solid var(--pix-neutral-500);
     outline: none;
     cursor: pointer;
     transition: all 0.15s ease-in-out;
 
     &:hover {
-      background: $pix-neutral-20;
+      background: var(--pix-neutral-20);
       opacity: 0.8;
     }
 
     &--active {
-      background: $pix-neutral-20;
+      background: var(--pix-neutral-20);
 
       &:hover {
         opacity: 1;

--- a/orga/app/styles/components/campaign/filters.scss
+++ b/orga/app/styles/components/campaign/filters.scss
@@ -1,7 +1,7 @@
 .campaign-filters {
   display: flex;
   flex-direction: column;
-  gap: $pix-spacing-s;
+  gap: var(--pix-spacing-4x);
   margin: 8px 5px;
   padding: 10px 14px;
   background-color: var(--pix-neutral-0);
@@ -46,7 +46,7 @@
   &__filter {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
 
     @include device-is('desktop') {
       flex-direction: row;
@@ -57,7 +57,7 @@
 
   &__action {
     display: flex;
-    gap: $pix-spacing-m;
+    gap: var(--pix-spacing-6x);
     border-top: 1.2px solid var(--pix-neutral-20);
 
     @include device-is('tablet') {

--- a/orga/app/styles/components/campaign/header/archived-banner.scss
+++ b/orga/app/styles/components/campaign/header/archived-banner.scss
@@ -8,8 +8,8 @@
   min-height: 60px;
   margin-bottom: 24px;
   padding: 8px 10px;
-  color: $pix-neutral-0;
-  background: $pix-neutral-60;
+  color: var(--pix-neutral-0);
+  background: var(--pix-neutral-500);
   border-radius: 6px;
 
   &__text {
@@ -26,16 +26,16 @@
 
   &__unarchive-button {
     margin-left: auto;
-    background: $pix-neutral-60;
-    border: 2px solid $pix-neutral-0;
+    background: var(--pix-neutral-500);
+    border: 2px solid var(--pix-neutral-0);
 
     &:hover {
-      background: $pix-neutral-60;
+      background: var(--pix-neutral-500);
       opacity: 0.8;
     }
 
     &:focus {
-      background: $pix-neutral-60;
+      background: var(--pix-neutral-500);
     }
   }
 }

--- a/orga/app/styles/components/campaign/header/title.scss
+++ b/orga/app/styles/components/campaign/header/title.scss
@@ -46,7 +46,7 @@
     & > * {
       margin-right: 15px;
       padding-right: 15px;
-      border-right: 1px solid $pix-neutral-20;
+      border-right: 1px solid var(--pix-neutral-20);
     }
 
     & > *:last-child {
@@ -59,7 +59,7 @@
   &__detail-item {
     @extend %pix-body-s;
 
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
 
     & > dt {
       display: block;
@@ -68,7 +68,7 @@
 
     & > dd {
       margin: 0;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
     }
   }
 

--- a/orga/app/styles/components/campaign/header/title.scss
+++ b/orga/app/styles/components/campaign/header/title.scss
@@ -1,5 +1,5 @@
 .campaign-header-title {
-  margin: $pix-spacing-l 0;
+  margin: var(--pix-spacing-8x) 0;
 
   &__informations {
     display: flex;
@@ -8,7 +8,7 @@
   }
 
   &__breadcrumb {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
   }
 
   &__type-icon {
@@ -23,9 +23,7 @@
 
     display: flex;
     flex: 0 1 auto;
-    flex-direction: row;
-    gap: $pix-spacing-s;
-    padding-right: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     overflow: hidden;
 
     .campaign-header-title__name {
@@ -63,7 +61,7 @@
 
     & > dt {
       display: block;
-      margin-bottom: $pix-spacing-xs;
+      margin-bottom: var(--pix-spacing-2x);
     }
 
     & > dd {
@@ -79,13 +77,12 @@
 
 @include device-is('mobile') {
   .campaign-header-title {
-    flex-direction: column;
     align-items: initial;
 
     &__headline {
       justify-content: center;
       width: 100%;
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
     }
 
     &__infos {

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -14,6 +14,6 @@
   &__table-header-background {
     @extend %pix-shadow-xs;
 
-    background: $pix-neutral-10;
+    background: var(--pix-neutral-20);
   }
 }

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -3,7 +3,7 @@
 
   &__campaign-link {
     display: flex;
-    gap: $pix-spacing-xs;
+    gap: var(--pix-spacing-2x);
     align-items: center;
   }
 

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -12,7 +12,8 @@
   }
 
   &__table-header-background {
+    @extend %pix-shadow-xs;
+
     background: $pix-neutral-10;
-    box-shadow: 0px 0px 0px 4px $pix-neutral-0 inset;
   }
 }

--- a/orga/app/styles/components/campaign/no-campaign-panel.scss
+++ b/orga/app/styles/components/campaign/no-campaign-panel.scss
@@ -7,6 +7,6 @@
   text-align: center;
 
   &__information-text {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }

--- a/orga/app/styles/components/campaign/settings/campaign-settings.scss
+++ b/orga/app/styles/components/campaign/settings/campaign-settings.scss
@@ -12,7 +12,7 @@
   justify-content: space-between;
 
   &:not(:last-child) {
-    border-bottom: 1px solid $pix-neutral-20;
+    border-bottom: 1px solid var(--pix-neutral-20);
   }
 }
 
@@ -32,7 +32,7 @@
   }
 
   &:not(:first-child) {
-    border-left: 1px solid $pix-neutral-20;
+    border-left: 1px solid var(--pix-neutral-20);
   }
 
   &__label {
@@ -73,7 +73,7 @@
 
 .campaign-settings-content__tooltip-icon {
   margin: 0 0 4px 0;
-  color: $pix-neutral-30;
+  color: var(--pix-neutral-100);
 }
 
 .campaign-settings-buttons {

--- a/orga/app/styles/components/campaign/settings/campaign-settings.scss
+++ b/orga/app/styles/components/campaign/settings/campaign-settings.scss
@@ -73,7 +73,7 @@
 
 .campaign-settings-content__tooltip-icon {
   margin: 0 0 4px 0;
-  color: var(--pix-neutral-100);
+  color: var(--pix-neutral-500);
 }
 
 .campaign-settings-buttons {

--- a/orga/app/styles/components/campaign/target-profile-details.scss
+++ b/orga/app/styles/components/campaign/target-profile-details.scss
@@ -27,7 +27,7 @@
         &::before {
           height: 0.3125rem;
           margin: auto 10px;
-          border-left: 1px solid $pix-neutral-25;
+          border-left: 1px solid var(--pix-neutral-100);
           content: '';
         }
       }

--- a/orga/app/styles/components/certificability/cell.scss
+++ b/orga/app/styles/components/certificability/cell.scss
@@ -1,4 +1,4 @@
 .cell-certifiable-at {
   display: block;
-  margin-top: $pix-spacing-xxs;
+  margin-top: var(--pix-spacing-1x);
 }

--- a/orga/app/styles/components/certificability/tooltip.scss
+++ b/orga/app/styles/components/certificability/tooltip.scss
@@ -2,7 +2,7 @@
   margin-top: auto;
   margin-bottom: auto;
   padding-left: 6px;
-  color: $pix-neutral-30;
+  color: var(--pix-neutral-100);
 
   [role='tooltip'] {
     font-weight: $font-normal;

--- a/orga/app/styles/components/certificability/tooltip.scss
+++ b/orga/app/styles/components/certificability/tooltip.scss
@@ -2,7 +2,7 @@
   margin-top: auto;
   margin-bottom: auto;
   padding-left: 6px;
-  color: var(--pix-neutral-100);
+  color: var(--pix-neutral-500);
 
   [role='tooltip'] {
     font-weight: $font-normal;

--- a/orga/app/styles/components/current-organization.scss
+++ b/orga/app/styles/components/current-organization.scss
@@ -2,7 +2,7 @@
   padding-top: 15px;
 
   &__label {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: 300;
     font-size: 0.7rem;
     letter-spacing: 0.07rem;
@@ -11,7 +11,7 @@
 
   &__name {
     padding-top: 8px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: 300;
     font-size: 0.82rem;
     letter-spacing: 0.05rem;

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -3,6 +3,8 @@
   display: inline-block;
 
   &__content {
+    @extend %pix-shadow-xs;
+
     position: absolute;
     z-index: 1;
     margin: 0;
@@ -10,7 +12,6 @@
     overflow: hidden;
     background-color: $pix-neutral-0;
     border-radius: 4px;
-    box-shadow: 1px 1px 3px 1px rgba($pix-neutral-110, 0.13), 0 1px 1px 0 rgba($pix-neutral-110, 0.08);
   }
 
   &__item {

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -10,7 +10,7 @@
     margin: 0;
     padding: 0;
     overflow: hidden;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 4px;
   }
 
@@ -32,7 +32,7 @@
         width: 100%;
         height: 100%;
         padding: 12px 16px;
-        color: $pix-neutral-60;
+        color: var(--pix-neutral-500);
         font-size: 0.875rem;
         cursor: pointer;
         transition: background-color 0.1s linear;
@@ -40,16 +40,16 @@
         &:hover,
         &:active,
         &:focus {
-          color: $pix-neutral-60;
+          color: var(--pix-neutral-500);
           text-decoration: none;
-          background-color: $pix-neutral-10;
+          background-color: var(--pix-neutral-20);
         }
 
         &:focus,
         &:focus-visible {
           border-radius: 4px;
           outline: none;
-          box-shadow: inset 0px 0px 0px 1.6px $pix-primary;
+          box-shadow: inset 0px 0px 0px 1.6px var(--pix-primary-500);
         }
       }
     }

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -3,7 +3,7 @@
   display: inline-block;
 
   &__content {
-    @extend %pix-shadow-xs;
+    @extend %pix-shadow-md;
 
     position: absolute;
     z-index: 1;

--- a/orga/app/styles/components/edit-student-number-modal.scss
+++ b/orga/app/styles/components/edit-student-number-modal.scss
@@ -1,10 +1,10 @@
 .edit-student-number-modal {
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-size: 1rem;
 
   &__student-number {
     display: block;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
   }
 }

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -9,7 +9,7 @@
 
   &__legal-information {
     max-width: 500px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.6875rem;
   }
 
@@ -19,7 +19,7 @@
     text-align: left;
 
     a {
-      color: $pix-communication-dark;
+      color: var(--pix-communication-dark);
       text-decoration: none;
 
       svg {

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -14,7 +14,7 @@
   }
 
   &__back {
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
     font-size: 1rem;
     text-align: left;
 

--- a/orga/app/styles/components/layout/footer.scss
+++ b/orga/app/styles/components/layout/footer.scss
@@ -5,7 +5,7 @@
   align-items: center;
   justify-content: space-between;
   margin: 0 $pix-spacing-m;
-  border-top: 1px solid $pix-neutral-20;
+  border-top: 1px solid var(--pix-neutral-20);
 
   @include device-is('desktop') {
     flex-direction: row;
@@ -34,7 +34,7 @@
 
   &__copyrights {
     padding: 16px 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
     font-size: 0.75rem;
     font-family: $font-roboto;
     cursor: default;
@@ -44,7 +44,7 @@
 .footer-navigation {
   &__item {
     margin-right: $pix-spacing-xxs;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 0.8125rem;
     font-family: $font-roboto;
@@ -55,15 +55,15 @@
     }
 
     &.active {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
     }
 
     &:focus {
-      color: $pix-neutral-50;
+      color: var(--pix-neutral-20)0;
     }
 
     &:hover {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
       cursor: pointer;
     }
   }

--- a/orga/app/styles/components/layout/footer.scss
+++ b/orga/app/styles/components/layout/footer.scss
@@ -4,7 +4,7 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
-  margin: 0 $pix-spacing-m;
+  margin: 0 var(--pix-spacing-6x);
   border-top: 1px solid var(--pix-neutral-20);
 
   @include device-is('desktop') {
@@ -43,7 +43,7 @@
 
 .footer-navigation {
   &__item {
-    margin-right: $pix-spacing-xxs;
+    margin-right: var(--pix-spacing-1x);
     color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 0.8125rem;
@@ -51,7 +51,7 @@
     text-decoration: none;
 
     @include device-is('desktop') {
-      margin-right: $pix-spacing-s;
+      margin-right: var(--pix-spacing-4x);
     }
 
     &.active {

--- a/orga/app/styles/components/layout/organization-credit-info.scss
+++ b/orga/app/styles/components/layout/organization-credit-info.scss
@@ -5,12 +5,12 @@
   font-size: 0.875rem;
 
   &__label {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: 500;
   }
 
   .info-icon {
     margin: 0 8px;
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
   }
 }

--- a/orga/app/styles/components/layout/sidebar.scss
+++ b/orga/app/styles/components/layout/sidebar.scss
@@ -25,7 +25,7 @@
     align-items: center;
     height: 40px;
     padding-left: 24px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: 0.875rem;
     font-family: $font-roboto;
     text-decoration: none;
@@ -37,7 +37,7 @@
 
     &.active {
       background-color: $chambray;
-      border-left: 3px solid $pix-warning-40;
+      border-left: 3px solid var(--pix-warning-500);
     }
   }
 

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -5,7 +5,7 @@
   align-items: center;
   justify-content: flex-end;
   height: 60px;
-  margin-bottom: $pix-spacing-m;
+  margin-bottom: var(--pix-spacing-6x);
   background-color: var(--pix-neutral-0);
 
   &__organization-credit-info {

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -6,7 +6,7 @@
   justify-content: flex-end;
   height: 60px;
   margin-bottom: $pix-spacing-m;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
 
   &__organization-credit-info {
     padding: 0 30px;

--- a/orga/app/styles/components/layout/user-logged-menu.scss
+++ b/orga/app/styles/components/layout/user-logged-menu.scss
@@ -3,23 +3,23 @@
   align-items: center;
   height: 100%;
   padding: 0 30px;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   background-color: transparent;
   border-width: 0;
-  border-left: 1px solid $pix-neutral-20;
+  border-left: 1px solid var(--pix-neutral-20);
   cursor: pointer;
 
   &:hover,
   &:active,
   &:focus {
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     text-decoration: none;
   }
 
   &:focus {
     border-radius: 4px;
     outline: none;
-    box-shadow: inset 0px 0px 0px 1.6px $pix-primary;
+    box-shadow: inset 0px 0px 0px 1.6px var(--pix-primary-500);
   }
 
   &__text {
@@ -46,7 +46,7 @@
     vertical-align: middle;
 
     &--up {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
     }
   }
 }

--- a/orga/app/styles/components/layout/user-logged-menu.scss
+++ b/orga/app/styles/components/layout/user-logged-menu.scss
@@ -27,7 +27,7 @@
     flex-direction: column;
     justify-content: center;
     height: 100%;
-    padding-right: $pix-spacing-xs;
+    padding-right: var(--pix-spacing-2x);
     font-weight: 700;
     font-size: 0.875rem;
     line-height: 1.1rem;

--- a/orga/app/styles/components/learner/header.scss
+++ b/orga/app/styles/components/learner/header.scss
@@ -1,14 +1,14 @@
 .learner-header {
-  margin: $pix-spacing-l 0;
+  margin: var(--pix-spacing-8x) 0;
 
   &__breadcrumb {
-    margin-bottom: $pix-spacing-m;
+    margin-bottom: var(--pix-spacing-6x);
     text-transform: capitalize;
   }
 
   &__informations-line {
     display: flex;
-    gap: $pix-spacing-xxl;
+    gap: var(--pix-spacing-12x);
     align-items: center;
   }
 

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -7,7 +7,7 @@
   &__information {
     @extend %pix-body-s;
 
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     text-align: center;
   }
@@ -15,7 +15,7 @@
   &__error-message {
     @extend %pix-body-s;
 
-    margin-top: $pix-spacing-m;
+    margin-top: var(--pix-spacing-6x);
     color: var(--pix-error-700);
     text-align: center;
 
@@ -56,7 +56,7 @@
   &__input-container {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     width: 100%;
 
     button[type="submit"] {

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -8,7 +8,7 @@
     @extend %pix-body-s;
 
     margin-top: $pix-spacing-s;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     text-align: center;
   }
 
@@ -16,7 +16,7 @@
     @extend %pix-body-s;
 
     margin-top: $pix-spacing-m;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     text-align: center;
 
     & a {
@@ -27,7 +27,7 @@
   &__forgotten-password {
     @extend %pix-body-s;
 
-    color: $pix-communication-dark;
+    color: var(--pix-communication-dark);
     text-align: left;
   }
 
@@ -48,7 +48,7 @@
 
     margin: 10px 0 16px 0;
     padding: 9px;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     text-align: center;
     border-radius: 3px;
   }

--- a/orga/app/styles/components/login-or-register.scss
+++ b/orga/app/styles/components/login-or-register.scss
@@ -38,7 +38,7 @@
 
   &__invitation {
     margin-top: 24px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: 500;
     font-size: 1.125rem;
     font-family: $font-roboto;
@@ -82,7 +82,7 @@
 
   &__divider {
     margin-top: 30px;
-    border-left: 1px solid $pix-neutral-30;
+    border-left: 1px solid var(--pix-neutral-100);
 
     @include device-is('tablet') {
       margin: 30px;

--- a/orga/app/styles/components/login-or-register.scss
+++ b/orga/app/styles/components/login-or-register.scss
@@ -1,5 +1,5 @@
 .login-or-register {
-  margin: $pix-spacing-m 0;
+  margin: var(--pix-spacing-6x) 0;
 
   @include device-is('mobile') {
     margin: 12px 0;
@@ -16,7 +16,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     padding: 20px 2px;
     border-radius: 10px;
 
@@ -25,7 +25,7 @@
     }
 
     @include device-is('large-screen') {
-      padding: $pix-spacing-xl 100px;
+      padding: var(--pix-spacing-10x) 100px;
     }
   }
 }
@@ -72,7 +72,7 @@
     }
 
     .form-title {
-      margin: $pix-spacing-m 0;
+      margin: var(--pix-spacing-6x) 0;
 
       @include device-is('mobile') {
         text-align: center;

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -2,29 +2,29 @@
   display: flex;
   flex-direction: column;
   padding: $pix-spacing-m;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 
   &__title {
     @extend %pix-title-xs;
 
     margin: 0;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 
   label {
     padding-bottom: 5px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: .88rem;
   }
 
   .disabled {
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border: none;
   }
 
   .help {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: normal;
     font-size: 0.85rem;
     letter-spacing: normal;
@@ -35,7 +35,7 @@
     input {
       box-sizing: border-box;
       width: 85%;
-      background-color: $pix-neutral-15;
+      background-color: var(--pix-neutral-20);
     }
   }
 
@@ -53,7 +53,7 @@
 
   &__warning {
     display: flex;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: .875rem;
 
     span {
@@ -65,7 +65,7 @@
     display: flex;
     flex-direction: column;
     padding-left: $pix-spacing-s;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: .875rem;
 
     li {
@@ -76,7 +76,7 @@
   &__footer {
     margin-top: $pix-spacing-s;
     padding: $pix-spacing-s $pix-spacing-m;
-    background-color: $pix-neutral-70;
+    background-color: var(--pix-neutral-800);
     border-radius: $pix-spacing-xs;
 
     button {
@@ -85,19 +85,19 @@
     }
 
     label {
-      color: $pix-neutral-0;
+      color: var(--pix-neutral-0);
     }
   }
 
   &__box {
     margin-top: $pix-spacing-s;
     padding: $pix-spacing-s $pix-spacing-m;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 8px;
 
     hr {
       margin-bottom: $pix-spacing-s;
-      color: $pix-neutral-22;
+      color: var(--pix-neutral-100);
     }
 
     > .input-container {
@@ -116,11 +116,11 @@
     }
 
     .green-icon {
-      color: $pix-success-70;
+      color: var(--pix-success-700);
     }
 
     .grey-icon {
-      color: $pix-neutral-45;
+      color: var(--pix-neutral-500);
     }
   }
 }

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -1,7 +1,7 @@
 .manage-authentication-window {
   display: flex;
   flex-direction: column;
-  padding: $pix-spacing-m;
+  padding: var(--pix-spacing-6x);
   background-color: var(--pix-neutral-20);
 
   &__title {
@@ -64,23 +64,23 @@
   &__informations {
     display: flex;
     flex-direction: column;
-    padding-left: $pix-spacing-s;
+    padding-left: var(--pix-spacing-4x);
     color: var(--pix-neutral-0);
     font-size: .875rem;
 
     li {
-      margin: $pix-spacing-xxs 0;
+      margin: var(--pix-spacing-1x) 0;
     }
   }
 
   &__footer {
-    margin-top: $pix-spacing-s;
-    padding: $pix-spacing-s $pix-spacing-m;
+    margin-top: var(--pix-spacing-4x);
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
     background-color: var(--pix-neutral-800);
-    border-radius: $pix-spacing-xs;
+    border-radius: var(--pix-spacing-2x);
 
     button {
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
       font-weight: 600;
     }
 
@@ -90,13 +90,13 @@
   }
 
   &__box {
-    margin-top: $pix-spacing-s;
-    padding: $pix-spacing-s $pix-spacing-m;
+    margin-top: var(--pix-spacing-4x);
+    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
     background-color: var(--pix-neutral-0);
     border-radius: 8px;
 
     hr {
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
       color: var(--pix-neutral-100);
     }
 
@@ -109,7 +109,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
 
     &--mediacentre {
       margin-bottom: 0;

--- a/orga/app/styles/components/organization-learner/activity/cards.scss
+++ b/orga/app/styles/components/organization-learner/activity/cards.scss
@@ -4,9 +4,9 @@
 
 .cards {
   display: flex;
-  gap: $pix-spacing-m;
+  gap: var(--pix-spacing-6x);
   justify-content: space-between;
-  margin: $pix-spacing-m 0;
+  margin: var(--pix-spacing-6x) 0;
 
   &__content {
     width: 100%;
@@ -14,7 +14,7 @@
 
   &__stats {
     display: inline-flex;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     justify-content: space-between;
     margin: 0;
     padding: 0;

--- a/orga/app/styles/components/organization-learner/activity/participation-list.scss
+++ b/orga/app/styles/components/organization-learner/activity/participation-list.scss
@@ -1,12 +1,12 @@
 .participation-list {
   &__table {
     th {
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-weight: 700;
     }
 
     td {
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
     }
   }
 }

--- a/orga/app/styles/components/pagination-control.scss
+++ b/orga/app/styles/components/pagination-control.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   margin: 16px 0;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 0.875rem;
   font-family: $font-roboto;
 }

--- a/orga/app/styles/components/participant/index.scss
+++ b/orga/app/styles/components/participant/index.scss
@@ -5,6 +5,6 @@
 .participant {
   &__link {
     margin-top: $pix-spacing-xs;
-    color: $pix-primary;
+    color: var(--pix-primary-500);
   }
 }

--- a/orga/app/styles/components/participant/index.scss
+++ b/orga/app/styles/components/participant/index.scss
@@ -4,7 +4,7 @@
 
 .participant {
   &__link {
-    margin-top: $pix-spacing-xs;
+    margin-top: var(--pix-spacing-2x);
     color: var(--pix-primary-500);
   }
 }

--- a/orga/app/styles/components/participant/no-participant-panel.scss
+++ b/orga/app/styles/components/participant/no-participant-panel.scss
@@ -7,10 +7,10 @@
   text-align: center;
 
   &__information-text {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 
   .link-icon {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
   }
 }

--- a/orga/app/styles/components/participant/profile.scss
+++ b/orga/app/styles/components/participant/profile.scss
@@ -1,7 +1,7 @@
 .campaign-prescriber-profile {
   .page-header {
     display: flex;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: center;
   }
 }

--- a/orga/app/styles/components/places/title.scss
+++ b/orga/app/styles/components/places/title.scss
@@ -1,6 +1,6 @@
 .places-page-header {
  display: flex;
- gap: $pix-spacing-xs;
+ gap: var(--pix-spacing-2x);
  align-items: baseline;
 
  &__date {

--- a/orga/app/styles/components/progress-bar.scss
+++ b/orga/app/styles/components/progress-bar.scss
@@ -1,10 +1,10 @@
 .progress-bar {
   width: 160px;
   height: 6px;
-  background-color: $pix-neutral-20;
+  background-color: var(--pix-neutral-20);
   border-radius: 10px;
 
   &--completion {
-    background-color: $pix-primary;
+    background-color: var(--pix-primary-500);
   }
 }

--- a/orga/app/styles/components/register-form.scss
+++ b/orga/app/styles/components/register-form.scss
@@ -9,14 +9,14 @@
 
   &__cgu-error {
     margin-top: 20px;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     font-size: 0.75em;
   }
 
   &__information {
     @extend %pix-body-s;
 
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     text-align: center;
   }
 

--- a/orga/app/styles/components/register-form.scss
+++ b/orga/app/styles/components/register-form.scss
@@ -21,7 +21,7 @@
   }
 
   .input-container {
-    margin: $pix-spacing-s 2px $pix-spacing-s 2px;
+    margin: var(--pix-spacing-4x) 2px var(--pix-spacing-4x) 2px;
   }
 
   .pix-input-password > .pix-input__error-message {

--- a/orga/app/styles/components/sco-organization-participant/reset-password-modal.scss
+++ b/orga/app/styles/components/sco-organization-participant/reset-password-modal.scss
@@ -1,5 +1,5 @@
 .reset-password-modal__content {
   display: flex;
   flex-direction: column;
-  gap: $pix-spacing-s;
+  gap: var(--pix-spacing-4x);
 }

--- a/orga/app/styles/components/search-input.scss
+++ b/orga/app/styles/components/search-input.scss
@@ -5,12 +5,12 @@
   box-sizing: border-box;
 
   &:focus-within {
-    border-color: $pix-primary;
-    box-shadow: inset 0 0 0 0.6px $pix-primary;
+    border-color: var(--pix-primary-500);
+    box-shadow: inset 0 0 0 0.6px var(--pix-primary-500);
   }
 
   svg {
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
   }
 
   &__invisible-field {
@@ -30,16 +30,16 @@
 
     /* IE 11 */
     &:-ms-input-placeholder {
-      color: $pix-neutral-30;
+      color: var(--pix-neutral-100);
     }
 
     /* older Chrome/Safari/Opera and Edge */
     &::-webkit-input-placeholder {
-      color: $pix-neutral-30;
+      color: var(--pix-neutral-100);
     }
 
     &::placeholder {
-      color: $pix-neutral-30;
+      color: var(--pix-neutral-100);
       opacity: 1; /* Firefox */
     }
   }

--- a/orga/app/styles/components/sup-organization-participant/replace-students-modal.scss
+++ b/orga/app/styles/components/sup-organization-participant/replace-students-modal.scss
@@ -1,5 +1,5 @@
 .replace-students-modal {
   &__content {
-    margin-bottom:$pix-spacing-s;
+    margin-bottom:var(--pix-spacing-4x);
   }
 }

--- a/orga/app/styles/components/team/leave-organization-modal.scss
+++ b/orga/app/styles/components/team/leave-organization-modal.scss
@@ -1,5 +1,5 @@
 .leave-organization-modal {
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-size: 1rem;
   line-height: $pix-spacing-m;
 

--- a/orga/app/styles/components/team/leave-organization-modal.scss
+++ b/orga/app/styles/components/team/leave-organization-modal.scss
@@ -1,18 +1,18 @@
 .leave-organization-modal {
   color: var(--pix-neutral-900);
   font-size: 1rem;
-  line-height: $pix-spacing-m;
+  line-height: var(--pix-spacing-6x);
 
   &__action-buttons {
 
     &--list {
       display: flex;
-      gap: $pix-spacing-s;
+      gap: var(--pix-spacing-4x);
       justify-content: flex-end;
     }
 
     &--container {
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
     }
   }
 }

--- a/orga/app/styles/components/team/remove-member-modal.scss
+++ b/orga/app/styles/components/team/remove-member-modal.scss
@@ -1,18 +1,18 @@
 .remove-member-modal {
   color: var(--pix-neutral-900);
   font-size: 1rem;
-  line-height: $pix-spacing-m;
+  line-height: var(--pix-spacing-6x);
 
   &__action-buttons {
 
     &--list {
       display: flex;
-      gap: $pix-spacing-s;
+      gap: var(--pix-spacing-4x);
       justify-content: flex-end;
     }
 
     &--container {
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
     }
   }
 }

--- a/orga/app/styles/components/team/remove-member-modal.scss
+++ b/orga/app/styles/components/team/remove-member-modal.scss
@@ -1,5 +1,5 @@
 .remove-member-modal {
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-size: 1rem;
   line-height: $pix-spacing-m;
 

--- a/orga/app/styles/components/ui/action-bar.scss
+++ b/orga/app/styles/components/ui/action-bar.scss
@@ -11,9 +11,9 @@
   justify-content: space-between;
   width: calc(100% - $app-sidebar-width) ;
   height: 68px;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-family: $font-roboto;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
 
   .action-bar__informations {
     display: flex;

--- a/orga/app/styles/components/ui/action-bar.scss
+++ b/orga/app/styles/components/ui/action-bar.scss
@@ -18,19 +18,19 @@
   .action-bar__informations {
     display: flex;
     align-items: baseline;
-    margin-left: $pix-spacing-xl;
+    margin-left: var(--pix-spacing-10x);
   }
 
   .action-bar__actions {
     display: flex;
-    padding: 0 $pix-spacing-m;
+    padding: 0 var(--pix-spacing-6x);
 
     .pix-button {
-      margin: 0 $pix-spacing-xs;
+      margin: 0 var(--pix-spacing-2x);
     }
   }
 }
 
 footer {
-  padding: $pix-spacing-s $pix-spacing-m;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
 }

--- a/orga/app/styles/components/ui/breadcrumb.scss
+++ b/orga/app/styles/components/ui/breadcrumb.scss
@@ -11,7 +11,7 @@
   }
 
   li:not(:last-child) {
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
   }
 
   li:not(:first-child) {
@@ -19,7 +19,7 @@
   }
 
   li:last-child {
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
   }
 
   li:not(:last-child)::after {
@@ -27,7 +27,7 @@
     width: 0.4375rem;
     height: 0.4375rem;
     margin: 0 .375rem;
-    border: .0625rem solid $pix-neutral-45;
+    border: .0625rem solid var(--pix-neutral-500);
     border-bottom: 0;
     border-left: 0;
     transform: rotate(45deg);

--- a/orga/app/styles/components/ui/cards.scss
+++ b/orga/app/styles/components/ui/cards.scss
@@ -3,7 +3,7 @@
 
   position: relative;
   padding: 16px 20px;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border: none;
   border-radius: 10px;
 
@@ -12,6 +12,6 @@
 
     margin-top: 0;
     margin-bottom: 32px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }

--- a/orga/app/styles/components/ui/cards.scss
+++ b/orga/app/styles/components/ui/cards.scss
@@ -1,10 +1,11 @@
 .chart-card {
+  @extend %pix-shadow-xs;
+
   position: relative;
   padding: 16px 20px;
   background-color: $pix-neutral-0;
   border: none;
   border-radius: 10px;
-  box-shadow: $shadow-base;
 
   &__title {
     @extend %pix-title-xs;

--- a/orga/app/styles/components/ui/empty-state.scss
+++ b/orga/app/styles/components/ui/empty-state.scss
@@ -1,4 +1,4 @@
 .participants-empty-state__text {
   margin-top: 0px;
-  margin-bottom: $pix-spacing-xs;
+  margin-bottom: var(--pix-spacing-2x);
 }

--- a/orga/app/styles/components/ui/explanation-card.scss
+++ b/orga/app/styles/components/ui/explanation-card.scss
@@ -1,5 +1,5 @@
 .explanation-card {
-  padding: $pix-spacing-s;
+  padding: var(--pix-spacing-4x);
   color: var(--pix-neutral-500);
   background: var(--pix-neutral-20);
   border-radius: 8px;
@@ -8,13 +8,13 @@
     @extend %pix-body-m;
 
     display: block;
-    margin-bottom: $pix-spacing-xs;
+    margin-bottom: var(--pix-spacing-2x);
     color: var(--pix-neutral-900);
     font-weight: 500;
   }
 
   &__icon {
-    margin-right: $pix-spacing-xs;
+    margin-right: var(--pix-spacing-2x);
     color: var(--pix-primary-500);
   }
 

--- a/orga/app/styles/components/ui/explanation-card.scss
+++ b/orga/app/styles/components/ui/explanation-card.scss
@@ -1,7 +1,7 @@
 .explanation-card {
   padding: $pix-spacing-s;
-  color: $pix-neutral-60;
-  background: $pix-neutral-15;
+  color: var(--pix-neutral-500);
+  background: var(--pix-neutral-20);
   border-radius: 8px;
 
   &__title {
@@ -9,18 +9,18 @@
 
     display: block;
     margin-bottom: $pix-spacing-xs;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: 500;
   }
 
   &__icon {
     margin-right: $pix-spacing-xs;
-    color: $pix-primary;
+    color: var(--pix-primary-500);
   }
 
   &__message {
     @extend %pix-body-s;
 
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }

--- a/orga/app/styles/components/ui/explanation-card.scss
+++ b/orga/app/styles/components/ui/explanation-card.scss
@@ -15,7 +15,7 @@
 
   &__icon {
     margin-right: var(--pix-spacing-2x);
-    color: var(--pix-primary-500);
+    color: var(--pix-info-700);
   }
 
   &__message {

--- a/orga/app/styles/components/ui/form-field.scss
+++ b/orga/app/styles/components/ui/form-field.scss
@@ -1,11 +1,11 @@
 $form-field-with: 500px;
 
 .form-field {
-  margin-bottom: $pix-spacing-m;
+  margin-bottom: var(--pix-spacing-6x);
 
   @include device-is('large-screen') {
     display: flex;
-    gap: $pix-spacing-m;
+    gap: var(--pix-spacing-6x);
     justify-content: space-between;
   }
 
@@ -14,7 +14,7 @@ $form-field-with: 500px;
   }
 
   &__element {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
 
     @include device-is('large-screen') {
       width: $form-field-with;
@@ -30,7 +30,7 @@ $form-field-with: 500px;
       width: auto;
 
       @include device-is('large-screen') {
-        width: calc(100% - ($form-field-with + $pix-spacing-m));
+        width: calc(100% - ($form-field-with + var(--pix-spacing-6x)));
       }
   }
 }

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -10,20 +10,20 @@
   padding: 0 $pix-spacing-xs;
   font-size: 0.875rem;
   text-align: left;
-  border-left: 1px solid $pix-neutral-22;
+  border-left: 1px solid var(--pix-neutral-100);
 
   &__title {
     margin-bottom: $pix-spacing-xs;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
   }
 
   &__content {
     margin: 0;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
 
 
     &--date {
-      color: $pix-neutral-50;
+      color: var(--pix-neutral-20)0;
       font-size: 0.75rem;
     }
   }

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -7,13 +7,13 @@
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
-  padding: 0 $pix-spacing-xs;
+  padding: 0 var(--pix-spacing-2x);
   font-size: 0.875rem;
   text-align: left;
   border-left: 1px solid var(--pix-neutral-100);
 
   &__title {
-    margin-bottom: $pix-spacing-xs;
+    margin-bottom: var(--pix-spacing-2x);
     color: var(--pix-neutral-20)0;
   }
 
@@ -29,7 +29,7 @@
   }
 
   &--certifiable {
-    padding-bottom: $pix-spacing-xxs;
+    padding-bottom: var(--pix-spacing-1x);
     text-align: center;
   }
 

--- a/orga/app/styles/components/ui/last-participation-date-tooltip.scss
+++ b/orga/app/styles/components/ui/last-participation-date-tooltip.scss
@@ -2,7 +2,7 @@
   font-weight: $font-normal;
 
   &__icon {
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
   }
 
   [role='tooltip'] {

--- a/orga/app/styles/components/ui/last-participation-date-tooltip.scss
+++ b/orga/app/styles/components/ui/last-participation-date-tooltip.scss
@@ -2,7 +2,7 @@
   font-weight: $font-normal;
 
   &__icon {
-    color: var(--pix-neutral-100);
+    color: var(--pix-neutral-500);
   }
 
   [role='tooltip'] {

--- a/orga/app/styles/components/ui/mastery-percentage-display.scss
+++ b/orga/app/styles/components/ui/mastery-percentage-display.scss
@@ -23,7 +23,7 @@
   }
 
   &__info-icon {
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
   }
 }
 

--- a/orga/app/styles/components/ui/modal-display.scss
+++ b/orga/app/styles/components/ui/modal-display.scss
@@ -3,8 +3,8 @@
   &__footer {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-s;
-    margin-bottom: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
+    margin-bottom: var(--pix-spacing-4x);
   
     @include device-is('tablet') {
       flex-flow: row wrap;

--- a/orga/app/styles/components/ui/placeholders.scss
+++ b/orga/app/styles/components/ui/placeholders.scss
@@ -1,34 +1,34 @@
 .placeholder-box {
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
   border-radius: 5px;
   animation: placeholder-background-color 1s infinite alternate;
 }
 
 @keyframes placeholder-background-color {
   from {
-    background-color: $pix-neutral-10;
-    border-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
+    border-color: var(--pix-neutral-20);
   }
 
   to {
-    background-color: $pix-neutral-20;
-    border-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
+    border-color: var(--pix-neutral-20);
   }
 }
 
 .placeholder-doughnut {
   box-sizing: border-box;
-  border: 50px solid $pix-neutral-10;
+  border: 50px solid var(--pix-neutral-20);
   border-radius: 50%;
   animation: placeholder-border-color 1s infinite alternate;
 }
 
 @keyframes placeholder-border-color {
   from {
-    border-color: $pix-neutral-10;
+    border-color: var(--pix-neutral-20);
   }
 
   to {
-    border-color: $pix-neutral-20;
+    border-color: var(--pix-neutral-20);
   }
 }

--- a/orga/app/styles/globals/competences.scss
+++ b/orga/app/styles/globals/competences.scss
@@ -8,7 +8,7 @@
 
     position: relative;
     padding-left: 1rem;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 0.875rem;
   }
 
@@ -25,28 +25,28 @@
     border-radius: 1.5px;
 
     &--jaffa {
-      background: $pix-information-light;
-      border-color: $pix-information-light;
+      background: var(--pix-information-light);
+      border-color: var(--pix-information-light);
     }
 
     &--emerald {
-      background: $pix-content-light;
-      border-color: $pix-content-light;
+      background: var(--pix-content-light);
+      border-color: var(--pix-content-light);
     }
 
     &--cerulean {
-      background: $pix-communication-light;
-      border-color: $pix-communication-light;
+      background: var(--pix-communication-light);
+      border-color: var(--pix-communication-light);
     }
 
     &--wild-strawberry {
-      background: $pix-security-light;
-      border-color: $pix-security-light;
+      background: var(--pix-security-light);
+      border-color: var(--pix-security-light);
     }
 
     &--butterfly-bush {
-      background: $pix-environment-light;
-      border-color: $pix-environment-light;
+      background: var(--pix-environment-light);
+      border-color: var(--pix-environment-light);
     }
 
     &--bottom {

--- a/orga/app/styles/globals/errors.scss
+++ b/orga/app/styles/globals/errors.scss
@@ -1,23 +1,23 @@
 .c-notification.notification {
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   font-weight: 500;
   font-size: 1rem;
   font-family: $font-roboto;
   line-height: 1.3125rem;
-  border: 1.5px solid $pix-neutral-60;
+  border: 1.5px solid var(--pix-neutral-500);
   border-radius: 6px;
 
   > div:first-child {
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: $pix-neutral-60;
+    background-color: var(--pix-neutral-500);
   }
 
   > div:nth-child(2) {
     align-items: center;
     padding: 8px 12px;
-    background-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
 
     > div {
       align-self: center;
@@ -27,7 +27,7 @@
   }
 
   a {
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
   }
 
   .fa {
@@ -35,80 +35,80 @@
   }
 
   .fa-exclamation-circle {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
   }
 
   .c-notification__close svg {
-    fill: $pix-neutral-60;
+    fill: var(--pix-neutral-500);
 
     &:hover,
     &:active {
-      fill: $pix-neutral-70;
+      fill: var(--pix-neutral-800);
     }
   }
 
   &--error {
-    border: 1.5px solid $pix-error-70;
+    border: 1.5px solid var(--pix-error-700);
 
     div:first-child {
-      background-color: $pix-error-70;
+      background-color: var(--pix-error-700);
     }
 
     div:nth-child(2) {
-      color: $pix-error-70;
-      background-color: $pix-error-5;
+      color: var(--pix-error-700);
+      background-color: var(--pix-error-50);
     }
 
     .c-notification__close svg {
-      fill: $pix-error-70;
+      fill: var(--pix-error-700);
 
       &:hover,
       &:active {
-        fill: $pix-error-80;
+        fill: var(--pix-error-900);
       }
     }
   }
 
   &--warning {
-    border: 1.5px solid $pix-warning-70;
+    border: 1.5px solid var(--pix-warning-700);
 
     div:first-child {
-      background-color: $pix-warning-70;
+      background-color: var(--pix-warning-700);
     }
 
     div:nth-child(2) {
-      color: $pix-warning-70;
-      background-color: $pix-warning-5;
+      color: var(--pix-warning-700);
+      background-color: var(--pix-warning-50);
     }
 
     .c-notification__close svg {
-      fill: $pix-warning-70;
+      fill: var(--pix-warning-700);
 
       &:hover,
       &:active {
-        fill: $pix-warning-80;
+        fill: var(--pix-warning-900);
       }
     }
   }
 
   &--success {
-    border: 1.5px solid $pix-success-70;
+    border: 1.5px solid var(--pix-success-700);
 
     div:first-child {
-      background-color: $pix-success-70;
+      background-color: var(--pix-success-700);
     }
 
     div:nth-child(2) {
-      color: $pix-success-70;
-      background-color: $pix-success-5;
+      color: var(--pix-success-700);
+      background-color: var(--pix-success-50);
     }
 
     .c-notification__close svg {
-      fill: $pix-success-70;
+      fill: var(--pix-success-700);
 
       &:hover,
       &:active {
-        fill: $pix-success-80;
+        fill: var(--pix-success-900);
       }
     }
   }
@@ -122,7 +122,7 @@
   text-align: right;
 
   &--error {
-    color: $pix-error-70;
+    color: var(--pix-error-700);
   }
 
   &--left {

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -1,12 +1,12 @@
 .form {
   display: flex;
   flex-direction: column;
-  margin-bottom: $pix-spacing-l;
+  margin-bottom: var(--pix-spacing-8x);
 
   &__field {
     display: flex;
     flex-direction: column;
-    margin: $pix-spacing-s 0;
+    margin: var(--pix-spacing-4x) 0;
 
     @include device-is('desktop') {
       width: 500px;
@@ -42,8 +42,8 @@
     display: flex;
     flex-direction: column;
     height: max-content;
-    margin: $pix-spacing-s 0 0 0;
-    padding: $pix-spacing-s;
+    margin: var(--pix-spacing-4x) 0 0 0;
+    padding: var(--pix-spacing-4x);
     color: var(--pix-neutral-500);
     font-size: 0.875rem;
     background: var(--pix-neutral-20);
@@ -53,18 +53,18 @@
       position: absolute;
       left: 100%;
       width: calc(100vw - 580px - #{$app-sidebar-width} - 32px);
-      margin: 0 0 0 $pix-spacing-s;
+      margin: 0 0 0 var(--pix-spacing-4x);
     }
 
     &-icon {
-      margin-right: $pix-spacing-xs;
+      margin-right: var(--pix-spacing-2x);
       color: var(--pix-primary-500);
     }
 
     &-title {
       @extend %pix-body-m;
 
-      margin-bottom: $pix-spacing-xs;
+      margin-bottom: var(--pix-spacing-2x);
       color: var(--pix-neutral-900);
       font-weight: 500;
     }
@@ -77,7 +77,7 @@
   }
 
   &__field-filters {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     padding: 0;
     border: 0;
 
@@ -88,8 +88,8 @@
     }
 
     .pix-selectable-tag {
-      margin-top: $pix-spacing-xs;
-      margin-inline-end: $pix-spacing-xs;
+      margin-top: var(--pix-spacing-2x);
+      margin-inline-end: var(--pix-spacing-2x);
     }
 
     @include device-is('desktop') {
@@ -101,7 +101,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: $pix-spacing-l;
+    margin-top: var(--pix-spacing-8x);
 
     @include device-is('desktop') {
       max-width: 500px;
@@ -109,11 +109,11 @@
   }
 
   &__error {
-    padding-top: $pix-spacing-xxs;
+    padding-top: var(--pix-spacing-1x);
   }
 
   &__information {
-    margin-top: $pix-spacing-xs;
+    margin-top: var(--pix-spacing-2x);
   }
 
   &__comment {
@@ -122,7 +122,7 @@
   }
 
   &__mandatory-fields-information {
-    margin: 0 0 $pix-spacing-l 0;
+    margin: 0 0 var(--pix-spacing-8x) 0;
     color: var(--pix-neutral-800);
     font-size: 0.875rem;
   }
@@ -144,12 +144,12 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  margin-bottom: $pix-spacing-m;
+  margin-bottom: var(--pix-spacing-6x);
 }
 
 .input {
   height: 36px;
-  padding-left: $pix-spacing-s;
+  padding-left: var(--pix-spacing-4x);
   color: var(--pix-neutral-900);
   font-size: 0.875rem;
   border: 1px solid var(--pix-neutral-500);

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -44,9 +44,9 @@
     height: max-content;
     margin: $pix-spacing-s 0 0 0;
     padding: $pix-spacing-s;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
-    background: $pix-neutral-15;
+    background: var(--pix-neutral-20);
     border-radius: 8px;
 
     @include device-is('desktop') {
@@ -58,21 +58,21 @@
 
     &-icon {
       margin-right: $pix-spacing-xs;
-      color: $pix-primary;
+      color: var(--pix-primary-500);
     }
 
     &-title {
       @extend %pix-body-m;
 
       margin-bottom: $pix-spacing-xs;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-weight: 500;
     }
 
     &-message {
       @extend %pix-body-s;
 
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
     }
   }
 
@@ -83,7 +83,7 @@
 
     > legend {
       margin-bottom: 2px;
-      color: $pix-neutral-50;
+      color: var(--pix-neutral-20)0;
       font-size: 0.875rem;
     }
 
@@ -123,13 +123,13 @@
 
   &__mandatory-fields-information {
     margin: 0 0 $pix-spacing-l 0;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 0.875rem;
   }
 
   abbr.mandatory-mark {
     padding-right: 5px;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     text-decoration: none;
     border: none;
     cursor: help;
@@ -150,23 +150,23 @@
 .input {
   height: 36px;
   padding-left: $pix-spacing-s;
-  color: $pix-neutral-100;
+  color: var(--pix-neutral-900);
   font-size: 0.875rem;
-  border: 1px solid $pix-neutral-40;
+  border: 1px solid var(--pix-neutral-500);
   border-radius: 4px;
   outline: none;
 
   &:focus {
-    border: 1px solid $pix-primary;
+    border: 1px solid var(--pix-primary-500);
   }
 
   &--error {
-    border: 1px solid $pix-error-70;
+    border: 1px solid var(--pix-error-700);
   }
 }
 
 .error-message {
-  color: $pix-error-70;
+  color: var(--pix-error-700);
   font-size: 0.75rem;
   font-family: $font-roboto;
 }

--- a/orga/app/styles/globals/icons.scss
+++ b/orga/app/styles/globals/icons.scss
@@ -5,6 +5,6 @@
   }
 
   &--warning {
-    color: $pix-warning-70;
+    color: var(--pix-warning-700);
   }
 }

--- a/orga/app/styles/globals/pages.scss
+++ b/orga/app/styles/globals/pages.scss
@@ -1,15 +1,15 @@
 .page {
-  padding: 0 $pix-spacing-m;
+  padding: 0 var(--pix-spacing-6x);
 
   @include device-is('tablet') {
-    padding: 0 $pix-spacing-xl;
+    padding: 0 var(--pix-spacing-10x);
   }
 
   &__title {
-    margin-bottom: $pix-spacing-m;
+    margin-bottom: var(--pix-spacing-6x);
   }
 }
 
 .navigation {
-  margin: $pix-spacing-l 0;
+  margin: var(--pix-spacing-8x) 0;
 }

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -1,8 +1,9 @@
 .panel {
+  @extend %pix-shadow-xs;
+
   background-color: $pix-neutral-0;
   border: none;
   border-radius: 4px;
-  box-shadow: $shadow-base;
 
   &--header {
     box-sizing: border-box;
@@ -147,7 +148,7 @@
     }
 
     &-item.active {
-      background-color: lighten($pix-primary, 32%);
+      background-color: var(--pix-primary-100);
       border-bottom-width: 0px;
     }
   }

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -1,7 +1,7 @@
 .panel {
   @extend %pix-shadow-xs;
 
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border: none;
   border-radius: 4px;
 
@@ -23,7 +23,7 @@
   box-sizing: border-box;
   width: 100%;
   padding-bottom: 24px;
-  border-bottom: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid var(--pix-neutral-20);
 
   .panel-header-title {
     margin: 0;
@@ -46,7 +46,7 @@
   font-family: $font-roboto;
 
   &--highlight {
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border-radius: 8px;
   }
 }
@@ -58,7 +58,7 @@
     align-content: center;
     align-items: flex-start;
     padding: 0 16px;
-    border-right: 1px solid $pix-neutral-20;
+    border-right: 1px solid var(--pix-neutral-20);
   }
 
   &__content:last-child {
@@ -106,7 +106,7 @@
     align-items: center;
     justify-content: center;
     padding: 0 24px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
     font-weight: 500;
     font-size: 0.9rem;
     font-family: $font-roboto;
@@ -120,19 +120,19 @@
 
     &:hover,
     &:focus {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
     }
 
     &-separator {
       height: 30px;
       margin: 15px 0px;
-      border-left: 1px solid $pix-neutral-25;
+      border-left: 1px solid var(--pix-neutral-100);
     }
   }
 
   &-item.active {
-    color: $pix-primary;
-    border-bottom: 2px solid $pix-primary;
+    color: var(--pix-primary-500);
+    border-bottom: 2px solid var(--pix-primary-500);
   }
 }
 

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -146,11 +146,6 @@
       width: 100%;
       height: 48px;
     }
-
-    &-item.active {
-      background-color: var(--pix-primary-100);
-      border-bottom-width: 0px;
-    }
   }
 
   .panel-header__body {

--- a/orga/app/styles/globals/shadows.scss
+++ b/orga/app/styles/globals/shadows.scss
@@ -1,1 +1,0 @@
-$shadow-base: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -7,14 +7,14 @@ table {
 
   .table__input {
     &:focus-within {
-      border: 1px solid $pix-primary;
+      border: 1px solid var(--pix-primary-500);
     }
   }
 
   .table__multi-select {
     > label {
       > input[type='text']::placeholder {
-        color: $pix-neutral-30;
+        color: var(--pix-neutral-100);
       }
     }
   }
@@ -22,7 +22,7 @@ table {
 
 thead {
   width: 100%;
-  color: $pix-neutral-100;
+  color: var(--pix-neutral-900);
 
   th {
     font-weight: 500;
@@ -39,12 +39,12 @@ caption {
 }
 
 tbody {
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
 
   tr {
     &:focus-within,
     &:hover {
-      background-color: $pix-neutral-15;
+      background-color: var(--pix-neutral-20);
     }
   }
 
@@ -54,8 +54,8 @@ tbody {
     &:hover,
     &:focus,
     &:active {
-      color: $pix-neutral-100;
-      background-color: $pix-neutral-10;
+      color: var(--pix-neutral-900);
+      background-color: var(--pix-neutral-20);
       transition: 0.25s ease;
     }
   }
@@ -69,13 +69,13 @@ tbody {
     background-color: white;
 
     &:hover {
-      background-color: $pix-neutral-15;
+      background-color: var(--pix-neutral-20);
     }
   }
 
   td {
     position: relative;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-weight: 400;
     font-size: 0.875rem;
     font-family: $font-roboto;
@@ -86,13 +86,13 @@ tbody {
     }
 
     > a {
-      color: $pix-neutral-80;
+      color: var(--pix-neutral-800);
       text-decoration: none;
 
       &:hover,
       &:focus,
       &:active {
-        color: $pix-neutral-80;
+        color: var(--pix-neutral-800);
       }
     }
   }
@@ -101,7 +101,7 @@ tbody {
 tr {
   width: 100%;
   height: 60px;
-  border-top: 1px solid $pix-neutral-15;
+  border-top: 1px solid var(--pix-neutral-20);
 }
 
 td,
@@ -172,7 +172,7 @@ th::first-letter {
   }
 
   &--highlight {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
   }
 }
 
@@ -196,5 +196,5 @@ th::first-letter {
   height: 180px;
   margin: 0;
   text-align: center;
-  border-top: 1px solid $pix-neutral-15;
+  border-top: 1px solid var(--pix-neutral-20);
 }

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -1,11 +1,11 @@
 .paragraph {
   @extend %pix-body-m;
 
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
 }
 
 .help-text {
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 0.75rem;
   font-family: $font-roboto;
 }
@@ -13,16 +13,16 @@
 .information-text {
   @extend %pix-title-s;
 
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
 }
 
 .label-text {
   @extend %pix-body-s;
 
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-20)0;
 
   &--dark {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 
   &--small {
@@ -33,22 +33,22 @@
 .value-text {
   @extend %pix-body-m;
 
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-weight: 500;
 
   &--highlight {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1.125rem;
   }
 }
 
 .content-text {
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 1rem;
   font-family: $font-roboto;
 
   &--bold {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: 700;
   }
 
@@ -63,7 +63,7 @@
 }
 
 .link {
-  color: $pix-primary;
+  color: var(--pix-primary-500);
   text-decoration: none;
   background-color: inherit;
   border: none;
@@ -72,7 +72,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
     text-decoration: underline;
   }
 
@@ -85,17 +85,17 @@
   }
 
   &--white {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
 
     &:hover {
-      color: $pix-neutral-0;
+      color: var(--pix-neutral-0);
       opacity: 0.85;
     }
 
     &:focus,
     &:active {
-      color: $pix-neutral-110;
-      background-color: $pix-warning-40;
+      color: var(--pix-neutral-900);
+      background-color: var(--pix-warning-500);
     }
   }
 

--- a/orga/app/styles/globals/titles.scss
+++ b/orga/app/styles/globals/titles.scss
@@ -8,7 +8,7 @@
 .page-sub-title {
   @extend %pix-title-s;
 
-  margin-bottom: $pix-spacing-m;
+  margin-bottom: var(--pix-spacing-6x);
   color: var(--pix-neutral-500);
 }
 

--- a/orga/app/styles/globals/titles.scss
+++ b/orga/app/styles/globals/titles.scss
@@ -2,31 +2,31 @@
   @extend %pix-title-m;
 
   margin-top: 0;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
 }
 
 .page-sub-title {
   @extend %pix-title-s;
 
   margin-bottom: $pix-spacing-m;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
 }
 
 .form-title {
   @extend %pix-title-m;
 
-  color: $pix-neutral-100;
+  color: var(--pix-neutral-900);
 }
 
 .panel-header-title {
   @extend  %pix-title-xs;
 
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
 }
 
 .back-title {
   margin: 0;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
 
   @extend  %pix-title-s;
 }

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -10,7 +10,7 @@
 
   // Minus 280px because it corresponds to the sidebar's width
   width: calc(100% - 280px);
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 
   &__body {
     flex: 1 0 auto;

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -10,7 +10,7 @@
   bottom: 0;
   height: 20px;
   margin: auto;
-  border-right: solid 0.5px $pix-neutral-30;
+  border-right: solid 0.5px var(--pix-neutral-100);
 
   &__content {
     width: auto;

--- a/orga/app/styles/pages/authenticated/campaigns/details/analysis.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/analysis.scss
@@ -1,5 +1,5 @@
 sub {
   @extend %pix-title-xs;
 
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -1,7 +1,7 @@
 .participant-list {
   &__mastery-percentage {
     margin-left: 26px;
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     font-size: 1.25rem;
   }
 
@@ -17,7 +17,7 @@
     align-items: center;
     height: 60px;
     padding-left: 30px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
     font-family: $font-roboto;
   }

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants/participant/header.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants/participant/header.scss
@@ -17,7 +17,7 @@
     flex-shrink: 1;
     width: 60%;
     margin: 0 0 0 3%;
-    border-right: 1px solid $pix-neutral-20;
+    border-right: 1px solid var(--pix-neutral-20);
   }
 
   &__right-wrapper {

--- a/orga/app/styles/pages/authenticated/campaigns/new.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/new.scss
@@ -2,5 +2,5 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 }

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -8,12 +8,12 @@
   &__tabs {
     display: flex;
     margin-bottom: $pix-spacing-s;
-    border-bottom: 1px solid $pix-neutral-20;
+    border-bottom: 1px solid var(--pix-neutral-20);
   }
 
   &__text {
     margin: 2px 0 32px 0;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 1rem;
     font-family: $font-roboto;
     line-height: 1.45rem;

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -2,12 +2,12 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin-bottom: $pix-spacing-l;
-  padding: $pix-spacing-s 0 0 $pix-spacing-s;
+  margin-bottom: var(--pix-spacing-8x);
+  padding: var(--pix-spacing-4x) 0 0 var(--pix-spacing-4x);
 
   &__tabs {
     display: flex;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     border-bottom: 1px solid var(--pix-neutral-20);
   }
 
@@ -22,10 +22,10 @@
   &__action {
     display: flex;
     flex-wrap: wrap;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: flex-end;
     min-width: 100%;
-    margin-bottom: $pix-spacing-xl;
+    margin-bottom: var(--pix-spacing-10x);
   }
 
   .pix-message {

--- a/orga/app/styles/pages/authenticated/organization-participants/deletion-modal.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/deletion-modal.scss
@@ -1,5 +1,5 @@
 .deletion-modal{
   &__permission-checkbox{
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
   }
 }

--- a/orga/app/styles/pages/authenticated/organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/list.scss
@@ -8,7 +8,7 @@ $margin-right: 32px;
 
   &__last-participation {
     display: flex;
-    gap: $pix-spacing-xs;
+    gap: var(--pix-spacing-2x);
     justify-content: center;
   }
 

--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -13,14 +13,14 @@
 
 .preselect-tube-table {
   .is-responsive {
-    color: $pix-success-70;
+    color: var(--pix-success-700);
   }
 
   .not-responsive {
     position: absolute;
     top: 50%;
     left: calc(50% + 12px);
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     transform: translate(-50%, -50%);
   }
 }
@@ -44,23 +44,23 @@
       }
 
       &.jaffa:before {
-        border-color: $pix-information-light;
+        border-color: var(--pix-information-light);
       }
 
       &.emerald:before {
-        border-color: $pix-content-light;
+        border-color: var(--pix-content-light);
       }
 
       &.cerulean:before {
-        border-color: $pix-communication-light;
+        border-color: var(--pix-communication-light);
       }
 
       &.wild-strawberry:before {
-        border-color: $pix-security-light;
+        border-color: var(--pix-security-light);
       }
 
       &.butterfly-bush:before {
-        border-color: $pix-environment-light;
+        border-color: var(--pix-environment-light);
       }
     }
 
@@ -73,15 +73,15 @@
 
         margin: 0;
         padding: 1rem;
-        color: $pix-neutral-90;
+        color: var(--pix-neutral-900);
       }
 
       table {
-        color: $pix-neutral-70;
+        color: var(--pix-neutral-800);
       }
 
       th {
-        color: $pix-neutral-100;
+        color: var(--pix-neutral-900);
         font-weight: 500;
       }
 
@@ -96,7 +96,7 @@
       }
 
       thead {
-        background: $pix-neutral-10;
+        background: var(--pix-neutral-20);
       }
     }
   }

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/import.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/import.scss
@@ -21,7 +21,7 @@
     height: 230px;
     margin: 16px;
     padding: 16px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 8px;
   }
 }
@@ -33,7 +33,7 @@
 
   &__details {
     margin: 8px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
     font-weight: 300;
     font-size: 1rem;
     font-family: $font-roboto;
@@ -53,7 +53,7 @@
 
   &__details {
     margin: 16px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-20)0;
     font-size: 0.875rem;
     font-family: $font-roboto;
     line-height: 22px;

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/import.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/import.scss
@@ -11,6 +11,8 @@
   }
 
   &__section {
+    @extend %pix-shadow-xs;
+
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -21,7 +23,6 @@
     padding: 16px;
     background-color: $pix-neutral-0;
     border-radius: 8px;
-    box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
   }
 }
 

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -16,7 +16,7 @@ $margin-right: $pix-spacing-l;
   &__tabs {
     display: flex;
     margin-bottom: $pix-spacing-m;
-    border-bottom: 1px solid $pix-neutral-20;
+    border-bottom: 1px solid var(--pix-neutral-20);
   }
 
   .modal-dialog-width {

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -1,4 +1,4 @@
-$margin-right: $pix-spacing-l;
+$margin-right: var(--pix-spacing-8x);
 
 .list-team-page {
   display: flex;
@@ -10,12 +10,12 @@ $margin-right: $pix-spacing-l;
   &__header {
     display: flex;
     align-items: center;
-    margin: $pix-spacing-s 0;
+    margin: var(--pix-spacing-4x) 0;
   }
 
   &__tabs {
     display: flex;
-    margin-bottom: $pix-spacing-m;
+    margin-bottom: var(--pix-spacing-6x);
     border-bottom: 1px solid var(--pix-neutral-20);
   }
 

--- a/orga/app/styles/pages/authenticated/team/new.scss
+++ b/orga/app/styles/pages/authenticated/team/new.scss
@@ -1,8 +1,8 @@
 .new-team-page {
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 
   &__form {
-    margin-top: $pix-spacing-l;
+    margin-top: var(--pix-spacing-8x);
   }
 }
 

--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -6,7 +6,7 @@
   width: 100%;
   height: 100%;
   min-height: 800px;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-secondary-500)-orga-gradient;
 }
 
 .terms-of-service-form {
@@ -14,7 +14,7 @@
   max-width: 800px;
   margin: auto;
   padding: 35px 0;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border-radius: 10px;
 
   @include device-is('mobile') {
@@ -34,7 +34,7 @@
     @extend %pix-title-s;
 
     margin-bottom: 30px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     text-align: center;
     text-transform: uppercase;
   }
@@ -43,7 +43,7 @@
     width: 100%;
     height: 1px;
     margin-bottom: 30px;
-    background-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
     border: none;
   }
 

--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -64,7 +64,7 @@
   &__actions {
     display: flex;
     flex-direction: row;
-    gap: $pix-spacing-m;
+    gap: var(--pix-spacing-6x);
     justify-content: flex-end;
     margin: 0 60px;
 

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   min-height: 100%;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-secondary-500)-orga-gradient;
 
   a {
     text-decoration: underline;
@@ -51,7 +51,7 @@
   &__success {
     margin-top: 54px;
     margin-bottom: 24px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     letter-spacing: 0.15px;
     text-align: center;
   }

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -42,7 +42,7 @@
 
   &__error-message {
     max-width: 497px;
-    margin-top: $pix-spacing-m;
+    margin-top: var(--pix-spacing-6x);
     margin-bottom: 24px;
     font-size: 0.875rem;
     text-align: center;

--- a/orga/app/styles/pages/join.scss
+++ b/orga/app/styles/pages/join.scss
@@ -1,8 +1,9 @@
 .join-page {
+  @extend %pix-shadow-sm;
+
   display: flex;
   justify-content: center;
   width: 100%;
   min-height: 100vh;
   background: $pix-secondary-orga-gradient;
-  box-shadow: 0 2px 8px 0 rgba($pix-neutral-110, 0.1);
 }

--- a/orga/app/styles/pages/join.scss
+++ b/orga/app/styles/pages/join.scss
@@ -5,5 +5,5 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-secondary-500)-orga-gradient;
 }

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: var(--pix-secondary-500)-orga-gradient;
+  background: $pix-secondary-orga-gradient;
 
   &__header {
     text-align: center;

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: $pix-secondary-orga-gradient;
+  background: var(--pix-secondary-500)-orga-gradient;
 
   &__header {
     text-align: center;
@@ -18,7 +18,7 @@
   &__container {
     margin-bottom: $pix-spacing-s;
     padding: $pix-spacing-xl 60px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 10px;
 
     @include device-is('mobile') {

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -16,13 +16,13 @@
   }
 
   &__container {
-    margin-bottom: $pix-spacing-s;
-    padding: $pix-spacing-xl 60px;
+    margin-bottom: var(--pix-spacing-4x);
+    padding: var(--pix-spacing-10x) 60px;
     background-color: var(--pix-neutral-0);
     border-radius: 10px;
 
     @include device-is('mobile') {
-      padding: $pix-spacing-xl $pix-spacing-s;
+      padding: var(--pix-spacing-10x) var(--pix-spacing-4x);
       border-radius: 0px;
     }
   }

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -4,10 +4,10 @@
   <div class="main-content">
     <header>
       <Layout::Topbar />
-      <Banner::Information />
     </header>
 
     <main class="main-content__body page">
+      <Banner::Information />
       {{outlet}}
     </main>
 


### PR DESCRIPTION
## :christmas_tree: Problème
Mise à jour de PixUI sur PixOrga par Renovate avec des modifications majeurs du Design system (variables scss => variables css pour les couleurs et espacements)

## :gift: Proposition
- Faire tourner le script pour la mise à jour des variables de couleurs
- Faire tourner le script pour la mise à jour des variables d'espacement
- Faire un tour global de PixOrga et réparer les petits trucs cassés par-ci/par-là
- Vérifier le style des `banner` car à l'origine on était quand même là pour ça :wink:

## :socks: Remarques

## :santa: Pour tester
Sur PixOrga :
- MIR de connexion => le gradient en background de la MIR de connexion est bien présent
- Participants => les bulles d'information ont maintenant une couleur accessible
- Membres/Inviter un membre => le bouton d'annulation a un style avec une border visible
- Paramètre d'une campagne => les infos-bulles ont maintenant une couleur accessible
- Paramètre d'une campagne => le bouton d'archivage est maintenant rouge
- Création de campagne => icônes d'information des encars informatifs sont à nouveau bleu
- Résultats d'une campagne => répartition des participants par résultat dorénavant violet
- Campagnes (version mobile) => même style qu'en version Desktop
- Vérifier le style des banners
- Faire une petite balade sur pixOrga et ne pas remarquer d'incohérences par rapport à la version avant la montée de version de PixUI
- Et enfin... 🎉 