### PR TITLE
[FEATURE] Ajouter l'information de campagne à envoi multiple dans la page de détail d'une campagne (PIX-10378)

### DIFF
--- a/orga/app/components/campaign/header/title.hbs
+++ b/orga/app/components/campaign/header/title.hbs
@@ -20,7 +20,6 @@
           {{dayjs-format @campaign.createdAt "DD/MM/YYYY" allow-empty=true}}
         </dd>
       </div>
-
       <div class="campaign-header-title__detail-item">
         <dt class="label-text">
           {{t "pages.campaign.created-by"}}
@@ -30,6 +29,16 @@
         </dd>
       </div>
 
+      {{#if this.shouldShowMultipleSending}}
+        <div class="campaign-header-title__detail-item">
+          <dt class="label-text">
+            {{t "pages.campaign.multiple-sendings.title"}}
+          </dt>
+          <dd>
+            {{this.multipleSendingText}}
+          </dd>
+        </div>
+      {{/if}}
       <div class="campaign-header-title__detail-item">
         <dt class="label-text">
           {{t "pages.campaign.code"}}

--- a/orga/app/components/campaign/header/title.js
+++ b/orga/app/components/campaign/header/title.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 
 export default class Header extends Component {
   @service intl;
+  @service currentUser;
 
   get breadcrumbLinks() {
     return [
@@ -23,5 +24,19 @@ export default class Header extends Component {
       ASSESSMENT: 'components.campaign.type.explanation.ASSESSMENT',
       PROFILES_COLLECTION: 'components.campaign.type.explanation.PROFILES_COLLECTION',
     };
+  }
+
+  get shouldShowMultipleSending() {
+    return this.args.campaign.isTypeProfilesCollection || this.isMultipleSendingsForAssessmentEnabled;
+  }
+
+  get isMultipleSendingsForAssessmentEnabled() {
+    return this.args.campaign.isTypeAssessment && this.currentUser.prescriber.enableMultipleSendingAssessment;
+  }
+
+  get multipleSendingText() {
+    return this.args.campaign.multipleSendings
+      ? this.intl.t('pages.campaign.multiple-sendings.status.enabled')
+      : this.intl.t('pages.campaign.multiple-sendings.status.disabled');
   }
 }

--- a/orga/tests/integration/components/campaign/header/title_test.js
+++ b/orga/tests/integration/components/campaign/header/title_test.js
@@ -27,4 +27,135 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
     assert.ok(screen.getByText('Mulan Fa'));
     assert.ok(screen.getByText('14/04/2021'));
   });
+
+  module('multiple sending display', function (hooks) {
+    let store;
+
+    hooks.beforeEach(function () {
+      store = this.owner.lookup('service:store');
+    });
+
+    module('when campaign type is PROFILES_COLLECTION', function () {
+      test('it should display multiple sendings label', async function (assert) {
+        // given
+        this.campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+        });
+
+        // when
+        const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+        // then
+        assert.ok(screen.getByText(this.intl.t('pages.campaign.multiple-sendings.title')));
+      });
+
+      module('when multiple sendings is true', function () {
+        test("it should display 'oui'", async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'PROFILES_COLLECTION',
+            multipleSendings: true,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+          // then
+          assert.ok(screen.getByText(this.intl.t('pages.campaign.multiple-sendings.status.enabled')));
+        });
+      });
+
+      module('when multiple sendings is false', function () {
+        test("it should display 'Non'", async function (assert) {
+          // given
+          this.campaign = store.createRecord('campaign', {
+            type: 'PROFILES_COLLECTION',
+            multipleSendings: false,
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+          // then
+          assert.ok(screen.getByText(this.intl.t('pages.campaign.multiple-sendings.status.disabled')));
+        });
+      });
+    });
+
+    module('when type is ASSESSMENT', function () {
+      module('when organization feature enableMultipleSending is false', function () {
+        test('it should not display multiple sendings label', async function (assert) {
+          // given
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.prescriber = {
+            enableMultipleSendingAssessment: false,
+          };
+          this.campaign = store.createRecord('campaign', {
+            type: 'ASSESSMENT',
+          });
+
+          // when
+          const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+          // then
+          assert.notOk(screen.queryByText(this.intl.t('pages.campaign.multiple-sendings.title')));
+        });
+      });
+
+      module('when organization feature enableMultipleSending is true', function (hooks) {
+        hooks.beforeEach(function () {
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.prescriber = {
+            enableMultipleSendingAssessment: true,
+          };
+        });
+
+        test('it should display multiple sendings label', async function (assert) {
+          // given
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.prescriber = {
+            enableMultipleSendingAssessment: true,
+          };
+          this.campaign = store.createRecord('campaign', {
+            type: 'ASSESSMENT',
+          });
+          // when
+          const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+          // then
+          assert.ok(screen.getByText(this.intl.t('pages.campaign.multiple-sendings.title')));
+        });
+
+        module('when the campaign multiple sending is true', function () {
+          test("it should display 'oui'", async function (assert) {
+            // given
+            this.campaign = store.createRecord('campaign', {
+              type: 'PROFILES_COLLECTION',
+              multipleSendings: true,
+            });
+
+            // when
+            const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+            // then
+            assert.ok(screen.getByText(this.intl.t('pages.campaign.multiple-sendings.status.enabled')));
+          });
+        });
+
+        module('when the campaign multiple sending is false', function () {
+          test("it should display 'non'", async function (assert) {
+            // given
+            this.campaign = store.createRecord('campaign', {
+              type: 'PROFILES_COLLECTION',
+              multipleSendings: false,
+            });
+
+            // when
+            const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+            // then
+            assert.ok(screen.getByText(this.intl.t('pages.campaign.multiple-sendings.status.disabled')));
+          });
+        });
+      });
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -330,6 +330,13 @@
       "created-by": "Owner",
       "created-on": "Created on",
       "empty-state": "No participants yet! Share with them the following link to join this campaign.",
+      "multiple-sendings": {
+        "title": "Multiple Sendings",
+        "status": {
+          "disabled": "No",
+          "enabled": "Yes"
+        }
+      },
       "name": "Name of the campaign",
       "tab": {
         "activity": "Activity",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -333,6 +333,13 @@
       "created-by": "Propriétaire",
       "created-on": "Créée le",
       "empty-state": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
+      "multiple-sendings": {
+        "title": "Envoi multiple",
+        "status": {
+          "disabled": "Non",
+          "enabled": "Oui"
+        }
+      },
       "name": "Nom de la campagne",
       "tab": {
         "activity": "Activité",


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, pour savoir si une campagne est à envoi multiple, il faut aller dans les paramètres de la campagne. 
Comme nous commençons à travailler sur l’historique des participations dont un des objectif est de pousser l’usage de l’envoi multiple, nous aimerions aider le prescripteur à identifier plus rapidement si la campagne est à envoi multiple ou non. 

## :gift: Proposition
Ajouter l’info envoi multiple : oui/non à droite du nom de la campagne entre le “Propriétaire” et le “Code” 

## :socks: Remarques
- Pour les campagnes de collecte de profil, l'info sera toujours présente avec Oui ou Non
- Pour les campagnes d'évaluation, l'info sera présente seulement si l'organisation à la fonctionnalité `MULTIPLE_SENDING_ASSESSMENT` activée

## :santa: Pour tester
- Aller sur le détail d'une campagne de collecte de profil
- Vérifier dans la partie supérieure droite si l'info de l'envoi multiple correspond bien à la réalité de la campagne
- Faire pour le cas inverse
- Aller sur sur le détail d'une campagne d'évaluation pour une organisation sans la fonctionnalité
- Vérifier que l'info n'est pas présente dans le header
- Faire la même chose que pour une campagne de collecte de profil, mais cette fois avec une organisation qui à la fonctionnalité `MULTIPLE_SENDING_ASSESSMENT` activée
- 🐈‍⬛ 
