### PR TITLE
[FEATURE] Ajoute une API pour récupérer les détails d'un profil cible à partir de son id (PIX-10137).

### DIFF
--- a/api/src/prescription/target-profile/application/api/target-profile-api.js
+++ b/api/src/prescription/target-profile/application/api/target-profile-api.js
@@ -1,4 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
+import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
 import { TargetProfile } from './TargetProfile.js';
 
 /**
@@ -18,4 +19,17 @@ export const getByOrganizationId = async (organizationId) => {
   const targetProfiles = await usecases.getAvailableTargetProfilesForOrganization({ organizationId });
 
   return targetProfiles.map((targetProfileForSpecifier) => new TargetProfile(targetProfileForSpecifier));
+};
+
+/**
+ * @function
+ * @name getById
+ *
+ * @param {number} id
+ * @returns {Promise<TargetProfile>}
+ */
+export const getById = async (id) => {
+  const targetProfileForAdmin = await libUsecases.getTargetProfileForAdmin({ targetProfileId: id });
+
+  return new TargetProfile(targetProfileForAdmin);
 };

--- a/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
+++ b/api/tests/prescription/target-profile/unit/application/api/target-profile-api_test.js
@@ -1,10 +1,38 @@
 import { usecases } from '../../../../../../src/prescription/target-profile/domain/usecases/index.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { usecases as libUsecases } from '../../../../../../lib/domain/usecases/index.js';
+import { expect, sinon, catchErr } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { TargetProfileForSpecifier } from '../../../../../../src/prescription/target-profile/domain/read-models/TargetProfileForSpecifier.js';
 import * as targetProfileApi from '../../../../../../src/prescription/target-profile/application/api/target-profile-api.js';
+import { TargetProfile } from '../../../../../../src/prescription/target-profile/application/api/TargetProfile.js';
 
 describe('Unit | API | TargetProfile', function () {
+  describe('#getById', function () {
+    it('should return target profile', async function () {
+      const targetProfileId = 1;
+      const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({ id: targetProfileId });
+      const expectedTargetProfile = new TargetProfile(targetProfileForAdmin);
+
+      const getTargetProfileForAdminStub = sinon.stub(libUsecases, 'getTargetProfileForAdmin');
+      getTargetProfileForAdminStub.withArgs({ targetProfileId }).resolves(targetProfileForAdmin);
+
+      const targetProfile = await targetProfileApi.getById(targetProfileId);
+
+      expect(targetProfile).to.deep.equal(expectedTargetProfile);
+    });
+
+    it('should throw an error', async function () {
+      const targetProfileId = 1;
+
+      const getTargetProfileForAdminStub = sinon.stub(libUsecases, 'getTargetProfileForAdmin');
+      getTargetProfileForAdminStub.withArgs({ targetProfileId }).rejects();
+
+      const error = await catchErr(targetProfileApi.getById)(targetProfileId);
+
+      expect(error).to.be.ok;
+    });
+  });
+
   describe('#getByOrganizationId', function () {
     it('should return target profiles from organization', async function () {
       const organizationId = domainBuilder.buildOrganization().id;


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l'Epix des parcours autonome, l'équipe ExpEval a besoin de s'assurer que les parcours sont créer avec des profils cibles à accès simplifié rattaché à l'organisation des parcours autonome.

## :gift: Proposition
On ajoute une API qui permet de récupérer les détails d'un profil cible à partir de son id.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
La CI passe :green_apple:
